### PR TITLE
Mesh and Texture replacement - Add initial support

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -58,3 +58,4 @@ Nystul_IncreasedTerrainDistance=False
 Nystul_RealtimeReflections=False
 UncannyValley_RealGrass=False
 UncannyValley_BirdsInDaggerfall=False
+MeshAndTextureReplacement=False

--- a/Assets/Scripts/DFMeshReplacement.cs
+++ b/Assets/Scripts/DFMeshReplacement.cs
@@ -1,0 +1,93 @@
+﻿// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Uncanny_Valley
+// Contributors:    TheLacus 
+// 
+// Notes:
+//
+
+using UnityEngine;
+using System.Collections;
+using DaggerfallWorkshop.Utility;
+
+namespace DaggerfallWorkshop
+{
+    static public class DFMeshReplacement
+    {
+        /// <summary>
+        /// Check existence of model in Resources
+        /// </summary>
+        /// <returns>Bool</returns>
+
+        /// models
+        static public bool ReplacmentModelExist(uint modelID)
+        {
+            if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
+                 && Resources.Load("Models/" + modelID.ToString() + "/" + modelID.ToString()) != null)
+                return true;
+
+            return false;
+        }
+
+        /// billboards
+        static public bool ReplacementFlatExist(int archive, int record)
+        {
+            if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
+                 && Resources.Load("Flats/" + archive.ToString() + "_" + record.ToString() + "/" + archive.ToString() + "_" + record.ToString()) != null)
+                return true;
+      
+            return false;
+        }
+
+        /// <summary>
+        /// Import the model and the material(s) from Resources
+        /// </summary>
+       
+        /// models
+        static public Mesh LoadReplacementModel(uint modelID, ref CachedMaterial[] cachedMaterialsOut)
+        {
+            GameObject object3D = Resources.Load("Models/" + modelID.ToString() + "/" + modelID.ToString()) as GameObject;
+            cachedMaterialsOut = new CachedMaterial[object3D.GetComponent<MeshRenderer>().sharedMaterials.Length];
+
+            // If it's NOT winter or the models doesn't have a winter version, it loads default materials
+            // "Material_x" where x go from zero to (number of materials)-1
+            if ((DaggerfallUnity.Instance.WorldTime.Now.SeasonValue != DaggerfallDateTime.Seasons.Winter) || (Resources.Load("Models/" + modelID.ToString() + "/material_w_0") == null))
+            {
+                for (int i = 0; i < cachedMaterialsOut.Length; i++)
+                {
+                    if (Resources.Load("Models/" + modelID.ToString() + "/material_" + i) != null)
+                    {
+                        cachedMaterialsOut[i].material = Resources.Load("Models/" + modelID.ToString() + "/material_" + i) as Material;
+                        cachedMaterialsOut[i].material.mainTexture.filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode; //assign texture filtermode as user settings
+                    }
+                }
+            }
+
+            // If it's winter and the model has a winter version, it loads winter materials
+            // "Material_w_x" where x go from zero to (number of materials)-1
+            else
+            {
+                for (int i = 0; i < cachedMaterialsOut.Length; i++)
+                {
+                    if (Resources.Load("Models/" + modelID.ToString() + "/material_w_" + i) != null)
+                    {
+                        cachedMaterialsOut[i].material = Resources.Load("Models/" + modelID.ToString() + "/material_w_" + i) as Material;
+                        cachedMaterialsOut[i].material.mainTexture.filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode; //assign texture filtermode as user settings
+                    }
+                }
+            }
+            return object3D.GetComponent<MeshFilter>().sharedMesh;
+        }
+
+        /// billboards
+        static public void LoadReplacementFlat(int archive, int record, Vector3 position, Transform parent)
+        {
+            GameObject object3D = GameObject.Instantiate(Resources.Load("Flats/" + archive.ToString() + "_" + record.ToString() + "/" + archive.ToString() + "_" + record.ToString()) as GameObject);
+            object3D.transform.parent = parent;
+            object3D.transform.localPosition = position;
+        }
+    }
+}

