### PR TITLE
More natural looking grass

### DIFF
--- a/Assets/Game/Addons/RealGrass/RealGrass ReadMe.txt
+++ b/Assets/Game/Addons/RealGrass/RealGrass ReadMe.txt
@@ -1,9 +1,14 @@
 Name: Real Grass 
 Made  by: Uncanny_Valley
 For:  DaggerFall Tools For Unity (1.3.31)
-Version: 1.04
+Version: 1.05
 
 This mod adds animated billboard grass in DaggerFall
+
+1.05
+*Adds more variety to grass patches
+*Tweaks density of grass so patches near non-grass terrain look more natural (no "grass walls")
+*Refactoring, cleanup, and comments
 
 1.04
 *Fixes error messages when traveling during winter in grassy climates

--- a/Assets/Game/Addons/RealGrass/RealGrass.cs
+++ b/Assets/Game/Addons/RealGrass/RealGrass.cs
@@ -4,31 +4,62 @@
 
 using UnityEngine;
 using DaggerfallWorkshop.Utility;
-using System.Collections;
 
 namespace DaggerfallWorkshop.Game
 {
     /// <summary>
-    /// Adds grass to the terrain based on the tiles
+    /// Adds grass to the terrain based on the tiles.
+    ///
+    /// The density of grass is set randomly based on the type of tile. Tiles that are all grass will have a higher
+    /// grass billboard density. Tiles that are partially grass will have lower density.
+    ///
+    /// The position, height, and width of the grass billboards are randomly generated.
     /// </summary>
     public class RealGrass : MonoBehaviour
     {
         public Texture2D greenGrass;
         public Texture2D brownGrass;
 
-        private DetailPrototype[] detailPrototype;
+        // Description of the grass billboards to render
+        DetailPrototype[] _detailPrototype;
 
-        //Differient values that determine the overal thickness and lenght of the grass, it creates some variation depedning on differient tiles. 
-        const int thickLower = 8;
-        const int thickHigher = 24;
-        const int thinLower = 4;
-        const int thinHigher = 12;
+        // Ranges for number of grass billboards per terrain tile
+        const int MinGrassThick = 3;
+        const int MaxGrassThick = 20;
+        const int MinGrassSparse = 0;
+        const int MaxGrassSparse = 7;
+        // Ranges for shape of grass billboards
+        const float MinGrassHeight = 0.5f;
+        const float MaxGrassHeight = 2.5f;
+        const float MinGrassWidth = 0.8f;
+        const float MaxGrassWidth = 1.3f;
+        // The "spread" of the variety of grass, if you view it as a distribution of heights & widths.
+        // The higher this is, the more varied the grass billboards will look.
+        // This does not control the density of the grass, but it does control the positions.
+        const float GrassVarietyFactor = 4.0f;
 
-        private Color32[] tilemap;
-        private int[,] details;
-        private DaggerfallDateTime.Seasons currentSeason;
+        // Convenience/readability enums for how a tile should be filled with grass
+        enum Fill
+        {
+            All,
+            UpperSide,
+            LowerSide,
+            RightSide,
+            LeftSide,
+            OnlyUpperRight,
+            OnlyUpperLeft,
+            OnlyLowerRight,
+            OnlyLowerLeft,
+            RightToLeft,
+            LeftToRight,
+            NotUpperRight,
+            NotLowerRight,
+            NotLowerLeft,
+            NotUpperLeft,
+            None
+        }
 
-        private void Awake()
+        void Awake()
         {
             // Disable self if mod not enabled
             if (!DaggerfallUnity.Settings.UncannyValley_RealGrass)
@@ -41,217 +72,286 @@ namespace DaggerfallWorkshop.Game
             DaggerfallTerrain.OnPromoteTerrainData += AddGrass;
 
             //Create a holder for our grass
-            detailPrototype = new DetailPrototype[1];
-            detailPrototype[0] = new DetailPrototype();
-
-            //All the settings
-            detailPrototype[0].minHeight = 0.65f;
-            detailPrototype[0].minWidth = 0.65f;
-            detailPrototype[0].maxHeight = 1.0f;
-            detailPrototype[0].maxWidth = 1.0f;
-            detailPrototype[0].noiseSpread = 0.4f;
-
-            detailPrototype[0].healthyColor = new Color(0.70f, 0.70f, 0.70f);
-            detailPrototype[0].dryColor = new Color(0.70f, 0.70f, 0.70f);
-            detailPrototype[0].renderMode = UnityEngine.DetailRenderMode.GrassBillboard;
-
+            _detailPrototype = new[]
+            {
+                new DetailPrototype
+                {
+                    minHeight = MinGrassHeight,
+                    maxHeight = MaxGrassHeight,
+                    minWidth = MinGrassWidth,
+                    maxWidth = MaxGrassWidth,
+                    noiseSpread = GrassVarietyFactor,
+                    healthyColor = new Color(0.70f, 0.70f, 0.70f),
+                    dryColor = new Color(0.70f, 0.70f, 0.70f),
+                    renderMode = DetailRenderMode.GrassBillboard
+                }
+            };
         }
-        // Add Grass
-        private void AddGrass(DaggerfallTerrain daggerTerrain, TerrainData terrainData)
-        {
-            //			Used to check performance
-            //			Stopwatch stopwatch = new Stopwatch();
-            //			stopwatch.Start();
 
-            details = new int[256, 256];
+        /// <summary>
+        /// Get a random grass count for thick patches of grass.
+        /// </summary>
+        /// <returns>Number of grass billboards to draw</returns>
+        static int GetThick()
+        {
+            return Random.Range(MinGrassThick, MaxGrassThick);
+        }
+
+        /// <summary>
+        /// Get a random grass count for sparse patches of grass.
+        /// </summary>
+        /// <returns>Number of grass billboards to draw</returns>
+        static int GetSparse()
+        {
+            return Random.Range(MinGrassSparse, MaxGrassSparse);
+        }
+
+        /// <summary>
+        /// Determines the quadrants that need to be filled. Broken out for readability.
+        /// </summary>
+        /// <param name="tileCode">The terrain tile information</param>
+        /// <returns>The fill type for the terrain tile</returns>
+        static Fill GetGrassFillType(byte tileCode)
+        {
+            switch (tileCode)
+            {
+                case 8:
+                case 9:
+                case 10:
+                case 11:
+                    return Fill.All;
+
+                case 40:
+                case 164:
+                case 176:
+                case 181:
+                case 224:
+                    return Fill.OnlyUpperLeft;
+
+                case 41:
+                case 165:
+                case 177:
+                case 182:
+                case 221:
+                    return Fill.OnlyLowerLeft;
+
+                case 42:
+                case 166:
+                case 178:
+                case 183:
+                case 222:
+                    return Fill.OnlyLowerRight;
+
+                case 43:
+                case 167:
+                case 179:
+                case 180:
+                case 223:
+                    return Fill.OnlyUpperRight;
+
+                case 44:
+                case 66:
+                case 84:
+                case 160:
+                case 168:
+                    return Fill.LeftSide;
+
+                case 45:
+                case 67:
+                case 85:
+                case 161:
+                case 169:
+                    return Fill.LowerSide;
+
+                case 46:
+                case 64:
+                case 86:
+                case 162:
+                case 170:
+                    return Fill.RightSide;
+
+                case 47:
+                case 65:
+                case 87:
+                case 163:
+                case 171:
+                    return Fill.UpperSide;
+
+                case 48:
+                case 62:
+                case 88:
+                case 156:
+                    return Fill.NotLowerRight;
+
+                case 49:
+                case 63:
+                case 89:
+                case 157:
+                    return Fill.NotUpperRight;
+
+                case 50:
+                case 60:
+                case 90:
+                case 158:
+                    return Fill.NotUpperLeft;
+
+                case 51:
+                case 61:
+                case 91:
+                case 159:
+                    return Fill.NotLowerLeft;
+
+                case 204:
+                case 206:
+                case 214:
+                    return Fill.LeftToRight;
+
+                case 205:
+                case 207:
+                case 213:
+                    return Fill.RightToLeft;
+            }
+            return Fill.None;
+        }
+
+        /// <summary>
+        /// Set the grass density into the given grass detail map
+        /// </summary>
+        /// <param name="grassFill">Quadrants to fill</param>
+        /// <param name="y">Y position on terrain detail map to fill</param>
+        /// <param name="x">X position on terrain detail map to fill</param>
+        /// <param name="grassMap">Terrain detail map to fill with grass counts</param>
+        static void SetGrassDensity(Fill grassFill, int y, int x, ref int[,] grassMap)
+        {
+            switch (grassFill)
+            {
+                case Fill.All:
+                    grassMap[y, x] = GetThick();
+                    grassMap[y, x + 1] = GetThick();
+                    grassMap[y + 1, x] = GetThick();
+                    grassMap[y + 1, x + 1] = GetThick();
+                    break;
+
+                case Fill.UpperSide:
+                    grassMap[y + 1, x + 1] = GetSparse();
+                    grassMap[y + 1, x] = GetSparse();
+                    break;
+
+                case Fill.LowerSide:
+                    grassMap[y, x + 1] = GetSparse();
+                    grassMap[y, x] = GetSparse();
+                    break;
+
+                case Fill.RightSide:
+                    grassMap[y + 1, x + 1] = GetSparse();
+                    grassMap[y, x + 1] = GetSparse();
+                    break;
+
+                case Fill.LeftSide:
+                    grassMap[y + 1, x] = GetSparse();
+                    grassMap[y, x] = GetSparse();
+                    break;
+
+                case Fill.OnlyUpperRight:
+                    grassMap[y + 1, x + 1] = GetSparse();
+                    break;
+
+                case Fill.OnlyUpperLeft:
+                    grassMap[y + 1, x] = GetSparse();
+                    break;
+
+                case Fill.OnlyLowerRight:
+                    grassMap[y, x + 1] = GetSparse();
+                    break;
+
+                case Fill.OnlyLowerLeft:
+                    grassMap[y, x] = GetSparse();
+                    break;
+
+                case Fill.RightToLeft:
+                    grassMap[y + 1, x] = GetSparse();
+                    grassMap[y, x + 1] = GetSparse();
+                    break;
+
+                case Fill.LeftToRight:
+                    grassMap[y, x] = GetSparse();
+                    grassMap[y + 1, x + 1] = GetSparse();
+                    break;
+
+                case Fill.NotUpperRight:
+                    grassMap[y, x] = GetSparse();
+                    grassMap[y, x + 1] = GetSparse();
+                    grassMap[y + 1, x] = GetSparse();
+                    break;
+
+                case Fill.NotLowerRight:
+                    grassMap[y, x] = GetSparse();
+                    grassMap[y + 1, x] = GetSparse();
+                    grassMap[y + 1, x + 1] = GetSparse();
+                    break;
+
+                case Fill.NotLowerLeft:
+                    grassMap[y, x + 1] = GetSparse();
+                    grassMap[y + 1, x] = GetSparse();
+                    grassMap[y + 1, x + 1] = GetSparse();
+                    break;
+
+                case Fill.NotUpperLeft:
+                    grassMap[y, x] = GetSparse();
+                    grassMap[y, x + 1] = GetSparse();
+                    grassMap[y + 1, x + 1] = GetSparse();
+                    break;
+
+                case Fill.None:
+                default:
+                    break;
+            }
+        }
+
+        // Add Grass
+        void AddGrass(DaggerfallTerrain daggerTerrain, TerrainData terrainData)
+        {
+//            // Used to check performance
+//            Stopwatch stopwatch = new Stopwatch();
+//            stopwatch.Start();
 
             //Get the current season
-            currentSeason = DaggerfallUnity.Instance.WorldTime.Now.SeasonValue;
+            var currentSeason = DaggerfallUnity.Instance.WorldTime.Now.SeasonValue;
 
             //Proceed if it's NOT winter, and if the worldClimate contains grass, which is everything above 225, with the exception of 229
-            if (currentSeason != DaggerfallDateTime.Seasons.Winter && (daggerTerrain.MapData.worldClimate > 225 && daggerTerrain.MapData.worldClimate != 229))
+            if (currentSeason == DaggerfallDateTime.Seasons.Winter || daggerTerrain.MapData.worldClimate <= 225 ||
+                daggerTerrain.MapData.worldClimate == 229)
+                return;
+
+            //Switch the grass texture based on the climate
+            if (daggerTerrain.MapData.worldClimate == 226 || daggerTerrain.MapData.worldClimate == 227 ||
+                daggerTerrain.MapData.worldClimate == 228 || daggerTerrain.MapData.worldClimate == 230)
+                _detailPrototype[0].prototypeTexture = brownGrass;
+            else
+                _detailPrototype[0].prototypeTexture = greenGrass;
+
+            var grassMap = new int[256, 256];
+
+            // The red channel specifies the kind of terrain.
+            // This tell us which quadrants of the tile grass can be drawn on.
+            for (int i = 0; i < 128; i++)
             {
-                //Switch the grass texture based on the climate
-                if (daggerTerrain.MapData.worldClimate == 226 || daggerTerrain.MapData.worldClimate == 227 || daggerTerrain.MapData.worldClimate == 228 || daggerTerrain.MapData.worldClimate == 230)
-                    detailPrototype[0].prototypeTexture = brownGrass;
-                else
-                    detailPrototype[0].prototypeTexture = greenGrass;
-
-                tilemap = daggerTerrain.TileMap;
-                terrainData.detailPrototypes = detailPrototype;
-                terrainData.wavingGrassTint = Color.gray;
-                terrainData.SetDetailResolution(256, 8);
-
-                int colorValue;
-
-                //Check all the tiles, Daggerfall uses the red color value to draw tiles
-                for (int i = 0; i < 128; i++)
+                for (int j = 0; j < 128; j++)
                 {
-                    for (int j = 0; j < 128; j++)
-                    {
-                        colorValue = tilemap[(i * 128) + j].r; //For easier checking
-
-                        switch (colorValue)
-                        {
-                            //Four corner tiles
-                            case 8:
-                            case 9:
-                            case 10:
-                            case 11:
-                                details[i * 2, j * 2] = Random.Range(thickLower, thickHigher);
-                                details[i * 2, (j * 2) + 1] = Random.Range(thickLower, thickHigher);
-                                details[(i * 2) + 1, j * 2] = Random.Range(thickLower, thickHigher);
-                                details[(i * 2) + 1, (j * 2) + 1] = Random.Range(thickLower, thickHigher);
-                                break;
-
-                            //Upper left corner 
-                            case 40:
-                            case 224:
-                            case 164:
-                            case 176:
-                            case 181:
-                                details[(i * 2) + 1, j * 2] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //Lower left corner 
-                            case 41:
-                            case 221:
-                            case 165:
-                            case 177:
-                            case 182:
-                                details[i * 2, j * 2] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //Lower right corner 
-                            case 42:
-                            case 222:
-                            case 166:
-                            case 178:
-                            case 183:
-                                details[i * 2, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //Upper right corner 
-                            case 43:
-                            case 223:
-                            case 167:
-                            case 179:
-                            case 180:
-                                details[(i * 2) + 1, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //Left side
-                            case 44:
-                            case 66:
-                            case 84:
-                            case 160:
-                            case 168:
-                                details[(i * 2) + 1, j * 2] = Random.Range(thinLower, thinHigher);
-                                details[i * 2, j * 2] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //lower side
-                            case 45:
-                            case 67:
-                            case 85:
-                            case 161:
-                            case 169:
-                                details[i * 2, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                details[i * 2, j * 2] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //right side
-                            case 46:
-                            case 64:
-                            case 86:
-                            case 162:
-                            case 170:
-                                details[(i * 2) + 1, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                details[i * 2, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //upper side
-                            case 47:
-                            case 65:
-                            case 87:
-                            case 163:
-                            case 171:
-                                details[(i * 2) + 1, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                details[(i * 2) + 1, j * 2] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //All expect lower right
-                            case 48:
-                            case 62:
-                            case 88:
-                            case 156:
-                                details[i * 2, j * 2] = Random.Range(thinLower, thinHigher);
-                                details[(i * 2) + 1, j * 2] = Random.Range(thinLower, thinHigher);
-                                details[(i * 2) + 1, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //All expect upper right
-                            case 49:
-                            case 63:
-                            case 89:
-                            case 157:
-                                details[i * 2, j * 2] = Random.Range(thinLower, thinHigher);
-                                details[i * 2, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                details[(i * 2) + 1, j * 2] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //All expect upper left
-                            case 50:
-                            case 60:
-                            case 90:
-                            case 158:
-                                details[i * 2, j * 2] = Random.Range(thinLower, thinHigher);
-                                details[i * 2, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                details[(i * 2) + 1, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //All expect lower left
-                            case 51:
-                            case 61:
-                            case 91:
-                            case 159:
-                                details[i * 2, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                details[(i * 2) + 1, j * 2] = Random.Range(thinLower, thinHigher);
-                                details[(i * 2) + 1, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //Left to right
-                            case 204:
-                            case 206:
-                            case 214:
-                                details[i * 2, j * 2] = Random.Range(thinLower, thinHigher);
-                                details[(i * 2) + 1, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                            //Right to left
-                            case 205:
-                            case 207:
-                            case 213:
-                                details[(i * 2) + 1, j * 2] = Random.Range(thinLower, thinHigher);
-                                details[i * 2, (j * 2) + 1] = Random.Range(thinLower, thinHigher);
-                                break;
-
-                        }
-
-                    }
+                    byte tileCode = daggerTerrain.TileMap[i * 128 + j].r;
+                    var fillType = GetGrassFillType(tileCode);
+                    SetGrassDensity(fillType, i * 2, j * 2, ref grassMap);
                 }
-                terrainData.SetDetailLayer(0, 0, 0, details);
             }
 
-            //			stopwatch.Stop();
-            //			// Write result
-            //			UnityEngine.Debug.Log("Time elapsed: " +
-            //			                      stopwatch.Elapsed);
+            terrainData.detailPrototypes = _detailPrototype;
+            terrainData.wavingGrassTint = Color.gray;
+            terrainData.SetDetailResolution(256, 8);
+            terrainData.SetDetailLayer(0, 0, 0, grassMap);
+
+//            stopwatch.Stop();
+//            // Write result
+//            Debug.LogWarning("Time elapsed: " + stopwatch.Elapsed.TotalMilliseconds + " ms");
         }
-
-
-
     }
-
-
 }


### PR DESCRIPTION
Grass felt a little sparse and uniform. The main change was adding ranges to the grass width/heights so Unity will generate some more variety in grass patches. The values were tweaked to make the grass look a little more lush and varied.

The grass billboard counts for thick/sparse patches were also tweaked. There'd be grass "walls" where the grass patches stop, which looked odd. So the sparse patches are even sparser and can even be empty, which gives a more natural, decreasing, scattered look near non-grass terrain.

`AddGrass` stop watch times at an outdoor location:
* Original: 2.5 - 4.4 ms
* Change: 3.5 - 6.8 ms

This is approximate from eye-balling the log output after loading my save state.

Also refactoring, cleanup, comments.

Screenshot before:
<img width="847" alt="screen shot 2016-12-17 at 11 18 08 pm" src="https://cloud.githubusercontent.com/assets/1522141/21292197/0d676716-c4b1-11e6-8a81-565c78fd8c10.png">

Screenshot after:
<img width="851" alt="screen shot 2016-12-17 at 11 39 50 pm" src="https://cloud.githubusercontent.com/assets/1522141/21292225/26704e3e-c4b2-11e6-964b-d84176883a2d.png">