### PR TITLE
Move text ID variables to method scope

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -25,16 +25,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     /// </summary>
     public class DaggerfallInventoryWindow : DaggerfallPopupWindow
     {
-        #region Classic Text IDs
-
-        const int noSpellsID = 12;
-        const int goldToDropID = 25;
-        const int armorTextID = 1000;
-        const int weaponTextID = 1001;
-        const int miscTextID = 1003;
-
-        #endregion
-
         #region UI Rects
 
         Rect weaponsAndArmorRect = new Rect(0, 0, 92, 10);
@@ -1144,8 +1134,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void GoldButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            const int goldToDropTextId = 25;
+
             // Get text tokens
-            TextFile.Token[] textTokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(goldToDropID);
+            TextFile.Token[] textTokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(goldToDropTextId);
 
             // Hack to set gold pieces in text token for now
             textTokens[0].text = textTokens[0].text.Replace("%gii", GameManager.Instance.PlayerEntity.GoldPieces.ToString());
@@ -1292,13 +1284,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void ShowInfoPopup(DaggerfallUnityItem item)
         {
+            const int armorTextId = 1000;
+            const int weaponTextId = 1001;
+            const int miscTextId = 1003;
+
             TextFile.Token[] tokens = null;
             if (item.ItemGroup == ItemGroups.Armor)
-                tokens = DaggerfallUnity.TextProvider.GetRSCTokens(armorTextID);
+                tokens = DaggerfallUnity.TextProvider.GetRSCTokens(armorTextId);
             else if (item.ItemGroup == ItemGroups.Weapons)
-                tokens = DaggerfallUnity.TextProvider.GetRSCTokens(weaponTextID);
+                tokens = DaggerfallUnity.TextProvider.GetRSCTokens(weaponTextId);
             else
-                tokens = DaggerfallUnity.TextProvider.GetRSCTokens(miscTextID);
+                tokens = DaggerfallUnity.TextProvider.GetRSCTokens(miscTextId);
 
             if (tokens != null && tokens.Length > 0)
             {
@@ -1364,6 +1360,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void LocalItemsButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            const int noSpellsTextId = 12;
+
             // Get index
             int index = localItemsScrollBar.ScrollIndex + (int)sender.Tag;
             if (index >= localItemsFiltered.Count)
@@ -1400,7 +1398,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     cannotUse.ClickAnywhereToClose = true;
                     cannotUse.Show();
                 } else if (item.TemplateIndex == (int)MiscItems.Spellbook) {
-                    TextFile.Token[] textTokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(noSpellsID);
+                    TextFile.Token[] textTokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(noSpellsTextId);
                     DaggerfallMessageBox noSpells = new DaggerfallMessageBox(uiManager, this);
                     noSpells.SetTextTokens(textTokens);
                     noSpells.ClickAnywhereToClose = true;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -23,16 +23,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
     public class DaggerfallRestWindow : DaggerfallPopupWindow
     {
-        #region Classic Text IDs
-
-        const int cannotRestMoreThan99Hours = 26;
-        const int cannotLoiterMoreThan3Hours = 27;
-        const int finishedLoitering = 349;
-        const int youAreHealed = 350;
-        const int youWakeUp = 353;
-
-        #endregion
-
         #region UI Rects
 
         Rect whileButtonRect = new Rect(4, 13, 48, 24);
@@ -285,21 +275,25 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void EndRest()
         {
+            const int youWakeUpTextId = 353;
+            const int youAreHealedTextId = 350;
+            const int finishedLoiteringTextId = 349;
+
             if (currentRestMode == RestModes.TimedRest)
             {
-                DaggerfallMessageBox mb = DaggerfallUI.MessageBox(youWakeUp);
+                DaggerfallMessageBox mb = DaggerfallUI.MessageBox(youWakeUpTextId);
                 mb.OnClose += RestFinishedPopup_OnClose;
                 currentRestMode = RestModes.Selection;
             }
             else if (currentRestMode == RestModes.FullRest)
             {
-                DaggerfallMessageBox mb = DaggerfallUI.MessageBox(youAreHealed);
+                DaggerfallMessageBox mb = DaggerfallUI.MessageBox(youAreHealedTextId);
                 mb.OnClose += RestFinishedPopup_OnClose;
                 currentRestMode = RestModes.Selection;
             }
             else if (currentRestMode == RestModes.Loiter)
             {
-                DaggerfallMessageBox mb = DaggerfallUI.MessageBox(finishedLoitering);
+                DaggerfallMessageBox mb = DaggerfallUI.MessageBox(finishedLoiteringTextId);
                 mb.OnClose += RestFinishedPopup_OnClose;
                 currentRestMode = RestModes.Selection;
             }
@@ -383,6 +377,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void TimedRestPrompt_OnGotUserInput(DaggerfallInputMessageBox sender, string input)
         {
+            const int cannotRestMoreThan99HoursTextId = 26;
+
             // Validate input
             int time = 0;
             bool result = int.TryParse(input, out time);
@@ -396,7 +392,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else if (time > 99)
             {
-                DaggerfallUI.MessageBox(cannotRestMoreThan99Hours);
+                DaggerfallUI.MessageBox(cannotRestMoreThan99HoursTextId);
                 return;
             }
 
@@ -407,6 +403,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void LoiterPrompt_OnGotUserInput(DaggerfallInputMessageBox sender, string input)
         {
+            const int cannotLoiterMoreThan3HoursTextId = 27;
+
             // Validate input
             int time = 0;
             bool result = int.TryParse(input, out time);
@@ -420,7 +418,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else if (time > 3)
             {
-                DaggerfallUI.MessageBox(cannotLoiterMoreThan3Hours);
+                DaggerfallUI.MessageBox(cannotLoiterMoreThan3HoursTextId);
                 return;
             }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -33,12 +33,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     /// </summary>
     public class DaggerfallTravelMapWindow : DaggerfallPopupWindow
     {
-        #region Classic Text IDs
-
-        const int doYouWishToTravelTo = 31;
-
-        #endregion
-
         #region Fields
 
         FilterMode filterMode = FilterMode.Point;
@@ -1350,11 +1344,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void CreateConfirmationPopUp()
         {
+            const int doYouWishToTravelToTextId = 31;
+
             if (!locationSelected)
                 return;
 
             // Get text tokens
-            TextFile.Token[] textTokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(doYouWishToTravelTo);
+            TextFile.Token[] textTokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(doYouWishToTravelToTextId);
 
             // Hack to set location name in text token for now
             textTokens[2].text = textTokens[2].text.Replace("%tcn", currentDFRegion.MapNames[locationSummary.MapIndex]);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -22,12 +22,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
     public class DaggerfallTravelPopUp : DaggerfallPopupWindow
     {
-        #region Classic Text IDs
-
-        const int notEnoughGoldTextId = 454;
-
-        #endregion
-
         #region fields
         DaggerfallTravelMapWindow travelWindow = null;
 
@@ -378,6 +372,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void showNotEnoughGoldPopup()
         {
+            const int notEnoughGoldTextId = 454;
+
             TextFile.Token[] tokens = DaggerfallUnity.TextProvider.GetRSCTokens(notEnoughGoldTextId);
             if (tokens != null && tokens.Length > 0)
             {


### PR DESCRIPTION
Based on discussion in https://github.com/Interkarma/daggerfall-unity/pull/289, this is how I understand you would like to declare the text ID variables. This gets rid of the classic text ID regions and puts the variables in method scope, since none are used in more than one place.

Very minor point: Do you prefer "ID" or "Id" in the variable names? I assume "Id" since that's what had been used before in the armor, weapon and misc item variables, so that's what I used for this PR.