### PR TITLE
travel time countdown implemented for worldmap

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -604,6 +604,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (pixelBuffer == null)
                     pixelBuffer = new Color32[width * height];
 
+                // note by Nystul: check necessary to prevent exception which could happen if pixelBuffer is 320x160 instead of 320x200 -
+                // otherwise marked line below will throw exception (e.g. after fast travel to a location in Wrothgarian Mountains and reopening map)
+                // not sure why this happens, but it happens, maybe Lypyl can take a look
+                if (pixelBuffer.GetLength(0) != width * height)
+                    return;
+
                 for (int y = 0; y < height; y++)
                 {
                     for (int x = 0; x < width; x++)
@@ -612,7 +618,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         int dstOffset = ((height - y - 1) * width) + x;
                         int sampleRegion = regionPickerBitmap.Data[srcOffset] - 128;
                         if (sampleRegion == playerRegion)
-                            pixelBuffer[dstOffset] = identifyFlashColor;
+                            pixelBuffer[dstOffset] = identifyFlashColor; // this is the line that might throw exception sometimes
                     }
                 }
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -280,6 +280,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 yield return new WaitForSecondsRealtime(0.05f);
             }
             inProgressCountdownTravelTime = false;
+
+            coroutineHandlerFastTravel.StartCoroutineFastTravelActions();
         }
 
 
@@ -341,7 +343,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             coroutineHandlerFastTravel.setDaggerfallTravelPopUp(this);
             coroutineHandlerFastTravel.StartCoroutineFastTravelCountdown();
-            coroutineHandlerFastTravel.StartCoroutineFastTravelActions();
+            //coroutineHandlerFastTravel.StartCoroutineFastTravelActions();
             coroutineHandlerFastTravel.StartCoroutineCheckFinishedFastTravel();
         }
 


### PR DESCRIPTION
this is done via coroutines
had to implement it with a helper class that inherits from MonoBehaviour so that coroutines could be used (since DaggerfallTravelPopUp class is not inheriting from MonoBehaviour)
this works reasonable well

unfortunately there are these limitations:

- location loading and countdown cannot be done in parallel - since unity does not allow different threads with calls to unity api functions (this would be needed since the gui needs to be updated and location loading also calls unity api funcions like gameobject creation etc., current approach with coroutines does  no concurrent processing

- countdown is done before actual fast travel actions right now

- since coroutines are involved now: camera updates happen now that did not before (I guess in between coroutines processing when yielded) - leading to "empty" scene loading in the background when new location is loaded (or in case of of farterrain and realtime reflecions mod some artifacts - camera glitches, and bottom side of reflection plane with green debug color)

- just disabling cameras and other camera update prevention measures did not work or made mods throw exceptions - so I decided to restrain from this for now - will further look for a solution

