### PR TITLE
Fix looking at lockpicks with 95 or better chance

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -139,7 +139,9 @@ namespace DaggerfallWorkshop
 
                 if (chance >= 30)
                     if (chance >= 35)
-                        if (chance >= 45)
+                        if (chance >= 95)
+                            Game.DaggerfallUI.SetMidScreenText(HardStrings.lockpickChance[9]);
+                        else if (chance >= 45)
                             Game.DaggerfallUI.SetMidScreenText(HardStrings.lockpickChance[(chance - 45) / 5]);
                         else
                             Game.DaggerfallUI.SetMidScreenText(HardStrings.lockpickChance3);


### PR DESCRIPTION
Hazelnut noticed that looking at a lockpick with a 95% chance of success caused an out of bounds exception on  the array of descriptions. This fixes it.

I think this is pretty much of an edge case because you have to be very good at lockpicking and facing a level 1 lock (weakest possible), and classic doesn't handle this situation right. It shows the next entry in the array which is "This is a magically held lock." I made it continue to show the easiest difficulty message for any chance 95% or higher.