### PR TITLE
travelmap location discovery implemented

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/RevealLocation.cs
+++ b/Assets/Scripts/Game/Questing/Actions/RevealLocation.cs
@@ -15,13 +15,15 @@ using FullSerializer;
 namespace DaggerfallWorkshop.Game.Questing
 {
     /// <summary>
-    /// Incomplete. Just stubbing out action for now so quest will compile.
+    /// Reveals location on travelmap
     /// </summary>
     public class RevealLocation : ActionTemplate
     {
+        Symbol placeSymbol;
+
         public override string Pattern
         {
-            get { return @"reveal"; }
+            get { return @"reveal (?<aPlace>\w+)"; }
         }
 
         public RevealLocation(Quest parentQuest)
@@ -39,12 +41,24 @@ namespace DaggerfallWorkshop.Game.Questing
             // Factory new action
             RevealLocation action = new RevealLocation(parentQuest);
 
+            action.placeSymbol = new Symbol(match.Groups["aPlace"].Value);
+
             return action;
         }
 
         public override void Update(Task caller)
         {
             // TODO: Perform action changes
+
+            // Get place resource
+            Place place = ParentQuest.GetPlace(placeSymbol);
+            if (place == null)
+                return;
+
+            if (place.SiteDetails.siteType == SiteTypes.Dungeon)
+            {
+                GameManager.Instance.PlayerGPS.DiscoverLocation(place.SiteDetails.regionName, place.SiteDetails.locationName);            
+            }
 
             SetComplete();
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -20,6 +20,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterface;
 using System.Collections.Generic;
+using Wenzil.Console;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -123,6 +124,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         bool draw                   = true;     //draws textures to panel
         bool loadNewImage           = true;     //loads current map image
 
+        static bool revealUndiscoveredLocations; // flag used to indicate cheat/debugging mode for revealing undiscovered locations
+
         static bool filterDungeons  = false;
         static bool filterTemples   = false;
         static bool filterHomes     = false;
@@ -167,6 +170,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             get { return identifying && findingLocation && RegionSelected; }
         }
+
         #endregion
 
 
@@ -244,6 +248,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             loadNewImage = true;
             draw = true;
             StartIdentify();
+
+            // register console commands
+            try
+            {
+                TravelMapConsoleCommands.RegisterCommands();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError(string.Format("Error Registering Travelmap Console commands: {0}", ex.Message));
+
+            }
         }
 
         public override void OnPush()
@@ -918,6 +933,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             StartIdentify();
         }
 
+        // checks if location with MapSummary summary is already discovered
+        bool checkLocationDiscovered(ContentReader.MapSummary summary)
+        {
+            if (GameManager.Instance.PlayerGPS.HasDiscoveredLocation(summary.ID) ||
+                PlayerGPS.checkIfLocationTypeAlwaysKnown(summary.LocationType) ||
+                revealUndiscoveredLocations == true)
+            {
+                return true;
+            }
+            return false;
+        }
+
         // Sets pixels for selected region
         void SetLocationPixels()
         {
@@ -956,8 +983,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                                 // This does not correctly account for locations that should always be shown
                                 // Purpose is only to test ID matching with discovery system
                                 // This is to be removed once proper discovery implemented
-                                //if (!GameManager.Instance.PlayerGPS.HasDiscoveredLocation(summary.ID))
-                                //    continue;
+                                if (!checkLocationDiscovered(summary))
+                                    continue;
 
                                 int index = GetPixelColorIndex(summary.LocationType);
                                 if (index == -1)
@@ -1043,6 +1070,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     int index = GetPixelColorIndex(locationSummary.LocationType);
                     if (index == -1)
                         return;
+
+                    // only make location selectable if it is already discovered
+                    if (!checkLocationDiscovered(locationSummary))
+                        return;
+
                     locationSelected = true;
                 }
             }
@@ -1466,5 +1498,65 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
 
         #endregion
