### PR TITLE
Multi popups and item name fixes

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -85,7 +85,6 @@ namespace DaggerfallWorkshop.Game
         DaggerfallBookReaderWindow dfBookReaderWindow;
         DaggerfallQuestJournalWindow dfQuestJournalWindow;
         QuestMachineInspectorWindow dfQuestInspector;
-        DaggerfallMessageBox dfStatusBox;
 
         DaggerfallFontPlus fontPetrock32;
 

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -85,6 +85,7 @@ namespace DaggerfallWorkshop.Game
         DaggerfallBookReaderWindow dfBookReaderWindow;
         DaggerfallQuestJournalWindow dfQuestJournalWindow;
         QuestMachineInspectorWindow dfQuestInspector;
+        DaggerfallMessageBox dfStatusBox;
 
         DaggerfallFontPlus fontPetrock32;
 
@@ -377,7 +378,7 @@ namespace DaggerfallWorkshop.Game
                     uiManager.PushWindow(dfQuestJournalWindow);
                     break;
                 case DaggerfallUIMessages.dfuiStatusInfo:
-                    MessageBox(22);
+                    DisplayStatusInfo();
                     break;
                 case DaggerfallUIMessages.dfuiExitGame:
 #if UNITY_EDITOR
@@ -966,6 +967,21 @@ namespace DaggerfallWorkshop.Game
         #endregion
 
         #region Private Methods
+
+        void DisplayStatusInfo()
+        {
+            // Setup status info as the first message box.
+            DaggerfallMessageBox statusBox = new DaggerfallMessageBox(Instance.uiManager, Instance.uiManager.TopWindow);
+            statusBox.SetTextTokens(22);
+
+            // Setup health info as the second message box.
+            DaggerfallMessageBox healthBox = new DaggerfallMessageBox(uiManager, statusBox);
+            healthBox.SetTextTokens(18);    // TODO: Various diseases are in msgs 100-117
+            healthBox.ClickAnywhereToClose = true;
+            statusBox.AddNextMessageBox(healthBox);
+
+            statusBox.Show();
+        }
 
         void TickFade()
         {

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -163,19 +163,19 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
-        /// Resolve this item's full name (mainly for tooltips).
+        /// Resolve this item's name.
         /// </summary>
-        public string LongName
+        public string ItemName
         {
             get { return DaggerfallUnity.Instance.ItemHelper.ResolveItemName(this); }
         }
 
         /// <summary>
-        /// Resolve this item's title name (mainly for info popups).
+        /// Resolve this item's full name (mainly for tooltips).
         /// </summary>
-        public string TitleName
+        public string LongName
         {
-            get { return DaggerfallUnity.Instance.ItemHelper.ResolveItemTitleName(this); }
+            get { return DaggerfallUnity.Instance.ItemHelper.ResolveItemLongName(this); }
         }
 
         /// <summary>
@@ -234,6 +234,14 @@ namespace DaggerfallWorkshop.Game.Items
         public bool IsShield
         {
             get { return GetIsShield(); }
+        }
+
+        /// <summary>
+        /// Checks if this item is identified.
+        /// </summary>
+        public bool IsIdentified
+        {
+            get { return GetIsIdentified(); }
         }
 
         /// <summary>
@@ -1273,6 +1281,15 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             return false;
+        }
+
+        // Check if this item is identified. (only relevant if legacymagic != null)
+        bool GetIsIdentified()
+        {
+            if (legacyMagic == null)
+                return true;
+            const ushort identifiedMask = 32;
+            return (flags & identifiedMask) > 0;
         }
 
         // Determines if world texture should be displayed in place of player texture

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -7,6 +7,7 @@
 
 using System;
 using DaggerfallWorkshop.Utility;
