### PR TITLE
Implement weapons and armor taking damage

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -250,14 +250,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 // Get slot used by this armor
                 EquipSlots slot = ItemEquipTable.GetEquipSlot(armor);
 
-                // This array maps equip slots to the order of the 7 armor values
-                EquipSlots[] equipSlots = { EquipSlots.Head, EquipSlots.RightArm, EquipSlots.LeftArm,
-                                            EquipSlots.ChestArmor, EquipSlots.Gloves, EquipSlots.LegsArmor,
-                                            EquipSlots.Feet };
-
-                // Get the index for the correct armor value and update the armor value.
-                // Armor value is 100 when no armor is equipped. For every point of armor as shown on the inventory screen, 5 is subtracted.
-                int index = System.Array.IndexOf(equipSlots, slot);
+                int index = (int)DaggerfallUnityItem.GetBodyPartForEquipSlot(slot);
 
                 if (equipping)
                 {
@@ -272,30 +265,12 @@ namespace DaggerfallWorkshop.Game.Entity
             {
                 // Shields armor values in classic are unaffected by their material type.
                 int[] values = { 0, 0, 0, 0, 0, 0, 0 }; // shield's effect on the 7 armor values
+                int armorBonus = armor.GetShieldArmorValue();
+                BodyParts[] protectedBodyParts = armor.GetShieldProtectedBodyParts();
 
-                if (armor.TemplateIndex == (int)Armor.Buckler)
+                foreach (var BodyParts in protectedBodyParts)
                 {
-                    values[2] = 1; // left arm
-                    values[4] = 1; // gloves
-                }
-                else if (armor.TemplateIndex == (int)Armor.Round_Shield)
-                {
-                    values[2] = 2; // left arm
-                    values[4] = 2; // gloves
-                    values[5] = 2; // legs armor
-                }
-                else if (armor.TemplateIndex == (int)Armor.Kite_Shield)
-                {
-                    values[2] = 3; // left arm
-                    values[4] = 3; // gloves
-                    values[5] = 3; // legs armor
-                }
-                else if (armor.TemplateIndex == (int)Armor.Tower_Shield)
-                {
-                    values[0] = 4; // head
-                    values[2] = 4; // left arm
-                    values[4] = 4; // gloves
-                    values[5] = 4; // legs armor
+                    values[(int)BodyParts] = armorBonus;
                 }
 
                 for (int i = 0; i < armorValues.Length; i++)

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -810,6 +810,127 @@ namespace DaggerfallWorkshop.Game.Items
             }
         }
 
+        public int GetShieldArmorValue()
+        {
+            switch (TemplateIndex)
+            {
+                case (int)Armor.Buckler:
+                    return 1;
+                case (int)Armor.Round_Shield:
+                    return 2;
+                case (int)Armor.Kite_Shield:
+                    return 3;
+                case (int)Armor.Tower_Shield:
+                    return 4;
+
+                default:
+                    return 0;
+            }
+        }
+
+        /// <summary>
+        /// Get body parts protected by a shield.
+        /// </summary>
+        public BodyParts[] GetShieldProtectedBodyParts()
+        {
+            switch (TemplateIndex)
+            {
+                case (int)Armor.Buckler:
+                    return new BodyParts[] { BodyParts.LeftArm, BodyParts.Hands };
+                case (int)Armor.Round_Shield:
+                case (int)Armor.Kite_Shield:
+                    return new BodyParts[] { BodyParts.LeftArm, BodyParts.Hands, BodyParts.Legs };
+                case (int)Armor.Tower_Shield:
+                    return new BodyParts[] { BodyParts.Head, BodyParts.LeftArm, BodyParts.Hands, BodyParts.Legs };
+
+                default:
+                    return new BodyParts[] { };
+            }
+        }
+
+        /// <summary>
+        /// Get the equip slot that matches to a body part.
+        /// Used in armor calculations.
+        /// </summary>
+        public static EquipSlots GetEquipSlotForBodyPart(BodyParts bodyPart)
+        {
+            switch (bodyPart)
+            {
+                case BodyParts.Head:
+                    return EquipSlots.Head;
+                case BodyParts.RightArm:
+                    return EquipSlots.RightArm;
+                case BodyParts.LeftArm:
+                    return EquipSlots.LeftArm;
+                case BodyParts.Chest:
+                    return EquipSlots.ChestArmor;
+                case BodyParts.Hands:
+                    return EquipSlots.Gloves;
+                case BodyParts.Legs:
+                    return EquipSlots.LegsArmor;
+                case BodyParts.Feet:
+                    return EquipSlots.Feet;
+
+                default:
+                    return EquipSlots.None;
+            }
+        }
+
+        /// <summary>
+        /// Get the body part that matches to an equip slot.
+        /// Used in armor calculations.
+        /// </summary>
+        public static BodyParts GetBodyPartForEquipSlot(EquipSlots equipSlot)
+        {
+            switch (equipSlot)
+            {
+                case EquipSlots.Head:
+                    return BodyParts.Head;
+                case EquipSlots.RightArm:
+                    return BodyParts.RightArm;
+                case EquipSlots.LeftArm:
+                    return BodyParts.LeftArm;
+                case EquipSlots.ChestArmor:
+                    return BodyParts.Chest;
+                case EquipSlots.Gloves:
+                    return BodyParts.Hands;
+                case EquipSlots.LegsArmor:
+                    return BodyParts.Legs;
+                case EquipSlots.Feet:
+                    return BodyParts.Feet;
+
+                default:
+                    return BodyParts.None;
+            }
+        }
+
+        public void DamageThroughPhysicalHit(int damage, DaggerfallEntity owner)
+        {
+            int amount = (10 * damage + 50) / 100;
+            if ((amount == 0) && UnityEngine.Random.Range(1, 100 + 1) < 20)
+                amount = 1;
+            currentCondition -= amount;
+            if (currentCondition <= 0)
+            {
+                ItemBreaks(owner);
+            }
+        }
+
+        public void ItemBreaks(DaggerfallEntity owner)
+        {
+            // Classic does not have the plural version of this string, and uses the short name rather than the long one.
+            // Also the classic string says "is" instead of "has"
+            string itemBroke = "";
+            if (TemplateIndex == (int)Armor.Boots || TemplateIndex == (int)Armor.Gauntlets || TemplateIndex == (int)Armor.Greaves)
+                itemBroke = UserInterfaceWindows.HardStrings.itemHasBrokenPlural;
+            else
+                itemBroke = UserInterfaceWindows.HardStrings.itemHasBroken;
+            itemBroke = itemBroke.Replace("%s", LongName);
+            DaggerfallUI.Instance.PopupMessage(itemBroke);
+            EquipSlots slot = owner.ItemEquipTable.GetEquipSlot(this);
+            if (owner.ItemEquipTable.GetItem(slot) == this)
+                owner.ItemEquipTable.UnequipItem(slot);
+        }
 
         /// <summary>
         /// Link this DaggerfallUnityItem to a quest Item resource.

