### PR TITLE
Implement starting crime guild quests

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -71,6 +71,10 @@ namespace DaggerfallConnect.Save
             doc.skillUses = parsedData.skillUses;
             doc.startingLevelUpSkillSum = parsedData.startingLevelUpSkillSum;
             doc.armorValues = parsedData.armorValues;
+            doc.timeForThievesGuildLetter = parsedData.timeForThievesGuildLetter;
+            doc.timeForDarkBrotherhoodLetter = parsedData.timeForDarkBrotherhoodLetter;
+            doc.darkBrotherhoodRequirementTally = parsedData.darkBrotherhoodRequirementTally;
+            doc.thievesGuildRequirementTally = parsedData.thievesGuildRequirementTally;
 
             return doc;
         }
@@ -156,6 +160,16 @@ namespace DaggerfallConnect.Save
 
             reader.BaseStream.Position = 0x1fd;
             parsedData.timeStamp = reader.ReadUInt32();
+
+            reader.BaseStream.Position = 0x211;
+            parsedData.timeForThievesGuildLetter = reader.ReadUInt32();
+            parsedData.timeForDarkBrotherhoodLetter = reader.ReadUInt32();
+
+            reader.BaseStream.Position = 0x21f;
+            parsedData.darkBrotherhoodRequirementTally = reader.ReadByte();
+
+            reader.BaseStream.Position = 0x222;
+            parsedData.thievesGuildRequirementTally = reader.ReadByte();
 
             reader.BaseStream.Position = 0x230;
             parsedData.career = ReadCareer(reader);
@@ -315,8 +329,12 @@ namespace DaggerfallConnect.Save
             public UInt32 lastTimePlayerCastLycanthropy;
             public UInt32 lastTimePlayerAteOrDrankAtTavern;
             public UInt32 lastTimePlayerBoughtTraining;
+            public UInt32 timeForThievesGuildLetter;
+            public UInt32 timeForDarkBrotherhoodLetter;
             public Byte vampireClan;
             public Byte effectStrength; // Used for Open and Shade effects at least.
+            public Byte darkBrotherhoodRequirementTally;
+            public Byte thievesGuildRequirementTally;
             public DFCareer career;
         }
 

--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -130,6 +130,8 @@ namespace DaggerfallWorkshop.Game.Entity
                 {
                     CheckedCurrentJump = false;
                 }
+
+                HandleStartingCrimeGuildQuests(Entity as PlayerEntity);
             }
         }
 
@@ -159,6 +161,28 @@ namespace DaggerfallWorkshop.Game.Entity
         {
             RaiseOnSetEntityHandler(entity, value);
             entity = value;
+        }
+
+        void HandleStartingCrimeGuildQuests(PlayerEntity player)
+        {
+            if (player.ThievesGuildRequirementTally != 100
+                && player.TimeForThievesGuildLetter > 0
+                && player.TimeForThievesGuildLetter < DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime()
+                && !GameManager.Instance.PlayerGPS.GetComponent<PlayerEnterExit>().IsPlayerInside)
+            {
+                player.ThievesGuildRequirementTally = 100;
+                player.TimeForThievesGuildLetter = 0;
+                Questing.QuestMachine.Instance.InstantiateQuest("O0A0AL00");
+            }
+            if (player.DarkBrotherhoodRequirementTally != 100
+                && player.TimeForDarkBrotherhoodLetter > 0
+                && player.TimeForDarkBrotherhoodLetter < DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime()
+                && !GameManager.Instance.PlayerGPS.GetComponent<PlayerEnterExit>().IsPlayerInside)
+            {
+                player.DarkBrotherhoodRequirementTally = 100;
+                player.TimeForDarkBrotherhoodLetter = 0;
+                Questing.QuestMachine.Instance.InstantiateQuest("L0A01L00");
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -57,6 +57,11 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int biographyResistPoisonMod = 0;
         protected int biographyFatigueMod = 0;
 
+        protected uint timeForThievesGuildLetter = 0;
+        protected uint timeForDarkBrotherhoodLetter = 0;
+        protected byte thievesGuildRequirementTally = 0;
+        protected byte darkBrotherhoodRequirementTally = 0;
+
         #endregion
 
         #region Properties
@@ -81,6 +86,10 @@ namespace DaggerfallWorkshop.Game.Entity
         public int BiographyAvoidHitMod { get { return biographyAvoidHitMod; } set { biographyAvoidHitMod = value; } }
         public int BiographyResistPoisonMod { get { return biographyResistPoisonMod; } set { biographyResistPoisonMod = value; } }
         public int BiographyFatigueMod { get { return biographyFatigueMod; } set { biographyFatigueMod = value; } }
+        public uint TimeForThievesGuildLetter { get { return timeForThievesGuildLetter; } set { timeForThievesGuildLetter = value; } }
+        public uint TimeForDarkBrotherhoodLetter { get { return timeForDarkBrotherhoodLetter; } set { timeForDarkBrotherhoodLetter = value; } }
+        public byte ThievesGuildRequirementTally { get { return thievesGuildRequirementTally; } set { thievesGuildRequirementTally = value; } }
+        public byte DarkBrotherhoodRequirementTally { get { return darkBrotherhoodRequirementTally; } set { darkBrotherhoodRequirementTally = value; } }
         public float CarriedWeight { get { return Items.GetWeight() + ((float)goldPieces / DaggerfallBankManager.gold1kg); } }
         public float WagonWeight { get { return WagonItems.GetWeight(); } }
 
@@ -146,6 +155,10 @@ namespace DaggerfallWorkshop.Game.Entity
             this.skillUses = character.skillUses;
             this.startingLevelUpSkillSum = character.startingLevelUpSkillSum;
             this.ArmorValues = character.armorValues;
+            this.TimeForThievesGuildLetter = character.timeForThievesGuildLetter;
+            this.TimeForDarkBrotherhoodLetter = character.timeForDarkBrotherhoodLetter;
+            this.DarkBrotherhoodRequirementTally = character.darkBrotherhoodRequirementTally;
+            this.ThievesGuildRequirementTally = character.thievesGuildRequirementTally;
 
             SetCurrentLevelUpSkillSum();
 
@@ -281,6 +294,44 @@ namespace DaggerfallWorkshop.Game.Entity
                 skillUses[skillId] = 0;
             }
         }
