### PR TITLE
Animation fixes and adjustments for enemies

### DIFF
--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -202,6 +202,7 @@ namespace DaggerfallWorkshop
         public bool ParrySounds;                    // Plays parry sounds when attacks against this enemy miss
         public int MapChance;                       // Chance of having a map
         public string LootTableKey;                 // Key to use when generating loot
+        public int HitFrame;                        // Frame of attack animation at which hit on target is attempted
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -44,7 +44,7 @@ namespace DaggerfallWorkshop.Game
         void Update()
         {
             // Handle state in progress
-            if (mobile.IsPlayingOneShot())
+            if (mobile.IsPlayingOneShot() && (mobile.LastFrameAnimated < mobile.Summary.Enemy.HitFrame))
             {
                 // Are we attacking?
                 if (mobile.IsAttacking())
@@ -54,7 +54,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // If an attack was in progress it is now complete and we can apply damage
-            if (isAttacking)
+            if (isAttacking && mobile.LastFrameAnimated == mobile.Summary.Enemy.HitFrame)
             {
                 MeleeDamage();
                 isAttacking = false;
@@ -66,6 +66,8 @@ namespace DaggerfallWorkshop.Game
             {
                 MeleeAnimation();
                 meleeTimer = MeleeAttackSpeed;
+                // Randomize
+                meleeTimer += Random.Range(-.50f, .50f);
             }
         }
 

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -138,9 +138,13 @@ namespace DaggerfallWorkshop.Game
 
         private void Move()
         {
-            // Do nothing if playing a one-shot animation
+            // Monster speed of movement follows the same formula as for when the player walks
+            EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
+            float moveSpeed = ((entity.Stats.Speed + PlayerMotor.dfWalkBase) / PlayerMotor.classicToUnitySpeedUnitRatio);
+
+            // Reduced speed if playing a one-shot animation
             if (mobile.IsPlayingOneShot())
-                return;
+                moveSpeed /= 4;
 
             // Remain idle when player not acquired or not hostile
             if (senses.LastKnownPlayerPos == EnemySenses.ResetPlayerPos || !isHostile)
@@ -183,19 +187,19 @@ namespace DaggerfallWorkshop.Game
                 targetPos.y -= deltaHeight;
             }
 
-            // Get direction & distance and face target
+            // Get direction & distance and face target, but only if not attacking, so player has a chance to see
+            // attack animations other than those directly facing the player
             var direction = targetPos - transform.position;
             float distance = direction.magnitude;
-            transform.forward = direction.normalized;
+            if (!mobile.IsPlayingOneShot())
+                transform.forward = direction.normalized;
 
             // Move towards target
             if (distance > stopDistance)
             {
-                mobile.ChangeEnemyState(MobileStates.Move);
-
-                // Monster speed of movement follows the same formula as for when the player walks
-                EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
-                var motion = transform.forward * ((entity.Stats.Speed + PlayerMotor.dfWalkBase) / PlayerMotor.classicToUnitySpeedUnitRatio);
+                if (!mobile.IsPlayingOneShot())
+                    mobile.ChangeEnemyState(MobileStates.Move);
+                var motion = transform.forward * moveSpeed;
 
                 // Prevent rat stacks (enemies don't stand on shorter enemies)
                 AvoidEnemies(ref motion);

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -40,6 +40,9 @@ namespace DaggerfallWorkshop.Game
         bool flies;                                 // The enemy can fly
         int enemyLayerMask;                         // Layer mask for Enemies to optimize collision checks
 
+        bool isAttackFollowsPlayerSet;              // For setting if the enemy will follow the player or not during an attack
+        bool attackFollowsPlayer;                   // For setting if the enemy will follow the player or not during an attack
+
         public bool IsHostile
         {
             get { return isHostile; }
@@ -56,6 +59,7 @@ namespace DaggerfallWorkshop.Game
                     mobile.Summary.Enemy.Behaviour == MobileBehaviour.Spectral;
             enemyLayerMask = LayerMask.GetMask("Enemies");
             entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
+            isAttackFollowsPlayerSet = false;
         }
 
         void Update()
@@ -144,7 +148,7 @@ namespace DaggerfallWorkshop.Game
 
             // Reduced speed if playing a one-shot animation
             if (mobile.IsPlayingOneShot())
-                moveSpeed /= 4;
+                moveSpeed /= 2;
 
             // Remain idle when player not acquired or not hostile
             if (senses.LastKnownPlayerPos == EnemySenses.ResetPlayerPos || !isHostile)
@@ -187,11 +191,21 @@ namespace DaggerfallWorkshop.Game
                 targetPos.y -= deltaHeight;
             }
 
-            // Get direction & distance and face target, but only if not attacking, so player has a chance to see
+            // Get direction & distance and face target.
+            // If attacking, randomly do not do so so player has a chance to see
             // attack animations other than those directly facing the player
             var direction = targetPos - transform.position;
             float distance = direction.magnitude;
-            if (!mobile.IsPlayingOneShot())
+
+            if (mobile.IsPlayingOneShot() && !isAttackFollowsPlayerSet)
+            {
+                attackFollowsPlayer = (Random.Range(0, 2) > 0);
+                isAttackFollowsPlayerSet = true;
+            }
+            else if (!mobile.IsPlayingOneShot())
+                isAttackFollowsPlayerSet = false;
+
+            if (!mobile.IsPlayingOneShot() || !attackFollowsPlayer)
                 transform.forward = direction.normalized;
 
             // Move towards target

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -133,7 +133,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
         public override void Update(DaggerfallEntityBehaviour sender)
         {
-            if (playerMotor = null)
+            if (playerMotor == null)
                 playerMotor = GameManager.Instance.PlayerMotor;
 
             uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -305,15 +305,6 @@ namespace DaggerfallWorkshop
             int record = summary.StateAnims[orientation].Record;
             Vector2 size = summary.RecordSizes[record];
 
-            // Post-fix female thief scale for orentations 1 and 7
-            // The scale read from Daggerfall's files is too small
-            if ((MobileTypes)summary.Enemy.ID == MobileTypes.Thief &&
-                summary.Enemy.Gender == MobileGender.Female &&
-                (orientation == 1 || orientation == 7))
-            {
-                size *= 1.35f;
-            }
-
             // Ensure walking enemies keep their feet aligned between states
             if (summary.Enemy.Behaviour != MobileBehaviour.Flying &&
                 summary.Enemy.Behaviour != MobileBehaviour.Aquatic &&

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -49,11 +49,22 @@ namespace DaggerfallWorkshop
         float enemyFacingAngle;
         int lastOrientation;
         int currentFrame;
+        int lastFrameAnimated;
         bool restartAnims = true;
 
         public MobileUnitSummary Summary
         {
             get { return summary; }
+        }
+
+        public int CurrentFrame
+        {
+            get { return currentFrame; }
+        }
+
+        public int LastFrameAnimated
+        {
+            get { return lastFrameAnimated; }
         }
 
         [Serializable]
@@ -324,8 +335,10 @@ namespace DaggerfallWorkshop
             // Check if orientation flip needed
             bool flip = summary.StateAnims[orientation].FlipLeftRight;
 
-            // Rat Idle animation needs to be inverted
-            if (summary.Enemy.ID == (int)MobileTypes.Rat && summary.EnemyState == MobileStates.Idle)
+            // Some characters' idle animations need to be inverted. Add as needed.
+            if ((summary.Enemy.ID == (int)MobileTypes.GiantBat
+                || summary.Enemy.ID == (int)MobileTypes.Imp)
+                && summary.EnemyState == MobileStates.Idle)
                 flip = !flip;
 
             // Scorpion Idle and Move animations need to be inverted
@@ -374,8 +387,13 @@ namespace DaggerfallWorkshop
             {
                 if (summary.IsSetup && summary.StateAnims != null && summary.StateAnims.Length > 0)
                 {
+                    // Update enemy and fps
+                    OrientEnemy(lastOrientation);
+                    fps = summary.StateAnims[lastOrientation].FramePerSecond;
                     // Step frame
+                    lastFrameAnimated = currentFrame;
                     currentFrame++;
+
                     if (currentFrame >= summary.StateAnims[lastOrientation].NumFrames)
                     {
                         if (IsPlayingOneShot())
@@ -383,10 +401,6 @@ namespace DaggerfallWorkshop
                         else
                             currentFrame = 0;                       // Otherwise keep looping frames
                     }
-
-                    // Update enemy and fps
-                    OrientEnemy(lastOrientation);
-                    fps = summary.StateAnims[lastOrientation].FramePerSecond;
                 }
 
                 yield return new WaitForSeconds(1f / fps);
@@ -572,7 +586,12 @@ namespace DaggerfallWorkshop
             // Assign number number of frames per anim
             for (int i = 0; i < anims.Length; i++)
                 anims[i].NumFrames = summary.RecordFrames[anims[i].Record];
-            
+
+            // If flying, set to faster flying animation speed
+            if ((state == MobileStates.Move || state == MobileStates.Idle) && summary.Enemy.Behaviour == MobileBehaviour.Flying)
+                for (int i = 0; i < anims.Length; i++)
+                    anims[i].FramePerSecond = EnemyBasics.FlyAnimSpeed;
+
             return anims;
         }
 

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -24,8 +24,9 @@ namespace DaggerfallWorkshop.Utility
         #region Enemy Animations
 
         // Speeds in frames-per-second
-        public static int MoveAnimSpeed = 7;
-        public static int PrimaryAttackAnimSpeed = 8;
+        public static int MoveAnimSpeed = 6;
+        public static int FlyAnimSpeed = 10;
+        public static int PrimaryAttackAnimSpeed = 10;
         public static int HurtAnimSpeed = 4;
         public static int IdleAnimSpeed = 4;
         public static int RangedAttack1AnimSpeed = 6;
@@ -145,6 +146,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = false,
                 MapChance = 0,
+                HitFrame = 3,
             },
 
             // Imp
@@ -174,6 +176,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "D",
+                HitFrame = 3,
             },
 
             // Spriggan
@@ -206,6 +209,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 LootTableKey = "B",
+                HitFrame = 3,
             },
 
             // Giant Bat
@@ -233,6 +237,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = false,
                 MapChance = 0,
+                HitFrame = 2,
             },
 
             // Grizzly Bear
