### PR TITLE
Implement lockpicking difficulty messages

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -376,11 +376,11 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
-        public static void SetModeText(string message, float delay = 1.5f)
+        public static void SetMidScreenText(string message, float delay = 1.5f)
         {
             if (Instance.dfHUD != null)
             {
-                Instance.dfHUD.SetModeText(message, delay);
+                Instance.dfHUD.SetMidScreenText(message, delay);
             }
         }
 

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -109,10 +109,21 @@ namespace DaggerfallWorkshop.Game.Formulas
             return Mathf.Max((int)Mathf.Floor(maxSpellPoints / 8), 1);
         }
 
-        // Calculate chance of successfully lockpicking a door in an interior. If this is higher than a random number between 0 and 100 (inclusive), the lockpicking succeeds.
+        // Calculate chance of successfully lockpicking a door in an interior (an animating door). If this is higher than a random number between 0 and 100 (inclusive), the lockpicking succeeds.
         public static int CalculateInteriorLockpickingChance(int level, int lockvalue, int lockpickingSkill)
         {
             int lockpickingChance = (5 * (level - lockvalue) + lockpickingSkill);
+            if (lockpickingChance > 95)
+                lockpickingChance = 95;
+            else if (lockpickingChance < 5)
+                lockpickingChance = 5;
+            return lockpickingChance;
+        }
+
+        // Calculate chance of successfully lockpicking a door in an exterior (a door that leads to an interior). If this is higher than a random number between 0 and 100 (inclusive), the lockpicking succeeds.
+        public static int CalculateExteriorLockpickingChance(int lockvalue, int lockpickingSkill)
+        {
+            int lockpickingChance = lockpickingSkill - (5 * lockvalue);
             if (lockpickingChance > 95)
                 lockpickingChance = 95;
             else if (lockpickingChance < 5)

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -390,7 +390,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Present new mode to player
-            DaggerfallUI.SetModeText(HardStrings.interactionIsNowInMode.Replace("%s", modeText));
+            DaggerfallUI.SetMidScreenText(HardStrings.interactionIsNowInMode.Replace("%s", modeText));
         }
 
         // Output building info to HUD

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -29,7 +29,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         float crosshairScale = 0.5f;
 
         PopupText popupText = new PopupText();
-        TextLabel modeTextLabel = new TextLabel();
+        TextLabel midScreenTextLabel = new TextLabel();
         HUDCrosshair crosshair = new HUDCrosshair();
         HUDVitals vitals = new HUDVitals();
         HUDCompass compass = new HUDCompass();
@@ -37,11 +37,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         GameObject player;
         DaggerfallEntityBehaviour playerEntity;
 
-        float modeTextTimer = -1;
-        float modeTextDelay = 1.5f;
+        float midScreenTextTimer = -1;
+        float midScreenTextDelay = 1.5f;
 
         public bool ShowPopupText { get; set; }
-        public bool ShowModeText { get; set; }
+        public bool ShowMidScreenText { get; set; }
         public bool ShowCrosshair { get; set; }
         public bool ShowVitals { get; set; }
         public bool ShowCompass { get; set; }
@@ -68,7 +68,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             parentPanel.BackgroundColor = Color.clear;
             ShowPopupText = true;
-            ShowModeText = true;
+            ShowMidScreenText = true;
             ShowCrosshair = DaggerfallUnity.Settings.Crosshair;
             ShowVitals = true;
             ShowCompass = true;
@@ -88,9 +88,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             popupText.Size = NativePanel.Size;
             NativePanel.Components.Add(popupText);
 
-            modeTextLabel.HorizontalAlignment = HorizontalAlignment.Center;
-            modeTextLabel.Position = new Vector2(0, 146);
-            NativePanel.Components.Add(modeTextLabel);
+            midScreenTextLabel.HorizontalAlignment = HorizontalAlignment.Center;
+            midScreenTextLabel.Position = new Vector2(0, 146);
+            NativePanel.Components.Add(midScreenTextLabel);
 
             placeMarker.Size = new Vector2(640, 400);
             placeMarker.AutoSize = AutoSizeModes.ScaleToFit;
@@ -101,7 +101,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // Update HUD visibility
             popupText.Enabled = ShowPopupText;
-            modeTextLabel.Enabled = ShowModeText;
+            midScreenTextLabel.Enabled = ShowMidScreenText;
             crosshair.Enabled = ShowCrosshair;
             vitals.Enabled = ShowVitals;
             compass.Enabled = ShowCompass;
@@ -118,14 +118,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             float compassY = screenRect.height - (compass.Size.y);
             compass.Position = new Vector2(compassX, compassY);
 
-            // Update mode text timer and remove once complete
-            if (modeTextTimer != -1)
+            // Update midscreen text timer and remove once complete
+            if (midScreenTextTimer != -1)
             {
-                modeTextTimer += Time.deltaTime;
-                if (modeTextTimer > modeTextDelay)
+                midScreenTextTimer += Time.deltaTime;
+                if (midScreenTextTimer > midScreenTextDelay)
                 {
-                    modeTextTimer = -1;
-                    modeTextLabel.Text = string.Empty;
+                    midScreenTextTimer = -1;
+                    midScreenTextLabel.Text = string.Empty;
                 }
             }
 
