### PR TITLE
Add fatigue loss for some actions

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -229,6 +229,13 @@ namespace DaggerfallWorkshop.Game.Entity
             return miscSkills;
         }
 
+        /// <summary>
+        /// Tally skill usage.
+        /// </summary>
+        public virtual void TallySkill(short skillId, short amount)
+        {
+        }
+
         #endregion
 
         #region Helpers

--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -42,9 +42,9 @@ namespace DaggerfallWorkshop.Game.Entity
         //private int SwimmingFatigueLoss = 44;     // According to DF Chronicles
 
         private int JumpingFatigueLoss = 11;        // According to DF Chronicles and verified in classic
-        bool AppliedFatigueLossThisJump = false;
+        private bool CheckedCurrentJump = false;
 
-        bool gameStarted = false;
+        private bool gameStarted = false;
 
         #endregion
 
@@ -106,16 +106,17 @@ namespace DaggerfallWorkshop.Game.Entity
                     else
                         Entity.DecreaseFatigue(DefaultFatigueLoss);
                 }
-                // Reduce fatigue when jumping
-                if (!AppliedFatigueLossThisJump && playerMotor.IsJumping)
+                // Reduce fatigue when jumping and tally jumping skill
+                if (!CheckedCurrentJump && playerMotor.IsJumping)
                 {
                     Entity.DecreaseFatigue(JumpingFatigueLoss);
-                    AppliedFatigueLossThisJump = true;
+                    Entity.TallySkill((short)Skills.Jumping, 1);
+                    CheckedCurrentJump = true;
                 }
                 // Reset jump fatigue check when grounded
-                if (AppliedFatigueLossThisJump && playerMotor.IsGrounded)
+                if (CheckedCurrentJump && playerMotor.IsGrounded)
                 {
-                    AppliedFatigueLossThisJump = false;
+                    CheckedCurrentJump = false;
                 }
             }
         }

--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -32,6 +32,20 @@ namespace DaggerfallWorkshop.Game.Entity
         EntityTypes lastEntityType = EntityTypes.None;
         DaggerfallEntity entity = null;
 
+        private int lastGameMinute = -1;
+        PlayerMotor playerMotor = null;
+
+        // Fatigue loss per in-game minute
+        private int DefaultFatigueLoss = 11;        // According to DF Chronicles and verified in classic
+        //private int ClimbingFatigueLoss = 22;     // According to DF Chronicles
+        private int RunningFatigueLoss = 88;        // According to DF Chronicles and verified in classic
+        //private int SwimmingFatigueLoss = 44;     // According to DF Chronicles
+
+        private int JumpingFatigueLoss = 11;        // According to DF Chronicles and verified in classic
+        bool AppliedFatigueLossThisJump = false;
+
+        bool gameStarted = false;
+
         #endregion
 
         #region Properties
@@ -52,6 +66,7 @@ namespace DaggerfallWorkshop.Game.Entity
         void Start()
         {
             SetEntityType(EntityType);
+            playerMotor = GameManager.Instance.PlayerMotor;
         }
 
         void Update()
@@ -69,6 +84,40 @@ namespace DaggerfallWorkshop.Game.Entity
 
             // Update entity
             Entity.Update(this);
+
+            if (EntityType == EntityTypes.Player)
+            {
+                // Wait until game has started and the game time has been set.
+                // If the game time is taken before then "30" is returned, which causes an initial player fatigue loss
+                // after loading or starting a game with a non-30 minute.
+                if (!gameStarted && !GameManager.Instance.StateManager.GameInProgress)
+                    return;
+                else if (!gameStarted)
+                    gameStarted = true;
+
+                // Every game minute, apply fatigue loss to the player
+                if (lastGameMinute == -1 && lastGameMinute != DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.Minute)
+                    lastGameMinute = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.Minute;
+                else if (lastGameMinute != DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.Minute)
+                {
+                    lastGameMinute = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.Minute;
+                    if (playerMotor.IsRunning)
+                        Entity.DecreaseFatigue(RunningFatigueLoss);
+                    else
+                        Entity.DecreaseFatigue(DefaultFatigueLoss);
+                }
+                // Reduce fatigue when jumping
+                if (!AppliedFatigueLossThisJump && playerMotor.IsJumping)
+                {
+                    Entity.DecreaseFatigue(JumpingFatigueLoss);
+                    AppliedFatigueLossThisJump = true;
+                }
+                // Reset jump fatigue check when grounded
+                if (AppliedFatigueLossThisJump && playerMotor.IsGrounded)
+                {
+                    AppliedFatigueLossThisJump = false;
+                }
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -171,7 +171,7 @@ namespace DaggerfallWorkshop.Game.Entity
         /// <summary>
         /// Tally skill usage.
         /// </summary>
-        public void TallySkill(short skillId, short amount)
+        public override void TallySkill(short skillId, short amount)
         {
             SkillUses[skillId] += amount;
             if (SkillUses[skillId] > 20000)

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -77,6 +77,7 @@ namespace DaggerfallWorkshop.Game
         private Vector3 contactPoint;
         private bool playerControl = false;
         private int jumpTimer;
+        private bool isJumping = false;
 
         private bool cancelMovement = false;
 
@@ -88,6 +89,11 @@ namespace DaggerfallWorkshop.Game
         public bool IsRunning
         {
             get { return (speed == runSpeed); }
+        }
+
+        public bool IsJumping
+        {
+            get { return isJumping; }
         }
 
         public bool IsCrouching
@@ -148,6 +154,7 @@ namespace DaggerfallWorkshop.Game
 
             if (grounded)
             {
+                isJumping = false;
                 bool sliding = false;
                 // See if surface immediately below should be slid down. We use this normally rather than a ControllerColliderHit point,
                 // because that interferes with step climbing amongst other annoyances
@@ -223,6 +230,7 @@ namespace DaggerfallWorkshop.Game
                     {
                         moveDirection.y = jumpSpeed;
                         jumpTimer = 0;
+                        isJumping = true;
 
                         // Modify crouching jump speed
                         if (isCrouching)

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -50,6 +50,7 @@ namespace DaggerfallWorkshop.Game
         bool isDamageFinished = false;
         Hand lastAttackHand = Hand.None;
         float cooldownTime = 0.0f;                  // Wait for weapon cooldown
+        int swingWeaponFatigueLoss = 11;            // According to DF Chronicles and verified in classic
 
         bool usingRightHand = true;
         bool holdingShield = false;
@@ -252,6 +253,9 @@ namespace DaggerfallWorkshop.Game
                 // Transfer damage.
                 bool hitEnemy = false;
                 WeaponDamage(weapon, out hitEnemy);
+
+                // Fatigue loss
+                playerEntity.DecreaseFatigue(swingWeaponFatigueLoss);
 
                 // Play swing sound if attack didn't hit an enemy.
                 if (!hitEnemy)


### PR DESCRIPTION
Adds fatigue loss for jumping and attacking, as well as per minute of game time based on whether the player is running or not. The values are from the Daggerfall Chronicles and I confirmed by testing in classic.