### PR TITLE
Implement lockpicking

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -115,6 +115,17 @@ namespace DaggerfallWorkshop.Game.Formulas
                 return 0;
         }
 
+        // Calculate chance of successfully lockpicking a door in an interior. If this is higher than a random number between 0 and 100 (inclusive), the lockpicking succeeds.
+        public static int CalculateInteriorLockpickingChance(int level, int lockvalue, int lockpickingSkill)
+        {
+            int lockpickingChance = (5 * (level - lockvalue) + lockpickingSkill);
+            if (lockpickingChance > 95)
+                lockpickingChance = 95;
+            else if (lockpickingChance < 5)
+                lockpickingChance = 5;
+            return lockpickingChance;
+        }
+
         #endregion
 
         #region Damage

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -146,7 +146,15 @@ namespace DaggerfallWorkshop.Game
                         DaggerfallActionDoor actionDoor;
                         if (ActionDoorCheck(hits[i], out actionDoor))
                         {
-                            actionDoor.ToggleDoor();
+                            if (currentMode == PlayerActivateModes.Steal && actionDoor.IsLocked)
+                            {
+                                if (actionDoor.IsNoLongerPickable)
+                                    return;
+                                else
+                                    actionDoor.AttemptLockpicking();
+                            }
+                            else
+                                actionDoor.ToggleDoor();
                         }
 
                         // Check for action record hit

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -60,5 +60,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string dialogue = "dialogue";
         public const string residence = "Residence";
         public const string youSee = "You see %s.";
+
+        public const string lockpickingSuccess = "The lock clicks open.";
+        public const string lockpickingFailure = "It does not unlock.";
     }
 }

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1053,7 +1053,7 @@ namespace DaggerfallWorkshop.Utility
             // Set starting lock value
             if (obj.Resources.ModelResource.TriggerFlag_StartingLock >= 16)
             {
-                actionDoor.StartingLockValue = (int)obj.Resources.ModelResource.TriggerFlag_StartingLock;
+                actionDoor.StartingLockValue = (int)obj.Resources.ModelResource.TriggerFlag_StartingLock / 8;
             }
 
             // Set LoadID


### PR DESCRIPTION
Here's an implementation of lockpicking.

I've found what I think is the formula for lockpicking interior doors in FALL.EXE. It involves randomness so it's hard to test in-game. It seems like I have higher success in the original game but that might have just been luck.

I also made an educated guess that the lock value of doors should be divided by 8 compared to what it is in DF Unity. DF Unity was marking a lock of 160 or more as magically locked, while original Daggerfall shows the magically-locked message for a value of 20 or more. Dividing the DF Unity lock values by 8 produces what seems like correct values for the locked doors in the Castle Daggerfall throne room.

The basic lockpicking behavior also replicates this behavior from the original game:
1. If you click on a locked door outside of steal mode, you get a message that the door is locked.
2. If you click on a non-magically locked door in steal mode, you make a lockpicking attempt. If you succeed the door opens and a click sound plays, which DF Unity was using for when you clicked on a locked door.
3. If you fail to pick a lock, you can no longer attempt to pick it unless you leave and re-enter the area. In original Daggerfall this persists across save and load.