### PR TITLE
Fix rest health rate calculation

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -94,7 +94,7 @@ namespace DaggerfallWorkshop.Game.Formulas
         // Calculate how much health the player should recover per hour of rest
         public static int CalculateHealthRecoveryRate(int medical, int endurance, int maxHealth)
         {
-            return (int)Mathf.Floor((HealingRateModifierMedical(medical) * HealingRateModifierMaxHealth(maxHealth)) + HealingRateModifier(endurance));
+            return Mathf.Max((int)Mathf.Floor(((HealingRateModifierMedical(medical) * HealingRateModifierMaxHealth(maxHealth)) + HealingRateModifier(endurance))), 1);
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -301,13 +301,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         bool TickVitals()
         {
-            // NOTE: The below is not working - player does not recover health on rest. Reverting to original rest model.
             // For alpha purposes, magicka and fatigue are recovered in a uniform manner
             // Need to decouple this back to formula provider when properly implemented
-            //int healthRecoveryRate = FormulaHelper.CalculateHealthRecoveryRate(playerEntity.Skills.Medical, playerEntity.Stats.Endurance, playerEntity.MaxHealth);
-            //playerEntity.CurrentHealth += healthRecoveryRate;
-
-            playerEntity.CurrentHealth += (int)(playerEntity.MaxHealth * recoveryRate);
+            int healthRecoveryRate = FormulaHelper.CalculateHealthRecoveryRate(playerEntity.Skills.Medical, playerEntity.Stats.Endurance, playerEntity.MaxHealth);
+            playerEntity.CurrentHealth += healthRecoveryRate;
             playerEntity.CurrentFatigue += (int)(playerEntity.MaxFatigue * recoveryRate);
             playerEntity.CurrentMagicka += (int)(playerEntity.MaxMagicka * recoveryRate);
 


### PR DESCRIPTION
The problem with the resting function was with the endurance modifier. If you had a negative endurance modifier you could regain no health or even lose health. In classic you regain a minimum of 1 no matter how low your endurance modifier is, and this PR makes DF Unity the same.