### PR TITLE
FarTerrain - starting up with EnhancedSky on/off now works correctly

### DIFF
--- a/Assets/Game/Addons/ReflectionsMod/Scripts/InjectReflectiveMaterialProperty.cs
+++ b/Assets/Game/Addons/ReflectionsMod/Scripts/InjectReflectiveMaterialProperty.cs
@@ -38,7 +38,6 @@ namespace ReflectionsMod
         private GameObject gameObjectReflectionPlaneSeaLevel = null;
         private GameObject gameObjectReflectionPlaneLowerLevel = null;
 
-        private bool isIncreasedTerrainDistanceMod = false;
         private float extraTranslationY = 0.0f;
 
         private GameObject gameObjectStreamingTarget = null;
@@ -130,7 +129,6 @@ namespace ReflectionsMod
             {
                 if (DaggerfallUnity.Settings.Nystul_IncreasedTerrainDistance)
                 {
-                    isIncreasedTerrainDistanceMod = true;
                     extraTranslationY = GameObject.Find("IncreasedTerrainDistanceMod").GetComponent<ProjectIncreasedTerrainDistance.IncreasedTerrainDistance>().ExtraTranslationY;
                 }
             }


### PR DESCRIPTION
FarTerrain - starting up with EnhancedSky on/off should now work correctly
toggle between EnhancedSky and vanilla sky at runtime is not working due to a unity bug - see my forum post in the IncreasedTerrainDistanceMod thread in the creator's corner