### PR TITLE
Mesh and Texture replacement - More on assetbundle

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -53,10 +53,10 @@ DebugWeaponSwings=False
 [Enhancements]
 LypyL_GameConsole=True
 LypyL_ModSystem=True
+MeshAndTextureReplacement=False
 LypyL_EnhancedSky=False
 Nystul_IncreasedTerrainDistance=False
 Nystul_RealtimeReflections=False
 UncannyValley_RealGrass=False
 TheLacus_GrassAndPlants=False
 UncannyValley_BirdsInDaggerfall=False
-MeshAndTextureReplacement=False

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -63,6 +63,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox mouseSmoothing;
         Checkbox leftHandWeapons;
         Checkbox playerNudity;
+        Checkbox meshAndTextureReplacement;
 
         Checkbox enhancedSky;
         Checkbox distantTerrain;
@@ -70,7 +71,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox tallGrass;
         Checkbox grassAndPlants;
         Checkbox flyingBirds;
-        Checkbox meshAndTextureReplacement;
 
         Color unselectedTextColor = new Color(0.6f, 0.6f, 0.6f, 1f);
         Color selectedTextColor = new Color(0.0f, 0.8f, 0.0f, 1.0f);
@@ -451,6 +451,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mouseSmoothing = AddOption(x, "Mouse Smoothing", "Smooth mouse-look sampling", DaggerfallUnity.Settings.MouseLookSmoothing);
             leftHandWeapons = AddOption(x, "Left Hand Weapons", "Draw weapons on left side of screen", GetLeftHandWeapons());
             playerNudity = AddOption(x, "Player Nudity", "Allow nudity on paper doll", DaggerfallUnity.Settings.PlayerNudity);
+            meshAndTextureReplacement = AddOption(x, "Support for Graphical Mods", "Enable replacement of textures and models", DaggerfallUnity.Settings.MeshAndTextureReplacement);
 
             // Setup mods checkboxes
             x = 165;
@@ -461,7 +462,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             tallGrass = AddOption(x, "Tall Grass (Uncanny_Valley)", "Animated tall grass", DaggerfallUnity.Settings.UncannyValley_RealGrass);
             grassAndPlants = AddOption(x, "Grass and Plants (TheLacus)", "Uncanny_Valley's Tall grass plus water plants", DaggerfallUnity.Settings.TheLacus_GrassAndPlants);
             flyingBirds = AddOption(x, "Flying Birds (Uncanny Valley)", "Animated flying birds", DaggerfallUnity.Settings.UncannyValley_BirdsInDaggerfall);
-            meshAndTextureReplacement = AddOption(x, "Support for texture packs", "Enable replacement of textures", DaggerfallUnity.Settings.MeshAndTextureReplacement);
 
             // Add mod note
             string modNote = "Note: Enabling mods can increase performance requirements";

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -81,8 +81,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
   
         /// <summary>
-        /// Import the custom gameobject if available
+        /// Import the custom GameObject if available
         /// Assetbundles should be created using the Mod Builder inside the Daggerfall Tools
+        /// TODO: Integrate with the mod system to import models from mods using load order
         /// </summary>
         static public void ImportCustomGameobject (uint modelID, Vector3 position, Transform parent, Quaternion rotation, out bool modelExist)
         {
@@ -103,29 +104,32 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             }
  
             // Load AssetBundle
-            // TODO: Use mod system to import prefabs from all mods and use load order
-            // Debug.Log("Loading Assetbundle");
-            string modelsPath = Path.Combine(Application.persistentDataPath, "Models");
-            string assetBundleName = "myassetbundle.dfmod";
-            var LoadedAssetBundle = AssetBundle.LoadFromFile(Path.Combine(modelsPath, assetBundleName));
+            string modelsPath = Path.Combine(Application.streamingAssetsPath, "Models");
+            string modelName = modelID.ToString();
+            modelsPath = Path.Combine(modelsPath, modelName + ".model");
+            if (!File.Exists(modelsPath))
+            {
+                modelExist = false;
+                return;
+            }
+            var LoadedAssetBundle = AssetBundle.LoadFromFile(modelsPath);
             if (LoadedAssetBundle == null)
             {
-                Debug.Log("Failed to load AssetBundle");
+                Debug.LogError("Failed to load AssetBundle " + modelName + ".model");
                 modelExist = false;
                 return;
             }
  
             // Check if AssetBundle contain the model we are looking for and assign the name according to the current season
-            string modelName = modelID.ToString();
             if (!LoadedAssetBundle.Contains(modelName))
             {
+                Debug.LogError("AssetBundle " + modelName + ".model is invalid");
                 modelExist = false;
                 LoadedAssetBundle.Unload(false);
                 return;
             }
             else if ((DaggerfallUnity.Instance.WorldTime.Now.SeasonValue == DaggerfallDateTime.Seasons.Winter) && (LoadedAssetBundle.Contains(modelName + "_winter")))
                 modelName += "_winter";
-            // Debug.Log("Assetbundle contains " + modelName);
  
             // Instantiate GameObject
             modelExist = true;
