### PR TITLE
ReflectionsMod fixes and code cleanup

### DIFF
--- a/Game/Addons/IncreasedTerrainDistanceMod/Scripts/CloneCameraPositionFromMainCamera.cs
+++ b/Game/Addons/IncreasedTerrainDistanceMod/Scripts/CloneCameraPositionFromMainCamera.cs
@@ -3,19 +3,9 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 1.54
 
 using UnityEngine;
-//using System;
-//using System.Collections;
-//using System.Collections.Generic;
-//using System.IO;
-//using DaggerfallConnect;
-//using DaggerfallConnect.Arena2;
-//using DaggerfallConnect.Utility;
-//using DaggerfallWorkshop;
 using DaggerfallWorkshop.Game;
-//using DaggerfallWorkshop.Utility;
 
 namespace ProjectIncreasedTerrainDistance
 {

--- a/Game/Addons/IncreasedTerrainDistanceMod/Scripts/CloneCameraRotationFromMainCamera.cs
+++ b/Game/Addons/IncreasedTerrainDistanceMod/Scripts/CloneCameraRotationFromMainCamera.cs
@@ -3,19 +3,9 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 1.54
 
 using UnityEngine;
-//using System;
-//using System.Collections;
-//using System.Collections.Generic;
-//using System.IO;
-//using DaggerfallConnect;
-//using DaggerfallConnect.Arena2;
-//using DaggerfallConnect.Utility;
-//using DaggerfallWorkshop;
 using DaggerfallWorkshop.Game;
-//using DaggerfallWorkshop.Utility;
 
 namespace ProjectIncreasedTerrainDistance
 {

--- a/Game/Addons/IncreasedTerrainDistanceMod/Scripts/ImprovedTerrainSampler.cs
+++ b/Game/Addons/IncreasedTerrainDistanceMod/Scripts/ImprovedTerrainSampler.cs
@@ -3,7 +3,6 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 1.54
 
 using UnityEngine;
 using System;

--- a/Game/Addons/IncreasedTerrainDistanceMod/Scripts/ImprovedWorldTerrain.cs
+++ b/Game/Addons/IncreasedTerrainDistanceMod/Scripts/ImprovedWorldTerrain.cs
@@ -3,7 +3,6 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 1.54
 
 // only define CREATE_* if you want to manually create the maps - usually this should not be necessary (and never do in executable build - only from editor - otherwise paths are wrong)
 //#define CREATE_PERSISTENT_LOCATION_RANGE_MAPS 

--- a/Game/Addons/IncreasedTerrainDistanceMod/Scripts/IncreasedTerrainDistance.cs
+++ b/Game/Addons/IncreasedTerrainDistanceMod/Scripts/IncreasedTerrainDistance.cs
@@ -3,7 +3,6 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 1.54
 //Contributors: Lypyl, Interkarma
 
 // uncomment next line if enhanced sky mod by Lypyl is present

--- a/Game/Addons/IncreasedTerrainDistanceMod/Scripts/RenderSkyboxWithoutSun.cs
+++ b/Game/Addons/IncreasedTerrainDistanceMod/Scripts/RenderSkyboxWithoutSun.cs
@@ -3,7 +3,6 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 1.54
 
 using UnityEngine;
 //using System;

--- a/Game/Addons/IncreasedTerrainDistanceMod/Shaders/DaggerfallIncreasedTerrainTilemap.shader
+++ b/Game/Addons/IncreasedTerrainDistanceMod/Shaders/DaggerfallIncreasedTerrainTilemap.shader
@@ -3,7 +3,6 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 1.54
 
 Shader "Daggerfall/IncreasedTerrainTilemap" {
 	Properties {

--- a/Game/Addons/ReflectionsMod/Scripts/MirrorReflection.cs
+++ b/Game/Addons/ReflectionsMod/Scripts/MirrorReflection.cs
@@ -3,7 +3,6 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 0.32
 
 // This script is derived from MirrorReflection4 script
 

--- a/Game/Addons/ReflectionsMod/Scripts/UpdateReflectionTextures.cs
+++ b/Game/Addons/ReflectionsMod/Scripts/UpdateReflectionTextures.cs
@@ -3,7 +3,6 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 0.32
 
 using UnityEngine;
 using System.Collections;

--- a/Game/Addons/ReflectionsMod/Shaders/DaggerfallTilemapWithReflections.shader
+++ b/Game/Addons/ReflectionsMod/Shaders/DaggerfallTilemapWithReflections.shader
@@ -3,7 +3,6 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 0.32
 
 Shader "Daggerfall/TilemapWithReflections" {
 	Properties {

--- a/Game/Addons/ReflectionsMod/Shaders/FloorMaterialWithReflections.shader
+++ b/Game/Addons/ReflectionsMod/Shaders/FloorMaterialWithReflections.shader
@@ -3,7 +3,6 @@
 //http://www.dfworkshop.net/
 //Author: Michael Rauter (a.k.a. Nystul)
 //License: MIT License (http://www.opensource.org/licenses/mit-license.php)
-//Version: 0.32
 
 Shader "Daggerfall/FloorMaterialWithReflections" {
 	Properties {

--- a/Scripts/Game/DaggerfallAutomap.cs
+++ b/Scripts/Game/DaggerfallAutomap.cs
@@ -953,7 +953,7 @@ namespace DaggerfallWorkshop.Game
             //{
             //    if (oldGeometryName != newGeometryName)
             //    {
-            //        UnityEngine.Object.DestroyImmediate(gameobjectGeometry);
+            //        UnityEngine.Object.Destroy(gameobjectGeometry);
             //    }
             //    else
             //    {
@@ -1017,7 +1017,7 @@ namespace DaggerfallWorkshop.Game
             //{
             //    if (oldGeometryName != newGeometryName)
             //    {
-            //        UnityEngine.Object.DestroyImmediate(gameobjectGeometry);
+            //        UnityEngine.Object.Destroy(gameobjectGeometry);
             //    }
             //    else
             //    {


### PR DESCRIPTION
ReflectionMod improvements
transition should work correct now in all cases (also building2dungeon and dungeon2building)
removed event listening for the approach suggested originally for the automap - but for the reflection mod it really makes things easier ;)
code cleanup
replaced DestroyImmediate with Destroy
removed version number from files (does not make much sense since everything is in git now anyway)