### PR TITLE
Action updates

### DIFF
--- a/Scripts/API/DFBlock.cs
+++ b/Scripts/API/DFBlock.cs
@@ -626,8 +626,8 @@ namespace DaggerfallConnect
             ///<summary>8 Rotation. </summary>
             Rotation = 0x08,
 
-            ///<summary>9 Cast spell / create spell effect. </summary>
-            CreateSpell = 0x09,
+            ///<summary>9 Cast spell / spell effect. </summary>
+            CastSpell = 0x09,
 
             ///<summary>11 Appears to display a text on activation </summary>
             ShowText = 0x0B,
@@ -650,7 +650,7 @@ namespace DaggerfallConnect
             ///<summary>20 Close door, lock if it has a starting lock value </summary>
             CloseDoor = 0x14,
 
-            ///<summary>21 Hurt Player, large amount of damage, 1 time activate </summary>
+            ///<summary>21 Hurt Player, random range </summary>
             Hurt21 = 0x15,
 
             ///<summary>22 Hurt player, damage = level * magnitude </summary>
@@ -664,6 +664,9 @@ namespace DaggerfallConnect
 
             ///<summary>25 Hurt player, damage = level * magnitude</summary>
             Hurt25 = 0x19,
+
+            ///<summary>26 Seems to Poison Player</summary>
+            Poison = 0x1A,
 
             ///<summary>27 Unknown</summary>
             Unknown27 = 0x1B,
@@ -704,29 +707,29 @@ namespace DaggerfallConnect
             /// <summary> None</summary>
             None = 0x00,
 
-            /// <summary> Activated by collision / walking on </summary>
+            /// <summary> Activated by collision / walking on; flats + models </summary>
             Collision01 = 0x01,
 
-            /// <summary> Activated by clicking on </summary>
+            /// <summary> Activated by clicking on; flats + models </summary>
             Direct = 0x02,
 
-            /// <summary> Activated by collision / walking on </summary>
+            /// <summary> Activated by colliding with (not walking on) - models only </summary>
             Collision03 = 0x03,
 
-            /// <summary>  Unknown      </summary>
-            Unknown5 = 0x05,
+            /// <summary> Activated by attacking, flats + models </summary>
+            Attack = 0x05,
 
-            /// <summary> Unknown       </summary>
-            Unknown6 = 0x06,
+            /// <summary> Seems to work just like flag 2; this appears to be only doors w/ actions; flats + models </summary>
+            Direct6 = 0x06,
 
-            /// <summary> Activated by clicking on and collisions</summary>
-            DualTrigger = 0x08,
+            /// <summary> Activated by clicking, attacking or colliding with action obj; flats + models</summary>
+            MultiTrigger = 0x08,
 
-            /// <summary> Activated by collision / walking on </summary>
+            /// <summary> Activated by collision / walking on; flats + models </summary>
             Collision09 = 0x09,
 
-            /// <summary> Mostly on doors in palaces </summary>
-            Unknown10 = 0x0A,
+            /// <summary> Activated by door opening/closing; doors only (have only tested standard doors - need to check trap doors etc) </summary>
+            Door = 0x0A,
         }
 
         /// <summary>

--- a/Scripts/API/DFBlock.cs
+++ b/Scripts/API/DFBlock.cs
@@ -672,7 +672,7 @@ namespace DaggerfallConnect
             Unknown27 = 0x1B,
 
             ///<summary>28 drain magicka. 1 magnitude = 1 pt magica </summary>
-            DrainMagicka28 = 0x1C,
+            DrainMagicka = 0x1C,
 
             ///<summary>29 Dialogue. Seems to ignore trigger flag</summary>
             Dialogue = 0x1D,

--- a/Scripts/Editor/DaggerfallActionEditor.cs
+++ b/Scripts/Editor/DaggerfallActionEditor.cs
@@ -11,12 +11,15 @@ public class DaggerfallActionEditor : Editor
         DrawDefaultInspector();
         DaggerfallAction thisAction = (DaggerfallAction)target;
 
