### PR TITLE
Reaction mod, serialize data, disable crime quests

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -76,6 +76,7 @@ namespace DaggerfallConnect.Save
             doc.timeForDarkBrotherhoodLetter = parsedData.timeForDarkBrotherhoodLetter;
             doc.darkBrotherhoodRequirementTally = parsedData.darkBrotherhoodRequirementTally;
             doc.thievesGuildRequirementTally = parsedData.thievesGuildRequirementTally;
+            doc.biographyReactionMod = parsedData.biographyReactionMod;
 
             return doc;
         }
@@ -171,6 +172,9 @@ namespace DaggerfallConnect.Save
 
             reader.BaseStream.Position = 0x222;
             parsedData.thievesGuildRequirementTally = reader.ReadByte();
+
+            reader.BaseStream.Position = 0x224;
+            parsedData.biographyReactionMod = reader.ReadSByte();
 
             reader.BaseStream.Position = 0x230;
             parsedData.career = ReadCareer(reader);
@@ -336,6 +340,7 @@ namespace DaggerfallConnect.Save
             public Byte effectStrength; // Used for Open and Shade effects at least.
             public Byte darkBrotherhoodRequirementTally;
             public Byte thievesGuildRequirementTally;
+            public SByte biographyReactionMod;
             public DFCareer career;
         }
 

--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -131,7 +131,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     CheckedCurrentJump = false;
                 }
 
-                HandleStartingCrimeGuildQuests(Entity as PlayerEntity);
+                //HandleStartingCrimeGuildQuests(Entity as PlayerEntity);
             }
         }
 

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -56,11 +56,12 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int biographyAvoidHitMod = 0;
         protected int biographyResistPoisonMod = 0;
         protected int biographyFatigueMod = 0;
+        protected int biographyReactionMod = 0;
 
         protected uint timeForThievesGuildLetter = 0;
         protected uint timeForDarkBrotherhoodLetter = 0;
-        protected byte thievesGuildRequirementTally = 0;
-        protected byte darkBrotherhoodRequirementTally = 0;
+        protected int thievesGuildRequirementTally = 0;
+        protected int darkBrotherhoodRequirementTally = 0;
 
         #endregion
 
@@ -86,10 +87,11 @@ namespace DaggerfallWorkshop.Game.Entity
         public int BiographyAvoidHitMod { get { return biographyAvoidHitMod; } set { biographyAvoidHitMod = value; } }
         public int BiographyResistPoisonMod { get { return biographyResistPoisonMod; } set { biographyResistPoisonMod = value; } }
         public int BiographyFatigueMod { get { return biographyFatigueMod; } set { biographyFatigueMod = value; } }
+        public int BiographyReactionMod { get { return biographyReactionMod; } set { biographyReactionMod = value; } }
         public uint TimeForThievesGuildLetter { get { return timeForThievesGuildLetter; } set { timeForThievesGuildLetter = value; } }
         public uint TimeForDarkBrotherhoodLetter { get { return timeForDarkBrotherhoodLetter; } set { timeForDarkBrotherhoodLetter = value; } }
-        public byte ThievesGuildRequirementTally { get { return thievesGuildRequirementTally; } set { thievesGuildRequirementTally = value; } }
-        public byte DarkBrotherhoodRequirementTally { get { return darkBrotherhoodRequirementTally; } set { darkBrotherhoodRequirementTally = value; } }
+        public int ThievesGuildRequirementTally { get { return thievesGuildRequirementTally; } set { thievesGuildRequirementTally = value; } }
+        public int DarkBrotherhoodRequirementTally { get { return darkBrotherhoodRequirementTally; } set { darkBrotherhoodRequirementTally = value; } }
         public float CarriedWeight { get { return Items.GetWeight() + ((float)goldPieces / DaggerfallBankManager.gold1kg); } }
         public float WagonWeight { get { return WagonItems.GetWeight(); } }
 

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -44,6 +44,7 @@ namespace DaggerfallWorkshop.Game.Player
         public uint timeForDarkBrotherhoodLetter;
         public byte darkBrotherhoodRequirementTally;
         public byte thievesGuildRequirementTally;
+        public sbyte biographyReactionMod;
 
         public CharacterDocument()
         {

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -186,7 +186,7 @@ namespace DaggerfallWorkshop.Game
                                         else // Breaking into building
                                         {
                                             PlayerEntity player = GameManager.Instance.PlayerEntity;
-                                            player.TallyCrimeGuildRequirements(true, 1);
+                                            //player.TallyCrimeGuildRequirements(true, 1);
                                         }
                                     }
 
