### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+


### PR DESCRIPTION
EditorConfig (http://editorconfig.org/) is a simple, readable IDE/editor config file that makes certain style guides easy and automatically enforced. Things like tabs, newlines, etc. It's supported by several IDEs/editors (Atom, Rider to name a few). Visual Studio will need a plugin. I personally use Rider.

These configs are just my own preference. Feel free to rework to what you want the general style to be. I actually also like the `insert_final_newline` option, but it's more preference than anything. I think the actual reasons for that behavior/style are mostly antiquated now.