### PR TITLE
Fix fatigue loss and skill tallying for jumping

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -113,8 +113,8 @@ namespace DaggerfallWorkshop.Game.Entity
                     Entity.TallySkill((short)Skills.Jumping, 1);
                     CheckedCurrentJump = true;
                 }
-                // Reset jump fatigue check when grounded
-                if (CheckedCurrentJump && playerMotor.IsGrounded)
+                // Reset jump fatigue check when finished jumping
+                if (CheckedCurrentJump && !playerMotor.IsJumping)
                 {
                     CheckedCurrentJump = false;
                 }

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -77,7 +77,7 @@ namespace DaggerfallWorkshop.Game
         private Vector3 contactPoint;
         private bool playerControl = false;
         private int jumpTimer;
-        private bool isJumping = false;
+        private bool jumping = false;
 
         private bool cancelMovement = false;
 
@@ -93,7 +93,7 @@ namespace DaggerfallWorkshop.Game
 
         public bool IsJumping
         {
-            get { return isJumping; }
+            get { return jumping; }
         }
 
         public bool IsCrouching
@@ -154,7 +154,8 @@ namespace DaggerfallWorkshop.Game
 
             if (grounded)
             {
-                isJumping = false;
+                if (jumping)
+                    jumping = false;
                 bool sliding = false;
                 // See if surface immediately below should be slid down. We use this normally rather than a ControllerColliderHit point,
                 // because that interferes with step climbing amongst other annoyances
@@ -230,7 +231,7 @@ namespace DaggerfallWorkshop.Game
                     {
                         moveDirection.y = jumpSpeed;
                         jumpTimer = 0;
-                        isJumping = true;
+                        jumping = true;
 
                         // Modify crouching jump speed
                         if (isCrouching)


### PR DESCRIPTION
I should have checked that IsJumping is false again before resetting the bool to check for decreasing fatigue and tallying skill uses. When a jump ends, Update() in DaggerfallEntityBehaviour.cs would run a few times in the interval between when IsGrounded is set to true and IsJumping is set to false, so fatigue and skill tallying were happening multiple times per jump.

Also I renamed the variable isJumping to jumping, to match with other booleans in there like sliding and falling, and only set it to false when needed.