### PR TITLE
Transport menu - ship basics

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2017 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -106,6 +106,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public PlayerEntityData_v1 playerEntity;
         public bool weaponDrawn;
         public TransportModes transportMode;
+        public PlayerPositionData_v1 boardShipPosition;  // Holds the player position from before boarding a ship.
     }
 
     [fsObject("v1")]

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -123,23 +123,14 @@ namespace DaggerfallWorkshop.Game.Serialization
             data.playerEntity.globalVars = entity.GlobalVars.SerializeGlobalVars();
 
             // Store player position data
-            data.playerPosition = new PlayerPositionData_v1();
-            data.playerPosition.position = transform.position;
-            data.playerPosition.yaw = playerMouseLook.Yaw;
-            data.playerPosition.pitch = playerMouseLook.Pitch;
-            data.playerPosition.isCrouching = playerMotor.IsCrouching;
-            data.playerPosition.worldPosX = StreamingWorld.LocalPlayerGPS.WorldX;
-            data.playerPosition.worldPosZ = StreamingWorld.LocalPlayerGPS.WorldZ;
-            data.playerPosition.insideDungeon = playerEnterExit.IsPlayerInsideDungeon;
-            data.playerPosition.insideBuilding = playerEnterExit.IsPlayerInsideBuilding;
-            data.playerPosition.terrainSamplerName = DaggerfallUnity.Instance.TerrainSampler.ToString();
-            data.playerPosition.terrainSamplerVersion = DaggerfallUnity.Instance.TerrainSampler.Version;
-            data.playerPosition.weather = GameManager.Instance.WeatherManager.PlayerWeather.WeatherType;
+            data.playerPosition = GetPlayerPositionData();
 
             // Store weapon state
             data.weaponDrawn = !weaponManager.Sheathed;
             // Store transport mode
             data.transportMode = transportManager.TransportMode;
+            // Store pre boarding ship position
+            data.boardShipPosition = transportManager.BoardShipPosition;
 
             // Store building exterior door data
             if (playerEnterExit.IsPlayerInsideBuilding)
@@ -148,6 +139,23 @@ namespace DaggerfallWorkshop.Game.Serialization
             }
 
             return data;
+        }
+
+        public PlayerPositionData_v1 GetPlayerPositionData()
+        {
+            PlayerPositionData_v1 playerPosition = new PlayerPositionData_v1();
+            playerPosition.position = transform.position;
+            playerPosition.yaw = playerMouseLook.Yaw;
+            playerPosition.pitch = playerMouseLook.Pitch;
+            playerPosition.isCrouching = playerMotor.IsCrouching;
+            playerPosition.worldPosX = StreamingWorld.LocalPlayerGPS.WorldX;
+            playerPosition.worldPosZ = StreamingWorld.LocalPlayerGPS.WorldZ;
+            playerPosition.insideDungeon = playerEnterExit.IsPlayerInsideDungeon;
+            playerPosition.insideBuilding = playerEnterExit.IsPlayerInsideBuilding;
+            playerPosition.terrainSamplerName = DaggerfallUnity.Instance.TerrainSampler.ToString();
+            playerPosition.terrainSamplerVersion = DaggerfallUnity.Instance.TerrainSampler.Version;
+            playerPosition.weather = GameManager.Instance.WeatherManager.PlayerWeather.WeatherType;
+            return playerPosition;
         }
 
         public object GetFactionSaveData()
@@ -249,16 +257,23 @@ namespace DaggerfallWorkshop.Game.Serialization
             // Restore player position
             if (restorePlayerPosition)
             {
-                transform.position = data.playerPosition.position;
-                playerMouseLook.Yaw = data.playerPosition.yaw;
-                playerMouseLook.Pitch = data.playerPosition.pitch;
-                playerMotor.IsCrouching = data.playerPosition.isCrouching;
+                RestorePosition(data.playerPosition);
             }
 
             // Restore sheath state
             weaponManager.Sheathed = !data.weaponDrawn;
             // Restore transport mode
             transportManager.TransportMode = data.transportMode;