@@ -264,6 +269,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = false,
                 MapChance = 0,
+                HitFrame = 3,
             },
 
             // Sabertooth Tiger
@@ -295,6 +301,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = false,
                 MapChance = 0,
+                HitFrame = 3,
             },
 
             // Spider
@@ -322,6 +329,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 5,
                 ParrySounds = false,
                 MapChance = 0,
+                HitFrame = 3,
             },
 
             // Orc
@@ -351,6 +359,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "A",
+                HitFrame = 3,
             },
 
             // Centaur
@@ -380,6 +389,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "C",
+                HitFrame = 3,
             },
 
             // Werewolf
@@ -412,6 +422,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 5,
                 MapChance = 0,
                 ParrySounds = false,
+                HitFrame = 2,
             },
 
             // Nymph
@@ -441,6 +452,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "C",
+                HitFrame = 5,
             },
 
             // Slaughterfish
@@ -468,6 +480,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 MapChance = 0,
                 ParrySounds = false,
+                HitFrame = 5,
             },
 
             // Orc Sergeant
@@ -497,6 +510,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "A",
+                HitFrame = 2,
             },
 
             // Harpy
@@ -525,6 +539,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 LootTableKey = "D",
+                HitFrame = 3,
             },
 
             // Wereboar
@@ -557,6 +572,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 3,
                 MapChance = 0,
                 ParrySounds = false,
