### PR TITLE
Adjust monster speeds

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -10,6 +10,7 @@
 //
 
 using UnityEngine;
+using DaggerfallWorkshop.Game.Entity;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -23,8 +24,6 @@ namespace DaggerfallWorkshop.Game
     [RequireComponent(typeof(CharacterController))]
     public class EnemyMotor : MonoBehaviour
     {
-        public float MoveSpeed = 5f;                // Speed enemy can move towards target using SimpleMove()
-        public float FlySpeed = 5f;                 // Speed enemy can fly towards target using Move()
         public float OpenDoorDistance = 2f;         // Maximum distance to open door
         public float GiveUpTime = 4f;               // Time in seconds enemy will give up if target is unreachable
 
@@ -32,6 +31,7 @@ namespace DaggerfallWorkshop.Game
         Vector3 targetPos;
         CharacterController controller;
         DaggerfallMobileUnit mobile;
+        DaggerfallEntityBehaviour entityBehaviour;
 
         float stopDistance = 1.7f;                  // Used to prevent orbiting
         Vector3 lastTargetPos;                      // Target from previous update
@@ -55,6 +55,7 @@ namespace DaggerfallWorkshop.Game
             flies = mobile.Summary.Enemy.Behaviour == MobileBehaviour.Flying ||
                     mobile.Summary.Enemy.Behaviour == MobileBehaviour.Spectral;
             enemyLayerMask = LayerMask.GetMask("Enemies");
+            entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
         }
 
         void Update()
@@ -191,7 +192,10 @@ namespace DaggerfallWorkshop.Game
             if (distance > stopDistance)
             {
                 mobile.ChangeEnemyState(MobileStates.Move);
-                var motion = transform.forward * (flies ? FlySpeed : MoveSpeed);
+
+                // Monster speed of movement follows the same formula as for when the player walks
+                EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
+                var motion = transform.forward * ((entity.Stats.Speed + PlayerMotor.dfWalkBase) / PlayerMotor.classicToUnitySpeedUnitRatio);
 
                 // Prevent rat stacks (enemies don't stand on shorter enemies)
                 AvoidEnemies(ref motion);

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -15,7 +15,7 @@ namespace DaggerfallWorkshop.Game
     {
         // Daggerfall base speed constants. (courtesy Allofich)
         public const float classicToUnitySpeedUnitRatio = 39.5f; // was estimated from comparing a walk over the same distance in classic and DF Unity
-        private const float dfWalkBase = 150f;
+        public const float dfWalkBase = 150f;
         private const float dfCrouchBase = 50f;
         private const float dfRideBase = dfWalkBase + 225f;
         private const float dfCartBase = dfWalkBase + 100f;

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -24,7 +24,7 @@ namespace DaggerfallWorkshop.Utility
 
         // Speeds in frames-per-second
         public static int MoveAnimSpeed = 7;
-        public static int PrimaryAttackAnimSpeed = 6;
+        public static int PrimaryAttackAnimSpeed = 8;
         public static int HurtAnimSpeed = 4;
         public static int IdleAnimSpeed = 4;
         public static int RangedAttack1AnimSpeed = 6;


### PR DESCRIPTION
Monster speed is the same formula as the player has when walking.

Also bumped up monster attack animation to be closer to classic. The speed of the swing in classic is not dependent on the monster's speed, and I think it may vary depending on the speed of the computer (or the "cycles" in DosBox), but I put it at what seems to me like a reasonable value that doesn't look overly fast.

I was also looking at adjusting the point in the animation swing where damage is applied. Interestingly, it seems like it varies by enemy in classic. Also I noticed, for example, that the imp plays its attack animation forward and then backward in classic. I don't know where this information is stored, though.