+            // Restore pre boarding ship position
+            transportManager.BoardShipPosition = data.boardShipPosition;
+        }
+
+        public void RestorePosition(PlayerPositionData_v1 positionData)
+        {
+            transform.position = positionData.position;
+            playerMouseLook.Yaw = positionData.yaw;
+            playerMouseLook.Pitch = positionData.pitch;
+            playerMotor.IsCrouching = positionData.isCrouching;
         }
 
         #endregion

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -58,7 +58,6 @@ namespace DaggerfallWorkshop.Game
         // TODO: Move into ImageHelper? (duplicated in FPSWeapon & DaggerfallVidPlayerWindow)
         const int nativeScreenHeight = 200;
 
-        // TODO: It would be better to define an event and have PlayerMotor listen, instead of having this dependency. (again, promised light touch on PM)
         PlayerMotor playerMotor;
         DaggerfallAudioSource dfAudioSource;
         AudioSource ridingAudioSource;
@@ -201,14 +200,20 @@ namespace DaggerfallWorkshop.Game
                 // Is player on board ship?
                 if (boardShipPosition != null)
                 {
+                    // Check for terrain sampler changes. (so don't fall through floor)
+                    StreamingWorld.RepositionMethods reposition = StreamingWorld.RepositionMethods.None;
+                    if (boardShipPosition.terrainSamplerName != DaggerfallUnity.Instance.TerrainSampler.ToString() ||
+                        boardShipPosition.terrainSamplerVersion != DaggerfallUnity.Instance.TerrainSampler.Version)
+                    {
+                        reposition = StreamingWorld.RepositionMethods.RandomStartMarker;
+                        if (DaggerfallUI.Instance.DaggerfallHUD != null)
+                            DaggerfallUI.Instance.DaggerfallHUD.PopupText.AddText("Terrain sampler changed. Repositioning player.");
+                    }
                     // Restore player position from before boarding ship.
                     DFPosition mapPixel = MapsFile.WorldCoordToMapPixel(boardShipPosition.worldPosX, boardShipPosition.worldPosZ);
-                    GameManager.Instance.StreamingWorld.TeleportToCoordinates(mapPixel.X, mapPixel.Y, StreamingWorld.RepositionMethods.None);
+                    GameManager.Instance.StreamingWorld.TeleportToCoordinates(mapPixel.X, mapPixel.Y, reposition);
                     serializablePlayer.RestorePosition(boardShipPosition);
                     boardShipPosition = null;
-                    // Alternate method:
-                    //PlayerEnterExit playerEnterExit = GetComponent<PlayerEnterExit>();
-                    //playerEnterExit.RespawnPlayer(boardShipPosition.worldPosX, boardShipPosition.worldPosZ, false, false);
                 }
                 else
                 {

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -7,6 +7,9 @@
 
 using UnityEngine;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallConnect.Arena2;
+using DaggerfallConnect.Utility;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -15,7 +18,7 @@ namespace DaggerfallWorkshop.Game
         Foot,
         Horse,
         Cart,
-//        Ship  // (not a real player transport mode)
+        Ship  // (not a real player transport mode)
     }
 
     public class TransportManager : MonoBehaviour
@@ -34,7 +37,15 @@ namespace DaggerfallWorkshop.Game
             get { return mode == TransportModes.Foot; }
         }
 
+        public PlayerPositionData_v1 BoardShipPosition
+        {
+            get { return boardShipPosition; }
+            set { boardShipPosition = value; }
+        }
+
         private TransportModes mode = TransportModes.Foot;
+        private PlayerPositionData_v1 boardShipPosition;    // Holds the player position from before boarding a ship.
+
 
         const string horseTextureName = "MRED00I0.CFA";
         const string cartTextureName = "MRED01I0.CFA";