-        if (GUILayout.Button("Activate") && EditorApplication.isPlaying)
+        if(EditorApplication.isPlaying)
         {
-            if (thisAction.PreviousObject == null)
-                thisAction.Play(GameObject.FindGameObjectWithTag("Player"));
-            else
-                thisAction.Play(thisAction.PreviousObject);
+            if (GUILayout.Button("Activate") )
+            {
+                if (thisAction.PreviousObject == null)
+                    thisAction.Play(GameObject.FindGameObjectWithTag("Player"));
+                else
+                    thisAction.Play(thisAction.PreviousObject);
+            }
         }
     }
 }

--- a/Scripts/Game/PlayerActivate.cs
+++ b/Scripts/Game/PlayerActivate.cs
@@ -100,7 +100,7 @@ namespace DaggerfallWorkshop.Game
                         DaggerfallAction action;
                         if (ActionCheck(hits[i], out action))
                         {
-                            action.Receive(this.gameObject, true);
+                            action.Receive(this.gameObject, DaggerfallAction.TriggerTypes.Direct);
                         }
                     }
                 }

--- a/Scripts/Game/PlayerCollision.cs
+++ b/Scripts/Game/PlayerCollision.cs
@@ -1,0 +1,28 @@
+﻿// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2015 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Lypyl (lypyl@dfworkshop.net)
+// Contributors:    
+// 
+// Notes:
+//
+
+using UnityEngine;
+using System.Collections;
+
+namespace DaggerfallWorkshop.Game
+{
+
+    public class PlayerCollision : MonoBehaviour
+    {
+        void OnControllerColliderHit(ControllerColliderHit hit)
+        {
+            PlayerCollisionHandler ch = hit.gameObject.GetComponent<PlayerCollisionHandler>();
+            if (ch)
+                ch.OnCharacterCollided(hit, transform);
+        }
+
+    }
+}

--- a/Scripts/Game/PlayerCollision.cs
+++ b/Scripts/Game/PlayerCollision.cs
@@ -17,11 +17,23 @@ namespace DaggerfallWorkshop.Game
 
     public class PlayerCollision : MonoBehaviour
     {
+        GameObject cachedObject;
+        PlayerCollisionHandler cachedCH;
+
         void OnControllerColliderHit(ControllerColliderHit hit)
         {
-            PlayerCollisionHandler ch = hit.gameObject.GetComponent<PlayerCollisionHandler>();
-            if (ch)
-                ch.OnCharacterCollided(hit, transform);
+            if (cachedObject == hit.transform.gameObject)
+                if (cachedCH)
+                    cachedCH.OnCharacterCollided(hit, transform);
+                else
+                    return;
+            else
+            {
+                cachedObject = hit.transform.gameObject;
+                cachedCH = hit.transform.gameObject.GetComponent<PlayerCollisionHandler>();
+            }
+            if (cachedCH)
+                cachedCH.OnCharacterCollided(hit, transform);
         }
 
     }

--- a/Scripts/Game/PlayerCollision.cs.meta
+++ b/Scripts/Game/PlayerCollision.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b09dedc752b43164193be10e675277cc
+timeCreated: 1456867582
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Game/PlayerCollisionHandler.cs
+++ b/Scripts/Game/PlayerCollisionHandler.cs
@@ -1,0 +1,29 @@
+﻿// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2015 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Lypyl (lypyl@dfworkshop.net)
+// Contributors:    
+// 
+// Notes:
+//
+
+using UnityEngine;
+using System.Collections;
+
+
+namespace DaggerfallWorkshop.Game
+{
+
+    public class PlayerCollisionHandler : MonoBehaviour
+    {
+
+
+        public virtual void OnCharacterCollided(ControllerColliderHit hit, Transform other)
+        {
+
+        }
+
+    }
+}

