### PR TITLE
Implement remaining formulas for resting

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -231,10 +231,14 @@ namespace DaggerfallWorkshop.Game.Entity
                 // TODO: Duplicates rest code in rest window. Should be unified.
                 DaggerfallUnity.Instance.WorldTime.Now.RaiseTime(1 * DaggerfallDateTime.SecondsPerHour);
                 int healthRecoveryRate = FormulaHelper.CalculateHealthRecoveryRate(Skills.Medical, Stats.Endurance, MaxHealth);
+                int fatigueRecoveryRate = FormulaHelper.CalculateFatigueRecoveryRate(MaxFatigue);
+                int spellPointRecoveryRate = FormulaHelper.CalculateSpellPointRecoveryRate(MaxMagicka);
 
-                IncreaseHealth(healthRecoveryRate);
-                IncreaseFatigue((int)(MaxFatigue * recoveryRate));
-                IncreaseMagicka((int)(MaxMagicka * recoveryRate));
+                CurrentHealth += healthRecoveryRate;
+                CurrentFatigue += fatigueRecoveryRate;
+                CurrentMagicka += spellPointRecoveryRate;
+
+                TallySkill((short)Skills.Medical, 1);
             }
             else
                 SetHealth(0);

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -97,6 +97,24 @@ namespace DaggerfallWorkshop.Game.Formulas
             return Mathf.Max((int)Mathf.Floor(((HealingRateModifierMedical(medical) * HealingRateModifierMaxHealth(maxHealth)) + HealingRateModifier(endurance))), 1);
         }
 
+        // Calculate how much fatigue the player should recover per hour of rest
+        public static int CalculateFatigueRecoveryRate(int maxFatigue)
+        {
+            if (maxFatigue > 0)
+                return Mathf.Max((int)Mathf.Floor(maxFatigue / 8), 1);
+            else
+                return 0;
+        }
+
+        // Calculate how many spell points the player should recover per hour of rest
+        public static int CalculateSpellPointRecoveryRate(int maxSpellPoints)
+        {
+            if (maxSpellPoints > 0)
+                return Mathf.Max((int)Mathf.Floor(maxSpellPoints / 8), 1);
+            else
+                return 0;
+        }
+
         #endregion
 
         #region Damage

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -64,7 +64,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         const float restWaitTimePerHour = 0.75f;
         const float loiterWaitTimePerHour = 1.25f;
-        const float recoveryRate = 0.125f;                          // Rate at which recovery runs (12.5% for alpha purposes)
 
         RestModes currentRestMode = RestModes.Selection;
         int hoursRemaining = 0;
@@ -301,12 +300,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         bool TickVitals()
         {
-            // For alpha purposes, magicka and fatigue are recovered in a uniform manner
-            // Need to decouple this back to formula provider when properly implemented
             int healthRecoveryRate = FormulaHelper.CalculateHealthRecoveryRate(playerEntity.Skills.Medical, playerEntity.Stats.Endurance, playerEntity.MaxHealth);
+            int fatigueRecoveryRate = FormulaHelper.CalculateFatigueRecoveryRate(playerEntity.MaxFatigue);
+            int spellPointRecoveryRate = FormulaHelper.CalculateSpellPointRecoveryRate(playerEntity.MaxMagicka);
+
             playerEntity.CurrentHealth += healthRecoveryRate;
-            playerEntity.CurrentFatigue += (int)(playerEntity.MaxFatigue * recoveryRate);
-            playerEntity.CurrentMagicka += (int)(playerEntity.MaxMagicka * recoveryRate);
+            playerEntity.CurrentFatigue += fatigueRecoveryRate;
+            playerEntity.CurrentMagicka += spellPointRecoveryRate;
+
+            playerEntity.TallySkill((short)Skills.Medical, 1);
 
             // Check if player fully healed
             // Will eventually need to tailor check for character


### PR DESCRIPTION
Implements the formulas from classic for recovering fatigue and spell points. This was easy because they are both just += (max points / 8). Also tallies the medical skill. This is all confirmed from testing in classic.

A pedantic point but I don't think the term "magicka" is used in Daggerfall, just "spell points," so that's what I used. If you want to refer to it as magicka I can change it.