+using DaggerfallConnect.Arena2;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -83,6 +84,14 @@ namespace DaggerfallWorkshop.Game.Items
             public override string ArmourMod()
             {   // %mod
                 return parent.GetMaterialArmorValue().ToString("+0;-0;0");
+            }
+
+            public override string BookAuthor()
+            {   // %ba
+                BookFile bookFile = new BookFile();
+                bookFile.OpenBook(DaggerfallUnity.Instance.Arena2Path, BookFile.messageToBookFilename(parent.message));
+                // Should the bookfile get closed?
+                return bookFile.Author;
             }
         }
     }

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -33,7 +33,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             public override string ItemName()
             {
-                return parent.TitleName;
+                return parent.ItemName;
             }
 
             public override string Worth()
@@ -46,9 +46,9 @@ namespace DaggerfallWorkshop.Game.Items
                 switch (parent.itemGroup)
                 {
                     case ItemGroups.Armor:
-                        return ((ArmorMaterialTypes)parent.nativeMaterialValue).ToString();
+                        return DaggerfallUnity.Instance.TextProvider.GetArmorMaterialName((ArmorMaterialTypes) parent.nativeMaterialValue);
                     case ItemGroups.Weapons:
-                        return ((WeaponMaterialTypes)parent.nativeMaterialValue).ToString();
+                        return DaggerfallUnity.Instance.TextProvider.GetWeaponMaterialName((WeaponMaterialTypes) parent.nativeMaterialValue);
                     default:
                         return base.Material();
                 }
@@ -70,7 +70,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             public override string Weight()
             {   // %kg
-                return parent.weightInKg.ToString();
+                return (parent.weightInKg * parent.stackCount).ToString();
             }
 
             public override string WeaponDamage()

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -8,6 +8,7 @@
 using System;
 using DaggerfallWorkshop.Utility;
 using DaggerfallConnect.Arena2;
+using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -93,6 +94,26 @@ namespace DaggerfallWorkshop.Game.Items
                 // Should the bookfile get closed?
                 return bookFile.Author;
             }
+
+            // TODO: Update once magic effects have been implemented. (just puts "Power number N" for now)
+            public override TextFile.Token[] MagicPowers(TextFile.Formatting format)
+            {   // %mpw
+                List<TextFile.Token> magicPowersTokens = new List<TextFile.Token>();
+                for (int i = 0; i < parent.legacyMagic.Length; i++)
+                {
+                    if (parent.legacyMagic[i] == 0xffff)
+                        break;
+                    TextFile.Token powerToken = new TextFile.Token();
+                    powerToken.text = "Power number " + parent.legacyMagic[i];
+                    powerToken.formatting = TextFile.Formatting.Text;
+                    magicPowersTokens.Add(powerToken);
+                    TextFile.Token formatToken = new TextFile.Token();
+                    formatToken.formatting = format;
+                    magicPowersTokens.Add(formatToken);
+                }
+                return magicPowersTokens.ToArray();
+            }
+
         }
     }
 }

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -9,6 +9,7 @@ using System;
 using DaggerfallWorkshop.Utility;
 using DaggerfallConnect.Arena2;
 using System.Collections.Generic;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -95,23 +96,37 @@ namespace DaggerfallWorkshop.Game.Items
                 return bookFile.Author;
             }
 
