### PR TITLE
Fix prohibited armor material check

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -988,9 +988,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // Check for prohibited armor type (leather, chain or plate)
                 else if ((1 << (item.NativeMaterialValue >> 8) & (int)playerEntity.Career.ForbiddenArmors) != 0)
                     prohibited = true;
+
                 // Check for prohibited material
                 else if (((item.NativeMaterialValue >> 8) == 2)
-                    && (1 << (item.NativeMaterialValue << 8) & (int)playerEntity.Career.ForbiddenMaterials) != 0)
+                    && (1 << (item.NativeMaterialValue & 0xFF) & (int)playerEntity.Career.ForbiddenMaterials) != 0)
                     prohibited = true;
             }
             else if (item.ItemGroup == ItemGroups.Weapons)


### PR DESCRIPTION
Fixes prohibited armor material checking. My earlier fix attempt by changing the shift direction was incorrect. First, I wasn't thinking straight -- if you have two bytes and want to shave off the right one and just use the left one, you can shift to the right, but if you do the same thing in the other direction to try to use only the right byte, you would need to again shift back after shaving off the left byte or the number would be too large.

Second, I didn't pay attention to the fact that the DF Unity material enum is a 4-byte int, so my shift didn't even shave off the left bit, it just made the number bigger.

For the fix this time I just cancel out everything but the rightmost byte. Tested on a character with prohibited leather, iron and steel equipping daedric armor (which Hazelnut said was wrongly prohibited from equipping), and it works now.