### PR TITLE
Play equipping sounds and correct weapon draw sounds

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -138,7 +138,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 for (int i = 0; i < characterRecord.ParsedData.equippedItems.Length; i++)
                 {
                     if (characterRecord.ParsedData.equippedItems[i] == (record.RecordRoot.RecordID >> 8))
-                        equipTable.EquipItem(newItem);
+                        equipTable.EquipItem(newItem, true, false);
                 }
             }
         }

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -406,6 +406,64 @@ namespace DaggerfallWorkshop.Game.Items
             return data;
         }
 
+        public SoundClips GetEquipSound()
+        {
+            switch (itemGroup)
+            {
+                case ItemGroups.MensClothing:
+                case ItemGroups.WomensClothing:
+                    return SoundClips.EquipClothing;
+                case ItemGroups.Jewellery:
+                case ItemGroups.Gems:
+                    return SoundClips.EquipJewellery;
+                case ItemGroups.Armor:
+                    if (GetIsShield() || TemplateIndex == (int)Armor.Helm)
+                        return SoundClips.EquipPlate;
+                    else if (nativeMaterialValue == (int)ArmorMaterialTypes.Leather)
+                        return SoundClips.EquipLeather;
+                    else if (nativeMaterialValue == (int)ArmorMaterialTypes.Chain)
+                        return SoundClips.EquipChain;
+                    else
+                        return SoundClips.EquipPlate;
+                case ItemGroups.Weapons:
+                    switch (TemplateIndex)
+                    {
+                        case (int)Weapons.Battle_Axe:
+                        case (int)Weapons.War_Axe:
+                            return SoundClips.EquipAxe;
+                        case (int)Weapons.Broadsword:
+                        case (int)Weapons.Longsword:
+                        case (int)Weapons.Saber:
+                        case (int)Weapons.Katana:
+                            return SoundClips.EquipLongBlade;
+                        case (int)Weapons.Claymore:
+                        case (int)Weapons.Dai_Katana:
+                            return SoundClips.EquipTwoHandedBlade;
+                        case (int)Weapons.Dagger:
+                        case (int)Weapons.Tanto:
+                        case (int)Weapons.Wakazashi:
+                        case (int)Weapons.Shortsword:
+                            return SoundClips.EquipShortBlade;
+                        case (int)Weapons.Flail:
+                            return SoundClips.EquipFlail;
+                        case (int)Weapons.Mace:
+                        case (int)Weapons.Warhammer:
+                            return SoundClips.EquipMaceOrHammer;
+                        case (int)Weapons.Staff:
+                            return SoundClips.EquipStaff;
+                        case (int)Weapons.Short_Bow:
+                        case (int)Weapons.Long_Bow:
+                            return SoundClips.EquipBow;
+
+                        default:
+                            return SoundClips.None;
+                    }
+
+                default:
+                    return SoundClips.None;
+            }
+        }
+
         #endregion
 
         #region Static Methods
@@ -680,7 +738,8 @@ namespace DaggerfallWorkshop.Game.Items
             {
                 if (TemplateIndex == (int)Armor.Kite_Shield ||
                     TemplateIndex == (int)Armor.Round_Shield ||
-                    TemplateIndex == (int)Armor.Tower_Shield)
+                    TemplateIndex == (int)Armor.Tower_Shield ||
+                    TemplateIndex == (int)Armor.Buckler)
                 {
                     return true;
                 }

--- a/Assets/Scripts/Game/Items/ItemEquipTable.cs
+++ b/Assets/Scripts/Game/Items/ItemEquipTable.cs
@@ -86,7 +86,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// <param name="item">Item to equip.</param>
         /// <param name="alwaysEquip">Always equip item, replacing another in the same slot if needed.</param>
         /// <returns>True when item equipped, otherwise false.</returns>
-        public bool EquipItem(DaggerfallUnityItem item, bool alwaysEquip = true)
+        public bool EquipItem(DaggerfallUnityItem item, bool alwaysEquip = true, bool playEquipSounds = true)
         {
             if (item == null)
                 return false;
@@ -135,6 +135,10 @@ namespace DaggerfallWorkshop.Game.Items
             // Equip item to slot
             item.EquipSlot = slot;
             equipTable[(int)slot] = item;
+
+            // Play equip sound
+            if (playEquipSounds)
+                DaggerfallUI.Instance.PlayOneShot(item.GetEquipSound());
 
             //Debug.Log(string.Format("Equipped {0} to {1}", item.LongName, slot.ToString()));
 

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -649,8 +649,8 @@ namespace DaggerfallWorkshop.Game.Items
             // Add and equip clothing
             items.AddItem(shortShirt);
             items.AddItem(casualPants);
-            equipTable.EquipItem(shortShirt);
-            equipTable.EquipItem(casualPants);
+            equipTable.EquipItem(shortShirt, true, false);
+            equipTable.EquipItem(casualPants, true, false);
 
             // Always add ebony dagger until biography implemented
             items.AddItem(ItemBuilder.CreateWeapon(Weapons.Dagger, WeaponMaterialTypes.Ebony));

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -272,7 +272,7 @@ namespace DaggerfallWorkshop.Game
             // Setup target
             target.WeaponType = DaggerfallUnity.Instance.ItemHelper.ConvertItemToAPIWeaponType(weapon);
             target.MetalType = DaggerfallUnity.Instance.ItemHelper.ConvertItemMaterialToAPIMetalType(weapon);
-            target.DrawWeaponSound = SoundClips.DrawWeapon;
+            target.DrawWeaponSound = weapon.GetEquipSound();
             target.SwingWeaponSound = SoundClips.PlayerSwing;
 
             // TODO: Adjust FPSWeapon attack speed scale for swing pitch variance

--- a/Assets/Scripts/SoundClips.cs
+++ b/Assets/Scripts/SoundClips.cs
@@ -406,7 +406,7 @@ namespace DaggerfallWorkshop
         EquipStaff = 380,
         EquipClothing = 381,
 
-        EquipJewelry = 383,
+        EquipJewellery = 383,
         OpenBook = 384,
 
         BlowingWindIntro = 388,
@@ -415,7 +415,7 @@ namespace DaggerfallWorkshop
         // 390-412 are more pain sounds.
         // Needs more research.
 
-        EquipBluntWeapon = 413,
+        EquipMaceOrHammer = 413,
         EquipFlail = 414,
         EquipAxe = 415,
         EquipBow = 416,


### PR DESCRIPTION
This makes items play the correct sounds when equipped, as far as I know. I tested all the weapon equip sounds, etc. I could only test one artifact that I had a save game for, but it played the correct sound, so hopefully those work correctly.

I also made the correct sound play for drawing a weapon, which is the same as the equip sounds. I didn't change the swing sound.

I also changed the spelling of "jewelry" I had added to "jewellery," to match the British spelling you were using. :) It's probably a good idea to keep references to things using the same spelling.

The "equip on load" was pretty jarring if you had a lot of items being equipped. I added in some code to stop it from happening.

Let me know if there is anything you want me to change.