### PR TITLE
Fix issue with more than one songplayer in scene and tdbg command

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -89,7 +89,7 @@ namespace Wenzil.Console
             {
                 DaggerfallWorkshop.StreamingWorld streamingWorld = GameManager.Instance.StreamingWorld;//GameObject.FindObjectOfType<DaggerfallWorkshop.StreamingWorld>();
                 DaggerfallWorkshop.DaggerfallUnity daggerfallUnity = DaggerfallUnity.Instance;
-                DaggerfallSongPlayer songPlayer = GameObject.FindObjectOfType<DaggerfallSongPlayer>();
+                DaggerfallSongPlayer[] songPlayers = GameObject.FindObjectsOfType<DaggerfallSongPlayer>();
 
                 DefaultCommands.showDebugStrings = !DefaultCommands.showDebugStrings;
                 bool show = DefaultCommands.showDebugStrings;
@@ -97,8 +97,14 @@ namespace Wenzil.Console
                     streamingWorld.ShowDebugString = show;
                 if (daggerfallUnity)
                     daggerfallUnity.WorldTime.ShowDebugString = show;
-                if (songPlayer)
-                    songPlayer.ShowDebugString = show;
+                foreach (DaggerfallSongPlayer songPlayer in songPlayers)
+                {
+                    if (songPlayer && songPlayer.IsPlaying)
+                    {
+                        songPlayer.ShowDebugString = show;
+                        break;
+                    }
+                }
                 if (FPSDisplay.fpsDisplay == null)
                     GameManager.Instance.gameObject.AddComponent<FPSDisplay>();
                 FPSDisplay.fpsDisplay.ShowDebugString = show;


### PR DESCRIPTION
A while ago i reported that the songplayer value in tdbg always shows that no song is playing.
This is caused by having more than one songplayer in scene, as two of them are detected but the correct one seems to be always the second. 
I don't know if this information can be trusted, so i have implemented a foreach to to seek wich one is playing.

On an unrelated note, i noticed that you started updating the copyright date, do you wish contributors to do the same when they submit a PR?