-            // TODO: Update once magic effects have been implemented. (just puts "Power number N" for now)
             public override TextFile.Token[] MagicPowers(TextFile.Formatting format)
             {   // %mpw
-                List<TextFile.Token> magicPowersTokens = new List<TextFile.Token>();
-                for (int i = 0; i < parent.legacyMagic.Length; i++)
+                if (!parent.IsIdentified)
                 {
-                    if (parent.legacyMagic[i] == 0xffff)
-                        break;
-                    TextFile.Token powerToken = new TextFile.Token();
-                    powerToken.text = "Power number " + parent.legacyMagic[i];
-                    powerToken.formatting = TextFile.Formatting.Text;
-                    magicPowersTokens.Add(powerToken);
-                    TextFile.Token formatToken = new TextFile.Token();
-                    formatToken.formatting = format;
-                    magicPowersTokens.Add(formatToken);
+                    // Powers unknown.
+                    TextFile.Token nopowersToken = new TextFile.Token();
+                    nopowersToken.text = HardStrings.powersUnknown;
+                    nopowersToken.formatting = TextFile.Formatting.Text;
+                    return new TextFile.Token[] { nopowersToken };
                 }
-                return magicPowersTokens.ToArray();
+                else
+                {
+                    // List item powers. 
+                    // TODO: Update once magic effects have been implemented. (just puts "Power number N" for now)
+                    // Pretty sure low numbers are type of application, and higher ones are effects.
+                    // e.g. shield of fortitude is [1, 87] which maps to "Cast when held: Fortitude" in classic.
+                    List<TextFile.Token> magicPowersTokens = new List<TextFile.Token>();
+                    for (int i = 0; i < parent.legacyMagic.Length; i++)
+                    {
+                        if (parent.legacyMagic[i] == 0xffff)
+                            break;
+                        TextFile.Token powerToken = new TextFile.Token();
+                        powerToken.text = "Power number " + parent.legacyMagic[i];
+                        powerToken.formatting = TextFile.Formatting.Text;
+                        magicPowersTokens.Add(powerToken);
+                        TextFile.Token formatToken = new TextFile.Token();
+                        formatToken.formatting = format;
+                        magicPowersTokens.Add(formatToken);
+                    }
+                    return magicPowersTokens.ToArray();
+                }
             }
 
         }

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -139,10 +139,14 @@ namespace DaggerfallWorkshop.Game.Items
             // Get item template
             ItemTemplate template = item.ItemTemplate;
 
-            // Return just the template name if item is unidentified.
-            if (!item.IsIdentified)
+            // Return just the template name if item is unidentified or an Artifact.
+            if (!item.IsIdentified || item.ItemGroup == ItemGroups.Artifacts)
                 return template.name;
-            
+
+            // Books are handled differently
+            if (item.ItemGroup == ItemGroups.Books)
+                return DaggerfallUnity.Instance.ItemHelper.getBookNameByMessage(item.message, item.shortName);
+
             // Start with base name
             string result = item.shortName;
 

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -132,51 +132,48 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
-        /// Resolves full item name using parameters like %it and material type.
+        /// Resolves full item name using parameters like %it.
         /// </summary>
         public string ResolveItemName(DaggerfallUnityItem item)
         {
-            // Start with base name
-            string result = item.shortName;
-
             // Get item template
             ItemTemplate template = item.ItemTemplate;
 
+            // Return just the template name if item is unidentified.
+            if (!item.IsIdentified)
+                return template.name;
+            
+            // Start with base name
+            string result = item.shortName;
+
             // Resolve %it parameter
             result = result.Replace("%it", template.name);
-
-            // Resolve weapon material
-            if (item.ItemGroup == ItemGroups.Weapons)
-            {
-                WeaponMaterialTypes weaponMaterial = (WeaponMaterialTypes)item.nativeMaterialValue;
-                string materialName = DaggerfallUnity.Instance.TextProvider.GetWeaponMaterialName(weaponMaterial);
-                result = string.Format("{0} {1}", materialName, result);
-            }
-
-            // Resolve armor material
-            if (item.ItemGroup == ItemGroups.Armor)
-            {
-                ArmorMaterialTypes armorMaterial = (ArmorMaterialTypes)item.nativeMaterialValue;
-                string materialName = DaggerfallUnity.Instance.TextProvider.GetArmorMaterialName(armorMaterial);
-                result = string.Format("{0} {1}", materialName, result);
-            }
 
             return result;
         }
 
         /// <summary>
-        /// Resolves item title name using parameters like %it, but does not prepend material name.
+        /// Resolves full item name using parameters like %it and material type.
         /// </summary>
