### PR TITLE
Use original Daggerfall text for travel message

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -33,6 +33,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     /// </summary>
     public class DaggerfallTravelMapWindow : DaggerfallPopupWindow
     {
+        #region Classic Text IDs
+
+        const int doYouWishToTravelTo = 31;
+
+        #endregion
+
         #region Fields
 
         const string nativeImgName                          = "TRAV0I00.IMG";
@@ -1282,12 +1288,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (!locationSelected)
                 return;
 
-            TextFile.Token[] textTokens = new TextFile.Token[2];
-            //int index = currentRegion.MapIdLookup[locationSummary.MapIndex];
-            textTokens[0].text = string.Format("Travel to  {0} : {1} ?", currentDFRegion.Name, currentDFRegion.MapNames[locationSummary.MapIndex]);
-            textTokens[0].formatting = TextFile.Formatting.Text;
-            textTokens[1].text = null;
-            textTokens[1].formatting = TextFile.Formatting.NewLine;
+            // Get text tokens
+            TextFile.Token[] textTokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(doYouWishToTravelTo);
+
+            // Hack to set location name in text token for now
+            textTokens[2].text = textTokens[2].text.Replace("%tcn", currentDFRegion.MapNames[locationSummary.MapIndex]);
 
             DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
             messageBox.SetTextTokens(textTokens);


### PR DESCRIPTION
Minor change to use the original Daggerfall text. I did the same thing that is done for the drop gold message to replace the token for the location name, and marked it as a temporary hack as it is marked there.

The message from TEXT.RSC is

> Do you wish to travel toý %tcn?ý

Using `GetRSCTokens` to put this into `TextFile.Token[] textTokens` the "%tcn?" is stored in `textTokens[2].text,` while `textTokens[0].text` holds the "Do you wish to travel to" part and  `textTokens[1].text` is null. I don't really understand why there is a null in between them, but this was how it was, so I tell the code to look in `textTokens[2].text` for the token to replace.
