### PR TITLE
Mesh and Texture replacement - Import rect sizes from xml files

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -19,6 +19,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallConnect.Utility;
 using DaggerfallConnect.Save;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Utility;
@@ -684,10 +685,11 @@ namespace DaggerfallWorkshop.Game
 
             ImgFile imgFile = new ImgFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, true);            
             Texture2D texture = null;
-
-            // Texture packs support
-            if (DaggerfallWorkshop.Utility.AssetInjection.TextureReplacement.CustomImageExist(name))
-                texture = DaggerfallWorkshop.Utility.AssetInjection.TextureReplacement.LoadCustomImage(name);
+ 
+            // Custom texture
+            if (TextureReplacement.CustomImageExist(name))
+                texture = TextureReplacement.LoadCustomImage(name);
+            // Daggerfall texture
             else
             {
                 imgFile.LoadPalette(Path.Combine(dfUnity.Arena2Path, imgFile.PaletteName));
@@ -737,11 +739,20 @@ namespace DaggerfallWorkshop.Game
                 return null;
 
             CifRciFile cifRciFile = new CifRciFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, true);
-            cifRciFile.LoadPalette(Path.Combine(dfUnity.Arena2Path, cifRciFile.PaletteName));
-            DFBitmap bitmap = cifRciFile.GetDFBitmap(record, frame);
-            Texture2D texture = new Texture2D(bitmap.Width, bitmap.Height, format, false);
-            texture.SetPixels32(cifRciFile.GetColor32(bitmap, 0));
-            texture.Apply(false, true);
+            Texture2D texture=null;
+            
+            // Custom texture
+            if (TextureReplacement.CustomCifExist(name, record, frame))
+                texture = TextureReplacement.LoadCustomCif(name, record, frame);
+            // Daggerfall texture
+            else
+            { 
+                cifRciFile.LoadPalette(Path.Combine(dfUnity.Arena2Path, cifRciFile.PaletteName));
+                DFBitmap bitmap = cifRciFile.GetDFBitmap(record, frame);
+                texture = new Texture2D(bitmap.Width, bitmap.Height, format, false);
+                texture.SetPixels32(cifRciFile.GetColor32(bitmap, 0));
+                texture.Apply(false, true);
+            }
             texture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
 
             offset = cifRciFile.GetOffset(record);

--- a/Assets/Scripts/Game/UserInterface/FacePicker.cs
+++ b/Assets/Scripts/Game/UserInterface/FacePicker.cs
@@ -18,6 +18,7 @@ using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Player;
 
@@ -102,7 +103,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
             currentFaceTexture = faceTextures[faceIndex];
             if (currentFaceTexture != null)
             {
-                facePanel.Size = new Vector2(currentFaceTexture.width, currentFaceTexture.height);
+                if ((raceGender == Genders.Male) && (TextureReplacement.CustomCifExist(raceTemplate.PaperDollHeadsMale, faceIndex)))
+                    facePanel.Size = new Vector2(XMLManager.GetValue(raceTemplate.PaperDollHeadsMale, "width", isCif: true, record: faceIndex), 
+                        XMLManager.GetValue(raceTemplate.PaperDollHeadsMale, "height", isCif: true, record: faceIndex));
+                else if ((raceGender == Genders.Female) && (TextureReplacement.CustomCifExist(raceTemplate.PaperDollHeadsFemale, faceIndex)))
+                    facePanel.Size = new Vector2(XMLManager.GetValue(raceTemplate.PaperDollHeadsFemale, "width", isCif: true, record: faceIndex),
+                        XMLManager.GetValue(raceTemplate.PaperDollHeadsFemale, "height", isCif: true, record: faceIndex));
+                else
+                    facePanel.Size = new Vector2(currentFaceTexture.width, currentFaceTexture.height);
+
                 facePanel.BackgroundTexture = currentFaceTexture;
             }
         }

