### PR TITLE
Fix gargoyle sounds

### DIFF
--- a/Assets/Scripts/SoundClips.cs
+++ b/Assets/Scripts/SoundClips.cs
@@ -233,11 +233,11 @@ namespace DaggerfallWorkshop
 
         EnemyOrcShamanMove = 178,
         EnemyOrcShamanBark = 179,
-        EnemyOrcShamanAttack = 180,
+        EnemyOrcShamanAttack = 138,
 
         EnemyGargoyleMove = 181,
         EnemyGargoyleBark = 182,
-        // Gargoyle attack sound missing.
+        EnemyGargoyleAttack = 180,
 
         EnemyWraithMove = 183,
         EnemyWraithBark = 184,

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -668,7 +668,7 @@ namespace DaggerfallWorkshop.Utility
                 BloodIndex = 2,
                 MoveSound = (int)SoundClips.EnemyGargoyleMove,
                 BarkSound = (int)SoundClips.EnemyGargoyleBark,
-                AttackSound = -1,
+                AttackSound = (int)SoundClips.EnemyGargoyleAttack,
                 MinMetalToHit = MetalTypes.Mithril,
                 MinDamage = 10,
                 MaxDamage = 15,


### PR DESCRIPTION
The gargoyle's attack sound was noted as missing, but actually it was being assigned to the orc shaman. For some reason, even though Daggerfall Jukebox will extract three sounds for the orc shaman, with the attack sound being identical to that of a regular orc (the files are identical), this index seems to be skipped over in Daggerfall Unity. I reassigned the orc shaman to use the regular orc's attack sound.