### PR TITLE
Implement clicking in info mode on dead mobiles.

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -273,7 +273,18 @@ namespace DaggerfallWorkshop.Game
                             switch (currentMode)
                             {
                                 case PlayerActivateModes.Info:
-                                    // TODO: "You see a dead..." Need to be able to get enemy type from loot object.
+                                    if (loot.ContainerType == LootContainerTypes.CorpseMarker && loot.EnemyEntity != null)
+                                    {
+                                        string message = string.Empty;
+                                        if (loot.EnemyEntity.EntityType == EntityTypes.EnemyClass)
+                                            message = HardStrings.youSeeADeadPerson;
+                                        else
+                                        {
+                                            message = HardStrings.youSeeADead;
+                                            message = message.Replace("%s", loot.EnemyEntity.MobileEnemy.Name);
+                                        }
+                                        DaggerfallUI.Instance.PopupMessage(message);
+                                    }
                                     break;
                                 case PlayerActivateModes.Grab:
                                 case PlayerActivateModes.Talk:

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -51,6 +51,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string youAreTooFarAway = "You are too far away...";
         public const string youSeeAn = "You see an %s.";
         public const string youSeeA = "You see a %s.";
+        public const string youSeeADeadPerson = "You see a dead person.";
+        public const string youSeeADead = "You see a dead %s.";
 
         public const string loiterHowManyHours = "Loiter how many hours : ";
         public const string restHowManyHours = "Rest how many hours : ";

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -49,6 +49,8 @@ namespace DaggerfallWorkshop
         ulong loadID = 0;
         ItemCollection items = new ItemCollection();
 
+        Game.Entity.EnemyEntity enemyEntity = null;
+
         public ulong LoadID
         {
             get { return loadID; }
@@ -58,6 +60,12 @@ namespace DaggerfallWorkshop
         public ItemCollection Items
         {
             get { return items; }
+        }
+
+        public Game.Entity.EnemyEntity EnemyEntity
+        {
+            get { return enemyEntity; }
+            set { enemyEntity = value; }
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -529,7 +529,8 @@ namespace DaggerfallWorkshop.Utility
             Transform parent,
             int textureArchive,
             int textureRecord,
-            ulong loadID = 0)
+            ulong loadID = 0,
+            EnemyEntity enemyEntity = null)
         {
             // Setup initial loot container prefab
             GameObject go = InstantiatePrefab(DaggerfallUnity.Instance.Option_LootContainerPrefab.gameObject, containerType.ToString(), parent, position);
@@ -560,6 +561,7 @@ namespace DaggerfallWorkshop.Utility
                 loot.ContainerImage = containerImage;
                 loot.TextureArchive = textureArchive;
                 loot.TextureRecord = textureRecord;
+                loot.EnemyEntity = enemyEntity;
             }
 
             loot.transform.position = position;
@@ -680,7 +682,8 @@ namespace DaggerfallWorkshop.Utility
                 parent,
                 archive,
                 record,
-                loadID);
+                loadID,
+                enemyEntity);
 
             // Set properties
             loot.LoadID = loadID;


### PR DESCRIPTION
Does as title says.

I think that classic still has a monster's stats within a corpse, so I did it the same way (adding an EnemyEntity field to the loot container) instead of just adding a name string and isEnemyClass bool.

Corpses EnemyEntity field isn't saved in DF Unity saves yet, so clicking on them after loading a DF Unity won't show anything.