--- a/Assets/Scripts/Game/UserInterface/HUDCompass.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCompass.cs
@@ -10,6 +10,7 @@
 //
 
 using UnityEngine;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop.Game.UserInterface
 {
@@ -65,7 +66,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (Enabled)
             {
                 base.Update();
-                Size = new Vector2(compassBoxTexture.width * Scale.x, compassBoxTexture.height * Scale.y);
+                if (TextureReplacement.CustomImageExist(compassBoxFilename))
+                    Size = new Vector2(XMLManager.GetValue(compassBoxFilename, "width", isImage: true) * Scale.x, 
+                        XMLManager.GetValue(compassBoxFilename, "height", isImage: true) * Scale.y);
+                else
+                    Size = new Vector2(compassBoxTexture.width * Scale.x, compassBoxTexture.height * Scale.y);
             }
         }
 
@@ -107,14 +112,39 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Rect compassBoxRect = new Rect();
             compassBoxRect.x = Position.x;
             compassBoxRect.y = Position.y;
-            compassBoxRect.width = compassBoxTexture.width * Scale.x;
-            compassBoxRect.height = compassBoxTexture.height * Scale.y;
+            if (TextureReplacement.CustomImageExist(compassBoxFilename))
+            {
+                // Get custom size of compass box for custom imag
+                compassBoxRect.width = XMLManager.GetValue(compassBoxFilename, "width", isImage:true) * Scale.x;
+                compassBoxRect.height = XMLManager.GetValue(compassBoxFilename, "height", isImage:true) * Scale.y; 
+            }
+            else
+            {
+                // Use default texture with default size
+                compassBoxRect.width = compassBoxTexture.width * Scale.x;
+                compassBoxRect.height = compassBoxTexture.height * Scale.y;
+            }
+
+            // Get compassTexture size
+            float compassTextureWidth, compassTextureHeight;
+            if (TextureReplacement.CustomImageExist(compassFilename))
+            {
+                // Get custom size for custom image
+                compassTextureWidth = XMLManager.GetValue(compassFilename, "width", isImage: true);
+                compassTextureHeight = XMLManager.GetValue(compassFilename, "height", isImage: true);
+            }
+            else
+            {
+                // Get default size for default texture
+                compassTextureWidth = (float)compassTexture.width;
+                compassTextureHeight = (float)compassTexture.height;
+            }
 
             // Compass strip source
             Rect compassSrcRect = new Rect();
-            compassSrcRect.xMin = scroll / (float)compassTexture.width;
+            compassSrcRect.xMin = scroll / compassTextureWidth;
             compassSrcRect.yMin = 0;
-            compassSrcRect.xMax = compassSrcRect.xMin + (float)boxInterior / (float)compassTexture.width;
+            compassSrcRect.xMax = compassSrcRect.xMin + (float)boxInterior / compassTextureWidth;
             compassSrcRect.yMax = 1;
 
             // Compass strip destination
@@ -122,7 +152,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             compassDstRect.x = compassBoxRect.x + boxOutlineSize * Scale.x;
             compassDstRect.y = compassBoxRect.y + boxOutlineSize * Scale.y;
             compassDstRect.width = compassBoxRect.width - (boxOutlineSize * 2) * Scale.x;
-            compassDstRect.height = compassTexture.height * Scale.y;
+            compassDstRect.height = compassTextureHeight * Scale.y;
 
             GUI.DrawTextureWithTexCoords(compassDstRect, compassTexture, compassSrcRect, false);
             GUI.DrawTexture(compassBoxRect, compassBoxTexture, ScaleMode.StretchToFill, true);

--- a/Assets/Scripts/Game/UserInterface/HUDCrosshair.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCrosshair.cs
@@ -10,7 +10,8 @@
 //
 
 using UnityEngine;
