### PR TITLE
Fix fast weather switching

### DIFF
--- a/Assets/Scripts/Game/WeatherManager.cs
+++ b/Assets/Scripts/Game/WeatherManager.cs
@@ -51,11 +51,10 @@ namespace DaggerfallWorkshop.Game
         [Range(0, 1)]
         public float HeavyFogDensity = 0.05f;
 
-        public float PollWeatherInSeconds = 30f;
-
         DaggerfallUnity _dfUnity;
         float _pollTimer;
         private WeatherTable _weatherTable;
+        private float _pollWeatherInSeconds = 30f;
 
         public bool IsRaining { get; private set; }
 
@@ -246,7 +245,7 @@ namespace DaggerfallWorkshop.Game
         {
             // Increment poll timer
             _pollTimer += Time.deltaTime;
-            if (_pollTimer < PollWeatherInSeconds)
+            if (_pollTimer < _pollWeatherInSeconds)
                 return;
 
             // Reset timer


### PR DESCRIPTION
If the field is public, it gets set to 4s for some reason. Nothing in the code directly accessed this so it seems to be something Unity is doing.