### PR TITLE
Fixes to appearance of UI windows

### DIFF
--- a/Assets/Scripts/API/TextFile.cs
+++ b/Assets/Scripts/API/TextFile.cs
@@ -99,6 +99,7 @@ namespace DaggerfallConnect.Arena2
 
             NewLine = 0x00,
             EndOfPage = 0xf6,
+            InputCursorPositioner = 0xf8,
             SubrecordSeparator = 0xff,
             EndOfRecord = 0xfe,
 

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -408,7 +408,7 @@ namespace DaggerfallWorkshop.Game
                     globalFilterMode);
             }
 
-            panel.SetMargins(Margins.All, 12);
+            panel.SetMargins(Margins.All, 10);
         }
 
         void LoadDaggerfallParchmentTextures()

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -240,6 +240,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     case TextFile.Formatting.Text:
                         AddTextLabel(token.text, font);
                         break;
+                    case TextFile.Formatting.InputCursorPositioner:
+                        break;
                     default:
                         Debug.Log("MultilineTextLabel: Unknown formatting token: " + (int)token.formatting);
                         break;

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharReflexSelect.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharReflexSelect.cs
@@ -69,7 +69,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             infoText.SetText(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(strPlayerReflexesDetermine));
             infoText.HorizontalAlignment = HorizontalAlignment.Center;
             infoText.VerticalAlignment = VerticalAlignment.Middle;
-            infoPanel.Size = infoText.Size;
+
+            // Setup panel size
+            int minimum = 44;
+            float width = (infoText.Size.x + infoPanel.LeftMargin + infoPanel.RightMargin);
+            float height = (infoText.Size.y + infoPanel.TopMargin + infoPanel.BottomMargin);
+
+            if (width > minimum)
+                width = (float)Math.Ceiling(width / 22) * 22;
+            else
+                width = minimum;
+
+            if (height > minimum)
+                height = (float)Math.Ceiling(height / 22) * 22;
+            else
+                height = minimum;
+
+            infoPanel.Size = new Vector2(width, height);
 
             // Setup button picker
             reflexPicker = new ReflexPicker();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs
@@ -18,6 +18,7 @@
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.UserInterface;
 using UnityEngine;
+using System;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -34,7 +35,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private Color parentPanelColor = Color.clear;
 
         private int textPanelDistance = 12;             //distance between the text prompt / input & the multiline label
-        private int inputDistance = 4;                  //distance between the input label & input box
+        private int inputDistance = 0;                  //distance between the input label & input box
         private bool useParchmentStyle = true;          //if true, box will use PopupStyle Parchment background
         private bool clickAnywhereToClose = false;
 
@@ -181,7 +182,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void UpdatePanelSizes()
         {
-            float height = (messagePanel.TopMargin + multiLineLabel.Size.y + textPanelDistance + Mathf.Max(textBox.MaxSize.y, textBoxLabel.Size.y) + messagePanel.BottomMargin);
+            int minimum = 44;
+            float height = (messagePanel.TopMargin + multiLineLabel.Size.y + textPanelDistance + textBoxLabel.Size.y + messagePanel.BottomMargin);
+            if (height > minimum)
+                height = (float)Math.Ceiling(height / 22) * 22;
+            else
+                height = minimum;
+
             float width = (Mathf.Max(multiLineLabel.Size.x, (textBoxLabel.Size.x + inputDistance + textBox.MaxSize.x)));
             messagePanel.Size = new Vector2(width, height);
             textBoxLabel.Position = new Vector2(messagePanel.RightMargin, multiLineLabel.Position.y + multiLineLabel.Size.y + textPanelDistance);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -116,7 +116,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             NativePanel.Components.Add(messagePanel);
 
             label.HorizontalAlignment = HorizontalAlignment.Center;
-            label.VerticalAlignment = VerticalAlignment.Top;
+            label.VerticalAlignment = VerticalAlignment.Middle;
             messagePanel.Components.Add(label);
 
             buttonPanel.HorizontalAlignment = HorizontalAlignment.Center;
@@ -234,9 +234,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
 
             buttonPanel.Size = finalSize;
-            messagePanel.Size = new Vector2(
-                label.Size.x + messagePanel.LeftMargin + messagePanel.RightMargin,
-                label.Size.y + buttonPanel.Size.y + buttonTextDistance + messagePanel.TopMargin + messagePanel.BottomMargin);
+
+            int minimum = 44;
+            float width = label.Size.x + messagePanel.LeftMargin + messagePanel.RightMargin;
+            float height = label.Size.y + buttonPanel.Size.y + buttonTextDistance + messagePanel.TopMargin + messagePanel.BottomMargin;
+
+            if (width > minimum)
+                width = (float)Math.Ceiling(width / 22) * 22;
+            else
+                width = minimum;
+
+            if (height > minimum)
+                height = (float)Math.Ceiling(height / 22) * 22;
+            else
+                height = minimum;
+
+            messagePanel.Size = new Vector2(width, height);
         }
 
         void SetupBox(int textId, CommonMessageBoxButtons buttons)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -333,7 +333,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallInputMessageBox mb = new DaggerfallInputMessageBox(uiManager, this);
             mb.SetTextBoxLabel(HardStrings.restHowManyHours);