-        public string ResolveItemTitleName(DaggerfallUnityItem item)
+        public string ResolveItemLongName(DaggerfallUnityItem item)
         {
-            // Start with base name
-            string result = item.shortName;
+            string result = ResolveItemName(item);
 
-            // Get item template
-            ItemTemplate template = item.ItemTemplate;
+            // Resolve weapon material
+            if (item.ItemGroup == ItemGroups.Weapons && item.TemplateIndex != (int) Weapons.Arrow)
+            {
+                WeaponMaterialTypes weaponMaterial = (WeaponMaterialTypes) item.nativeMaterialValue;
+                string materialName = DaggerfallUnity.Instance.TextProvider.GetWeaponMaterialName(weaponMaterial);
+                result = string.Format("{0} {1}", materialName, result);
+            }
 
-            // Resolve %it parameter
-            result = result.Replace("%it", template.name);
+            // Resolve armor material
+            if (item.ItemGroup == ItemGroups.Armor && !item.IsShield && item.TemplateIndex != (int) Armor.Helm)
+            {
+                ArmorMaterialTypes armorMaterial = (ArmorMaterialTypes) item.nativeMaterialValue;
+                string materialName = DaggerfallUnity.Instance.TextProvider.GetArmorMaterialName(armorMaterial);
+                result = string.Format("{0} {1}", materialName, result);
+            }
 
             return result;
         }

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceManager.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceManager.cs
@@ -191,8 +191,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             UserInterfaceWindow oldWindow = TopWindow;
             if (oldWindow != null)
             {
-                oldWindow.OnPop();
                 windows.Pop();
+                oldWindow.OnPop();
                 if (TopWindow != null)
                     TopWindow.OnReturn();
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1417,8 +1417,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
                 messageBox.SetTextTokens(tokens, item);
-                messageBox.ClickAnywhereToClose = true;
-                messageBox.Show();
+                if (item.legacyMagic == null)
+                {
+                    messageBox.ClickAnywhereToClose = true;
+                    messageBox.Show();
+                }
+                else
+                {   // Setup the next message box with the magic effect info.
+                    DaggerfallMessageBox messageBoxMagic = new DaggerfallMessageBox(uiManager, messageBox);
+                    messageBoxMagic.SetTextTokens(1016, item);
+                    messageBoxMagic.ClickAnywhereToClose = true;
+
+                    messageBox.AddNextMessageBox(messageBoxMagic);
+                    messageBox.Show();
+                }
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -951,14 +951,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     remoteItemsStackLabels[i].Text = item.stackCount.ToString();
 
                 // Tooltip text
-                string text;
-                if (item.ItemGroup == ItemGroups.Books)
-                {
-                    text = DaggerfallUnity.Instance.ItemHelper.getBookNameByMessage(item.message, item.LongName);
-                } else {
-                    text = item.LongName;
-                }
-                remoteItemsButtons[i].ToolTipText = text;
+                remoteItemsButtons[i].ToolTipText = item.LongName;
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1424,8 +1424,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
                 else
                 {   // Setup the next message box with the magic effect info.
+                    int msgId = 1016;
+                    if (item.ItemGroup == ItemGroups.Artifacts)
+                    {
+                        // Use appropriate artifact description message. (8700-8721)
+                        msgId = 8700 + item.GroupIndex;
+                    }
                     DaggerfallMessageBox messageBoxMagic = new DaggerfallMessageBox(uiManager, messageBox);
-                    messageBoxMagic.SetTextTokens(1016, item);
+                    messageBoxMagic.SetTextTokens(msgId, item);
                     messageBoxMagic.ClickAnywhereToClose = true;
 
                     messageBox.AddNextMessageBox(messageBoxMagic);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -36,6 +36,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         int buttonTextDistance = 4;
         MessageBoxButtons selectedButton = MessageBoxButtons.Cancel;
         bool clickAnywhereToClose = false;
+        DaggerfallMessageBox nextMessageBox;
 
         /// <summary>
         /// Default message box buttons are indices into BUTTONS.RCI.
@@ -150,9 +151,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.OnPop();
             parentPanel.OnMouseClick -= ParentPanel_OnMouseClick;
+
+            // Check if any previous message boxes need to be closed as well.
+            DaggerfallMessageBox prevWindow = PreviousWindow as DaggerfallMessageBox;
+            if (prevWindow != null && prevWindow.nextMessageBox != null)
+                prevWindow.nextMessageBox.CloseWindow();
         }
 
         #region Public Methods
+
+        /// <summary>
+        /// Adds another nested message box to be displayed next when click detected.
+        /// </summary>
+        /// <param name="nextMessageBox">Next message box.</param>
+        public void AddNextMessageBox(DaggerfallMessageBox nextMessageBox)
+        {
+            this.nextMessageBox = nextMessageBox;
+        }
 
         public void Show()
         {
@@ -335,8 +350,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ParentPanel_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            if (uiManager.TopWindow == this && clickAnywhereToClose)
-                CloseWindow();
+            if (uiManager.TopWindow == this)
+            {
+                if (nextMessageBox != null)
+                    nextMessageBox.Show();
+                else if (clickAnywhereToClose)
+                    CloseWindow();
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -103,5 +103,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public const string cannotChangeTransportationIndoors = "You cannot change transportation indoors.";
         public const string cannotTravelWithEnemiesNearby = "You cannot travel with enemies nearby.";
+
+        public const string powersUnknown = "Powers unknown.";
     }
 }

--- a/Assets/Scripts/Utility/MacroDataSource.cs
+++ b/Assets/Scripts/Utility/MacroDataSource.cs
@@ -95,6 +95,11 @@ namespace DaggerfallWorkshop.Utility
             throw new NotImplementedException();
         }
 
