### PR TITLE
Fix errors when rendering during winter

### DIFF
--- a/Assets/Game/Addons/RealGrass/RealGrass ReadMe.txt
+++ b/Assets/Game/Addons/RealGrass/RealGrass ReadMe.txt
@@ -1,9 +1,12 @@
 Name: Real Grass 
 Made  by: Uncanny_Valley
 For:  DaggerFall Tools For Unity (1.3.31)
-Version: 1.03
+Version: 1.04
 
 This mod adds animated billboard grass in DaggerFall
+
+1.04
+*Fixes error messages when traveling during winter in grassy climates
 
 1.03
 *Fixes a few misplaced grass placements

--- a/Assets/Game/Addons/RealGrass/RealGrass.cs
+++ b/Assets/Game/Addons/RealGrass/RealGrass.cs
@@ -240,9 +240,8 @@ namespace DaggerfallWorkshop.Game
 
                     }
                 }
+                terrainData.SetDetailLayer(0, 0, 0, details);
             }
-
-            terrainData.SetDetailLayer(0, 0, 0, details);
 
             //			stopwatch.Stop();
             //			// Write result


### PR DESCRIPTION
Console got a bunch of error messages when I exited the starting dungeon during winter.

It's a grassy climate, but there should be no grass because it's winter. But the code was trying to set the grass texture details (probably with garbage/invalid data). Since grass isn't present during winter, don't try to set texture details.

Original error message:
```
Detail index out of bounds in DetailDatabase.SetLayers
UnityEngine.TerrainData:SetDetailLayer(Int32, Int32, Int32, Int32[,])
DaggerfallWorkshop.Game.RealGrass:AddGrass(DaggerfallTerrain, TerrainData) (at Assets/Game/Addons/RealGrass/RealGrass.cs:245)
DaggerfallWorkshop.DaggerfallTerrain:RaiseOnPromoteTerrainDataEvent(TerrainData) (at Assets/Scripts/Terrain/DaggerfallTerrain.cs:343)
DaggerfallWorkshop.DaggerfallTerrain:PromoteTerrainData() (at Assets/Scripts/Terrain/DaggerfallTerrain.cs:257)
ProjectIncreasedTerrainDistance.IncreasedTerrainDistance:UpdateTerrainDataTransitionRing(TransitionTerrainDesc) (at Assets/Game/Addons/IncreasedTerrainDistanceMod/Scripts/IncreasedTerrainDistance.cs:1282)
ProjectIncreasedTerrainDistance.IncreasedTerrainDistance:PlaceTerrainOfTransitionRing(Int32) (at Assets/Game/Addons/IncreasedTerrainDistanceMod/Scripts/IncreasedTerrainDistance.cs:1426)
ProjectIncreasedTerrainDistance.<UpdateTerrainsTransitionRing>c__Iterator0:MoveNext() (at Assets/Game/Addons/IncreasedTerrainDistanceMod/Scripts/IncreasedTerrainDistance.cs:1537)
```