### PR TITLE
Fix for null reference on Unity saves

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -296,7 +296,10 @@ namespace DaggerfallWorkshop.Game.Entity
         {
             float estimatedLevel = level + 0.5f; // Assume the player is halfway through advancing a level
             int estimatedSum = (int)((estimatedLevel * 15) - (28 + currentLevelUpSkillSum)) * -1;
-            startingLevelUpSkillSum = estimatedSum;
+            if ((currentLevelUpSkillSum > 0) && (startingLevelUpSkillSum > currentLevelUpSkillSum))
+                startingLevelUpSkillSum = currentLevelUpSkillSum;
+            else
+                startingLevelUpSkillSum = estimatedSum;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -190,7 +190,12 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.ItemEquipTable.DeserializeEquipTable(data.playerEntity.equipTable, entity.Items);
             entity.GoldPieces = data.playerEntity.goldPieces;
             entity.SetCurrentLevelUpSkillSum();
-            entity.EstimateStartingLevelUpSkillSum(); // TODO: Save and load starting skill sum. Only estimate if supporting saves without this data.
+
+            // Fill in missing data for saves
+            if (entity.StartingLevelUpSkillSum <= 0)
+                entity.EstimateStartingLevelUpSkillSum();
+            if (entity.SkillUses == null)
+                entity.SkillUses = new short[DaggerfallSkills.Count];
 
             // Flag determines if player position is restored
             bool restorePlayerPosition = true;


### PR DESCRIPTION
In an earlier PR I fixed null reference to skillUses[] on a new character, but it also happens with Unity saves that were saved before the additional data. This PR initializes the array in that case. It also sets EstimateStartingLevelUpSkillSum() to only be called if the skillsum is 0 because nothing was in the save file.

I guess stuff will continue to be added to the save file, so is this the way to handle missing data? Maybe defaults should be set first and things only assigned from the loaded file if they are non-null/non-0.