-
+using DaggerfallWorkshop.Utility.AssetInjection;
+ 
 namespace DaggerfallWorkshop.Game.UserInterface
 {
     /// <summary>
@@ -36,14 +37,23 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (CrosshairTexture && Enabled)
             {
                 BackgroundTexture = CrosshairTexture;
-                Size = new Vector2(CrosshairTexture.width * CrosshairScale, CrosshairTexture.height * CrosshairScale);
+
+                if (TextureReplacement.CustomTextureExist(defaultCrosshairFilename))
+                    Size = new Vector2(XMLManager.GetValue(defaultCrosshairFilename, "width") * CrosshairScale, 
+                        XMLManager.GetValue(defaultCrosshairFilename, "height") * CrosshairScale);
+                else
+                    Size = new Vector2(CrosshairTexture.width * CrosshairScale, CrosshairTexture.height * CrosshairScale);
+
                 base.Update();
             }
         }
 
         void LoadAssets()
         {
-            CrosshairTexture = Resources.Load<Texture2D>(defaultCrosshairFilename);
+            if (TextureReplacement.CustomTextureExist(defaultCrosshairFilename))
+                CrosshairTexture = TextureReplacement.LoadCustomTexture(defaultCrosshairFilename);
+            else
+                CrosshairTexture = Resources.Load<Texture2D>(defaultCrosshairFilename);
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using DaggerfallConnect.Save;
 using DaggerfallWorkshop;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.UserInterface;
 
@@ -110,7 +111,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.VerticalAlignment = VerticalAlignment.Middle;
             mainPanel.Size = mainPanelSize;
             mainPanel.Outline.Enabled = true;
-            mainPanel.BackgroundColor = mainPanelBackgroundColor;
+            if (TextureReplacement.CustomTextureExist("mainPanelBackgroundColor"))
+                mainPanel.BackgroundTexture = TextureReplacement.LoadCustomTexture("mainPanelBackgroundColor");
+            else
+                mainPanel.BackgroundColor = mainPanelBackgroundColor;
             NativePanel.Components.Add(mainPanel);
 
             // Prompt
@@ -123,7 +127,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             namePanel.Position = new Vector2(4, 12);
             namePanel.Size = new Vector2(272, 9);
             namePanel.Outline.Enabled = true;
-            namePanel.BackgroundColor = namePanelBackgroundColor;
+            if (TextureReplacement.CustomTextureExist("namePanelBackgroundColor"))
+                namePanel.BackgroundTexture = TextureReplacement.LoadCustomTexture("namePanelBackgroundColor");
+            else
+                namePanel.BackgroundColor = namePanelBackgroundColor;
             mainPanel.Components.Add(namePanel);
 
             // Name input
@@ -143,7 +150,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             savesList.Position = new Vector2(2, 2);
             savesList.Size = new Vector2(91, 129);
             savesList.TextColor = savesListTextColor;
-            savesList.BackgroundColor = savesListBackgroundColor;
+            if (TextureReplacement.CustomTextureExist("savesListBackgroundColor"))
+                savesList.BackgroundTexture = TextureReplacement.LoadCustomTexture("savesListBackgroundColor");
+            else
+                savesList.BackgroundColor = savesListBackgroundColor;
             savesList.ShadowPosition = Vector2.zero;
             savesList.RowsDisplayed = 16;
             savesList.OnScroll += SavesList_OnScroll;
@@ -162,7 +172,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             goButton.Position = new Vector2(108, 150);
             goButton.Size = new Vector2(40, 16);
             goButton.Label.ShadowColor = Color.black;
-            goButton.BackgroundColor = saveButtonBackgroundColor;
+            if (TextureReplacement.CustomTextureExist("saveButtonBackgroundColor"))
+                TextureReplacement.SetCustomButton(ref goButton, "saveButtonBackgroundColor");
+            else
+                goButton.BackgroundColor = saveButtonBackgroundColor;
             goButton.Outline.Enabled = true;
             goButton.OnMouseClick += SaveLoadEventHandler;
             mainPanel.Components.Add(goButton);
@@ -173,7 +186,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             switchClassicButton.Label.Text = "Classic";
             //switchClassicButton.Label.TextColor = new Color(0.6f, 0.3f, 0.6f);
             switchClassicButton.Label.ShadowColor = Color.black;
-            switchClassicButton.BackgroundColor = new Color(0.2f, 0.2f, 0);
+            if (TextureReplacement.CustomTextureExist("switchClassicButtonBackgroundColor"))
+                TextureReplacement.SetCustomButton(ref switchClassicButton, "switchClassicButtonBackgroundColor");
+            else
+                switchClassicButton.BackgroundColor = new Color(0.2f, 0.2f, 0);
             switchClassicButton.Outline.Enabled = true;
             switchClassicButton.OnMouseClick += SwitchClassicButton_OnMouseClick;
             mainPanel.Components.Add(switchClassicButton);
@@ -184,7 +200,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             cancelButton.Size = new Vector2(40, 16);
             cancelButton.Label.Text = "Cancel";
             cancelButton.Label.ShadowColor = Color.black;
-            cancelButton.BackgroundColor = cancelButtonBackgroundColor;
+            if (TextureReplacement.CustomTextureExist("cancelButtonBackgroundColor"))
+                TextureReplacement.SetCustomButton(ref cancelButton, "cancelButtonBackgroundColor");
+            else
+                cancelButton.BackgroundColor = cancelButtonBackgroundColor;
             cancelButton.Outline.Enabled = true;
             cancelButton.OnMouseClick += CancelButton_OnMouseClick;
             mainPanel.Components.Add(cancelButton);
@@ -193,7 +212,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             screenshotPanel.Position = new Vector2(108, 25);
             screenshotPanel.Size = new Vector2(168, 95);
             screenshotPanel.BackgroundTextureLayout = BackgroundLayout.ScaleToFit;
-            screenshotPanel.BackgroundColor = savesListBackgroundColor;
+            if (TextureReplacement.CustomTextureExist("screenshotPanelBackgroundColor"))
+                screenshotPanel.BackgroundTexture = TextureReplacement.LoadCustomTexture("screenshotPanelBackgroundColor");
+            else
+                screenshotPanel.BackgroundColor = savesListBackgroundColor;
             screenshotPanel.Outline.Enabled = true;
             mainPanel.Components.Add(screenshotPanel);
 
@@ -232,7 +254,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             deleteSaveButton.HorizontalAlignment = HorizontalAlignment.Center;
             deleteSaveButton.Label.Text = "Delete Save";
             deleteSaveButton.Label.ShadowColor = Color.black;
-            deleteSaveButton.BackgroundColor = namePanelBackgroundColor;
+            if (TextureReplacement.CustomTextureExist("deleteSaveButtonBackgroundColor"))
+                TextureReplacement.SetCustomButton(ref deleteSaveButton, "deleteSaveButtonBackgroundColor");
+            else
+                deleteSaveButton.BackgroundColor = namePanelBackgroundColor;
             deleteSaveButton.Outline.Enabled = false;
             deleteSaveButton.OnMouseClick += DeleteSaveButton_OnMouseClick;
             savesPanel.Components.Add(deleteSaveButton);
@@ -242,7 +267,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             switchCharButton.Size = new Vector2(60, 8);
             switchCharButton.Label.Text = "Switch Char";
             switchCharButton.Label.ShadowColor = Color.black;
-            switchCharButton.BackgroundColor = saveButtonBackgroundColor;
+            if (TextureReplacement.CustomTextureExist("switchCharButtonBackgroundColor"))
+                TextureReplacement.SetCustomButton(ref switchCharButton, "switchCharButtonBackgroundColor");
+            else
+                switchCharButton.BackgroundColor = saveButtonBackgroundColor;
             switchCharButton.OnMouseClick += SwitchCharButton_OnMouseClick;
             mainPanel.Components.Add(switchCharButton);
         }

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -28,9 +28,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     /// </summary>
     static public class TextureReplacement
     {
-        static string texturesPath = Path.Combine(Application.streamingAssetsPath, "Textures");
-        static string imgPath = Path.Combine(texturesPath, "img");
-        static string cifPath = Path.Combine(texturesPath, "cif");
+        static public string texturesPath = Path.Combine(Application.streamingAssetsPath, "Textures");
+        static public string imgPath = Path.Combine(texturesPath, "img");
+        static public string cifPath = Path.Combine(texturesPath, "cif");
 
         #region Textures import
 

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -19,6 +19,7 @@
 
 using System.IO;
 using UnityEngine;
+using DaggerfallWorkshop.Game.UserInterface;
 
 namespace DaggerfallWorkshop.Utility.AssetInjection
 {
@@ -273,6 +274,27 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 // Import textures for each frame 
                 go.GetComponent<DaggerfallBillboard>().SetCustomMaterial(archive, record, NumberOfFrames, isEmissive);
             }
+        }
+
+        /// <summary>
+        /// Import custom texture and label settings for buttons
+        /// </summary>
+        /// <param name="button">Button</param>
+        /// <param name="colorName">Name of texture</param>
+        static public void SetCustomButton(ref Button button, string colorName)
+        {
+            // Load texture
+            button.BackgroundTexture = TextureReplacement.LoadCustomTexture(colorName);
+
+            // Load settings from Xml (if present)
+            // Set custom color
+            if (XMLManager.GetString(colorName, "customtext", false) == "true")
+                button.Label.TextColor = new Color(XMLManager.GetColorValue(colorName, "r"), 
+                    XMLManager.GetColorValue(colorName, "g"),  XMLManager.GetColorValue(colorName, "b"), 
+                    XMLManager.GetColorValue(colorName, "a"));
+            // Disable text. This is useful if text is drawn on texture
+            else if (XMLManager.GetString(colorName, "customtext", false) == "notext")
+                button.Label.Text = "";
         }
 
         #endregion

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -121,7 +121,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
         /// check if file exist on disk. 
         /// <returns>Bool</returns>