@@ -141,12 +141,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             base.Update();
         }
 
-        public void SetModeText(string message, float delay = 1.5f)
+        public void SetMidScreenText(string message, float delay = 1.5f)
         {
             // Set text and start timing
-            modeTextLabel.Text = message;
-            modeTextTimer = 0;
-            modeTextDelay = delay;
+            midScreenTextLabel.Text = message;
+            midScreenTextTimer = 0;
+            midScreenTextDelay = delay;
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -64,5 +64,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public const string lockpickingSuccess = "The lock clicks open.";
         public const string lockpickingFailure = "It does not unlock.";
+        public const string magicLock = "This is a magically held lock...";
+        public const string lockpickChance1 = "This lock has nothing to fear from you...";
+        public const string lockpickChance2 = "It'd be a miracle if you picked this lock...";
+        public const string lockpickChance3 = "This lock looks to be beyond your skills...";
+        public static readonly string[] lockpickChance =  {"You doubt your ability to open this lock...",
+                                                    "This lock looks difficult...",
+                                                    "You would be challenged by this lock...",
+                                                    "This lock would prove a good challenge...",
+                                                    "You think you should be able to pick this lock...",
+                                                    "This lock seems relatively easy...",
+                                                    "You are amused by this lock...",
+                                                    "You laugh at the amateur quality of this lock...",
+                                                    "You see a pathetic excuse for a lock...",
+                                                    "This lock is an insult to your abilities..."};
+
     }
 }

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -146,16 +146,16 @@ namespace DaggerfallWorkshop
                 if (chance >= 30)
                     if (chance >= 35)
                         if (chance >= 45)
-                            Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickChance[(chance - 45) / 5]);
+                            Game.DaggerfallUI.SetMidScreenText(HardStrings.lockpickChance[(chance - 45) / 5]);
                         else
-                            Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickChance3);
+                            Game.DaggerfallUI.SetMidScreenText(HardStrings.lockpickChance3);
                     else
-                        Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickChance2);
+                        Game.DaggerfallUI.SetMidScreenText(HardStrings.lockpickChance2);
                 else
-                    Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickChance1);
+                    Game.DaggerfallUI.SetMidScreenText(HardStrings.lockpickChance1);
             }
             else
-                Game.DaggerfallUI.Instance.PopupMessage(HardStrings.magicLock);
+                Game.DaggerfallUI.SetMidScreenText(HardStrings.magicLock);
         }
 
         public void AttemptLockpicking()

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -133,6 +133,31 @@ namespace DaggerfallWorkshop
                 Close(duration);
         }
 
+        public void LookAtLock()
+        {
+            if (CurrentLockValue < 20)
+            {
+                PlayerEntity player = Game.GameManager.Instance.PlayerEntity;
+                // There seems to be an oversight in classic. It uses two separate lockpicking functions (seems to be one for animated doors in interiors and one for exterior doors)
+                // but the difficulty text is always based on the exterior function.
+                // DF Unity doesn't have exterior locked doors yet, so the below uses the interior function.
+                int chance = FormulaHelper.CalculateInteriorLockpickingChance(player.Level, CurrentLockValue, player.Skills.Lockpicking);
+
+                if (chance >= 30)
+                    if (chance >= 35)
+                        if (chance >= 45)
+                            Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickChance[(chance - 45) / 5]);
+                        else
+                            Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickChance3);
+                    else
+                        Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickChance2);
+                else
+                    Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickChance1);
+            }
+            else
+                Game.DaggerfallUI.Instance.PopupMessage(HardStrings.magicLock);
+        }
+
         public void AttemptLockpicking()
         {
             int chance = 0;
@@ -236,14 +261,8 @@ namespace DaggerfallWorkshop
             // Do nothing if door cannot be opened right now
             if ((IsLocked && !ignoreLocks) || IsOpen)
             {
-                //Just a temp. setup to provide feedback on locks until lockpicking is added
                 if(!IsOpen)
-                {
-                    string lockedDoorMessage = "This door is locked";
-                    if (IsMagicallyHeld)
-                        lockedDoorMessage = "This is a magically held door";
-                    DaggerfallWorkshop.Game.DaggerfallUI.Instance.PopupMessage(lockedDoorMessage);
-                }
+                    LookAtLock();
                 return;
             }
 


### PR DESCRIPTION
Implements lockpicking messages. I noted what seems to be an oversight in classic: the lockpicking difficulty messages in classic are always for the harder of two lockpicking formulas. That harder formula is used (I think) on exterior doors that lead into interiors, while an easier one is used for lockpicking the animating doors in interiors. I don't know whether the oversight is that the difficulty messages only account for one of the formulas, or if its that there are two different formulas.

I have hooked up the text to use the interior door formula (since DF Unity right now only has locked doors in interiors), so you will get accurate messages instead of the ones you will get in classic.

BTW, to be like classic, the text should be in the middle of the screen, the same spot currently being used for interaction mode changes. This spot is also used in classic for some other messages like "You have no arrows." when you try to equip a bow. If it's okay I'd like to change its name from ModeText to "MidscreenText" or something and use it for these other messages.