--- a/Assets/Scripts/DFTextureReplacement.cs
+++ b/Assets/Scripts/DFTextureReplacement.cs
@@ -1,0 +1,155 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: TheLacus
+// Contributors:
+// 
+// Notes: LoadCustomTexture can import textures for billboards, but the actual sprites replacement is not implemented yet
+// TO DO: add support for bump maps
+//
+
+using System.IO;
+using UnityEngine;
+using System.Collections;
+using DaggerfallWorkshop.Utility;
+
+namespace DaggerfallWorkshop
+{
+    static public class DFTextureReplacement
+    {
+        /// <summary>
+        /// Load custom image files from disk to use as textures on models or billboards
+        /// .png files are located in persistentData/textures
+        /// and are named 'archive_record-frame.png' 
+        /// for example '86_3-0.png'
+        /// </summary>
+        /// <param name="archive">Archive index from TEXTURE.XXX</param>
+        /// <param name="record">Record index.</param>
+        /// <param name="frame">Frame index. It's different than zero only for animated billboards</param>
+
+        /// check if file exist on disk. 
+        /// <returns>Bool</returns>
+        static public bool CustomTextureExist(int archive, int record, int frame)
+        {
+            if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
+                && File.Exists(Application.persistentDataPath + "/textures/" + archive.ToString() + "_" + record.ToString() + "-" + frame.ToString() + ".png"))
+                return true;
+
+            return false;
+        }
+
+        /// import custom image as texture2D
+        /// <returns>Texture2D</returns>
+        static public Texture2D LoadCustomTexture(int archive, int record, int frame)
+        {
+            Texture2D tex = new Texture2D(2, 2); //create empty texture, size will be the actual size of .png file
+
+            //load image as Texture2D
+            tex.LoadImage(File.ReadAllBytes(Application.persistentDataPath + "/textures/" + archive.ToString() + "_" + record.ToString() + "-" + frame.ToString() + ".png"));
+
+            return tex; //assign image to the actual texture
+        }
+
+        /// <summary>
+        /// Load custom image files from disk to replace .IMGs. Useful for customizing the UI
+        /// .png files are located in persistentdata/textures/img
+        /// and are named 'imagefile.png' 
+        /// for example 'REST02I0.IMG.png'
+        /// </summary>
+        /// <param name="filename">Name of standalone file as it appears in arena2 folder.</param>
+
+        /// check if file exist on disk. 
+        /// <returns>Bool</returns>
+        static public bool CustomImageExist(string filename)
+        {
+
+            if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
+                && File.Exists(Application.persistentDataPath + "/textures/img/" + filename + ".png"))
+                return true;
+
+            return false;
+        }
+
+        /// load custom image as texture2D
+        /// <returns>Texture2D.</returns>
+        static public Texture2D LoadCustomImage(string filename)
+        {
+            Texture2D tex = new Texture2D(2, 2); //create empty texture, size will be the actual size of .png file
+
+            //load image as Texture2D
+            tex.LoadImage(File.ReadAllBytes(Application.persistentDataPath + "/textures/img/" + filename + ".png"));
+
+            return tex; //assign image to the actual texture
+        }
+
+        /// <summary>
+        /// Load custom image files from disk to replace .CIFs and .RCIs
+        /// .png files are located in persistentdata/textures/cif
+        /// and are named 'CifFile_record-frame.png' 
+        /// for example 'INVE16I0.CIF_1-0.png'
+        /// </summary>
+        /// <param name="filename">Name of standalone file as it appears in arena2 folder.</param>
+        /// <param name="record">Record index.</param>
+        /// <param name="frame">Frame index. It's different than zero only for weapon animations (WEAPONXX.CIF) </param>
+
+        /// check if file exist on disk. 
+        /// <returns>Bool</returns>
+        static public bool CustomCifExist(string filename, int record, int frame)
+        {
+
+            if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
+                && File.Exists(Application.persistentDataPath + "/textures/cif/" + filename + "_" + record.ToString() + "-" + frame.ToString() + ".png"))
+                return true;
+
+            return false;
+        }
+
+        /// load custom image as texture2D
+        /// <returns>Texture2D.</returns>
+        static public Texture2D LoadCustomCif(string filename, int record, int frame)
+        {
+            Texture2D tex = new Texture2D(2, 2); //create empty texture, size will be the actual size of .png file
+
+            //load image as Texture2D
+            tex.LoadImage(File.ReadAllBytes(Application.persistentDataPath + "/textures/cif/" + filename + "_" + record.ToString() + "-" + frame.ToString() + ".png"));
+
+            return tex; //assign image to the actual texture
+        }
+
+        /// <summary>
+        /// Load custom image files from disk to use as emission maps
+        /// This is useful for walls, where only the windows emits light
+        /// .png files are located in persistentData/textures
+        /// and are named 'archive_record-frame_Emission.png' 
+        /// for example '112_3-0_Emission.png'
+        /// </summary>
+        /// <param name="archive">Archive index from TEXTURE.XXX</param>
+        /// <param name="record">Record index.</param>
+        /// <param name="frame">Frame index. It's different than zero only for animated billboards</param>
+
+        /// check if file exist on disk. 
+        /// <returns>Bool</returns>
+        static public bool CustomEmissionExist(int archive, int record, int frame)
+        {
+            if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
+                && File.Exists(Application.persistentDataPath + "/textures/" + archive.ToString() + "_" + record.ToString() + "-" + frame.ToString() + "_Emission.png"))
+                return true;
+
+            return false;
+        }
+
+        /// import custom image as texture2D
+        /// <returns>Texture2D</returns>
+        static public Texture2D LoadCustomEmission(int archive, int record, int frame)
+        {
+            Texture2D tex = new Texture2D(2, 2); //create empty texture, size will be the actual size of .png file
+
+            //load image as Texture2D
+            tex.LoadImage(File.ReadAllBytes(Application.persistentDataPath + "/textures/" + archive.ToString() + "_" + record.ToString() + "-" + frame.ToString() + "_Emission.png"));
+
+            return tex; //assign image to the actual texture
+        }
+    }
+}

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -642,11 +642,19 @@ namespace DaggerfallWorkshop.Game
             if (!dfUnity.IsReady)
                 return null;
 