-        static public bool CustomCifExist(string filename, int record, int frame)
+        static public bool CustomCifExist(string filename, int record, int frame = 0)
         {
 
             if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting

--- a/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
+++ b/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
@@ -27,22 +27,50 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="valueName">Name of value to be searched</param>
         /// <param name="isImage">True if .IMG</param>
         /// <param name="isCif">True if .CIF or .RCI</param>
+        /// <param name="record">Texture record</param>
         /// <returns>Integer value</returns>
-        static public int GetValue(string fileName, string valueName, bool isImage = false, bool isCif=false)
+        static public int GetValue(string fileName, string valueName, bool isImage = false, bool isCif = false, int record = 0)
         {
             // Get path
             string path;
             if (isImage)
                 path = TextureReplacement.imgPath;
             else if (isCif)
+            {
                 path = TextureReplacement.cifPath;
+                fileName = fileName + "_" + record + "-0";
+            } 
             else
                 path = TextureReplacement.texturesPath;
 
-            // Get value
-            XElement xml = XElement.Load(Path.Combine(path, fileName + ".xml"));
-            return (int)xml.Element(valueName);
-        }
+            path = Path.Combine(path, fileName);
 
+            // Get value from xml
+            if (File.Exists(path + ".xml"))
+            {
+                XElement xml = XElement.Load(path + ".xml");
+                return (int)xml.Element(valueName);
+            }
+
+            // If missing, try to get value from texture
+            // This may give the wanted result if texture is same resolution as vanilla
+            if (valueName == "width")
+            {
+                Debug.Log(path + ".xml is missing, get width from " + fileName + ".png");
+                Texture2D tex = new Texture2D(2, 2);
+                tex.LoadImage(File.ReadAllBytes(path + ".png"));
+                return tex.width;
+            }
+            if (valueName == "height")
+            {
+                Debug.Log(path + ".xml is missing, get height from " + fileName + ".png");
+                Texture2D tex = new Texture2D(2, 2);
+                tex.LoadImage(File.ReadAllBytes(path + ".png"));
+                return tex.height;
+            }
+
+            Debug.LogError(path + ".xml is missing");
+            return 0;         
+        }
     }
 }

