### PR TITLE
Mesh and Texture replacement - More changes

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -221,10 +221,8 @@ namespace DaggerfallWorkshop
                 if (modelData.Doors != null)
                     doors.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, entryDoor.blockIndex, entryDoor.recordIndex, modelMatrix));
 
-                // Import custom GameObject
-                bool modelExist;
-                MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, modelMatrix.GetColumn(3), node.transform, GameObjectHelper.QuaternionFromMatrix(modelMatrix), out modelExist);
-                if (!modelExist)
+                // Get GameObject
+                if (!MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, modelMatrix.GetColumn(3), node.transform, GameObjectHelper.QuaternionFromMatrix(modelMatrix)))
                 {
                     // Use Daggerfall Mesh: Combine or add
                     if (dfUnity.Option_CombineRMB)

--- a/Assets/Scripts/Internal/DaggerfallLocation.cs
+++ b/Assets/Scripts/Internal/DaggerfallLocation.cs
@@ -241,16 +241,20 @@ namespace DaggerfallWorkshop
                 {
                     // Apply recalculated nature archive
                     db.SetMaterial(natureArchive, db.Summary.Record);
+
+                    // Custom texture
+                    if (Utility.AssetInjection.TextureReplacement.CustomTextureExist(natureArchive, db.Summary.Record))
+                        Utility.AssetInjection.TextureReplacement.LoadCustomBillboardTexture(db.gameObject, natureArchive, db.Summary.Record);
                 }
                 else
                 {
                     // All other flats are just reapplied to handle any other changes
                     db.SetMaterial(db.Summary.Archive, db.Summary.Record);
-                }
 
-                // Custom texture
-                if (Utility.AssetInjection.TextureReplacement.CustomTextureExist(natureArchive, db.Summary.Record))
-                    Utility.AssetInjection.TextureReplacement.LoadCustomBillboardTexture(db.gameObject, natureArchive, db.Summary.Record);
+                    // Custom texture
+                    if (Utility.AssetInjection.TextureReplacement.CustomTextureExist(db.Summary.Archive, db.Summary.Record))
+                        Utility.AssetInjection.TextureReplacement.LoadCustomBillboardTexture(db.gameObject, db.Summary.Archive, db.Summary.Record);
+                }
             }
 
             // Process nature billboard batch

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -11,9 +11,10 @@
 
 /*
  * TODO:
- * 1. Exterior billboards
+ * 1. StreamingWorld billboards
  * 2. PaperDoll CharacterLayer textures works only if resolution is the same as vanilla 
  *        (http://forums.dfworkshop.net/viewtopic.php?f=22&p=3547&sid=6a99dbcffad1a15b08dd5e157274b772#p3547)
+ * 3. Terrain textures
  */
 
 using System.IO;

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -554,14 +554,11 @@ namespace DaggerfallWorkshop.Utility
                         // Check if model has an action record
                         bool hasAction = HasAction(obj);
 
-                        // Import custom GameObject
-                        bool modelExist;
-                        if (!hasAction)
-                            MeshReplacement.ImportCustomGameobject(modelId, modelMatrix.GetColumn(3), modelsParent, GameObjectHelper.QuaternionFromMatrix(modelMatrix), out modelExist);
-                        else
-                            modelExist = false;
+                        // Get GameObject
+                        GameObject standaloneObject = null;
+                        Transform parent = (hasAction) ? actionModelsParent : modelsParent;
 
-                        if (!modelExist)
+                        if (!MeshReplacement.ImportCustomGameobject(modelId, modelMatrix.GetColumn(3), parent, GameObjectHelper.QuaternionFromMatrix(modelMatrix), out standaloneObject))
                         {
                             // Special handling for tapestries and banners
                             // Some of these are so far out from wall player can become stuck behind them
@@ -574,8 +571,6 @@ namespace DaggerfallWorkshop.Utility
                             }
 
                             // Add or combine
-                            GameObject standaloneObject = null;
-                            Transform parent = (hasAction) ? actionModelsParent : modelsParent;
                             if (combiner == null || hasAction)
                             {
                                 standaloneObject = AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent, hasAction);
@@ -585,15 +580,14 @@ namespace DaggerfallWorkshop.Utility
                             {
                                 combiner.Add(ref modelData, modelMatrix);
                             }
-
-                            // Add action
-                            if (hasAction && standaloneObject != null)
-                                AddActionModelHelper(standaloneObject, actionLinkDict, obj, ref blockData, serialize);
                         }
+
+                        // Add action
+                        if (hasAction && standaloneObject != null)
+                            AddActionModelHelper(standaloneObject, actionLinkDict, obj, ref blockData, serialize);
                     }
                 }
             }
-
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -483,9 +483,7 @@ namespace DaggerfallWorkshop.Utility
                         doorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, recordCount, modelMatrix));
 
                     // Import custom GameObject
-                    bool modelExist;
-                    MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, modelMatrix.GetColumn(3), parent, GameObjectHelper.QuaternionFromMatrix(modelMatrix), out modelExist);
-                    if (modelExist)
+                    if (MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, modelMatrix.GetColumn(3), parent, GameObjectHelper.QuaternionFromMatrix(modelMatrix)))
                         continue;
 
                     // Use Daggerfall Model
@@ -527,9 +525,7 @@ namespace DaggerfallWorkshop.Utility
                     doorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, 0, modelMatrix));
 
                 // Import custom GameObject
-                bool modelExist;
-                MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, modelMatrix.GetColumn(3), parent, GameObjectHelper.QuaternionFromMatrix(modelMatrix), out modelExist);
-                if (modelExist)
+                if (MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, modelMatrix.GetColumn(3), parent, GameObjectHelper.QuaternionFromMatrix(modelMatrix)))
                     continue;
 
                 // Use Daggerfall Model


### PR DESCRIPTION
* Minor changes for exteriors billboards.
* Minor changes in RDB and code organization
* Models that replace billboards have a random rotation. This should be particularly useful for trees, as they look more natural and not all facing the same direction. I used a value from Position as seed so the rotation is always the same.