+                HitFrame = 3,
             },
 
             // Skeletal Warrior
@@ -587,6 +603,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "H",
+                HitFrame = 4,
             },
 
             // Giant
@@ -616,6 +633,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "F",
+                HitFrame = 3,
             },
 
             // Zombie
@@ -644,6 +662,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "G",
+                HitFrame = 3,
             },
 
             // Ghost
@@ -673,6 +692,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "I",
+                HitFrame = 3,
             },
 
             // Mummy
@@ -702,6 +722,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "E",
+                HitFrame = 4,
             },
 
             // Giant Scorpion
@@ -729,6 +750,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 0,
                 MapChance = 0,
                 ParrySounds = false,
+                HitFrame = 3,
             },
 
             // Orc Shaman
@@ -758,6 +780,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 3,
                 LootTableKey = "U",
+                HitFrame = 3,
             },
 
             // Gargoyle
@@ -786,6 +809,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 0,
                 MapChance = 0,
                 ParrySounds = false,
+                HitFrame = 3,
             },
 
             // Wraith
@@ -815,6 +839,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "I",
+                HitFrame = 3,
             },
 
             // Orc Warlord
@@ -844,6 +869,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 2,
                 LootTableKey = "T",
+                HitFrame = 3,
             },
 
             // Frost Daedra
