### PR TITLE
Add player death sound

### DIFF
--- a/Assets/Scripts/Game/PlayerDeath.cs
+++ b/Assets/Scripts/Game/PlayerDeath.cs
@@ -31,6 +31,8 @@ namespace DaggerfallWorkshop.Game
         public float FadeDuration = 2f;
         public float TimeBeforeReset = 3;
 
+        public SoundClips PlayerDeathSound = SoundClips.PlayerDeath;
+
         StartGameBehaviour startGameBehaviour;
         DaggerfallEntityBehaviour entityBehaviour;
         PlayerEntity playerEntity;
@@ -159,6 +161,9 @@ namespace DaggerfallWorkshop.Game
             targetCameraHeight = playerController.height - (playerController.height * 1.25f);
             currentCameraHeight = startCameraHeight;
             DaggerfallUI.Instance.FadeHUDToBlack(FadeDuration);
+
+            if (DaggerfallUI.Instance.DaggerfallAudioSource)
+                DaggerfallUI.Instance.DaggerfallAudioSource.PlayOneShot(PlayerDeathSound, 0);
 
             if (OnPlayerDeath != null)
                 OnPlayerDeath(this, null);


### PR DESCRIPTION
Another tiny PR. I know you could easily add this yourself, so if you don't want these kinds of tiny PRs, just say so.

This adds the player death yell, which I'm sure is all too familiar to people who've played the original Daggerfall. :)

Classic Daggerfall uses this same voice for both male and female player characters. As you know there are various unused male and female pain sounds in the game. Maybe the player could be offered a choice of voice, and/or they could be used for human enemies. For now, anyway, this is just the Classic Daggerfall voice.