@@ -139,7 +143,6 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
  
             // Finalise gameobject
             FinaliseCustomGameObject(ref object3D, modelName);
-            // Debug.Log(modelName + " injected");
         }
         
         /// <summary>
@@ -179,8 +182,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Import the custom gameobject for billboard if available
+        /// Import the custom GameObject for billboard if available
         /// Assetbundles should be created using the Mod Builder inside the Daggerfall Tools
+        /// TODO: Integrate with the mod system to import models from mods using load order
         /// </summary>
         static public void ImportCustomFlatGameobject (int archive, int record, Vector3 position, Transform parent, out bool modelExist)
         {
@@ -201,28 +205,30 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             }
 
             // Load AssetBundle
-            // TODO: Use mod system to import prefabs from all mods and use load order
-            // Debug.Log("Loading Assetbundle");
-            string modelsPath = Path.Combine(Application.persistentDataPath, "Models");
-            string assetBundleName = "myassetbundle.dfmod";
-            var LoadedAssetBundle = AssetBundle.LoadFromFile(Path.Combine(modelsPath, assetBundleName));
+            string modelsPath = Path.Combine(Application.persistentDataPath, "Flats");
+            string modelName = archive.ToString() + "_" + record.ToString();
+            modelsPath = Path.Combine(modelsPath, modelName + ".flat");
+            if (!File.Exists(modelsPath))
+            {
+                modelExist = false;
+                return;
+            }
+            var LoadedAssetBundle = AssetBundle.LoadFromFile(modelsPath);
             if (LoadedAssetBundle == null)
             {
-                // Debug.Log("Failed to load AssetBundle");
-                Debug.Log("Failed to load AssetBundle");
+                Debug.LogError("Failed to load AssetBundle " + modelName + ".flat");
                 modelExist = false;
                 return;
             }
  
             // Check if AssetBundle contain the model we are looking for
-            string modelName = archive.ToString() + "_" + record.ToString();
             if (!LoadedAssetBundle.Contains(modelName))
             {
+                Debug.LogError("AssetBundle " + modelName + ".flat is invalid");
                 modelExist = false;
                 LoadedAssetBundle.Unload(false);
                 return;
             }
-            // Debug.Log("Assetbundle contains " + modelName);
 
             // Instantiate GameObject
             modelExist = true;
@@ -235,7 +241,6 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             
             // Finalise gameobject
             FinaliseCustomGameObject(ref object3D, modelName);
-            // Debug.Log(modelName + " injected");
         }
         
         /// <summary>

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -205,7 +205,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             }
 
             // Load AssetBundle
-            string modelsPath = Path.Combine(Application.persistentDataPath, "Flats");
+            string modelsPath = Path.Combine(Application.streamingAssetsPath, "Flats");
             string modelName = archive.ToString() + "_" + record.ToString();
             modelsPath = Path.Combine(modelsPath, modelName + ".flat");
             if (!File.Exists(modelsPath))

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -28,6 +28,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     /// </summary>
     static public class TextureReplacement
     {
+        static string texturesPath = Path.Combine(Application.streamingAssetsPath, "Textures");
+        static string imgPath = Path.Combine(texturesPath, "img");
+        static string cifPath = Path.Combine(texturesPath, "cif");
 
         #region Textures import
 
@@ -51,7 +54,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static public bool CustomTextureExist(string name)
         {
             if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
-                && File.Exists(Application.persistentDataPath + "/textures/" + name + ".png"))
+                && File.Exists(Path.Combine(texturesPath, name + ".png")))
                 return true;
 
             return false;
@@ -69,7 +72,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             Texture2D tex = new Texture2D(2, 2); //create empty texture, size will be the actual size of .png file
 
             //load image as Texture2D
-            tex.LoadImage(File.ReadAllBytes(Application.persistentDataPath + "/textures/" + name + ".png"));
+            tex.LoadImage(File.ReadAllBytes(Path.Combine(texturesPath, name + ".png")));
 
             return tex; //assign image to the actual texture
         }
@@ -88,7 +91,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         {
 
             if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
-                && File.Exists(Application.persistentDataPath + "/textures/img/" + filename + ".png"))
+                && File.Exists(Path.Combine(imgPath, filename + ".png")))
                 return true;
 
             return false;
@@ -101,7 +104,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             Texture2D tex = new Texture2D(2, 2); //create empty texture, size will be the actual size of .png file
 
             //load image as Texture2D
-            tex.LoadImage(File.ReadAllBytes(Application.persistentDataPath + "/textures/img/" + filename + ".png"));
+            tex.LoadImage(File.ReadAllBytes(Path.Combine(imgPath, filename + ".png")));
 
             return tex; //assign image to the actual texture
         }
@@ -122,7 +125,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         {
 
             if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
-                && File.Exists(Application.persistentDataPath + "/textures/cif/" + filename + "_" + record.ToString() + "-" + frame.ToString() + ".png"))
+                && File.Exists(Path.Combine(cifPath, filename + "_" + record.ToString() + "-" + frame.ToString() + ".png")))
                 return true;
 
             return false;
@@ -135,7 +138,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             Texture2D tex = new Texture2D(2, 2); //create empty texture, size will be the actual size of .png file
 
             //load image as Texture2D
