### PR TITLE
Import and save region data structures from classic

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -68,7 +68,7 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int thievesGuildRequirementTally = 0;
         protected int darkBrotherhoodRequirementTally = 0;
 
-        protected ushort[] priceAdjustmentByRegion = FormulaHelper.RandomRegionalPriceAdjustments();
+        protected RegionDataRecord[] regionData = new RegionDataRecord[62];
 
         // Fatigue loss per in-game minute
         public const int DefaultFatigueLoss = 11;
@@ -121,7 +121,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public int DarkBrotherhoodRequirementTally { get { return darkBrotherhoodRequirementTally; } set { darkBrotherhoodRequirementTally = value; } }
         public float CarriedWeight { get { return Items.GetWeight() + ((float)goldPieces / DaggerfallBankManager.gold1kg); } }
         public float WagonWeight { get { return WagonItems.GetWeight(); } }
-        public ushort[] PriceAdjustmentByRegion { get { return priceAdjustmentByRegion; } set { priceAdjustmentByRegion = value; } }
+        public RegionDataRecord[] RegionData { get { return regionData; } set { regionData = value; } }
         public uint LastGameMinutes { get { return lastGameMinutes; } set { lastGameMinutes = value; } }
 
         #endregion
@@ -195,7 +195,7 @@ namespace DaggerfallWorkshop.Game.Entity
             int daysPast = (int)(currentDay - lastDay);
 
             if (daysPast > 0)
-                FormulaHelper.ModifyPriceAdjustmentByRegion(priceAdjustmentByRegion, daysPast);
+                FormulaHelper.ModifyPriceAdjustmentByRegion(ref regionData, daysPast);
 
             lastGameMinutes = gameMinutes;
 
@@ -647,6 +647,25 @@ namespace DaggerfallWorkshop.Game.Entity
             // Optionally make permanent
             if (makePermanent)
                 item.MakePermanent();
+        }
+
+        #endregion
+
+        #region RegionData
+        public struct RegionDataRecord // 80 bytes long
+        {
+            public byte[] Values; // 29 bytes long
+            public bool[] Flags; // 29 bytes long
+            public bool[] Flags2; // 14 bytes long
+            // bytes 72 to 74 unknown
+            public short LegalRep; // bytes 74 to 76
+            public ushort Unknown; // bytes 76 to 78
+            public ushort PriceAdjustment; // bytes 78 to 80
+        }
+
+        public void InitializeRegionPrices()
+        {
+            FormulaHelper.RandomizeInitialPriceAdjustments(ref regionData);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -11,6 +11,7 @@
 
 using UnityEngine;
 using System;
+using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game.Formulas
 {
@@ -771,30 +772,25 @@ namespace DaggerfallWorkshop.Game.Formulas
             else
                 return cost;
 
-            adjustedCost = cost * player.PriceAdjustmentByRegion[currentRegionIndex] / 1000;
+            adjustedCost = cost * player.RegionData[currentRegionIndex].PriceAdjustment / 1000;
             if (adjustedCost < 1)
                 adjustedCost = 1;
             return adjustedCost;
         }
 
-        public static ushort[] RandomRegionalPriceAdjustments()
+        public static void RandomizeInitialPriceAdjustments(ref Entity.PlayerEntity.RegionDataRecord[] regionData)
         {
-            ushort[] priceAdjustments = new ushort[62];
-            for (int i = 0; i < 62; ++i)
-            {
-                priceAdjustments[i] = (ushort)(UnityEngine.Random.Range(0, 501) + 750);
-            }
-
-            return priceAdjustments;
+            for (int i = 0; i < regionData.Length; i++)
+                regionData[i].PriceAdjustment = (ushort)(UnityEngine.Random.Range(0, 501) + 750);
         }
 
-        public static ushort[] ModifyPriceAdjustmentByRegion(ushort[] currentPriceAdjustments, int times)
+        public static void ModifyPriceAdjustmentByRegion(ref Entity.PlayerEntity.RegionDataRecord[] regionData, int times)
         {
             DaggerfallConnect.Arena2.FactionFile.FactionData merchantsFaction;
             if (!GameManager.Instance.PlayerEntity.FactionData.GetFactionData(510, out merchantsFaction))
-                return currentPriceAdjustments;
+                return;
 
-            for (int i = 0; i < 62; ++i)
+            for (int i = 0; i < regionData.Length; ++i)
             {
                 DaggerfallConnect.Arena2.FactionFile.FactionData regionFaction;
                 if (GameManager.Instance.PlayerEntity.FactionData.FindFactionByTypeAndRegion(7, i + 1, out regionFaction))
@@ -802,20 +798,16 @@ namespace DaggerfallWorkshop.Game.Formulas
                     for (int j = 0; j < times; ++j)
                     {
                         int chanceOfPriceRise = ((merchantsFaction.power) - (regionFaction.power)) / 5
-                            + 50 - (currentPriceAdjustments[i] - 1000) / 25;
+                            + 50 - (regionData[i].PriceAdjustment - 1000) / 25;
                         if (UnityEngine.Random.Range(0, 101) >= chanceOfPriceRise)
-                            currentPriceAdjustments[i] = (ushort)(49 * currentPriceAdjustments[i] / 50);
+                            regionData[i].PriceAdjustment = (ushort)(49 * regionData[i].PriceAdjustment / 50);
                         else
-                            currentPriceAdjustments[i] = (ushort)(51 * currentPriceAdjustments[i] / 50);
+                            regionData[i].PriceAdjustment = (ushort)(51 * regionData[i].PriceAdjustment / 50);
 
-                        Mathf.Clamp(currentPriceAdjustments[i], 250, 4000);
+                        Mathf.Clamp(regionData[i].PriceAdjustment, 250, 4000);
                     }
                 }
-
-                // TODO: There is a bit more to this, possibly adjustments to regional power.
             }
-
-            return currentPriceAdjustments;
         }
 
         #endregion

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -11,7 +11,6 @@
 
 using UnityEngine;
 using System;
