### PR TITLE
Track fatigue at 64 times character sheet value

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -73,7 +73,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public ItemEquipTable ItemEquipTable { get { return equipTable; } }
         public int MaxHealth { get { return maxHealth; } set { maxHealth = value; } }
         public int CurrentHealth { get { return currentHealth; } set { SetHealth(value); } }
-        public int MaxFatigue { get { return stats.Strength + stats.Endurance; } }
+        public int MaxFatigue { get { return (stats.Strength + stats.Endurance) * 64; } }
         public int CurrentFatigue { get { return currentFatigue; } set { SetFatigue(value); } }
         public int MaxMagicka { get { return FormulaHelper.SpellPoints(stats.Intelligence, career.SpellPointMultiplierValue); } }
         public int CurrentMagicka { get { return currentMagicka; } set { SetMagicka(value); } }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -275,7 +275,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             classLabel.Text = PlayerEntity.Career.Name;
             levelLabel.Text = PlayerEntity.Level.ToString();
             goldLabel.Text = PlayerEntity.GoldPieces.ToString();
-            fatigueLabel.Text = string.Format("{0}/{1}", PlayerEntity.CurrentFatigue, PlayerEntity.MaxFatigue);
+            fatigueLabel.Text = string.Format("{0}/{1}", PlayerEntity.CurrentFatigue / 64, PlayerEntity.MaxFatigue / 64);
             healthLabel.Text = string.Format("{0}/{1}", PlayerEntity.CurrentHealth, PlayerEntity.MaxHealth);
 
             // Update stat labels


### PR DESCRIPTION
Track fatigue internally at 64 times the value shown in the character sheet, the same as classic does. This will allow for implementing loss of fatigue values in the same way.