### PR TITLE
Implement stat-based player hand-to-hand damage

### DIFF
--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -481,7 +481,22 @@ namespace DaggerfallWorkshop.Game
 
                 // TODO: Use correct damage based on weapon and swing type
                 // Just using fudge values during development
-                int damage = Random.Range(1, 25);
+                int damage_low = 1;
+                int damage_high = 24;
+
+                // Hand-to-hand damage formula based on Daggerfall Chronicles and testing original game.
+                // Daggerfall Chronicles table lists hand-to-hand skills of 80 and above (45 through 79 are omitted)
+                // as if they cause 2 to be added to damage_high instead of 1, but the hand-to-hand damage display in the
+                // character sheet in the original game contradicts this.
+                // From some quick testing in original Daggerfall there didn't seem to be a difference in damage from swing type
+                if (weapon.WeaponType == WeaponTypes.Melee)
+                {
+                    int skill = playerEntity.Skills.HandToHand;
+                    damage_low = (skill / 10) + 1;
+                    damage_high = (skill / 5) + 1;
+                }
+                
+                int damage = Random.Range(damage_low, damage_high + 1);
 
                 //// Check if hit has an EnemyHealth
                 //// This is part of the old Demo code and will eventually be removed

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -183,27 +183,40 @@ namespace DaggerfallWorkshop.Game
             ShowWeapons(false);
         }
 
-        public int CalculateWeaponDamage(WeaponTypes weaponType, MetalTypes metalType)
+        public int CalculateWeaponMinDamage(WeaponTypes weaponType, MetalTypes metalType)
         {
-            // Fudge values, to be replaced
+            // Temp value, to be replaced
             int damage_low = 1;
-            int damage_high = 24;
 
-            // Hand-to-hand damage formula based on Daggerfall Chronicles and testing original game.
-            // Daggerfall Chronicles table lists hand-to-hand skills of 80 and above (45 through 79 are omitted)
-            // as if they cause 2 to be added to damage_high instead of 1, but the hand-to-hand damage display
-            // in the in-game character sheet contradicts this.
-            // From testing in original Daggerfall there didn't seem to be a difference in damage from swing type.
+            // Hand-to-hand damage formula from Daggerfall Chronicles and testing
             if (weaponType == WeaponTypes.Melee)
             {
                 int skill = playerEntity.Skills.HandToHand;
                 damage_low = (skill / 10) + 1;
-                damage_high = (skill / 5) + 1;
             }
-            return Random.Range(damage_low, damage_high + 1);
+
+            return damage_low;
         }
 
-        public void Reset()
+        public int CalculateWeaponMaxDamage(WeaponTypes weaponType, MetalTypes metalType)
+        {
+            // Temp value, to be replaced
+            int damage_high = 24;
+
+            // Hand-to-hand damage formula from Daggerfall Chronicles and testing
+            // Daggerfall Chronicles table lists hand-to-hand skills of 80 and above (45 through 79 are omitted)
+            // as if they cause 2 to be added to damage_high instead of 1, but the hand-to-hand damage display
+            // in the in-game character sheet contradicts this.
+            if (weaponType == WeaponTypes.Melee)
+            {
+                int skill = playerEntity.Skills.HandToHand;
+                damage_high = (skill / 5) + 1;
+            }
+
+            return damage_high;
+        }
+
+    public void Reset()
         {
             usingRightHand = true;
             holdingShield = false;
@@ -414,6 +427,24 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
+        private int CalculateWeaponDamage(FPSWeapon weapon)
+        {          
+            int damage_low = CalculateWeaponMinDamage(weapon.WeaponType, weapon.MetalType);
+            int damage_high = CalculateWeaponMaxDamage(weapon.WeaponType, weapon.MetalType);
+            int damage = Random.Range(damage_low, damage_high + 1);
+
+            // Apply the strength modifier. Testing in original Daggerfall shows hand-to-hand ignores it.
+            if (weapon.WeaponType != WeaponTypes.Melee)
+            {
+                int strengthModifier = (playerEntity.Stats.Strength / 10) - 5;
+
+                // Weapons can do 0 damage. Causes no blood or hit sound in original Daggerfall.
+                damage = Mathf.Max(0, damage + strengthModifier);
+            }
+
+            return damage;
+        }
+
         private bool IsPassive(float value, float threshold)
         {
             if (value > -threshold && value < threshold)
@@ -502,17 +533,10 @@ namespace DaggerfallWorkshop.Game
                 // TODO: Use correct damage based on weapon and swing type
                 // Just using fudge values during development
 
-                // Get damage before strength modifier
-                int damage = CalculateWeaponDamage(weapon.WeaponType, weapon.MetalType);
+                // Calculate damage
+                int damage = CalculateWeaponDamage(weapon);
 
-                // Apply the strength modifier. Testing in original Daggerfall shows hand-to-hand ignores it
-                if (weapon.WeaponType != WeaponTypes.Melee)
-                {
-                    int strengthModifier = (playerEntity.Stats.Strength / 10) - 5;
-
-                    // Weapons can do 0 damage (no blood or hit sound in original Daggerfall)
-                    damage = Mathf.Max(0, damage + strengthModifier);
-                }
+                Debug.Log(damage);
 
                 //// Check if hit has an EnemyHealth
                 //// This is part of the old Demo code and will eventually be removed


### PR DESCRIPTION
Simply implements hand-to-hand damage based on what the Daggerfall Chronicles says. I also did some quick testing in original Daggerfall and there was no difference in the number of hand-to-hand hits it took to kill an enemy with an up-to-down hit and a down-to-up hit, so I think all hand-to-hand hits might be the same.