### PR TITLE
Don't choose a new song for the same playlist

### DIFF
--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -58,6 +58,7 @@ namespace DaggerfallWorkshop.Game
         PlayerMusicTime lastPlayerMusicTime;
 
         SongFiles[] currentPlaylist;
+        SongFiles[] lastPlaylist;
         SongFiles currentSong;
         int currentSongIndex = 0;
         bool playSong = true;
@@ -150,31 +151,30 @@ namespace DaggerfallWorkshop.Game
             UpdatePlayerMusicWeather();
             UpdatePlayerMusicTime();
 
-            // Switch playlists if context changes or if not playing then select a new song
+            // Update current playlist if context changed
             bool overrideSong = false;
             if (currentPlayerMusicEnvironment != lastPlayerMusicEnvironment || 
                 currentPlayerMusicWeather != lastPlayerMusicWeather ||
                 currentPlayerMusicTime != lastPlayerMusicTime ||
                 (!songPlayer.IsPlaying && playSong))
             {
-                // Keep song if playing the same weather, but not when entering dungeons
-                if (currentPlayerMusicWeather != PlayerMusicWeather.Normal &&
-                    currentPlayerMusicWeather == lastPlayerMusicWeather &&
-                    currentPlayerMusicEnvironment != PlayerMusicEnvironment.DungeonInterior)
-                {
-                    return;
-                }
-
-                // Change song
                 lastPlayerMusicEnvironment = currentPlayerMusicEnvironment;
                 lastPlayerMusicWeather = currentPlayerMusicWeather;
                 lastPlayerMusicTime = currentPlayerMusicTime;
+                lastPlaylist = currentPlaylist;
+
+                // Get playlist for current context
                 AssignPlaylist();
-                SelectCurrentSong();
-                overrideSong = true;
+
+                // If current playlist is different from last playlist, pick a song from the current playlist
+                if (currentPlaylist != lastPlaylist)
+                {
+                    SelectCurrentSong();
+                    overrideSong = true;
+                }
             }
 
-            // Play song
+            // Play song if no song was playing or if playlist changed
             if (!songPlayer.IsPlaying || overrideSong)
                 PlayCurrentSong();
         }


### PR DESCRIPTION
New songs are being chosen when switching between contexts with the same playlist (e.g. going from dungeon exterior at night to wilderness area at night, or weather changing at night). This is not what happens in classic, and this PR prevents it.

I noticed something when testing this. For some reason, the area just outside Privateer's Hold is being classified as "Wilderness" instead of "DungeonExterior." If you walk away from the entrance to the west somewhat, you'll enter a DungeonExterior area, and going farther away will put you in the wider Wilderness area. A couple other dungeons I looked at, including the same class of dungeon as Privateer's Hold, didn't seem to have this problem.

Edit: Accidentally added a heart emoji for my own message, lol. Oh well.