### PR TITLE
automap - slice level can now be adjusted with middle mouse button

### DIFF
--- a/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
+++ b/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
@@ -45,8 +45,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
         VerticalAlignment verticalAlignment = VerticalAlignment.None;
 
         float doubleClickDelay = 0.3f;
-        float clickTime;
-        float lastClickTime;
+        float leftClickTime;
+        float lastLeftClickTime;
+        float rightClickTime;
+        float lastRightClickTime;
+        float middleClickTime;
+        float lastMiddleClickTime;
 
         float updateTime;
         float lastUpdateTime;
@@ -65,6 +69,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         bool mouseOverComponent = false;
         bool leftMouseWasHeldDown = false;
         bool rightMouseWasHeldDown = false;
+        bool middleMouseWasHeldDown = false;
 
         float minAutoScale = 0;
         float maxAutoScale = 0;
@@ -87,6 +92,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public delegate void OnMouseClickHandler(BaseScreenComponent sender, Vector2 position);
         public event OnMouseClickHandler OnMouseClick;
 
+        public delegate void OnMouseDoubleClickHandler(BaseScreenComponent sender, Vector2 position);
+        public event OnMouseDoubleClickHandler OnMouseDoubleClick;
+
         public delegate void OnRightMouseDownHandler(BaseScreenComponent sender, Vector2 position);
         public event OnRightMouseDownHandler OnRightMouseDown;
         
@@ -96,8 +104,20 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public delegate void OnRightMouseClickHandler(BaseScreenComponent sender, Vector2 position);
         public event OnRightMouseClickHandler OnRightMouseClick;
 
-        public delegate void OnMouseDoubleClickHandler(BaseScreenComponent sender, Vector2 position);
-        public event OnMouseDoubleClickHandler OnMouseDoubleClick;
+        public delegate void OnRightMouseDoubleClickHandler(BaseScreenComponent sender, Vector2 position);
+        public event OnRightMouseDoubleClickHandler OnRightMouseDoubleClick;
+
+        public delegate void OnMiddleMouseDownHandler(BaseScreenComponent sender, Vector2 position);
+        public event OnMiddleMouseDownHandler OnMiddleMouseDown;
+
+        public delegate void OnMiddleMouseUpHandler(BaseScreenComponent sender, Vector2 position);
+        public event OnMiddleMouseUpHandler OnMiddleMouseUp;
+
+        public delegate void OnMiddleMouseClickHandler(BaseScreenComponent sender, Vector2 position);
+        public event OnMiddleMouseClickHandler OnMiddleMouseClick;
+
+        public delegate void OnMiddleMouseDoubleClickHandler(BaseScreenComponent sender, Vector2 position);
+        public event OnMiddleMouseDoubleClickHandler OnMiddleMouseDoubleClick;
 
         public delegate void OnMouseScrollUpEventHandler();
         public event OnMouseScrollUpEventHandler OnMouseScrollUp;
@@ -444,10 +464,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // Get left and right mouse down for general click handling and double-click sampling
             bool leftMouseDown = Input.GetMouseButtonDown(0);
             bool rightMouseDown = Input.GetMouseButtonDown(1);
+            bool middleMouseDown = Input.GetMouseButtonDown(2);
 
             // Get left and right mouse down for up/down events
             bool leftMouseHeldDown = Input.GetMouseButton(0);
             bool rightMouseHeldDown = Input.GetMouseButton(1);
+            bool middleMouseHeldDown = Input.GetMouseButton(2);
 
             // Handle left mouse down/up events
             // Can only trigger mouse down while over component but can release from anywhere
@@ -479,6 +501,21 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     OnRightMouseUp(this, scaledMousePosition);
             }
 
+            // Handle middle mouse down/up events
+            // Can only trigger mouse down while over component but can release from anywhere
+            if (mouseOverComponent && middleMouseHeldDown && !middleMouseWasHeldDown)
+            {
+                middleMouseWasHeldDown = true;
+                if (OnMiddleMouseDown != null)
+                    OnMiddleMouseDown(this, scaledMousePosition);
+            }
+            if (!middleMouseHeldDown && middleMouseWasHeldDown)
+            {
+                middleMouseWasHeldDown = false;
+                if (OnMiddleMouseUp != null)
+                    OnMiddleMouseUp(this, scaledMousePosition);
+            }
+
             // Handle left mouse clicks
             if (mouseOverComponent && leftMouseDown)
             {
@@ -486,11 +523,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 MouseClick(scaledMousePosition);
 
                 // Store mouse click timing
-                lastClickTime = clickTime;
-                clickTime = Time.realtimeSinceStartup;
+                lastLeftClickTime = leftClickTime;
+                leftClickTime = Time.realtimeSinceStartup;
 
                 // Handle left mouse double-clicks
-                if (clickTime - lastClickTime < doubleClickDelay)
+                if (leftClickTime - lastLeftClickTime < doubleClickDelay)
                     MouseDoubleClick(scaledMousePosition);
             }
 
