### PR TITLE
Match monster loot lists to classic

### DIFF
--- a/Assets/Scripts/Game/Items/LootTables.cs
+++ b/Assets/Scripts/Game/Items/LootTables.cs
@@ -28,29 +28,52 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Default loot table chance matrices.
         /// Note: Temporary implementation. Will eventually be moved to an external file and loaded as keyed dict.
+        /// Note: Many loot tables are defined with a lower chance for magic items in FALL.EXE's tables than is
+        /// shown in Daggerfall Chronicles.
+        /// These are shown below in the order "Key", "Chronicles chance", "FALL.EXE chance".
+        /// E, 5, 3
+        /// F, 2, 1
+        /// G, 3, 1
+        /// H, 2, 1
+        /// I, 10, 2
+        /// J, 20, 3
+        /// K, 5, 3
+        /// L, 2, 1
+        /// N, 2, 1
+        /// O, 3, 2
+        /// P, 3, 2
+        /// Q, 10, 3
+        /// R, 5, 2
+        /// S, 20, 3
+        /// T, 3, 1
+        /// U, 3, 2
         /// </summary>
         public static LootChanceMatrix[] DefaultLootTables = new LootChanceMatrix[]
         {
             new LootChanceMatrix() {key = "-", MinGold = 0, MaxGold = 0, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = 0, CL = 0, BK = 0, M2 = 0, RL = 0 },
             new LootChanceMatrix() {key = "A", MinGold = 1, MaxGold = 10, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 5, WP = 5, MI = 2, CL = 4, BK = 0, M2 = 2, RL = 0 },
-            new LootChanceMatrix() {key = "B", MinGold = 0, MaxGold = 0, P1 = 0, P2 = 10, C1 = 10, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = 0, CL = 0, BK = 0, M2 = 0, RL = 0 },
-            new LootChanceMatrix() {key = "C", MinGold = 2, MaxGold = 20, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 25, AM = 3, WP = 0, MI = 2, CL = 0, BK = 2, M2 = 2, RL = 2 },
+            // Chronicles says B has 10 for Warm Plant and Misc. Monster, but in FALL.EXE it is Temperate Plant and Warm Plant.
+            new LootChanceMatrix() {key = "B", MinGold = 0, MaxGold = 0, P1 = 10, P2 = 10, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = 0, CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "C", MinGold = 2, MaxGold = 20, P1 = 10, P2 = 10, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 25, MI = 3, CL = 0, BK = 2, M2 = 2, RL = 2 },
             new LootChanceMatrix() {key = "D", MinGold = 1, MaxGold = 4, P1 = 6, P2 = 6, C1 = 6, C2 = 6, C3 = 6, M1 = 6, AM = 0, WP = 0, MI = 0, CL = 0, BK = 0, M2 = 0, RL = 4 },
-            new LootChanceMatrix() {key = "E", MinGold = 20, MaxGold = 80, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 10, WP = 10, MI = 5, CL = 4, BK = 2, M2 = 1, RL = 15 },
-            new LootChanceMatrix() {key = "F", MinGold = 4, MaxGold = 30, P1 = 2, P2 = 2, C1 = 5, C2 = 5, C3 = 5, M1 = 2, AM = 50, WP = 50, MI = 2, CL = 0, BK = 0, M2 = 3, RL = 0 },
-            new LootChanceMatrix() {key = "G", MinGold = 3, MaxGold = 15, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 50, WP = 50, MI = 3, CL = 5, BK = 0, M2 = 3, RL = 0 },
-            new LootChanceMatrix() {key = "H", MinGold = 2, MaxGold = 10, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 100, MI = 2, CL = 2, BK = 0, M2 = 0, RL = 0 },
-            // Chronicles missing I
-            new LootChanceMatrix() {key = "J", MinGold = 0, MaxGold = 0, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = 10, CL = 0, BK = 0, M2 = 0, RL = 5 },
-            new LootChanceMatrix() {key = "K", MinGold = 50, MaxGold = 150, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 5, WP = 5, MI = 20, CL = 0, BK = 0, M2 = 0, RL = 0 },
-            new LootChanceMatrix() {key = "L", MinGold = 1, MaxGold = 10, P1 = 3, P2 = 3, C1 = 3, C2 = 3, C3 = 3, M1 = 3, AM = 5, WP = 5, MI = 5, CL = 0, BK = 5, M2 = 2, RL = 100 },
-            new LootChanceMatrix() {key = "M", MinGold = 1, MaxGold = 20, P1 = 0, P2 = 0, C1 = 3, C2 = 3, C3 = 3, M1 = 3, AM = 50, WP = 50, MI = 2, CL = 75, BK = 0, M2 = 5, RL = 3 },
-            new LootChanceMatrix() {key = "N", MinGold = 1, MaxGold = 15, P1 = 1, P2 = 1, C1 = 1, C2 = 1, C3 = 1, M1 = 2, AM = 10, WP = 10, MI = 1, CL = 15, BK = 2, M2 = 3, RL = 1 },
-            new LootChanceMatrix() {key = "O", MinGold = 1, MaxGold = 80, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 5, MI = 2, CL = 20, BK = 5, M2 = 2, RL = 5 },
-            new LootChanceMatrix() {key = "P", MinGold = 5, MaxGold = 20, P1 = 1, P2 = 1, C1 = 1, C2 = 1, C3 = 1, M1 = 1, AM = 10, WP = 15, MI = 3, CL = 0, BK = 0, M2 = 0, RL = 0 },
-            new LootChanceMatrix() {key = "Q", MinGold = 5, MaxGold = 20, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 10, MI = 3, CL = 0, BK = 10, M2 = 5, RL = 0 },
-            new LootChanceMatrix() {key = "R", MinGold = 20, MaxGold = 80, P1 = 2, P2 = 2, C1 = 8, C2 = 8, C3 = 8, M1 = 2, AM = 10, WP = 25, MI = 10, CL = 35, BK = 5, M2 = 3, RL = 0 },
-            new LootChanceMatrix() {key = "S", MinGold = 5, MaxGold = 20, P1 = 0, P2 = 0, C1 = 3, C2 = 3, C3 = 3, M1 = 5, AM = 5, WP = 15, MI = 5, CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "E", MinGold = 20, MaxGold = 80, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 10, WP = 10, MI = 3, CL = 4, BK = 2, M2 = 1, RL = 15 },
+            new LootChanceMatrix() {key = "F", MinGold = 4, MaxGold = 30, P1 = 2, P2 = 2, C1 = 5, C2 = 5, C3 = 5, M1 = 2, AM = 50, WP = 50, MI = 1, CL = 0, BK = 0, M2 = 3, RL = 0 },
+            new LootChanceMatrix() {key = "G", MinGold = 3, MaxGold = 15, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 50, WP = 50, MI = 1, CL = 5, BK = 0, M2 = 3, RL = 0 },
+            new LootChanceMatrix() {key = "H", MinGold = 2, MaxGold = 10, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 100, MI = 1, CL = 2, BK = 0, M2 = 0, RL = 0 },
+            // Chronicles is missing "I" but lists its data in table "J." All the tables from here are off by one compared to Chronicles.
+            new LootChanceMatrix() {key = "I", MinGold = 0, MaxGold = 0, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = 2, CL = 0, BK = 0, M2 = 0, RL = 5 },
+            new LootChanceMatrix() {key = "J", MinGold = 50, MaxGold = 150, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 5, WP = 5, MI = 3, CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "K", MinGold = 1, MaxGold = 10, P1 = 3, P2 = 3, C1 = 3, C2 = 3, C3 = 3, M1 = 3, AM = 5, WP = 5, MI = 3, CL = 0, BK = 5, M2 = 2, RL = 100 },
+            new LootChanceMatrix() {key = "L", MinGold = 1, MaxGold = 20, P1 = 0, P2 = 0, C1 = 3, C2 = 3, C3 = 3, M1 = 3, AM = 50, WP = 50, MI = 1, CL = 75, BK = 0, M2 = 5, RL = 3 },
+            new LootChanceMatrix() {key = "M", MinGold = 1, MaxGold = 15, P1 = 1, P2 = 1, C1 = 1, C2 = 1, C3 = 1, M1 = 2, AM = 10, WP = 10, MI = 1, CL = 15, BK = 2, M2 = 3, RL = 1 },
+            new LootChanceMatrix() {key = "N", MinGold = 1, MaxGold = 80, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 5, MI = 1, CL = 20, BK = 5, M2 = 2, RL = 5 },
+            new LootChanceMatrix() {key = "O", MinGold = 5, MaxGold = 20, P1 = 1, P2 = 1, C1 = 1, C2 = 1, C3 = 1, M1 = 1, AM = 10, WP = 15, MI = 2, CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "P", MinGold = 5, MaxGold = 20, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 10, MI = 2, CL = 0, BK = 10, M2 = 5, RL = 0 },
+            new LootChanceMatrix() {key = "Q", MinGold = 20, MaxGold = 80, P1 = 2, P2 = 2, C1 = 8, C2 = 8, C3 = 8, M1 = 2, AM = 10, WP = 25, MI = 3, CL = 35, BK = 5, M2 = 3, RL = 0 },
+            new LootChanceMatrix() {key = "R", MinGold = 5, MaxGold = 20, P1 = 0, P2 = 0, C1 = 3, C2 = 3, C3 = 3, M1 = 5, AM = 5, WP = 15, MI = 2, CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "S", MinGold = 50, MaxGold = 125, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 15, AM = 10, WP = 10, MI = 3, CL = 0, BK = 5, M2 = 5, RL = 0 },
+            new LootChanceMatrix() {key = "T", MinGold = 20, MaxGold = 80, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 100, WP = 100, MI = 1, CL = 0, BK = 0, M2 = 0, RL = 0},
+            new LootChanceMatrix() {key = "U", MinGold = 7, MaxGold = 30, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 10, AM = 10, WP = 10, MI = 2, CL = 0, BK = 2, M2 = 2, RL = 10 },
 
             // Special humanoid loot table - not 100% sure how Daggerfall handles random loot for humanoids but appears different to monsters
             // Seems to always deliver 1-3 weapons and 2-5 armor pieces regardless of level

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -340,8 +340,8 @@ namespace DaggerfallWorkshop.Utility
                 MaxHealth = 34,
                 Level = 5,
                 ArmorValue = 7,
-                LootTableKey = "A",
                 ParrySounds = true,
+                LootTableKey = "A",
             },
 
             // Centaur