@@ -793,7 +793,7 @@ namespace DaggerfallWorkshop.Game
                         gotGold = gotGold.Replace("%d", pinchedGoldPieces.ToString());
                     }
                     DaggerfallUI.MessageBox(gotGold);
-                    player.TallyCrimeGuildRequirements(true, 1);
+                    //player.TallyCrimeGuildRequirements(true, 1);
                 }
                 else
                 {

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -281,15 +281,15 @@ namespace DaggerfallWorkshop.Game
                             switch (currentMode)
                             {
                                 case PlayerActivateModes.Info:
-                                    if (loot.ContainerType == LootContainerTypes.CorpseMarker && loot.EnemyEntity != null)
+                                    if (loot.ContainerType == LootContainerTypes.CorpseMarker && !string.IsNullOrEmpty(loot.entityName))
                                     {
                                         string message = string.Empty;
-                                        if (loot.EnemyEntity.EntityType == EntityTypes.EnemyClass)
+                                        if (loot.isEnemyClass)
                                             message = HardStrings.youSeeADeadPerson;
                                         else
                                         {
                                             message = HardStrings.youSeeADead;
-                                            message = message.Replace("%s", loot.EnemyEntity.MobileEnemy.Name);
+                                            message = message.Replace("%s", loot.entityName);
                                         }
                                         DaggerfallUI.Instance.PopupMessage(message);
                                     }

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -276,8 +276,10 @@ namespace DaggerfallWorkshop.Game.Serialization
         public int textureArchive;
         public int textureRecord;
         public string lootTableKey;
+        public string entityName;
         public bool playerOwned;
         public bool customDrop;
+        public bool isEnemyClass;
         public ItemData_v1[] items;
         public EnemyEntity enemyEntity;
     }

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -134,6 +134,17 @@ namespace DaggerfallWorkshop.Game.Serialization
         public ItemData_v1[] otherItems;
         public int goldPieces;
         public GlobalVar[] globalVars;
+        public WeaponMaterialTypes minMetalToHit;
+        public int biographyResistDiseaseMod;
+        public int biographyResistMagicMod;
+        public int biographyAvoidHitMod;
+        public int biographyResistPoisonMod;
+        public int biographyFatigueMod;
+        public int biographyReactionMod;
+        public uint timeForThievesGuildLetter;
+        public uint timeForDarkBrotherhoodLetter;
+        public int thievesGuildRequirementTally;
+        public int darkBrotherhoodRequirementTally;
     }
 
     [fsObject("v1")]
@@ -268,6 +279,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public bool playerOwned;
         public bool customDrop;
         public ItemData_v1[] items;
+        public EnemyEntity enemyEntity;
     }
 
     #endregion

--- a/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
@@ -71,6 +71,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             data.playerOwned = loot.playerOwned;
             data.customDrop = loot.customDrop;
             data.items = loot.Items.SerializeItems();
+            data.entityName = loot.entityName;
+            data.isEnemyClass = loot.isEnemyClass;
 
             return data;
         }
@@ -114,6 +116,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             loot.playerOwned = data.playerOwned;
             loot.customDrop = data.customDrop;
             loot.name = loot.ContainerType.ToString();
+            loot.entityName = data.entityName;
+            loot.isEnemyClass = data.isEnemyClass;
 
             // Remove loot container if empty
             if (loot.Items.Count == 0)

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -121,6 +121,17 @@ namespace DaggerfallWorkshop.Game.Serialization
             data.playerEntity.otherItems = entity.OtherItems.SerializeItems();
             data.playerEntity.goldPieces = entity.GoldPieces;
             data.playerEntity.globalVars = entity.GlobalVars.SerializeGlobalVars();
+            data.playerEntity.minMetalToHit = entity.MinMetalToHit;
+            data.playerEntity.biographyResistDiseaseMod = entity.BiographyResistDiseaseMod;
+            data.playerEntity.biographyResistMagicMod = entity.BiographyResistMagicMod;
+            data.playerEntity.biographyAvoidHitMod = entity.BiographyAvoidHitMod;
+            data.playerEntity.biographyResistPoisonMod = entity.BiographyResistPoisonMod;
+            data.playerEntity.biographyFatigueMod = entity.BiographyFatigueMod;
+            data.playerEntity.biographyReactionMod = entity.BiographyReactionMod;
+            data.playerEntity.timeForThievesGuildLetter = entity.TimeForThievesGuildLetter;
+            data.playerEntity.timeForDarkBrotherhoodLetter = entity.TimeForDarkBrotherhoodLetter;
+            data.playerEntity.thievesGuildRequirementTally = entity.ThievesGuildRequirementTally;
+            data.playerEntity.darkBrotherhoodRequirementTally = entity.DarkBrotherhoodRequirementTally;
 
             // Store player position data
             data.playerPosition = GetPlayerPositionData();
