### PR TITLE
Fix for indexing bug in TextLabel.SetText()

### DIFF
--- a/Scripts/Game/UserInterface/TextLabel.cs
+++ b/Scripts/Game/UserInterface/TextLabel.cs
@@ -128,7 +128,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             // Truncate string to max characters
             if (maxCharacters != -1)
-                value = value.Substring(0, maxCharacters);
+                value = value.Substring(0, Math.Min(value.Length, maxCharacters));
 
             this.text = value;
             CreateLabelTexture();


### PR DESCRIPTION
Recent change to apply a max characters value to the text label will raise an
indexing error if max characters > length of the string