### PR TITLE
Implement travel costs

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -661,7 +661,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (FindingLocation)
                     StopRegionIdentify(true);
                 else
-                    CreateConfirmationPopUp();
+                    CreatePopUpWindow();
             }
             else if (MouseOverOtherRegion)      //if clicked while mouse over other region & not a location, switch to that region
                 OpenRegionPanel(mouseOverRegion);


### PR DESCRIPTION
What this PR does:

1. Available gold is displayed when fast traveling, and is removed after travel. If the player doesn't have enough, the "You do not have enough gold." popup shows.

2. Tried to recreate the cost calculations of classic Daggerfall. It should be basically correct. The calculations for the amount of time are producing different results from classic, though, so the resulting costs are also different. For one thing, inland lakes or relatively short trips across bays don't cause ship travel while they do in classic Daggerfall. I looked and no "ocean" terrains were being processed in this case.

3. Implemented healing for cautious travel.

4. Set the modifier for ship travel based on some limited testing in classic Daggerfall.

5. Changed the "Do you wish to travel to" popup to not show when you click on a location, same as in classic Daggerfall.