### PR TITLE
Identify classic save tree header data

### DIFF
--- a/Assets/Scripts/API/Save/SaveTreeHeader.cs
+++ b/Assets/Scripts/API/Save/SaveTreeHeader.cs
@@ -25,15 +25,16 @@ namespace DaggerfallConnect.Save
     public class SaveTreeHeader
     {
         // Consts
-        public const int HeaderLength = 18;
-        public const int VersionNumber = 0x26;
+        public const int HeaderLength = 19;
+        public const int VersionNumber = 0x126;
 
         // Public fields
         public long StreamPosition;                             // Starting position in file stream
         public byte[] RawData;                                  // Raw byte data read from stream
-        public Byte Version;                                    // Version - must be 0x26
+        public int Version;                                     // Version - must be 0x126
         public HeaderCharacterPositionRecord CharacterPosition; // Character position
-        public UInt16 Unknown;                                  // Unknown
+        public UInt16 MapID;                                    // ID of current map. 0xFFFF if not in a location.
+        public Byte Environment;                                // Player environment. 1 = outside, 2 = building, 3 = dungeon
 
         /// <summary>
         /// Reads header from file.
@@ -64,25 +65,20 @@ namespace DaggerfallConnect.Save
             MemoryStream stream = new MemoryStream(RawData);
             BinaryReader reader = new BinaryReader(stream, Encoding.UTF8);
 
-            // Read Version - must be 0x26
-            Version = reader.ReadByte();
+            // Read Version - must be 0x126
+            Version = reader.ReadInt32();
             if (Version != VersionNumber)
-                throw new Exception("SaveTree file has an invalid version number, must be 0x26.");
-
-            // Read CharacterPosition.RecordType - must be 0x01
-            CharacterPosition = new HeaderCharacterPositionRecord();
-            CharacterPosition.RecordType = reader.ReadByte();
-            if (CharacterPosition.RecordType != (int)RecordTypes.CharacterPosition)
-                throw new Exception("Expected CharacterPosition in SaveTreeHeader has an invalid record type, must be 0x01.");
-
-            // Read CharacterPosition.Unknown
-            CharacterPosition.Unknown = reader.ReadUInt16();
+                throw new Exception("SaveTree file has an invalid version number, must be 0x126.");
 
             // Read CharacterPosition.Position
+            CharacterPosition = new HeaderCharacterPositionRecord();
             CharacterPosition.Position = SaveTree.ReadPosition(reader);
 
-            // Read Unknown
-            Unknown = reader.ReadUInt16();
+            // Read MapID
+            MapID = reader.ReadUInt16();
+
+            // Read Environment
+            Environment = reader.ReadByte();
 
             reader.Close();
         }
@@ -95,17 +91,14 @@ namespace DaggerfallConnect.Save
             // Write Version
             writer.Write(Version);
 
-            // Write CharacterPosition.RecordType
-            writer.Write(CharacterPosition.RecordType);
-
-            // Write CharacterPosition.Unknown
-            writer.Write(CharacterPosition.Unknown);
-
             // Write CharacterPosition.Position
             SaveTree.WritePosition(writer, CharacterPosition.Position);
 
-            // Write Unknown
-            writer.Write(Unknown);
+            // Write MapID
+            writer.Write(MapID);
+
+            // Write Environment
+            writer.Write(Environment);
 
             writer.Close();
         }

--- a/Assets/Scripts/Editor/SaveExplorerWindow.cs
+++ b/Assets/Scripts/Editor/SaveExplorerWindow.cs
@@ -163,11 +163,10 @@ namespace DaggerfallWorkshop
             });
             GUILayoutHelper.Horizontal(() =>
             {
-                string positionText = string.Format("X={0}, Y={1}, Z={2}, Base={3}",
+                string positionText = string.Format("X={0}, Y={1}, Z={2}",
                     positionRecord.RecordRoot.Position.WorldX,
-                    positionRecord.RecordRoot.Position.YOffset,
-                    positionRecord.RecordRoot.Position.WorldZ,
-                    positionRecord.RecordRoot.Position.YBase);
+                    positionRecord.RecordRoot.Position.WorldY,
+                    positionRecord.RecordRoot.Position.WorldZ);
 
                 EditorGUILayout.LabelField(new GUIContent("Player Position", "Position of player in the world."), GUILayout.Width(EditorGUIUtility.labelWidth - 4));
                 EditorGUILayout.SelectableLabel(positionText, EditorStyles.textField, GUILayout.Height(EditorGUIUtility.singleLineHeight));
@@ -190,8 +189,8 @@ namespace DaggerfallWorkshop
             });
             GUILayoutHelper.Horizontal(() =>
             {
-                EditorGUILayout.LabelField(new GUIContent("LocationDetail records"), GUILayout.Width(EditorGUIUtility.labelWidth - 4));
-                EditorGUILayout.SelectableLabel(currentSaveTree.LocationDetail.RecordCount.ToString(), EditorStyles.textField, GUILayout.Height(EditorGUIUtility.singleLineHeight));
+                EditorGUILayout.LabelField(new GUIContent("Player Environment"), GUILayout.Width(EditorGUIUtility.labelWidth - 4));
+                EditorGUILayout.SelectableLabel(((Environments)currentSaveTree.Header.Environment).ToString(), EditorStyles.textField, GUILayout.Height(EditorGUIUtility.singleLineHeight));
             });
             GUILayoutHelper.Horizontal(() =>
             {


### PR DESCRIPTION
Identified data in the classic save tree header and modified the SaveExplorer a little to match.

To keep compatibility with the current loading behavior, which uses the byte at 18 as the record length of SaveTreeLocationDetail, I reset the stream here for that class, but that byte is actually the current environment of the player.