### PR TITLE
Implement correct greetings based on reaction

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -67,6 +67,11 @@ namespace DaggerfallConnect.Save
             doc.currentHealth = parsedData.currentHealth;
             doc.maxHealth = parsedData.maxHealth;
             doc.currentSpellPoints = parsedData.currentSpellPoints;
+            doc.reputationCommoners = parsedData.reputationCommoners;
+            doc.reputationMerchants = parsedData.reputationMerchants;
+            doc.reputationNobility = parsedData.reputationNobility;
+            doc.reputationScholars = parsedData.reputationScholars;
+            doc.reputationUnderworld = parsedData.reputationUnderworld;
             doc.currentFatigue = parsedData.currentFatigue;
             doc.skillUses = parsedData.skillUses;
             doc.startingLevelUpSkillSum = parsedData.startingLevelUpSkillSum;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -52,6 +52,8 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int currentLevelUpSkillSum = 0;
         protected bool readyToLevelUp = false;
 
+        protected short[] sGroupReputations = new short[5];
+
         protected int biographyResistDiseaseMod = 0;
         protected int biographyResistMagicMod = 0;
         protected int biographyAvoidHitMod = 0;
@@ -85,6 +87,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public int StartingLevelUpSkillSum { get { return startingLevelUpSkillSum; } set { startingLevelUpSkillSum = value; } }
         public int CurrentLevelUpSkillSum {  get { return currentLevelUpSkillSum; } }
         public bool ReadyToLevelUp { get { return readyToLevelUp; } set { readyToLevelUp = value; } }
+        public short[] SGroupReputations { get { return sGroupReputations; } set { sGroupReputations = value; } }
         public int BiographyResistDiseaseMod { get { return biographyResistDiseaseMod; } set { biographyResistDiseaseMod = value; } }
         public int BiographyResistMagicMod { get { return biographyResistMagicMod; } set { biographyResistMagicMod = value; } }
         public int BiographyAvoidHitMod { get { return biographyAvoidHitMod; } set { biographyAvoidHitMod = value; } }
@@ -157,6 +160,11 @@ namespace DaggerfallWorkshop.Game.Entity
             this.maxHealth = character.maxHealth;
             this.currentHealth = character.currentHealth;
             this.currentMagicka = character.currentSpellPoints;
+            this.sGroupReputations[0] = character.reputationCommoners;
+            this.sGroupReputations[1] = character.reputationMerchants;
+            this.sGroupReputations[2] = character.reputationNobility;
+            this.sGroupReputations[3] = character.reputationScholars;
+            this.sGroupReputations[4] = character.reputationUnderworld;
             this.currentFatigue = character.currentFatigue;
             this.skillUses = character.skillUses;
             this.startingLevelUpSkillSum = character.startingLevelUpSkillSum;

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -35,6 +35,11 @@ namespace DaggerfallWorkshop.Game.Player
         public int currentHealth;
         public int maxHealth;
         public int currentSpellPoints;
+        public short reputationCommoners;
+        public short reputationMerchants;
+        public short reputationNobility;
+        public short reputationScholars;
+        public short reputationUnderworld;
         public int currentFatigue;
         public short[] skillUses;
         public int startingLevelUpSkillSum;

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -142,6 +142,7 @@ namespace DaggerfallWorkshop.Game
         string currentKeySubject = "";
         KeySubjectType currentKeySubjectType = KeySubjectType.Unset;
         int currentKeySubjectBuildingKey = -1;
+        int reactionToPlayer = 0;
 
         List<ListItem> listTopicTellMeAbout;
         List<ListItem> listTopicLocation;
@@ -256,7 +257,7 @@ namespace DaggerfallWorkshop.Game
 
         #region Public Methods        
 
-        public void SetTargetNPC(MobilePersonNPC targetNPC)
+        public void SetTargetNPC(MobilePersonNPC targetNPC, int reactionToPlayer)
         {
             if (targetNPC == lastTargetNPC)
                 return;
@@ -266,6 +267,8 @@ namespace DaggerfallWorkshop.Game
             lastTargetNPC = targetNPC;
 
             nameNPC = targetNPC.NameNPC;
+
+            this.reactionToPlayer = reactionToPlayer;
 
             // reset npc knowledge, for now it resets every time the npc has changed (player talked to new npc)
             // TODO: match classic daggerfall - in classic npc remember their knowledge about topics for their time of existence
@@ -283,10 +286,31 @@ namespace DaggerfallWorkshop.Game
 
         public string GetNPCGreetingText()
         {
-            //string greetingString = DaggerfallUnity.Instance.TextProvider.GetRandomText(7206);
-            //string greetingString = DaggerfallUnity.Instance.TextProvider.GetRandomText(7207);
-            //string greetingString = DaggerfallUnity.Instance.TextProvider.GetRandomText(7208);
-            string greetingString = expandRandomTextRecord(7209) + " ";
+            const int dislikePlayerGreetingTextId = 7206;
+            const int neutralToPlayerGreetingTextId = 7207;
+            const int likePlayerGreetingTextId = 7208;
+            const int veryLikePlayerGreetingTextId = 7209;
+
+            string greetingString = "";
+
+            if (reactionToPlayer >= 0)
+            {
+                if (reactionToPlayer >= 10)
+                {
+                    if (reactionToPlayer >= 30)
+                        greetingString = expandRandomTextRecord(veryLikePlayerGreetingTextId);
+                    else
+                        greetingString = expandRandomTextRecord(likePlayerGreetingTextId);
+                }
+                else
+                {
+                    greetingString = expandRandomTextRecord(neutralToPlayerGreetingTextId);
+                }
+            }
+            else
+            {
+                greetingString = expandRandomTextRecord(dislikePlayerGreetingTextId);
+            }
             
             return (greetingString);
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -102,7 +102,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Texture2D texturePortrait;
 
         Panel panelNameNPC;
-        TextLabel labelNameNPC = null;        
+        TextLabel labelNameNPC = null;
 
         Color[] textureTellMeAboutNormal;
         Color[] textureTellMeAboutHighlighted;


### PR DESCRIPTION
This should hopefully give correct greetings based on reputation. A few other things, (masque of clavicus, something to do with guilds) in classic can affect NPC reaction to player, which isn't in yet.

The reputation modifiers with the general social groups (commoners, merchants, etc.) are imported from classic saves. They aren't saved in DF Unity yet because I want to be sure that the manner I'm storing them in the player entity is OK, which is as an array, to make it simple to access using the sgroup values from faction.txt.