### PR TITLE
Don't treat enemies as moving platforms

### DIFF
--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -391,6 +391,12 @@ namespace DaggerfallWorkshop.Game
         {
             contactPoint = hit.point;
 
+            // Don't consider enemies as moving platforms
+            // Otherwise, if we're positioned just right on top of one, the player camera gets unstable
+            // This still allows standing on enemies
+            if (hit.collider.gameObject.GetComponent<DaggerfallEnemy>() != null)
+                return;
+
             // Get active platform
             if (hit.moveDirection.y < -0.9 && hit.normal.y > 0.5)
                 activePlatform = hit.collider.transform;


### PR DESCRIPTION
If we stand just right on an enemy, the player camera will get unstable. This still allows use to stand on an enemy, however.