@@ -179,6 +190,36 @@ namespace DaggerfallWorkshop.Game
             {
                 // Tell player motor we're not riding.
                 playerMotor.IsRiding = false;
+            }
+
+            if (mode == TransportModes.Ship)
+            {
+                GameManager.Instance.PlayerMotor.CancelMovement = true;
+                SerializablePlayer serializablePlayer = GetComponent<SerializablePlayer>();
+                DaggerfallUI.Instance.SmashHUDToBlack();
+
+                // Is player on board ship?
+                if (boardShipPosition != null)
+                {
+                    // Restore player position from before boarding ship.
+                    DFPosition mapPixel = MapsFile.WorldCoordToMapPixel(boardShipPosition.worldPosX, boardShipPosition.worldPosZ);
+                    GameManager.Instance.StreamingWorld.TeleportToCoordinates(mapPixel.X, mapPixel.Y, StreamingWorld.RepositionMethods.None);
+                    serializablePlayer.RestorePosition(boardShipPosition);
+                    boardShipPosition = null;
+                    // Alternate method:
+                    //PlayerEnterExit playerEnterExit = GetComponent<PlayerEnterExit>();
+                    //playerEnterExit.RespawnPlayer(boardShipPosition.worldPosX, boardShipPosition.worldPosZ, false, false);
+                }
+                else
+                {
+                    // Record current player position before boarding ship.
+                    boardShipPosition = serializablePlayer.GetPlayerPositionData();
+
+                    // Teleport to ship
+                    GameManager.Instance.StreamingWorld.TeleportToCoordinates(2, 2, StreamingWorld.RepositionMethods.RandomStartMarker);
+                }
+                DaggerfallUI.Instance.FadeHUDFromBlack();
+                mode = TransportModes.Foot;
             }
         }
     }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -73,7 +73,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             ItemCollection inventory = GameManager.Instance.PlayerEntity.Items;
             bool hasHorse = inventory.Contains(ItemGroups.Transportation, (int) Transportation.Horse);
             bool hasCart = inventory.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart);
-            bool hasShip = false;
+            bool hasShip = true;    // Does ship deed go in inventory, or is it a global var?
 
             // Load all textures
             LoadTextures();
@@ -110,7 +110,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             } else {
                 shipButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, shipDisabledRect);
             }
-            shipButton.BackgroundColor = DaggerfallUI.DaggerfallUnityNotImplementedColor;
 
             // Exit button
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
@@ -153,11 +152,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
 
         private void CartButton_OnMouseClick(BaseScreenComponent sender, Vector2 position) {
+            // Change to riding a cart.
             GameManager.Instance.TransportManager.TransportMode = TransportModes.Cart;
             CloseWindow();
         }
 
         private void ShipButton_OnMouseClick(BaseScreenComponent sender, Vector2 position) {
+            // Teleport to your ship, or back.
+            GameManager.Instance.TransportManager.TransportMode = TransportModes.Ship;
             CloseWindow();
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Items;
+using DaggerfallWorkshop.Game.Banking;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -73,7 +74,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             ItemCollection inventory = GameManager.Instance.PlayerEntity.Items;
             bool hasHorse = inventory.Contains(ItemGroups.Transportation, (int) Transportation.Horse);
             bool hasCart = inventory.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart);
-            bool hasShip = true;    // Does ship deed go in inventory, or is it a global var?
+            bool hasShip = DaggerfallBankManager.OwnsShip;
 
             // Load all textures
             LoadTextures();

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2017 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -1233,7 +1233,8 @@ namespace DaggerfallWorkshop
                 origin,
                 width,
                 height,
-                (currentLocation.Summary.LocationType == DFRegion.LocationTypes.TownCity));
+                (currentLocation.Summary.LocationType == DFRegion.LocationTypes.TownCity ||
+                currentLocation.Summary.LocationType == DFRegion.LocationTypes.HomeYourShips));
         }
 
         // Sets player to ground level near a location


### PR DESCRIPTION
Enabled ship option of transport menu.

Teleports to ship at 2,2
Stores player boarding position for transport back.
Saves and loads boarding position.
Handles terrain sampler changes on stored position.

Would like to do other ships but no idea where they are in gameworld, so they can wait.