-            ImgFile imgFile = new ImgFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, true);
-            imgFile.LoadPalette(Path.Combine(dfUnity.Arena2Path, imgFile.PaletteName));
-            Texture2D texture = GetTextureFromImg(imgFile, format);
-            texture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            ImgFile imgFile = new ImgFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, true);            
+            Texture2D texture = null;
 
+            // Texture packs support
+            if (DFTextureReplacement.CustomImageExist(name))
+                texture = DFTextureReplacement.LoadCustomImage(name);
+            else
+            {
+                imgFile.LoadPalette(Path.Combine(dfUnity.Arena2Path, imgFile.PaletteName));
+                texture = GetTextureFromImg(imgFile, format);
+            }
+                
+            texture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             offset = imgFile.ImageOffset;
 
             return texture;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -120,7 +120,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.HorizontalAlignment = HorizontalAlignment.Center;
             mainPanel.BackgroundTexture = baseTexture;
             mainPanel.Position = new Vector2(0, 50);
-            mainPanel.Size = new Vector2(baseTexture.width, baseTexture.height);
+            mainPanel.Size = new Vector2(ImageReader.GetImageData("REST00I0.IMG", 0, 0, false, false).width, ImageReader.GetImageData("REST00I0.IMG", 0, 0, false, false).height);
+
             NativePanel.Components.Add(mainPanel);
 
             // Create buttons

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -69,6 +69,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox realtimeReflections;
         Checkbox tallGrass;
         Checkbox flyingBirds;
+        Checkbox meshAndTextureReplacement;
 
         Color unselectedTextColor = new Color(0.6f, 0.6f, 0.6f, 1f);
         Color selectedTextColor = new Color(0.0f, 0.8f, 0.0f, 1.0f);
@@ -458,6 +459,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             realtimeReflections = AddOption(x, "Realtime Reflections (Nystul)", "Realtime reflections on water and select surfaces", DaggerfallUnity.Settings.Nystul_RealtimeReflections);
             tallGrass = AddOption(x, "Tall Grass (Uncanny_Valley)", "Animated tall grass", DaggerfallUnity.Settings.UncannyValley_RealGrass);
             flyingBirds = AddOption(x, "Flying Birds (Uncanny Valley)", "Animated flying birds", DaggerfallUnity.Settings.UncannyValley_BirdsInDaggerfall);