+
+        #region console_commands
+
+        public static class TravelMapConsoleCommands
+        {
+            public static void RegisterCommands()
+            {
+                try
+                {
+                    ConsoleCommandsDatabase.RegisterCommand(RevealLocations.name, RevealLocations.description, RevealLocations.usage, RevealLocations.Execute);
+                    ConsoleCommandsDatabase.RegisterCommand(HideLocations.name, HideLocations.description, HideLocations.usage, HideLocations.Execute);
+                }
+                catch (System.Exception ex)
+                {
+                    DaggerfallUnity.LogMessage(ex.Message, true);
+                }
+            }
+
+            private static class RevealLocations
+            {
+                public static readonly string name = "map_reveallocations";
+                public static readonly string description = "Reveals undiscovered locations on travelmap (temporary)";
+                public static readonly string usage = "map_reveallocations";
+
+
+                public static string Execute(params string[] args)
+                {
+                    if (GameManager.Instance.IsPlayerInside)
+                    {
+                        return "this command only has an effect when outside";
+                    }
+
+                    revealUndiscoveredLocations = true;
+                    return "undiscovered locations have been revealed (temporary) on the travelmap";
+                }
+            }
+
+            private static class HideLocations
+            {
+                public static readonly string name = "map_hidelocations";
+                public static readonly string description = "Hides undiscovered locations on travelmap";
+                public static readonly string usage = "map_hidelocations";
+
+
+                public static string Execute(params string[] args)
+                {
+                    if (GameManager.Instance.IsPlayerInside)
+                    {
+                        return "this command only has an effect when outside";
+                    }
+
+                    revealUndiscoveredLocations = false;
+                    return "undiscovered locations have been hidden on the travelmap again";
+                }
+
+            }
+        }
+
+        #endregion
+
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -1285,7 +1285,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     locationInfo = currentDFRegion.MapTable[index];
                     DFPosition pos = MapsFile.LongitudeLatitudeToMapPixel((int)locationInfo.Longitude, (int)locationInfo.Latitude);
                     if (DaggerfallUnity.ContentReader.HasLocation(pos.X, pos.Y, out locationSummary))
+                    {
+                        // only make location searchable if it is already discovered
+                        if (!checkLocationDiscovered(locationSummary))
+                            continue;
+
                         return true;
+                    }
                 }
             }
 
@@ -1303,9 +1309,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     locationInfo = currentDFRegion.MapTable[index];
                     DFPosition pos = MapsFile.LongitudeLatitudeToMapPixel((int)locationInfo.Longitude, (int)locationInfo.Latitude);
                     if (DaggerfallUnity.ContentReader.HasLocation(pos.X, pos.Y, out locationSummary))
+                    {
+                        // only make location searchable if it is already discovered
+                        if (!checkLocationDiscovered(locationSummary))
+                            continue;
+
                         return true;
+                    }
                     else
+                    {
                         return false;
+                    }
                 }
                 else if (locations[i][0] > name[0])
                     return false;

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -564,6 +564,25 @@ namespace DaggerfallWorkshop
 
         #region Location Discovery
 
+        public static bool checkIfLocationTypeAlwaysKnown(DFRegion.LocationTypes locationType)
+        {
+            if (locationType == DFRegion.LocationTypes.GraveyardCommon ||
+                // locationType == DFRegion.LocationTypes.GraveyardForgotten && // not sure about forgotten graveyards - if i understand it right here http://en.uesp.net/wiki/Daggerfall:Location_types - it should not be shown on default
+                locationType == DFRegion.LocationTypes.HomeFarms ||
+                locationType == DFRegion.LocationTypes.HomePoor ||
+                locationType == DFRegion.LocationTypes.HomeWealthy ||
+                locationType == DFRegion.LocationTypes.ReligionCult ||
+                locationType == DFRegion.LocationTypes.ReligionTemple ||
+                locationType == DFRegion.LocationTypes.Tavern ||
+                locationType == DFRegion.LocationTypes.TownCity ||
+                locationType == DFRegion.LocationTypes.TownHamlet ||
+                locationType == DFRegion.LocationTypes.TownVillage)
+            {
+                return true;
+            }
+            return false;
+        }
+
         /// <summary>
         /// Discover current location.
         /// Does nothing if player in wilderness or location already dicovered.
