### PR TITLE
Correct stat raising calculations

### DIFF
--- a/Assets/Scripts/API/Save/SaveVars.cs
+++ b/Assets/Scripts/API/Save/SaveVars.cs
@@ -30,12 +30,14 @@ namespace DaggerfallConnect.Save
         const int weaponDrawnOffset = 0x3BF;
         const int gameTimeOffset = 0x3C9;
         const int godModeOffset = 0x173B;
+        const int lastSkillCheckTimeOffset = 0x179A;
         const int factionDataOffset = 0x17D0;
         const int factionDataLength = 92;
 
         bool weaponDrawn = false;
         uint gameTime = 0;
         bool godMode = false;
+        uint lastSkillCheckTime = 0;
 
         // Private fields
         FileProxy saveVarsFile = new FileProxy();
@@ -72,6 +74,14 @@ namespace DaggerfallConnect.Save
         public bool GodMode
         {
             get { return godMode; }
+        }
+
+        /// <summary>
+        /// Gets time of last check for raising skills, read from savevars.
+        /// </summary>
+        public uint LastSkillCheckTime
+        {
+            get { return lastSkillCheckTime; }
         }
 
         /// <summary>
@@ -127,6 +137,7 @@ namespace DaggerfallConnect.Save
             ReadWeaponDrawn(reader);
             ReadGameTime(reader);
             ReadGodMode(reader);
+            ReadLastSkillCheckTime(reader);
             ReadFactionData(reader);
 
             return true;
@@ -154,6 +165,12 @@ namespace DaggerfallConnect.Save
             reader.BaseStream.Position = godModeOffset;
             if (reader.ReadByte() == 0x40)
                 godMode = true;
+        }
+
+        void ReadLastSkillCheckTime(BinaryReader reader)
+        {
+            reader.BaseStream.Position = lastSkillCheckTimeOffset;
+            lastSkillCheckTime = reader.ReadUInt32();
         }
 
         void ReadFactionData(BinaryReader reader)

--- a/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
@@ -368,20 +368,17 @@ namespace DaggerfallWorkshop.Game.Entity
             return GetPrimaryStat((DFCareer.Skills)index);
         }
 
