### PR TITLE
Fix spinner missing on level-up screen in builds

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -46,7 +46,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         TextLabel[] statLabels = new TextLabel[DaggerfallStats.Count];
         PaperDoll characterPortrait = new PaperDoll();
 
-        StatsRollout statsRollout = new StatsRollout(true);
+        StatsRollout statsRollout;
 
         bool leveling = false;
 
@@ -147,6 +147,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 pos.y += 24f;
             }
 
+            statsRollout = new StatsRollout(true);
             statsRollout.OnStatChanged += StatsRollout_OnStatChanged;
 
             // Update player paper doll for first time


### PR DESCRIPTION
Tested and confirmed working in a build using latest master, both from a DF Unity new game and from an imported classic save.