--- a/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
+++ b/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
@@ -22,6 +22,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     {
         /// <summary>
         /// Get value from Xml file on disk
+        /// This is useful to get additional informations for custom textures.
         /// </summary>
         /// <param name="fileName">Name of texture. Correspond to the name of Xml file</param>
         /// <param name="valueName">Name of value to be searched</param>
@@ -33,6 +34,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         {
             // Get path
             string path;
+            string originalName = fileName;
             if (isImage)
                 path = TextureReplacement.imgPath;
             else if (isCif)
@@ -51,8 +53,26 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 XElement xml = XElement.Load(path + ".xml");
                 return (int)xml.Element(valueName);
             }
-
-            // If missing, try to get value from texture
+            
+            // If missing, try to get value from Daggerfall vanilla texture
+            if (isImage)
+            {
+                ImageData imageData = ImageReader.GetImageData(fileName, createTexture: false);
+                if (valueName == "width")
+                    return imageData.width;
+                else if (valueName == "height")
+                    return imageData.height;
+            }
+            else if (isCif)
+            {
+                ImageData imageData = ImageReader.GetImageData(originalName, record, createTexture: false);
+                if (valueName == "width")
+                    return imageData.width;
+                else if (valueName == "height")
+                    return imageData.height;
+            }
+             
+            // If missing, try to get value from custom texture
             // This may give the wanted result if texture is same resolution as vanilla
             if (valueName == "width")
             {
@@ -71,6 +91,54 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
             Debug.LogError(path + ".xml is missing");
             return 0;         
+        }
+
+        /// <summary>
+        /// Get float value from Xml file on disk.
+        /// This is useful to import rgba values.
+        /// </summary>
+        /// <param name="fileName">Name of texture. Correspond to the name of Xml file</param>
+        /// <param name="valueName">Name of value to be searched</param>
+        /// <returns>Float value</returns>
+        static public float GetColorValue(string fileName, string valueName)
+        {
+            // Get path
+            string path = Path.Combine(TextureReplacement.texturesPath, fileName);
+
+            // Get value from xml
+            if (File.Exists(path + ".xml"))
+            {
+                XElement xml = XElement.Load(path + ".xml");
+                return (float)xml.Element(valueName);
+            }
+
+            Debug.LogError(path + ".xml is missing");
+            return 0;
+        }
+
+        /// <summary>
+        /// Get string from Xml file on disk.
+        /// </summary>
+        /// <param name="fileName">Name of texture. Correspond to the name of Xml file</param>
+        /// <param name="valueName">Name of value to be searched</param>
+        /// <param name="isRequired">By default return an empty string if file is missing, if false return "NULL"</param>
+        /// <returns>String</returns>
+        static public string GetString (string fileName, string valueName, bool isRequired = true)
+        {
+            string path = Path.Combine(TextureReplacement.texturesPath, fileName);
+
+            // Get string from xml
+            if (File.Exists(path + ".xml"))
+            {
+                XElement xml = XElement.Load(path + ".xml");
+                return (string)xml.Element(valueName);
+            }
+            // Return NULL if the file is not found and isRequired is false
+            else if (!isRequired)
+                return "NULL";
+
+            Debug.LogError(path + ".xml is missing");
+            return "";
         }
     }
 }

