### PR TITLE
Implement classic cost formula for selling

### DIFF
--- a/Assets/Scripts/API/Save/SaveVars.cs
+++ b/Assets/Scripts/API/Save/SaveVars.cs
@@ -46,6 +46,9 @@ namespace DaggerfallConnect.Save
         const int cheatFlagsOffset = 0x173B;
         const int lastSkillCheckTimeOffset = 0x179A;
 
+        const int regionDataOffset = 0x3DA;
+        const int regionDataLength = 4960;
+
         const int factionDataOffset = 0x17D0;
         const int factionDataLength = 92;
 
@@ -86,6 +89,8 @@ namespace DaggerfallConnect.Save
         bool godMode = false;
 
         uint lastSkillCheckTime = 0;
+
+        ushort[] priceAdjustmentsByRegion = new ushort[62];
 
         List<FactionFile.FactionData> factions = new List<FactionFile.FactionData>();
 
@@ -341,6 +346,14 @@ namespace DaggerfallConnect.Save
             get { return globalVars; }
         }
 
+        /// <summary>
+        /// Gets array of how much prices are adjusted in each region.
+        /// </summary>
+        public ushort[] PriceAdjustmentsByRegion
+        {
+            get { return priceAdjustmentsByRegion; }
+        }
+
         #endregion
 
         #region Constructors
@@ -398,6 +411,7 @@ namespace DaggerfallConnect.Save
             ReadUsingLeftHandWeapon(reader);
             ReadCheatFlags(reader);
             ReadLastSkillCheckTime(reader);
+            ReadRegionData(reader);
             ReadFactionData(reader);
 
             return true;
@@ -521,6 +535,29 @@ namespace DaggerfallConnect.Save
         {
             reader.BaseStream.Position = lastSkillCheckTimeOffset;
             lastSkillCheckTime = reader.ReadUInt32();
+        }
+
+        void ReadRegionData(BinaryReader reader)
+        {
+            byte[] regionData = new byte[regionDataLength];
+            reader.BaseStream.Position = regionDataOffset;
+            regionData = reader.ReadBytes(regionDataLength);
+
+            GetPriceAdjustmentsByRegion(regionData);
+        }
+
+        void GetPriceAdjustmentsByRegion(byte[] regionData)
+        {
+            int priceAdjustmentsOffset = 0x4E;
+            byte byte1;
+            byte byte2;
+
+            for (int i = 0; i < 62; i++)
+            {
+                byte1 = regionData[priceAdjustmentsOffset + (80 * i)];
+                byte2 = regionData[priceAdjustmentsOffset + (80 * i) + 1];
+                priceAdjustmentsByRegion[i] = (ushort)((byte1) | (byte2 << 8));
+            }
         }
 
         void ReadFactionData(BinaryReader reader)

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -63,6 +63,8 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int thievesGuildRequirementTally = 0;
         protected int darkBrotherhoodRequirementTally = 0;
 
+        protected ushort[] priceAdjustmentByRegion = FormulaHelper.RandomRegionalPriceAdjustments();
+
         #endregion
 
         #region Properties
@@ -94,6 +96,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public int DarkBrotherhoodRequirementTally { get { return darkBrotherhoodRequirementTally; } set { darkBrotherhoodRequirementTally = value; } }
         public float CarriedWeight { get { return Items.GetWeight() + ((float)goldPieces / DaggerfallBankManager.gold1kg); } }
         public float WagonWeight { get { return WagonItems.GetWeight(); } }
+        public ushort[] PriceAdjustmentByRegion { get { return priceAdjustmentByRegion; } set { priceAdjustmentByRegion = value; } }
 
         #endregion
 

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -690,9 +690,15 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         public static int CalculateItemSellCost(int baseItemValue, int shopQuality)
         {
-            // TODO - this is made-up BS by Hazelnut, needs classic formula to be implemented here!
-            Debug.Log(string.Format("baseVal={0}, shopQual={1}, cost= {0} / {2} = {3}", baseItemValue, shopQuality, (float)shopQuality / 10, (baseItemValue / ((float)shopQuality / 10))));
-            return (int)(baseItemValue / ((float)shopQuality / 10));
+            int cost = baseItemValue;
+
+            if (cost < 1)
+                cost = 1;
+
+            cost = ApplyRegionalPriceAdjustment(cost);
+            cost = 2 * (cost * (shopQuality - 10) / 100 + cost);
+
+            return cost;
         }
 
         public static int CalculateItemRepairCost(int baseItemValue, int shopQuality, int condition, int max)
@@ -705,11 +711,58 @@ namespace DaggerfallWorkshop.Game.Formulas
             return (int)(baseItemValue / ((float)shopQuality / 10) * ((1 - ((float)condition / (float)max)) * 5));
         }
 
