### PR TITLE
detection of other mods and dependent behavior improved

### DIFF
--- a/Game/Addons/IncreasedTerrainDistanceMod/Scripts/IncreasedTerrainDistance.cs
+++ b/Game/Addons/IncreasedTerrainDistanceMod/Scripts/IncreasedTerrainDistance.cs
@@ -7,9 +7,9 @@
 //Contributors: Lypyl, Interkarma
 
 // uncomment next line if enhanced sky mod by Lypyl is present
-#define ENHANCED_SKY_AVAILABLE
+#define ENHANCED_SKY_CODE_AVAILABLE
 
-#define REFLECTIONSMOD_AVAILABLE
+#define REFLECTIONSMOD_CODE_AVAILABLE
 
 using UnityEngine;
 using System;
@@ -70,6 +70,8 @@ namespace ProjectIncreasedTerrainDistance
         [Range(0.0f, 300000.0f)]
         public float blendEnd = 145000.0f;
 
+        bool isActiveReflectionsMod = false;
+        bool isActiveEnhancedSkyMod = false;
 
         // is dfUnity ready?
         bool isReady = false;
@@ -128,7 +130,7 @@ namespace ProjectIncreasedTerrainDistance
         public Camera getFarTerrainCamera() { return stackedCamera; }
         public Camera getStackedNearCamera() { return stackedNearCamera; }
 
-        #if ENHANCED_SKY_AVAILABLE
+        #if ENHANCED_SKY_CODE_AVAILABLE
         EnhancedSky.SkyManager skyMan = null;
         bool sampleFogColorFromSky = false;
         #endif
@@ -244,8 +246,11 @@ namespace ProjectIncreasedTerrainDistance
 
             PlayerEnterExit.OnTransitionExterior += TransitionToExterior;
             PlayerEnterExit.OnTransitionDungeonExterior += TransitionToExterior;
-            #if ENHANCED_SKY_AVAILABLE
+            #if ENHANCED_SKY_CODE_AVAILABLE
+            if (isActiveEnhancedSkyMod)
+            {
                 EnhancedSky.SkyManager.toggleSkyObjectsEvent += EnhancedSkyToggle;
+            }
             #endif
         }
 
@@ -263,13 +268,17 @@ namespace ProjectIncreasedTerrainDistance
             PlayerEnterExit.OnTransitionExterior -= TransitionToExterior;
             PlayerEnterExit.OnTransitionDungeonExterior -= TransitionToExterior;
 
