### PR TITLE
Fix horse casule height and prevent horse crouching

### DIFF
--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -417,6 +417,10 @@ namespace DaggerfallWorkshop.Game
                 pos.y = (ridingHeight / 2) - eyeHeight;
                 mainCamera.transform.localPosition = pos;
                 controller.height = ridingHeight;
+                pos = controller.transform.position;
+                float prevHeight = isCrouching ? crouchingHeight : standingHeight;
+                pos.y += (ridingHeight - prevHeight) / 2.0f;
+                controller.transform.position = pos;
                 riding = true;
             }
             else if (!isRiding && riding)
@@ -425,9 +429,12 @@ namespace DaggerfallWorkshop.Game
                 pos.y = (standingHeight / 2) - eyeHeight;
                 mainCamera.transform.localPosition = pos;
                 controller.height = standingHeight;
+                pos = controller.transform.position;
+                pos.y -= (ridingHeight - standingHeight) / 2.0f;
+                controller.transform.position = pos;
                 riding = false;
             }
-            else
+            else if (!isRiding)
             {
                 try
                 {


### PR DESCRIPTION
Thanks for pointing out why the y axis capsule center needs repositioning.

Also realised I had re-allowed crouching at some point. Horses cant crouch right?