-        public static int CalculateTradePrice(int cost, int shopQuality)
+        public static int CalculateTradePrice(int cost, int shopQuality, bool selling)
         {
-            // TODO - The cost is modified for trade based on mercantile skill etc - just using 75% cost for now.
+            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            int merchant_mercantile_level = 5 * (shopQuality - 10) + 50;
+            int merchant_personality_level = 5 * (shopQuality - 10) + 50;
 
-            return (int)(cost * 0.75);
+            int delta_mercantile;
+            int delta_personality;
+            int amount = 0;
+
+            if (selling)
+            {
+                delta_mercantile = (((100 - merchant_mercantile_level) << 8) / 200 + 128) * (((player.Skills.Mercantile) << 8) / 200 + 128) >> 8;
+                delta_personality = (((100 - merchant_personality_level) << 8) / 200 + 128) * ((player.Stats.Personality << 8) / 200 + 128) >> 8;
+                amount = ((((179 * delta_mercantile) >> 8) + ((51 * delta_personality) >> 8)) * cost) >> 8;
+            }
+            else // buying
+            {
+                delta_mercantile = ((merchant_mercantile_level << 8) / 200 + 128) * (((100 - (player.Skills.Mercantile)) << 8) / 200 + 128) >> 8;
+                delta_personality = ((merchant_personality_level << 8) / 200 + 128) * (((100 - player.Stats.Personality) << 8) / 200 + 128) >> 8 << 6;
+                amount = ((((192 * delta_mercantile) >> 8) + (delta_personality >> 8)) * cost) >> 8;
+            }
+
+            return amount;
+        }
+
+        public static int ApplyRegionalPriceAdjustment(int cost)
+        {
+            int adjustedCost;
+            int currentRegionIndex;
+            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            PlayerGPS gps = GameManager.Instance.PlayerGPS;
+            if (gps.HasCurrentLocation)
+                currentRegionIndex = gps.CurrentRegionIndex;
+            else
+                return cost;
+
+            adjustedCost = cost * player.PriceAdjustmentByRegion[currentRegionIndex] / 1000;
+            if (adjustedCost < 1)
+                adjustedCost = 1;
+            return adjustedCost;
+        }
+
+        public static ushort[] RandomRegionalPriceAdjustments()
+        {
+            ushort[] priceAdjustments = new ushort[62];
+            for (int i = 0; i < 62; ++i)
+            {
+                priceAdjustments[i] = (ushort)(UnityEngine.Random.Range(0, 501) + 750);
+            }
+
+            return priceAdjustments;
         }
 
         #endregion

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -688,7 +688,7 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         #region Commerce
 
-        public static int CalculateItemSellCost(int baseItemValue, int shopQuality)
+        public static int CalculateCost(int baseItemValue, int shopQuality)
         {
             int cost = baseItemValue;
 
@@ -706,9 +706,16 @@ namespace DaggerfallWorkshop.Game.Formulas
             // Don't cost already repaired item
             if (condition == max)
                 return 0;
-            // TODO - this is made-up BS by Hazelnut, needs classic formula to be implemented here!
-            Debug.Log(string.Format("baseVal={0}, shopQual={1}, cond={3}, cost= {0} / ({2} * {3})", baseItemValue, shopQuality, (baseItemValue / ((float)shopQuality / 10)), (1-((float)condition / (float)max))*5));
-            return (int)(baseItemValue / ((float)shopQuality / 10) * ((1 - ((float)condition / (float)max)) * 5));
+
+            int cost = baseItemValue;
+
+            cost = 10 * baseItemValue / 100;
+
+            if (cost < 1)
+                cost = 1;
+
+            cost = CalculateCost(cost, shopQuality);
+            return cost;
         }
 
         public static int CalculateTradePrice(int cost, int shopQuality, bool selling)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -586,7 +586,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 switch (windowMode)
                 {
                     case WindowModes.Sell:
-                        PlayerEntity.GoldPieces += GetTradePrice();
+                        int goldAmount = GetTradePrice();
+                        float goldWeight = (float)goldAmount / DaggerfallBankManager.gold1kg;
+                        if (PlayerEntity.CarriedWeight + goldWeight <= PlayerEntity.MaxEncumbrance)
+                            PlayerEntity.GoldPieces += goldAmount;
+                        else
+                        {
+                            DaggerfallUnityItem loc = ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Letter_of_credit);
+                            loc.value = goldAmount;
+                            GameManager.Instance.PlayerEntity.Items.AddItem(loc, Items.ItemCollection.AddPosition.Front);
+                        }
                         remoteItems.Clear();
                         break;
                     case WindowModes.Repair:

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -325,7 +325,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private int GetTradePrice()
         {
-            return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality);
+            return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, true); // Note: This should pass false when buying is implemented
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -312,7 +312,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 switch (windowMode)
                 {
                     case WindowModes.Sell:
-                        cost += FormulaHelper.CalculateItemSellCost(item.value, buildingDiscoveryData.quality) * item.stackCount;
+                        cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality) * item.stackCount;
                         break;
                     case WindowModes.Repair:
                         cost += FormulaHelper.CalculateItemRepairCost(item.value, buildingDiscoveryData.quality, item.currentCondition, item.maxCondition) * item.stackCount;
