### PR TITLE
Fix enumerator error

### DIFF
--- a/Assets/Scripts/Game/UserInterface/Panel.cs
+++ b/Assets/Scripts/Game/UserInterface/Panel.cs
@@ -98,10 +98,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             base.Update();
 
             // Update child components
-            foreach (BaseScreenComponent component in components)
+            for (int i = 0; i < components.Count; i++)
             {
-                if (component.Enabled)
-                    component.Update();
+                if (components[i].Enabled)
+                    Components[i].Update();
             }
         }
 


### PR DESCRIPTION
As mentioned in https://github.com/Interkarma/daggerfall-unity/pull/288, an error appears in the console when turning pages in books.

I borrowed a solution for the same error from here:
http://answers.unity3d.com/questions/290595/enumeration-operation-may-not-execute-problem-with.html

The error is gone, and I can't see any difference in behavior when turning pages or opening and closing the various panels.