+        public virtual string BookAuthor()
+        {   // %ba
+            throw new NotImplementedException();
+        }
+
         public virtual string Pronoun()
         {   // %g & %g1
             throw new NotImplementedException();

--- a/Assets/Scripts/Utility/MacroDataSource.cs
+++ b/Assets/Scripts/Utility/MacroDataSource.cs
@@ -6,6 +6,7 @@
 // Original Author: Hazelnut
 
 using System;
+using DaggerfallConnect.Arena2;
 
 namespace DaggerfallWorkshop.Utility
 {
@@ -134,6 +135,11 @@ namespace DaggerfallWorkshop.Utility
 
         public virtual string God()
         {   // %god
+            throw new NotImplementedException();
+        }
+
+        public virtual TextFile.Token[] MagicPowers(TextFile.Formatting format)
+        {   // %mpw
             throw new NotImplementedException();
         }
 

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -90,11 +90,11 @@ namespace DaggerfallWorkshop.Utility
             { "%agi", Agi }, //  Amount of Agility
             { "%arm", ItemName }, //  Armour
             { "%ark", AttributeRating }, // What property attribute is considered
-            { "%ba", null },  // Book Author
+            { "%ba", BookAuthor },  // Book Author
             { "%bch", null }, // Base chance
             { "%bdr", null }, // Base Duration
             { "%bn", null },  // ?
-            { "%bt", null },  // Book title
+            { "%bt", ItemName },  // Book title
             { "%cbl", null }, // Cash balance in current region
             { "%clc", null }, // Per level (Chance)
             { "%cld", null }, // Per level (Duration)
@@ -529,6 +529,11 @@ namespace DaggerfallWorkshop.Utility
         public static string ArmourMod(IMacroContextProvider mcp)
         {   // %mod
             return mcp.GetMacroDataSource().ArmourMod();
+        }
+
+        public static string BookAuthor(IMacroContextProvider mcp)
+        {   // %ba
+            return mcp.GetMacroDataSource().BookAuthor();
         }
 
         public static string Pronoun(IMacroContextProvider mcp)

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -5,13 +5,11 @@
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Hazelnut
 
-using UnityEngine;
-using DaggerfallWorkshop.Game;
-using DaggerfallConnect.Arena2;
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
+using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.Player;
-
 
 namespace DaggerfallWorkshop.Utility
 {
@@ -21,50 +19,7 @@ namespace DaggerfallWorkshop.Utility
      * arena2\text.rsc, fall.exe, arena2\*.qrc, or arena2\bio*.txt
      * </summary>
      * 
-     * If any messages displayed in game contain the following markup, this is what needs adding:
-     * %abc[undefined]      -> macro needs adding to <c>macroHandlers</c> list
-     * %abc[unhandled]      -> macro requires handler method name in <c>macroHandlers</c> list
-     * %abc[srcDataUnknown] -> macro context provider object needs handler method adding
-     * 
-     * Adding new macro handlers:
-     * 
-     * Open the file <c>DaggerfallWorkshop.Utility.MacroHelper</c>.
-     * Does the macro need an object instance to provide context? (e.g. item, quest)
-     * 
-     * If no context required:
-     * 1) Find the macro in <c>macroHandlers</c>, if the macro isn't in the list then add it at the bottom. e.g. '%ra'
-     * 2) Define the handler method name, replacing 'null' with it. e.g. 'PlayerRace'
-     * 3) Add a suitable handler method to the region <c>global macro handlers</c>. (mcp will be null so don't use it) e.g.
-     * <code>
-     * private static string PlayerRace(IMacroContextProvider mcp)
-     * {   // %ra
-     *     return GameManager.Instance.PlayerEntity.RaceTemplate.Name;
-     * }
-     * </code>
-     *      
-     * If context required:
-     * 1) Find the macro in <c>macroHandlers</c>, if the macro isn't in the list then add it at the bottom. e.g. '%ra'
-     * 2) Define the handler method name, replacing 'null' with it. e.g. 'PlayerRace'
-     * 3) Add a suitable handler method that delegates to the an <c>MacroDataSource</c> to the region <c>contextual macro handlers</c>. e.g.
-     * <code>
-     * public static string Region(IMacroContextProvider mcp)
-     * {   // %reg
-     *     return mcp.GetMacroDataSource().Region();
-     * }
-     * </code>
-     * 4) Add an unimplemented implementation to the <c>MacroDataSource</c> base class. e.g.
-     * <code>
-     * public virtual string Region()
-     * {   // %reg
-     *     throw new NotImplementedException();
-     * }
-     * </code>
-     * 5) Find the class that will provide the context (named using suffix 'MCP') and override the handler method. (<c>parent</c> refers to the context providing class) e.g.
-     * <code>
-     * public override string Region()
-     * {
-     *     return (parent.LastPersonReferenced != null) ? parent.LastPersonReferenced.HomeRegionName : "";
-     * }
+     * See http://forums.dfworkshop.net/viewtopic.php?f=23&t=673 for details about adding new macro handlers.
      * 
      */
     public static class MacroHelper
