### PR TITLE
Replaced any remaining non generic FindObjectOfType calls with generic version

### DIFF
--- a/Assets/Scripts/DaggerfallUnity.cs
+++ b/Assets/Scripts/DaggerfallUnity.cs
@@ -411,7 +411,7 @@ namespace DaggerfallWorkshop
 
         public static bool FindDaggerfallUnity(out DaggerfallUnity dfUnityOut)
         {
-            dfUnityOut = GameObject.FindObjectOfType(typeof(DaggerfallUnity)) as DaggerfallUnity;
+            dfUnityOut = GameObject.FindObjectOfType<DaggerfallUnity>();
             if (dfUnityOut == null)
             {
                 LogMessage("Could not locate DaggerfallUnity GameObject instance in scene!", true);

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -910,7 +910,7 @@ namespace DaggerfallWorkshop.Game
 
         public static bool FindDaggerfallUI(out DaggerfallUI dfUnityOut)
         {
-            dfUnityOut = GameObject.FindObjectOfType(typeof(DaggerfallUI)) as DaggerfallUI;
+            dfUnityOut = GameObject.FindObjectOfType<DaggerfallUI>();
             if (dfUnityOut == null)
             {
                 DaggerfallUnity.LogMessage("Could not locate DaggerfallUI GameObject instance in scene!", true);

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -472,7 +472,7 @@ namespace DaggerfallWorkshop.Game
 
         public static bool FindSingleton(out GameManager singletonOut)
         {
-            singletonOut = GameObject.FindObjectOfType(typeof(GameManager)) as GameManager;
+            singletonOut = GameObject.FindObjectOfType<GameManager>();
             if (singletonOut == null)
             {
                 DaggerfallUnity.LogMessage("Could not locate GameManager GameObject instance in scene!", true);

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -509,7 +509,7 @@ namespace DaggerfallWorkshop.Game
 
         public static bool FindSingleton(out InputManager singletonOut)
         {
-            singletonOut = GameObject.FindObjectOfType(typeof(InputManager)) as InputManager;
+            singletonOut = GameObject.FindObjectOfType<InputManager>();
             if (singletonOut == null)
             {
                 DaggerfallUnity.LogMessage("Could not locate InputManager GameObject instance in scene!", true);

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -952,7 +952,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
         public static bool FindQuestMachine(out QuestMachine questMachineOut)
         {
-            questMachineOut = GameObject.FindObjectOfType(typeof(QuestMachine)) as QuestMachine;
+            questMachineOut = GameObject.FindObjectOfType<QuestMachine>();
             if (questMachineOut == null)
             {
                 DaggerfallUnity.LogMessage("Could not locate QuestMachine GameObject instance in scene!", true);

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -417,7 +417,7 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         public static bool FindSingleton(out SaveLoadManager singletonOut)
         {
-            singletonOut = FindObjectOfType(typeof(SaveLoadManager)) as SaveLoadManager;
+            singletonOut = FindObjectOfType<SaveLoadManager>();
             return singletonOut != null;
         }
 


### PR DESCRIPTION
There were a couple of stragglers that used the old style of FindObjectOfType. These were not trying to get an interface for example so the non generic version wasn't required.

Did a similar search for GetComponent but those were all generic.