### PR TITLE
Fixes for training

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -77,6 +77,7 @@ namespace DaggerfallConnect.Save
             doc.startingLevelUpSkillSum = parsedData.startingLevelUpSkillSum;
             doc.minMetalToHit = parsedData.minMetalToHit;
             doc.armorValues = parsedData.armorValues;
+            doc.lastTimePlayerBoughtTraining = parsedData.lastTimePlayerBoughtTraining;
             doc.timeForThievesGuildLetter = parsedData.timeForThievesGuildLetter;
             doc.timeForDarkBrotherhoodLetter = parsedData.timeForDarkBrotherhoodLetter;
             doc.darkBrotherhoodRequirementTally = parsedData.darkBrotherhoodRequirementTally;
@@ -167,6 +168,9 @@ namespace DaggerfallConnect.Save
 
             reader.BaseStream.Position = 0x1fd;
             parsedData.timeStamp = reader.ReadUInt32();
+
+            reader.BaseStream.Position = 0x209;
+            parsedData.lastTimePlayerBoughtTraining = reader.ReadUInt32();
 
             reader.BaseStream.Position = 0x211;
             parsedData.timeForThievesGuildLetter = reader.ReadUInt32();

--- a/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
@@ -368,7 +368,7 @@ namespace DaggerfallWorkshop.Game.Entity
             return GetPrimaryStat((DFCareer.Skills)index);
         }
 
-        public int GetAdvancementMultiplier(DFCareer.Skills skill)
+        public static int GetAdvancementMultiplier(DFCareer.Skills skill)
         {
             switch (skill)
             {

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -71,10 +71,10 @@ namespace DaggerfallWorkshop.Game.Entity
         protected ushort[] priceAdjustmentByRegion = FormulaHelper.RandomRegionalPriceAdjustments();
 
         // Fatigue loss per in-game minute
-        private int DefaultFatigueLoss = 11;        // According to DF Chronicles and verified in classic
-        //private int ClimbingFatigueLoss = 22;     // According to DF Chronicles
-        private int RunningFatigueLoss = 88;        // According to DF Chronicles and verified in classic
-        //private int SwimmingFatigueLoss = 44;     // According to DF Chronicles
+        public const int DefaultFatigueLoss = 11;
+        //public const int ClimbingFatigueLoss = 22;
+        public const int RunningFatigueLoss = 88;
+        //public const int SwimmingFatigueLoss = 44;
 
         private float runningTallyTimer = 0f;
         private float runningTallyInterval = 0.0625f; // Tally every 1/16 second of running. The rate at which the running skill
@@ -255,11 +255,12 @@ namespace DaggerfallWorkshop.Game.Entity
             this.skillUses = character.skillUses;
             this.startingLevelUpSkillSum = character.startingLevelUpSkillSum;
             this.minMetalToHit = (WeaponMaterialTypes)character.minMetalToHit;
-            this.ArmorValues = character.armorValues;
-            this.TimeForThievesGuildLetter = character.timeForThievesGuildLetter;
-            this.TimeForDarkBrotherhoodLetter = character.timeForDarkBrotherhoodLetter;
-            this.DarkBrotherhoodRequirementTally = character.darkBrotherhoodRequirementTally;
-            this.ThievesGuildRequirementTally = character.thievesGuildRequirementTally;
+            this.armorValues = character.armorValues;
+            this.timeOfLastSkillTraining = character.lastTimePlayerBoughtTraining;
+            this.timeForThievesGuildLetter = character.timeForThievesGuildLetter;
+            this.timeForDarkBrotherhoodLetter = character.timeForDarkBrotherhoodLetter;
+            this.darkBrotherhoodRequirementTally = character.darkBrotherhoodRequirementTally;
+            this.thievesGuildRequirementTally = character.thievesGuildRequirementTally;
 
             SetCurrentLevelUpSkillSum();
 
@@ -277,7 +278,6 @@ namespace DaggerfallWorkshop.Game.Entity
                 FillVitalSigns();
 
             timeOfLastSkillIncreaseCheck = DaggerfallUnity.Instance.WorldTime.Now.ToClassicDaggerfallTime();
-            timeOfLastSkillTraining = 0;
 
             DaggerfallUnity.LogMessage("Assigned character " + this.name, true);
         }
@@ -518,7 +518,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
             for (short i = 0; i < skillUses.Length; i++)
             {
-                int skillAdvancementMultiplier = skills.GetAdvancementMultiplier((DaggerfallConnect.DFCareer.Skills)i);
+                int skillAdvancementMultiplier = DaggerfallSkills.GetAdvancementMultiplier((DFCareer.Skills)i);
                 float careerAdvancementMultiplier = Career.AdvancementMultiplier;
                 int usesNeededForAdvancement = FormulaHelper.CalculateSkillUsesForAdvancement(skills.GetSkillValue(i), skillAdvancementMultiplier, careerAdvancementMultiplier, level);
                 if (skillUses[i] >= usesNeededForAdvancement)

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -45,6 +45,7 @@ namespace DaggerfallWorkshop.Game.Player
         public int startingLevelUpSkillSum;
         public byte minMetalToHit;
         public sbyte[] armorValues = new sbyte[DaggerfallEntity.NumberBodyParts];
+        public uint lastTimePlayerBoughtTraining;
         public uint timeForThievesGuildLetter;
         public uint timeForDarkBrotherhoodLetter;
         public byte darkBrotherhoodRequirementTally;


### PR DESCRIPTION
Fixes and adjustments to training to make it more like classic.

1. Fixed black screen background on message popups.
2. Added "You don't have enough gold" popup and prevent training if player doesn't have enough gold.
3. Fatigue loss is now defaultFatigueLoss per minute * 180 minutes, which I think is what it is in classic.
4. Number of skill tallies gained matches classic.
5. Time of last training is imported from classic saves.

Hazelnut, I think I can add in all of the trainers and their lists of offered skills pretty easily, too, unless you want to do it.