--- a/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
+++ b/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
@@ -1,0 +1,48 @@
+﻿// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: TheLacus
+// Contributors:
+// 
+// Notes:
+//
+
+using System.IO;
+using System.Xml.Linq;
+using UnityEngine;
+
+namespace DaggerfallWorkshop.Utility.AssetInjection
+{
+    /// <summary>
+    /// Read XML files from disk for modding purposes
+    /// </summary>
+    static public class XMLManager
+    {
+        /// <summary>
+        /// Get value from Xml file on disk
+        /// </summary>
+        /// <param name="fileName">Name of texture. Correspond to the name of Xml file</param>
+        /// <param name="valueName">Name of value to be searched</param>
+        /// <param name="isImage">True if .IMG</param>
+        /// <param name="isCif">True if .CIF or .RCI</param>
+        /// <returns>Integer value</returns>
+        static public int GetValue(string fileName, string valueName, bool isImage = false, bool isCif=false)
+        {
+            // Get path
+            string path;
+            if (isImage)
+                path = TextureReplacement.imgPath;
+            else if (isCif)
+                path = TextureReplacement.cifPath;
+            else
+                path = TextureReplacement.texturesPath;
+
+            // Get value
+            XElement xml = XElement.Load(Path.Combine(path, fileName + ".xml"));
+            return (int)xml.Element(valueName);
+        }
+
+    }
+}

--- a/Assets/Scripts/Utility/AssetInjection/XMLManager.cs.meta
+++ b/Assets/Scripts/Utility/AssetInjection/XMLManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cc2f74c613a9f9c438b7253d8df0ca6f
+timeCreated: 1486331343
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Allow higher resolution textures for certain UI elements, using xml files to get rect size. This also means that user can customize these values, for example to change the size of the compass on screen.