### PR TITLE
Read trapped souls from classic saves and display info

### DIFF
--- a/Assets/Scripts/API/Save/SaveTree.cs
+++ b/Assets/Scripts/API/Save/SaveTree.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -245,6 +245,9 @@ namespace DaggerfallConnect.Save
                     case RecordTypes.Container:
                         record = new ContainerRecord(reader, length);
                         break;
+                    case RecordTypes.Soul:
+                        record = new TrappedSoulRecord(reader, length);
+                        break;
                     //case RecordTypes.Door:
                     //    record = new SaveTreeBaseRecord(reader, length);    // Read then skip these records for now
                     //    continue;
@@ -382,6 +385,7 @@ namespace DaggerfallConnect.Save
         QBNData = 0x0e,
         QuestTree = 0x10,                           // Fixsave calls this "quest tree".
         EnemyMobile = 0x12,
+        Soul = 0x14,                                // Souls held in soul traps.
         SpellcastingCreatureListHead = 0x16,
         UserOptions = 0x17,                         // Fixsave calls this "user options"
         LocationName1 = 0x18,                       // Possibly logbook entries. chunktcl calls this "Logbook"

--- a/Assets/Scripts/API/Save/SaveTree.cs
+++ b/Assets/Scripts/API/Save/SaveTree.cs
@@ -245,7 +245,7 @@ namespace DaggerfallConnect.Save
                     case RecordTypes.Container:
                         record = new ContainerRecord(reader, length);
                         break;
-                    case RecordTypes.Soul:
+                    case RecordTypes.TrappedSoul:
                         record = new TrappedSoulRecord(reader, length);
                         break;
                     //case RecordTypes.Door:
@@ -385,7 +385,7 @@ namespace DaggerfallConnect.Save
         QBNData = 0x0e,
         QuestTree = 0x10,                           // Fixsave calls this "quest tree".
         EnemyMobile = 0x12,
-        Soul = 0x14,                                // Souls held in soul traps.
+        TrappedSoul = 0x14,                                // Souls held in soul traps.
         SpellcastingCreatureListHead = 0x16,
         UserOptions = 0x17,                         // Fixsave calls this "user options"
         LocationName1 = 0x18,                       // Possibly logbook entries. chunktcl calls this "Logbook"