@@ -368,8 +368,8 @@ namespace DaggerfallWorkshop.Utility
                 MaxHealth = 46,
                 Level = 5,
                 ArmorValue = 6,
-                LootTableKey = "C",
                 ParrySounds = true,
+                LootTableKey = "C",
             },
 
             // Werewolf
@@ -539,8 +539,8 @@ namespace DaggerfallWorkshop.Utility
                 MinHealth = 17,
                 MaxHealth = 66,
                 Level = 8,
-                ParrySounds = false,
                 ArmorValue = 3,
+                ParrySounds = false,
             },
 
             // Skeletal Warrior
@@ -624,7 +624,7 @@ namespace DaggerfallWorkshop.Utility
                 Level = 10,
                 ArmorValue = 0,
                 ParrySounds = false,
-                LootTableKey = "E",     // TODO: Not in Chronicles, check
+                LootTableKey = "G",
             },
 
             // Ghost
@@ -683,11 +683,11 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "E",
             },
 
-            // Giant Scorpian
+            // Giant Scorpion
             new MobileEnemy()
             {
                 ID = 20,
-                Name = "Giant Scorpian",
+                Name = "Giant Scorpion",
                 Behaviour = MobileBehaviour.General,
                 Affinity = MobileAffinity.Animal,
                 MaleTexture = 275,
@@ -705,8 +705,8 @@ namespace DaggerfallWorkshop.Utility
                 MinHealth = 18,
                 MaxHealth = 74,
                 Level = 12,
-                ParrySounds = false,
                 ArmorValue = 0,
+                ParrySounds = false,
             },
 
             // Orc Shaman