-            tex.LoadImage(File.ReadAllBytes(Application.persistentDataPath + "/textures/cif/" + filename + "_" + record.ToString() + "-" + frame.ToString() + ".png"));
+            tex.LoadImage(File.ReadAllBytes(Path.Combine(cifPath, filename + "_" + record.ToString() + "-" + frame.ToString() + ".png")));
 
             return tex; //assign image to the actual texture
         }
@@ -160,7 +163,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static public bool CustomNormalExist(string name)
         {
             if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
-                && File.Exists(Application.persistentDataPath + "/textures/" + name + "_Normal.png"))
+                && File.Exists(Path.Combine(texturesPath, name + "_Normal.png")))
                 return true;
 
             return false;
@@ -176,7 +179,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static public Texture2D LoadCustomNormal(string name)
         {
             Texture2D tex = new Texture2D(2, 2, TextureFormat.ARGB32, true); //create empty texture, size will be the actual size of .png file
-            tex.LoadImage(File.ReadAllBytes(Application.persistentDataPath + "/textures/" + name + "_Normal.png"));
+            tex.LoadImage(File.ReadAllBytes(Path.Combine(texturesPath, name + "_Normal.png")));
 
             Color32[] colours = tex.GetPixels32();
             for (int i = 0; i < colours.Length; i++)
@@ -206,7 +209,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static public bool CustomEmissionExist(int archive, int record, int frame)
         {
             if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
-                && File.Exists(Application.persistentDataPath + "/textures/" + archive.ToString() + "_" + record.ToString() + "-" + frame.ToString() + "_Emission.png"))
+                && File.Exists(Path.Combine(texturesPath, archive.ToString() + "_" + record.ToString() + "-" + frame.ToString() + "_Emission.png")))
                 return true;
 
             return false;
@@ -219,7 +222,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             Texture2D tex = new Texture2D(2, 2); //create empty texture, size will be the actual size of .png file
 
             //load image as Texture2D
-            tex.LoadImage(File.ReadAllBytes(Application.persistentDataPath + "/textures/" + archive.ToString() + "_" + record.ToString() + "-" + frame.ToString() + "_Emission.png"));
+            tex.LoadImage(File.ReadAllBytes(Path.Combine(texturesPath, archive.ToString() + "_" + record.ToString() + "-" + frame.ToString() + "_Emission.png")));
 
             return tex; //assign image to the actual texture
         }

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -480,11 +480,15 @@ namespace DaggerfallWorkshop.Utility
                     if (modelData.Doors != null)
                         doorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, recordCount, modelMatrix));
 
-                    // Use custom prefab
-                    if (MeshReplacement.ReplacementPrefabExist(obj.ModelIdNum))
-                        MeshReplacement.LoadReplacementPrefab(obj.ModelIdNum, modelMatrix.GetColumn(3), parent, GameObjectHelper.QuaternionFromMatrix(modelMatrix));
+                    // Import custom GameObject
+                    bool modelExist;
+                    MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, modelMatrix.GetColumn(3), parent, GameObjectHelper.QuaternionFromMatrix(modelMatrix), out modelExist);
+                    if (modelExist)
+                        continue;
+
+                    // Use Daggerfall Model
                     // Add or combine
-                    else if (combiner == null || IsCityGate(obj.ModelIdNum) || MeshReplacement.ReplacmentModelExist(obj.ModelIdNum))
+                    if (combiner == null || IsCityGate(obj.ModelIdNum) || MeshReplacement.ReplacmentModelExist(obj.ModelIdNum))
                         AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent);
                     else
                         combiner.Add(ref modelData, modelMatrix);
@@ -520,11 +524,15 @@ namespace DaggerfallWorkshop.Utility
                 if (modelData.Doors != null)
                     doorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, 0, modelMatrix));
 
-                // Use custom prefab
-                if (MeshReplacement.ReplacementPrefabExist(obj.ModelIdNum))
-                    MeshReplacement.LoadReplacementPrefab(obj.ModelIdNum, modelMatrix.GetColumn(3), parent, GameObjectHelper.QuaternionFromMatrix(modelMatrix));
+                // Import custom GameObject
+                bool modelExist;
+                MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, modelMatrix.GetColumn(3), parent, GameObjectHelper.QuaternionFromMatrix(modelMatrix), out modelExist);
+                if (modelExist)
+                    continue;
+
+                // Use Daggerfall Model
                 // Add or combine
-                else if (combiner == null || MeshReplacement.ReplacmentModelExist(obj.ModelIdNum))
+                if (combiner == null || MeshReplacement.ReplacmentModelExist(obj.ModelIdNum))
                     AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent);
                 else
                     combiner.Add(ref modelData, modelMatrix);


### PR DESCRIPTION
* More on AssetBundle import
* It's now possible to import models from more AssetBundles.  It's a
simple method for now which uses a little assetbundle for each model
(ID.model or Archive_Texture.flat for billboards), so it shouldn't
impact loading times too much.
* Textures, Models and Flats folders are now in StreamingAssetPath
* Moved option in main menu with the other settings