### PR TITLE
Cancel player movement when entering interior

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -777,6 +777,8 @@ namespace DaggerfallWorkshop.Game
             Ray ray = new Ray(transform.position, Vector3.down);
             if (Physics.Raycast(ray, out hit, controller.height * 2f))
             {
+                // Cancel movement so player doesn't take falling damage if they transitioned into a dungeon while jumping
+                GameManager.Instance.PlayerMotor.CancelMovement = true;
                 // Position player at hit position plus just over half controller height up
                 Vector3 pos = hit.point;
                 pos.y += controller.height / 2f + 0.25f;


### PR DESCRIPTION
Fixes a bug I found where if you enter a dungeon while jumping, you take falling damage when the dungeon loads.