### PR TITLE
Fix parsing of PositionPrefix format token

### DIFF
--- a/Assets/Scripts/API/TextFile.cs
+++ b/Assets/Scripts/API/TextFile.cs
@@ -379,7 +379,7 @@ namespace DaggerfallConnect.Arena2
                     break;
                 case Formatting.PositionPrefix:
                     peek = PeekByte(ref buffer, position);
-                    if (peek != null && IsFormattingToken(peek.Value))
+                    if (peek != null)
                     {
                         x = peek.Value;
                         position++;

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -228,7 +228,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         if (token.x != 0)
                         {
                             // Tab by specific number of pixels
-                            cursorX += token.x;
+                            cursorX = token.x;
                         }
                         else
                         {


### PR DESCRIPTION
Just a minor fix. I noticed that the Strength attribute description had a few stray parentheses not there in original Daggerfall. I poked around and found that the check for the "PositionPrefix" token that what comes after it is not a normal character seems to be wrong. This was causing it to show the parentheses instead of use them for PositionPrefix. As far as I saw you can use any value there other than 0x00, which causes Daggerfall to show endless gibberish and crash.

Also Daggerfall Unity was summing together the PositionPrefix to the x cursor but it should be used as an absolute position and not summed. Summing it would cause the second use of PositionPrefix on a line to be moved over too far.

Edit: I wrote various things here about how I thought there should be a default indentation of 5, since using PositionPrefix of 0x04 places text one pixel to the left of the other lines, but it seems like it's already displaying correctly in Daggerfall Unity.