### PR TITLE
Add sounds when enemy hits player or swing misses

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -126,9 +126,9 @@ namespace DaggerfallWorkshop.Game
                         if (dfAudioSource)
                         {
                             if (weapon == null)
-                                dfAudioSource.PlayOneShot((int)SoundClips.Hit1 + UnityEngine.Random.Range(2, 4), 0);
+                                dfAudioSource.PlayOneShot((int)SoundClips.Hit1 + UnityEngine.Random.Range(2, 4), 0, 1.1f);
                             else
-                                dfAudioSource.PlayOneShot((int)SoundClips.Hit1 + UnityEngine.Random.Range(0, 5), 0);
+                                dfAudioSource.PlayOneShot((int)SoundClips.Hit1 + UnityEngine.Random.Range(0, 5), 0, 1.1f);
                         }
                     }
                     else

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -98,24 +98,41 @@ namespace DaggerfallWorkshop.Game
                 EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
                 MobileEnemy enemy = entity.MobileEnemy;
 
+                int damage = 0;
+
                 // Are we still in range and facing player? Then apply melee damage.
                 if (senses.DistanceToPlayer < MeleeDistance && senses.PlayerInSight)
                 {
                     // Calculate damage
-                    int damage = Game.Formulas.FormulaHelper.CalculateWeaponDamage(entity, GameManager.Instance.PlayerEntity, null);
+                    damage = Game.Formulas.FormulaHelper.CalculateWeaponDamage(entity, GameManager.Instance.PlayerEntity, null);
                     if (damage > 0)
                     {
                         GameManager.Instance.PlayerObject.SendMessage("RemoveHealth", damage);
-                        // TODO: Play hit sound
-                    }
-                    else if (sounds)
-                    {
-                        Items.DaggerfallUnityItem weapon = entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
-                        sounds.PlayMissSound(weapon);
                     }
 
                     // Tally player's dodging skill
                     GameManager.Instance.PlayerEntity.TallySkill((short)Skills.Dodging, 1);
+                }
+
+                if (sounds)
+                {
+                    Items.DaggerfallUnityItem weapon = entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
+                    if (weapon == null)
+                        weapon = entity.ItemEquipTable.GetItem(Items.EquipSlots.LeftHand);
+                    if (damage > 0)
+                    {
+                        // TODO: Play hit and parry sounds on other AI characters once attacks against other AI are possible
+                        DaggerfallAudioSource dfAudioSource = GetComponent<DaggerfallAudioSource>();
+                        if (dfAudioSource)
+                        {
+                            if (weapon == null)
+                                dfAudioSource.PlayOneShot((int)SoundClips.Hit1 + UnityEngine.Random.Range(2, 4), 0);
+                            else
+                                dfAudioSource.PlayOneShot((int)SoundClips.Hit1 + UnityEngine.Random.Range(0, 5), 0);
+                        }
+                    }
+                    else
+                        sounds.PlayMissSound(weapon);
                 }
             }
         }

--- a/Assets/Scripts/Game/EnemyDeath.cs
+++ b/Assets/Scripts/Game/EnemyDeath.cs
@@ -72,7 +72,7 @@ namespace DaggerfallWorkshop.Game
             if (DaggerfallUI.Instance.DaggerfallAudioSource)
             {
                 AudioClip collapseSound = DaggerfallUI.Instance.DaggerfallAudioSource.GetAudioClip((int)SoundClips.BodyFall);
-                AudioSource.PlayClipAtPoint(collapseSound, entityBehaviour.transform.position);
+                AudioSource.PlayClipAtPoint(collapseSound, entityBehaviour.transform.position, 1.05f);
             }
 
             // Disable enemy gameobject

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -171,7 +171,7 @@ namespace DaggerfallWorkshop.Game
             if (dfAudioSource)
             {
                 dfAudioSource.AudioSource.pitch = 1f * AttackSpeedScale;
-                dfAudioSource.PlayOneShot(SwingWeaponSound, 0);
+                dfAudioSource.PlayOneShot(SwingWeaponSound, 0, 1.1f);
             }
         }
 


### PR DESCRIPTION
Adds hit sounds when enemy hits player based on their weapon, or lack of, and also plays an appropriate miss sound if the player isn't in range of their attack.