-        // These are based on observations from testing classic and may not be completely accurate.
-        // They are used with the formula (int)((skillLevel * x) + PlayerLevel)) to give the number of skill uses needed to advance a skill,
-        // where x is the value returned from this function.
-        public float GetAdvancementDifficultyModifier(DFCareer.Skills skill)
+        public int GetAdvancementMultiplier(DFCareer.Skills skill)
         {
             switch (skill)
             {
                 case DFCareer.Skills.Medical:
-                    return 4.9f;
+                    return 12;
                 case DFCareer.Skills.Etiquette:
                 case DFCareer.Skills.Streetwise:
-                    return .4f;
+                    return 1;
                 case DFCareer.Skills.Jumping:
-                    return 2f;
+                    return 5;
                 case DFCareer.Skills.Orcish:
                 case DFCareer.Skills.Harpy:
                 case DFCareer.Skills.Giantish:
@@ -391,45 +388,45 @@ namespace DaggerfallWorkshop.Game.Entity
                 case DFCareer.Skills.Spriggan:
                 case DFCareer.Skills.Centaurian:
                 case DFCareer.Skills.Impish:
-                    return 6.2f;
+                    return 15;
                 case DFCareer.Skills.Lockpicking:
-                    return .8f;
+                    return 2;
                 case DFCareer.Skills.Mercantile:
-                    return .4f;
+                    return 1;
                 case DFCareer.Skills.Pickpocket:
                 case DFCareer.Skills.Stealth:
-                    return .8f;
+                    return 2;
                 case DFCareer.Skills.Swimming:
-                    return .4f;
+                    return 1;
                 case DFCareer.Skills.Climbing:
-                    return .8f;
+                    return 2;
                 case DFCareer.Skills.Backstabbing:
-                    return .4f;
+                    return 1;
                 case DFCareer.Skills.Dodging:
-                    return 1.6f;
+                    return 4;
                 case DFCareer.Skills.Running:
-                    return 20.8f;
+                    return 50;
                 case DFCareer.Skills.Destruction:
-                    return .4f;
+                    return 1;
                 case DFCareer.Skills.Restoration:
-                    return .8f;
+                    return 2;
                 case DFCareer.Skills.Illusion:
                 case DFCareer.Skills.Alteration:
-                    return .4f;
+                    return 1;
                 case DFCareer.Skills.Thaumaturgy:
-                    return .8f;
+                    return 2;
                 case DFCareer.Skills.Mysticism:
-                    return .4f;
+                    return 1;
                 case DFCareer.Skills.ShortBlade:
                 case DFCareer.Skills.LongBlade:
                 case DFCareer.Skills.HandToHand:
                 case DFCareer.Skills.Axe:
                 case DFCareer.Skills.BluntWeapon:
-                    return .8f;
+                    return 2;
                 case DFCareer.Skills.Archery:
-                    return .4f;
+                    return 1;
                 case DFCareer.Skills.CriticalStrike:
-                    return 3.3f;
+                    return 8;
                 default:
                     return 0;
             }

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -233,8 +233,9 @@ namespace DaggerfallWorkshop.Game.Entity
 
             for (short i = 0; i < skillUses.Length; i++)
             {
-                float modifier = skills.GetAdvancementDifficultyModifier((DaggerfallConnect.DFCareer.Skills)i);
-                int usesNeededForAdvancement = FormulaHelper.CalculateSkillUsesForAdvancement(skills.GetSkillValue(i), modifier, level);
+                int skillAdvancementMultiplier = skills.GetAdvancementMultiplier((DaggerfallConnect.DFCareer.Skills)i);
+                float careerAdvancementMultiplier = Career.AdvancementMultiplier;
+                int usesNeededForAdvancement = FormulaHelper.CalculateSkillUsesForAdvancement(skills.GetSkillValue(i), skillAdvancementMultiplier, careerAdvancementMultiplier, level);
                 if (skillUses[i] >= usesNeededForAdvancement)
                 {
                     skillUses[i] = 0;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -41,7 +41,7 @@ namespace DaggerfallWorkshop.Game.Entity
         protected PersistentFactionData factionData = new PersistentFactionData();
 
         protected short[] skillUses;
-        protected uint timeOfLastSkillIncreaseCheck = 0; // TODO: Load from classic saves
+        protected uint timeOfLastSkillIncreaseCheck = 0;
 
         protected int startingLevelUpSkillSum = 0;
         protected int currentLevelUpSkillSum = 0;
@@ -94,6 +94,7 @@ namespace DaggerfallWorkshop.Game.Entity
             startingLevelUpSkillSum = 0;
             currentLevelUpSkillSum = 0;
             goldPieces = 0;
+            timeOfLastSkillIncreaseCheck = 0;
             if (skillUses != null)
                 System.Array.Clear(skillUses, 0, skillUses.Length);
         }

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -131,10 +131,11 @@ namespace DaggerfallWorkshop.Game.Formulas
             return lockpickingChance;
         }
 
-        // Calculate how many uses a skill needs before its value will rise. This is based on observations from classic and may not be completely accurate.
-        public static int CalculateSkillUsesForAdvancement(int skillValue, float modifier, int level)
+        // Calculate how many uses a skill needs before its value will rise.
+        public static int CalculateSkillUsesForAdvancement(int skillValue, int skillAdvancementMultiplier, float careerAdvancementMultiplier, int level)
         {
-            return (int)Mathf.Floor((skillValue * modifier) + level);
+            double levelMod = Math.Pow(1.04, level);
+            return (int)Math.Floor((skillValue * skillAdvancementMultiplier * careerAdvancementMultiplier * levelMod * 2 / 5) + 1);
         }
 
         // Calculate player level.

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -468,6 +468,9 @@ namespace DaggerfallWorkshop.Game.Utility
             PlayerEntity playerEntity = FindPlayerEntity();
             playerEntity.AssignCharacter(characterDocument, characterRecord.ParsedData.level, characterRecord.ParsedData.maxHealth, false);
 
+            // Set time of last check for raising skills
+            playerEntity.TimeOfLastSkillIncreaseCheck = saveVars.LastSkillCheckTime;
+
             // Assign items to player entity
             playerEntity.AssignItems(saveTree);
 


### PR DESCRIPTION
Stat raising calculations should now be correct with this PR. This works for all the test cases I've used.

In a werewolf save I'm using (downloaded from the Internet), it looks like the skills raised by being a werewolf also have their advancement modifier halved, so they rise more easily. The character in the save is in human form but gets this benefit it seems. There may be something similar with vampires. This will need some more testing but I'm not going to bother with it for now.