### PR TITLE
automap - fireplaces are now correctly shown on automap

### DIFF
--- a/Assets/Scripts/Game/DaggerfallAutomap.cs
+++ b/Assets/Scripts/Game/DaggerfallAutomap.cs
@@ -920,6 +920,13 @@ namespace DaggerfallWorkshop.Game
                     {
                         foreach (Transform inner2Elem in innerElem.gameObject.transform)
                         {
+                            // get rid of animated materials (will not break automap rendering but is not necessary)
+                            AnimatedMaterial[] animatedMaterials = inner2Elem.gameObject.GetComponents<AnimatedMaterial>();                            
+                            foreach (AnimatedMaterial animatedMaterial in animatedMaterials)
+                            {
+                                UnityEngine.Object.Destroy(animatedMaterial);
+                            }
+
                             MeshRenderer meshRenderer = inner2Elem.gameObject.GetComponent<MeshRenderer>();
                             if (meshRenderer == null)
                                 break;
@@ -942,6 +949,13 @@ namespace DaggerfallWorkshop.Game
                         {
                             foreach (Transform inner3Elem in inner2Elem.gameObject.transform)
                             {
+                                // get rid of animated materials (will not break automap rendering but is not necessary)
+                                AnimatedMaterial[] animatedMaterials = inner3Elem.gameObject.GetComponents<AnimatedMaterial>();
+                                foreach (AnimatedMaterial animatedMaterial in animatedMaterials)
+                                {
+                                    UnityEngine.Object.Destroy(animatedMaterial);
+                                }
+
                                 MeshRenderer meshRenderer = inner3Elem.gameObject.GetComponent<MeshRenderer>();
                                 if (meshRenderer == null)
                                     break;

--- a/Assets/Shaders/DaggerfallAutomap.shader
+++ b/Assets/Shaders/DaggerfallAutomap.shader
@@ -70,8 +70,8 @@ Shader "Daggerfall/Automap"
 			{
 				float4 outColor;
 				half4 albedo = tex2D(_MainTex, IN.uv) * _Color;
-				half3 emission = tex2D(_EmissionMap, IN.uv).rgb * _EmissionColor;
-				outColor.rgb = albedo.rgb - emission; // Emission cancels out other lights
+				//half3 emission = tex2D(_EmissionMap, IN.uv).rgb * _EmissionColor;
+				outColor.rgb = albedo.rgb; // - emission; // Emission cancels out other lights
 				outColor.a = albedo.a;
 				if (IN.worldPos.y > _SclicingPositionY)
 				{				
@@ -203,8 +203,8 @@ Shader "Daggerfall/Automap"
 			{
 				float4 outColor;
 				half4 albedo = tex2D(_MainTex, IN.uv) * _Color;
-				half3 emission = tex2D(_EmissionMap, IN.uv).rgb * _EmissionColor;
-				outColor.rgb = albedo.rgb - emission; // Emission cancels out other lights
+				//half3 emission = tex2D(_EmissionMap, IN.uv).rgb * _EmissionColor;
+				outColor.rgb = albedo.rgb; // - emission; // Emission cancels out other lights
 				outColor.a = albedo.a;
 				if (IN.worldPos.y > _SclicingPositionY)
 				{
@@ -300,8 +300,8 @@ Shader "Daggerfall/Automap"
 			{
 				float4 outColor;
 			half4 albedo = tex2D(_MainTex, IN.uv) * _Color;
-			half3 emission = tex2D(_EmissionMap, IN.uv).rgb * _EmissionColor;
-			outColor.rgb = albedo.rgb - emission; // Emission cancels out other lights
+			//half3 emission = tex2D(_EmissionMap, IN.uv).rgb * _EmissionColor;
+			outColor.rgb = albedo.rgb; // - emission; // Emission cancels out other lights
 			outColor.a = albedo.a;
 			if (IN.worldPos.y > _SclicingPositionY)
 			{
@@ -373,8 +373,8 @@ Shader "Daggerfall/Automap"
 			{
 				float4 outColor;
 				half4 albedo = tex2D(_MainTex, IN.uv) * _Color;
-				half3 emission = tex2D(_EmissionMap, IN.uv).rgb * _EmissionColor;
-				outColor.rgb = albedo.rgb - emission; // Emission cancels out other lights
+				//half3 emission = tex2D(_EmissionMap, IN.uv).rgb * _EmissionColor;
+				outColor.rgb = albedo.rgb; // - emission; // Emission cancels out other lights
 				outColor.a = albedo.a;
 				if (IN.worldPos.y > _SclicingPositionY)
 				{


### PR DESCRIPTION
issue was caused by emission color on some textures (for the moment just ignoring emission in the automap shader
added code to remove texture animation for automap geometry (since it is not necessary for automap)