### PR TITLE
Fix Daedra Seducer attack

### DIFF
--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -1018,7 +1018,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 1,
                 LootTableKey = "Q",
-                HitFrame = 3,
+                HitFrame = 2,
             },
 
             // Vampire Ancient


### PR DESCRIPTION
I accidentally set the daedra seducer's to hit on frame 3 instead of 2, which is outside of the frame range.