### PR TITLE
Set same ambient dungeon effects as classic

### DIFF
--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -258,12 +258,12 @@ namespace DaggerfallWorkshop.Game
                     SoundClips.AmbientGrind,
                     SoundClips.AmbientStrumming,
                     SoundClips.AmbientWindBlow1,
-                    SoundClips.AmbientWindBlow2,
-                    SoundClips.AmbientMetalJangleLow,
+                    SoundClips.AmbientWindBlow1a,
+                    SoundClips.AmbientWindBlow1b,
+                    SoundClips.AmbientMonsterRoar,
+                    SoundClips.AmbientGoldPieces,
                     SoundClips.AmbientBirdCall,
-                    SoundClips.ArenaRat,
-                    SoundClips.AmbientClank,
-                    SoundClips.ArenaGhost,
+                    SoundClips.AmbientDoorClose,
                 };
             }
             else if (Presets == AmbientSoundPresets.Storm)

--- a/Assets/Scripts/SoundClips.cs
+++ b/Assets/Scripts/SoundClips.cs
@@ -85,10 +85,10 @@ namespace DaggerfallWorkshop
         AmbientWindBlow1 = 70,
         AmbientWindBlow1a = 71,
         AmbientWindBlow1b = 72,
-        AmbientWindBlow2 = 73,
-        AmbientMetalJangleLow = 74,
+        AmbientMonsterRoar = 73,
+        AmbientGoldPieces = 74,
         AmbientBirdCall = 75,
-        AmbientClank = 76,
+        AmbientDoorClose = 76,
 
         FanfareSolo = 77,
 


### PR DESCRIPTION
Sets the same ambient dungeon effects as classic, which are all next to each other in the list of sounds.

Alternate ambient sounds might be fun, too, but I figure we want to at least have the same ones as classic ready for use.