### PR TITLE
Item hover info panel in inventory

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -30,6 +30,7 @@ EnableToolTips=True
 ToolTipDelayInSeconds=0.0
 ToolTipBackgroundColor=404040D2
 ToolTipTextColor=E6E6C8FF
+EnableInventoryInfoPanel = False
 AutomapNumberOfDungeons=5
 ShopQualityPresentation=0
 ShopQualityHUDDelay=4

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -88,6 +88,7 @@ namespace DaggerfallWorkshop.Game
         QuestMachineInspectorWindow dfQuestInspector;
 
         DaggerfallFontPlus fontPetrock32;
+        DaggerfallFontPlus fontExeter32;
 
         public DaggerfallFont Font1 { get { return GetFont(1); } }
         public DaggerfallFont Font2 { get { return GetFont(2); } }
@@ -190,6 +191,7 @@ namespace DaggerfallWorkshop.Game
         public enum HQPixelFonts
         {
             Petrock_32,
+            Exeter_32,
         }
 
         void Awake()
@@ -458,7 +460,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Gets a new DaggerfallFont.
         /// </summary>
-        /// <param name="index">I ndex of font between 1-5 (default is 4).</param>
+        /// <param name="index">Index of font between 1-5 (default is 4).</param>
         /// <returns>DaggerfallFont</returns>
         public DaggerfallFont GetFont(int index = 4)
         {
@@ -502,6 +504,10 @@ namespace DaggerfallWorkshop.Game
                     if (fontPetrock32 == null)
                         fontPetrock32 = new DaggerfallFontPlus(Resources.Load<Texture2D>("Kingthings-Petrock-Light-PixelFont"), 16, 16, 32);
                     return fontPetrock32;
+                case HQPixelFonts.Exeter_32:
+                    if (fontExeter32 == null)
+                        fontExeter32 = new DaggerfallFontPlus(Resources.Load<Texture2D>("Kingthings-Exeter-PixelFont"), 16, 16, 32);
+                    return fontExeter32;
             }
 
             return null;

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -88,7 +88,6 @@ namespace DaggerfallWorkshop.Game
         QuestMachineInspectorWindow dfQuestInspector;
 
         DaggerfallFontPlus fontPetrock32;
-        DaggerfallFontPlus fontExeter32;
 
         public DaggerfallFont Font1 { get { return GetFont(1); } }
         public DaggerfallFont Font2 { get { return GetFont(2); } }
@@ -191,7 +190,6 @@ namespace DaggerfallWorkshop.Game
         public enum HQPixelFonts
         {
             Petrock_32,
-            Exeter_32,
         }
 
         void Awake()
@@ -504,10 +502,6 @@ namespace DaggerfallWorkshop.Game
                     if (fontPetrock32 == null)
                         fontPetrock32 = new DaggerfallFontPlus(Resources.Load<Texture2D>("Kingthings-Petrock-Light-PixelFont"), 16, 16, 32);
                     return fontPetrock32;
-                case HQPixelFonts.Exeter_32:
-                    if (fontExeter32 == null)
-                        fontExeter32 = new DaggerfallFontPlus(Resources.Load<Texture2D>("Kingthings-Exeter-PixelFont"), 16, 16, 32);
-                    return fontExeter32;
             }
 
             return null;

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -18,6 +18,8 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Utility;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -439,6 +441,110 @@ namespace DaggerfallWorkshop.Game.Items
                 default:
                     return false;
             }