@@ -1012,7 +1012,7 @@ namespace DaggerfallWorkshop.Utility
                 Level = 20,
                 ArmorValue = -10,
                 ParrySounds = true,
-                LootTableKey = "T",
+                LootTableKey = "S",
             },
 
             // Lich
@@ -1041,7 +1041,7 @@ namespace DaggerfallWorkshop.Utility
                 Level = 20,
                 ArmorValue = -10,
                 ParrySounds = false,
-                LootTableKey = "T",
+                LootTableKey = "S",
             },
 
             // Ancient Lich
@@ -1070,7 +1070,7 @@ namespace DaggerfallWorkshop.Utility
                 Level = 21,
                 ArmorValue = -12,
                 ParrySounds = false,
-                LootTableKey = "T",
+                LootTableKey = "S",
             },
 
             // Dragonling
@@ -1250,10 +1250,10 @@ namespace DaggerfallWorkshop.Utility
                 MaxDamage = 15,
                 MinHealth = 13,
                 MaxHealth = 34,
-                LootTableKey = "S",
                 Level = 16,
                 ArmorValue = 6,
                 ParrySounds = false,
+                LootTableKey = "R",
             },
 
             // Lamia
@@ -1280,7 +1280,7 @@ namespace DaggerfallWorkshop.Utility
                 Level = 16,
                 ArmorValue = 6,
                 ParrySounds = false,
-                LootTableKey = "S",
+                LootTableKey = "R",
             },
 
             // Mage


### PR DESCRIPTION
Matches monster loot lists to classic. Also a few minor cleanups to the enemyBasics.cs file.

Looks like Bethesda probably decided to cut back on magic item spawns in between the time of the data Chronicles uses and the game's release. Similar to how they disabled magic item repair.

This PR doesn't touch loot from enemy classes.