### PR TITLE
Allow return key and keypad enter key to close message boxes

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs
@@ -154,7 +154,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (Input.GetKeyDown(KeyCode.Return))
+            if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter))
             {
                 ReturnPlayerInputEvent(this, textBox.Text);
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -148,6 +148,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             uiManager.PushWindow(this);
         }
 
+        public override void Update()
+        {
+            base.Update();
+        
+            if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter))
+              CloseWindow();
+        }
+
         public Button AddButton(MessageBoxButtons messageBoxButton)
         {
             if (!IsSetup)


### PR DESCRIPTION
Edit: I had a few other changes but I decided I want to reconsider them. I left this one in that I felt was probably worthwhile. It's possible in original Daggerfall to close message windows with the big enter key and the little enter key on the keypad, which in the unity engine means the `Return` KeyCode and the `KeypadEnter` KeyCode.