+        }
+
+        public static TextFile.Token[] GetItemInfo(DaggerfallUnityItem item, ITextProvider textProvider)
+        {
+            const int paintingTextId = 250;
+            const int armorTextId = 1000;
+            const int weaponTextId = 1001;
+            const int miscTextId = 1003;
+            const int soulTrapTextId = 1004;
+            const int letterOfCreditTextId = 1007;
+            //const int potionTextId = 1008;
+            const int bookTextId = 1009;
+            const int arrowTextId = 1011;
+            const int weaponNoMaterialTextId = 1012;
+            const int armorNoMaterialTextId = 1014;
+            const int oghmaInfiniumTextId = 1015;
+            const int houseDeedTextId = 1073;
+
+            TextFile.Token[] tokens = null;
+
+            // Handle by item group
+            switch (item.ItemGroup)
+            {
+                case (ItemGroups.Armor):
+                    if (item.IsShield || item.TemplateIndex == (int)Armor.Helm || item.IsArtifact)
+                        tokens = textProvider.GetRSCTokens(armorNoMaterialTextId);
+                    else
+                        tokens = textProvider.GetRSCTokens(armorTextId);
+                    break;
+
+                case (ItemGroups.Weapons):
+                    if (item.TemplateIndex == (int)Weapons.Arrow)
+                        tokens = textProvider.GetRSCTokens(arrowTextId);
+                    else if (item.IsArtifact)
+                        tokens = textProvider.GetRSCTokens(weaponNoMaterialTextId);
+                    else
+                        tokens = textProvider.GetRSCTokens(weaponTextId);
+                    break;
+
+                case (ItemGroups.Books):
+                    // Handle Oghma Infinium
+                    if (item.legacyMagic != null && item.legacyMagic[0] == 26)
+                    {
+                        tokens = textProvider.GetRSCTokens(oghmaInfiniumTextId);
+                    }
+                    // Handle other books
+                    else
+                    {
+                        tokens = textProvider.GetRSCTokens(bookTextId);
+                    }
+                    break;
+
+                // TODO: Check for potion in glass bottle.
+                // In classic, the check is whether RecordRoot.SublistHead is non-null
+                // and of PotionMix type.
+
+                case (ItemGroups.Paintings):
+                    // TODO: Show painting. Uses file paint.dat.
+                    tokens = textProvider.GetRSCTokens(paintingTextId);
+                    break;
+
+                default:
+                    // A few items in the MiscItems group have their own text display
+                    if (item.ItemGroup == ItemGroups.MiscItems)
+                    {
+                        // Handle potion recipes
+                        if (item.TemplateIndex == (int)MiscItems.Potion_recipe)
+                        {
+                            //TODO - deprecate potion recipe window now macro handling is in
+
+                            //DaggerfallPotionRecipeWindow readerWindow = new DaggerfallPotionRecipeWindow(DaggerfallUI.UIManager, item.typeDependentData, this);
+                            //DaggerfallUI.UIManager.PushWindow(readerWindow);
+                            //return;
+                        }
+                        // Handle house deeds
+                        else if (item.TemplateIndex == (int)MiscItems.House_Deed)
+                        {
+                            tokens = textProvider.GetRSCTokens(houseDeedTextId);
+                        }
+                        // Handle soul traps
+                        else if (item.TemplateIndex == (int)MiscItems.Soul_trap)
+                        {
+                            tokens = textProvider.GetRSCTokens(soulTrapTextId);
+                        }
+                        else if (item.TemplateIndex == (int)MiscItems.Letter_of_credit)
+                        {
+                            tokens = textProvider.GetRSCTokens(letterOfCreditTextId);
+                        }
+                        if (tokens != null)
+                            break;
+                    }
+
+                    // Handle Azura's Star
+                    if (item.legacyMagic != null && item.legacyMagic[0] == 26 && item.legacyMagic[1] == 9)
+                    {
+                        tokens = textProvider.GetRSCTokens(soulTrapTextId);
+                        break;
+                    }
+
+                    // Default fallback if none of the above applied
+                    tokens = textProvider.GetRSCTokens(miscTextId);
+                    break;
+            }
+            return tokens;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
+++ b/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -74,10 +74,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
         float minAutoScale = 0;
         float maxAutoScale = 0;
 
-        public delegate void OnMouseEnterHandler();
+        public delegate void OnMouseEnterHandler(BaseScreenComponent sender);
         public event OnMouseEnterHandler OnMouseEnter;
 
-        public delegate void OnMouseLeaveHandler();
+        public delegate void OnMouseLeaveHandler(BaseScreenComponent sender);
         public event OnMouseLeaveHandler OnMouseLeave;
 
         public delegate void OnMouseMoveHandler(int x, int y);
@@ -745,7 +745,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         protected virtual void MouseEnter()
         {
             if (OnMouseEnter != null)
-                OnMouseEnter();
+                OnMouseEnter(this);
         }
 
         /// <summary>
@@ -754,7 +754,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         protected virtual void MouseExit()
         {
             if (OnMouseLeave != null)
-                OnMouseLeave();
+                OnMouseLeave(this);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -28,6 +28,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         const int tabWidth = 35;
 
         PixelFont font;
+        float textScale = 1.0f; // scale text 
         int rowLeading = 0;
         Vector2 shadowPosition = DaggerfallUI.DaggerfallDefaultShadowPos;
         Color textColor = DaggerfallUI.DaggerfallDefaultTextColor;
@@ -61,6 +62,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             get { return maxTextWidth; }
             set { maxTextWidth = value; }
+        }
+
+        /// <summary>
+        /// set text scale factor - 1.0f is default value, 0.5f is half sized text, 2.0f double sized text and so on
+        /// </summary>
+        public float TextScale
+        {
+            get { return textScale; }
+            set { textScale = value; }
         }
 
         /// <summary>
@@ -160,6 +170,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             textLabel.Font = font;
             textLabel.Position = new Vector2(cursorX, cursorY);
             textLabel.WrapText = wrapText;
+            textLabel.TextScale = TextScale;
 
             // Use max width if it has been specified
             if (maxTextWidth > 0)

--- a/Assets/Scripts/Game/UserInterface/TextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/TextLabel.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -263,6 +263,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 innerRect = new Rect(0, 0, (float)totalWidth / (float)textureWidth, (float)totalHeight / (float)textureHeight);
                 textureToDraw = labelTexture;
             }
