### PR TITLE
Differentiate between unarmed hit sounds and weapon hit sounds

### DIFF
--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -160,8 +160,12 @@ namespace DaggerfallWorkshop.Game
         {
             if (dfAudioSource)
             {
+                int sound;
                 dfAudioSource.AudioSource.pitch = 1f;
-                int sound = (int)SoundClips.Hit1 + UnityEngine.Random.Range(0, 5);
+                if (WeaponType == WeaponTypes.Melee || WeaponType == WeaponTypes.Werecreature) 
+                    sound = (int)SoundClips.Hit1 + UnityEngine.Random.Range(2, 4);
+                else
+                    sound = (int)SoundClips.Hit1 + UnityEngine.Random.Range(0, 5);
                 dfAudioSource.PlayOneShot(sound, 0);
             }
         }


### PR DESCRIPTION
After some testing in Daggerfall, I found that unarmed hits, including those as a werecreature, only play two of the possible hit sounds. Weapons seem to play all of them.

I made sure by using the program DaggerSound to replace the hit sounds with ones that were easy to tell apart. This made it obvious that only the 3rd and 4th of the 5 possible hit sounds play for unarmed hits.

This is also true for enemy hits. Unarmed enemies only play those same two hit sounds, while enemies with weapons play all of them. This PR only affects the sounds for when the player hits an enemy.
