### PR TITLE
Recreate classic Daggerfall's music playlists

### DIFF
--- a/Assets/Game/Addons/ReflectionsMod/Resources/configInjectionTextures.ini.txt
+++ b/Assets/Game/Addons/ReflectionsMod/Resources/configInjectionTextures.ini.txt
@@ -183,7 +183,7 @@ useMetallicGlossMap = false
 reflectivity = 0.16
 smoothness = 0.72
 
-[044_3 {House and Palace Ground Texture (Desert)}]
+[044_3 {House and Castle Ground Texture (Desert)}]
 textureArchive = 044
 textureRecord = 3
 textureFrame = 0

--- a/Assets/Game/Addons/ReflectionsMod/Scripts/InjectReflectiveMaterialProperty.cs
+++ b/Assets/Game/Addons/ReflectionsMod/Scripts/InjectReflectiveMaterialProperty.cs
@@ -32,7 +32,7 @@ namespace ReflectionsMod
         private Texture texReflectionGround = null;
         private Texture texReflectionLowerLevel = null;
         private bool playerInside = false;
-        private enum InsideSpecification { Building, DungeonOrPalace, Unknown };
+        private enum InsideSpecification { Building, DungeonOrCastle, Unknown };
         InsideSpecification whereInside = InsideSpecification.Unknown;
         private GameObject gameObjectInterior = null;
         private GameObject gameObjectDungeon = null;
@@ -162,7 +162,7 @@ namespace ReflectionsMod
             if ((texReflectionGround) && (texReflectionLowerLevel)) // do not change playerInside state before the reflection textures are initialized
             {
                 // mechanism implemented according to Interkarma's suggestions
-                // transition: inside -> dungeon/palace/building
+                // transition: inside -> dungeon/castle/building
                 if (GameManager.Instance.PlayerEnterExit.IsPlayerInside && !playerInside)
                 {
                     playerInside = true; // player now inside
@@ -173,15 +173,15 @@ namespace ReflectionsMod
                         gameObjectInterior = GameObject.Find("Interior");
                         whereInside = InsideSpecification.Building;
                     }
-                    else if ((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsidePalace))
+                    else if ((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsideCastle))
                     {
                         gameObjectDungeon = GameObject.Find("Dungeon");
-                        whereInside = InsideSpecification.DungeonOrPalace;
+                        whereInside = InsideSpecification.DungeonOrCastle;
                     }
 
                     InjectMaterialPropertiesIndoor();
                 }
-                // transition: dungeon/palace/building -> outside
+                // transition: dungeon/castle/building -> outside
                 else if (!GameManager.Instance.PlayerEnterExit.IsPlayerInside && playerInside)
                 {
                     playerInside = false; // player no longer inside
@@ -193,8 +193,8 @@ namespace ReflectionsMod
                     whereInside = InsideSpecification.Unknown;
                 }
 
-                // transition: dungeon/palace -> building
-                if ((GameManager.Instance.IsPlayerInsideBuilding) && (whereInside == InsideSpecification.DungeonOrPalace))
+                // transition: dungeon/castle -> building
+                if ((GameManager.Instance.IsPlayerInsideBuilding) && (whereInside == InsideSpecification.DungeonOrCastle))
                 {
                     gameObjectInterior = GameObject.Find("Interior");
                     gameObjectDungeon = null;
@@ -202,13 +202,13 @@ namespace ReflectionsMod
                     //injectIndoor = true;
                     whereInside = InsideSpecification.Building;
                 }
-                // transition: building -> dungeon/palace
-                else if (((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsidePalace)) && (whereInside == InsideSpecification.Building))
+                // transition: building -> dungeon/castle
+                else if (((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsideCastle)) && (whereInside == InsideSpecification.Building))
                 {
                     gameObjectDungeon = GameObject.Find("Dungeon");
                     gameObjectInterior = null;
                     InjectMaterialPropertiesIndoor();
-                    whereInside = InsideSpecification.DungeonOrPalace;
+                    whereInside = InsideSpecification.DungeonOrCastle;
                 }
             }
             else
@@ -350,7 +350,7 @@ namespace ReflectionsMod
             {
                 renderers = gameObjectInterior.GetComponentsInChildren<Renderer>();
             }
-            else if (GameManager.Instance.IsPlayerInsideDungeon || GameManager.Instance.IsPlayerInsidePalace)
+            else if (GameManager.Instance.IsPlayerInsideDungeon || GameManager.Instance.IsPlayerInsideCastle)
             {
                 renderers = gameObjectDungeon.GetComponentsInChildren<Renderer>();
             }

--- a/Assets/Scripts/API/DFLocation.cs
+++ b/Assets/Scripts/API/DFLocation.cs
@@ -205,7 +205,7 @@ namespace DaggerfallConnect
             Exterior_Barn_Snow = 172,
 
             // Interior sets
