### PR TITLE
Identify more data from classic saves

### DIFF
--- a/Assets/Scripts/API/Save/SaveTreeBaseRecord.cs
+++ b/Assets/Scripts/API/Save/SaveTreeBaseRecord.cs
@@ -222,24 +222,49 @@ namespace DaggerfallConnect.Save
                 return;
             }
 
+            // Direction
+            reader.BaseStream.Position = 1;
+            recordRoot.Pitch = reader.ReadInt16();
+            recordRoot.Yaw = reader.ReadInt16();
+
             // Position
-            reader.BaseStream.Position = 6;
+            reader.BaseStream.Position = 7;
             recordRoot.Position = SaveTree.ReadPosition(reader);
 
+            // 3d View Picture
+            reader.BaseStream.Position = 27;
+            recordRoot.Picture1 = reader.ReadUInt16();
+
+            // Inventory Picture
+            recordRoot.Picture2 = reader.ReadUInt16();
+
             // RecordID
-            reader.BaseStream.Position = 30;
             recordRoot.RecordID = reader.ReadUInt32();
 
             // QuestID
-            reader.BaseStream.Position = 37;
+            reader.BaseStream.Position = 38;
             recordRoot.QuestID = reader.ReadByte();
 
             // ParentRecordID
-            reader.BaseStream.Position = 38;
             recordRoot.ParentRecordID = reader.ReadUInt32();
 
+            // ItemObject
+            reader.BaseStream.Position = 47;
+            recordRoot.ItemObject = reader.ReadUInt32();
+
+            // QuestObjectID
+            recordRoot.QuestObjectID = reader.ReadUInt32();
+
+            // NextObject
+            recordRoot.NextObject = reader.ReadUInt32();
+
+            // ChildObject
+            recordRoot.ChildObject = reader.ReadUInt32();
+
+            // SublistHead
+            recordRoot.SublistHead = reader.ReadUInt32();
+
             // ParentRecordType
-            reader.BaseStream.Position = 66;
             recordRoot.ParentRecordType = (RecordTypes)reader.ReadInt32();
 
             reader.Close();

--- a/Assets/Scripts/API/Save/SaveTreeHeader.cs
+++ b/Assets/Scripts/API/Save/SaveTreeHeader.cs
@@ -32,7 +32,7 @@ namespace DaggerfallConnect.Save
         public long StreamPosition;                             // Starting position in file stream
         public byte[] RawData;                                  // Raw byte data read from stream
         public Byte Version;                                    // Version - must be 0x26
-        public CharacterPositionRecord CharacterPosition;       // Character position
+        public HeaderCharacterPositionRecord CharacterPosition; // Character position
         public UInt16 Unknown;                                  // Unknown
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace DaggerfallConnect.Save
                 throw new Exception("SaveTree file has an invalid version number, must be 0x26.");
 
             // Read CharacterPosition.RecordType - must be 0x01
-            CharacterPosition = new CharacterPositionRecord();
+            CharacterPosition = new HeaderCharacterPositionRecord();
             CharacterPosition.RecordType = reader.ReadByte();
             if (CharacterPosition.RecordType != (int)RecordTypes.CharacterPosition)
                 throw new Exception("Expected CharacterPosition in SaveTreeHeader has an invalid record type, must be 0x01.");

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -434,6 +434,8 @@ namespace DaggerfallWorkshop.Game.Utility
             SaveTree saveTree = saveGames.SaveTree;
             SaveVars saveVars = saveGames.SaveVars;
 
+            SaveTreeBaseRecord positionRecord = saveTree.FindRecord(RecordTypes.CharacterPositionRecord);
+
             if (NoWorld)
             {
                 playerEnterExit.DisableAllParents();
@@ -443,8 +445,8 @@ namespace DaggerfallWorkshop.Game.Utility
                 // Set player to world position
                 playerEnterExit.EnableExteriorParent();
                 StreamingWorld streamingWorld = FindStreamingWorld();
-                int worldX = saveTree.Header.CharacterPosition.Position.WorldX;
-                int worldZ = saveTree.Header.CharacterPosition.Position.WorldZ;
+                int worldX = positionRecord.RecordRoot.Position.WorldX;
+                int worldZ = positionRecord.RecordRoot.Position.WorldZ;
                 streamingWorld.TeleportToWorldCoordinates(worldX, worldZ);
                 streamingWorld.suppressWorld = false;
             }
@@ -455,12 +457,12 @@ namespace DaggerfallWorkshop.Game.Utility
             {
                 // Classic save value ranges from -256 (looking up) to 256 (looking down).
                 // The maximum up and down range of view in classic is similar to 45 degrees up and down in DF Unity.
-                float pitch = saveTree.DirectionRecord.Pitch;
+                float pitch = positionRecord.RecordRoot.Pitch;
                 if (pitch != 0)
                     pitch = (pitch * 45 / 256);
                 mouseLook.Pitch = pitch;
 
-                float yaw = saveTree.DirectionRecord.Yaw;
+                float yaw = positionRecord.RecordRoot.Yaw;
                 // In classic saves 2048 units of yaw is 360 degrees.
                 if (yaw != 0)
                     yaw = (yaw * 360 / 2048);


### PR DESCRIPTION
I identified quite a lot more data from classic saves with the help of Donald Tipton's save-viewing program chunktcl. I also found on my own that pitch and yaw seem to be default properties of all records.

The player's location is now gotten from the type 0x04 record, which I named "CharacterPositionRecord." I renamed the old CharacterPositionRecord to  HeaderCharacterPositionRecord.

Some of the record root data already being read into SaveTreeBaseRecord was reading data from the wrong location, but they should be reading from the correct spots now.

One thing that I think would now be possible is to recreate nearby monsters from save games, since I found the monster record and it includes their position. They have their name at the beginning of their data, so we could use that to determine the type. I'm not real sure about how you would want to handle spawning those monsters from a saved game, though.