### PR TITLE
Mesh and Texture replacement - animated billboards

### DIFF
--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -260,9 +260,9 @@ namespace DaggerfallWorkshop.Utility
             DaggerfallBillboard dfBillboard = go.AddComponent<DaggerfallBillboard>();
             dfBillboard.SetMaterial(archive, record);
 
-            // Import custom texture
-            if (DFTextureReplacement.CustomTextureExist(archive, record, 0))
-                DFTextureReplacement.LoadCustomBillboardTexture(archive, record, ref go);
+            // Import custom texture(s)
+            if (DFTextureReplacement.CustomTextureExist(archive, record))
+                DFTextureReplacement.LoadCustomBillboardTexture(ref go, archive, record);
 
             return go;
         }


### PR DESCRIPTION
I enabled import of custom textures for statics billboards in interiors a few days ago, now this introduce support for animations, too.

The user can import any number of texture to be used as frames, independently from the original number used in Daggerfall, and it is possible to import emission maps, which i see it could be pretty useful for texture artists.
https://i.imgur.com/G5bn52P.png

I haven't enabled import of normal maps instead, because i'm not sure how they could be of any help for sprites. Do you think i should do it?

It's to note that textures are placed on original billboard meshes so they look fine as long as they have the same proportions as originals. Maybe in the future we can provide even more possibility of customization using XML files as you suggested and creating custom gameobjects.