### PR TITLE
Fix damage values

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -25,7 +25,7 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         public static int DamageModifier(int strength)
         {
-            return (int)Mathf.Floor((float)strength / 10f) - 5;
+            return (int)Mathf.Floor((float)(strength - 50) / 5f);
         }
 
         public static int MaxEncumbrance(int strength)
@@ -216,13 +216,15 @@ namespace DaggerfallWorkshop.Game.Formulas
                 if (onScreenWeapon != null)
                 {
                     // Apply swing modifier.
+                    // The Daggerfall manual groups diagonal slashes to the left and right as if they are the same, but they are different.
                     if (onScreenWeapon.WeaponState == WeaponStates.StrikeUp)
+                        damage_result += -4;
+                    if (onScreenWeapon.WeaponState == WeaponStates.StrikeDownRight)
                         damage_result += -2;
-                    if (onScreenWeapon.WeaponState == WeaponStates.StrikeDownLeft
-                        || onScreenWeapon.WeaponState == WeaponStates.StrikeDownRight)
-                        damage_result += 1;
+                    if (onScreenWeapon.WeaponState == WeaponStates.StrikeDownLeft)
+                        damage_result += 2;
                     if (onScreenWeapon.WeaponState == WeaponStates.StrikeDown)
-                        damage_result += 3;
+                        damage_result += 4;
 
                     // Apply weapon expertise modifier
                     if (weapon != null && ((int)attacker.Career.ExpertProficiencies & weapon.GetWeaponSkillUsed()) != 0)
@@ -238,15 +240,17 @@ namespace DaggerfallWorkshop.Game.Formulas
                 }
 
                 // Apply the strength modifier.
+                // The in-game display of the strength modifier in Daggerfall is incorrect. It is actually ((STR - 50) / 5).
                 damage_result += DamageModifier(attacker.Stats.Strength);
 
-                // Apply the material modifier
+                // Apply the material modifier.
+                // The in-game display in Daggerfall of weapon damages with material modifiers is incorrect. The material modifier is half of what the display suggests.
                 if (weapon != null)
                 {
                     damage_result += weapon.GetMaterialDamageModifier();
                 }
 
-                // 0 damage is possible. Plays no hit sound or blood splash.
+                // 0 damage is possible. Creates no blood splash.
                 damage_result = Mathf.Max(0, damage_result);
             }
 

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -741,23 +741,23 @@ namespace DaggerfallWorkshop.Game.Items
             switch (nativeMaterialValue)
             {
                 case (int)WeaponMaterialTypes.Iron:
-                    return -2;
+                    return -1;
                 case (int)WeaponMaterialTypes.Steel:
                 case (int)WeaponMaterialTypes.Silver:
                     return 0;
                 case (int)WeaponMaterialTypes.Elven:
-                    return 2;
+                    return 1;
                 case (int)WeaponMaterialTypes.Dwarven:
-                    return 4;
+                    return 2;
                 case (int)WeaponMaterialTypes.Mithril:
                 case (int)WeaponMaterialTypes.Adamantium:
-                    return 6;
+                    return 3;
                 case (int)WeaponMaterialTypes.Ebony:
-                    return 8;
+                    return 4;
                 case (int)WeaponMaterialTypes.Orcish:
-                    return 10;
+                    return 5;
                 case (int)WeaponMaterialTypes.Daedric:
-                    return 12;
+                    return 6;
 
                 default:
                     return 0;


### PR DESCRIPTION
Here are some fixes to damage values from the player's weapon hits.

It turns out there were a number of inaccurate things in the information Daggerfall gives about damage values, which were throwing me off until I figured them out. One is that the diagonal slash down to the right is actually a weaker attack than the horizontal attacks. The other diagonal attack is stronger, and the manual groups them together as both being stronger.

Another was that the strength damage modifier is different from what classic shows in the character sheet. It's actually (STR - 50) / 5, roughly twice the value that classic shows, in either negative or positive direction.

And then another was that the damage display for weapons with material modifiers (those other than steel and silver) is also incorrect! The material modifier to damage is half of what is shown, in both positive and negative direction.

This is backed up by a whole lot of testing and I'm pretty sure about these.