### PR TITLE
Implement enemy equipment

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -102,15 +102,16 @@ namespace DaggerfallWorkshop.Game
                 if (senses.DistanceToPlayer < MeleeDistance && senses.PlayerInSight)
                 {
                     // Calculate damage
-                    // TODO: Implement enemy use of weapons. Play hit or miss sounds.
                     int damage = Game.Formulas.FormulaHelper.CalculateWeaponDamage(entity, GameManager.Instance.PlayerEntity, null);
                     if (damage > 0)
                     {
                         GameManager.Instance.PlayerObject.SendMessage("RemoveHealth", damage);
+                        // TODO: Play hit sound
                     }
                     else if (sounds)
                     {
-                        sounds.PlayMissSound();
+                        Items.DaggerfallUnityItem weapon = entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
+                        sounds.PlayMissSound(weapon);
                     }
 
                     // Tally player's dodging skill

--- a/Assets/Scripts/Game/EnemyDeath.cs
+++ b/Assets/Scripts/Game/EnemyDeath.cs
@@ -94,6 +94,17 @@ namespace DaggerfallWorkshop.Game
 
             // Generate items
             loot.GenerateItems();
+            // Add any equipped items to loot
+            for (int i = (int)Items.EquipSlots.Head; i < (int)Items.EquipSlots.Feet; i++)
+            {
+                Items.DaggerfallUnityItem item = enemyEntity.ItemEquipTable.GetItem((Items.EquipSlots)i);
+                if (item != null)
+                {
+                    enemyEntity.ItemEquipTable.UnequipItem((Items.EquipSlots)i);
+                    loot.Items.AddItem(item);
+                }
+            }
+
             entityBehaviour.CorpseLootContainer = loot;
 
             // Transfer any items owned by entity to loot container

--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -108,13 +108,13 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
-        public void PlayMissSound()
+        public void PlayMissSound(Items.DaggerfallUnityItem weapon)
         {
             if (IsReady())
             {
-                if (mobile.Summary.Enemy.ID > 127)
+                if (weapon != null)
                 {
-                    dfAudioSource.PlayOneShot(SoundClips.SwingMediumPitch);
+                    dfAudioSource.PlayOneShot(weapon.GetSwingSound());
                 }
                 else
                 {

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -114,6 +114,24 @@ namespace DaggerfallWorkshop.Game.Entity
                 return;
             }
 
+            // Enemy classes and some monsters use equipment
+            if (careerIndex == (int)MonsterCareers.Orc || careerIndex == (int)MonsterCareers.OrcShaman)
+            {
+                SetEnemyEquipment(0);
+            }
+            else if (careerIndex == (int)MonsterCareers.Centaur || careerIndex == (int)MonsterCareers.OrcSergeant)
+            {
+                SetEnemyEquipment(1);
+            }
+            else if (careerIndex == (int)MonsterCareers.OrcWarlord)
+            {
+                SetEnemyEquipment(2);
+            }
+            else if (entityType == EntityTypes.EnemyClass)
+            {
+                SetEnemyEquipment(UnityEngine.Random.Range(0, 2)); // 0 or 1
+            }
+
             this.mobileEnemy = mobileEnemy;
             this.entityType = entityType;
             name = career.Name;
@@ -130,6 +148,88 @@ namespace DaggerfallWorkshop.Game.Entity
             }
 
             FillVitalSigns();
+        }
+
+        public void SetEnemyEquipment(int variant)
+        {
+            // TODO: Calculate armor value from equipped armor
+            PlayerEntity player = GameManager.Instance.PlayerEntity;
+            int itemLevel = player.Level;
+            Genders gender = player.Gender;
+            Races race = player.Race;
+            int chance = 0;
+            if (variant == 0)
+            {
+                // right-hand weapon
+                int item = UnityEngine.Random.Range((int)Game.Items.Weapons.Broadsword, (int)(Game.Items.Weapons.Longsword) + 1);
+                Items.DaggerfallUnityItem weapon = Game.Items.ItemBuilder.CreateWeapon((Items.Weapons)item, Game.Items.ItemBuilder.RandomWeaponMaterial(itemLevel));
+                ItemEquipTable.EquipItem(weapon, true, false);
+
+                chance = 50;
+
+                // left-hand shield
+                item = UnityEngine.Random.Range((int)Game.Items.Armor.Buckler, (int)(Game.Items.Armor.Round_Shield) + 1);
+                if (UnityEngine.Random.Range(1, 101) <= chance)
+                {
+                    Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(gender, race, (Items.Armor)item, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
+                    ItemEquipTable.EquipItem(armor, true, false);
+                }
+                // left-hand weapon
+                else if (UnityEngine.Random.Range(1, 101) <= chance)
+                {
+                    item = UnityEngine.Random.Range((int)Game.Items.Weapons.Dagger, (int)(Game.Items.Weapons.Shortsword) + 1);
+                    weapon = Game.Items.ItemBuilder.CreateWeapon((Items.Weapons)item, Game.Items.ItemBuilder.RandomWeaponMaterial(itemLevel));
+                    ItemEquipTable.EquipItem(weapon, true, false);
+                }
+            }
+            else
+            {
+                // right-hand weapon
+                int item = UnityEngine.Random.Range((int)Game.Items.Weapons.Claymore, (int)(Game.Items.Weapons.Battle_Axe) + 1);
+                Items.DaggerfallUnityItem weapon = Game.Items.ItemBuilder.CreateWeapon((Items.Weapons)item, Game.Items.ItemBuilder.RandomWeaponMaterial(itemLevel));
+                ItemEquipTable.EquipItem(weapon, true, false);
+
+                if (variant == 1)
+                    chance = 75;
+                else if (variant == 2)
+                    chance = 90;
+            }
+            // helm
+            if (UnityEngine.Random.Range(1, 101) <= chance)
+            {
+                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(gender, race, Game.Items.Armor.Helm, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
+                ItemEquipTable.EquipItem(armor, true, false);
+            }
+            // right pauldron
+            if (UnityEngine.Random.Range(1, 101) <= chance)
+            {
+                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(gender, race, Game.Items.Armor.Right_Pauldron, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
+                ItemEquipTable.EquipItem(armor, true, false);
+            }
+            // left pauldron
+            if (UnityEngine.Random.Range(1, 101) <= chance)
+            {
+                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(gender, race, Game.Items.Armor.Left_Pauldron, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
+                ItemEquipTable.EquipItem(armor, true, false);
+            }
+            // cuirass
+            if (UnityEngine.Random.Range(1, 101) <= chance)
+            {
+                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(gender, race, Game.Items.Armor.Cuirass, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
+                ItemEquipTable.EquipItem(armor, true, false);
+            }
+            // greaves
+            if (UnityEngine.Random.Range(1, 101) <= chance)
+            {
+                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(gender, race, Game.Items.Armor.Greaves, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
+                ItemEquipTable.EquipItem(armor, true, false);
+            }
+            // boots
+            if (UnityEngine.Random.Range(1, 101) <= chance)
+            {
+                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(gender, race, Game.Items.Armor.Boots, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
+                ItemEquipTable.EquipItem(armor, true, false);
+            }
         }
 
         public DFCareer.EnemyGroups GetEnemyGroup()

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -205,6 +205,14 @@ namespace DaggerfallWorkshop.Game.Formulas
             if (attacker != player)
             {
                 AIAttacker = attacker as Entity.EnemyEntity;
+                weapon = attacker.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
+                if (weapon == null)
+                    weapon = attacker.ItemEquipTable.GetItem(Items.EquipSlots.LeftHand);
+            }
+            else
+            {
+                if (GameManager.Instance.WeaponManager.UsingRightHand)
+                    weapon = attacker.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
             }
 
             if (target != player)
@@ -212,31 +220,25 @@ namespace DaggerfallWorkshop.Game.Formulas
                 AITarget = target as Entity.EnemyEntity;
             }
 
-            // TODO: Get weapons of enemy classes and monsters.
-            if (attacker == player)
+            if (weapon == null)
             {
-                if (GameManager.Instance.WeaponManager.UsingRightHand)
-                    weapon = attacker.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
-                else
-                    weapon = attacker.ItemEquipTable.GetItem(Items.EquipSlots.LeftHand);
+                // If the player is attacking with no weapon equipped, use hand-to-hand skill for damage
+                if (attacker == player)
+                {
+                    damageLow = CalculateHandToHandMinDamage(attacker.Skills.HandToHand);
+                    damageHigh = CalculateHandToHandMaxDamage(attacker.Skills.HandToHand);
+                    chanceToHitMod = attacker.Skills.HandToHand;
+                }
+                // If a monster is attacking, use damage values from enemy definitions
+                else if (AIAttacker != null)
+                {
+                    damageLow = AIAttacker.MobileEnemy.MinDamage;
+                    damageHigh = AIAttacker.MobileEnemy.MaxDamage;
+                    chanceToHitMod = attacker.Skills.HandToHand;
+                }
             }
-
-            // If the player is attacking with no weapon equipped, use hand-to-hand skill for damage
-            if (weapon == null && attacker == player)
-            {
-                damageLow = CalculateHandToHandMinDamage(attacker.Skills.HandToHand);
-                damageHigh = CalculateHandToHandMaxDamage(attacker.Skills.HandToHand);
-                chanceToHitMod = attacker.Skills.HandToHand;
-            }
-            // If a monster is attacking, use damage values from enemy definitions
-            else if (weapon == null && AIAttacker != null)
-            {
-                damageLow = AIAttacker.MobileEnemy.MinDamage;
-                damageHigh = AIAttacker.MobileEnemy.MaxDamage;
-                chanceToHitMod = attacker.Skills.HandToHand;
-            }
-            // If the player is attacking with a weapon equipped, use the weapon's damage
-            else if (attacker == player)
+            // If the a weapon is being used, use the weapon's damage
+            else
             {
                 damageLow = weapon.GetBaseDamageMin();
                 damageHigh = weapon.GetBaseDamageMax();

--- a/Assets/Scripts/Game/Items/LootTables.cs
+++ b/Assets/Scripts/Game/Items/LootTables.cs
@@ -74,12 +74,6 @@ namespace DaggerfallWorkshop.Game.Items
             new LootChanceMatrix() {key = "S", MinGold = 50, MaxGold = 125, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 15, AM = 10, WP = 10, MI = 3, CL = 0, BK = 5, M2 = 5, RL = 0 },
             new LootChanceMatrix() {key = "T", MinGold = 20, MaxGold = 80, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 100, WP = 100, MI = 1, CL = 0, BK = 0, M2 = 0, RL = 0},
             new LootChanceMatrix() {key = "U", MinGold = 7, MaxGold = 30, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 10, AM = 10, WP = 10, MI = 2, CL = 0, BK = 2, M2 = 2, RL = 10 },
-
-            // Special humanoid loot table - not 100% sure how Daggerfall handles random loot for humanoids but appears different to monsters
-            // Seems to always deliver 1-3 weapons and 2-5 armor pieces regardless of level
-            // Other items are random as usual
-            // Creating special handling for this loot table in GenerateRandomLoot()
-            new LootChanceMatrix() {key = "HM", MinGold = 5, MaxGold = 50, P1 = 3, P2 = 3, C1 = 3, C2 = 3, C3 = 3, M1 = 3, AM = 0, WP = 0, MI = 5, CL = 5, BK = 5, M2 = 3, RL = 3 },
         };
 
         /// <summary>
@@ -186,27 +180,6 @@ namespace DaggerfallWorkshop.Game.Items
             {
                 items.Add(ItemBuilder.CreateRandomReligiousItem());
                 chance *= 0.5f;
-            }
-
-            // Special humanoid handling
-            // Daggerfall seems to always drop between 1-3 weapons and 2-5 armor pieces regardless of player level
-            // This is probably totally off track, but for now generating closer results than loot table alone
-            // TODO: Revisit humanoid loot tables later
-            if (key == "HM")
-            {
-                // Create 1-3 weapons
-                int count = Random.Range(1, 3);
-                for (int i = 0; i < count; i++)
-                {
-                    items.Add(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
-                }
-
-                // Create 2-5 armor pieces
-                count = Random.Range(2, 5);
-                for (int i = 0; i < count; i++)
-                {
-                    items.Add(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
-                }
             }
 
             return items.ToArray();

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -1301,7 +1301,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = false,
-                LootTableKey = "HM",
+                LootTableKey = "U",
             },
 
             // Spellsword
@@ -1322,7 +1322,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "P",
             },
 
             // Battlemage
@@ -1343,7 +1343,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "U",
             },
 
             // Sorcerer
@@ -1364,7 +1364,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = false,
-                LootTableKey = "HM",
+                LootTableKey = "U",
             },
 
             // Healer
@@ -1385,7 +1385,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = false,
-                LootTableKey = "HM",
+                LootTableKey = "U",
             },
 
             // Nightblade
@@ -1406,7 +1406,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "U",
             },
 
             // Bard
@@ -1427,7 +1427,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "O",
             },
 
             // Burglar
@@ -1448,7 +1448,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "O",
             },
 
             // Rogue
@@ -1469,7 +1469,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "O",
             },
 
             // Acrobat