@@ -578,6 +597,11 @@ namespace DaggerfallWorkshop
             // Check if already discovered
             int mapPixelID = MapsFile.GetMapPixelIDFromLongitudeLatitude((int)CurrentLocation.MapTableData.Longitude, CurrentLocation.MapTableData.Latitude);
             if (HasDiscoveredLocation(mapPixelID))
+                return;
+
+            // only discover location with locationType that should not be automatically known (like towns, villages, temples, graveyards - behaviour of vanilla daggerfall)
+            // don't discover these to reduce savegame size
+            if (checkIfLocationTypeAlwaysKnown(CurrentLocation.MapTableData.LocationType))
                 return;
 
             // Add to discovered locations dict

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -567,7 +567,7 @@ namespace DaggerfallWorkshop
         public static bool checkIfLocationTypeAlwaysKnown(DFRegion.LocationTypes locationType)
         {
             if (locationType == DFRegion.LocationTypes.GraveyardCommon ||
-                // locationType == DFRegion.LocationTypes.GraveyardForgotten && // not sure about forgotten graveyards - if i understand it right here http://en.uesp.net/wiki/Daggerfall:Location_types - it should not be shown on default
+                locationType == DFRegion.LocationTypes.GraveyardForgotten ||
                 locationType == DFRegion.LocationTypes.HomeFarms ||
                 locationType == DFRegion.LocationTypes.HomePoor ||
                 locationType == DFRegion.LocationTypes.HomeWealthy ||

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -615,6 +615,28 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
+        /// Discover location with regionName and locationName.
+        /// </summary>
+        public void DiscoverLocation(string regionName, string locationName)
+        {
+            DFLocation location;        
+            dfUnity.ContentReader.GetLocation(regionName, locationName, out location);
+
+            // Check if already discovered
+            int mapPixelID = MapsFile.GetMapPixelIDFromLongitudeLatitude((int)location.MapTableData.Longitude, location.MapTableData.Latitude);
+            if (HasDiscoveredLocation(mapPixelID))
+                return;
+
+            // Add to discovered locations dict
+            DiscoveredLocation dl = new DiscoveredLocation();
+            dl.mapID = location.MapTableData.MapId;
+            dl.mapPixelID = mapPixelID;
+            dl.regionName = location.RegionName;
+            dl.locationName = location.Name;
+            discoveredLocations.Add(mapPixelID, dl);
+        }
+
+        /// <summary>
         /// Discover the specified building in current location.
         /// Does nothing if player not inside a location or building already discovered.
         /// </summary>
@@ -636,7 +658,11 @@ namespace DaggerfallWorkshop
 
             // Get location discovery
             int mapPixelID = MapsFile.GetMapPixelIDFromLongitudeLatitude((int)CurrentLocation.MapTableData.Longitude, CurrentLocation.MapTableData.Latitude);
-            DiscoveredLocation dl = discoveredLocations[mapPixelID];
+            DiscoveredLocation dl = new DiscoveredLocation();
+            if (discoveredLocations.ContainsKey(mapPixelID))
+            {
+                dl = discoveredLocations[mapPixelID];
+            }
 
             // Ensure the building dict is created
             if (dl.discoveredBuildings == null)


### PR DESCRIPTION
Hi Interkarma!
I added static function checkIfLocationTypeAlwaysKnown to PlayerGPS - reason is because I added a check to location discovery function DiscoverCurrentLocation which checks if the location type is one of those that should always be known to the player like town, village, temple, common graveyard - I did add the check so that discovery dictionary (and savegame data) remains as small as possible - imagine a player that travels a lot will have lots of locations in there that could be saved
BUT: if you don't like it JUST remove the check (line 604, 605) - then the function checkIfLocationTypeAlwaysKnown could be moved over to DaggerfallTravelMapWindow.cs...

added 2 console commands (in DaggerfallTravelMapWindow.cs): map_reveallocations and map_hidelocations (it is only a temporal reveal - discovery state is of course not changed)

best regards!