@@ -873,6 +899,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "J",
+                HitFrame = 3,
             },
 
             // Fire Daedra
@@ -902,6 +929,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "J",
+                HitFrame = 2,
             },
 
             // Daedroth
@@ -930,6 +958,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "E",
+                HitFrame = 3,
             },
 
             // Vampire
@@ -959,6 +988,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 3,
                 LootTableKey = "Q",
+                HitFrame = 4,
             },
 
             // Daedra Seducer
@@ -988,6 +1018,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "Q",
+                HitFrame = 3,
             },
 
             // Vampire Ancient
@@ -1017,6 +1048,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 3,
                 LootTableKey = "Q",
+                HitFrame = 3,
             },
 
             // Daedra Lord
@@ -1046,6 +1078,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "S",
+                HitFrame = 3,
             },
 
             // Lich
@@ -1076,6 +1109,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 4,
                 LootTableKey = "S",
+                HitFrame = 3,
             },
 
             // Ancient Lich
@@ -1106,6 +1140,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 4,
                 LootTableKey = "S",
+                HitFrame = 3,
             },
 
             // Dragonling
@@ -1133,6 +1168,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = false,
                 MapChance = 0,
+                HitFrame = 2,
             },
 
             // Fire Atronach
@@ -1160,6 +1196,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = false,
                 MapChance = 0,
+                HitFrame = 3,
             },
 
             // Iron Atronach
@@ -1187,6 +1224,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = true,
                 MapChance = 0,
+                HitFrame = 3,
             },
 
             // Flesh Atronach
@@ -1214,6 +1252,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = false,
                 MapChance = 0,
+                HitFrame = 3,
             },
 
             // Ice Atronach
@@ -1241,6 +1280,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = true,
                 MapChance = 0,
+                HitFrame = 3,
             },
 
             // Dragonling
@@ -1268,6 +1308,7 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = false,
                 MapChance = 0,
+                HitFrame = 2,
             },
 
             // Dreugh
@@ -1296,6 +1337,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 LootTableKey = "R",
+                HitFrame = 3,
             },
 
             // Lamia
@@ -1324,6 +1366,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 LootTableKey = "R",
+                HitFrame = 4,
             },
 
             // Mage
@@ -1346,6 +1389,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 3,
                 LootTableKey = "U",
+                HitFrame = 3,
             },
 
             // Spellsword
@@ -1368,6 +1412,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "P",
+                HitFrame = 3,
             },
 
             // Battlemage
@@ -1390,6 +1435,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 2,
                 LootTableKey = "U",
+                HitFrame = 3,
             },
 
             // Sorcerer
@@ -1412,6 +1458,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 3,
                 LootTableKey = "U",
