### PR TITLE
Bugfix: face picker skipped a face

### DIFF
--- a/Assets/Scripts/Game/UserInterface/FacePicker.cs
+++ b/Assets/Scripts/Game/UserInterface/FacePicker.cs
@@ -128,7 +128,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         void NextFaceButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             faceIndex++;
-            if (faceIndex >= maxFaceIndex)
+            if (faceIndex > maxFaceIndex)
                 faceIndex = minFaceIndex;
 
             SetCurrentFace();


### PR DESCRIPTION
When clicking the next face button, the last possible face for each race/gender is skipped due to an off-by-one error. This should fix it.