+
+        /// <summary>
+        /// Tally thefts/break-ins and murders for starting Thieves Guild and Dark Brotherhood quests
+        /// </summary>
+        public void TallyCrimeGuildRequirements(bool thievingCrime, byte amount)
+        {
+            if (thievingCrime)
+            {
+                if (timeForThievesGuildLetter == 0)
+                {
+                    if (thievesGuildRequirementTally != 100) // Tally is set to 100 when the thieves guild quest line has already started
+                    {
+                        thievesGuildRequirementTally += amount;
+                        if (thievesGuildRequirementTally >= 10)
+                        {
+                            uint currentMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+                            timeForThievesGuildLetter = currentMinutes + 4320; // 3 days
+                       }
+                    }
+                }
+            }
+            else // murder
+            {
+                if (timeForDarkBrotherhoodLetter == 0)
+                {
+                    if (darkBrotherhoodRequirementTally != 100) // Tally is set to 100 when the thieves guild quest line has already started
+                    {
+                        darkBrotherhoodRequirementTally += amount;
+                        if (darkBrotherhoodRequirementTally >= 15)
+                        {
+                            uint currentMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+                            timeForDarkBrotherhoodLetter = currentMinutes + 4320; // 3 days
+                        }
+                    }
+                }
+            }
+        }
+
 
         /// <summary>
         /// Raise skills if conditions are met.

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -39,6 +39,10 @@ namespace DaggerfallWorkshop.Game.Player
         public short[] skillUses;
         public int startingLevelUpSkillSum;
         public sbyte[] armorValues = new sbyte[DaggerfallEntity.ArmorValuesArrayLength];
+        public uint timeForThievesGuildLetter;
+        public uint timeForDarkBrotherhoodLetter;
+        public byte darkBrotherhoodRequirementTally;
+        public byte thievesGuildRequirementTally;
 
         public CharacterDocument()
         {

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -175,11 +175,19 @@ namespace DaggerfallWorkshop.Game
 
                                     // TODO: Implement lockpicking and door bashing for exterior doors
                                     // For now, any locked building door can be entered by using steal mode
-                                    if (!buildingUnlocked && (currentMode != PlayerActivateModes.Steal))
+                                    if (!buildingUnlocked)
                                     {
-                                        string Locked = "Locked.";
-                                        DaggerfallUI.Instance.PopupMessage(Locked);
-                                        return;
+                                        if (currentMode != PlayerActivateModes.Steal)
+                                        {
+                                            string Locked = "Locked.";
+                                            DaggerfallUI.Instance.PopupMessage(Locked);
+                                            return;
+                                        }
+                                        else // Breaking into building
+                                        {
+                                            PlayerEntity player = GameManager.Instance.PlayerEntity;
+                                            player.TallyCrimeGuildRequirements(true, 1);
+                                        }
                                     }
 
                                     // If entering a shop let player know the quality level
@@ -774,6 +782,7 @@ namespace DaggerfallWorkshop.Game
                         gotGold = gotGold.Replace("%d", pinchedGoldPieces.ToString());
                     }
                     DaggerfallUI.MessageBox(gotGold);
+                    player.TallyCrimeGuildRequirements(true, 1);
                 }
                 else
                 {

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -646,6 +646,16 @@ namespace DaggerfallWorkshop.Game
                         hitEnemy = true;
                     }
                 }
+
+                // Check if hit a mobile NPC
+                MobilePersonNPC mobileNpc = hit.transform.GetComponent<MobilePersonNPC>();
+                if (mobileNpc)
+                {
+                    // TODO: Create blood splash.
+                    weapon.PlayHitSound();
+                    mobileNpc.Motor.gameObject.SetActive(false);
+                    GameManager.Instance.PlayerEntity.TallyCrimeGuildRequirements(false, 5);
+                }
             }
         }
 


### PR DESCRIPTION
This starts the thieves guild and dark brotherhood quests in the same manner as classic. The necessary data is also imported from classic saves.

Problems:
- I don't know Unity and its "components" and stuff very well and couldn't figure out how to make a blood splash appear when a citizen is killed. Copying the approach used in the file for hitting an enemyMobile didn't work. I guess that mobileNPCs need to have "EnemyBlood" assigned to them somehow.
- The population manager may need to be told when a mobileNPC is killed. I don't know much about it and haven't touched it.
- The thieves guild quest and dark brotherhood quest might not necessarily work. Are we only activating quests that are curated? Should these be commented out from starting for now?
- Variables aren't saved in Unity saves yet.