### PR TITLE
Updates to activating objects

### DIFF
--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -32,6 +32,7 @@ namespace DaggerfallWorkshop.Game.Entity
         int careerIndex = -1;
         EntityTypes entityType = EntityTypes.None;
         MobileEnemy mobileEnemy;
+        bool pickpocketByPlayerAttempted = false;
 
         #endregion
 
@@ -50,6 +51,12 @@ namespace DaggerfallWorkshop.Game.Entity
         public MobileEnemy MobileEnemy
         {
             get { return mobileEnemy; }
+        }
+
+        public bool PickpocketByPlayerAttempted
+        {
+            get { return (pickpocketByPlayerAttempted); }
+            set { pickpocketByPlayerAttempted = value; }
         }
 
         #endregion

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -132,14 +132,13 @@ namespace DaggerfallWorkshop.Game.Formulas
         }
 
         // Calculate chance of successfully pickpocketing a target
-        public static int CalculatePickpocketingChance(Entity.PlayerEntity player, Entity.DaggerfallEntityBehaviour target)
+        public static int CalculatePickpocketingChance(Entity.PlayerEntity player, Entity.EnemyEntity target)
         {
             int chance = player.Skills.Pickpocket;
             // If target is an enemy mobile, apply level modifier.
-            if (target)
+            if (target != null)
             {
-                Entity.EnemyEntity enemyEntity = target.Entity as Entity.EnemyEntity;
-                chance += 5 * ((player.Level) - (enemyEntity.Level));
+                chance += 5 * ((player.Level) - (target.Level));
             }
             return Mathf.Clamp(chance, 5, 95);
         }

--- a/Assets/Scripts/Game/MobilePersonNPC.cs
+++ b/Assets/Scripts/Game/MobilePersonNPC.cs
@@ -48,6 +48,7 @@ namespace DaggerfallWorkshop.Game
         private string nameNPC;                                 // name of the npc
         private int personOutfitVariant;                        // which basic outfit does the person wear
         private int personFaceRecordId;                         // used for portrait in talk window
+        private bool pickpocketByPlayerAttempted = false;       // player can only attempt pickpocket on a mobile NPC once
 
         private MobilePersonBillboard billboard;    // billboard for npc
         private MobilePersonMotor motor;            // motor for npc
@@ -91,6 +92,12 @@ namespace DaggerfallWorkshop.Game
         public int PersonFaceRecordId
         {
             get { return (personFaceRecordId); }
+        }
+
+        public bool PickpocketByPlayerAttempted
+        {
+            get { return (pickpocketByPlayerAttempted); }
+            set { pickpocketByPlayerAttempted = value; }
         }
 
         public MobilePersonBillboard Billboard

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -346,12 +346,16 @@ namespace DaggerfallWorkshop.Game
                                     Talk(mobileNpc);
                                     break;
                                 case PlayerActivateModes.Steal:
-                                    if (hit.distance > (PickpocketDistance * MeshReader.GlobalScale))
+                                    if (!mobileNpc.PickpocketByPlayerAttempted)
                                     {
-                                        DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
-                                        break;
+                                        if (hit.distance > (PickpocketDistance * MeshReader.GlobalScale))
+                                        {
+                                            DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
+                                            break;
+                                        }
+                                        mobileNpc.PickpocketByPlayerAttempted = true;
+                                        Pickpocket();
                                     }
-                                    Pickpocket();
                                     break;
                             }
                         }
@@ -360,12 +364,12 @@ namespace DaggerfallWorkshop.Game
                         DaggerfallEntityBehaviour mobileEnemyBehaviour;
                         if (MobileEnemyCheck(hit, out mobileEnemyBehaviour))
                         {
+                            EnemyEntity enemyEntity = mobileEnemyBehaviour.Entity as EnemyEntity;
                             switch (currentMode)
                             {
                                 case PlayerActivateModes.Info:
                                 case PlayerActivateModes.Grab:
                                 case PlayerActivateModes.Talk:
-                                    EnemyEntity enemyEntity = mobileEnemyBehaviour.Entity as EnemyEntity;
                                     if (enemyEntity != null)
                                     {
                                         MobileEnemy mobileEnemy = enemyEntity.MobileEnemy;
@@ -386,12 +390,17 @@ namespace DaggerfallWorkshop.Game
                                     // For now, the only enemy mobiles being allowed by DF Unity are classes.
                                     if (mobileEnemyBehaviour && (mobileEnemyBehaviour.EntityType != EntityTypes.EnemyClass))
                                         break;
-                                    if (hit.distance > (PickpocketDistance * MeshReader.GlobalScale))
+                                    // Classic doesn't set any flag when pickpocketing enemy mobiles, so infinite attempts are possible
+                                    if (enemyEntity != null && !enemyEntity.PickpocketByPlayerAttempted)
                                     {
-                                        DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
-                                        break;
+                                        if (hit.distance > (PickpocketDistance * MeshReader.GlobalScale))
+                                        {
+                                            DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
+                                            break;
+                                        }
+                                        enemyEntity.PickpocketByPlayerAttempted = true;
+                                        Pickpocket(enemyEntity);
                                     }
-                                    Pickpocket(mobileEnemyBehaviour);
                                     break;
                             }
                         }
@@ -738,7 +747,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Player has clicked on a pickpocket target in steal mode
-        void Pickpocket(DaggerfallEntityBehaviour target = null)
+        void Pickpocket(EnemyEntity target = null)
         {
             const int foundNothingValuableTextId = 8999;
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -45,6 +45,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string noSavesFound = "No saves found. Load a Classic save?";
 
         public const string theBodyHasNoTreasure = "The body has no treasure.";
+        public const string youAreTooFarAway = "You are too far away...";
+        public const string youSeeAn = "You see an %s.";
+        public const string youSeeA = "You see a %s.";
 
         public const string loiterHowManyHours = "Loiter how many hours : ";
         public const string restHowManyHours = "Rest how many hours : ";


### PR DESCRIPTION
Changes:
1) Implements "You are too far away..." message, shown when player tries to activate various objects out of range.
2) Implements "You see a/an %s." when you click on an enemyMobile in info mode.
3) Activation ranges match classic. Buildings and enemy mobiles can be identified from far away like in classic.
4) Fixed being able to activate things through walls (ex. pickpocketing guards in Daggerfall castle through the wall)

To do this, I upped the raycast length when activating things to a long one. There was a problem with this though: I was able to click on things behind walls. There was a comment that RayCastAll was being used because when things block the raycast, it feels unresponsive to the player, but changing to RayCast fixed my problem and also fixed being able to activate through walls, and I don't notice any obvious unresponsiveness. Is there a particular case you were thinking of Interkarma? Could using a layer mask on the ray cast to filter out certain colliders solve the issue?