### PR TITLE
Various changes to make UI text positioning more like original Daggerfall

### DIFF
--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -25,7 +25,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
     /// </summary>
     public class MultiFormatTextLabel : BaseScreenComponent
     {
-        const int tabWidth = 45;
+        const int tabWidth = 35;
 
         PixelFont font;
         int rowLeading = 0;
@@ -79,6 +79,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             get { return textAlignment; }
             set { textAlignment = value; }
+        }
+
+        public void ResizeY(float newSize)
+        {
+            Size = new Vector2(totalWidth, newSize);
         }
 
         public override void Draw()
@@ -164,7 +169,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             cursorX = 0;
             cursorY += LineHeight;
-            totalHeight += LineHeight;
             tabStop = 0;
         }
 
@@ -218,6 +222,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         break;
                     case TextFile.Formatting.JustifyLeft:
                         NewLine();
+                        totalHeight += LineHeight; // Justify left adds to height regardless of there being anything afterwards
                         break;
                     case TextFile.Formatting.JustifyCenter:
                         if (lastLabel != null)
@@ -252,6 +257,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     int rowWidth = (int)lastLabel.Position.x + lastLabel.TextWidth;
                     if (rowWidth > totalWidth)
                         totalWidth = rowWidth;
+                    int rowHeight = (int)lastLabel.Position.y + lastLabel.TextHeight;
+                    if (rowHeight > totalHeight)
+                        totalHeight = rowHeight;
                 }
             }
 

--- a/Assets/Scripts/Game/UserInterface/TextBox.cs
+++ b/Assets/Scripts/Game/UserInterface/TextBox.cs
@@ -24,6 +24,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
     {
         int maxCharacters = 31;
         int cursorPosition = 0;
+        int widthOverride = 0;
         DaggerfallFont font;
         TextCursor textCursor = new TextCursor();
         string text = string.Empty;
@@ -38,6 +39,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             get { return maxCharacters; }
             set { maxCharacters = value; MaxSize = CalculateMaximumSize(); }
+        }
+
+        public int WidthOverride
+        {
+              get { return widthOverride; }
+              set { widthOverride = value; }
         }
 
         public DaggerfallFont Font

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -180,10 +180,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             skillPrimaryStatToken.text = DaggerfallUnity.Instance.TextProvider.GetAbbreviatedStatName(primaryStat);
             skillPrimaryStatToken.formatting = TextFile.Formatting.Text;
 
-            TextFile.Token spacesToken = new TextFile.Token();
-            spacesToken.formatting = TextFile.Formatting.Text;
-            spacesToken.text = "  ";
-
             TextFile.Token tabToken = new TextFile.Token();
             tabToken.formatting = TextFile.Formatting.PositionPrefix;
 
@@ -191,8 +187,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             tokens.Add(skillNameToken);
             tokens.Add(tabToken);
             tokens.Add(tabToken);
+            tokens.Add(tabToken);
             tokens.Add(skillValueToken);
-            tokens.Add(spacesToken);
+            tokens.Add(tabToken);
             tokens.Add(skillPrimaryStatToken);
 
             return tokens.ToArray();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs
@@ -34,8 +34,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private TextLabel textBoxLabel = new TextLabel();
         private Color parentPanelColor = Color.clear;
 
-        private int textPanelDistance = 12;             //distance between the text prompt / input & the multiline label
-        private int inputDistance = 0;                  //distance between the input label & input box
+        private int textPanelDistanceX = 0;             //horizontal distance between the text prompt / input & the multiline label
+        private int textPanelDistanceY = 12;            //vertical distance between the text prompt / input & the multiline label  
+        private int inputDistanceX = 0;                 //horizontal distance between the input label & input box
+        private int inputDistanceY = 0;                 //vertical distance between the input label & input box
         private bool useParchmentStyle = true;          //if true, box will use PopupStyle Parchment background
         private bool clickAnywhereToClose = false;
 