@@ -207,6 +218,17 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.ItemEquipTable.DeserializeEquipTable(data.playerEntity.equipTable, entity.Items);
             entity.GoldPieces = data.playerEntity.goldPieces;
             entity.GlobalVars.DeserializeGlobalVars(data.playerEntity.globalVars);
+            entity.MinMetalToHit = data.playerEntity.minMetalToHit;
+            entity.BiographyResistDiseaseMod = data.playerEntity.biographyResistDiseaseMod;
+            entity.BiographyResistMagicMod = data.playerEntity.biographyResistMagicMod;
+            entity.BiographyAvoidHitMod = data.playerEntity.biographyAvoidHitMod;
+            entity.BiographyResistPoisonMod = data.playerEntity.biographyResistPoisonMod;
+            entity.BiographyFatigueMod = data.playerEntity.biographyFatigueMod;
+            entity.BiographyReactionMod = data.playerEntity.biographyReactionMod;
+            entity.TimeForThievesGuildLetter = data.playerEntity.timeForThievesGuildLetter;
+            entity.TimeForDarkBrotherhoodLetter = data.playerEntity.timeForDarkBrotherhoodLetter;
+            entity.ThievesGuildRequirementTally = data.playerEntity.thievesGuildRequirementTally;
+            entity.DarkBrotherhoodRequirementTally = data.playerEntity.darkBrotherhoodRequirementTally;
             entity.SetCurrentLevelUpSkillSum();
 
             // Fill in missing data for saves

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -654,7 +654,7 @@ namespace DaggerfallWorkshop.Game
                     // TODO: Create blood splash.
                     weapon.PlayHitSound();
                     mobileNpc.Motor.gameObject.SetActive(false);
-                    GameManager.Instance.PlayerEntity.TallyCrimeGuildRequirements(false, 5);
+                    //GameManager.Instance.PlayerEntity.TallyCrimeGuildRequirements(false, 5);
                 }
             }
         }

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -41,15 +41,15 @@ namespace DaggerfallWorkshop
         public LootContainerTypes ContainerType = LootContainerTypes.Nothing;
         public InventoryContainerImages ContainerImage = InventoryContainerImages.Chest;
         public string LootTableKey = string.Empty;
+        public string entityName = string.Empty;
         public int TextureArchive = 0;
         public int TextureRecord = 0;
         public bool playerOwned = false;
         public bool customDrop = false;         // Custom drop loot is not part of base scene and must be respawned on deserialization
+        public bool isEnemyClass = false;
 
         ulong loadID = 0;
         ItemCollection items = new ItemCollection();
-
-        Game.Entity.EnemyEntity enemyEntity = null;
 
         public ulong LoadID
         {
@@ -60,12 +60,6 @@ namespace DaggerfallWorkshop
         public ItemCollection Items
         {
             get { return items; }
-        }
-
-        public Game.Entity.EnemyEntity EnemyEntity
-        {
-            get { return enemyEntity; }
-            set { enemyEntity = value; }
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -561,7 +561,11 @@ namespace DaggerfallWorkshop.Utility
                 loot.ContainerImage = containerImage;
                 loot.TextureArchive = textureArchive;
                 loot.TextureRecord = textureRecord;
-                loot.EnemyEntity = enemyEntity;
+                if (enemyEntity != null)
+                {
+                    loot.entityName = enemyEntity.MobileEnemy.Name;
+                    loot.isEnemyClass = (enemyEntity.EntityType == EntityTypes.EnemyClass);
+                }
             }
 
             loot.transform.position = position;


### PR DESCRIPTION
Identifies and imports the biography reaction mod, serializes new player entity data (minMetalToHit, biography mods, thieves guild and dark brotherhood) and disables starting dark brotherhood and thieves guild quests or tallying their requirements.

The only piece of data I didn't serialize was that for the enemy entity in corpses. I gave it a quick go, just saving and loading the EnemyEntity in SerializableLootContainer, but not all the data was being saved, as it would just show "You see a dead ." after killing an enemy, saving, loading the save and clicking the corpse again. Interkarma, do you know what needs to be done there?