### PR TITLE
bugfixes for exterior automap

### DIFF
--- a/Assets/Scripts/Game/DaggerfallExteriorAutomap.cs
+++ b/Assets/Scripts/Game/DaggerfallExteriorAutomap.cs
@@ -1816,6 +1816,10 @@ namespace DaggerfallWorkshop.Game
                     loadAndCreateLocationExteriorAutomap();
                 }
             }
+            else
+            {
+                gameobjectExteriorAutomap.SetActive(false);
+            }
         }
         #endregion
     }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -465,6 +465,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 daggerfallExteriorAutomap.ResetAutomapSettingsSignalForExternalScript = false; // indicate the settings were reset
             }
 
+            // focus player position on exterior automap
+            ActionFocusPlayerPosition();
+
             // and update the automap view
             updateAutomapView();
         }


### PR DESCRIPTION
when exterior automap is opened player position is now always in focus
exterior automap gameobject is now always deactivated correctly when a savegame is loaded with pc in an interior location (this would have resulted in a phantom player marker somewhere on the interior automap)