### PR TITLE
Make loot generation chance closer to classic

### DIFF
--- a/Assets/Scripts/Game/Items/LootTables.cs
+++ b/Assets/Scripts/Game/Items/LootTables.cs
@@ -98,7 +98,7 @@ namespace DaggerfallWorkshop.Game.Items
             List<DaggerfallUnityItem> items = new List<DaggerfallUnityItem>();
 
             // Random gold
-            int goldCount = Random.Range(matrix.MinGold, matrix.MaxGold) * playerEntity.Level;
+            int goldCount = Random.Range(matrix.MinGold, matrix.MaxGold + 1) * playerEntity.Level;
             if (goldCount > 0)
             {
                 items.Add(ItemBuilder.CreateGoldPieces(goldCount));
@@ -106,7 +106,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random weapon
             chance = matrix.WP;
-            while (Random.Range(1, 100) < chance)
+            while (Random.Range(0, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
                 chance *= 0.5f;
@@ -114,7 +114,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random armor
             chance = matrix.AM;
-            while (Random.Range(1, 100) < chance)
+            while (Random.Range(0, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
@@ -131,7 +131,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // TEMP: Magic item chance is just another shot at armor or weapon for now
             chance = matrix.MI;
-            while (Random.Range(1, 100) < chance)
+            while (Random.Range(0, 100) < chance)
             {
                 if (Random.value < 0.5f)
                     items.Add(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
@@ -143,7 +143,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random clothes
             chance = matrix.CL;
-            while (Random.Range(1, 100) < chance)
+            while (Random.Range(0, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomClothing(playerEntity.Gender));
                 chance *= 0.5f;
@@ -151,7 +151,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random books
             chance = matrix.BK;
-            while (Random.Range(1, 100) < chance)
+            while (Random.Range(0, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomBook());
                 chance *= 0.5f;
@@ -159,7 +159,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random religious item
             chance = matrix.RL;
-            while (Random.Range(1, 100) < chance)
+            while (Random.Range(0, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomReligiousItem());
                 chance *= 0.5f;
@@ -193,7 +193,7 @@ namespace DaggerfallWorkshop.Game.Items
 
         static void RandomIngredient(float chance, ItemGroups ingredientGroup, List<DaggerfallUnityItem> targetItems)
         {
-            while (Random.Range(1, 100) < chance)
+            while (Random.Range(0, 100) < chance)
             {
                 targetItems.Add(ItemBuilder.CreateRandomIngredient(ingredientGroup));
                 chance *= 0.5f;

--- a/Assets/Scripts/Game/Items/LootTables.cs
+++ b/Assets/Scripts/Game/Items/LootTables.cs
@@ -85,6 +85,15 @@ namespace DaggerfallWorkshop.Game.Items
         /// <returns>DaggerfallUnityItem array.</returns>
         public static DaggerfallUnityItem[] GenerateRandomLoot(string key, LootChanceMatrix matrix, PlayerEntity playerEntity)
         {
+            // Notes: The first part of the DF Chronicles explanation of how loot is generated does not match the released game.
+            // It says the chance for each item category is the matrix amount * the level of the NPC. Actual behavior in the
+            // released game is (matrix amount * PC level) for the first 4 item categories (temperate plants, warm plants,
+            // miscellaneous monster, warm monster), and just matrix amount for the categories after that.
+            // The second part of the DF Chronicles explanation (roll repeatedly for items from a category, each time at halved
+            // chance), matches the game.
+            // In classic, since a 0-99 roll is compared to whether it is less or greater than item chance,
+            // even a 0% chance category has a 1/100 chance to appear, and the chance values are effectively
+            // 1 higher than what the loot tables show.
             float chance;
             List<DaggerfallUnityItem> items = new List<DaggerfallUnityItem>();
 
@@ -96,7 +105,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             // Random weapon
-            chance = matrix.WP * playerEntity.Level;
+            chance = matrix.WP;
             while (Random.Range(1, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
@@ -104,7 +113,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             // Random armor
-            chance = matrix.AM * playerEntity.Level;
+            chance = matrix.AM;
             while (Random.Range(1, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
@@ -114,14 +123,14 @@ namespace DaggerfallWorkshop.Game.Items
             // Random ingredients
             RandomIngredient(matrix.C1 * playerEntity.Level, ItemGroups.CreatureIngredients1, items);
             RandomIngredient(matrix.C2 * playerEntity.Level, ItemGroups.CreatureIngredients2, items);
-            RandomIngredient(matrix.C3 * playerEntity.Level, ItemGroups.CreatureIngredients3, items);
+            RandomIngredient(matrix.C3, ItemGroups.CreatureIngredients3, items);
             RandomIngredient(matrix.P1 * playerEntity.Level, ItemGroups.PlantIngredients1, items);
             RandomIngredient(matrix.P2 * playerEntity.Level, ItemGroups.PlantIngredients2, items);
-            RandomIngredient(matrix.M1 * playerEntity.Level, ItemGroups.MiscellaneousIngredients1, items);
-            RandomIngredient(matrix.M2 * playerEntity.Level, ItemGroups.MiscellaneousIngredients2, items);
+            RandomIngredient(matrix.M1, ItemGroups.MiscellaneousIngredients1, items);
+            RandomIngredient(matrix.M2, ItemGroups.MiscellaneousIngredients2, items);
 
             // TEMP: Magic item chance is just another shot at armor or weapon for now
-            chance = matrix.MI * playerEntity.Level;
+            chance = matrix.MI;
             while (Random.Range(1, 100) < chance)
             {
                 if (Random.value < 0.5f)
@@ -133,7 +142,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             // Random clothes
-            chance = matrix.CL * playerEntity.Level;
+            chance = matrix.CL;
             while (Random.Range(1, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomClothing(playerEntity.Gender));
@@ -141,7 +150,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             // Random books
-            chance = matrix.BK * playerEntity.Level;
+            chance = matrix.BK;
             while (Random.Range(1, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomBook());
@@ -149,7 +158,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             // Random religious item
-            chance = matrix.RL * playerEntity.Level;
+            chance = matrix.RL;
             while (Random.Range(1, 100) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomReligiousItem());


### PR DESCRIPTION
This makes loot generation chance closer to classic.

I had noticed that in DF Unity tons of loot would be found by higher level characters. DF Unity multiplies the chance of finding all item types by the player's level, but classic only does this for the first four categories of items (ingredients). Everything else is just the chance seen in the loot matrices regardless of player level.

Also, classic's compare is (random value from 0 to 99) <= chance, so even a 0% chance category can create an item. This also means the values in the matrices are effectively 1 higher. My guess is that this is probably unintended, so I didn't recreate it.