### PR TITLE
Identify more save vars, use avoidHit mod

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -50,6 +50,12 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int currentLevelUpSkillSum = 0;
         protected bool readyToLevelUp = false;
 
+        protected int biographyResistDiseaseMod = 0;
+        protected int biographyResistMagicMod = 0;
+        protected int biographyAvoidHitMod = 0;
+        protected int biographyResistPoisonMod = 0;
+        protected int biographyFatigueMod = 0;
+
         #endregion
 
         #region Properties
@@ -69,6 +75,11 @@ namespace DaggerfallWorkshop.Game.Entity
         public int StartingLevelUpSkillSum { get { return startingLevelUpSkillSum; } set { startingLevelUpSkillSum = value; } }
         public int CurrentLevelUpSkillSum {  get { return currentLevelUpSkillSum; } }
         public bool ReadyToLevelUp { get { return readyToLevelUp; } set { readyToLevelUp = value; } }
+        public int BiographyResistDiseaseMod { get { return biographyResistDiseaseMod; } set { biographyResistDiseaseMod = value; } }
+        public int BiographyResistMagicMod { get { return biographyResistMagicMod; } set { biographyResistMagicMod = value; } }
+        public int BiographyAvoidHitMod { get { return biographyAvoidHitMod; } set { biographyAvoidHitMod = value; } }
+        public int BiographyResistPoisonMod { get { return biographyResistPoisonMod; } set { biographyResistPoisonMod = value; } }
+        public int BiographyFatigueMod { get { return biographyFatigueMod; } set { biographyFatigueMod = value; } }
 
         #endregion
 

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -474,6 +474,12 @@ namespace DaggerfallWorkshop.Game.Formulas
 
             int armorValue = 0;
 
+            // Apply hit mod from character biography
+            if (target == player)
+            {
+                chanceToHit -= player.BiographyAvoidHitMod;
+            }
+
             // Get armor value for struck body part
             if (struckBodyPart <= target.ArmorValues.Length)
             {

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -498,6 +498,13 @@ namespace DaggerfallWorkshop.Game.Utility
             PlayerEntity playerEntity = FindPlayerEntity();
             playerEntity.AssignCharacter(characterDocument, characterRecord.ParsedData.level, characterRecord.ParsedData.maxHealth, false);
 
+            // Assign biography modifiers
+            playerEntity.BiographyResistDiseaseMod = saveVars.BiographyResistDiseaseMod;
+            playerEntity.BiographyResistMagicMod = saveVars.BiographyResistMagicMod;
+            playerEntity.BiographyAvoidHitMod = saveVars.BiographyAvoidHitMod;
+            playerEntity.BiographyResistPoisonMod = saveVars.BiographyResistPoisonMod;
+            playerEntity.BiographyFatigueMod = saveVars.BiographyFatigueMod;
+
             // Assign faction data
             playerEntity.FactionData.ImportClassicReputation(saveVars);
 


### PR DESCRIPTION
Identifies several values in savevars, and uses the mod to avoiding hits that can be set during character generation in the combat formula.

I also identified the other mods that can be set during character generation (you get one of these as the result of the "You have the most trouble ___." question.) The only one I haven't found yet is the reaction modifier, which I think affects how much NPCs like you. The modifiers I found were all next to each other but the reaction one didn't show up.