-using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game.Formulas
 {

--- a/Assets/Scripts/Game/Questing/Item.cs
+++ b/Assets/Scripts/Game/Questing/Item.cs
@@ -262,9 +262,26 @@ namespace DaggerfallWorkshop.Game.Questing
             // Get amount
             int amount = 0;
             if (rangeLow == -1 || rangeHigh == -1)
-                amount = GameManager.Instance.PlayerEntity.Level * UnityEngine.Random.Range(90, 110);
+            {
+                Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+
+                // TODO: If this is a faction quest, playerMod is (player factionrank + 1) rather than level
+                int playerMod = (player.Level / 2) + 1;
+                if (playerMod > 10)
+                    playerMod = 10;
+
+                // TODO: If this is a faction quest, factionMod = faction.power rather than 50
+                int factionMod = 50;
+
+                PlayerGPS gps = GameManager.Instance.PlayerGPS;
+                int regionPriceMod = player.RegionData[gps.CurrentRegionIndex].PriceAdjustment / 2;
+                amount = UnityEngine.Random.Range(150 * playerMod, (200 * playerMod) + 1) * (regionPriceMod + 500) / 1000 * (factionMod + 50) / 100;
+            }
             else
                 amount = UnityEngine.Random.Range(rangeLow, rangeHigh + 1);
+
+            if (amount < 1)
+                amount = 1;
 
             // Create item
             DaggerfallUnityItem result = new DaggerfallUnityItem(ItemGroups.Currency, 0);

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -147,6 +147,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public int thievesGuildRequirementTally;
         public int darkBrotherhoodRequirementTally;
         public uint timeOfLastSkillTraining;
+        public PlayerEntity.RegionDataRecord[] regionData;
     }
 
     [fsObject("v1")]

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -133,6 +133,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             data.playerEntity.timeForDarkBrotherhoodLetter = entity.TimeForDarkBrotherhoodLetter;
             data.playerEntity.thievesGuildRequirementTally = entity.ThievesGuildRequirementTally;
             data.playerEntity.darkBrotherhoodRequirementTally = entity.DarkBrotherhoodRequirementTally;
+            data.playerEntity.regionData = entity.RegionData;
 
             // Store player position data
             data.playerPosition = GetPlayerPositionData();