@@ -297,7 +252,7 @@ namespace DaggerfallWorkshop.Utility
         /// </summary>
         /// <returns>The expanded macro value.</returns>
         /// <param name="symbolStr">macro symbol string.</param>
-        /// <param name="mcp">an object instance providing context for macro expansion. (optional)</param>
+        /// <param name="mcp">an object instance providing context for macro expansion.</param>
         public static string GetValue(string symbolStr, IMacroContextProvider mcp)
         {
             if (macroHandlers.ContainsKey(symbolStr))
@@ -447,7 +402,7 @@ namespace DaggerfallWorkshop.Utility
         private static string GuildTitle(IMacroContextProvider mcp)
         {   // %pct
             // Just use "Apprentice" for all %pct guild titles for now
-            // Guilds are not implemented yet, will need to move into MacroDataSource
+            // Guilds are not implemented yet, will need to move into a MacroDataSource
             return "Apprentice";
         }
 


### PR DESCRIPTION
- Added identified state to items. (first use of flags)
- Most item names now match classic, including unidentified magic items.
- Artifacts not currently identified by item system but names will be correct once that has been done.
- Tooltips also now match item titles on popups.
- Book title & author now shown on popups.
- DaggerfallMessageBox can now have a next message box added which will be displayed when user clicks. The last message box will close all of them. As far as I know Daggerfall only ever uses 2, but I wrote it so you can nest to any level. (of course) Actually found a couple of the artifacts do use 3! (skele key & mask)
- Add second info popup for health status.
- Implement magic item powers popup using multiline macros. Just displays "Power number N" for each power for now until magic systems implemented and a mapping for the DF spell effect numbers is availiable.