-            Interior_PalaceInt = 11,
+            Interior_CastleInt = 11,
             Interior_CityInt = 16,
             Interior_CryptA = 19,
             Interior_CryptB = 20,

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -25,7 +25,7 @@ namespace DaggerfallWorkshop.Game
         public int MinWaitTime = 4;             // Min wait time in seconds before next sound
         public int MaxWaitTime = 35;            // Max wait time in seconds before next sound
         public AmbientSoundPresets Presets;     // Ambient sound preset
-        public bool doNotPlayInPalace = true;   // Do not play ambient effects in palace blocks
+        public bool doNotPlayInCastle = true;   // Do not play ambient effects in castle blocks
         public bool PlayLightningEffect;        // Play a lightning effect where appropriate
         //public DaggerfallSky SkyForEffects;     // Sky to receive effects
         public Light LightForEffects;           // Light to receive effects
@@ -140,13 +140,13 @@ namespace DaggerfallWorkshop.Game
             }
             else
             {
-                // Do not play ambient effect in palace blocks
-                if (doNotPlayInPalace)
+                // Do not play ambient effect in castle blocks
+                if (doNotPlayInCastle)
                 {
                     PlayerEnterExit playerEnterExit = GameManager.Instance.PlayerEnterExit;
                     if (playerEnterExit)
                     {
-                        if (playerEnterExit.IsPlayerInsideDungeonPalace)
+                        if (playerEnterExit.IsPlayerInsideDungeonCastle)
                             return;
                     }
                 }

--- a/Assets/Scripts/Game/DaggerfallAutomap.cs
+++ b/Assets/Scripts/Game/DaggerfallAutomap.cs
@@ -126,7 +126,7 @@ namespace DaggerfallWorkshop.Game
         {
             dictAutomapDungeonsDiscoveryState = savedDictAutomapDungeonsDiscoveryState;
 
-            if ((GameManager.Instance.IsPlayerInsidePalace)||(GameManager.Instance.IsPlayerInsideDungeon))
+            if ((GameManager.Instance.IsPlayerInsideCastle)||(GameManager.Instance.IsPlayerInsideDungeon))
             {                
                 InitWhenInInteriorOrDungeon(null, true);
                 restoreStateAutomapDungeon();
@@ -307,7 +307,7 @@ namespace DaggerfallWorkshop.Game
             
             gameobjectBeacons.SetActive(false);
 
-            if ((GameManager.Instance.PlayerEnterExit.IsPlayerInside) && ((GameManager.Instance.PlayerEnterExit.IsPlayerInsideBuilding) || (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon) || (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeonPalace)))
+            if ((GameManager.Instance.PlayerEnterExit.IsPlayerInside) && ((GameManager.Instance.PlayerEnterExit.IsPlayerInsideBuilding) || (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon) || (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeonCastle)))
             {
                 // and get rid of lights used to light the automap level geometry
                 UnityEngine.Object.Destroy(gameobjectAutomapKeyLight);
@@ -558,7 +558,7 @@ namespace DaggerfallWorkshop.Game
                     // test if startup was inside dungeon or interior (and no transition event happened)                
                     InitWhenInInteriorOrDungeon();
                     // do initial geometry discovery
-                    if (gameobjectGeometry) // this is necessary since when game starts up it can happen that InitWhenInInteriorOrDungeon() does not create geometry because GameManger.Instance.IsPlayerInsideDungeon and GameManager.Instance.IsPlayerInsidePalace are false
+                    if (gameobjectGeometry) // this is necessary since when game starts up it can happen that InitWhenInInteriorOrDungeon() does not create geometry because GameManger.Instance.IsPlayerInsideDungeon and GameManager.Instance.IsPlayerInsideCastle are false
                     {
                         gameobjectGeometry.SetActive(true); // enable automap level geometry for revealing (so raycasts can hit colliders of automap level geometry)
                         CheckForNewlyDiscoveredMeshes();
@@ -716,7 +716,7 @@ namespace DaggerfallWorkshop.Game
             if (!GameManager.Instance.IsPlayerInside)
                 return;
 
-            if ((gameobjectGeometry != null) && ((GameManager.Instance.IsPlayerInsideBuilding) || (GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsidePalace)))
+            if ((gameobjectGeometry != null) && ((GameManager.Instance.IsPlayerInsideBuilding) || (GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsideCastle)))
             {
                 // enable automap level geometry for revealing (so raycasts can hit colliders of automap level geometry)
                 gameobjectGeometry.SetActive(true);
@@ -896,7 +896,7 @@ namespace DaggerfallWorkshop.Game
         /// will inject materials and properties to MeshRenderer in the proper hierarchy level of automap level geometry GameObject
         /// note: the proper hierarchy level differs between an "Interior" and a "Dungeon" geometry GameObject
         /// </summary>
-        /// <param name="resetDiscoveryState"> if true resets the discovery state for geometry that needs to be discovered (when inside dungeons or palaces) </param>
+        /// <param name="resetDiscoveryState"> if true resets the discovery state for geometry that needs to be discovered (when inside dungeons or castles) </param>
         private void injectMeshAndMaterialProperties(bool resetDiscoveryState = true)
         {
             if (GameManager.Instance.IsPlayerInsideBuilding)
@@ -926,7 +926,7 @@ namespace DaggerfallWorkshop.Game
                     }
                 }
             }
-            else if ((GameManager.Instance.IsPlayerInsideDungeon)||(GameManager.Instance.IsPlayerInsidePalace))
+            else if ((GameManager.Instance.IsPlayerInsideDungeon)||(GameManager.Instance.IsPlayerInsideCastle))
             {
                 // find all MeshRenderers in 4th hierarchy level
                 foreach (Transform elem in gameobjectGeometry.transform)
@@ -1042,7 +1042,7 @@ namespace DaggerfallWorkshop.Game
                 gameObjectEntrancePositionCubeMarker.transform.localScale = new Vector3(0.8f, 0.8f, 0.8f);
             }
 
-            if ((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsidePalace))
+            if ((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsideCastle))
             {
                 // entrance marker to dungeon start marker
                 DaggerfallDungeon dungeon = GameManager.Instance.DungeonParent.GetComponentInChildren<DaggerfallDungeon>();                
@@ -1290,7 +1290,7 @@ namespace DaggerfallWorkshop.Game
                 fillLight.intensity = 0.6f;
                 backLight.intensity = 0.2f;
             }
-            else if ((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsidePalace))
+            else if ((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsideCastle))
             {
                 Light keyLight = gameobjectAutomapKeyLight.GetComponent<Light>();
                 Light fillLight = gameobjectAutomapFillLight.GetComponent<Light>();
@@ -1655,7 +1655,7 @@ namespace DaggerfallWorkshop.Game
                 gameobjectGeometry.SetActive(false);
                 gameobjectBeacons.SetActive(false);
             }
-            else if ((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsidePalace))
+            else if ((GameManager.Instance.IsPlayerInsideDungeon) || (GameManager.Instance.IsPlayerInsideCastle))
             {
                 createDungeonGeometryForAutomap();
                 restoreStateAutomapDungeon(!initFromLoadingSave); // if a save game was loaded, do not reset the revisited state (don't set parameter forceNotVisitedInThisRun to true)

--- a/Assets/Scripts/Game/EnablePlayerTorch.cs
+++ b/Assets/Scripts/Game/EnablePlayerTorch.cs
@@ -39,7 +39,7 @@ namespace DaggerfallWorkshop.Game
             bool enableTorch = false;
             if (!playerEnterExit.IsPlayerInside && dfUnity.WorldTime.Now.IsCityLightsOn)
                 enableTorch = true;
-            if (playerEnterExit.IsPlayerInsideDungeon && !playerEnterExit.IsPlayerInsideDungeonPalace)
+            if (playerEnterExit.IsPlayerInsideDungeon && !playerEnterExit.IsPlayerInsideDungeonCastle)
                 enableTorch = true;
 
             PlayerTorch.SetActive(enableTorch);

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -276,9 +276,9 @@ namespace DaggerfallWorkshop.Game
             get { return PlayerEnterExit.IsPlayerInsideBuilding; }
         }
 
-        public bool IsPlayerInsidePalace
+        public bool IsPlayerInsideCastle
         {
-            get { return PlayerEnterExit.IsPlayerInsideDungeonPalace; }
+            get { return PlayerEnterExit.IsPlayerInsideDungeonCastle; }
         }
 
         #endregion

--- a/Assets/Scripts/Game/PlayerAmbientLight.cs
+++ b/Assets/Scripts/Game/PlayerAmbientLight.cs
@@ -17,8 +17,8 @@ namespace DaggerfallWorkshop.Game
 {
     /// <summary>
     /// Peer this with Player and PlayerEnterExit to change ambient light based on player surroundings.
-    /// For example, Daggerfall scales ambient light up and down in dungeons with palace blocks (e.g. Wayrest).
-    /// Ambient light is dimmed when player leaves palace block and brightened on return.
+    /// For example, Daggerfall scales ambient light up and down in dungeons with castle blocks (e.g. Wayrest).
+    /// Ambient light is dimmed when player leaves castle block and brightened on return.
     /// </summary>
     public class PlayerAmbientLight : MonoBehaviour
     {
@@ -26,7 +26,7 @@ namespace DaggerfallWorkshop.Game
         public Color ExteriorNightAmbientLight = new Color(0.25f, 0.25f, 0.25f);
         public Color InteriorAmbientLight = new Color(0.18f, 0.18f, 0.18f);
         public Color DungeonAmbientLight = new Color(0.12f, 0.12f, 0.12f);
-        public Color PalaceAmbientLight = new Color(0.58f, 0.58f, 0.58f);
+        public Color CastleAmbientLight = new Color(0.58f, 0.58f, 0.58f);
         public float FadeDuration = 3f;
         public float FadeStep = 0.1f;
 
@@ -65,8 +65,8 @@ namespace DaggerfallWorkshop.Game
                 }
                 else if (playerEnterExit.IsPlayerInside && playerEnterExit.IsPlayerInsideDungeon)
                 {
-                    if (playerEnterExit.IsPlayerInsideDungeonPalace)
-                        targetAmbientLight = PalaceAmbientLight;
+                    if (playerEnterExit.IsPlayerInsideDungeonCastle)
+                        targetAmbientLight = CastleAmbientLight;
                     else
                         targetAmbientLight = DungeonAmbientLight;
                 }

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -33,7 +33,7 @@ namespace DaggerfallWorkshop.Game
         //PlayerMouseLook playerMouseLook;
         bool isPlayerInside = false;
         bool isPlayerInsideDungeon = false;
-        bool isPlayerInsideDungeonPalace = false;
+        bool isPlayerInsideDungeonCastle = false;
         bool isRespawning = false;
         DaggerfallInterior interior;
         DaggerfallDungeon dungeon;
@@ -77,12 +77,12 @@ namespace DaggerfallWorkshop.Game
         }
 
         /// <summary>
-        /// True only when player inside palace blocks of a dungeon.
+        /// True only when player inside castle blocks of a dungeon.
         /// For example, main hall in Daggerfall castle.
         /// </summary>
-        public bool IsPlayerInsideDungeonPalace
+        public bool IsPlayerInsideDungeonCastle
         {
-            get { return isPlayerInsideDungeonPalace; }
+            get { return isPlayerInsideDungeonCastle; }
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace DaggerfallWorkshop.Game
                 {
                     dungeon.GetBlockData(playerBlockIndex, out playerDungeonBlockData);
                     lastPlayerDungeonBlockIndex = playerBlockIndex;
-                    PalaceCheck();
+                    CastleCheck();
                     //Debug.Log(string.Format("Player is now inside block {0}", playerDungeonBlockData.BlockName));
                 }
             }
@@ -223,7 +223,7 @@ namespace DaggerfallWorkshop.Game
             // Reset inside state
             isPlayerInside = false;
             isPlayerInsideDungeon = false;
-            isPlayerInsideDungeonPalace = false;
+            isPlayerInsideDungeonCastle = false;
 
             // Set player GPS coordinates
             playerGPS.WorldX = worldX;
@@ -656,7 +656,7 @@ namespace DaggerfallWorkshop.Game
             // Player is now outside dungeon
             isPlayerInside = false;
             isPlayerInsideDungeon = false;
-            isPlayerInsideDungeonPalace = false;
+            isPlayerInsideDungeonCastle = false;
             lastPlayerDungeonBlockIndex = -1;
             playerDungeonBlockData = new DFLocation.DungeonBlock();
 
@@ -675,28 +675,28 @@ namespace DaggerfallWorkshop.Game
 
         #region Private Methods
 
-        // Check if current block is a palace block
-        private void PalaceCheck()
+        // Check if current block is a castle block
+        private void CastleCheck()
         {
             if (!isPlayerInsideDungeon)
             {
-                isPlayerInsideDungeonPalace = false;
+                isPlayerInsideDungeonCastle = false;
                 return;
             }
 
             switch (playerDungeonBlockData.BlockName)
             {
-                case "S0000020.RDB":    // Orsinium palace area
-                case "S0000040.RDB":    // Sentinel palace area
+                case "S0000020.RDB":    // Orsinium castle area
+                case "S0000040.RDB":    // Sentinel castle area
                 case "S0000041.RDB":
                 case "S0000042.RDB":
-                case "S0000080.RDB":    // Wayrest palace area
+                case "S0000080.RDB":    // Wayrest castle area
                 case "S0000081.RDB":
-                case "S0000160.RDB":    // Daggerfall palace area
-                    isPlayerInsideDungeonPalace = true;
+                case "S0000160.RDB":    // Daggerfall castle area
+                    isPlayerInsideDungeonCastle = true;
                     break;
                 default:
-                    isPlayerInsideDungeonPalace = false;
+                    isPlayerInsideDungeonCastle = false;
                     break;
             }
         }

--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -32,19 +32,18 @@ namespace DaggerfallWorkshop.Game
         public PlayerGPS LocalPlayerGPS;            // Must be peered with PlayerWeather and PlayerEnterExit for full support
         public StreamingWorld StreamingWorld;
 
-        public SongFiles[] CityDaySongs = _cityDaySongs;
-        public SongFiles[] CityNightSongs = _cityNightSongs;
-        public SongFiles[] DungeonExteriorSongs = _dungeonExteriorSongs;
-        public SongFiles[] DungeonInteriorSongs = _dungeonInteriorSongs;
-        public SongFiles[] GraveyardSongs = _graveyardSongs;
-        public SongFiles[] GuildSongs = _guildSongs;
-        public SongFiles[] InteriorSongs = _interiorSongs;
-        public SongFiles[] PalaceSongs = _palaceSongs;
-        public SongFiles[] ShopSongs = _shopSongs;
-        public SongFiles[] TavernSongs = _tavernSongs;
+        public SongFiles[] DungeonInteriorSongs = _dungeonSongs;
+        public SongFiles[] DaySongs = _daySongs;
         public SongFiles[] WeatherRainSongs = _weatherRainSongs;
         public SongFiles[] WeatherSnowSongs = _weatherSnowSongs;
-        public SongFiles[] WildernessSongs = _wildernessSongs;
+        public SongFiles[] TempleSongs = _templeSongs;
+        public SongFiles[] TavernSongs = _tavernSongs;
+        public SongFiles[] NightSongs = _nightSongs;
+        public SongFiles[] ShopSongs = _shopSongs;
+        public SongFiles[] MagesGuildSongs = _magesGuildSongs;
+        public SongFiles[] InteriorSongs = _interiorSongs;
+        public SongFiles[] PalaceSongs = _palaceSongs;
+        public SongFiles[] CastleSongs = _castleSongs;
 
         DaggerfallUnity dfUnity;
         DaggerfallSongPlayer songPlayer;
@@ -69,15 +68,17 @@ namespace DaggerfallWorkshop.Game
 
         enum PlayerMusicEnvironment
         {
+            Castle,
             City,
             DungeonExterior,
             DungeonInterior,
             Graveyard,
-            Guild,
+            MagesGuild,
             Interior,
             Palace,
             Shop,
             Tavern,
+            Temple,
             Wilderness,
         }
 
@@ -322,8 +323,8 @@ namespace DaggerfallWorkshop.Game
             // Dungeons
             if (playerEnterExit.IsPlayerInsideDungeon)
             {
-                if (playerEnterExit.IsPlayerInsideDungeonPalace)
-                    currentPlayerMusicEnvironment = PlayerMusicEnvironment.Palace;
+                if (playerEnterExit.IsPlayerInsideDungeonCastle)
+                    currentPlayerMusicEnvironment = PlayerMusicEnvironment.Castle;
                 else
                     currentPlayerMusicEnvironment = PlayerMusicEnvironment.DungeonInterior;
 
@@ -352,10 +353,13 @@ namespace DaggerfallWorkshop.Game
                         currentPlayerMusicEnvironment = PlayerMusicEnvironment.Tavern;
                         break;
                     case DFLocation.BuildingTypes.GuildHall:
-                        currentPlayerMusicEnvironment = PlayerMusicEnvironment.Guild;
+                        currentPlayerMusicEnvironment = PlayerMusicEnvironment.MagesGuild;
                         break;
                     case DFLocation.BuildingTypes.Palace:
                         currentPlayerMusicEnvironment = PlayerMusicEnvironment.Palace;
+                        break;
+                    case DFLocation.BuildingTypes.Temple:
+                        currentPlayerMusicEnvironment = PlayerMusicEnvironment.Temple;
                         break;
                     default:
                         currentPlayerMusicEnvironment = PlayerMusicEnvironment.Interior;
@@ -416,13 +420,13 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Cities
-            if (currentPlayerMusicEnvironment == PlayerMusicEnvironment.City)
+            if (currentPlayerMusicEnvironment == PlayerMusicEnvironment.City || currentPlayerMusicEnvironment == PlayerMusicEnvironment.Wilderness)
             {
                 // Day/night
                 if (!dfUnity.WorldTime.Now.IsNight)
-                    currentPlaylist = CityDaySongs;
+                    currentPlaylist = DaySongs;
                 else
-                    currentPlaylist = CityNightSongs;
+                    currentPlaylist = NightSongs;
 
                 return;
             }
@@ -430,17 +434,20 @@ namespace DaggerfallWorkshop.Game
             // Environment
             switch (currentPlayerMusicEnvironment)
             {
+                case PlayerMusicEnvironment.Castle:
+                    currentPlaylist = CastleSongs;
+                    break;
                 case PlayerMusicEnvironment.DungeonExterior:
-                    currentPlaylist = DungeonExteriorSongs;
+                    currentPlaylist = NightSongs;
                     break;
                 case PlayerMusicEnvironment.DungeonInterior:
                     currentPlaylist = DungeonInteriorSongs;
                     break;
                 case PlayerMusicEnvironment.Graveyard:
-                    currentPlaylist = GraveyardSongs;
+                    currentPlaylist = NightSongs;
                     break;
-                case PlayerMusicEnvironment.Guild:
-                    currentPlaylist = GuildSongs;
+                case PlayerMusicEnvironment.MagesGuild:
+                    currentPlaylist = MagesGuildSongs;
                     break;
                 case PlayerMusicEnvironment.Interior:
                     currentPlaylist = InteriorSongs;
@@ -454,8 +461,8 @@ namespace DaggerfallWorkshop.Game
                 case PlayerMusicEnvironment.Tavern:
                     currentPlaylist = TavernSongs;
                     break;
-                case PlayerMusicEnvironment.Wilderness:
-                    currentPlaylist = WildernessSongs;
+                case PlayerMusicEnvironment.Temple:
+                    currentPlaylist = TempleSongs;
                     break;
             }
         }
@@ -464,54 +471,192 @@ namespace DaggerfallWorkshop.Game
 
         #region Song Playlists
 
-        // City - Day
-        static SongFiles[] _cityDaySongs = new SongFiles[]
+        // Dungeon
+        static SongFiles[] _dungeonSongs = new SongFiles[]
         {
+            SongFiles.song_dungeon,
+            SongFiles.song_dungeon5,
+            SongFiles.song_dungeon6,
+            SongFiles.song_dungeon7,
+            SongFiles.song_dungeon8,
+            SongFiles.song_dungeon9,
+            SongFiles.song_gdngn10,
+            SongFiles.song_gdngn11,
+            SongFiles.song_gdungn4,
+            SongFiles.song_gdungn9,
+            SongFiles.song_04,
+            SongFiles.song_05,
+            SongFiles.song_07,
+            SongFiles.song_15,
+            SongFiles.song_28,
+        };
+
+        // Day
+        static SongFiles[] _daySongs = new SongFiles[]
+        {
+            SongFiles.song_gday___d,
+            SongFiles.song_swimming,
+            SongFiles.song_gsunny2,
+            SongFiles.song_sunnyday,
             SongFiles.song_02,
             SongFiles.song_03,
-            SongFiles.song_06,
-            SongFiles.song_12,
-            SongFiles.song_15,
-            SongFiles.song_20,
             SongFiles.song_22,
             SongFiles.song_29,
-            SongFiles.song_gday___d,
-            SongFiles.song_ggood,
-            SongFiles.song_sunnyday,
-            SongFiles.song_gsunny2,
-            SongFiles.song_swimming,
+            SongFiles.song_12,
+            SongFiles.song_13,
+            SongFiles.song_gpalac,
         };
 
-        // City - night
-        static SongFiles[] _cityNightSongs = new SongFiles[]
+        // Weather - Raining
+        static SongFiles[] _weatherRainSongs = new SongFiles[]
         {
-            SongFiles.song_07,
+            SongFiles.song_overcast,
+            SongFiles.song_overlong,        // Long version of overcast
+            SongFiles.song_raining,
+            SongFiles.song_08,
+        };
+
+        // Weather - Snowing
+        static SongFiles[] _weatherSnowSongs = new SongFiles[]
+        {
+            SongFiles.song_20,
+            SongFiles.song_gsnow__b,
+            SongFiles.song_oversnow,
+            SongFiles.song_snowing,
+        };
+
+        // Sneaking? These are next to each other in FALL.EXE but seem to be unused in-game
+        /*static SongFiles[] _sneakingSongs = new SongFiles[]
+        {
+            SongFiles.song_gsneak2,
+            SongFiles.song_sneaking,
+            SongFiles.song_sneakng2,        // Used in Arena when trespassing in homes
+            SongFiles.song_16,
+            SongFiles.song_09,
+            SongFiles.song_25,
+            SongFiles.song_30,
+        };*/
+
+        // Temple
+        static SongFiles[] _templeSongs = new SongFiles[]
+        {
+            SongFiles.song_ggood,
+            SongFiles.song_gbad,
+            SongFiles.song_gneut,
+        };
+
+        // Tavern
+        static SongFiles[] _tavernSongs = new SongFiles[]
+        {
+            SongFiles.song_square_2,
+            SongFiles.song_tavern,
+            SongFiles.song_folk1,
+            SongFiles.song_folk2,
+            SongFiles.song_folk3,
+        };
+
+        // Night
+        static SongFiles[] _nightSongs = new SongFiles[]
+        {
             SongFiles.song_10,
             SongFiles.song_11,
-            SongFiles.song_13,
-            SongFiles.song_16,
-            SongFiles.song_21,
-            SongFiles.song_25,
-        };
-
-        // Dungeon - Exterior
-        static SongFiles[] _dungeonExteriorSongs = new SongFiles[]
-        {
-            SongFiles.song_04,
-            SongFiles.song_07,
-            SongFiles.song_10,
-            SongFiles.song_13,
-            SongFiles.song_18,
-            SongFiles.song_21,
             SongFiles.song_gcurse,
+            SongFiles.song_geerie,
             SongFiles.song_gruins,
+            SongFiles.song_18,
+            SongFiles.song_21,          // Missing in Daggerfall classic. Only the FM version is used there.
         };
 
-        // Dungeon - Interior
-        static SongFiles[] _dungeonInteriorSongs = new SongFiles[]
+        // Dungeon FM version
+        /*static SongFiles[] _dungeonSongsFM = new SongFiles[]
+        {
+            SongFiles.song_fm_dngn1,
+            SongFiles.song_fm_dngn2,
+            SongFiles.song_fm_dngn3,
+            SongFiles.song_fm_dngn4,
+            SongFiles.song_fm_dngn5,
+            SongFiles.song_fdngn10,
+            SongFiles.song_fdngn11,
+            SongFiles.song_fdungn4,
+            SongFiles.song_fdungn9,
+            SongFiles.song_04fm,
+            SongFiles.song_05fm,
+            SongFiles.song_07fm,
+            SongFiles.song_15fm,
+        };
+
+        // Day FM version
+        static SongFiles[] _daySongsFM = new SongFiles[]
+        {
+            SongFiles.song_fday___d,
+            SongFiles.song_fm_swim2,
+            SongFiles.song_fm_sunny,
+            SongFiles.song_02fm,
+            SongFiles.song_03fm,
+            SongFiles.song_22fm,
+            SongFiles.song_29fm,
+            SongFiles.song_12fm,
+            SongFiles.song_13fm,
+            SongFiles.song_fpalac,
+        };
+
+        // Weather - Raining FM version
+        static SongFiles[] _weatherRainSongsFM = new SongFiles[]
+        {
+            SongFiles.song_fmover_c,
+            SongFiles.song_fm_rain,
+            SongFiles.song_08fm,
+        };
+
+        // Weather - Snowing FM version
+        static SongFiles[] _weatherSnowSongsFM = new SongFiles[]
+        {
+            SongFiles.song_20fm,
+            SongFiles.song_fsnow__b,
+            SongFiles.song_fmover_s,
+        };
+
+        // Sneaking? FM version. These are next to each other in FALL.EXE but seem to be unused in-game.
+        static SongFiles[] _sneakingSongsFM = new SongFiles[]
+        {
+            SongFiles.song_fsneak2,
+            SongFiles.song_fmsneak2,        // Used in Arena when trespassing in homes
+            SongFiles.song_fsneak2,
+            SongFiles.song_16fm,
+            SongFiles.song_09fm,
+            SongFiles.song_25fm,
+            SongFiles.song_30fm,
+        };
+
+        // Temple FM version
+        static SongFiles[] _templeSongsFM = new SongFiles[]
+        {
+            SongFiles.song_fgood,
+            SongFiles.song_fbad,
+            SongFiles.song_fneut,
+        };
+
+        // Tavern FM version
+        static SongFiles[] _tavernSongsFM = new SongFiles[]
+        {
+            SongFiles.song_fm_sqr_2,
+        };
+
+        // Night FM version
+        static SongFiles[] _nightSongsFM = new SongFiles[]
+        {
+            SongFiles.song_11fm,
+            SongFiles.song_fcurse,
+            SongFiles.song_feerie,
+            SongFiles.song_fruins,
+            SongFiles.song_18fm,
+            SongFiles.song_21fm,
+        };
+
+        // Unused dungeon music?
+        static SongFiles[] _unusedDungeonSongs = new SongFiles[]
         {
             SongFiles.song_d1,
-            SongFiles.song_d10,
             SongFiles.song_d2,
             SongFiles.song_d3,
             SongFiles.song_d4,
@@ -520,108 +665,90 @@ namespace DaggerfallWorkshop.Game
             SongFiles.song_d7,
             SongFiles.song_d8,
             SongFiles.song_d9,
-            SongFiles.song_dungeon,
-            SongFiles.song_gdngn10,
-            SongFiles.song_gdngn11,
-            SongFiles.song_gdungn4,
-            SongFiles.song_gdungn9,
+            SongFiles.song_d10,
         };
 
-        // Graveyards
-        static SongFiles[] _graveyardSongs = new SongFiles[]
+        // Unused dungeon music? FM version
+        static SongFiles[] _unusedDungeonSongsFM = new SongFiles[]
         {
-            SongFiles.song_04,
-            SongFiles.song_07,
-            SongFiles.song_10,
-            SongFiles.song_13,
-            SongFiles.song_21,
-            SongFiles.song_geerie,
-            SongFiles.song_gruins,
+            SongFiles.song_d1fm,
+            SongFiles.song_d2fm,
+            SongFiles.song_d3fm,
+            SongFiles.song_d4fm,
+            SongFiles.song_d5fm,
+            SongFiles.song_d6fm,
+            SongFiles.song_d7fm,
+            SongFiles.song_d8fm,
+            SongFiles.song_d9fm,
+            SongFiles.song_d10fm,
+        };*/
+
+        // Shop
+        static SongFiles[] _shopSongs = new SongFiles[]
+        {
+            SongFiles.song_gshop,
         };
 
-        // Guilds
-        static SongFiles[] _guildSongs = new SongFiles[]
+        // Shop FM version
+        /*static SongFiles[] _shopSongsFM = new SongFiles[]
+        {
+            SongFiles.song_fm_sqr_2,
+        };*/
+
+        // Mages Guild
+        static SongFiles[] _magesGuildSongs = new SongFiles[]
         {
             SongFiles.song_gmage_3,
             SongFiles.song_magic_2,
         };
 
-        // Interiors
+        // Mages Guild FM version
+        /*static SongFiles[] _magesGuildSongsFM = new SongFiles[]
+        {
+            SongFiles.song_fm_nite3,
+        };*/
+
+        // Interior
         static SongFiles[] _interiorSongs = new SongFiles[]
         {
             SongFiles.song_23,
-            SongFiles.song_gneut,
         };
+
+        // Interior FM version
+        /*static SongFiles[] _interiorSongsFM = new SongFiles[]
+        {
+            SongFiles.song_23fm,
+        };*/
+
+        // Unknown. Doesn't seem to be used in final product
+        /*static SongFiles[] _unknownSong = new SongFiles[]
+        {  
+            SongFiles.song_17,
+        };
+
+        // Unknown. Doesn't seem to be used in final product
+        static SongFiles[] _unknownSongFM = new SongFiles[]
+        {
+            SongFiles.song_17fm,
+        };*/
 
         // Palace
         static SongFiles[] _palaceSongs = new SongFiles[]
         {
+            SongFiles.song_06,
+        };
+
+        // Palace FM version
+        /*static SongFiles[] _palaceSongsFM = new SongFiles[]
+        {
+            SongFiles.song_06fm,
+        };*/
+
+        // Castle
+        static SongFiles[] _castleSongs = new SongFiles[]
+        {
             SongFiles.song_gpalac,
         };
-
-        // Shops
-        static SongFiles[] _shopSongs = new SongFiles[]
-        {
-            SongFiles.song_gshop,
-            SongFiles.song_square_2,
-        };
-
-        // Taverns
-        static SongFiles[] _tavernSongs = new SongFiles[]
-        {
-            SongFiles.song_folk1,
-            SongFiles.song_folk2,
-            SongFiles.song_folk3,
-            SongFiles.song_tavern,
-        };
-
-        // Weather - Raining
-        static SongFiles[] _weatherRainSongs = new SongFiles[]
-        {
-            SongFiles.song_12,
-            SongFiles.song_gbad,
-            SongFiles.song_overcast,
-            SongFiles.song_overlong,        // Long version of overcast
-            SongFiles.song_raining,
-        };
-
-        // Weather - Snowing
-        static SongFiles[] _weatherSnowSongs = new SongFiles[]
-        {
-            SongFiles.song_08,
-            SongFiles.song_gsnow__b,
-            SongFiles.song_snowing,
-        };
-
-        // Wilderness
-        static SongFiles[] _wildernessSongs = new SongFiles[]
-        {
-            SongFiles.song_11,
-            SongFiles.song_13,
-            SongFiles.song_18,
-            SongFiles.song_21,
-            SongFiles.song_gcurse,
-            SongFiles.song_gruins,
-        };
-
-        //// Uncategorized
-        //static SongFiles[] UnCategorizedSongs = new SongFiles[]
-        //{
-        //    SongFiles.song_05,              // dungeon?
-        //    SongFiles.song_09,              // unknown
-        //    SongFiles.song_17,              // unknown
-        //    SongFiles.song_28,              // unknown
-        //    SongFiles.song_30,              // dungeon?
-        //    SongFiles.song_sneaking,        // unknown
-        //    SongFiles.song_gsneak2,         // unknown
-        //    SongFiles.song_sneakng2,        // unknown
-        //    SongFiles.song_dungeon5,        // Not sure these dungeont tracks fit the mood (or if Daggerfall uses)
-        //    SongFiles.song_dungeon6,
-        //    SongFiles.song_dungeon7,
-        //    SongFiles.song_dungeon8,
-        //    SongFiles.song_dungeon9,
-        //};
-
         #endregion
     }
 }

--- a/Assets/Scripts/Utility/ClimateSwaps.cs
+++ b/Assets/Scripts/Utility/ClimateSwaps.cs
@@ -192,7 +192,7 @@ namespace DaggerfallWorkshop.Utility
                     break;
 
                 // Interior sets (do not support winter)
-                case DFLocation.ClimateTextureSet.Interior_PalaceInt:
+                case DFLocation.ClimateTextureSet.Interior_CastleInt:
                 case DFLocation.ClimateTextureSet.Interior_CityInt:
                 case DFLocation.ClimateTextureSet.Interior_CryptA:
                 case DFLocation.ClimateTextureSet.Interior_CryptB:


### PR DESCRIPTION
This recreates the music playlists of classic Daggerfall, based on what look like playlists in FALL.EXE. In-game testing seems to confirm it.

Also I renamed references to "palace" throughout the code with "castle." In classic Daggerfall, the rulers' structures in Daggerfall, Wayrest and Sentinel are all called "-- Castle" on the automap, while the ones for minor rulers in other places are called "Palace." I think this also is consistent with the text of quests that send you to palaces. The only inconsistency I saw is that the castle music is called "gpalac."

Some things remain to be done. One is that "palaces" are insisting on playing the "castle" music for some reason. I can't figure this out, and I'm asking for your help Interkarma if you know what's going on. It seems to be bypassing the playlists, because even if I remove or replace the "gpalac" music from the playlists it is still played.

Also currently all guilds play mage's guild music. The guild's besides the mage's guild should all be the standard "interior" music, I think.

