### PR TITLE
Adjust attack-related timings to resemble classic

### DIFF
--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -131,10 +131,7 @@ namespace DaggerfallWorkshop.Game
 
             // Do not change if already playing attack animation
             if (!IsPlayingOneShot())
-            {
-                PlaySwingSound();
                 ChangeWeaponState(state);
-            }
         }
 
         public void ChangeWeaponState(WeaponStates state)
@@ -147,6 +144,11 @@ namespace DaggerfallWorkshop.Game
         public bool IsAttacking()
         {
             return IsPlayingOneShot();
+        }
+
+        public bool IsPastMiddleFrame()
+        {
+            return (currentFrame > (weaponAnims[(int)weaponState].NumFrames / 2));
         }
 
         public void PlayActivateSound()

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -132,7 +132,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return damage_high;
         }
 
-        public static int CalculateMeleeDamage(FPSWeapon weapon, DaggerfallWorkshop.Game.Entity.PlayerEntity player)
+        public static int CalculateWeaponDamage(FPSWeapon weapon, DaggerfallWorkshop.Game.Entity.PlayerEntity player)
         {
             int damage_low = CalculateWeaponMinDamage(weapon.WeaponType, weapon.MetalType, player.Skills.HandToHand);
             int damage_high = CalculateWeaponMaxDamage(weapon.WeaponType, weapon.MetalType, player.Skills.HandToHand);


### PR DESCRIPTION
Here are some changes to make the combat feel a little more like Daggerfall classic.

Daggerfall Unity's swing sound played at the start of an attack, played whether an enemy was hit or not, and the hit didn't register until after the animation finished.

In classic the swing seems to play at just about the frame after the middle frame. It plays if the player misses or the player hits a door, but not if they hit an enemy. The hit registers at about this same time.

This PR tries to make the above behavior like classic.