### PR TITLE
Identify and import more data from classic saves

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -64,6 +64,11 @@ namespace DaggerfallConnect.Save
             doc.workingStats = parsedData.currentStats;
             doc.workingSkills = parsedData.skills;
             doc.reflexes = parsedData.reflexes;
+            doc.currentHealth = parsedData.currentHealth;
+            doc.maxHealth = parsedData.maxHealth;
+            doc.currentSpellPoints = parsedData.currentSpellPoints;
+            doc.currentFatigue = parsedData.currentFatigue;
+            doc.skillUses = parsedData.skillUses;
 
             return doc;
         }
@@ -89,12 +94,15 @@ namespace DaggerfallConnect.Save
             parsedData.armorValues = reader.ReadBytes(7);
 
             reader.BaseStream.Position = 0x58;
-            parsedData.startSumUnknown = reader.ReadInt32();
+            parsedData.levelUpModifier = reader.ReadInt32(); // the starting total of all the primary skills, the two top major skills and the top minor skill
             parsedData.opponentUnknown = reader.ReadInt32();
+
+            reader.BaseStream.Position = 0x5c;
+            parsedData.baseHealth = reader.ReadInt16();
 
             reader.BaseStream.Position = 0x7c;
             parsedData.currentHealth = reader.ReadInt16();
-            parsedData.startingHealth = reader.ReadInt16();
+            parsedData.maxHealth = reader.ReadInt16();
             parsedData.faceIndex = reader.ReadByte();
             parsedData.level = reader.ReadByte();
 
@@ -105,12 +113,18 @@ namespace DaggerfallConnect.Save
             parsedData.physicalGold = reader.ReadUInt32();
 
             reader.BaseStream.Position = 0x8d;
-            parsedData.maxMagicka = reader.ReadInt16();
+            parsedData.currentSpellPoints = reader.ReadInt16();
+            parsedData.maxSpellPoints = reader.ReadInt16();
 
-            // TODO: 0x91 reputation?
+            parsedData.reputationCommoners = reader.ReadInt16();
+            parsedData.reputationMerchants = reader.ReadInt16();
+            parsedData.reputationScholars = reader.ReadInt16();
+            parsedData.reputationNobility = reader.ReadInt16();
+            parsedData.reputationUnderworld = reader.ReadInt16();
 
-            reader.BaseStream.Position = 0x9d;
-            parsedData.skills = ReadSkills(reader);
+            parsedData.currentFatigue = reader.ReadUInt16();
+
+            parsedData.skills = ReadSkills(reader, out parsedData.skillUses);
 
             reader.BaseStream.Position = 0x016f;
             parsedData.equippedItems = ReadEquippedItems(reader);
@@ -170,15 +184,18 @@ namespace DaggerfallConnect.Save
             return (PlayerReflexes)value;
         }
 
-        DaggerfallSkills ReadSkills(BinaryReader reader)
+        DaggerfallSkills ReadSkills(BinaryReader reader, out Int16[] skillUses)
         {
             DaggerfallSkills skills = new DaggerfallSkills();
+            skillUses = new Int16[DaggerfallSkills.Count];
 
             for (int i = 0; i < DaggerfallSkills.Count; i++)
             {
-                Int16 shortValue = reader.ReadInt16();
-                reader.ReadInt32(); // Skip unknown Int32
-                skills.SetSkillValue(i, shortValue);
+                Int16 skillValue = reader.ReadInt16();
+                Int16 skillCounterValue = reader.ReadInt16();
+                reader.ReadInt16(); // Seems to always be 00
+                skills.SetSkillValue(i, skillValue);
+                skillUses[i] = skillCounterValue;
             }
 
             return skills;
@@ -221,16 +238,25 @@ namespace DaggerfallConnect.Save
             public UInt16 transportationFlags;
             public Races race;
             public Byte[] armorValues;
-            public Int32 startSumUnknown;
+            public Int32 levelUpModifier;
             public Int32 opponentUnknown;
+            public Int16 baseHealth;
             public Int16 currentHealth;
-            public Int16 startingHealth;
+            public Int16 maxHealth;
             public Byte faceIndex;
             public Byte level;
             public PlayerReflexes reflexes;
             public UInt32 physicalGold;
-            public Int16 maxMagicka;
+            public Int16 currentSpellPoints;
+            public Int16 maxSpellPoints;
+            public Int16 reputationCommoners;
+            public Int16 reputationNobility;
+            public Int16 reputationScholars;
+            public Int16 reputationMerchants;
+            public Int16 reputationUnderworld;
+            public UInt16 currentFatigue;
             public DaggerfallSkills skills;
+            public Int16[] skillUses;
             public UInt32[] equippedItems;
             public UInt32 timeStamp;
             public DFCareer career;

--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -170,6 +170,10 @@ namespace DaggerfallConnect.Save
 
         UInt16 ReadTransportationFlags(BinaryReader reader)
         {
+            // Known values:
+            // 1 = Foot
+            // 3 = Horse
+            // 5 = Cart
             return reader.ReadUInt16();
         }
 

--- a/Assets/Scripts/Editor/SaveExplorerWindow.cs
+++ b/Assets/Scripts/Editor/SaveExplorerWindow.cs
@@ -234,7 +234,7 @@ namespace DaggerfallWorkshop
             });
             GUILayoutHelper.Horizontal(() =>
             {
-                string health = string.Format("{0} / {1}", characterRecord.ParsedData.currentHealth, characterRecord.ParsedData.startingHealth);
+                string health = string.Format("{0} / {1}", characterRecord.ParsedData.currentHealth, characterRecord.ParsedData.maxHealth);
                 EditorGUILayout.LabelField(new GUIContent("Health"), GUILayout.Width(EditorGUIUtility.labelWidth - 4));
                 EditorGUILayout.SelectableLabel(health, EditorStyles.textField, GUILayout.Height(EditorGUIUtility.singleLineHeight));
             });

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -104,13 +104,16 @@ namespace DaggerfallWorkshop.Game.Entity
             this.stats = character.workingStats;
             this.skills = character.workingSkills;
             this.reflexes = character.reflexes;
