### PR TITLE
Raise foe max spawn limit

### DIFF
--- a/Assets/Scripts/Game/Questing/Foe.cs
+++ b/Assets/Scripts/Game/Questing/Foe.cs
@@ -25,8 +25,8 @@ namespace DaggerfallWorkshop.Game.Questing
     /// </summary>
     public class Foe : QuestResource
     {
-        // Arbitrary limit to spawn count, need to check this is at/above max classic expects
-        const int maxSpawnCount = 10;
+        // Testing shows classic can spawn at least 50 of the same enemy at a time, and probably many more
+        const int maxSpawnCount = 50;
 
         int spawnCount;
         MobileTypes foeType;


### PR DESCRIPTION
I saw the comment about foe spawn limits and decided to test it. I found no limit to the number of spawns classic can do of the same foe at a time.

I know for 100% sure it can spawn 20 at a time, as I was able to count them. I then raised it to 50, and what looked like 50 (I didn't actually count this time) spawned. An additional 50 (or what looked like 50) of another enemy spawned at the same time. If there is any limit it is very high.