### PR TITLE
FarTerrain - found a fix for global fog to work with camera stack

### DIFF
--- a/Assets/Game/Addons/IncreasedTerrainDistanceMod/Scripts/IncreasedTerrainDistance.cs
+++ b/Assets/Game/Addons/IncreasedTerrainDistanceMod/Scripts/IncreasedTerrainDistance.cs
@@ -595,6 +595,9 @@ namespace ProjectIncreasedTerrainDistance
             stackedNearCamera.depth = stackedNearCameraDepth;
             //Camera.main.depth = 3; // renders over stacked camera
 
+            UnityStandardAssets.ImageEffects.GlobalFog globalFogScript = Camera.main.GetComponent<UnityStandardAssets.ImageEffects.GlobalFog>();
+            globalFogScript.excludeFarPixels = false; // this is important so that global fog works correctly with camera stack
+
             cameraRenderSkyboxToTexture.depth = cameraRenderSkyboxToTextureDepth; // make sure to render first
             cameraRenderSkyboxToTexture.renderingPath = stackedCamera.renderingPath;
 
@@ -857,7 +860,7 @@ namespace ProjectIncreasedTerrainDistance
 
         private void updatePositionWorldTerrain(ref GameObject terrainGameObject, Vector3 offset)
         {
-            float extraTranslationY = -0.5f; // -30.0f;
+            float extraTranslationY = -10.0f;
 
             // world scale computed as in StreamingWorld.cs and DaggerfallTerrain.cs scripts
             float scale = MapsFile.WorldMapTerrainDim * MeshReader.GlobalScale;


### PR DESCRIPTION
actually these are really good news! I found a fix for global fog to work with the far terrain camera stack. It was easier than expected in the end. only had to fix some bugs on my side and uncheck the checkbox "Exclude Far Pixels" in GlobalFog script. I do this by script when FarTerrain mod is enabled automatically - so it should not break anything when FarTerrain is not active.
you can try it out, go to a location in the mountains (so you see far terrain) and than go to the lighting tab to fog settings and change them (don't let yourself get confused by unity's message about fog and deferred shading - (the message is actually misleading since global fog still uses these values - it should have better been called "without global fog script attached to camera component these values do not have any effect on opaque objects in deferred shading" or something))
FarTerrain is now ready for foggy weather conditions in daggerfall. it should be even possible to make dynamic foggy weather now very easy by changing the fog settings dynamically