### PR TITLE
Work in progress

### DIFF
--- a/Scripts/Game/UserInterface/DaggerfallVideo.cs
+++ b/Scripts/Game/UserInterface/DaggerfallVideo.cs
@@ -54,6 +54,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // Init empty texture
             vidTexture = TextureReader.CreateFromSolidColor(1, 1, Color.black, false, false);
             vidTexture.wrapMode = TextureWrapMode.Clamp;
+            vidTexture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
         }
 
         public void Open(string name)
@@ -64,6 +65,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             vidTexture = TextureReader.CreateFromSolidColor(vidFile.FrameWidth, vidFile.FrameHeight, Color.black, false, false);
             vidTexture.wrapMode = TextureWrapMode.Clamp;
+            vidTexture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
         }
 
         public void Play(string name)

--- a/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -174,6 +174,7 @@ namespace DaggerfallWorkshop.Game.Utility
 
             // Filter settings
             DaggerfallUnity.Instance.MaterialReader.MainFilterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
+            DaggerfallUI.Instance.GlobalFilterMode = (FilterMode)DaggerfallUnity.Settings.GUIFilterMode;
 
             // HUD settings
             DaggerfallHUD hud = DaggerfallUI.Instance.DaggerfallHUD;


### PR DESCRIPTION
This started out as a way to expose point sampling on videos for a more old-school experience, but along the way I noticed that GUIFilterMode wasn't hooked up to anything. I studied the revision history and played around with the code for a bit, and ultimately the break seemed like an oversight rather than an intentional ("this isn't quite working yet") omission. 

So now, the GUIFilterMode setting gets applied to DaggerfallUI's global filter mode. In turn, DaggerfallUI's filter mode is applied to DaggerfallVideos. Smoothed UIs get smoothed video, and pixely UIs get pixely video.

This does eliminate the current shipping default configuration of point-scaled UI and smooth videos, though. It might be better to expose a separate filter setting for the videos? Let me know if that's what you'd prefer.