### PR TITLE
Implement skill raising

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
@@ -367,5 +367,72 @@ namespace DaggerfallWorkshop.Game.Entity
         {
             return GetPrimaryStat((DFCareer.Skills)index);
         }
+
+        // These are based on observations from testing classic and may not be completely accurate.
+        // They are used with the formula (int)((skillLevel * x) + PlayerLevel)) to give the number of skill uses needed to advance a skill,
+        // where x is the value returned from this function.
+        public float GetAdvancementDifficultyModifier(DFCareer.Skills skill)
+        {
+            switch (skill)
+            {
+                case DFCareer.Skills.Medical:
+                    return 4.9f;
+                case DFCareer.Skills.Etiquette:
+                case DFCareer.Skills.Streetwise:
+                    return .4f;
+                case DFCareer.Skills.Jumping:
+                    return 2f;
+                case DFCareer.Skills.Orcish:
+                case DFCareer.Skills.Harpy:
+                case DFCareer.Skills.Giantish:
+                case DFCareer.Skills.Dragonish:
+                case DFCareer.Skills.Nymph:
+                case DFCareer.Skills.Daedric:
+                case DFCareer.Skills.Spriggan:
+                case DFCareer.Skills.Centaurian:
+                case DFCareer.Skills.Impish:
+                    return 6.2f;
+                case DFCareer.Skills.Lockpicking:
+                    return .8f;
+                case DFCareer.Skills.Mercantile:
+                    return .4f;
+                case DFCareer.Skills.Pickpocket:
+                case DFCareer.Skills.Stealth:
+                    return .8f;
+                case DFCareer.Skills.Swimming:
+                    return .4f;
+                case DFCareer.Skills.Climbing:
+                    return .8f;
+                case DFCareer.Skills.Backstabbing:
+                    return .4f;
+                case DFCareer.Skills.Dodging:
+                    return 1.6f;
+                case DFCareer.Skills.Running:
+                    return 20.8f;
+                case DFCareer.Skills.Destruction:
+                    return .4f;
+                case DFCareer.Skills.Restoration:
+                    return .8f;
+                case DFCareer.Skills.Illusion:
+                case DFCareer.Skills.Alteration:
+                    return .4f;
+                case DFCareer.Skills.Thaumaturgy:
+                    return .8f;
+                case DFCareer.Skills.Mysticism:
+                    return .4f;
+                case DFCareer.Skills.ShortBlade:
+                case DFCareer.Skills.LongBlade:
+                case DFCareer.Skills.HandToHand:
+                case DFCareer.Skills.Axe:
+                case DFCareer.Skills.BluntWeapon:
+                    return .8f;
+                case DFCareer.Skills.Archery:
+                    return .4f;
+                case DFCareer.Skills.CriticalStrike:
+                    return 3.3f;
+                default:
+                    return 0;
+            }
+        }
     }
 }

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -131,6 +131,12 @@ namespace DaggerfallWorkshop.Game.Formulas
             return lockpickingChance;
         }
 
+        // Calculate how many uses a skill needs before its value will rise. This is based on observations from classic and may not be completely accurate.
+        public static int CalculateSkillUsesForAdvancement(int skillValue, float modifier, int level)
+        {
+            return (int)((skillValue * modifier) + level);
+        }
+
         #endregion
 
         #region Damage

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -194,6 +194,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Progress world time
             DaggerfallUnity.WorldTime.Now.RaiseTime(totalHours * DaggerfallDateTime.SecondsPerHour);
             Debug.Log(string.Format("Resting raised time by {0} hours", totalHours));
+            playerEntity.RaiseSkills();
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -432,6 +432,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             terrains.Clear();
             DaggerfallUI.Instance.UserInterfaceManager.PopWindow();
             travelWindow.CloseTravelWindows(true);
+            GameManager.Instance.PlayerEntity.RaiseSkills();
         }
 
         public void ExitButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -79,5 +79,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                                                     "You see a pathetic excuse for a lock...",
                                                     "This lock is an insult to your abilities..."};
 
+        public const string skillImprove = "Your %s skill has improved.";
     }
 }


### PR DESCRIPTION
Implements skill raising. From testing classic, I think the only factors that affect how many skill uses are needed to raise a skill are the skill value (it's percentage) and the player's level. Different skills have different modifiers to how many uses they need. Running has such a high one because it is tallied very quickly while moving.