### PR TITLE
Texture fix

### DIFF
--- a/Assets/Scripts/Utility/ClimateSwaps.cs
+++ b/Assets/Scripts/Utility/ClimateSwaps.cs
@@ -31,6 +31,10 @@ namespace DaggerfallWorkshop.Utility
         /// <returns>Archive index of new texture.</returns>
         public static int ApplyClimate(int archive, int record, ClimateBases climate, ClimateSeason season)
         {
+            // Don't swap textures for door 3. Same behavior as classic.
+            if (((archive % 100) == 74) && record == 3)
+                return archive;
+
             // Get climate texture info
             ClimateTextureInfo ci = ClimateSwaps.GetClimateTextureInfo(archive);
 

--- a/Assets/Scripts/Utility/ClimateSwaps.cs
+++ b/Assets/Scripts/Utility/ClimateSwaps.cs
@@ -47,7 +47,6 @@ namespace DaggerfallWorkshop.Utility
             {
                 switch (ci.textureSet)
                 {
-                    case DFLocation.ClimateTextureSet.Interior_TempleInt:
                     case DFLocation.ClimateTextureSet.Interior_MarbleFloors:
                         return archive;
                 }


### PR DESCRIPTION
2 Fixes.

1. Fixes http://forums.dfworkshop.net/viewtopic.php?f=24&t=376.

I found that classic omits and of the 3rd exterior door records from being climate-swapped. This fixes the dungeon door mentioned in the bug report and also the doors at Daggerfall Castle (out on the towers in the courtyard). In the bug report you mentioned that you had patched out some doors this way but I couldn't find the code for it, and without this PR there are tavern doors on the courtyard towers of Daggerfall Castle. Was that code removed or never applied to master? If it does exist in master maybe we should remove it.

2. Added the swamp temple interior textures. These were disabled as "missing" but they aren't missing. They exist under "Swamp Temple Int." and are used in classic. They do look pretty unusual (pinkish-purplish) so I can see if maybe you thought they were incorrect, but I don't think they are.