### PR TITLE
Temporarily ignore player ship for travel costs

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -246,7 +246,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             tripCost = travelTimeCalculator.CalculateTripCost(
                 travelTimeMinutes,
                 sleepModeInn,
-                hasShip,
+                false,  // TODO: Replace with hasShip when ship buying is implemented.
                 travelShip
                 );
 


### PR DESCRIPTION
Forces ocean travel costs as if player didn't own a ship so that ocean travel costs can be tested for a while.