### PR TITLE
Implement basics of status window

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -32,6 +32,12 @@ namespace DaggerfallWorkshop.Game
     [RequireComponent(typeof(DaggerfallAudioSource))]
     public class DaggerfallUI : MonoBehaviour
     {
+        #region Classic Text IDs
+
+        const int youAreIn = 22;
+
+        #endregion
+
         const string parchmentBorderRCIFile = "SPOP.RCI";
         const string splashVideo = "ANIM0001.VID";
         const string deathVideo = "ANIM0012.VID";
@@ -334,6 +340,19 @@ namespace DaggerfallWorkshop.Game
                     if (GameManager.Instance.CanPlayerRest())
                     {
                         uiManager.PushWindow(new DaggerfallRestWindow(uiManager));
+                    }
+                    break;
+                case DaggerfallUIMessages.dfuiOpenStatusWindow:
+                    ITextProvider textProvider = DaggerfallUnity.Instance.TextProvider;
+
+                    TextFile.Token[] tokens = textProvider.GetRSCTokens(youAreIn);
+                    if (tokens != null && tokens.Length > 0)
+                    {
+                        DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager);
+                        messageBox.SetTextTokens(tokens);
+                        messageBox.ClickAnywhereToClose = true;
+                        messageBox.ParentPanel.BackgroundColor = Color.clear;
+                        messageBox.Show();
                     }
                     break;
                 case DaggerfallUIMessages.dfuiOpenQuestInspector:

--- a/Assets/Scripts/Game/DaggerfallUIMessages.cs
+++ b/Assets/Scripts/Game/DaggerfallUIMessages.cs
@@ -49,6 +49,7 @@ namespace DaggerfallWorkshop.Game
         public const string dfuiOpenMouseControlsWindow = "dfuiOpenMouseControlsWindow";
         public const string dfuiOpenTravelMapWindow = "dfuiOpenTravelMapWindow";
         public const string dfuiOpenRestWindow = "dfuiOpenRestWindow";
+        public const string dfuiOpenStatusWindow = "dfuiOpenStatusWindow";
         public const string dfuiOpenAutomap = "dfuiOpenAutomap";
 
         // "Debug" window messages

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -23,6 +23,7 @@ using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Questing;
+using DaggerfallConnect.Arena2;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -369,6 +370,11 @@ namespace DaggerfallWorkshop.Game
             else if (InputManager.Instance.ActionComplete(InputManager.Actions.Rest))
             {
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenRestWindow);
+            }
+
+            if (InputManager.Instance.ActionStarted(InputManager.Actions.Status))
+            {
+                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenStatusWindow);
             }
 
             if (InputManager.Instance.ActionStarted(InputManager.Actions.AutoMap))

--- a/Assets/Scripts/Utility/DaggerfallDateTime.cs
+++ b/Assets/Scripts/Utility/DaggerfallDateTime.cs
@@ -361,7 +361,17 @@ namespace DaggerfallWorkshop.Utility
         }
 
         /// <summary>
-        /// Gets a short time string.
+        /// Gets a short time string without seconds.
+        /// </summary>
+        public string ShortTimeStringNoSeconds()
+        {
+            string final = string.Format("{0:00}:{1:00}", Hour, Minute);
+
+            return final;
+        }
+
+        /// <summary>
+        /// Gets a short time string with seconds.
         /// </summary>
         public string ShortTimeString()
         {


### PR DESCRIPTION
This implements the basics of the status window (I key). It shows the place name and date. Right now the legal reputation just shows "a common citizen."

Some variables in TEXT.RSC that start with % are interpreted now. Anything with % followed by a letter or number is considered a variable that needs interpreting. This seems like the case in Daggerfall classic, because something like %a or %1 will just display as a blank in the game. If there's a space or a period or an exclamation point, and probably other things, after the % it will show in Daggerfall classic as it is, like "% " or "%." or "%!"