+
+            // compensate for textScale
+            totalRect.xMax = totalRect.xMin + totalRect.width * textScale;
+            totalRect.yMax = totalRect.yMin + totalRect.height * textScale;
 
             // Draw shadow            
             if (shadowPosition != Vector2.zero)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -260,6 +260,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Character portrait
             SetupPaperdoll();
 
+            // Setup local and remote target icon panels
+            localTargetIconPanel = DaggerfallUI.AddPanel(localTargetIconRect, NativePanel);
+            remoteTargetIconPanel = DaggerfallUI.AddPanel(remoteTargetIconRect, NativePanel);
+            remoteTargetIconLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(1, 2), remoteTargetIconPanel);
+
+            // Setup item info panel in local target icon if configured
+            SetupItemInfoPanel();
+
             // Setup UI
             SetupTabPageButtons();
             SetupActionButtons();
@@ -272,22 +280,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Exit buttons
             Button exitButton = DaggerfallUI.AddButton(exitButtonRect, NativePanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
-
-            // Setup local and remote target icon panels
-            localTargetIconPanel = DaggerfallUI.AddPanel(localTargetIconRect, NativePanel);
-            localTargetIconPanel.BackgroundTexture = infoTexture;
-            remoteTargetIconPanel = DaggerfallUI.AddPanel(remoteTargetIconRect, NativePanel);
-            remoteTargetIconLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(1, 2), remoteTargetIconPanel);
-
-            // Setup item info panel in local target icon if configured
-            localTargetItemInfoLabel = new MultiFormatTextLabel();
-            localTargetItemInfoLabel.Position = new Vector2(2, 0);
-            localTargetItemInfoLabel.VerticalAlignment = VerticalAlignment.Middle;
-            localTargetItemInfoLabel.MaxTextWidth = 53;
-            localTargetItemInfoLabel.ShadowPosition = Vector2.zero;
-            localTargetItemInfoLabel.TextScale = 0.6f;
-            localTargetItemInfoLabel.TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
-            localTargetIconPanel.Components.Add(localTargetItemInfoLabel);
 
             // Setup initial state
             SelectTabPage(TabPages.WeaponsAndArmor);
@@ -304,6 +296,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             UpdateAccessoryItemsDisplay();
             UpdateLocalTargetIcon();
             UpdateRemoteTargetIcon();
+        }
+
+        private void SetupItemInfoPanel()
+        {
+            if (DaggerfallUnity.Settings.EnableInventoryInfoPanel)
+            {
+                localTargetIconPanel.BackgroundTexture = infoTexture;
+                localTargetItemInfoLabel = new MultiFormatTextLabel();
+                localTargetItemInfoLabel.Position = new Vector2(2, 0);
+                localTargetItemInfoLabel.VerticalAlignment = VerticalAlignment.Middle;
+                localTargetItemInfoLabel.MaxTextWidth = 53;
+                localTargetItemInfoLabel.ShadowPosition = Vector2.zero;
+                localTargetItemInfoLabel.TextScale = 0.6f;
+                localTargetItemInfoLabel.TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
+                localTargetIconPanel.Components.Add(localTargetItemInfoLabel);
+            }
         }
 
         protected void SetupPaperdoll()
