### PR TITLE
Fix getting High Rock sea coast region index

### DIFF
--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -119,7 +119,10 @@ namespace DaggerfallWorkshop
         /// </summary>
         public int CurrentRegionIndex
         {
-            get { return currentPoliticIndex - 128; }
+            get { if (currentPoliticIndex == 64)
+                    return 31; // High Rock sea coast
+                  else
+                    return currentPoliticIndex - 128; }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes an out-of-bounds array error with legal reputation and the blank place names when using the status popup outside of a political region (in "High Rock sea coast").