+            meshAndTextureReplacement = AddOption(x, "Support for texture packs", "Enable replacement of textures", DaggerfallUnity.Settings.MeshAndTextureReplacement);
 
             // Add mod note
             string modNote = "Note: Enabling mods can increase performance requirements";
@@ -706,6 +708,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.Nystul_RealtimeReflections = realtimeReflections.IsChecked;
             DaggerfallUnity.Settings.UncannyValley_RealGrass = tallGrass.IsChecked;
             DaggerfallUnity.Settings.UncannyValley_BirdsInDaggerfall = flyingBirds.IsChecked;
+            DaggerfallUnity.Settings.MeshAndTextureReplacement = meshAndTextureReplacement.IsChecked;
 
             DaggerfallUnity.Settings.SaveSettings();
             moveNextStage = true;

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -221,7 +221,7 @@ namespace DaggerfallWorkshop
                     doors.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, entryDoor.blockIndex, entryDoor.recordIndex, modelMatrix));
 
                 // Combine or add
-                if (dfUnity.Option_CombineRMB)
+                if (dfUnity.Option_CombineRMB && !DFMeshReplacement.ReplacmentModelExist(obj.ModelIdNum))
                 {
                     combiner.Add(ref modelData, modelMatrix);
                 }
@@ -269,6 +269,12 @@ namespace DaggerfallWorkshop
             markers.Clear();
             foreach (DFBlock.RmbBlockFlatObjectRecord obj in recordData.Interior.BlockFlatObjectRecords)
             {
+                // use 3d model instead of flat
+                if (DFMeshReplacement.ReplacementFlatExist(obj.TextureArchive, obj.TextureRecord))
+                    DFMeshReplacement.LoadReplacementFlat(obj.TextureArchive, obj.TextureRecord, new Vector3(obj.XPos, -obj.YPos, obj.ZPos) * MeshReader.GlobalScale, node.transform);
+                // use billboard
+                else
+                {
                 // Spawn billboard gameobject
                 GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(obj.TextureArchive, obj.TextureRecord, node.transform);
 
@@ -288,6 +294,7 @@ namespace DaggerfallWorkshop
                 if (obj.TextureArchive == TextureReader.LightsTextureArchive)
                 {
                     AddLight(obj, go.transform);
+                }
                 }
             }
         }
@@ -523,7 +530,6 @@ namespace DaggerfallWorkshop
 
             // TODO: Could also adjust light colour and intensity, or change prefab entirely above for any obj.TextureRecord
         }
-
         /// <summary>
         /// Add interior people flats.
         /// </summary>

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -315,6 +315,26 @@ namespace DaggerfallWorkshop
 
             // Get texture
             GetTextureResults results = textureReader.GetTexture2D(settings, AlphaTextureFormat, NonAlphaTextureFormat);
+
+            /// import custom textures
+            // TODO: normal maps 
+            if (DFTextureReplacement.CustomTextureExist(archive, record, frame))
+            {
+                // main texture
+                results.albedoMap = DFTextureReplacement.LoadCustomTexture(archive, record, frame);
+
+                // emission map
+                // windowed walls use a custom emission map or stick with vanilla
+                // non-window use the main texture as emission, unless a custom map is provided
+                if (results.isEmissive)
+                {
+                    if (DFTextureReplacement.CustomEmissionExist(archive, record, frame)) //import emission texture
+                        results.emissionMap = DFTextureReplacement.LoadCustomEmission(archive, record, frame);
+                    else if (!results.isWindow) //reuse albedo map for basic colour emission
+                        results.emissionMap = results.albedoMap;
+                } 
+            } 
+
             rectOut = results.singleRect;
 
             // Create material

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -117,6 +117,7 @@ namespace DaggerfallWorkshop
         public bool Nystul_RealtimeReflections { get; set; }
         public bool UncannyValley_RealGrass { get; set; }
         public bool UncannyValley_BirdsInDaggerfall { get; set; }
+        public bool MeshAndTextureReplacement { get; set; }
 
         #endregion
 
@@ -176,6 +177,7 @@ namespace DaggerfallWorkshop
             Nystul_RealtimeReflections = GetBool(sectionEnhancements, "Nystul_RealtimeReflections");
             UncannyValley_RealGrass = GetBool(sectionEnhancements, "UncannyValley_RealGrass");
             UncannyValley_BirdsInDaggerfall = GetBool(sectionEnhancements, "UncannyValley_BirdsInDaggerfall");
