### PR TITLE
Do nothing if rest key is pushed while in air

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -338,15 +338,15 @@ namespace DaggerfallWorkshop.Game
                     }
                     break;
                 case DaggerfallUIMessages.dfuiOpenRestWindow:
-                    if (!GameManager.Instance.AreEnemiesNearby() && GameManager.Instance.PlayerController.isGrounded)
-                    {
-                        uiManager.PushWindow(new DaggerfallRestWindow(uiManager));
-                    }
-                    else
+                    if (GameManager.Instance.AreEnemiesNearby())
                     {
                         // Alert player if monsters nearby
                         const int enemiesNearby = 354;
                         MessageBox(enemiesNearby);
+                    }
+                    else if (GameManager.Instance.PlayerController.isGrounded)
+                    {
+                        uiManager.PushWindow(new DaggerfallRestWindow(uiManager));
                     }
                     break;
                 case DaggerfallUIMessages.dfuiOpenQuestInspector:


### PR DESCRIPTION
Currently in DF Unity if you push the rest key while in the air you get the "There are enemies nearby." message. With this PR instead nothing happens, the same as classic.