@@ -406,7 +414,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 localItemsButtons[i].ToolTip = defaultToolTip;
                 localItemsButtons[i].Tag = i;
                 localItemsButtons[i].OnMouseClick += LocalItemsButton_OnMouseClick;
-                localItemsButtons[i].OnMouseEnter += LocalItemsButton_OnMouseEnter;
+                if (localTargetItemInfoLabel != null)
+                    localItemsButtons[i].OnMouseEnter += LocalItemsButton_OnMouseEnter;
 
                 // Icon image panel
                 localItemsIconPanels[i] = DaggerfallUI.AddPanel(localItemsButtons[i], AutoSizeModes.ScaleToFit);
@@ -439,7 +448,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 remoteItemsButtons[i].ToolTip = defaultToolTip;
                 remoteItemsButtons[i].Tag = i;
                 remoteItemsButtons[i].OnMouseClick += RemoteItemsButton_OnMouseClick;
-                remoteItemsButtons[i].OnMouseEnter += RemoteItemsButton_OnMouseEnter;
+                if (localTargetItemInfoLabel != null)
+                    remoteItemsButtons[i].OnMouseEnter += RemoteItemsButton_OnMouseEnter;
 
                 // Icon image panel
                 remoteItemsIconPanels[i] = DaggerfallUI.AddPanel(remoteItemsButtons[i], AutoSizeModes.ScaleToFit);
@@ -1716,8 +1726,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (item != null)
                         text = item.LongName;
 
-                    // Update the info panel
-                    UpdateItemInfoPanel(item);
+                    // Update the info panel if used
+                    if (localTargetItemInfoLabel != null)
+                        UpdateItemInfoPanel(item);
                 }
                 // Update tooltip text
                 paperDoll.ToolTipText = text;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -306,9 +306,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 localTargetItemInfoLabel = new MultiFormatTextLabel();
                 localTargetItemInfoLabel.Position = new Vector2(2, 0);
                 localTargetItemInfoLabel.VerticalAlignment = VerticalAlignment.Middle;
-                localTargetItemInfoLabel.MaxTextWidth = 53;
                 localTargetItemInfoLabel.ShadowPosition = Vector2.zero;
-                localTargetItemInfoLabel.TextScale = 0.6f;
+                localTargetItemInfoLabel.TextScale = 0.75f;
+                localTargetItemInfoLabel.MaxTextWidth = 71;
                 localTargetItemInfoLabel.TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
                 localTargetIconPanel.Components.Add(localTargetItemInfoLabel);
             }
@@ -493,6 +493,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 button.ToolTip = defaultToolTip;
                 button.Tag = i;
                 button.OnMouseClick += AccessoryItemsButton_OnMouseClick;
+                if (localTargetItemInfoLabel != null)
+                    button.OnMouseEnter += AccessoryItemsButton_OnMouseEnter;
                 accessoryButtons[i] = button;
 
                 // Create icon panel
@@ -1625,19 +1627,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        protected virtual void LocalItemsButton_OnMouseEnter(BaseScreenComponent sender)
-        {
-            // Get index
-            int index = localItemsScrollBar.ScrollIndex + (int)sender.Tag;
-            if (index >= localItemsFiltered.Count)
-                return;
-            // Get item
-            DaggerfallUnityItem item = localItemsFiltered[index];
-            if (item == null)
-                return;
-            UpdateItemInfoPanel(item);
-        }
-
         protected virtual void RemoteItemsButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             // Get index
@@ -1685,19 +1674,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        protected virtual void RemoteItemsButton_OnMouseEnter(BaseScreenComponent sender)
-        {
-            // Get index
-            int index = remoteItemsScrollBar.ScrollIndex + (int)sender.Tag;
-            if (index >= remoteItemsFiltered.Count)
-                return;
-            // Get item
-            DaggerfallUnityItem item = remoteItemsFiltered[index];
-            if (item == null)
-                return;
-            UpdateItemInfoPanel(item);
-        }
-
         protected void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             CloseWindow();
