### PR TITLE
Make Orsinium have dungeon music and lighting throughout

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -689,7 +689,6 @@ namespace DaggerfallWorkshop.Game
 
             switch (playerDungeonBlockData.BlockName)
             {
-                case "S0000020.RDB":    // Orsinium castle area
                 case "S0000040.RDB":    // Sentinel castle area
                 case "S0000041.RDB":
                 case "S0000042.RDB":


### PR DESCRIPTION
Daggerfall Unity used the castle music and lighting in Orsinium, until you got out of the first block and into the dungeon area. In classic, it has dungeon music and lighting throughout.