### PR TITLE
Implement hit/miss calculations for player

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -744,7 +744,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
         }
 
-        public int GetMaterialDamageModifier()
+        public int GetMaterialModifier()
         {
             switch (nativeMaterialValue)
             {

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -631,6 +631,14 @@ namespace DaggerfallWorkshop.Game
                                 blood.ShowBloodSplash(enemyEntity.MobileEnemy.BloodIndex, hit.point);
                             }
                         }
+                        else
+                        {
+                            // TODO: Figure out what determines what type of sound plays.
+                            if (enemyEntity.EntityType == EntityTypes.EnemyMonster || weapon.WeaponType == WeaponTypes.Melee)
+                                weapon.PlaySwingSound();
+                            else
+                                weapon.PlayParrySound();
+                        }
 
                         // Remove health
                         enemyEntity.DecreaseHealth(damage);


### PR DESCRIPTION
These are hit and miss calculations for the player. It's reverse-engineered from the executable so I think it's correct. There's no easy way to test it since it uses probabilities, but the results seem to match classic well.