### PR TITLE
Set all men's clothing that have variants

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -334,11 +334,19 @@ namespace DaggerfallWorkshop.Game.Items
             // This list will expand as more supported items are discovered
             bool canChangeVariant = false;
             switch(TemplateIndex)
-            {
-                case (int)MensClothing.Plain_robes:
-                case (int)MensClothing.Formal_cloak:
+            {        
                 case (int)MensClothing.Casual_cloak:
+                case (int)MensClothing.Formal_cloak:
                 case (int)MensClothing.Reversible_tunic:
+                case (int)MensClothing.Plain_robes:
+                case (int)MensClothing.Short_shirt:
+                case (int)MensClothing.Short_shirt_with_belt:
+                case (int)MensClothing.Long_shirt:
+                case (int)MensClothing.Long_shirt_with_belt:
+                case (int)MensClothing.Short_shirt_closed_top:
+                case (int)MensClothing.Short_shirt_closed_top2:
+                case (int)MensClothing.Long_shirt_closed_top:
+                case (int)MensClothing.Long_shirt_closed_top2:
                 case (int)WomensClothing.Plain_robes:
                 case (int)WomensClothing.Formal_cloak:
                 case (int)WomensClothing.Casual_cloak:


### PR DESCRIPTION
I tested all the men's clothing in the game, and set the ones that have variants.
I also reordered the existing variant clothing to match the ordering of the enums.

Apparently, though, the number of variants isn't being read correctly from the data files or something. The shirts only cycle through two variants, if any.

For reference, here are the testing results, including the number of clickable variants I saw.

Clothing,                                          Has clickable variants, # of clickable variants

Straps						n
Armbands					n
Kimono						n
Fancy_Armbands				n
Sash						        n
Eodoric						n
Shoes						n
Tall_Boots					        n
Boots						n
Sandals						n
Casual_pants 				        n
Breeches					        n
Short_skirt					n
Casual_cloak				        y, 6
Formal_cloak				        y, 2
Khajiit_suit				        n
Dwynnen_surcoat				n
Short_tunic					n
Formal_tunic				        n
Toga						n
Reversible_tunic			        y, 2
Loincloth					        n
Plain_robes 				        y, 2
Priest_robes				        n
Short_shirt					y, 5
Short_shirt_with_belt		        y, 4
Long_shirt					y, 5
Long_shirt_with_belt		                y, 4
Short_shirt_closed_top		        y, 4
Short_shirt_closed_top2 	                y, 4
Long_shirt_closed_top		        y, 4
Long_shirt_closed_top2		        y, 4
Open_Tunic					n
Wrap						n
Long_Skirt					n
Anticlere_Surcoat			        n
Challenger_Straps			        n
Short_shirt_unchangeable	        n
Long_shirt_unchangeable		        n
Vest						        n
Champion_straps				n