### PR TITLE
Implement building opened/closed hours

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -53,6 +53,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public const string youAreEntering = "You are entering %s";
 
+        public const string storeClosed = "Store is closed. Open from %d1:00 to %d2:00.";
+
         public const string interactionIsNowInMode = "Interaction is now in %s mode.";
         public const string steal = "steal";
         public const string grab = "grab";


### PR DESCRIPTION
Implements:

- All buildings except houses should have the same hours for the doors being locked/unlocked. You can get a message for stores' opening and closing hours by clicking info mode, as in classic.
- Houses 1 through 4 are open during the day and closed at night, and you get a greeting when you enter, like in classic.

To be done:
- There's something more to how the houses' open hours are calculated, but I haven't figured it out yet.
- Since exterior doors don't have lock values and can't be picked or bashed yet, you can get in through any exterior door right now by clicking in steal mode.