### PR TITLE
Fix issues with horse riding

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleUI.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleUI.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using System;
@@ -45,7 +45,7 @@ namespace Wenzil.Console
             if (!DaggerfallWorkshop.Game.GameManager.Instance.IsPlayerOnHUD && !force)
                 return;
 
-            // Do nothing if HUD not enabled in settings
+            // Do nothing if console not enabled in settings
             if (!DaggerfallWorkshop.DaggerfallUnity.Settings.LypyL_GameConsole && !force)
                 return;
 

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -98,7 +98,7 @@ namespace DaggerfallWorkshop.Game
             // Handle horse & cart riding animation & sounds.
             if (mode == TransportModes.Horse || mode == TransportModes.Cart)
             {
-                if (playerMotor.IsStandingStill || !playerMotor.IsGrounded)
+                if (playerMotor.IsStandingStill || !playerMotor.IsGrounded || GameManager.IsGamePaused)
                 {   // Stop animation frames and sound playing.
                     lastFrameTime = 0;
                     ridingTexure = ridingTexures[0];
@@ -131,7 +131,7 @@ namespace DaggerfallWorkshop.Game
 
         void OnGUI()
         {
-            if (Event.current.type.Equals(EventType.Repaint))
+            if (Event.current.type.Equals(EventType.Repaint) && !GameManager.IsGamePaused)
             {
                 if ((mode == TransportModes.Horse || mode == TransportModes.Cart) && ridingTexure != null)
                 {
@@ -159,7 +159,7 @@ namespace DaggerfallWorkshop.Game
 
             if (mode == TransportModes.Horse || mode == TransportModes.Cart)
             {
-                // Tell player motor we're riding.
+                // Tell player motor we're riding. TODO: Change to event system so other classes can listen for transport changes.
                 playerMotor.IsRiding = true;
 
                 // Setup appropriate riding sounds.


### PR DESCRIPTION
- Capsule height and camera height now set correctly. Height when riding is now 2.6m and camera is always set at 9cm below the top of the capsule. (execpt for when crouching cos that is strange and I didn't want to mess with it)
- Speed is calculated using the base units from DF provided by Allofich (thanks!) and affected by speed skill level. (moved numbers into constants)
- Sounds and animations stop when game is paused.