### PR TITLE
Set gargoyle to have blood splash

### DIFF
--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -665,7 +665,6 @@ namespace DaggerfallWorkshop.Utility
                 HasRangedAttack1 = false,
                 HasRangedAttack2 = false,
                 CanOpenDoors = true,
-                BloodIndex = 2,
                 MoveSound = (int)SoundClips.EnemyGargoyleMove,
                 BarkSound = (int)SoundClips.EnemyGargoyleBark,
                 AttackSound = (int)SoundClips.EnemyGargoyleAttack,


### PR DESCRIPTION
I can see why it was set without, but the gargoyle should have a blood splash like in classic, because it has blood in its corpse texture.