### PR TITLE
Minor changes to Enemy classes.

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -106,7 +106,7 @@ namespace DaggerfallWorkshop.Game
                     int damage = Game.Formulas.FormulaHelper.CalculateWeaponDamage(entity, GameManager.Instance.PlayerEntity, null);
                     if (damage > 0)
                     {
-                        senses.Player.SendMessage("RemoveHealth", damage);
+                        GameManager.Instance.PlayerObject.SendMessage("RemoveHealth", damage);
                     }
                     // Tally player's dodging skill
                     GameManager.Instance.PlayerEntity.TallySkill((short)Skills.Dodging, 1);

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -177,7 +177,7 @@ namespace DaggerfallWorkshop.Game
                 // Ground enemies target at their own height
                 // This avoids short enemies from stepping on each other as they approach the player
                 // Otherwise, their target vector aims up towards the player
-                var playerController = senses.Player.GetComponent<CharacterController>();
+                var playerController = GameManager.Instance.PlayerController;
                 var deltaHeight = (playerController.height - controller.height) / 2;
                 targetPos.y -= deltaHeight;
             }


### PR DESCRIPTION
- Enemy classes might as well use the GameManager.Instance.PlayerXXX variables instead of grabbing the player themselves on Start.
- EnemySenses's DirectionToPlayer was not normalized.
- Moved hasEncounteredPlayer handling outside of CanHearPlayer and CanSeePlayer functions.