### PR TITLE
default rendermode dep. on building/dungeon,double-click left/right

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
@@ -345,6 +345,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             panelRenderAutomap.OnRightMouseUp += PanelAutomap_OnRightMouseUp;
             panelRenderAutomap.OnMiddleMouseDown += PanelAutomap_OnMiddleMouseDown;
             panelRenderAutomap.OnMiddleMouseUp += PanelAutomap_OnMiddleMouseUp;
+            panelRenderAutomap.OnMouseDoubleClick += PanelAutomap_OnMouseDoubleClick;
+            panelRenderAutomap.OnRightMouseDoubleClick += PanelAutomap_OnRightMouseDoubleClick;
+            panelRenderAutomap.OnMiddleMouseDoubleClick += PanelAutomap_OnMiddleMouseDoubleClick;
 
             // Grid button (toggle 2D <-> 3D view)
             gridButton = DaggerfallUI.AddButton(new Rect(78, 171, 27, 19), NativePanel);
@@ -423,7 +426,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             upstairsButton.OnRightMouseDown += UpstairsButton_OnRightMouseDown;
             upstairsButton.OnRightMouseUp += UpstairsButton_OnRightMouseUp;
             upstairsButton.ToolTip = defaultToolTip;
-            upstairsButton.ToolTipText = "left click: increase viewpoint (hotkey: page up)\rright click: increase slice level (hotkey: control+page up)\rslice level can also be adjusted by holding down middle mouse button\r\rhint: different render modes may show hidden geometry:\rhotkey F2: cutout mode\rhotkey F3: wireframe mode\rhotkey F4: transparent mode\rswitch between modes with return key";
+            upstairsButton.ToolTipText = "left click: increase viewpoint (hotkey: page up)\rright click: increase slice level (hotkey: control+page up)\rslice level can also be adjusted by holding down middle mouse button\r\rhint: different render modes may show hidden geometry:\rhotkey F2: cutout mode\rhotkey F3: wireframe mode\rhotkey F4: transparent mode\rswitch between modes with return key\r(alternative: double-click middle mouse button)";
             upstairsButton.ToolTip.ToolTipDelay = toolTipDelay;
 
             // downstairs button
@@ -433,7 +436,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             downstairsButton.OnRightMouseDown += DownstairsButton_OnRightMouseDown;
             downstairsButton.OnRightMouseUp += DownstairsButton_OnRightMouseUp;
             downstairsButton.ToolTip = defaultToolTip;
-            downstairsButton.ToolTipText = "left click: decrease viewpoint (hotkey: page down)\rright click: decrease slice level (hotkey: control+page down)\rslice level can also be adjusted by holding down middle mouse button\r\rhint: different render modes may show hidden geometry:\rhotkey F2: cutout mode\rhotkey F3: wireframe mode\rhotkey F4: transparent mode\rswitch between modes with return key";
+            downstairsButton.ToolTipText = "left click: decrease viewpoint (hotkey: page down)\rright click: decrease slice level (hotkey: control+page down)\rslice level can also be adjusted by holding down middle mouse button\r\rhint: different render modes may show hidden geometry:\rhotkey F2: cutout mode\rhotkey F3: wireframe mode\rhotkey F4: transparent mode\rswitch between modes with return key\r(alternative: double-click middle mouse button)";
             downstairsButton.ToolTip.ToolTipDelay = toolTipDelay;
 
             // Exit button
@@ -448,7 +451,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             dummyPanelCompass.OnMouseClick += Compass_OnMouseClick;
             dummyPanelCompass.OnRightMouseClick += Compass_OnRightMouseClick;
             dummyPanelCompass.ToolTip = defaultToolTip;
-            dummyPanelCompass.ToolTipText = "left click: toggle focus (hotkey: tab)\rred beacon: player, green beacon: entrance, blue beacon: rotation center\r\rright click: reset view (hotkey: backspace)";
+            dummyPanelCompass.ToolTipText = "left click: toggle focus (hotkey: tab,\ralternative: double-click left mouse button)\rred beacon: player, green beacon: entrance, blue beacon: rotation center\r\rright click: reset view (hotkey: backspace,\ralternative: double-click right mouse button)";
             dummyPanelCompass.ToolTip.ToolTipDelay = toolTipDelay;
 
             // compass            
@@ -473,7 +476,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             daggerfallAutomap.IsOpenAutomap = true; // signal DaggerfallAutomap script that automap is open and it should do its stuff in its Update() function            
 
-            daggerfallAutomap.updateAutomapStateOnWindowPush(); // signal DaggerfallAutomap script that automap window was closed and that it should update its state (updates player marker arrow)
+            daggerfallAutomap.updateAutomapStateOnWindowPush(); // signal DaggerfallAutomap script that automap window was opened and that it should update its state (updates player marker arrow)
 
             // get automap camera
             cameraAutomap = daggerfallAutomap.CameraAutomap;
@@ -514,6 +517,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // reset values to default whenever player enters building or dungeon
                 resetCameraPosition();
                 fieldOfViewCameraMode3D = defaultFieldOfViewCameraMode3D;
+
+                // set standard automap render mode dependent where player is
+                if (GameManager.Instance.IsPlayerInsideBuilding) // if inside building
+                {
+                    ActionSwitchToAutomapRenderModeCutout(); // set automap render mode to cutout (since floors above the current are often distracting when viewing a building)
+                }
+                else // if inside dungeon or palace
+                {
+                    ActionSwitchToAutomapRenderModeTransparent(); // set automap render mode to transparent (since people that don't know the map functionality often think cutout mode is a bug)
+                }
 
                 daggerfallAutomap.ResetAutomapSettingsSignalForExternalScript = false; // indicate the settings were reset
             }
@@ -1683,6 +1696,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void PanelAutomap_OnMouseScrollDown()
         {
             ActionZoomOut(zoomSpeedMouseWheel);
+        }
+
+        private void PanelAutomap_OnMouseDoubleClick(BaseScreenComponent sender, Vector2 position)
+        {
+            ActionSwitchFocusToNextBeaconObject();
+        }
+
+        private void PanelAutomap_OnRightMouseDoubleClick(BaseScreenComponent sender, Vector2 position)
+        {
+            ActionResetView();
+        }
+
+        private void PanelAutomap_OnMiddleMouseDoubleClick(BaseScreenComponent sender, Vector2 position)
+        {
+            ActionSwitchToNextAutomapRenderMode();
         }
 
         private void PanelAutomap_OnMouseDown(BaseScreenComponent sender, Vector2 position)


### PR DESCRIPTION
default automap render mode (automap opened for new location) is now dependent on if player is inside building or dungeon/palace:

building: cutout
dungeon/palace: transparent

this is done because: in buildings higher level floors easily distract when viewing the interior map, in dungeons people that don't know all the functions of the map often think the map is bugged when they don't see geometry above the slice level (I watched several youtube videos with confused people)

double click on left mouse button now switches between beacons
double click on right mouse button now resets view
double click on middle mouse button now switches rendering modes