-            #if ENHANCED_SKY_AVAILABLE
+            #if ENHANCED_SKY_CODE_AVAILABLE
+            if (isActiveEnhancedSkyMod)
+            {
                 EnhancedSky.SkyManager.toggleSkyObjectsEvent -= EnhancedSkyToggle;
+            }
             #endif
         }
 
         void EnhancedSkyToggle(bool toggle)
         {
+            #if ENHANCED_SKY_CODE_AVAILABLE
             if (toggle)
             {
                 sampleFogColorFromSky = true;
@@ -278,6 +287,7 @@ namespace ProjectIncreasedTerrainDistance
             {
                 sampleFogColorFromSky = false;
             }
+            #endif
         }
 
         void InitImprovedWorldTerrain()
@@ -392,6 +402,12 @@ namespace ProjectIncreasedTerrainDistance
         {
             if (!DaggerfallUnity.Settings.Nystul_IncreasedTerrainDistance)
                 return;
+
+            if (GameObject.Find("EnhancedSkyController") != null)
+                isActiveEnhancedSkyMod = true;
+
+            if (GameObject.Find("ReflectionsMod") != null)
+                isActiveReflectionsMod = true;
 
             if (worldTerrainGameObject == null) // lazy creation
             {
@@ -532,7 +548,9 @@ namespace ProjectIncreasedTerrainDistance
             cameraRenderSkyboxToTexture.depth = cameraRenderSkyboxToTextureDepth; // make sure to render first
             cameraRenderSkyboxToTexture.renderingPath = stackedCamera.renderingPath;
 
-            #if ENHANCED_SKY_AVAILABLE
+            #if ENHANCED_SKY_CODE_AVAILABLE
+            if (isActiveEnhancedSkyMod)
+            {
                 //skyMan = GameObject.Find("EnhancedSkyController").GetComponent<EnhancedSky.SkyManager>();
                 EnhancedSky.SkyManager[] skyManagers = Resources.FindObjectsOfTypeAll<EnhancedSky.SkyManager>();
                 foreach (EnhancedSky.SkyManager currentSkyManager in skyManagers)
@@ -546,10 +564,11 @@ namespace ProjectIncreasedTerrainDistance
                     }
                 }
 
-                if ((skyMan)&&(skyMan.gameObject.activeInHierarchy))
+                if ((skyMan) && (skyMan.gameObject.activeInHierarchy))
                 {
                     sampleFogColorFromSky = true;
                 }
+            }
             #endif
     
             cameraRenderSkyboxToTexture.targetTexture = renderTextureSky;
@@ -603,7 +622,9 @@ namespace ProjectIncreasedTerrainDistance
                 {
                     setMaterialFogParameters();
             
-                    #if ENHANCED_SKY_AVAILABLE
+                    #if ENHANCED_SKY_CODE_AVAILABLE
+                    if (isActiveEnhancedSkyMod)
+                    {
                         if ((sampleFogColorFromSky == true) && (!skyMan.IsOvercast))
                         {
                             terrain.materialTemplate.SetFloat("_FogFromSkyTex", 1);
@@ -612,6 +633,7 @@ namespace ProjectIncreasedTerrainDistance
                         {
                             terrain.materialTemplate.SetFloat("_FogFromSkyTex", 0);
                         }
+                    }
                     #endif
 
                     //terrain.materialTemplate.SetFloat("_BlendFactor", blendFactor);
@@ -987,7 +1009,9 @@ namespace ProjectIncreasedTerrainDistance
             terrainMaterial.SetFloat("_BlendStart", blendStart);
             terrainMaterial.SetFloat("_BlendEnd", blendEnd);
 
-            #if REFLECTIONSMOD_AVAILABLE
+            #if REFLECTIONSMOD_CODE_AVAILABLE
+            if (isActiveReflectionsMod)
+            {
                 RenderTexture reflectionSeaTexture = GameObject.Find("ReflectionsMod").GetComponent<ReflectionsMod.UpdateReflectionTextures>().getSeaReflectionRenderTexture();
                 if (reflectionSeaTexture != null)
                 {
@@ -999,8 +1023,9 @@ namespace ProjectIncreasedTerrainDistance
                 {
                     terrainMaterial.SetInt("_UseSeaReflectionTex", 0);
                 }
+            }
             #else
-                terrainMaterial.SetInt("_UseSeaReflectionTex", 0);
+            terrainMaterial.SetInt("_UseSeaReflectionTex", 0);
             #endif
 
             // Promote material

--- a/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -704,45 +704,41 @@ namespace Wenzil.Console
                                     if (DaggerfallWorkshop.DaggerfallUnity.Instance.ContentReader.HasLocation(xpos, ypos, out mapSummary))
                                     {
                                         streamingWorld.TeleportToCoordinates(xpos, ypos); // random location
-                                        break;
+                                        return (string.Format("Teleported player to location at: {0}, {1}", xpos, ypos));
                                     }
                                 }                                
-                                break;
                             case 1:
-                                streamingWorld.TeleportToCoordinates(207, 213); // Daggerfall/Daggerfall  
-                                break;
+                                streamingWorld.TeleportToCoordinates(207, 213);
+                                return ("Teleported player to Daggerfall/Daggerfall");
                             case 2:
-                                streamingWorld.TeleportToCoordinates(859, 244); // Wayrest/Wayrest
-                                break;
+                                streamingWorld.TeleportToCoordinates(859, 244);
+                                return ("Teleported player to Wayrest/Wayrest");
                             case 3:
-                                streamingWorld.TeleportToCoordinates(397, 343); // Sentinel/Sentinel
-                                break;
+                                streamingWorld.TeleportToCoordinates(397, 343);
+                                return ("Teleported player to Sentinel/Sentinel");
                             case 4:
-                                streamingWorld.TeleportToCoordinates(892, 146); // Orsinium Area/Orsinium
-                                break;
+                                streamingWorld.TeleportToCoordinates(892, 146);
+                                return ("Teleported player to Orsinium Area/Orsinium");
                             case 5:
-                                streamingWorld.TeleportToCoordinates(67, 119); // Tulune/The Old Copperham Place
-                                break;
+                                streamingWorld.TeleportToCoordinates(67, 119);
+                                return ("Teleported player to Tulune/The Old Copperham Place");
                             case 6:
-                                streamingWorld.TeleportToCoordinates(254, 408); // Pothago/The Stronghold of Cirden
-                                break;
+                                streamingWorld.TeleportToCoordinates(254, 408);
+                                return ("Teleported player to Pothago/The Stronghold of Cirden");
                             case 7:
-                                streamingWorld.TeleportToCoordinates(109, 158); // Daggerfall/Privateer's Hold
-                                break;
+                                streamingWorld.TeleportToCoordinates(109, 158);
+                                return ("Teleported player to Daggerfall/Privateer's Hold");
                             case 8:
-                                streamingWorld.TeleportToCoordinates(860, 245); // Wayrest/Merwark Hollow
-                                break;
+                                streamingWorld.TeleportToCoordinates(860, 245);
+                                return ("Teleported player to Wayrest/Merwark Hollow");
                             case 9:
-                                streamingWorld.TeleportToCoordinates(718, 204); // Isle of Balfiera/Direnni Tower
-                                break;
+                                streamingWorld.TeleportToCoordinates(718, 204);
+                                return ("Teleported player to Isle of Balfiera/Direnni Tower");
                             default:
                                 break;
                         }
-
                     }
-
                 }
-
                 return "Invalid location index";
             }
         }


### PR DESCRIPTION
renamed ENHANCED_SKY_AVAILABLE define into ENHANCED_SKY_CODE_AVAILABLE to make it clear that it is a define used to enable/disable code lines dependent on if the mod's code is available

same for REFLECTIONSMOD_CODE_AVAILABLE

there are now 2 boolean flags isActiveReflectionsMod, isActiveEnhancedSkyMod which are set to true at startup if the corresonding mods are active
these flags are used to control IncreasedTerrainDistance mod's behaviour dependent on the available other mods (this should for example fix the nullpointer error when reflectionsmod is disabled)

console command "location" now gives feedback to which location the player has been teleported