@@ -45,16 +47,28 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             set { clickAnywhereToClose = value; }
         }
 
-        public int TextPanelDistance
+        public int TextPanelDistanceY
         {
-            get { return textPanelDistance; }
-            set { textPanelDistance = value; }
+            get { return textPanelDistanceY; }
+            set { textPanelDistanceY = value; }
         }
 
-        public int InputDistance
+        public int TextPanelDistanceX
         {
-            get { return inputDistance; }
-            set { inputDistance = value; }
+            get { return textPanelDistanceX; }
+            set { textPanelDistanceX = value; }
+        }
+
+        public int InputDistanceX
+        {
+            get { return inputDistanceX; }
+            set { inputDistanceX = value; }
+        }
+
+        public int InputDistanceY
+        {
+            get { return inputDistanceY; }
+            set { inputDistanceY = value; }
         }
 
         public TextBox TextBox
@@ -121,7 +135,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             NativePanel.Components.Add(messagePanel);
 
             multiLineLabel.HorizontalAlignment = HorizontalAlignment.Center;
-            multiLineLabel.VerticalAlignment = VerticalAlignment.Top;
+            multiLineLabel.VerticalAlignment = VerticalAlignment.Middle;
             messagePanel.Components.Add(multiLineLabel);
 
             messagePanel.Components.Add(textPanel);
@@ -183,16 +197,26 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void UpdatePanelSizes()
         {
             int minimum = 44;
-            float height = (messagePanel.TopMargin + multiLineLabel.Size.y + textPanelDistance + textBoxLabel.Size.y + messagePanel.BottomMargin);
+
+            float width = textBox.WidthOverride;
+            if (width <= 0)
+                width = (Mathf.Max(multiLineLabel.Size.x + messagePanel.LeftMargin + messagePanel.RightMargin, (textBoxLabel.Size.x + inputDistanceX + textBox.MaxSize.x)));
+
+            if (width > minimum)
+                width = (float)Math.Ceiling(width / 22) * 22;
+            else
+                width = minimum;
+
+            float height = (messagePanel.TopMargin + multiLineLabel.Size.y + textPanelDistanceY + messagePanel.BottomMargin);
+
             if (height > minimum)
                 height = (float)Math.Ceiling(height / 22) * 22;
             else
                 height = minimum;
 
-            float width = (Mathf.Max(multiLineLabel.Size.x, (textBoxLabel.Size.x + inputDistance + textBox.MaxSize.x)));
             messagePanel.Size = new Vector2(width, height);
-            textBoxLabel.Position = new Vector2(messagePanel.RightMargin, multiLineLabel.Position.y + multiLineLabel.Size.y + textPanelDistance);
-            textBox.Position = new Vector2(textBoxLabel.Position.x + textBoxLabel.Size.x + inputDistance, textBoxLabel.Position.y);
+            textBoxLabel.Position = new Vector2(textPanelDistanceX, multiLineLabel.Position.y + multiLineLabel.Size.y + textPanelDistanceY);
+            textBox.Position = new Vector2(textBoxLabel.Position.x + textBoxLabel.Size.x + inputDistanceX, textBoxLabel.Position.y + inputDistanceY);
         }
 
         private void MessagePanel_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1137,8 +1137,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Show message box
             DaggerfallInputMessageBox mb = new DaggerfallInputMessageBox(uiManager, this);
             mb.SetTextTokens(textTokens);
-            mb.TextPanelDistance = 0;
+            mb.TextPanelDistanceY = 0;
+            mb.InputDistanceX = 15;
+            mb.InputDistanceY = -6;
             mb.TextBox.Numeric = true;
+            mb.TextBox.MaxCharacters = 8;
             mb.OnGotUserInput += DropGoldPopup_OnGotUserInput;
             mb.Show();
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -233,11 +233,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     finalSize.x += buttonSpacing;
             }
 
