### PR TITLE
Add DoorText action

### DIFF
--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -714,8 +714,9 @@ namespace DaggerfallConnect
             ///<summary>50 Unknown </summary>
             Unknown50 = 0x32,
 
-            ///<summary>99 Unknown - seems to be releated to enemy hostility in special blocks</summary>
-            Unknown99 = 0x63,
+            ///<summary>99 Displays text at the top of the screen when clicked in info mode.
+            ///            Can cause castle guards to go hostile if clicked outside of info mode.</summary>
+            DoorText = 0x63,
 
             ///<summary>100 Unknown, only on 2 objects</summary>
             Unknown100 = 0x64,

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -40,6 +40,11 @@ namespace DaggerfallWorkshop.Game
 
         public float RayDistance = 2.4f;        // Distance of ray check, tune this to your scale and preference
 
+        public PlayerActivateModes CurrentMode
+        {
+            get { return currentMode; }
+        }
+
         void Start()
         {
             playerGPS = GetComponent<PlayerGPS>();
@@ -165,7 +170,7 @@ namespace DaggerfallWorkshop.Game
                                 actionDoor.AttemptLockpicking();
                             }
                             else
-                                actionDoor.ToggleDoor();
+                                actionDoor.ToggleDoor(true);
                         }
 
                         // Check for action record hit

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -108,15 +108,15 @@ namespace DaggerfallWorkshop
                 Open(0, true);
         }
 
-        public void ToggleDoor()
+        public void ToggleDoor(bool activatedByPlayer = false)
         {
             if (IsMoving)
                 return;
 
             if (IsOpen)
-                Close(OpenDuration);
+                Close(OpenDuration, activatedByPlayer);
             else
-                Open(OpenDuration);
+                Open(OpenDuration, false, activatedByPlayer);
         }
 
         public void SetOpen(bool open, bool instant = false, bool ignoreLocks = false)
@@ -190,7 +190,7 @@ namespace DaggerfallWorkshop
                         if (dfAudioSource != null)
                             dfAudioSource.PlayOneShot(PickedLockSound);
                     }
-                    ToggleDoor();
+                    ToggleDoor(true);
                 }
             }
             else
@@ -220,7 +220,7 @@ namespace DaggerfallWorkshop
                     if (roll >= (1f - ChanceToBash))
                     {
                         CurrentLockValue = 0;
-                        ToggleDoor();
+                        ToggleDoor(true);
                     }
                 }
             }
@@ -257,7 +257,7 @@ namespace DaggerfallWorkshop
 
         #region Private Methods
 
-        private void Open(float duration, bool ignoreLocks = false)
+        private void Open(float duration, bool ignoreLocks = false, bool activatedByPlayer = false)
         {
             // Do nothing if door cannot be opened right now
             if ((IsLocked && !ignoreLocks) || IsOpen)
@@ -297,15 +297,18 @@ namespace DaggerfallWorkshop
                     dfAudioSource.PlayOneShot(OpenSound);
             }
 
-            //For Doors that are also action objects, executes action when door opened / closed
-            ExecuteActionOnToggle();
+            // For doors that are also action objects, execute action when door opened / closed
+            // Only doing so if player was the activator, to keep DoorText actions from running
+            // when enemies open doors.
+            if (activatedByPlayer)
+                ExecuteActionOnToggle();
 
             // Set flag
             //IsMagicallyHeld = false;
             CurrentLockValue = 0;
         }
 
-        private void Close(float duration)
+        private void Close(float duration, bool activatedByPlayer = false)
         {
             // Do nothing if door cannot be closed right now
             if (IsClosed)
@@ -321,8 +324,11 @@ namespace DaggerfallWorkshop
             __ExternalAssets.iTween.RotateTo(gameObject, rotateParams);
             currentState = ActionState.PlayingReverse;
 
-            //For Doors that are also action objects, executes action when door opened / closed
-            ExecuteActionOnToggle();
+            // For doors that are also action objects, execute action when door opened / closed
+            // Only doing so if player was the activator, to keep DoorText actions from running
+            // when enemies open doors.
+            if (activatedByPlayer)
+                ExecuteActionOnToggle();
         }
 
         private void OnCompleteOpen()


### PR DESCRIPTION
This partially implements Action 99, which displays text at the top of the screen when clicking on some doors in info mode. Cases I know of that exist:
1) Doors in Castle Daggerfall off of throne room.
2) Doors in Castle Wayrest off of entrance area and in basement area before dungeon.
3) Doors in back of Orsinium throne room.

There's a few other texts in the used area of TEXT.RSC that might be unused or there might be a few other doors somewhere with this action.

There's an issue with this that I wanted your help with Interkarma. This action displays text at the top of the screen, but the text used is multi-line text. Is there currently a way to display this? Right now the text just runs off the screen.

This action can also cause castle guards to go hostile but this isn't implemented yet.

I found a few places where classic calls the wrong ID, creating an error message. I put in patches for these doors. Also, for fun, I recreated the Daggerfall error message if a wrong ID is called. :) Although I already patched the only wrong ID calls I know of. If you want me to remove the Daggerfall-style message and do a normal exception message I can do so.

Also, incidentally, do you know why the textIDs here are numbered as they are? From 7701 to 7705 are the first IDs, but then it suddenly jumps to 7717 for the orsinium one, and the next one is ID 7764.

Also, I display the popup text for 2 seconds. I measured the time in classic and it was 2 seconds or very close to it.