### PR TITLE
Change lockpicking to be closer to classic

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -153,12 +153,9 @@ namespace DaggerfallWorkshop.Game
                         DaggerfallActionDoor actionDoor;
                         if (ActionDoorCheck(hits[i], out actionDoor))
                         {
-                            if (currentMode == PlayerActivateModes.Steal && actionDoor.IsLocked)
+                            if (currentMode == PlayerActivateModes.Steal && actionDoor.IsLocked && !actionDoor.IsOpen)
                             {
-                                if (actionDoor.IsNoLongerPickable)
-                                    return;
-                                else
-                                    actionDoor.AttemptLockpicking();
+                                actionDoor.AttemptLockpicking();
                             }
                             else
                                 actionDoor.ToggleDoor();


### PR DESCRIPTION
I found out a little more how lockpicking works in classic.
It turns out that when the player fails to pick a lock (not counting magic locks), the door stores the player's lockpicking skill, and subsequent attempts fail if the player's lockpicking skill matches that value. I thought you couldn't try again at all if you failed once (unless you left and re-entered the area), but you can try again if your lockpicking skill rises.