### PR TITLE
Show hand-to-hand damage in character sheet

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -101,44 +101,32 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         #region Damage
 
-        public static int CalculateWeaponMinDamage(WeaponTypes weaponType, MetalTypes metalType, int handToHandSkill)
+        public static int CalculateHandToHandMinDamage(int handToHandSkill)
         {
-            // Temp value, to be replaced
-            int damage_low = 1;
-
-            if (weaponType == WeaponTypes.Melee)
-            {
-                int skill = handToHandSkill;
-                damage_low = (skill / 10) + 1;
-            }
-
-            return damage_low;
+            return (handToHandSkill / 10) + 1;
         }
 
-        public static int CalculateWeaponMaxDamage(WeaponTypes weaponType, MetalTypes metalType, int handToHandSkill)
+        public static int CalculateHandToHandMaxDamage(int handToHandSkill)
         {
-            // Temp value, to be replaced
-            int damage_high = 24;
-
             // Daggerfall Chronicles table lists hand-to-hand skills of 80 and above (45 through 79 are omitted)
-            // as if they cause 2 to be added to damage_high instead of 1, but the hand-to-hand damage display
-            // in the in-game character sheet contradicts this.
-            if (weaponType == WeaponTypes.Melee)
-            {
-                int skill = handToHandSkill;
-                damage_high = (skill / 5) + 1;
-            }
-
-            return damage_high;
+            // as if they are (handToHandSkill / 5) + 2, but the hand-to-hand damage display in the character sheet
+            // in classic Daggerfall shows the damage as continuing to be (handToHandSkill / 5) + 1
+            return (handToHandSkill / 5) + 1;
         }
 
         public static int CalculateWeaponDamage(FPSWeapon weapon, DaggerfallWorkshop.Game.Entity.PlayerEntity player)
         {
-            int damage_low = CalculateWeaponMinDamage(weapon.WeaponType, weapon.MetalType, player.Skills.HandToHand);
-            int damage_high = CalculateWeaponMaxDamage(weapon.WeaponType, weapon.MetalType, player.Skills.HandToHand);
+            int damage_low = 1; // Temp value
+            if (weapon.WeaponType == WeaponTypes.Melee)
+                damage_low = CalculateHandToHandMinDamage(player.Skills.HandToHand);
+
+            int damage_high = 24; // Temp value
+            if (weapon.WeaponType == WeaponTypes.Melee)
+                damage_high = CalculateHandToHandMaxDamage(player.Skills.HandToHand);
+
             int damage = UnityEngine.Random.Range(damage_low, damage_high + 1);
 
-            // Apply the strength modifier. Testing in original Daggerfall shows hand-to-hand ignores it.
+            // Apply the strength modifier. Testing in classic Daggerfall shows hand-to-hand ignores it.
             if (weapon.WeaponType != WeaponTypes.Melee)
             {
                 // Weapons can do 0 damage. Plays no hit sound or blood splash.

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -22,6 +22,7 @@ using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Player;
 using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -219,9 +220,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         void ShowSkillsDialog(List<DFCareer.Skills> skills, bool twoColumn = false)
         {
             bool secondColumn = false;
+            bool showHandToHandDamage = false;
             List<TextFile.Token> tokens = new List<TextFile.Token>();
             for (int i = 0; i < skills.Count; i++)
             {
+                if (!showHandToHandDamage && (skills[i] == DFCareer.Skills.HandToHand))
+                    showHandToHandDamage = true;
+
                 if (!twoColumn)
                 {
                     tokens.AddRange(CreateSkillTokens(skills[i]));
@@ -243,6 +248,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                             tokens.Add(TextFile.NewLineToken);
                     }
                 }
+            }
+
+            if (showHandToHandDamage)
+            {
+                tokens.Add(TextFile.NewLineToken);
+                TextFile.Token HandToHandDamageToken = new TextFile.Token();
+                int minDamage = FormulaHelper.CalculateHandToHandMinDamage(playerEntity.Skills.GetSkillValue(DFCareer.Skills.HandToHand));
+                int maxDamage = FormulaHelper.CalculateHandToHandMaxDamage(playerEntity.Skills.GetSkillValue(DFCareer.Skills.HandToHand));
+                HandToHandDamageToken.text = DaggerfallUnity.Instance.TextProvider.GetSkillName(DFCareer.Skills.HandToHand) + " dmg: " + minDamage + "-" + maxDamage;
+                HandToHandDamageToken.formatting = TextFile.Formatting.Text;
+                tokens.Add(HandToHandDamageToken);
             }
 
             DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);

--- a/Assets/Scripts/Utility/TextProvider.cs
+++ b/Assets/Scripts/Utility/TextProvider.cs
@@ -388,7 +388,7 @@ namespace DaggerfallWorkshop.Utility
                 case DFCareer.Skills.LongBlade:
                     return "Long Blade";
                 case DFCareer.Skills.HandToHand:
-                    return "Hand To Hand";
+                    return "Hand-to-Hand";
                 case DFCareer.Skills.Axe:
                     return "Axe";
                 case DFCareer.Skills.BluntWeapon:


### PR DESCRIPTION
Shows the hand to hand damage in the character sheet, like classic Daggerfall.

In classic, this text is colored a light blue. I don't know off the top of my head if there are any other places with other-colored text like this, but if I'm not mistaken at the moment Daggerfall Unity only supports one color of text per text label/message box.  I want to change just the color of this one token, but the only way I thought of was to add a color property to `TextFile.Token,` and I thought you might not want that, so for now the text is the default color.