### PR TITLE
Approximate classic player movement speeds

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -210,7 +210,7 @@ namespace Wenzil.Console
         {
             public static readonly string name = "set_walkspeed";
             public static readonly string error = "Failed to set walk speed - invalid setting or PlayerMotor object not found";
-            public static readonly string description = "Set walk speed. Default is 3";
+            public static readonly string description = "Set walk speed. Set to -1 to return to default speed.";
             public static readonly string usage = "set_walkspeed [#]";
 
             public static string Execute(params string[] args)
@@ -225,7 +225,7 @@ namespace Wenzil.Console
                 {
                     try
                     {
-                        Console.Log(string.Format("Current Walk Speed: {0}", playerMotor.walkSpeed));
+                        Console.Log(string.Format("Current Walk Speed: {0}", playerMotor.GetWalkSpeed(GameManager.Instance.PlayerEntity)));
                         return HelpCommand.Execute(SetWalkSpeed.name);
 
                     }
@@ -237,9 +237,15 @@ namespace Wenzil.Console
                 }
                 else if (!int.TryParse(args[0], out speed))
                     return error;
+                else if (speed == -1)
+                {
+                    playerMotor.useWalkSpeedOverride = false;
+                    return string.Format("Walk speed set to default.");
+                }
                 else
                 {
-                    playerMotor.walkSpeed = speed;
+                    playerMotor.useWalkSpeedOverride = true;
+                    playerMotor.walkSpeedOverride = speed;
                     return string.Format("Walk speed set to: {0}", speed);
                 }
 
@@ -250,7 +256,7 @@ namespace Wenzil.Console
         {
             public static readonly string name = "set_runspeed";
             public static readonly string error = "Failed to set run speed - invalid setting or PlayerMotor object not found";
-            public static readonly string description = "Set run speed. Default is 7";
+            public static readonly string description = "Set run speed. Set to -1 to return to default speed.";
             public static readonly string usage = "set_runspeed [#]";
 
             public static string Execute(params string[] args)
@@ -265,7 +271,7 @@ namespace Wenzil.Console
                 {
                     try
                     {
-                        Console.Log(string.Format("Current RunSpeed: {0}", playerMotor.runSpeed));
+                        Console.Log(string.Format("Current RunSpeed: {0}", playerMotor.GetRunSpeed(playerMotor.GetWalkSpeed(GameManager.Instance.PlayerEntity))));
                         return HelpCommand.Execute(SetRunSpeed.name);
 
                     }
@@ -280,9 +286,15 @@ namespace Wenzil.Console
                 {
                     return error;
                 }
+                else if (speed == -1)
+                {
+                    playerMotor.useRunSpeedOverride = false;
+                    return string.Format("Run speed set to default.");
+                }
                 else
                 {
-                    playerMotor.runSpeed = speed;
+                    playerMotor.runSpeedOverride = speed;
+                    playerMotor.useRunSpeedOverride = true;
                     return string.Format("Run speed set to: {0}", speed);
                 }
             }


### PR DESCRIPTION
This PR approximates classic player movement speeds.

First I recorded the length of time it took to walk the same distance with the same speed stat in classic and Unity. Comparing the movement values used in FALL.EXE for to those of DF Unity I found the ratio was about 39.5 to 1, meaning a speed value of 39.5 in classic is about the same as a speed value of 1 in DF Unity. This is probably slightly off. For one thing movement is classic seems to be instant stop-and-go but there is acceleration and deceleration in DF Unity.

The walk, crouch and run formulas are matched to classic. The run formula is also in DF Chronicles and matched what I saw in the assembly code.

One little thing I found: the "maxSpeed" value in z.cfg can be used to modify walk speed in Daggerfall version 1.0 but as of the latest Daggerfall version maxSpeed now seems to be hardcoded at 200 and is no longer read from z.cfg. Also I'm not sure why they named it "maxSpeed" because that doesn't seem to be what it does. Maybe it was used in a different way at some point or maybe I'm missing something. Walk speed in classic is calculated as (Player.Speed - 50 + maxSpeed).

Also I modified the get_walkingspeed and get_runningspeed commands to fit with the new code. If you set a value with them it's used as an override. You can return to the classic formula-based speeds by setting a value of -1.