@@ -1490,7 +1490,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "O",
             },
 
             // Thief
@@ -1511,7 +1511,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "O",
             },
 
             // Assassin
@@ -1532,7 +1532,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "O",
             },
 
             // Monk
@@ -1553,7 +1553,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "T",
             },
 
             // Archer
@@ -1575,7 +1575,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "C",
             },
 
             // Ranger
@@ -1596,7 +1596,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "C",
             },
 
             // Barbarian
@@ -1617,7 +1617,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "T",
             },
 
             // Warrior
@@ -1638,7 +1638,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "T",
             },
 
             // Knight
@@ -1659,7 +1659,7 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.EnemyHumanBark,
                 AttackSound = (int)SoundClips.EnemyHumanAttack,
                 ParrySounds = true,
-                LootTableKey = "HM",
+                LootTableKey = "T",
             },
 
             // City Watch - The Haltmeister
@@ -1680,7 +1680,6 @@ namespace DaggerfallWorkshop.Utility
                 BarkSound = (int)SoundClips.Halt,
                 AttackSound = (int)SoundClips.None,
                 ParrySounds = true,
-                LootTableKey = "HM",
             },
         };
 


### PR DESCRIPTION
This PR implements enemy equipment. Enemy classes and some monsters receive it, and the equipment can be found on their bodies when they die. Enemies with weapons use it for their attack damage now. I haven't yet implemented the effect of the armor on enemies' armor values. Also, right now the materials are using the random material methods in ItemBuilder, but I haven't looked into how classic chooses material.

Also, enemy classes now use the same loot table keys as classic. Their equipped items are added on top of this.