--- a/Scripts/Game/PlayerCollisionHandler.cs.meta
+++ b/Scripts/Game/PlayerCollisionHandler.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 881dd4e4a8226e543b577389adf414c3
+timeCreated: 1456852267
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Game/WeaponManager.cs
+++ b/Scripts/Game/WeaponManager.cs
@@ -280,6 +280,13 @@ namespace DaggerfallWorkshop.Game
             Ray ray = new Ray(mainCamera.transform.position, mainCamera.transform.forward);
             if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Range - SphereCastRadius))
             {
+                //check if hit has an DaggerfallAction component
+                DaggerfallAction action = hit.transform.gameObject.GetComponent<DaggerfallAction>();
+                if (action)
+                {
+                    action.Receive(player, DaggerfallAction.TriggerTypes.Attack);
+                }
+
                 // Check if hit has an DaggerfallActionDoor component
                 DaggerfallActionDoor actionDoor = hit.transform.gameObject.GetComponent<DaggerfallActionDoor>();
                 if (actionDoor)

--- a/Scripts/Internal/DaggerfallAction.cs
+++ b/Scripts/Internal/DaggerfallAction.cs
@@ -10,13 +10,10 @@
 //
 
 using UnityEngine;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using DaggerfallConnect;
-using DaggerfallConnect.Utility;
-using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.Entity;
@@ -140,6 +137,7 @@ namespace DaggerfallWorkshop
 
         public enum TriggerTypes
         {
+            None,
             ActionObject, //sent from other action object
             Direct,     //player clicked on this
             WalkOn,     //Only using WalkInto for now
@@ -179,7 +177,7 @@ namespace DaggerfallWorkshop
                         break;
                     case DFBlock.RdbTriggerFlags.Collision01:
                         {
-                            if (triggerType != TriggerTypes.WalkInto) //In daggerfall this is WalkOn only - using WalkInto for all collisions currently
+                            if (triggerType != TriggerTypes.WalkOn)
                                 return;
                         }
                         break;
@@ -191,7 +189,7 @@ namespace DaggerfallWorkshop
                         break;
                     case DFBlock.RdbTriggerFlags.Collision03:
                         {
-                            if (triggerType != TriggerTypes.WalkInto && this.IsFlat)
+                            if (triggerType != TriggerTypes.WalkInto)
                                 return;
                         }
                         break;
@@ -215,7 +213,7 @@ namespace DaggerfallWorkshop
                         break;
                     case DFBlock.RdbTriggerFlags.Collision09:
                         {
-                            if (triggerType != TriggerTypes.Direct && triggerType != TriggerTypes.WalkInto )
+                            if (triggerType != TriggerTypes.Direct && triggerType != TriggerTypes.WalkInto)
                                 return;
                         }
                         break;
@@ -226,7 +224,7 @@ namespace DaggerfallWorkshop
                         }
                         break;
                     default:
-                        break;
+                        return;
                 }
             }
 

--- a/Scripts/Internal/DaggerfallAction.cs
+++ b/Scripts/Internal/DaggerfallAction.cs
@@ -117,7 +117,7 @@ namespace DaggerfallWorkshop
         {DFBlock.RdbActionFlags.NegativeZ,  new ActionDelegate(Move)},
         {DFBlock.RdbActionFlags.PositiveY,  new ActionDelegate(Move)},
         {DFBlock.RdbActionFlags.NegativeY,  new ActionDelegate(Move)},
-        {DFBlock.RdbActionFlags.CastSpell,new ActionDelegate(Move)},
+        {DFBlock.RdbActionFlags.CastSpell,  new ActionDelegate(Move)},
         {DFBlock.RdbActionFlags.ShowText,   new ActionDelegate(ShowText)},
         {DFBlock.RdbActionFlags.ShowTextWithInput,   new ActionDelegate(ShowTextWithInput)},
         {DFBlock.RdbActionFlags.Teleport,   new ActionDelegate(Teleport)},
@@ -131,7 +131,7 @@ namespace DaggerfallWorkshop
         {DFBlock.RdbActionFlags.Hurt24,     new ActionDelegate(DrainHealth)},
         {DFBlock.RdbActionFlags.Hurt25,     new ActionDelegate(DrainHealth)},
         {DFBlock.RdbActionFlags.Poison,     new ActionDelegate(Poison)},
-        {DFBlock.RdbActionFlags.DrainMagicka28,     new ActionDelegate(DrainMagicka)},
+        {DFBlock.RdbActionFlags.DrainMagicka, new ActionDelegate(DrainMagicka)},
         {DFBlock.RdbActionFlags.Activate,   new ActionDelegate(Activate)},
         };
 
@@ -251,7 +251,7 @@ namespace DaggerfallWorkshop
             //sound & activating next, but for testing purposes is done after
             if (d == null)
             {
-                DaggerfallUnity.LogMessage(string.Format("No delegate found for this action flag: {0}", ActionFlag));
+                //DaggerfallUnity.LogMessage(string.Format("No delegate found for this action flag: {0}", ActionFlag));
                 return;
             }
 
