### PR TITLE
Added keybind events that are raised when bindings are loaded / saved.

### DIFF
--- a/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
+++ b/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
@@ -14,14 +14,12 @@ namespace Wenzil.Console
     public class ConsoleController : MonoBehaviour
     {
         private const int inputHistoryCapacity = 20;
- 
+
         public ConsoleUI ui;
         public KeyCode toggleKey = KeyCode.BackQuote;
         public bool closeOnEscape = false;
-        
 
-
-        private ConsoleInputHistory inputHistory = new ConsoleInputHistory(inputHistoryCapacity); 
+        private ConsoleInputHistory inputHistory = new ConsoleInputHistory(inputHistoryCapacity);
 
         void Awake()
         {
@@ -32,31 +30,22 @@ namespace Wenzil.Console
 
         void Start()
         {
-            toggleKey = DaggerfallWorkshop.Game.InputManager.Instance.GetBinding(DaggerfallWorkshop.Game.InputManager.Actions.ToggleConsole);
-            if (toggleKey == KeyCode.None)
-                toggleKey = KeyCode.BackQuote;
-
         }
 
         void OnEnable()
         {
+            DaggerfallWorkshop.Game.InputManager.OnLoadedKeyBinds += GetConsoleKeyBind;
             Console.OnConsoleLog += ui.AddNewOutputLine;
             ui.onSubmitCommand += ExecuteCommand;
             ui.onClearConsole += inputHistory.Clear;
-
-            
-
         }
 
         void OnDisable()
         {
+            DaggerfallWorkshop.Game.InputManager.OnLoadedKeyBinds -= GetConsoleKeyBind;
             Console.OnConsoleLog -= ui.AddNewOutputLine;
             ui.onSubmitCommand -= ExecuteCommand;
             ui.onClearConsole -= inputHistory.Clear;
-
-           
-
-
         }
 
         void Update()
@@ -69,9 +58,6 @@ namespace Wenzil.Console
                 NavigateInputHistory(true);
             else if (Input.GetKeyDown(KeyCode.DownArrow))
                 NavigateInputHistory(false);
-
-        
-
         }
 
         private void NavigateInputHistory(bool up)
@@ -85,12 +71,19 @@ namespace Wenzil.Console
             string[] parts = input.Split(' ');
             string command = parts[0];
             string[] args = parts.Skip(1).ToArray();
-        
+
             Console.Log("> " + input);
             Console.Log(ConsoleCommandsDatabase.ExecuteCommand(command, args));
             inputHistory.AddNewInputEntry(input);
         }
 
+
+        public void GetConsoleKeyBind()
+        {
+            toggleKey = DaggerfallWorkshop.Game.InputManager.Instance.GetBinding(DaggerfallWorkshop.Game.InputManager.Actions.ToggleConsole);
+            if (toggleKey == KeyCode.None)
+                toggleKey = KeyCode.BackQuote;
+        }
 
 
 

--- a/Scripts/Game/InputManager.cs
+++ b/Scripts/Game/InputManager.cs
@@ -400,6 +400,7 @@ namespace DaggerfallWorkshop.Game
             actionKeyDict.Clear();
 
             SetBinding(KeyCode.Escape, Actions.Escape);
+            SetBinding(KeyCode.BackQuote, Actions.ToggleConsole);
 
             SetBinding(KeyCode.W, Actions.MoveForwards);
             SetBinding(KeyCode.S, Actions.MoveBackwards);
@@ -581,6 +582,7 @@ namespace DaggerfallWorkshop.Game
             keyBindsData.actionKeyBinds = actionKeyDict;
             string json = SaveLoadManager.Serialize(keyBindsData.GetType(), keyBindsData);
             File.WriteAllText(path, json);
+            RaiseSavedKeyBindsEvent();
         }
 
         void LoadKeyBinds()
@@ -590,6 +592,34 @@ namespace DaggerfallWorkshop.Game
             string json = File.ReadAllText(path);
             KeyBindData_v1 keyBindsData = SaveLoadManager.Deserialize(typeof(KeyBindData_v1), json) as KeyBindData_v1;
             actionKeyDict = keyBindsData.actionKeyBinds;
+            RaiseLoadedKeyBindsEvent();
+        }
+
+        #endregion
+
+        #region Events
+
+        public delegate void OnLoadSaveKeyBinds();
+        public static event OnLoadSaveKeyBinds OnLoadedKeyBinds;
+        protected virtual void RaiseLoadedKeyBindsEvent()
+        {
+            if (OnLoadedKeyBinds != null)
+                OnLoadedKeyBinds();
+        }
+
+        public static event OnLoadSaveKeyBinds OnSavedKeyBinds;
+        protected virtual void RaiseSavedKeyBindsEvent()
+        {
+            if (OnSavedKeyBinds != null)
+                OnSavedKeyBinds();
+        }
+
+        public delegate void OnUpdateKeyBind(KeyCode code);
+        public static event OnUpdateKeyBind OnUpdatedKeyBind;
+        protected virtual void RaiseUpdatedKeyBindsEvent(KeyCode code)
+        {
+            if (OnUpdatedKeyBind != null)
+                OnUpdatedKeyBind(code);
         }
 
         #endregion


### PR DESCRIPTION
created a default keybinding for ToggleConsole key in SetupDefaults()

ConsoleController now sets consoleKey after InputManager.OnLoadedKeyBind event
is triggered to make sure it isn't set before keybinds.ini has been parsed by inputmanager.

"BackQuote": "ToggleConsole", entry needs to be added to KeyBinds.ini