+            MeshAndTextureReplacement = GetBool(sectionEnhancements, "MeshAndTextureReplacement");
         }
 
         /// <summary>
@@ -229,6 +231,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionEnhancements, "Nystul_RealtimeReflections", Nystul_RealtimeReflections);
             SetBool(sectionEnhancements, "UncannyValley_RealGrass", UncannyValley_RealGrass);
             SetBool(sectionEnhancements, "UncannyValley_BirdsInDaggerfall", UncannyValley_BirdsInDaggerfall);
+            SetBool(sectionEnhancements, "MeshAndTextureReplacement", MeshAndTextureReplacement);
 
             // Write settings to persistent file
             WriteSettingsFile();

--- a/Assets/Scripts/Utility/ImageReader.cs
+++ b/Assets/Scripts/Utility/ImageReader.cs
@@ -220,6 +220,14 @@ namespace DaggerfallWorkshop.Utility
                     imageData.offset = imgFile.ImageOffset;
                     imageData.scale = new DFSize();
                     imageData.size = imgFile.GetSize(0);
+
+                    // texture pack support
+                    if ((DFTextureReplacement.CustomImageExist(filename)) && (createTexture))
+                    {
+                        imageData.texture = DFTextureReplacement.LoadCustomImage(filename);
+                        createTexture = false;
+                    }
+
                     break;
 
                 case ImageTypes.CIF:
@@ -230,6 +238,14 @@ namespace DaggerfallWorkshop.Utility
                     imageData.offset = cifFile.GetOffset(record);
                     imageData.scale = new DFSize();
                     imageData.size = cifFile.GetSize(record);
+
+                    // texture pack support
+                    if ((DFTextureReplacement.CustomCifExist(filename, record, frame)) && (createTexture))
+                    {
+                        imageData.texture = DFTextureReplacement.LoadCustomCif(filename, record, frame);
+                        createTexture = false;
+                    }
+
                     break;
 
                 default:

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -559,7 +559,7 @@ namespace DaggerfallWorkshop.Utility
                         // Add or combine
                         GameObject standaloneObject = null;
                         Transform parent = (hasAction) ? actionModelsParent : modelsParent;
-                        if (combiner == null || hasAction)
+                        if (combiner == null || hasAction || DFMeshReplacement.ReplacmentModelExist(modelId)) 
                         {
                             standaloneObject = AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent, hasAction);
                             standaloneObject.GetComponent<DaggerfallMesh>().SetDungeonTextures(textureTable);

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -457,7 +457,7 @@ namespace DaggerfallWorkshop.Utility
                         doorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, recordCount, modelMatrix));
 
                     // Add or combine
-                    if (combiner == null || IsCityGate(obj.ModelIdNum))
+                    if (combiner == null || IsCityGate(obj.ModelIdNum) || DFMeshReplacement.ReplacmentModelExist(obj.ModelIdNum))
                         AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent);
                     else
                         combiner.Add(ref modelData, modelMatrix);
@@ -494,7 +494,7 @@ namespace DaggerfallWorkshop.Utility
                     doorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, 0, modelMatrix));
 
                 // Add or combine
-                if (combiner == null)
+                if (combiner == null || DFMeshReplacement.ReplacmentModelExist(obj.ModelIdNum))
                     AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent);
                 else
                     combiner.Add(ref modelData, modelMatrix);


### PR DESCRIPTION
Mesh replacement 
-------------------
(by Uncanny_Valley)
Enable replacement of vanilla 3d models with custom meshes, and flats with custom prefabs.
Models and respective materials need to be placed in Resources during compile.

Texture replacement
----------------------
Enable real-time import of custom textures and images.
* textures for (vanilla) models:
_archive_record-frame.png_ (ex: 9_1-0.png) -and, if necessary, _archive_record-frame_Emission.png_- in
Application.persistentDataPath/textures
* .IMGs:
_imagefile.png_ (ex: REST02I0.IMG.png) in
Application.persistentDataPath/textures/img
* .CIFs and .RCIs:
_CifFile_record-frame.png_ (ex: INVE16I0.CIF_1-0.png) in
Application.persistentDataPath/textures/cif