@@ -285,7 +285,7 @@ namespace DaggerfallWorkshop
         {
             if (NextObject == null)
             {
-                DaggerfallUnity.LogMessage(string.Format("Next action object in chain is null"));
+                //DaggerfallUnity.LogMessage(string.Format("Next action object in chain is null"));
                 return;
             }
             else
@@ -369,10 +369,8 @@ namespace DaggerfallWorkshop
 
             door = go.GetComponent<DaggerfallActionDoor>();
             if (door == null)
-            {
-                DaggerfallUnity.LogMessage(string.Format("No DaggerfallActionDoor component found to unlock door: {0}", go.name));
                 return false;
-            }
+
             else
                 return true;
         }
@@ -442,8 +440,7 @@ namespace DaggerfallWorkshop
         /// <param name="thisAction"></param>
         public static void CastSpell(GameObject triggerObj, DaggerfallAction thisAction)
         {
-            Debug.Log("Action Type 9: CastSpell");
-
+            //Debug.Log("Action Type 9: CastSpell");
         }
 
         /// <summary>
@@ -497,7 +494,7 @@ namespace DaggerfallWorkshop
 
             if (thisAction.NextObject == null)
             {
-                DaggerfallUnity.LogMessage(string.Format("Teleport next object null - can't teleport"));
+                DaggerfallUnity.LogMessage(string.Format("Teleport next object null - can't teleport"), true);
                 return;
             }
 
@@ -540,7 +537,7 @@ namespace DaggerfallWorkshop
         {
             DaggerfallActionDoor door;
             if (!GetDoor(thisAction.gameObject, out door))
-                DaggerfallUnity.LogMessage(string.Format("No DaggerfallActionDoor component found to unlock door"));
+                DaggerfallUnity.LogMessage(string.Format("No DaggerfallActionDoor component found to unlock door"), true);
             else
                 door.CurrentLockValue = 0;
         }
@@ -554,7 +551,7 @@ namespace DaggerfallWorkshop
         {
             DaggerfallActionDoor door;
             if (!GetDoor(thisAction.gameObject, out door))
-                DaggerfallUnity.LogMessage(string.Format("No DaggerfallActionDoor component found"));
+                DaggerfallUnity.LogMessage(string.Format("No DaggerfallActionDoor component found"), true);
             else
             {
                 if (door.IsOpen)
@@ -577,7 +574,7 @@ namespace DaggerfallWorkshop
 
             DaggerfallActionDoor door;
             if (!GetDoor(thisAction.gameObject, out door))
-                DaggerfallUnity.LogMessage(string.Format("No DaggerfallActionDoor component found"));
+                DaggerfallUnity.LogMessage(string.Format("No DaggerfallActionDoor component found"), true);
             else
             {
                 if (!door.IsOpen)
@@ -658,8 +655,7 @@ namespace DaggerfallWorkshop
         /// <param name="thisAction"></param>
         public static void Poison(GameObject triggerObj, DaggerfallAction thisAction)
         {
-            Debug.Log("Action Type 26: Poison");
-
+            //Debug.Log("Action Type 26: Poison");
         }
 
         /// <summary>

--- a/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Scripts/Internal/DaggerfallActionDoor.cs
@@ -214,6 +214,9 @@ namespace DaggerfallWorkshop
                     dfAudioSource.PlayOneShot(OpenSound);
             }
 
+            //For Doors that are also action objects, executes action when door opened / closed
+            ExecuteActionOnToggle();
+
             // Set flag
             IsMagicallyHeld = false;
             CurrentLockValue = 0;
@@ -234,6 +237,9 @@ namespace DaggerfallWorkshop
                 "oncompleteparams", duration);
             __ExternalAssets.iTween.RotateTo(gameObject, rotateParams);
             currentState = ActionState.PlayingReverse;
+
+            //For Doors that are also action objects, executes action when door opened / closed
+            ExecuteActionOnToggle();
         }
 
         private void OnCompleteOpen()
@@ -260,6 +266,15 @@ namespace DaggerfallWorkshop
         {
             if (IsTriggerWhenOpen && boxCollider != null)
                 boxCollider.isTrigger = isTrigger;
+        }
+
+        //For Doors that are also action objects, executes action when door opened / closed
+        private void ExecuteActionOnToggle()
+        {
+            DaggerfallAction action = GetComponent<DaggerfallAction>();
+            if(action != null)
+                action.Receive(gameObject, DaggerfallAction.TriggerTypes.Door);
+
         }
 
         #endregion

