### PR TITLE
Implement zero-fatigue behavior

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -331,9 +331,15 @@ namespace DaggerfallWorkshop.Game
                     }
                     break;
                 case DaggerfallUIMessages.dfuiOpenRestWindow:
-                    if (GameManager.Instance.CanPlayerRest())
+                    if (!GameManager.Instance.AreEnemiesNearby() && GameManager.Instance.PlayerController.isGrounded)
                     {
                         uiManager.PushWindow(new DaggerfallRestWindow(uiManager));
+                    }
+                    else
+                    {
+                        // Alert player if monsters nearby
+                        const int enemiesNearby = 354;
+                        MessageBox(enemiesNearby);
                     }
                     break;
                 case DaggerfallUIMessages.dfuiOpenQuestInspector:

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -128,7 +128,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public int SetFatigue(int amount)
         {
             currentFatigue = Mathf.Clamp(amount, 0, MaxFatigue);
-            if (currentFatigue <= 0)
+            if (currentFatigue <= 0 && currentHealth > 0)
                 RaiseOnExhaustedEvent();
 
             return currentFatigue;
@@ -256,7 +256,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
         public delegate void OnDeathHandler(DaggerfallEntity entity);
         public event OnDeathHandler OnDeath;
-        void RaiseOnDeathEvent()
+        protected void RaiseOnDeathEvent()
         {
             if (OnDeath != null && !quiesce)
                 OnDeath(this);

--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -114,7 +114,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     CheckedCurrentJump = true;
                 }
                 // Reset jump fatigue check when grounded
-                if (CheckedCurrentJump && playerMotor.IsGrounded)
+                if (CheckedCurrentJump && !playerMotor.IsJumping)
                 {
                     CheckedCurrentJump = false;
                 }

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -425,19 +425,14 @@ namespace DaggerfallWorkshop.Game
         }
 
         /// <summary>
-        /// Determines if player is able to rest or not.
+        /// Determines if enemies are nearby. Uses include whether player is able to rest or not.
         /// Based on minimum distance to nearest monster, and if monster can actually sense player.
         /// </summary>
         /// <param name="minMonsterDistance">Monsters must be at least this far away.</param>
-        /// <returns>True if player can rest.</returns>
-        public bool CanPlayerRest(float minMonsterDistance = 12f)
+        /// <returns>True if enemies are nearby.</returns>
+        public bool AreEnemiesNearby(float minMonsterDistance = 12f)
         {
-            const int enemiesNearby = 354;
-
-            if (!PlayerController.isGrounded)
-                return false;
-
-            bool canRest = true;
+            bool areEnemiesNearby = false;
             DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
             for (int i = 0; i < entityBehaviours.Length; i++)
             {
@@ -447,7 +442,7 @@ namespace DaggerfallWorkshop.Game
                     // Is a monster inside min distance?
                     if (Vector3.Distance(entityBehaviour.transform.position, PlayerController.transform.position) < minMonsterDistance)
                     {
-                        canRest = false;
+                        areEnemiesNearby = true;
                         break;
                     }
 
@@ -457,20 +452,14 @@ namespace DaggerfallWorkshop.Game
                     {
                         if (enemySenses.PlayerInSight || enemySenses.PlayerInEarshot)
                         {
-                            canRest = false;
+                            areEnemiesNearby = true;
                             break;
                         }
                     }
                 }
             }
 
-            // Alert player if monsters neaby
-            if (!canRest)
-            {
-                DaggerfallUI.MessageBox(enemiesNearby);
-            }
-
-            return canRest;
+            return areEnemiesNearby;
         }
 
         #endregion


### PR DESCRIPTION
This implements the game behavior when the player runs out of fatigue. There are two cases, depending on whether there are enemies nearby:

Enemies nearby: "you are easy prey for monsters" message, and player dies
No enemies nearby: "you awaken one hour later" message, and player is forced to rest for one hour

I redid the CanPlayerRest() function into a AreEnemiesNearby() function, because I needed this functionality separated out from the rest function.

There are a few issues that could be ironed out.
1. When the player dies with the "you are easy prey for monsters" message, he can still move the view and move slightly, unlike when you die from damage. I don't know why.
2. The player death sound plays while "you are easy prey for monsters" message is up.
3.  If you lose your last fatigue points from jumping, you will start the jump before getting the message box, whereas in classic you just lose the fatigue points and get the message box with no jump. I use cancelMovement() so the jump doesn't continue after the message box, but ideally I'd like to copy classic and stop the jump before it starts, but I know you don't want game logic in PlayerMotor.cs.