--- a/Assets/Scripts/Game/Items/ItemEnums.cs
+++ b/Assets/Scripts/Game/Items/ItemEnums.cs
@@ -136,6 +136,21 @@ namespace DaggerfallWorkshop.Game.Items
         Feet = 26,              // Boots / Shoes / Sandals / etc.
     }
 
+    /// <summary>
+    /// Body parts, used for armor value calculations.
+    /// </summary>
+    public enum BodyParts
+    {
+        None = -1,
+        Head = 0,
+        RightArm = 1,
+        LeftArm = 2,
+        Chest = 3,
+        Hands = 4,
+        Legs = 5,
+        Feet = 6,
+    }
+
     public enum Drugs //checked
     {
         Indulcet = 78,

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1258,6 +1258,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void EquipItem(DaggerfallUnityItem item)
         {
+            const int itemBrokenTextId = 29;
+
+            if (item.currentCondition < 1)
+            {
+                TextFile.Token[] tokens = DaggerfallUnity.TextProvider.GetRSCTokens(itemBrokenTextId);
+                if (tokens != null && tokens.Length > 0)
+                {
+                    DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
+                    messageBox.SetTextTokens(tokens);
+                    messageBox.ClickAnywhereToClose = true;
+                    messageBox.Show();
+                }
+                return;
+            }
+
             if (playerEntity.ItemEquipTable.EquipItem(item) && item.ItemGroup == ItemGroups.Armor)
             {
                 playerEntity.UpdateEquippedArmorValues(item, true);

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -33,6 +33,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string leftHandEquipped = "Left hand equipped.";
         public const string usingRightHand = "Using weapon in right hand.";
         public const string usingLeftHand = "Using weapon in left hand.";
+        public const string itemHasBroken = "%s has broken.";
+        public const string itemHasBrokenPlural = "%s have broken.";
 
         public const string enterSaveName = "Enter save name";
         public const string selectSaveName = "Select a save";


### PR DESCRIPTION
Weapons and armor take damage now.

For now at least, I've copied classic behavior of only damaging non-magical weapons and armor when a damage-causing hit is made with a weapon. I know Morrowind has the same thing where creature hits don't damage armor, so this may have been a conscious decision.

I found what seems to be an oversight in classic, in that there is no code for damaging shields, only the weapons and the armor on the body part that gets hit, so I introduced an attempt at adding shield damage in. Going on the assumption that an attacked target first tries to avoid an attack completely with agility, luck, etc. and then uses their shield and then any armor equipped under the shield, I put in a "what if" calculation that looks at whether the attack gets avoided at the shield stage, in which case the shield takes damage. If the attack is not avoided, the armor worn underneath takes damage.

As part of putting that in, I needed to refactor some stuff for getting shield armor values (or else there would have been duplicate code), which makes the PR a little bigger.

I named the damage function DamageThroughPhysicalHit. Classic uses a separate function for damaging magic items when you use them, and we might, too.

The damage to items is done with the same calculation as classic. A message appears for the player and and also for enemies when an item breaks, which I think would also happen in classic, but I didn't test enemy. Item is unequipped from both player and enemy when it breaks.

I improved the message when an item breaks to show the long name of the item rather than the short name, and to be grammatically correct ("have" for boots, gauntlets and greaves) and say "has/have" broken rather than "is" broken. I noted the difference from classic in a comment.