### PR TITLE
fixed broken fog

### DIFF
--- a/Assets/Scripts/Game/WeatherManager.cs
+++ b/Assets/Scripts/Game/WeatherManager.cs
@@ -102,7 +102,8 @@ namespace DaggerfallWorkshop.Game
 
         public void SetFog(bool isFoggy, float density)
         {
-            RenderSettings.fog = isFoggy;
+            // edit by Nystul: don't disable RenderSettings fog! Rendering Fog != Weather Fog
+            //RenderSettings.fog = isFoggy;
 
             if (isFoggy)
             {


### PR DESCRIPTION
some recent changes to WeatherManager broke the camera fog (the kind of fog one will always want even on a sunny day).

don't disable RenderSettingsFog! Rendering Fog != Weather Fog

to see the broken fog: uncomment the line that is now commented out (and should finally be removed), go to privateer's hold (outside) on a sunny day with all mods disabled and see that there is no transition from foreground to background - this is wrong
