### PR TITLE
Compute attacks from mouse gestures

### DIFF
--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -196,9 +196,7 @@ namespace DaggerfallWorkshop.Game.Utility
 
             // Weapon swing settings
             WeaponManager weaponManager = GameManager.Instance.WeaponManager;
-            weaponManager.HorizontalThreshold = DaggerfallUnity.Settings.WeaponSwingThreshold;
-            weaponManager.VerticalThreshold = DaggerfallUnity.Settings.WeaponSwingThreshold;
-            weaponManager.TriggerCount = DaggerfallUnity.Settings.WeaponSwingTriggerCount;
+            weaponManager.SwingThreshold = DaggerfallUnity.Settings.WeaponSwingThreshold;
 
             // Weapon hand settings
             // Only supporting left-hand rendering for now

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -96,7 +96,6 @@ namespace DaggerfallWorkshop
         public bool HeadBobbing { get; set; }
         public int Handedness { get; set; }
         public float WeaponSwingThreshold { get; set; }
-        public int WeaponSwingTriggerCount { get; set; }
         public float WeaponSensitivity { get; set; }
 
         // [Startup]
@@ -107,7 +106,6 @@ namespace DaggerfallWorkshop
         // [Experimental]
         public bool HQTooltips { get; set; }
         public int TerrainDistance { get; set; }
-        public bool DebugWeaponSwings { get; set; }
 
         // [Enhancements]
         public bool LypyL_GameConsole { get; set; }
@@ -162,13 +160,11 @@ namespace DaggerfallWorkshop
             HeadBobbing = GetBool(sectionControls, "HeadBobbing");
             Handedness = GetInt(sectionControls, "Handedness", 0, 3);
             WeaponSwingThreshold = GetFloat(sectionControls, "WeaponSwingThreshold", 0.1f, 1.0f);
-            WeaponSwingTriggerCount = GetInt(sectionControls, "WeaponSwingTriggerCount", 1, 10);
             WeaponSensitivity = GetFloat(sectionControls, "WeaponSensitivity", 0.1f, 10.0f);
             StartCellX = GetInt(sectionStartup, "StartCellX", 2, 997);
             StartCellY = GetInt(sectionStartup, "StartCellY", 2, 497);
             StartInDungeon = GetBool(sectionStartup, "StartInDungeon");
             HQTooltips = GetBool(sectionExperimental, "HQTooltips");
-            DebugWeaponSwings = GetBool(sectionExperimental, "DebugWeaponSwings");
             TerrainDistance = GetInt(sectionExperimental, "TerrainDistance", 1, 4);
             LypyL_GameConsole = GetBool(sectionEnhancements, "LypyL_GameConsole");
             LypyL_ModSystem = GetBool(sectionEnhancements, "LypyL_ModSystem");
@@ -216,13 +212,11 @@ namespace DaggerfallWorkshop
             SetBool(sectionControls, "HeadBobbing", HeadBobbing);
             SetInt(sectionControls, "Handedness", Handedness);
             SetFloat(sectionControls, "WeaponSwingThreshold", WeaponSwingThreshold);
-            SetInt(sectionControls, "WeaponSwingTriggerCount", WeaponSwingTriggerCount);
             SetFloat(sectionControls, "WeaponSensitivity", WeaponSensitivity);
             SetInt(sectionStartup, "StartCellX", StartCellX);
             SetInt(sectionStartup, "StartCellY", StartCellY);
             SetBool(sectionStartup, "StartInDungeon", StartInDungeon);
             SetBool(sectionExperimental, "HQTooltips", HQTooltips);
-            SetBool(sectionExperimental, "DebugWeaponSwings", DebugWeaponSwings);
             SetInt(sectionExperimental, "TerrainDistance", TerrainDistance);
             SetBool(sectionEnhancements, "LypyL_GameConsole", LypyL_GameConsole);
             SetBool(sectionEnhancements, "LypyL_ModSystem", LypyL_ModSystem);


### PR DESCRIPTION
Mouse movement is now tracked as a gesture. The travel distance and final gesture vector is used to compute the angle of attack.

Practically, this doesn't feel much different from the original way of computing weapon attacks. Initially this was an attempt to get attacks working nicely on a trackpad, but after some thought I think the trackpad compatibility is more about tweaking the sensitivity and threshold values.

The advantage of this approach is gives a bit more control over how attacks can be initiated, how angles are computed, and gives a more natural abstraction of the user input to control (no longer have to maintain the same mouse direction over N frames/cycles).