### PR TITLE
Set message text color to match Daggerfall classic

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -36,9 +36,10 @@ namespace DaggerfallWorkshop.Game
         const string splashVideo = "ANIM0001.VID";
         const string deathVideo = "ANIM0012.VID";
 
-        public static Color DaggerfallDefaultTextColor = new Color32(243, 239, 44, 255);
+        public static Color DaggerfallDefaultTextColor = new Color32(226, 220, 0, 255); // Matched to Daggerfall Classic.
         public static Color DaggerfallDefaultInputTextColor = new Color32(227, 223, 0, 255);
-        public static Color DaggerfallDefaultShadowColor = new Color32(93, 77, 12, 255);
+        public static Color DaggerfallDefaultShadowColor = new Color32(93, 78, 14, 255); // Matched to Daggerfall Classic.
+        public static Color DaggerfallQuestTextColor = new Color32(255, 246, 103, 255); // Matched to Daggerfall Classic
         public static Color DaggerfallAlternateShadowColor1 = new Color32(44, 60, 60, 255);
         public static Color DaggerfallDefaultSelectedTextColor = new Color32(162, 36, 12, 255);
         public static Color DaggerfallDefaultTextCursorColor = new Color32(154, 134, 0, 200);

--- a/Assets/Scripts/Game/Questing/Actions/Say.cs
+++ b/Assets/Scripts/Game/Questing/Actions/Say.cs
@@ -70,6 +70,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             messageBox.ClickAnywhereToClose = true;
             messageBox.AllowCancel = true;
             messageBox.ParentPanel.BackgroundColor = Color.clear;
+            messageBox.Label.TextColor = DaggerfallUI.DaggerfallQuestTextColor;
             messageBox.Show();
         }
     }

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -66,7 +66,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public Color TextColor
         {
             get { return textColor; }
-            set { textColor = value; }
+            set { SetTextColor(value); }
         }
 
         public Color ShadowColor
@@ -272,6 +272,19 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 font = DaggerfallUI.DefaultFont;
 
             return font;
+        }
+
+        /// <summary>
+        /// Sets text colour.
+        /// </summary>
+        /// <param name="color">Color to use as text colour.</param>
+        private void SetTextColor(Color color)
+        {
+            textColor = color;
+            for (int i = 0; i < labels.Count; i++)
+            {
+                labels[i].TextColor = color;
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -82,6 +82,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             set { buttonTextDistance = value; }
         }
 
+        public MultiFormatTextLabel Label
+        {
+            get { return label; }
+            set { label = value; }
+        }
+
         public MessageBoxButtons SelectedButton
         {
             get { return selectedButton; }


### PR DESCRIPTION
This probably shouldn't be merged yet, because there's an issue with the colors that I hope you can help me with, @Interkarma.

This is an attempt to set text colors to match Daggerfall classic. I think the text colors of Daggerfall classic correspond to these colors found in its .COL palette files.

Regular yellow color - e2 dc 00 (R226, G220, B0)
Text shadow color - 5d 4e 0e (R93, G78, B14)
Light yellow color used in quest messages ("say" command) - ff f6 67 (R255, G246, B103)

Unlike when testing FMAP_PAL.COL with the travel map, I couldn't see a difference in the game's colors from modiying these values in any of the .COL or .PAL files, so I don't know for 100% sure, but they are so close to the RGB values of the pixels seen when running in DOSBox that I think we can assume these are the values.

I tried to set these values for DF Unity. For some reason, though, the colors in-game don't match the RGB values I've set in the source code, though, and I have no idea why. My test case was using the tutorial quest and checking the font colors of the first two messages. The lighter-colored text completely loses its blue value even though it should have a blue of around 103.

Also, should I note the previous color values in a comment? Since they could be retrieved from the git history I don't suppose I need to.