### PR TITLE
Fix hit point calculations

### DIFF
--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -86,7 +86,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
                 // Enemy class is levelled to player and uses same health rules
                 level = GameManager.Instance.PlayerEntity.Level;
-                maxHealth = FormulaHelper.RollMaxHealth(level, stats.Endurance, career.HitPointsPerLevelOrMonsterLevel);
+                maxHealth = FormulaHelper.RollMaxHealth(level, career.HitPointsPerLevelOrMonsterLevel);
 
                 // Enemy class damage is temporarily set by a fudged level multiplier
                 // This will change once full entity setup and items are available

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -140,7 +140,7 @@ namespace DaggerfallWorkshop.Game.Entity
             }
 
             if (maxHealth <= 0)
-                this.maxHealth = FormulaHelper.RollMaxHealth(level, stats.Endurance, career.HitPointsPerLevelOrMonsterLevel);
+                this.maxHealth = FormulaHelper.RollMaxHealth(level, career.HitPointsPerLevelOrMonsterLevel);
             else
                 this.maxHealth = maxHealth;
 
@@ -205,7 +205,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 gender = Genders.Male;
                 stats.SetFromCareer(career);
                 level = testPlayerLevel;
-                maxHealth = FormulaHelper.RollMaxHealth(level, stats.Endurance, career.HitPointsPerLevelOrMonsterLevel);
+                maxHealth = FormulaHelper.RollMaxHealth(level, career.HitPointsPerLevelOrMonsterLevel);
                 name = testPlayerName;
                 stats.SetDefaults();
                 skills.SetDefaults();

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -82,7 +82,7 @@ namespace DaggerfallWorkshop.Game.Formulas
         }
 
         // Calculate how much health the player should recover per hour of rest
-        public static int CalculateHealthRecoveryRate(DaggerfallWorkshop.Game.Entity.PlayerEntity player)
+        public static int CalculateHealthRecoveryRate(Entity.PlayerEntity player)
         {
             short medical = player.Skills.Medical;
             int endurance = player.Stats.Endurance;

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -155,6 +155,18 @@ namespace DaggerfallWorkshop.Game.Formulas
             return (int)Mathf.Floor((currentLevelUpSkillsSum - startingLevelUpSkillsSum + 28) / 15);
         }
 
+        // Calculate hit points player gains per level.
+        public static int CalculateHitPointsPerLevelUp(Entity.PlayerEntity player)
+        {
+            int minRoll = player.Career.HitPointsPerLevelOrMonsterLevel / 2;
+            int maxRoll = player.Career.HitPointsPerLevelOrMonsterLevel + 1;
+            int addHitPoints = UnityEngine.Random.Range(minRoll, maxRoll);
+            addHitPoints += HitPointsModifier(player.Stats.Endurance);
+            if (addHitPoints < 1)
+                addHitPoints = 1;
+            return addHitPoints;
+        }
+
         #endregion
 
         #region Damage

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -64,18 +64,15 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         #region Player
 
-        // Generates player health based on level, endurance, and career hit points per level
-        public static int RollMaxHealth(int level, int endurance, int hitPointsPerLevel)
+        // Generates player health based on level and career hit points per level
+        public static int RollMaxHealth(int level, int hitPointsPerLevel)
         {
             const int baseHealth = 25;
 
             int maxHealth = baseHealth;
-            int bonusHealth = HitPointsModifier(endurance);
-            int minRoll = hitPointsPerLevel / 2;
-            int maxRoll = hitPointsPerLevel + 1;    // Adding +1 as Unity Random.Range(int,int) is exclusive of maximum value
             for (int i = 0; i < level; i++)
             {
-                maxHealth += UnityEngine.Random.Range(minRoll, maxRoll) + bonusHealth;
+                maxHealth += hitPointsPerLevel;
             }
 
             return maxHealth;
@@ -159,7 +156,7 @@ namespace DaggerfallWorkshop.Game.Formulas
         public static int CalculateHitPointsPerLevelUp(Entity.PlayerEntity player)
         {
             int minRoll = player.Career.HitPointsPerLevelOrMonsterLevel / 2;
-            int maxRoll = player.Career.HitPointsPerLevelOrMonsterLevel + 1;
+            int maxRoll = player.Career.HitPointsPerLevelOrMonsterLevel + 1; // Adding +1 as Unity Random.Range(int,int) is exclusive of maximum value
             int addHitPoints = UnityEngine.Random.Range(minRoll, maxRoll);
             addHitPoints += HitPointsModifier(player.Stats.Endurance);
             if (addHitPoints < 1)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -297,7 +297,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 leveling = true;
                 PlayerEntity.Level++;
-                PlayerEntity.MaxHealth += PlayerEntity.Career.HitPointsPerLevelOrMonsterLevel;
+                PlayerEntity.MaxHealth += FormulaHelper.CalculateHitPointsPerLevelUp(PlayerEntity);
                 DaggerfallUI.Instance.PlayOneShot(levelUpSound);
 
                 // Roll bonus pool for player to distribute


### PR DESCRIPTION
For level up, I was just adding the Career.HitPointsPerLevelOrMonsterLevel. Actually it is a random number between this value and half of it, plus the endurance modifier.