@@ -325,7 +325,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private int GetTradePrice()
         {
-            return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, true); // Note: This should pass false when buying is implemented
+            if (windowMode == WindowModes.Sell)
+                return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, true);
+            else
+                return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, false);
         }
 
         #endregion
@@ -571,7 +574,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ModeActionButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            if (remoteItems.Count > 0)
+            if (cost > 0)
                 ShowTradePopup();
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -569,7 +569,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ModeActionButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            ShowTradePopup();
+            if (remoteItems.Count > 0)
+                ShowTradePopup();
         }
 
         private void ClearButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -621,18 +621,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             const int tradeMessageBaseId = 260;
             const int notEnoughGoldId = 454;
             int msgOffset = 0;
+            int tradePrice = GetTradePrice();
 
-            if (windowMode != WindowModes.Sell && PlayerEntity.GetGoldAmount() < GetTradePrice())
+            if (windowMode != WindowModes.Sell && PlayerEntity.GetGoldAmount() < tradePrice)
             {
                 DaggerfallUI.MessageBox(notEnoughGoldId);
             }
             else
             {
-                // TODO what is classic algorithm? (seems repair can use all even though not correct contextually)
-                if (windowMode == WindowModes.Buy)
-                    msgOffset = (buildingDiscoveryData.quality > 10) ? 1 : 0;
-                else
-                    msgOffset = 1 + (buildingDiscoveryData.quality / 5);
+                if (cost >> 1 <= tradePrice)
+                {
+                    if (cost - (cost >> 2) <= tradePrice)
+                        msgOffset = 2;
+                    else
+                        msgOffset = 1;
+                }
+                if (windowMode == WindowModes.Sell)
+                    msgOffset += 3;
 
                 DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
                 TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(tradeMessageBaseId + msgOffset);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -481,6 +481,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void LocalItemsButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            const int doesNotNeedToBeRepairedTextId = 24;
+
             // Get index
             int index = localItemsScrollBar.ScrollIndex + (int)sender.Tag;
             if (index >= localItemsFiltered.Count)
@@ -503,10 +505,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 else if (windowMode == WindowModes.Repair)
                 {
                     // Check if item is damaged & transfer
-                    if (item.currentCondition < item.maxCondition)
+                    if ((item.currentCondition < item.maxCondition) && item.TemplateIndex != (int)Weapons.Arrow)
                         TransferItem(item, localItems, remoteItems);
                     else
-                        DaggerfallUI.MessageBox(24);
+                        DaggerfallUI.MessageBox(doesNotNeedToBeRepairedTextId);
                 }
 
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -608,6 +608,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         break;
                 }
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.GoldPieces);
+                PlayerEntity.TallySkill((short)Skills.Mercantile, 1);
                 Refresh();
             }
             CloseWindow();

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -530,6 +530,10 @@ namespace DaggerfallWorkshop.Game.Utility
             var bankRecords = saveTree.FindRecord(RecordTypes.BankAccount);
             Banking.DaggerfallBankManager.ReadNativeBankData(bankRecords);
 
+            // Get regional data.
+            // Currently this only gets the regional price adjustments.
+            playerEntity.PriceAdjustmentByRegion = saveVars.PriceAdjustmentsByRegion;
+
             // Start game
             DaggerfallUI.Instance.PopToHUD();
             GameManager.Instance.PauseGame(false);


### PR DESCRIPTION
Implements classic cost formula for selling.

Prices in classic are influenced by a value, set for each region in the game, that changes every in-game day. This value is imported from classic saves now. It's in a big chunk of data I called RegionData, but I'm just assuming it's all region-related. Most of it is 0 in my saved game I was using for research, but a few other values are set. For now I'm storing the regional price adjustments in the player entity for convenience, but we might want to have some sort of storage for regional data in the future, so I didn't include it in DF Unity saves. When starting a new game or loading a DF Unity save the values will be randomized to the same range they are randomized to in a new game in classic.

I haven't implemented the daily change in the values (either up 2% or down 2%, depending on something to do with the merchants faction).

I also put in the buying formula, which isn't used being used yet and probably needs more work.