@@ -233,6 +234,11 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.ThievesGuildRequirementTally = data.playerEntity.thievesGuildRequirementTally;
             entity.DarkBrotherhoodRequirementTally = data.playerEntity.darkBrotherhoodRequirementTally;
             entity.SetCurrentLevelUpSkillSum();
+
+            if (data.playerEntity.regionData != null)
+                entity.RegionData = data.playerEntity.regionData;
+            else // If data doesn't exist, initialize to random values
+                entity.InitializeRegionPrices();
 
             // Set time tracked in player entity
             entity.LastGameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -382,8 +382,11 @@ namespace DaggerfallWorkshop.Game.Utility
             // Assign starting gear to player entity
             DaggerfallUnity.Instance.ItemHelper.AssignStartingGear(playerEntity);
 
-            //##Setup bank accounts
+            // Setup bank accounts
             Banking.DaggerfallBankManager.SetupAccounts();
+
+            // Randomize initial region prices
+            playerEntity.InitializeRegionPrices();
 
             // Start game
             GameManager.Instance.PauseGame(false);
@@ -537,8 +540,7 @@ namespace DaggerfallWorkshop.Game.Utility
             Banking.DaggerfallBankManager.ReadNativeBankData(bankRecords);
 
             // Get regional data.
-            // Currently this only gets the regional price adjustments.
-            playerEntity.PriceAdjustmentByRegion = saveVars.PriceAdjustmentsByRegion;
+            playerEntity.RegionData= saveVars.RegionData;
 
             // Set time tracked by playerEntity for game minute-based updates
             playerEntity.LastGameMinutes = saveVars.GameTime;

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -405,8 +405,8 @@ namespace DaggerfallWorkshop.Utility
         private static string LocalReputation(IMacroContextProvider mcp)
         {   // %ltn
             PlayerGPS gps = GameManager.Instance.PlayerGPS;
-            PersistentFactionData factionData = Game.GameManager.Instance.PlayerEntity.FactionData;
-            int rep = factionData.GetLegalReputation(gps.CurrentRegionIndex).value;
+            int rep = GameManager.Instance.PlayerEntity.RegionData[gps.CurrentRegionIndex].LegalRep;
+
             if (rep > 80)
                 return "revered";
             else if (rep > 60)
@@ -421,18 +421,19 @@ namespace DaggerfallWorkshop.Utility
                 return "dependable";
             else if (rep == 0)
                 return "a common citizen";
-            else if (rep < 0)
-                return "undependable";
-            else if (rep < -10)
-                return "a scoundrel";
-            else if (rep < -20)
-                return "a criminal";
-            else if (rep < -40)
-                return "a villain";
-            else if (rep < -60)
-                return "pond scum";
             else if (rep < -80)
                 return "hated";
+            else if (rep < -60)
+                return "pond scum";
+            else if (rep < -40)
+                return "a villain";
+            else if (rep < -20)
+                return "a criminal";
+            else if (rep < -10)
+                return "a scoundrel";
+            else if (rep < 0)
+                return "undependable";
+
             return "unknown";
         }
 


### PR DESCRIPTION
Imports and saves region data structures from classic. A lot of the data is still unknown, but I've been able to determine the data size of them. I think a lot of them are flags for various region events, things like a ruler dying or some group becoming a public enemy, the stuff you see in rumors or on the signboards at city entrances.

Right now, the game play benefit is that regional price variations are saved and loaded, and so will no longer be re-randomized every time you open a DF Unity save.

The region data includes the legal reputation per region. I went ahead and hooked this up to the status pop-up (and fixed a problem that caused all legal reputations under 0 to be shown as "undependable"), but I see that some groundwork has already been laid in place for storing legal reputation as a part of the persistent faction data, rather than in the regional data. Interkarma, I know you're busy with the quest stuff, but can you take a look and decide how to proceed here? We could just use the legal reputation in the region data records like classic does, and it will keep things simple. But maybe you have plans for managing the legal reputation from within the persistant faction data? In that case, should all the regional data stuff (just price adjustments, currently) be in there, too? 