-            mb.TextPanelDistance = 0;
+            mb.TextPanelDistance = 8;
             mb.TextBox.Text = "0";
             mb.TextBox.Numeric = true;
             mb.OnGotUserInput += TimedRestPrompt_OnGotUserInput;
@@ -350,7 +350,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallInputMessageBox mb = new DaggerfallInputMessageBox(uiManager, this);
             mb.SetTextBoxLabel(HardStrings.loiterHowManyHours);
-            mb.TextPanelDistance = 0;
+            mb.TextPanelDistance = 8;
             mb.TextBox.Text = "0";
             mb.TextBox.Numeric = true;
             mb.OnGotUserInput += LoiterPrompt_OnGotUserInput;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -676,7 +676,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 StopRegionIdentify();
                 DaggerfallInputMessageBox findPopUp = new DaggerfallInputMessageBox(uiManager, null, 31, HardStrings.findLocationPrompt, true, this);
-                findPopUp.TextPanelDistance = 0;
+                findPopUp.TextPanelDistance = 5;
                 findPopUp.OnGotUserInput += HandleLocationFindEvent;
                 findPopUp.Show();
             }


### PR DESCRIPTION
This is a number of minor fixes to the UI windows. I'll try to explain it all here, and please let me know if you want me to change anything.

1. Identify 0xf8 format token.

This token appears in TEXT.RSC for the gold drop input message, and for two tavern room renting input messages. From testing with the gold drop message, it looks like it positions the input cursor. Without it, the cursor appears in the middle of the text window, overlapping other text, so it seems to be used for that. I put in a debug message for it that will show instead of the "Unknown formatting token" one that was showing before.

2. Change panel margins from 12 to 10.

From testing with the text in Daggerfall, I know at least that attribute popup text can go as close as 10 pixels to the left edge, and the top can be at least as close as 11 pixels. I couldn't test the top any more finely than that, because I can't add by individual pixels vertically like I could horizontally, but for now it seems reasonable to assume it is 10 all around.

3. Make message window borders be applied by multiples of 22 pixels to avoid misaligned parchment border textures, and make parchment popups be a minimum of four border tiles (44 pixels by 44 pixels).

From testing, the attribute windows and other windows in Daggerfall seem to have this as a minimum size, and the windows are always sized so that the textures line up properly.

This code is assuming 22 x 22 textures are used, which is what the vanilla ones are.

I also used the code for the reflex selection window during character creation, which was just resizing to the text size before. I've put similar code in 3 spots for the sizing of windows, so maybe it could all be consolidated somewhere to avoid code duplication.

4. Change input distance for input messages from 4 to 0. Change text panel distances for other input messages from 0 to 8 or 5.

This is to match what I see in Daggerfall, and to look correct with new border sizes from the changes to the window sizing, which seems to make all the message windows I saw vertically the same size as in Daggerfall.

5. Change label vertical alignment from top to middle.

Makes things look more correct with the resized borders. However, they seem to be positioned slightly lower than the middle, which I haven't been able to find the reason for, so it doesn't look perfect. Any idea there? Also, I think the race selection dialogs need to have the buttons at the bottom somehow factored in to the vertical text alignment in order to look right.

6. Change vertical panel sizing for input messages.

The `textBox.MaxSize.y` in `Mathf.Max(textBox.MaxSize.y, textBoxLabel.Size.y)` was causing the gold dropping dialog to be too high vertically, so I removed it as it didn't seem necessary to me (you can only enter up to 8 digits for the input in Daggerfall). I just used `textBoxLabel.Size.y.`