### PR TITLE
MeshReplacement: Treasures

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
@@ -89,9 +89,18 @@ namespace DaggerfallWorkshop.Game.Serialization
             // Restore position
             loot.transform.position = data.currentPosition;
 
-            // Restore billboard appearance if present
-            if (billboard)
+            // Restore appearance
+            if (MeshReplacement.ImportCustomFlatGameobject(data.textureArchive, data.textureRecord, Vector3.zero, loot.transform))
+            {
+                // Use imported model instead of billboard
+                if (billboard) Destroy(billboard);
+                Destroy(GetComponent<MeshRenderer>());
+            }
+            else if (billboard)
+            {
+                // Restore billboard appearance if present
                 billboard.SetMaterial(data.textureArchive, data.textureRecord);
+            }
 
             // Restore items
             loot.Items.DeserializeItems(data.items);

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -20,6 +20,7 @@ using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Questing;
 using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop.Utility
 {
@@ -533,9 +534,22 @@ namespace DaggerfallWorkshop.Utility
             // Setup initial loot container prefab
             GameObject go = InstantiatePrefab(DaggerfallUnity.Instance.Option_LootContainerPrefab.gameObject, containerType.ToString(), parent, position);
 
-            // Setup billboard component
-            DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
-            dfBillboard.SetMaterial(textureArchive, textureRecord);
+            // Setup appearance
+            if (MeshReplacement.ImportCustomFlatGameobject(textureArchive, textureRecord, Vector3.zero, go.transform))
+            {
+                // Use imported model instead of billboard
+                GameObject.Destroy(go.GetComponent<DaggerfallBillboard>());
+                GameObject.Destroy(go.GetComponent<MeshRenderer>());
+            }
+            else
+            {
+                // Setup billboard component
+                DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                dfBillboard.SetMaterial(textureArchive, textureRecord);
+
+                // Now move up loot icon by half own size so bottom is aligned with position
+                position.y += (dfBillboard.Summary.Size.y / 2f);
+            }
 
             // Setup DaggerfallLoot component to make lootable
             DaggerfallLoot loot = go.GetComponent<DaggerfallLoot>();
@@ -548,8 +562,6 @@ namespace DaggerfallWorkshop.Utility
                 loot.TextureRecord = textureRecord;
             }
 
-            // Now move up loot icon by half own size so bottom is aligned with position
-            position.y += (dfBillboard.Summary.Size.y / 2f);
             loot.transform.position = position;
 
             return loot;


### PR DESCRIPTION
Imports 3d models for treasures and lootable corpses. 
I don't think this is the best way to deal with the fact that the treasure prefab is loaded from resources, but if I replace the entire gameobject (and add lootable script and sphere collider) i have troubles preserving serialization. I'm open for suggestions.