### PR TITLE
Re-enable and fix price adjustments

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -772,7 +772,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return priceAdjustments;
         }
 
-        public static ushort[] ModifyPriceAdjustmentByRegion(ushort[] currentPriceAdjustments, uint times)
+        public static ushort[] ModifyPriceAdjustmentByRegion(ushort[] currentPriceAdjustments, int times)
         {
             DaggerfallConnect.Arena2.FactionFile.FactionData merchantsFaction;
             if (!GameManager.Instance.PlayerEntity.FactionData.GetFactionData(510, out merchantsFaction))

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -232,6 +232,9 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.DarkBrotherhoodRequirementTally = data.playerEntity.darkBrotherhoodRequirementTally;
             entity.SetCurrentLevelUpSkillSum();
 
+            // Set time tracked in player entity
+            entity.LastGameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+
             // Fill in missing data for saves
             if (entity.StartingLevelUpSkillSum <= 0)
                 entity.EstimateStartingLevelUpSkillSum();

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -333,6 +333,9 @@ namespace DaggerfallWorkshop.Game.Utility
             // Set game time
             DaggerfallUnity.Instance.WorldTime.Now.SetClassicGameStartTime();
 
+            // Set time tracked in playerEntity
+            playerEntity.LastGameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+
             // Get start parameters
             DFPosition mapPixel = new DFPosition(DaggerfallUnity.Settings.StartCellX, DaggerfallUnity.Settings.StartCellY);
             bool startInDungeon = DaggerfallUnity.Settings.StartInDungeon;
@@ -533,6 +536,9 @@ namespace DaggerfallWorkshop.Game.Utility
             // Get regional data.
             // Currently this only gets the regional price adjustments.
             playerEntity.PriceAdjustmentByRegion = saveVars.PriceAdjustmentsByRegion;
+
+            // Set time tracked by playerEntity for game minute-based updates
+            playerEntity.LastGameMinutes = saveVars.GameTime;
 
             // Start game
             DaggerfallUI.Instance.PopToHUD();


### PR DESCRIPTION
Fixes the game freezing. Also moves player-specific code out of DaggerfallEntityBehaviour and into PlayerEntity.

The `lastGameMinutes` variable is also in PlayerEntity now and is set to the current game minute whether starting a new game, loading a Unity save or loading a classic save. Feel free to get rid of this variable and replace it with a more elegant solution if you like, it's just a simple way to handle events that are based on in-game minutes passing.