+            this.MaxHealth = character.maxHealth;
+            this.CurrentHealth = character.currentHealth;
+            this.CurrentMagicka = character.currentSpellPoints;
+            this.currentFatigue = character.currentFatigue;
+            this.skillUses = character.skillUses;
 
             if (maxHealth <= 0)
                 this.maxHealth = FormulaHelper.RollMaxHealth(level, stats.Endurance, career.HitPointsPerLevelOrMonsterLevel);
             else
                 this.maxHealth = maxHealth;
-
-            FillVitalSigns();
 
             DaggerfallUnity.LogMessage("Assigned character " + this.name, true);
         }

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -204,16 +204,15 @@ namespace DaggerfallWorkshop.Game.Entity
 
         private void PlayerEntity_OnExhausted(DaggerfallEntity entity)
         {
-            GameManager.Instance.PlayerMotor.CancelMovement = true;
-
             const int youDropToTheGround1 = 1071;
             const int youDropToTheGround2 = 1072;
-            const float recoveryRate = 0.125f; // temporary value
 
             bool enemiesNearby = GameManager.Instance.AreEnemiesNearby();
 
             ITextProvider textProvider = DaggerfallUnity.Instance.TextProvider;
             TextFile.Token[] tokens;
+
+            GameManager.Instance.PlayerMotor.CancelMovement = true;
 
             if (!enemiesNearby)
                 tokens = textProvider.GetRSCTokens(youDropToTheGround1);

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -32,6 +32,11 @@ namespace DaggerfallWorkshop.Game.Player
         public DaggerfallSkills startingSkills;
         public DaggerfallSkills workingSkills;
         public PlayerReflexes reflexes;
+        public int currentHealth;
+        public int maxHealth;
+        public int currentSpellPoints;
+        public int currentFatigue;
+        public short[] skillUses;
 
         public CharacterDocument()
         {

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -450,7 +450,7 @@ namespace DaggerfallWorkshop.Game.Utility
 
             // Assign data to player entity
             PlayerEntity playerEntity = FindPlayerEntity();
-            playerEntity.AssignCharacter(characterDocument, characterRecord.ParsedData.level, characterRecord.ParsedData.startingHealth);
+            playerEntity.AssignCharacter(characterDocument, characterRecord.ParsedData.level, characterRecord.ParsedData.maxHealth);
 
             // Assign items to player entity
             playerEntity.AssignItems(saveTree);


### PR DESCRIPTION
Through a combination of testing with the save editor DagHex and confirming in-game, new values have been identified in classic saves. Current health, spell points and fatigue are imported as they are into DF Unity, as are skill use counts.

The player's reputation with commoners, nobility, scholars, merchants and underworld is based on the message you get about your reputation being higher or lower during character creation. DagHex has nobility and merchants switched compared to this, and DaggeD, another save editor, has the reputations in the opposite order of how they're shown in-game. I'm going with the in-game display as most reliable until it can be confirmed somehow.