+                HitFrame = 3,
             },
 
             // Healer
@@ -1434,6 +1481,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "U",
+                HitFrame = 3,
             },
 
             // Nightblade
@@ -1456,6 +1504,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "U",
+                HitFrame = 3,
             },
 
             // Bard
@@ -1478,6 +1527,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 2,
                 LootTableKey = "O",
+                HitFrame = 3,
             },
 
             // Burglar
@@ -1500,6 +1550,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "O",
+                HitFrame = 3,
             },
 
             // Rogue
@@ -1522,6 +1573,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "O",
+                HitFrame = 3,
             },
 
             // Acrobat
@@ -1544,6 +1596,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "O",
+                HitFrame = 3,
             },
 
             // Thief
@@ -1566,6 +1619,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 2,
                 LootTableKey = "O",
+                HitFrame = 3,
             },
 
             // Assassin
@@ -1588,6 +1642,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "O",
+                HitFrame = 3,
             },
 
             // Monk
@@ -1610,6 +1665,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "T",
+                HitFrame = 3,
             },
 
             // Archer
@@ -1633,6 +1689,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "C",
+                HitFrame = 3,
             },
 
             // Ranger
@@ -1655,6 +1712,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "C",
+                HitFrame = 3,
             },
 
             // Barbarian
@@ -1677,6 +1735,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "T",
+                HitFrame = 3,
             },
 
             // Warrior
@@ -1699,6 +1758,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 LootTableKey = "T",
+                HitFrame = 3,
             },
 
             // Knight
@@ -1721,6 +1781,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 1,
                 LootTableKey = "T",
+                HitFrame = 3,
             },
 
             // City Watch - The Haltmeister
@@ -1742,6 +1803,7 @@ namespace DaggerfallWorkshop.Utility
                 AttackSound = (int)SoundClips.None,
                 ParrySounds = true,
                 MapChance = 0,
+                HitFrame = 3,
             },
         };
 


### PR DESCRIPTION
Fixes and adjustments for enemy animations. I'll go through everything below.

1. (not animation related) Fixed an incorrect null assignment (from my earlier PR) that made a warning in Unity.
2. Fixed rat being flipped horizontally. For some reason there was specifically code to flip the rat. Instead, the same code was used to flip the giant bat and the imp, who both needed it. There is also existing code to flip the scorpion, but I haven't tested it yet to see if that is functioning properly.
3. Fixed enemies not playing the first frame of their attack animation. currentFrame was incremented immediately in AnimateEnemy() of DaggerfallMobileUnit, so the first frame didn't show.
4. Adjusted animation speeds. Slightly sped up enemy attacks, lowered enemy movement animation and added faster animation for flying enemies. The animations should be somewhat closer to classic, and I think they look better.
5. Added code for enemies to hit on a particular frame of their attack, rather than after finishing. I don't know how classic handles this, and I don't see myself figuring it out anytime soon. Instead I went through all the enemy animations (your Daggerfall Imaging 2 software is so helpful for this stuff) and set each enemy to hit on the frame that it looks like their attack should connect on.
6. Enemies can continue to move some (1/4 speed) while attacking. I'm not 100% sure about this because the animations for enemies do look like they should be standing still and not "sliding" along the floor, but the player can move while attacking and IMO it's too easy to defeat enemies in DF Unity currently because you can outmaneuver them. Since people are making quests now I think getting game difficulty problems under control is starting to take on some more importance. Enemies can also move while attacking in classic.

I experimented with them moving at 1/2 speed, but I felt like it would maybe be too difficult for new characters in privateer's hold, and I didn't like having the enemies constantly up in my face, so for now I settled on 1/4 speed as making it more difficult but still possible to dodge hits. I would like to alleviate the "walking backwards while swinging your weapon" playstyle somehow. Maybe we can improve the AI at some point to not rush the player so much.

6. Enemies have some randomness to the time between weapon swings, to make enemies a bit less predictable and robotic.