### PR TITLE
Minor fail-safe to video loading / playing

### DIFF
--- a/Assets/Scripts/API/VidFile.cs
+++ b/Assets/Scripts/API/VidFile.cs
@@ -86,7 +86,10 @@ namespace DaggerfallConnect.Arena2
         {
             // Open file proxy
             if (!vidFile.Load(filename, FileUsage.UseMemory, true))
+            {
+                endOfFileReached = true;
                 return false;
+            }
 
             // Close existing reader
             if (reader != null)
@@ -117,7 +120,7 @@ namespace DaggerfallConnect.Arena2
 
         int ReadBlock()
         {
-            if (endOfFileReached || reader == null || reader.BaseStream == null)
+            if (endOfFileReached)
                 return 0;
 
             reader.BaseStream.Position = streamPosition;

--- a/Assets/Scripts/API/VidFile.cs
+++ b/Assets/Scripts/API/VidFile.cs
@@ -117,7 +117,7 @@ namespace DaggerfallConnect.Arena2
 
         int ReadBlock()
         {
-            if (endOfFileReached)
+            if (endOfFileReached || reader == null || reader.BaseStream == null)
                 return 0;
 
             reader.BaseStream.Position = streamPosition;

--- a/Assets/Scripts/Game/UserInterface/DaggerfallVideo.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallVideo.cs
@@ -60,8 +60,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public void Open(string name)
         {
             string path = Path.Combine(DaggerfallUnity.Instance.Arena2Path, name);
-            if (!vidFile.Open(path))
+            if (!vidFile.Open(path)) 
+            {
+                Debug.LogError(string.Format("Failed to open video file: {0}", name));
                 return;
+            }
 
             vidTexture = TextureReader.CreateFromSolidColor(vidFile.FrameWidth, vidFile.FrameHeight, Color.black, false, false);
             vidTexture.wrapMode = TextureWrapMode.Clamp;


### PR DESCRIPTION
This prevents a stream of errors in case someone didn't set up their daggerfall directory properly and is missing video files.

If the vidFile is unable to Load endOfFileReached is set to true so the video player just skips it and won't stay on a black screen forever.