### PR TITLE
Initialize player armor values to 100 when loading

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -169,7 +169,6 @@ namespace DaggerfallWorkshop.Game.Serialization
             // Restore player entity data
             PlayerData_v1 data = (PlayerData_v1)dataIn;
             PlayerEntity entity = playerEntityBehaviour.Entity as PlayerEntity;
-            //entity.Reset();
 
             entity.Gender = data.playerEntity.gender;
             entity.RaceTemplate = data.playerEntity.raceTemplate;
@@ -201,9 +200,14 @@ namespace DaggerfallWorkshop.Game.Serialization
             if (entity.SkillUses == null)
                 entity.SkillUses = new short[DaggerfallSkills.Count];
 
+            // Initialize body part armor values to 100 (no armor)
+            for (int i = 0; i < entity.ArmorValues.Length; i++)
+            {
+                entity.ArmorValues[i] = 100;
+            }
+
             // Apply armor values from equipped armor
             Items.DaggerfallUnityItem[] equipTable = entity.ItemEquipTable.EquipTable;
-
             for (int i = 0; i < equipTable.Length; i++)
             {
                 if (equipTable[i] != null && (equipTable[i].ItemGroup == Items.ItemGroups.Armor))


### PR DESCRIPTION
Directly and only resets the armor values to their starting value of 100 when loading DF Unity saves, since the previous attempt of calling PlayerEntity.reset() also reset faction data, which wasn't wanted.

Another approach would be to save the armor values in DF Unity saves, and then we could just copy without worrying about resetting the values or calculating the armor values when loading a game. Loading from classic saves is already working this way, since classic saves have the armor values in them.