### PR TITLE
Fix input text overlapping

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs
@@ -40,6 +40,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private int inputDistanceY = 0;                 //vertical distance between the input label & input box
         private bool useParchmentStyle = true;          //if true, box will use PopupStyle Parchment background
         private bool clickAnywhereToClose = false;
+        private bool showAtTopOfScreen = false;
 
         public bool ClickAnywhereToClose
         {
@@ -99,12 +100,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             int maxCharacters = 31,
             string textBoxLabel = null,
             bool useParchmentBackGround = true,
+            bool showAtTopOfScreen = false,
             UserInterfaceWindow previous = null)
             : base(uiManager, previous)
         {
             this.textBox.MaxCharacters = maxCharacters;
             this.useParchmentStyle = useParchmentBackGround;
             this.SetTextBoxLabel(textBoxLabel);
+            this.showAtTopOfScreen = showAtTopOfScreen;
             SetupBox(textId);
         }
 
@@ -129,13 +132,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (useParchmentStyle)
                 DaggerfallUI.Instance.SetDaggerfallPopupStyle(DaggerfallUI.PopupStyle.Parchment, messagePanel);
+
             messagePanel.HorizontalAlignment = HorizontalAlignment.Center;
-            messagePanel.VerticalAlignment = VerticalAlignment.Middle;
+            if (showAtTopOfScreen)
+                messagePanel.VerticalAlignment = VerticalAlignment.Top;
+            else
+                messagePanel.VerticalAlignment = VerticalAlignment.Middle;
             messagePanel.OnMouseClick += MessagePanel_OnMouseClick;
             NativePanel.Components.Add(messagePanel);
 
             multiLineLabel.HorizontalAlignment = HorizontalAlignment.Center;
-            multiLineLabel.VerticalAlignment = VerticalAlignment.Middle;
+            if (showAtTopOfScreen)
+                multiLineLabel.VerticalAlignment = VerticalAlignment.Top;
+            else
+                multiLineLabel.VerticalAlignment = VerticalAlignment.Middle;
             messagePanel.Components.Add(multiLineLabel);
 
             messagePanel.Components.Add(textPanel);

--- a/Assets/Scripts/Internal/DaggerfallAction.cs
+++ b/Assets/Scripts/Internal/DaggerfallAction.cs
@@ -475,15 +475,11 @@ namespace DaggerfallWorkshop
             {
                 Debug.LogError(string.Format("Error: invalid key: {0} for action type 12, couldn't get answer(s)", textID));//todo - display error message
             }
-            DaggerfallInputMessageBox inputBox = new DaggerfallInputMessageBox(DaggerfallWorkshop.Game.DaggerfallUI.UIManager, textID, 20, "\t> ", false, null);
+            DaggerfallInputMessageBox inputBox = new DaggerfallInputMessageBox(DaggerfallWorkshop.Game.DaggerfallUI.UIManager, textID, 20, "\t> ", false, true, null);
             inputBox.ParentPanel.BackgroundColor = Color.clear;
             inputBox.OnGotUserInput += thisAction.UserInputHandler;
             inputBox.Show();
         }
-
-
-
-
 
         /// <summary>
         /// 14


### PR DESCRIPTION
This is sort of a patched-on-top fix for overlapping text when you click on the banner/statue at Shedungent. This problem has been around since one of the changes I made some time ago to text formatting.

What classic seems to actually do is add these input text prompts to the same "popup text" lines used for things like "-- just died."