--- a/Scripts/Utility/RDBLayout.cs
+++ b/Scripts/Utility/RDBLayout.cs
@@ -691,7 +691,6 @@ namespace DaggerfallWorkshop.Utility
                     vector.z = -magnitude;
                     break;
                 default:
-                    magnitude = 0f;
                     break;
             }
             action.ActionTranslation = vector * MeshReader.GlobalScale;
@@ -809,6 +808,7 @@ namespace DaggerfallWorkshop.Utility
             action.TriggerFlag = triggerFlag;
             action.ActionFlag = actionFlag;
             action.LoadID = loadID;
+            action.ActionAxisRawValue = axis_raw;
 
             // If SaveLoadManager present in game then attach SerializableActionObject
             if (SaveLoadManager.Instance != null)
@@ -816,19 +816,22 @@ namespace DaggerfallWorkshop.Utility
                 go.AddComponent<SerializableActionObject>();
             }
 
+            if (description == "FLT")
+            {
+                action.IsFlat = true;
+                //add box collider to flats with actions for raycasting - only flats that can be activated directly need this, so this can possibly be restricted in future
+                Collider col = go.AddComponent<BoxCollider>();
+                col.isTrigger = true;
+            }
+            else
+                action.IsFlat = false;
+
             //if a collision type action or action flat, add DaggerFallActionCollision component
             if (action.TriggerFlag == DFBlock.RdbTriggerFlags.Collision01 || action.TriggerFlag == DFBlock.RdbTriggerFlags.Collision03 ||
-                action.TriggerFlag == DFBlock.RdbTriggerFlags.DualTrigger || action.TriggerFlag == DFBlock.RdbTriggerFlags.Collision09)
+                action.TriggerFlag == DFBlock.RdbTriggerFlags.MultiTrigger || action.TriggerFlag == DFBlock.RdbTriggerFlags.Collision09)
             {
-                DaggerfallActionCollision collision = go.AddComponent<DaggerfallActionCollision>();
-                collision.isFlat = false;
+                go.AddComponent<DaggerfallActionCollision>();
             }
-            else if (description == "FLT")
-            {
-                DaggerfallActionCollision collision = go.AddComponent<DaggerfallActionCollision>();
-                collision.isFlat = true;
-            }
-
 
             switch (action.ActionFlag)
             {
@@ -890,8 +893,6 @@ namespace DaggerfallWorkshop.Utility
                     break;
                 default:
                     {
-                        //Dmg actions use axis value to modifiy tot. dmg.
-                        action.Magnitude = axis_raw;
                     }
                     break;
             }
@@ -934,7 +935,7 @@ namespace DaggerfallWorkshop.Utility
             if (actionLinkDict.Count == 0)
                 return;
 
-            // Iterate through actions #Lypl
+            // Iterate through actions
             foreach (var item in actionLinkDict)
             {
                 ActionLink link = item.Value;
@@ -960,23 +961,6 @@ namespace DaggerfallWorkshop.Utility
                 }
             }
 
-            //// Exit if no actions
-            //if (actionLinkDict.Count == 0)
-            //    return;
-
-            //// Iterate through actions
-            //foreach (var item in actionLinkDict)
-            //{
-            //    ActionLink link = item.Value;
-
-            //    // Link to next node
-            //    if (actionLinkDict.ContainsKey(link.nextKey))
-            //        link.gameObject.GetComponent<DaggerfallAction>().NextObject = actionLinkDict[link.nextKey].gameObject;
-
-            //    // Link to previous node
-            //    if (actionLinkDict.ContainsKey(link.prevKey))
-            //        link.gameObject.GetComponent<DaggerfallAction>().PreviousObject = actionLinkDict[link.prevKey].gameObject;
-            //}
         }
 
         /// <summary>


### PR DESCRIPTION
The "hurt" type actions work like in Daggerfall now.

Added a functioning Drain magicka action.

Fixed up the collision handling for actions

The trigger flags now work like they should in Daggerfall, and  the action will only trigger if the type is valid for that flag

WeaponManager will check for DaggerfallAction component on gameobject the player attacks

DaggerfallActionDoor will check for DaggerfallAction component when its opened / closed
