### PR TITLE
Play correct weapon swing sounds

### DIFF
--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -36,7 +36,7 @@ namespace DaggerfallWorkshop.Game
         public float Reach = 2.5f;
         public float AttackSpeedScale = 1.0f;
         public SoundClips DrawWeaponSound = SoundClips.DrawWeapon;
-        public SoundClips SwingWeaponSound = SoundClips.PlayerSwing;
+        public SoundClips SwingWeaponSound = SoundClips.SwingMediumPitch;
 
         WeaponTypes currentWeaponType;
         MetalTypes currentMetalType;

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -464,6 +464,34 @@ namespace DaggerfallWorkshop.Game.Items
             }
         }
 
+        public SoundClips GetSwingSound()
+        {
+            switch (TemplateIndex)
+            {
+                case (int)Weapons.Warhammer:
+                case (int)Weapons.Battle_Axe:
+                case (int)Weapons.Katana:
+                case (int)Weapons.Claymore:
+                case (int)Weapons.Dai_Katana:
+                case (int)Weapons.Flail:
+                    return SoundClips.SwingLowPitch;
+                case (int)Weapons.Broadsword:
+                case (int)Weapons.Longsword:
+                case (int)Weapons.Saber:
+                case (int)Weapons.Wakazashi:
+                case (int)Weapons.War_Axe:
+                case (int)Weapons.Staff:
+                    return SoundClips.SwingMediumPitch;
+                case (int)Weapons.Dagger:
+                case (int)Weapons.Tanto:                
+                case (int)Weapons.Shortsword:
+                    return SoundClips.SwingHighPitch;
+
+                default:
+                    return SoundClips.None;
+            }
+        }
+
         #endregion
 
         #region Static Methods

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -258,7 +258,7 @@ namespace DaggerfallWorkshop.Game
             target.WeaponType = WeaponTypes.Melee;
             target.MetalType = MetalTypes.None;
             target.DrawWeaponSound = SoundClips.None;
-            target.SwingWeaponSound = SoundClips.PlayerSwing;
+            target.SwingWeaponSound = SoundClips.SwingHighPitch;
 
             // TODO: Adjust FPSWeapon attack speed scale for swing pitch variance
         }
@@ -273,7 +273,7 @@ namespace DaggerfallWorkshop.Game
             target.WeaponType = DaggerfallUnity.Instance.ItemHelper.ConvertItemToAPIWeaponType(weapon);
             target.MetalType = DaggerfallUnity.Instance.ItemHelper.ConvertItemMaterialToAPIMetalType(weapon);
             target.DrawWeaponSound = weapon.GetEquipSound();
-            target.SwingWeaponSound = SoundClips.PlayerSwing;
+            target.SwingWeaponSound = weapon.GetSwingSound();
 
             // TODO: Adjust FPSWeapon attack speed scale for swing pitch variance
         }

--- a/Assets/Scripts/SoundClips.cs
+++ b/Assets/Scripts/SoundClips.cs
@@ -119,8 +119,8 @@ namespace DaggerfallWorkshop
         AnimalCow = 103,
         HorseAndCart = 104,
 
-        EnemySwing1 = 105,
-        EnemySwing2 = 106,
+        SwingLowPitch = 105,
+        SwingHighPitch = 106,
 
         Bells = 107,
 
@@ -363,14 +363,13 @@ namespace DaggerfallWorkshop
         StopThief = 345,
         SplashSmall = 346,
 
-        // Player swing pitch is changed based on weapon speed.
-        PlayerSwing = 347,
+        SwingMediumPitch = 347,
 
         StormLightningShort = 348,
         StormLightningThunder = 349,
         StormThunderRoll = 350,
 
-        PlayerSwing2 = 353,
+        SwingMediumPitch2 = 353,
 
         StrangledHowl = 357,
         LongMoanHigh = 358,


### PR DESCRIPTION
With this PR the player's weapons will play the correct weapon sounds (as far as I know.)

There are comments in the code about varying the pitch of weapon swings according to attack speed. As far as I can see, this is not what happens in Daggerfall. It just plays one of three sound effects. Two of these were labeled as "EnemySwing1" and "EnemySwing2," but these are used by the player as well, so I renamed them.

The sound effect used seems to be based on the type of weapon. I tried a few different materials of the weapons, and swinging some of them with two different characters, and I got the same results.

I'm not completely sure what all the stuff about attack speeds and sound pitches in the comments is, so I'll leave it to you Interkarma if you want to remove the related TODO comments or any code, etc.