### PR TITLE
Small changes to InputManager

### DIFF
--- a/Scripts/Game/InputManager.cs
+++ b/Scripts/Game/InputManager.cs
@@ -262,11 +262,20 @@ namespace DaggerfallWorkshop.Game
             posVerticalImpulse = false;
             negVerticalImpulse = false;
 
-            // Do nothing if paused
-            if (isPaused)
+            // Do nothing if paused or death animation in progress
+            // prevents player from opening char. windows etc. while dying
+            if (isPaused || GameManager.Instance.PlayerDeath.DeathInProgress)
             {
                 frameSkipCount = 0;
                 wasPaused = true;
+
+                //temp fix for player cont. moving forward after dying
+                if(GameManager.Instance.PlayerDeath.DeathInProgress)
+                {
+                    horizontal = 0;
+                    vertical = 0;
+                }
+
                 return;
             }
 

--- a/Scripts/Game/PlayerDeath.cs
+++ b/Scripts/Game/PlayerDeath.cs
@@ -42,6 +42,12 @@ namespace DaggerfallWorkshop.Game
 
         #endregion
 
+        #region properties
+
+        public bool DeathInProgress { get { return deathInProgress;} }
+
+        #endregion
+
         #region Unity
 
         void Awake()
@@ -128,7 +134,7 @@ namespace DaggerfallWorkshop.Game
 
             // Start camera falling and fading to black
             startCameraHeight = mainCamera.transform.localPosition.y;
-            targetCameraHeight -= playerController.height / 3;
+            targetCameraHeight = playerController.height - (playerController.height * 1.25f);
             currentCameraHeight = startCameraHeight;
             DaggerfallUI.Instance.FadeHUDToBlack(FadeDuration);
         }


### PR DESCRIPTION
Adds PlayerDeathInProgress getter to PlayerDeath, 

fixes camera height bug in death animation in PlayerDeath

Stops InputManager from opening windows during death animation (settings window still works), and includes a temp. fix for the constant forward movement when the player dies