@@ -1705,7 +1681,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #endregion
 
-        #region Other Event Handlers
+        #region Hover & StartGame Event Handlers
 
         private void PaperDoll_OnMouseMove(int x, int y)
         {
@@ -1739,6 +1715,42 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 paperDoll.ToolTipText = string.Empty;
                 lastMouseOverPaperDollEquipIndex = value;
             }
+        }
+
+        protected virtual void AccessoryItemsButton_OnMouseEnter(BaseScreenComponent sender)
+        {
+            // Get item
+            EquipSlots slot = (EquipSlots)sender.Tag;
+            DaggerfallUnityItem item = playerEntity.ItemEquipTable.GetItem(slot);
+            if (item == null)
+                return;
+            UpdateItemInfoPanel(item);
+        }
+
+        protected virtual void LocalItemsButton_OnMouseEnter(BaseScreenComponent sender)
+        {
+            // Get index
+            int index = localItemsScrollBar.ScrollIndex + (int)sender.Tag;
+            if (index >= localItemsFiltered.Count)
+                return;
+            // Get item
+            DaggerfallUnityItem item = localItemsFiltered[index];
+            if (item == null)
+                return;
+            UpdateItemInfoPanel(item);
+        }
+
+        protected virtual void RemoteItemsButton_OnMouseEnter(BaseScreenComponent sender)
+        {
+            // Get index
+            int index = remoteItemsScrollBar.ScrollIndex + (int)sender.Tag;
+            if (index >= remoteItemsFiltered.Count)
+                return;
+            // Get item
+            DaggerfallUnityItem item = remoteItemsFiltered[index];
+            if (item == null)
+                return;
+            UpdateItemInfoPanel(item);
         }
 
         private void UpdateItemInfoPanel(DaggerfallUnityItem item)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -99,6 +99,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Panel[] accessoryIconPanels = new Panel[accessoryCount];
 
         PaperDoll paperDoll = new PaperDoll();
+        protected Panel localTargetIconPanel;
+        protected MultiFormatTextLabel localTargetInfoLabel;
         protected Panel remoteTargetIconPanel;
         protected TextLabel remoteTargetIconLabel;
 
@@ -268,8 +270,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
 
             // Setup local and remote target icon panels
+            localTargetIconPanel = DaggerfallUI.AddPanel(localTargetIconRect, NativePanel);
             remoteTargetIconPanel = DaggerfallUI.AddPanel(remoteTargetIconRect, NativePanel);
             remoteTargetIconLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(1, 2), remoteTargetIconPanel);
+
+            // Setup item info panel
+            localTargetInfoLabel = new MultiFormatTextLabel(); //DaggerfallUI.AddTextLabel(DaggerfallUI.Instance.Font4, Vector2.zero, string.Empty, localTargetIconPanel);
+            localTargetInfoLabel.HorizontalAlignment = HorizontalAlignment.Left;
+            localTargetInfoLabel.VerticalAlignment = VerticalAlignment.Top;
+            localTargetInfoLabel.ShadowPosition = Vector2.zero;
+            //localTargetInfoLabel.Font = DaggerfallUI.Instance.GetHQPixelFont(DaggerfallUI.HQPixelFonts.Petrock_32);
+            localTargetInfoLabel.TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
+            localTargetIconPanel.Components.Add(localTargetInfoLabel);
 
             // Setup initial state
             SelectTabPage(TabPages.WeaponsAndArmor);
@@ -388,6 +400,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 localItemsButtons[i].ToolTip = defaultToolTip;
                 localItemsButtons[i].Tag = i;
                 localItemsButtons[i].OnMouseClick += LocalItemsButton_OnMouseClick;
+                localItemsButtons[i].OnMouseEnter += LocalItemsButton_OnMouseEnter;
 
                 // Icon image panel
                 localItemsIconPanels[i] = DaggerfallUI.AddPanel(localItemsButtons[i], AutoSizeModes.ScaleToFit);
