### PR TITLE
Wrap long text messages over multiple lines

### DIFF
--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -144,6 +144,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             textLabel.AutoSize = AutoSizeModes.None;
             textLabel.Font = font;
             textLabel.Position = new Vector2(cursorX, cursorY);
+            textLabel.MaxWidth = 288;
             textLabel.Text = text;
             textLabel.Parent = this;
 


### PR DESCRIPTION
Fixes long text messages going off screen, which could happen with many of the pickpocketing messages where you find nothing useful.

It doesn't intelligently wrap by word, but by letter, but Daggerfall is the same way and it doesn't really bother me.