### PR TITLE
Make building discovery closer to classic

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -119,23 +119,26 @@ namespace DaggerfallWorkshop.Game
                                 // Store building type
                                 buildingType = buildingSummary.BuildingType;
 
-                                // Discover building
-                                GameManager.Instance.PlayerGPS.DiscoverBuilding(building.buildingKey);
-
-                                // Get discovered building
-                                PlayerGPS.DiscoveredBuilding db;
-                                if (GameManager.Instance.PlayerGPS.GetDiscoveredBuilding(building.buildingKey, out db))
+                                if (currentMode == PlayerActivateModes.Info)
                                 {
-                                    // TODO: Check against quest system for an overriding quest-assigned display name for this building
-                                    DaggerfallUI.AddHUDText(db.displayName);
+                                    // Discover building
+                                    GameManager.Instance.PlayerGPS.DiscoverBuilding(building.buildingKey);
 
-                                    if (!buildingUnlocked && buildingType < DFLocation.BuildingTypes.Temple
-                                        && buildingType != DFLocation.BuildingTypes.HouseForSale)
+                                    // Get discovered building
+                                    PlayerGPS.DiscoveredBuilding db;
+                                    if (GameManager.Instance.PlayerGPS.GetDiscoveredBuilding(building.buildingKey, out db))
                                     {
-                                        string storeClosedMessage = HardStrings.storeClosed;
-                                        storeClosedMessage = storeClosedMessage.Replace("%d1", openHours[(int)buildingType].ToString());
-                                        storeClosedMessage = storeClosedMessage.Replace("%d2", closeHours[(int)buildingType].ToString());
-                                        DaggerfallUI.Instance.PopupMessage(storeClosedMessage);
+                                        // TODO: Check against quest system for an overriding quest-assigned display name for this building
+                                        DaggerfallUI.AddHUDText(db.displayName);
+
+                                        if (!buildingUnlocked && buildingType < DFLocation.BuildingTypes.Temple
+                                            && buildingType != DFLocation.BuildingTypes.HouseForSale)
+                                        {
+                                            string storeClosedMessage = HardStrings.storeClosed;
+                                            storeClosedMessage = storeClosedMessage.Replace("%d1", openHours[(int)buildingType].ToString());
+                                            storeClosedMessage = storeClosedMessage.Replace("%d2", closeHours[(int)buildingType].ToString());
+                                            DaggerfallUI.Instance.PopupMessage(storeClosedMessage);
+                                        }
                                     }
                                 }
                             }
@@ -151,6 +154,9 @@ namespace DaggerfallWorkshop.Game
                             {
                                 if (door.doorType == DoorTypes.Building && !playerEnterExit.IsPlayerInside)
                                 {
+                                    // Discover building
+                                    GameManager.Instance.PlayerGPS.DiscoverBuilding(building.buildingKey);
+
                                     // TODO: Implement lockpicking and door bashing for exterior doors
                                     // For now, any locked building door can be entered by using steal mode
                                     if (!buildingUnlocked && (currentMode != PlayerActivateModes.Steal))

--- a/Assets/Scripts/Utility/BuildingNames.cs
+++ b/Assets/Scripts/Utility/BuildingNames.cs
@@ -34,6 +34,9 @@ namespace DaggerfallWorkshop.Utility
             DFRandom.srand(seed);
             switch (type)
             {
+                case DFLocation.BuildingTypes.HouseForSale:
+                    return "House for sale";
+
                 case DFLocation.BuildingTypes.Tavern:
                     b = TavernsB[DFRandom.random_range(0, TavernsB.Length)];
                     a = TavernsA[DFRandom.random_range(0, TavernsA.Length)];


### PR DESCRIPTION
Does these changes:

1. Houses on sale now identified as "House for sale" when clicked in info mode, and on automap
2. Clicking on buildings only discovers them (unless door is clicked) and shows shop times if in info mode
3. Buildings are discovered when their doors are clicked, in any mode

This all matches classic behavior as far as I can tell.