@@ -1416,104 +1429,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ShowInfoPopup(DaggerfallUnityItem item)
         {
-            const int paintingTextId = 250;
-            const int armorTextId = 1000;
-            const int weaponTextId = 1001;
-            const int miscTextId = 1003;
-            const int soulTrapTextId = 1004;
-            const int letterOfCreditTextId = 1007;
-            //const int potionTextId = 1008;
-            const int bookTextId = 1009;
-            const int arrowTextId = 1011;
-            const int weaponNoMaterialTextId = 1012;
-            const int armorNoMaterialTextId = 1014;
-            const int oghmaInfiniumTextId = 1015;
-            const int houseDeedTextId = 1073;
-
-            TextFile.Token[] tokens = null;
-
-            // Handle by item group
-            switch (item.ItemGroup)
-            {
-                case (ItemGroups.Armor):
-                    if (item.IsShield || item.TemplateIndex == (int)Armor.Helm || item.IsArtifact)
-                        tokens = DaggerfallUnity.TextProvider.GetRSCTokens(armorNoMaterialTextId);
-                    else
-                        tokens = DaggerfallUnity.TextProvider.GetRSCTokens(armorTextId);
-                    break;
-
-                case (ItemGroups.Weapons):
-                    if (item.TemplateIndex == (int)Weapons.Arrow)
-                        tokens = DaggerfallUnity.TextProvider.GetRSCTokens(arrowTextId);
-                    else if (item.IsArtifact)
-                        tokens = DaggerfallUnity.TextProvider.GetRSCTokens(weaponNoMaterialTextId);
-                    else
-                        tokens = DaggerfallUnity.TextProvider.GetRSCTokens(weaponTextId);
-                    break;
-
-                case (ItemGroups.Books):
-                    // Handle Oghma Infinium
-                    if (item.legacyMagic != null && item.legacyMagic[0] == 26)
-                    {
-                        tokens = DaggerfallUnity.TextProvider.GetRSCTokens(oghmaInfiniumTextId);
-                    }
-                    // Handle other books
-                    else
-                    {
-                        tokens = DaggerfallUnity.TextProvider.GetRSCTokens(bookTextId);
-                    }
-                    break;
-
-                // TODO: Check for potion in glass bottle.
-                // In classic, the check is whether RecordRoot.SublistHead is non-null
-                // and of PotionMix type.
-
-                case (ItemGroups.Paintings):
-                    // TODO: Show painting. Uses file paint.dat.
-                    tokens = DaggerfallUnity.TextProvider.GetRSCTokens(paintingTextId);
-                    break;
-
-                default:
-                    // A few items in the MiscItems group have their own text display
-                    if (item.ItemGroup == ItemGroups.MiscItems)
-                    {
-                        // Handle potion recipes
-                        if (item.TemplateIndex == (int)MiscItems.Potion_recipe)
-                        {
-                            DaggerfallPotionRecipeWindow readerWindow = new DaggerfallPotionRecipeWindow(uiManager, item.typeDependentData, this);
-                            uiManager.PushWindow(readerWindow);
-                            return;
-                        }
-                        // Handle house deeds
-                        else if (item.TemplateIndex == (int)MiscItems.House_Deed)
-                        {
-                            tokens = DaggerfallUnity.TextProvider.GetRSCTokens(houseDeedTextId);
-                        }
-                        // Handle soul traps
-                        else if (item.TemplateIndex == (int)MiscItems.Soul_trap)
-                        {
-                            tokens = DaggerfallUnity.TextProvider.GetRSCTokens(soulTrapTextId);
-                        }
-                        else if (item.TemplateIndex == (int)MiscItems.Letter_of_credit)
-                        {
-                            tokens = DaggerfallUnity.TextProvider.GetRSCTokens(letterOfCreditTextId);
-                        }
-                        if (tokens != null)
-                            break;
-                    }
-
-                    // Handle Azura's Star
-                    if (item.legacyMagic != null && item.legacyMagic[0] == 26 && item.legacyMagic[1] == 9)
-                    {
-                        tokens = DaggerfallUnity.TextProvider.GetRSCTokens(soulTrapTextId);
-                        break;
-                    }
-
-                    // Default fallback if none of the above applied
-                    tokens = DaggerfallUnity.TextProvider.GetRSCTokens(miscTextId);
-                    break;
-            }
-
+            TextFile.Token[] tokens = ItemHelper.GetItemInfo(item, DaggerfallUnity.TextProvider);
             if (tokens != null && tokens.Length > 0)
             {
                 DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
@@ -1688,6 +1604,26 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 ShowInfoPopup(item);
             }
+        }
+
+        protected virtual void LocalItemsButton_OnMouseEnter(BaseScreenComponent sender)
+        {
+            Debug.Log("mouse enter");
+            // Get index
+            int index = localItemsScrollBar.ScrollIndex + (int)sender.Tag;
+            if (index >= localItemsFiltered.Count)
+                return;
+
+            // Get item
+            DaggerfallUnityItem item = localItemsFiltered[index];
+            if (item == null)
+                return;
+
+            // Display info in local target icon panel
+            TextFile.Token[] tokens = ItemHelper.GetItemInfo(item, DaggerfallUnity.TextProvider);
+            MacroHelper.ExpandMacros(ref tokens, item);
+            localTargetInfoLabel.SetText(tokens);
+            Debug.Log(tokens[0].ToString());
         }
 
         protected virtual void RemoteItemsButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -271,14 +271,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Setup local and remote target icon panels
             localTargetIconPanel = DaggerfallUI.AddPanel(localTargetIconRect, NativePanel);
