### PR TITLE
Fixed texture wrapping artifacts on video textures.

### DIFF
--- a/Scripts/Game/UserInterface/DaggerfallVideo.cs
+++ b/Scripts/Game/UserInterface/DaggerfallVideo.cs
@@ -53,6 +53,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             // Init empty texture
             vidTexture = TextureReader.CreateFromSolidColor(1, 1, Color.black, false, false);
+            vidTexture.wrapMode = TextureWrapMode.Clamp;
         }
 
         public void Open(string name)
@@ -62,6 +63,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
 
             vidTexture = TextureReader.CreateFromSolidColor(vidFile.FrameWidth, vidFile.FrameHeight, Color.black, false, false);
+            vidTexture.wrapMode = TextureWrapMode.Clamp;
         }
 
         public void Play(string name)


### PR DESCRIPTION
Set DaggerfallVideo textures to use the "clamp" repeat mode, which fixes wrapping artifacts when enlarged using smooth filtering (most easily visible in the live-action intro with the torch on the side of the screen).