@@ -499,6 +536,29 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 // Single click event
                 RightMouseClick(scaledMousePosition);
+
+                // Store mouse click timing
+                lastRightClickTime = rightClickTime;
+                rightClickTime = Time.realtimeSinceStartup;
+
+                // Handle right mouse double-clicks
+                if (rightClickTime - lastRightClickTime < doubleClickDelay)
+                    RightMouseDoubleClick(scaledMousePosition);
+            }
+
+            // Handle middle mouse clicks
+            if (mouseOverComponent && middleMouseDown)
+            {
+                // Single click event
+                MiddleMouseClick(scaledMousePosition);
+
+                // Store mouse click timing
+                lastMiddleClickTime = middleClickTime;
+                middleClickTime = Time.realtimeSinceStartup;
+
+                // Handle middle mouse double-clicks
+                if (middleClickTime - lastMiddleClickTime < doubleClickDelay)
+                    MiddleMouseDoubleClick(scaledMousePosition);
             }
 
             // Handle mouse wheel
@@ -627,12 +687,25 @@ namespace DaggerfallWorkshop.Game.UserInterface
         }
 
         /// <summary>
-        /// Mouse clicked inside control area.
+        /// Right Mouse clicked inside control area.
         /// </summary>
         protected virtual void RightMouseClick(Vector2 clickPosition)
         {
             if (OnRightMouseClick != null)
                 OnRightMouseClick(this, clickPosition);
+
+            // Set focus on click
+            if (UseFocus)
+                SetFocus();
+        }
+
+        /// <summary>
+        /// Middle Mouse clicked inside control area.
+        /// </summary>
+        protected virtual void MiddleMouseClick(Vector2 clickPosition)
+        {
+            if (OnMiddleMouseClick != null)
+                OnMiddleMouseClick(this, clickPosition);
 
             // Set focus on click
             if (UseFocus)
@@ -646,6 +719,24 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             if (OnMouseDoubleClick != null)
                 OnMouseDoubleClick(this, clickPosition);
+        }
+
+        /// <summary>
+        /// Right Mouse double-clicked inside control area.
+        /// </summary>
+        protected virtual void RightMouseDoubleClick(Vector2 clickPosition)
+        {
+            if (OnRightMouseDoubleClick != null)
+                OnRightMouseDoubleClick(this, clickPosition);
+        }
+
+        /// <summary>
+        /// Middle Mouse double-clicked inside control area.
+        /// </summary>
+        protected virtual void MiddleMouseDoubleClick(Vector2 clickPosition)
+        {
+            if (OnMiddleMouseDoubleClick != null)
+                OnMiddleMouseDoubleClick(this, clickPosition);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
@@ -190,6 +190,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         bool leftMouseClickedOnPanelAutomap = false; // used for debug teleport mode clicks
         bool leftMouseDownOnPanelAutomap = false;
         bool rightMouseDownOnPanelAutomap = false;
+        bool middleMouseDownOnPanelAutomap = false;
         bool leftMouseDownOnForwardButton = false;
         bool rightMouseDownOnForwardButton = false;
         bool leftMouseDownOnBackwardButton = false;
@@ -208,7 +209,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         bool rightMouseDownOnDownstairsButton = false;
         bool alreadyInMouseDown = false;
         bool alreadyInRightMouseDown = false;
-        bool inDragMode() { return leftMouseDownOnPanelAutomap || rightMouseDownOnPanelAutomap; }
+        bool alreadyInMiddleMouseDown = false;
+        bool inDragMode() { return leftMouseDownOnPanelAutomap || rightMouseDownOnPanelAutomap || middleMouseDownOnPanelAutomap; }
 
         Texture2D nativeTexture; // background image will be stored in this Texture2D
 
@@ -341,6 +343,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             panelRenderAutomap.OnMouseUp += PanelAutomap_OnMouseUp;
             panelRenderAutomap.OnRightMouseDown += PanelAutomap_OnRightMouseDown;
             panelRenderAutomap.OnRightMouseUp += PanelAutomap_OnRightMouseUp;
+            panelRenderAutomap.OnMiddleMouseDown += PanelAutomap_OnMiddleMouseDown;
+            panelRenderAutomap.OnMiddleMouseUp += PanelAutomap_OnMiddleMouseUp;
 
             // Grid button (toggle 2D <-> 3D view)
             gridButton = DaggerfallUI.AddButton(new Rect(78, 171, 27, 19), NativePanel);
@@ -419,7 +423,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             upstairsButton.OnRightMouseDown += UpstairsButton_OnRightMouseDown;
             upstairsButton.OnRightMouseUp += UpstairsButton_OnRightMouseUp;
             upstairsButton.ToolTip = defaultToolTip;
-            upstairsButton.ToolTipText = "left click: increase viewpoint (hotkey: page up)\rright click: increase slice level (hotkey: control+page up)\r\rhint: different render modes may show hidden geometry:\rhotkey F2: cutout mode\rhotkey F3: wireframe mode\rhotkey F4: transparent mode\rswitch between modes with return key";
+            upstairsButton.ToolTipText = "left click: increase viewpoint (hotkey: page up)\rright click: increase slice level (hotkey: control+page up)\rslice level can also be adjusted by holding down middle mouse button\r\rhint: different render modes may show hidden geometry:\rhotkey F2: cutout mode\rhotkey F3: wireframe mode\rhotkey F4: transparent mode\rswitch between modes with return key";
             upstairsButton.ToolTip.ToolTipDelay = toolTipDelay;
 
             // downstairs button
@@ -429,7 +433,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             downstairsButton.OnRightMouseDown += DownstairsButton_OnRightMouseDown;
             downstairsButton.OnRightMouseUp += DownstairsButton_OnRightMouseUp;
             downstairsButton.ToolTip = defaultToolTip;
-            downstairsButton.ToolTipText = "left click: decrease viewpoint (hotkey: page down)\rright click: decrease slice level (hotkey: control+page down)\r\rhint: different render modes may show hidden geometry:\rhotkey F2: cutout mode\rhotkey F3: wireframe mode\rhotkey F4: transparent mode\rswitch between modes with return key";
+            downstairsButton.ToolTipText = "left click: decrease viewpoint (hotkey: page down)\rright click: decrease slice level (hotkey: control+page down)\rslice level can also be adjusted by holding down middle mouse button\r\rhint: different render modes may show hidden geometry:\rhotkey F2: cutout mode\rhotkey F3: wireframe mode\rhotkey F4: transparent mode\rswitch between modes with return key";
             downstairsButton.ToolTip.ToolTipDelay = toolTipDelay;
 
             // Exit button
@@ -798,6 +802,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         ActionrotateCameraOnCameraYZplaneAroundObject(-dragRotateCameraOnCameraYZplaneAroundObjectSpeedInView3D * bias.y);
                         break;
                 }