+            localTargetIconPanel.BackgroundColor = new Color(0.1f, 0.2f, 0.6f, 0.5f);
             remoteTargetIconPanel = DaggerfallUI.AddPanel(remoteTargetIconRect, NativePanel);
             remoteTargetIconLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(1, 2), remoteTargetIconPanel);
 
             // Setup item info panel
             localTargetInfoLabel = new MultiFormatTextLabel(); //DaggerfallUI.AddTextLabel(DaggerfallUI.Instance.Font4, Vector2.zero, string.Empty, localTargetIconPanel);
-            localTargetInfoLabel.HorizontalAlignment = HorizontalAlignment.Left;
-            localTargetInfoLabel.VerticalAlignment = VerticalAlignment.Top;
+            //localTargetInfoLabel.HorizontalAlignment = HorizontalAlignment.Left;
+            //localTargetInfoLabel.VerticalAlignment = VerticalAlignment.Top;
+            localTargetInfoLabel.BackgroundColor = new Color(0.1f, 0.6f, 0.1f, 0.5f);
+
             localTargetInfoLabel.ShadowPosition = Vector2.zero;
+            localTargetInfoLabel.AutoSize = AutoSizeModes.ResizeToFill;
+            //localTargetInfoLabel.Scale = new Vector2(0.5f, 0.5f);
             //localTargetInfoLabel.Font = DaggerfallUI.Instance.GetHQPixelFont(DaggerfallUI.HQPixelFonts.Petrock_32);
             localTargetInfoLabel.TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
             localTargetIconPanel.Components.Add(localTargetInfoLabel);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -47,7 +47,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region UI Controls
 
-        protected Panel localTargetIconPanel;
         protected TextLabel localTargetIconLabel;
         TextLabel[] remoteItemsRepairLabels = new TextLabel[listDisplayUnits];
 

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -93,6 +93,7 @@ namespace DaggerfallWorkshop
         public int ShopQualityPresentation { get; set; }
         public int ShopQualityHUDDelay { get; set; }
         public bool ShowQuestJournalClocksAsCountdown { get; set; }
+        public bool EnableInventoryInfoPanel { get; set; }
 
         // [Controls]
         public bool InvertMouseVertical { get; set; }
@@ -155,6 +156,7 @@ namespace DaggerfallWorkshop
             ToolTipDelayInSeconds = GetFloat(sectionGUI, "ToolTipDelayInSeconds", 0, 10);
             ToolTipBackgroundColor = GetColor(sectionGUI, "ToolTipBackgroundColor", DaggerfallUI.DaggerfallUnityDefaultToolTipBackgroundColor);
             ToolTipTextColor = GetColor(sectionGUI, "ToolTipTextColor", DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor);
+            EnableInventoryInfoPanel = GetBool(sectionGUI, "EnableInventoryInfoPanel");
             AutomapNumberOfDungeons = GetInt(sectionGUI, "AutomapNumberOfDungeons", 0, 100);
             ShopQualityPresentation = GetInt(sectionGUI, "ShopQualityPresentation", 0, 2);
             ShopQualityHUDDelay = GetInt(sectionGUI, "ShopQualityHUDDelay", 1, 10);


### PR DESCRIPTION
Enabled by a setting, disabled by default.
Thanks to Nystul for the text scaling.