--- a/Assets/Scripts/API/Save/TrappedSoulRecord.cs
+++ b/Assets/Scripts/API/Save/TrappedSoulRecord.cs
@@ -72,7 +72,7 @@ namespace DaggerfallConnect.Save
         void ReadNativeContainerData()
         {
             // Must be a container type
-            if (recordType != RecordTypes.Soul)
+            if (recordType != RecordTypes.TrappedSoul)
                 return;
 
             // Prepare stream

--- a/Assets/Scripts/API/Save/TrappedSoulRecord.cs
+++ b/Assets/Scripts/API/Save/TrappedSoulRecord.cs
@@ -1,0 +1,92 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Hazelnut
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using System.Text;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using DaggerfallConnect.Utility;
+using UnityEngine;
+
+namespace DaggerfallConnect.Save
+{
+    /// <summary>
+    /// Trapped Soul record.
+    /// SaveTreeRecordTypes = 0x14
+    /// </summary>
+    public class TrappedSoulRecord : SaveTreeBaseRecord
+    {
+        #region Fields
+
+        TrappedSoulRecordData parsedData;
+
+        #endregion
+
+        #region Properties
+
+        public TrappedSoulRecordData ParsedData
+        {
+            get { return parsedData; }
+            set { parsedData = value; }
+        }
+
+        #endregion
+
+        #region Structures
+
+        /// <summary>
+        /// Soul records have a 2 byte monster id at offset 0x1B which is part of the root record so this is not used.
+        /// </summary>
+        public struct TrappedSoulRecordData
+        {
+            public byte[] unknown;
+        }
+
+        #endregion
+
+        #region Constructors
+
+        public TrappedSoulRecord()
+        {
+        }
+
+        public TrappedSoulRecord(BinaryReader reader, int length)
+            : base(reader, length)
+        {
+            ReadNativeContainerData();
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        void ReadNativeContainerData()
+        {
+            // Must be a container type
+            if (recordType != RecordTypes.Soul)
+                return;
+
+            // Prepare stream
+            MemoryStream stream = new MemoryStream(RecordData);
+            BinaryReader reader = new BinaryReader(stream);
+
+            // Read container data
+            parsedData = new TrappedSoulRecordData();
+            parsedData.unknown = reader.ReadBytes(RecordLength);    // Seems always is a single byte value = 150
+
+            // Close stream
+            reader.Close();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/API/Save/TrappedSoulRecord.cs
+++ b/Assets/Scripts/API/Save/TrappedSoulRecord.cs
@@ -71,7 +71,7 @@ namespace DaggerfallConnect.Save
 
         void ReadNativeContainerData()
         {
-            // Must be a container type
+            // Must be a trapped soul type
             if (recordType != RecordTypes.TrappedSoul)
                 return;
 
@@ -79,9 +79,9 @@ namespace DaggerfallConnect.Save
             MemoryStream stream = new MemoryStream(RecordData);
             BinaryReader reader = new BinaryReader(stream);
 
-            // Read container data
+            // Read container data - seems always is a single byte value = 150, use unknown
             parsedData = new TrappedSoulRecordData();
-            parsedData.unknown = reader.ReadBytes(RecordLength);    // Seems always is a single byte value = 150
+            parsedData.unknown = reader.ReadBytes(RecordLength);    
 
             // Close stream
             reader.Close();

--- a/Assets/Scripts/API/Save/TrappedSoulRecord.cs.meta
+++ b/Assets/Scripts/API/Save/TrappedSoulRecord.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: eafa4f59160123442aa3f8ce05c38c64
+timeCreated: 1505663542
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -75,7 +75,7 @@ namespace DaggerfallWorkshop.Game.Banking
 
         private static int loanMaxPerLevel = 50000;
 
-        private static float locCommission = 1.01f;
+        private static double locCommission = 1.01;
 
         private static DaggerfallDateTime dateTime;
 
@@ -242,7 +242,7 @@ namespace DaggerfallWorkshop.Game.Banking
         public static TransactionResult Withdraw_LOC(int amount, int regionIndex)
         {
             // Create LOC and deduct from account
-            int amountPlusCommission = (int)Math.Round(amount * locCommission);
+            int amountPlusCommission = (int)(amount * locCommission);
             if (amountPlusCommission > BankAccounts[regionIndex].accountGold)
                 return TransactionResult.NOT_ENOUGH_ACCOUNT_LOC;
             else if (amount < 100)

--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -75,7 +75,7 @@ namespace DaggerfallWorkshop.Game.Banking
 
         private static int loanMaxPerLevel = 50000;
 
-        private static float locCommission = 1.1f;
+        private static float locCommission = 1.01f;
 
         private static DaggerfallDateTime dateTime;
 
@@ -242,7 +242,7 @@ namespace DaggerfallWorkshop.Game.Banking
         public static TransactionResult Withdraw_LOC(int amount, int regionIndex)
         {
             // Create LOC and deduct from account
-            int amountPlusCommission = (int)(amount * locCommission);
+            int amountPlusCommission = (int)Math.Round(amount * locCommission);
             if (amountPlusCommission > BankAccounts[regionIndex].accountGold)
                 return TransactionResult.NOT_ENOUGH_ACCOUNT_LOC;
             else if (amount < 100)

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -20,6 +20,7 @@ using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Utility;
 using UnityEngine;
+using System;
 
 namespace DaggerfallWorkshop.Game.Entity
 {
@@ -207,6 +208,15 @@ namespace DaggerfallWorkshop.Game.Entity
 
                 // Add to local inventory or wagon
                 DaggerfallUnityItem newItem = new DaggerfallUnityItem((ItemRecord)record);
+                if (newItem.ItemGroup == ItemGroups.MiscItems && newItem.GroupIndex == 1)
+                {
+                    UInt32 subList = record.RecordRoot.SublistHead;
+                    SaveTreeBaseRecord subrec = record.Children[0];
+                    string str = "";
+                    for (int i = 0; i < subrec.StreamLength; i++)
+                        str += subrec.StreamData[i] + ", ";
+                    Debug.Log(str);
+                }
                 if (containerRecord.IsWagon)
                     wagonItems.AddItem(newItem);
                 else

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -206,17 +206,14 @@ namespace DaggerfallWorkshop.Game.Entity
                 // Get container parent
                 ContainerRecord containerRecord = (ContainerRecord)record.Parent;
 
-                // Add to local inventory or wagon
+                // Create item, grabbing trapped soul if needed
                 DaggerfallUnityItem newItem = new DaggerfallUnityItem((ItemRecord)record);
                 if (newItem.ItemGroup == ItemGroups.MiscItems && newItem.GroupIndex == 1)
                 {
-                    UInt32 subList = record.RecordRoot.SublistHead;
-                    SaveTreeBaseRecord subrec = record.Children[0];
-                    string str = "";
-                    for (int i = 0; i < subrec.StreamLength; i++)
-                        str += subrec.StreamData[i] + ", ";
-                    Debug.Log(str);
+                    TrappedSoulRecord soulRecord = (TrappedSoulRecord) record.Children[0];    // Can items have any other types of children?
+                    newItem.TrappedSoulType = (MobileTypes) soulRecord.RecordRoot.SpriteIndex;
                 }
+                // Add to local inventory or wagon
                 if (containerRecord.IsWagon)
                     wagonItems.AddItem(newItem);
                 else

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -54,6 +54,9 @@ namespace DaggerfallWorkshop.Game.Items
         int currentVariant = 0;
         ulong uid;
 
+        // Soul trapped
+        MobileTypes trappedSoulType = MobileTypes.None;
+
         // Quest-related fields
         bool isQuestItem = false;
         ulong questUID = 0;
@@ -257,6 +260,15 @@ namespace DaggerfallWorkshop.Game.Items
         public bool IsIdentified
         {
             get { return GetIsIdentified(); }
+        }
+
+        /// <summary>
+        /// Gets the soul trapped in a soul trap.
+        /// </summary>
+        public MobileTypes TrappedSoulType
+        {
+            get { return trappedSoulType; }
+            set { trappedSoulType = value; }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -98,10 +98,12 @@ namespace DaggerfallWorkshop.Game.Items
                 return bookFile.Author;
             }
 
-            //public override string HeldSoul()
-            //{   // %hs
-            //    return ;
-            //}
+            public override string HeldSoul()
+            {   // %hs
+                MobileEnemy soul;
+                EnemyBasics.GetEnemy(parent.trappedSoulType, out soul);
+                return soul.Name;
+            }
 
 
             public override TextFile.Token[] MagicPowers(TextFile.Formatting format)

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -98,6 +98,12 @@ namespace DaggerfallWorkshop.Game.Items
                 return bookFile.Author;
             }
 
+            //public override string HeldSoul()
+            //{   // %hs
+            //    return ;
+            //}
+
+
             public override TextFile.Token[] MagicPowers(TextFile.Formatting format)
             {   // %mpw
                 if (parent.IsArtifact)

--- a/Assets/Scripts/Utility/MacroDataSource.cs
+++ b/Assets/Scripts/Utility/MacroDataSource.cs
@@ -114,6 +114,11 @@ namespace DaggerfallWorkshop.Utility
             throw new NotImplementedException();
         }
 
+        public virtual string HeldSoul()
+        {   // %hs
+            throw new NotImplementedException();
+        }
+
         public virtual string Pronoun()
         {   // %g & %g1
             throw new NotImplementedException();

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -105,7 +105,7 @@ namespace DaggerfallWorkshop.Utility
             { "%hpn", null }, // ?
             { "%hpw", null }, // ?
             { "%hrg", null }, // House region
-            { "%hs", null },  //  Holding Soul type
+            { "%hs", HeldSoul },  //  Holding Soul type
             { "%htwn", null },// House town
             { "%imp", null }, // ?
             { "%int", Int }, // Amount of Intelligence
@@ -599,6 +599,11 @@ namespace DaggerfallWorkshop.Utility
         public static string BookAuthor(IMacroContextProvider mcp)
         {   // %ba
             return mcp.GetMacroDataSource().BookAuthor();
+        }
+
+        public static string HeldSoul(IMacroContextProvider mcp)
+        {   // %hs
+            return mcp.GetMacroDataSource().HeldSoul();
         }
 
         public static string Pronoun(IMacroContextProvider mcp)


### PR DESCRIPTION
Not sure if the TrappedSoulRecord is right since the data with the soul monster id is at 0x1B which is part of the root record - SpriteIndex in fact.

All the records seem to have above the root record is a single byte, value = 150

Anyway after mapping to the corresponding MobileEnemy, the soul names are now displaying correctly. Guess there will be more to do once magic is implemented.