+
+                updateAutomapView();
+                oldMousePosition = mousePosition;
+            }
+
+            if (middleMouseDownOnPanelAutomap)
+            {
+                Vector2 mousePosition = new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y);
+
+                Vector2 bias = mousePosition - oldMousePosition;
+
+                ActionMoveSliceLevel(bias.y);
 
                 updateAutomapView();
                 oldMousePosition = mousePosition;
@@ -1408,6 +1424,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
 
         /// <summary>
+        /// action for moving (adjusting) slice level relative to current level
+        /// </summary>
+        private void ActionMoveSliceLevel(float bias)
+        {
+            daggerfallAutomap.SlicingBiasY += Vector3.down.y * bias * Time.unscaledDeltaTime;
+            updateAutomapView();
+        }
+
+        /// <summary>
         /// action for zooming in
         /// </summary>
         private void ActionZoomIn(float zoomSpeed)
@@ -1698,6 +1723,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             rightMouseDownOnPanelAutomap = false;
             alreadyInRightMouseDown = false;
+        }
+
+        private void PanelAutomap_OnMiddleMouseDown(BaseScreenComponent sender, Vector2 position)
+        {
+            if (alreadyInMiddleMouseDown)
+                return;
+
+            Vector2 mousePosition = new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y);
+            oldMousePosition = mousePosition;
+            middleMouseDownOnPanelAutomap = true;
+            alreadyInMiddleMouseDown = true;
+        }
+
+        private void PanelAutomap_OnMiddleMouseUp(BaseScreenComponent sender, Vector2 position)
+        {
+            middleMouseDownOnPanelAutomap = false;
+            alreadyInMiddleMouseDown = false;
         }
 
         private void GridButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)


### PR DESCRIPTION
interior automap (DaggerfallAutomapWindow.cs) - slice level can now be adjusted with middle mouse button:
hold down middle mouse button over main panel and move up/down to adjust the slice level

BaseScreenComponent.cs:
support for middle mouse button added, right mouse double-click added