### PR TITLE
Action component for flat->3d object /2

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -215,6 +215,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
             // Finalise gameobject material
             FinaliseMaterials(go);
+
+            // Add NPC trigger collider
+            if (RDBLayout.IsNPCFlat(archive))
+            {
+                Collider col = go.AddComponent<BoxCollider>();
+                col.isTrigger = true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Sorry for the long delay :P

Add a trigger to imported gameobjects for NPCs. Flats with an action are already given a trigger on [AddAction()](https://github.com/Interkarma/daggerfall-unity/blob/master/Assets/Scripts/Utility/RDBLayout.cs#L853) so custom flats should be already covered for that.