### PR TITLE
Prevent Rat Stacks

### DIFF
--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -72,6 +72,8 @@ namespace DaggerfallWorkshop.Game
                     // However they will appear sunken into ground as a result
                     //if (controller.height > 1.9f)
                     //    controller.height = 1.9f;
+
+                    controller.gameObject.layer = LayerMask.NameToLayer("Enemies");
                 }
 
                 // Setup sounds

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -16,7 +16,7 @@ TagManager:
   - SkyLayer
   - WorldTerrain
   - Automap
-  - 
+  - Enemies
   - 
   - 
   - 


### PR DESCRIPTION
This isn't a perfect solution, but I figured I'd put it up and see if anyone else has ideas on how to solve this in a simple, elegant manner (without using NavMeshes because I'm not sure if that should be introduced at this stage of development).

In the original game, enemies could overlap if they got close to you. But I assume that isn't the desired behavior for Daggerfall Unity.