### PR TITLE
Fix songs not repeating

### DIFF
--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -269,7 +269,7 @@ namespace DaggerfallWorkshop.Game
         void PlayCurrentSong(bool forcePlay = false)
         {
             // Do nothing if already playing this song or play disabled
-            if ((songPlayer.Song == currentSong || !playSong) && !forcePlay)
+            if (((songPlayer.Song == currentSong && songPlayer.IsPlaying) || !playSong) && !forcePlay)
                 return;
 
             songPlayer.Song = currentSong;

--- a/Assets/Scripts/Internal/DaggerfallSongPlayer.cs
+++ b/Assets/Scripts/Internal/DaggerfallSongPlayer.cs
@@ -134,6 +134,7 @@ namespace DaggerfallWorkshop
                 midiSequencer.Play();
                 currentMidiName = filename;
                 playEnabled = true;
+                IsPlaying = true;
             }
         }
 


### PR DESCRIPTION
Fixes the problem of songs not repeating, mentioned here
http://forums.dfworkshop.net/viewtopic.php?f=24&t=423. I don't know anything about the crash mentioned there.

I don't know the whole path of execution, but when songs were stopping, it looks like PlayCurrentSong() was called from Update() in SongManager, then PlayCurrentSong() was returning immediately because the `songPlayer.Song == currentSong` condition was true, even though the song had stopped playing. I added a check for `songPlayer.IsPlaying,` and this fixed the problem.

Adding this check caused a stutter in the music when loading a new context, though. Apparently IsPlaying wasn't being updated quickly enough, so `(songPlayer.Song == currentSong && songPlayer.IsPlaying)` would evaluate to false and the song would restart once. I made Play() in DaggerfallSongPlayer, which gets called before the end of PlayCurrentSong(), update IsPlaying to true, and this fixed the stutter. 