### PR TITLE
Pass down wrapText parameter

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -888,9 +888,9 @@ namespace DaggerfallWorkshop.Game
             return texture;
         }
 
-        public static DaggerfallMessageBox MessageBox(string message, IMacroContextProvider mds = null)
+        public static DaggerfallMessageBox MessageBox(string message, IMacroContextProvider mds = null, bool wrapText = false)
         {
-            DaggerfallMessageBox messageBox = new DaggerfallMessageBox(Instance.uiManager, Instance.uiManager.TopWindow);
+            DaggerfallMessageBox messageBox = new DaggerfallMessageBox(Instance.uiManager, Instance.uiManager.TopWindow, wrapText);
             messageBox.SetText(message);
             messageBox.ClickAnywhereToClose = true;
             messageBox.Show();

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -675,7 +675,7 @@ namespace DaggerfallWorkshop.Game
                 else
                 {
                     string noGoldFound = DaggerfallUnity.Instance.TextProvider.GetRandomText(foundNothingValuableTextId);
-                    DaggerfallUI.MessageBox(noGoldFound);
+                    DaggerfallUI.MessageBox(noGoldFound, null, true);
                 }
             }
             else

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -42,10 +42,25 @@ namespace DaggerfallWorkshop.Game.UserInterface
         int cursorY = 0;
         int tabStop = 0;
 
+        bool wrapText = false;
+        int maxTextWidth = 0;
+
         public PixelFont Font
         {
             get { return GetFont(); }
             set { font = value; }
+        }
+
+        public bool WrapText
+        {
+            get { return wrapText; }
+            set { wrapText = value; }
+        }
+
+        public int MaxTextWidth
+        {
+            get { return maxTextWidth; }
+            set { maxTextWidth = value; }
         }
 
         /// <summary>
@@ -135,7 +150,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// <param name="text">Text for this label.</param>
         /// <param name="font">Font for this label.</param>
         /// <returns>TextLabel.</returns>
-        public TextLabel AddTextLabel(string text, PixelFont font = null, bool wrapText = false, int maxWidth = 0)
+        public TextLabel AddTextLabel(string text, PixelFont font = null)
         {
             if (font == null)
                 font = GetFont();
@@ -144,14 +159,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
             textLabel.AutoSize = AutoSizeModes.None;
             textLabel.Font = font;
             textLabel.Position = new Vector2(cursorX, cursorY);
-            textLabel.Text = text;
-            textLabel.Parent = this;
             textLabel.WrapText = wrapText;
 
-            // Optionally specify max width
-            if (maxWidth > 0)
-                textLabel.MaxWidth = maxWidth;
-
+            // Use max width if it has been specified
+            if (maxTextWidth > 0)
+                textLabel.MaxWidth = maxTextWidth;
+            textLabel.Text = text;
+            textLabel.Parent = this;
             textLabel.TextColor = TextColor;
             textLabel.ShadowColor = ShadowColor;
             textLabel.ShadowPosition = ShadowPosition;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -95,9 +95,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             set { clickAnywhereToClose = value; }
         }
 
-        public DaggerfallMessageBox(IUserInterfaceManager uiManager, IUserInterfaceWindow previous = null)
+        public DaggerfallMessageBox(IUserInterfaceManager uiManager, IUserInterfaceWindow previous = null, bool wrapText = false)
             : base(uiManager, previous)
         {
+            if (wrapText)
+            {
+                label.WrapText = true;
+                // If wrapping text, set maxWidth to 288. This is just an aesthetically chosen value, as
+                // it is the widest text can be without making the parchment textures expand off the edges of the screen.
+                label.MaxTextWidth = 288;
+            }
         }
 
         public DaggerfallMessageBox(IUserInterfaceManager uiManager, CommonMessageBoxButtons buttons, TextFile.Token[] tokens, IUserInterfaceWindow previous = null)


### PR DESCRIPTION
This just passes down the wrapText parameter from where pickpocketing happens. It ends up passing a bool through a bunch of functions, which might not be to your liking. Feel free to reject this if you have something better in mind.

I removed maxWidth as a parameter for now, since it's not currently used.