### PR TITLE
Mesh and Texture replacement - check integrity of materials

### DIFF
--- a/Assets/Scripts/DFMeshReplacement.cs
+++ b/Assets/Scripts/DFMeshReplacement.cs
@@ -15,8 +15,14 @@ using DaggerfallWorkshop.Utility;
 
 namespace DaggerfallWorkshop
 {
+    /// <summary>
+    /// Handles import and injection of custom meshes and materials
+    /// with the purpose of providing modding support.
+    /// </summary>
     static public class DFMeshReplacement
     {
+        #region asset-injection
+
         /// <summary>
         /// Check existence of model in Resources
         /// </summary>
@@ -59,42 +65,42 @@ namespace DaggerfallWorkshop
         // Models (mesh + materials)
         static public Mesh LoadReplacementModel(uint modelID, ref CachedMaterial[] cachedMaterialsOut)
         {
+            // Import mesh
             GameObject object3D = Resources.Load("Models/" + modelID.ToString() + "/" + modelID.ToString()) as GameObject;
+
+            // Import materials
             cachedMaterialsOut = new CachedMaterial[object3D.GetComponent<MeshRenderer>().sharedMaterials.Length];
 
+            string materialPath;
+
             // If it's not winter or the model doesn't have a winter version, it loads default materials
-            // "Material_x" where x go from zero to (number of materials)-1
             if ((DaggerfallUnity.Instance.WorldTime.Now.SeasonValue != DaggerfallDateTime.Seasons.Winter) || (Resources.Load("Models/" + modelID.ToString() + "/material_w_0") == null))
+                materialPath = "/material_";
+            // If it's winter and the model has a winter version, it loads winter materials
+            else
+                materialPath = "/material_w_";
+
+            for (int i = 0; i < cachedMaterialsOut.Length; i++)
             {
-                for (int i = 0; i < cachedMaterialsOut.Length; i++)
+                if (Resources.Load("Models/" + modelID.ToString() + materialPath + i) != null)
                 {
-                    if (Resources.Load("Models/" + modelID.ToString() + "/material_" + i) != null)
-                    {
-                        cachedMaterialsOut[i].material = Resources.Load("Models/" + modelID.ToString() + "/material_" + i) as Material;
+                    cachedMaterialsOut[i].material = Resources.Load("Models/" + modelID.ToString() + materialPath + i) as Material;
+                    if (cachedMaterialsOut[i].material.mainTexture != null)
                         cachedMaterialsOut[i].material.mainTexture.filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode; //assign texture filtermode as user settings
-                    }
+                    else
+                        Debug.LogError("Custom model " + modelID + " is missing a texture");
                 }
+                else
+                    Debug.LogError("Custom model " + modelID + " is missing a material");
             }
 
-            // If it's winter and the model has a winter version, it loads winter materials
-            // "Material_w_x" where x go from zero to (number of materials)-1
-            else
-            {
-                for (int i = 0; i < cachedMaterialsOut.Length; i++)
-                {
-                    if (Resources.Load("Models/" + modelID.ToString() + "/material_w_" + i) != null)
-                    {
-                        cachedMaterialsOut[i].material = Resources.Load("Models/" + modelID.ToString() + "/material_w_" + i) as Material;
-                        cachedMaterialsOut[i].material.mainTexture.filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode; //assign texture filtermode as user settings
-                    }
-                }
-            }
             return object3D.GetComponent<MeshFilter>().sharedMesh;
         }
 
         // Models (prefabs)
         static public void LoadReplacementPrefab(uint modelID, Vector3 position, Transform parent, Quaternion rotation)
         {
+            // Import GameObject
             GameObject object3D = null;
 
             // If it's not winter or the model doesn't have a winter version, it loads default prefab
@@ -108,22 +114,41 @@ namespace DaggerfallWorkshop
             object3D.transform.parent = parent;
             object3D.transform.position = position;
             object3D.transform.rotation = rotation;
-            
-            // Assign texture filtermode as user settings
-            for (int i=0; i < object3D.GetComponent<Renderer>().materials.Length; i++)
-                object3D.GetComponent<Renderer>().materials[i].mainTexture.filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
+
+            FinaliseCustomGameObject(ref object3D, modelID.ToString());
         }
 
         // Billboards
         static public void LoadReplacementFlat(int archive, int record, Vector3 position, Transform parent)
         {
+            // Import GameObject
             GameObject object3D = GameObject.Instantiate(Resources.Load("Flats/" + archive.ToString() + "_" + record.ToString() + "/" + archive.ToString() + "_" + record.ToString()) as GameObject);
+
+            // Position
             object3D.transform.parent = parent;
             object3D.transform.localPosition = position;
 
-            // Assign texture filtermode as user settings
-            for (int i = 0; i < object3D.GetComponent<Renderer>().materials.Length; i++)
-                object3D.GetComponent<Renderer>().materials[i].mainTexture.filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
+            FinaliseCustomGameObject(ref object3D, archive.ToString() + "_" + record.ToString());
         }
+
+        #endregion
+        
+        #region Utilities
+
+        /// <summary>
+        /// Assign texture filtermode as user settings and check integrity of materials
+        /// </summary>
+        static public void FinaliseCustomGameObject(ref GameObject object3D, string ModelName)
+        {
+            for (int i = 0; i < object3D.GetComponent<Renderer>().materials.Length; i++)
+            {
+                if (object3D.GetComponent<Renderer>().materials[i].mainTexture != null)
+                    object3D.GetComponent<Renderer>().materials[i].mainTexture.filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
+                else
+                    Debug.LogError("Custom model " + ModelName + " is missing a material or a texture");
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
* Avoid assigning filtermode in case of a missing material or texture,
which would cause a NullReferenceException and consequently would break
the entire placement of models in the given area.

* Minor changes to organization of code.