+            if (finalSize.y - buttonPanel.Size.y > 0)
+                label.ResizeY(label.Size.y + finalSize.y + buttonTextDistance);
+
             buttonPanel.Size = finalSize;
 
             int minimum = 44;
             float width = label.Size.x + messagePanel.LeftMargin + messagePanel.RightMargin;
-            float height = label.Size.y + buttonPanel.Size.y + buttonTextDistance + messagePanel.TopMargin + messagePanel.BottomMargin;
+            float height = label.Size.y + messagePanel.TopMargin + messagePanel.BottomMargin;
 
             if (width > minimum)
                 width = (float)Math.Ceiling(width / 22) * 22;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -333,9 +333,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallInputMessageBox mb = new DaggerfallInputMessageBox(uiManager, this);
             mb.SetTextBoxLabel(HardStrings.restHowManyHours);
-            mb.TextPanelDistance = 8;
+            mb.TextPanelDistanceX = 9;
+            mb.TextPanelDistanceY = 8;
             mb.TextBox.Text = "0";
             mb.TextBox.Numeric = true;
+            mb.TextBox.MaxCharacters = 8;
+            mb.TextBox.WidthOverride = 286;
             mb.OnGotUserInput += TimedRestPrompt_OnGotUserInput;
             mb.Show();
         }
@@ -350,9 +353,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallInputMessageBox mb = new DaggerfallInputMessageBox(uiManager, this);
             mb.SetTextBoxLabel(HardStrings.loiterHowManyHours);
-            mb.TextPanelDistance = 8;
+            mb.TextPanelDistanceX = 5;
+            mb.TextPanelDistanceY = 8;
             mb.TextBox.Text = "0";
             mb.TextBox.Numeric = true;
+            mb.TextBox.MaxCharacters = 8;
+            mb.TextBox.WidthOverride = 286;
             mb.OnGotUserInput += LoiterPrompt_OnGotUserInput;
             mb.Show();
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -676,7 +676,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 StopRegionIdentify();
                 DaggerfallInputMessageBox findPopUp = new DaggerfallInputMessageBox(uiManager, null, 31, HardStrings.findLocationPrompt, true, this);
-                findPopUp.TextPanelDistance = 5;
+                findPopUp.TextPanelDistanceY = 5;
+                findPopUp.TextBox.WidthOverride = 308;
+                findPopUp.TextBox.MaxCharacters = 32;
                 findPopUp.OnGotUserInput += HandleLocationFindEvent;
                 findPopUp.Show();
             }


### PR DESCRIPTION
Here are various changes to make the UI text look more like original Daggerfall. Everything in the UI windows I worked on should be positioned like Daggerfall now except for buttons, which are still at the bottom of the window as before this PR, and the items in the misc skills window.

I'll go through the changes here.

1. Skills windows were changed to match what I saw in original Daggerfall, using tabs and no spaces. Tabs of 35 spaces are used, not 45.

2. I determined through experimentation that having a text entry that ends with justify left in original Daggerfall  adds the final newline into the length of the text, while ending with a justify center does not. Unity Daggerfall was adding the newline to the length in either case. Doing the same thing as original Daggerfall allows the attribute popups, which end with justify center, to be correctly sized.

3. I fixed the problem of messages with middle vertical alignment being too low. The initial row wasn't being added into `totalHeight.`

I'm pretty confident about the top three fixes. The below fixes have good results, but I'm not an experienced programmer and they might not be implemented well.

4. I added hardcoded width overrides and positioning information for the sizing of the rest, loiter and find location input windows. These windows don't use text from TEXT.RSC and I couldn't see what rules if any they followed for their positioning.

5. I added in the same max input character limits as Daggerfall for the rest, loiter, find location and gold drop windows. The find location actually allows up to 32 characters. This fixes a problem where the rest and loiter windows weren't giving their "you can only rest/loiter for ___ hours" popups if you entered in very large values.

6. I added in resizing of text labels when buttons are added. This positions the text correctly, but I couldn't figure out how to get the buttons correctly positioned 4 pixels under the text, so I just left them for now as aligned at the bottom.