### PR TITLE
Import player orientation from classic saves

### DIFF
--- a/Assets/Scripts/API/Save/SaveTree.cs
+++ b/Assets/Scripts/API/Save/SaveTree.cs
@@ -30,6 +30,7 @@ namespace DaggerfallConnect.Save
         public SaveTreeHeader Header;
         public SaveTreeLocationDetail LocationDetail;
         public SaveTreeBaseRecord RootRecord = new SaveTreeBaseRecord();
+        public PlayerDirectionRecord DirectionRecord = new PlayerDirectionRecord();
         public Dictionary<uint, SaveTreeBaseRecord> RecordDictionary = new Dictionary<uint, SaveTreeBaseRecord>();
 
         // Private fields
@@ -247,6 +248,18 @@ namespace DaggerfallConnect.Save
                     case RecordTypes.Container:
                         record = new ContainerRecord(reader, length);
                         break;
+                    case RecordTypes.CharacterParentUnknown1:
+                        // CharacterParentUnknown1's first values after the record type are the pitch and yaw of the player's view.
+                        // The same player position data as in the header, and then unknown data, follows.
+                        // For now just get the pitch and yaw.
+                        long position = reader.BaseStream.Position;
+                        reader.ReadByte();
+                        DirectionRecord.Pitch = reader.ReadInt16();
+                        DirectionRecord.Yaw = reader.ReadInt16();
+                        // Reset stream position and continue with default behavior
+                        reader.BaseStream.Position = position;
+                        record = new SaveTreeBaseRecord(reader, length);
+                        break;
                     //case RecordTypes.UnknownTownLink:
                     //    record = new SaveTreeBaseRecord(reader, length);    // Read then skip these records for now
                     //    continue;
@@ -324,6 +337,8 @@ namespace DaggerfallConnect.Save
         public Byte RecordType;                 // Must always be 0x01
         public UInt16 Unknown;
         public RecordPosition Position;
+        public Int16 Pitch;
+        public Int16 Yaw;
     }
 
     /// <summary>
@@ -344,6 +359,13 @@ namespace DaggerfallConnect.Save
         public Byte QuestID;                    // Associated quest ID of this record (0 if no quest)
         public UInt32 ParentRecordID;           // ID of parent record
         public RecordTypes ParentRecordType;    // Type of parent record
+    }
+
+    // Temporary struct until CharacterParentUnknown1 is understood
+    public struct PlayerDirectionRecord
+    {
+        public Int16 Pitch;
+        public Int16 Yaw;
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -449,6 +449,24 @@ namespace DaggerfallWorkshop.Game.Utility
                 streamingWorld.suppressWorld = false;
             }
 
+            GameObject cameraObject = GameObject.FindGameObjectWithTag("MainCamera");
+            PlayerMouseLook mouseLook = cameraObject.GetComponent<PlayerMouseLook>();
+            if (mouseLook)
+            {
+                // Classic save value ranges from -256 (looking up) to 256 (looking down).
+                // The maximum up and down range of view in classic is similar to 45 degrees up and down in DF Unity.
+                float pitch = saveTree.DirectionRecord.Pitch;
+                if (pitch != 0)
+                    pitch = (pitch * 45 / 256);
+                mouseLook.Pitch = pitch;
+
+                float yaw = saveTree.DirectionRecord.Yaw;
+                // In classic saves 2048 units of yaw is 360 degrees.
+                if (yaw != 0)
+                    yaw = (yaw * 360 / 2048);
+                mouseLook.Yaw = yaw;
+            }
+
             // Set whether the player's weapon is drawn
             GameManager.Instance.WeaponManager.Sheathed = (!saveVars.WeaponDrawn);
 


### PR DESCRIPTION
This imports the pitch and yaw values from classic saves, resolving http://forums.dfworkshop.net/viewtopic.php?f=24&t=424&sid=3e361409f513f292e15381a7752cc11f.

After the pitch and yaw data is what seems to be a copy of the player position data found in the header. It is this position data, and not the player position data in the header, that determines where the player is when a save is loaded in classic. There is additional data after that, but I don't know what it is.