### PR TITLE
Add player armor calculations and enemy combat sounds

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -108,6 +108,11 @@ namespace DaggerfallWorkshop.Game
                     {
                         senses.Player.SendMessage("RemoveHealth", damage);
                     }
+                    else if (sounds)
+                    {
+                        sounds.PlayMissSound();
+                    }
+
                     // Tally player's dodging skill
                     GameManager.Instance.PlayerEntity.TallySkill((short)Skills.Dodging, 1);
                 }

--- a/Assets/Scripts/Game/EnemyDeath.cs
+++ b/Assets/Scripts/Game/EnemyDeath.cs
@@ -68,6 +68,13 @@ namespace DaggerfallWorkshop.Game
                     return;
             }
 
+            // Play body collapse sound
+            if (DaggerfallUI.Instance.DaggerfallAudioSource)
+            {
+                AudioClip collapseSound = DaggerfallUI.Instance.DaggerfallAudioSource.GetAudioClip((int)SoundClips.BodyFall);
+                AudioSource.PlayClipAtPoint(collapseSound, entityBehaviour.transform.position);
+            }
+
             // Disable enemy gameobject
             // Do not destroy as we must still save enemy state when dead
             gameObject.SetActive(false);

--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -108,6 +108,21 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
+        public void PlayMissSound()
+        {
+            if (IsReady())
+            {
+                if (mobile.Summary.Enemy.ID > 127)
+                {
+                    dfAudioSource.PlayOneShot(SoundClips.SwingMediumPitch);
+                }
+                else
+                {
+                    dfAudioSource.PlayOneShot(SoundClips.SwingHighPitch);
+                }
+            }
+        }
+
         #region Private Methods
 
         private bool IsReady()

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -748,7 +748,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
         }
 
-        public int GetMaterialModifier()
+        public int GetWeaponMaterialModifier()
         {
             switch (nativeMaterialValue)
             {
@@ -770,6 +770,39 @@ namespace DaggerfallWorkshop.Game.Items
                     return 5;
                 case (int)WeaponMaterialTypes.Daedric:
                     return 6;
+
+                default:
+                    return 0;
+            }
+        }
+
+        public int GetMaterialArmorValue()
+        {
+            switch (nativeMaterialValue)
+            {
+                case (int)ArmorMaterialTypes.Leather:
+                    return 3;
+                case (int)ArmorMaterialTypes.Chain:
+                case (int)ArmorMaterialTypes.Chain2:
+                    return 6;
+                case (int)ArmorMaterialTypes.Iron:
+                    return 7;
+                case (int)ArmorMaterialTypes.Steel:
+                case (int)ArmorMaterialTypes.Silver:
+                    return 9;
+                case (int)ArmorMaterialTypes.Elven:
+                    return 11;
+                case (int)ArmorMaterialTypes.Dwarven:
+                    return 13;
+                case (int)ArmorMaterialTypes.Mithril:
+                case (int)ArmorMaterialTypes.Adamantium:
+                    return 15;
+                case (int)ArmorMaterialTypes.Ebony:
+                    return 17;
+                case (int)ArmorMaterialTypes.Orcish:
+                    return 19;
+                case (int)ArmorMaterialTypes.Daedric:
+                    return 21;
 
                 default:
                     return 0;


### PR DESCRIPTION
Added player armor to the hit calculations, and miss sounds and collapse sound on death for enemies.

I wanted to add sounds for when enemies hit the player (two types, when the attack is done without a weapon and with), but I wasn't sure how that should be handled as far as what audio source to use.