### PR TITLE
Implement castle guards going hostile

### DIFF
--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -497,6 +497,26 @@ namespace DaggerfallWorkshop.Game
             return areEnemiesNearby;
         }
 
+        /// <summary>
+        /// Make all enemies in an area go hostile.
+        /// </summary>
+        public void MakeEnemiesHostile()
+        {
+            DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
+            for (int i = 0; i < entityBehaviours.Length; i++)
+            {
+                DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
+                if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
+                {
+                    EnemyMotor enemyMotor = entityBehaviour.GetComponent<EnemyMotor>();
+                    if (enemyMotor)
+                    {
+                        enemyMotor.IsHostile = true;
+                    }
+                }
+            }
+        }
+
         #endregion
 
         #region Public Static Methods

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -448,7 +448,7 @@ namespace DaggerfallWorkshop.Game
                                             break;
                                         }
                                         enemyEntity.PickpocketByPlayerAttempted = true;
-                                        Pickpocket(enemyEntity);
+                                        Pickpocket(mobileEnemyBehaviour);
                                     }
                                     break;
                             }
@@ -895,14 +895,17 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Player has clicked on a pickpocket target in steal mode
-        void Pickpocket(EnemyEntity target = null)
+        void Pickpocket(DaggerfallEntityBehaviour target = null)
         {
             const int foundNothingValuableTextId = 8999;
 
             PlayerEntity player = GameManager.Instance.PlayerEntity;
+            EnemyEntity enemyEntity = null;
+            if (target != null)
+                enemyEntity = target.Entity as EnemyEntity;
             player.TallySkill(DFCareer.Skills.Pickpocket, 1);
 
-            int chance = Formulas.FormulaHelper.CalculatePickpocketingChance(player, target);
+            int chance = Formulas.FormulaHelper.CalculatePickpocketingChance(player, enemyEntity);
 
             if (UnityEngine.Random.Range(0, 101) <= chance)
             {
@@ -934,6 +937,19 @@ namespace DaggerfallWorkshop.Game
             {
                 string notSuccessfulMessage = HardStrings.youAreNotSuccessful;
                 DaggerfallUI.Instance.PopupMessage(notSuccessfulMessage);
+
+                // Make enemies in an area aggressive if player failed to pickpocket a non-hostile one.
+                EnemyMotor enemyMotor = null;
+                if (target != null)
+                    enemyMotor = target.GetComponent<EnemyMotor>();
+                if (enemyMotor)
+                {
+                    if (!enemyMotor.IsHostile)
+                    {
+                        GameManager.Instance.MakeEnemiesHostile();
+                    }
+                    enemyMotor.MakeEnemyHostileToPlayer(gameObject);
+                }
             }
         }       
     }

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -652,6 +652,11 @@ namespace DaggerfallWorkshop.Game
                         EnemyMotor enemyMotor = hit.transform.GetComponent<EnemyMotor>();
                         if (enemyMotor)
                         {
+                            // Make enemies in an area aggressive if player attacked a non-hostile one.
+                            if (!enemyMotor.IsHostile)
+                            {
+                                GameManager.Instance.MakeEnemiesHostile();
+                            }
                             enemyMotor.MakeEnemyHostileToPlayer(gameObject);
                         }
                     }

--- a/Assets/Scripts/Internal/DaggerfallAction.cs
+++ b/Assets/Scripts/Internal/DaggerfallAction.cs
@@ -737,7 +737,6 @@ namespace DaggerfallWorkshop
         /// <summary>
         /// 32
         /// Shows text at the top of the screen when player clicks on associated door in info mode.
-        /// TODO: Can cause castle guards to go hostile if player clicked door outside of info mode.
         /// </summary>
         public static void DoorText(GameObject triggerObj, DaggerfallAction thisAction)
         {
@@ -794,9 +793,13 @@ namespace DaggerfallWorkshop
                         throw new System.Exception(string.Format("DaggerfallAction: Bad DoorTextID requested: {0}.", DoorTextID));
                     }
                 }
-                else
+            }
+            else
+            {
+                // Classic seems to only check whether this value is greater than 5, as a trespassing check
+                if (thisAction.ActionAxisRawValue > 5)
                 {
-                    // TODO: Fourth byte of thisAction determines if guards turn hostile.
+                    GameManager.Instance.MakeEnemiesHostile();
                 }
             }
         }

--- a/Assets/Scripts/Internal/DaggerfallAction.cs
+++ b/Assets/Scripts/Internal/DaggerfallAction.cs
@@ -31,7 +31,7 @@ namespace DaggerfallWorkshop
         public const int ANSWER_TEXT_INDEX = 5656;
         public const int TYPE_99_TEXT_INDEX = 7700;
 
-        public bool ActionEnabled = false;                                          // Enable/disable action - not currently being used, but some objects are single activate
+        public bool ActionEnabled = false;                                          // Enable/disable action. Currently only used in the DoorText action, but some objects are single activate
         public bool PlaySound = true;                                               // Play sound if present (ActionSound > 0)
         public string ModelDescription = string.Empty;                              // Description string for this model
         public DFBlock.RdbActionFlags ActionFlag = DFBlock.RdbActionFlags.None;     // Action flag value
@@ -740,58 +740,56 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void DoorText(GameObject triggerObj, DaggerfallAction thisAction)
         {
-            if (GameManager.Instance.PlayerActivate.CurrentMode == PlayerActivateModes.Info)
+            // The way that classic handles this action has some problems. The text is only displayed
+            // if the door is clicked in info mode, so it can easily be missed, and if clicked in info mode
+            // the trespassing check isn't run but the door is still opened, making it an exploit.
+            // For DF Unity, we're showing the text on the first click of the door, and opening the door
+            // and running the trespassing check from the second click onward, all regardless of interaction mode.
+
+            int DoorTextID = TYPE_99_TEXT_INDEX + thisAction.Index;
+
+            // Patch some textID lookups.
+            switch (DoorTextID)
             {
-                if (thisAction.Index != 0)
+                case 7700:  // action.Index was 0.
+                    thisAction.ActionEnabled = true; // This means skip over trying to display the message and proceed to the trespassing check.
+                                                     // DaggerfallActionDoor will also proceed with opening the door even on first activation.
+                    break;
+                case 7701:
+                case 7702:
+                case 7703:
+                case 7704:
+                    {
+                        DoorTextID = 7705; // All of these are the same except that only 7705 correctly has "allowed" instead of "allow"
+                        break;
+                    }
+                case 7706:  // Doesn't exist. This is on a door in Castle Wayrest to a room with some potions, bookshelves, weighting scales and a telescope.
+                    {
+                        thisAction.ActionEnabled = true;
+                        break;
+                    }
+                case 7715:  // Doesn't exist. Found on doors in back of Orsinium throne room.
+                    {
+                        thisAction.ActionEnabled = true;
+                        break;
+                    }
+                case 7719:  // Doesn't exist. This is on the doors to a room near the start of the Orsinium dungeon area with a long table lined with chairs and a fireplace.
+                    {
+                        thisAction.ActionEnabled = true;
+                        break;
+                    }
+            }
+
+            if (thisAction.activationCount == 1 && DoorTextID != 7700 && !thisAction.ActionEnabled)
+            {
+                TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(DoorTextID);
+                if (tokens != null)
                 {
-                    int DoorTextID = TYPE_99_TEXT_INDEX + thisAction.Index;
-
-                    // Patch some textID lookups. Cases 7706, 7715 and 7719 cause "Bad DAGTEXT number requested : %d." to display in classic.
-                    switch (DoorTextID)
-                    {
-                        case 7701:
-                        case 7702:
-                        case 7703:
-                        case 7704:
-                            {
-                                DoorTextID = 7705; // All of these are the same except that only 7705 correctly has "allowed" instead of "allow"
-                            }
-                            break;
-                        case 7706: // This is on a door in Castle Wayrest to a room with some potions, bookshelves, weighting scales and a telescope.
-                                   // TextID 7764 "Chanting and odd, alien noises seep under the door. The smell of sulphur and noxious potions invades your nose"
-                                   // was maybe supposed to be used here, but not sure.
-                            {
-                                return;
-                            }
-                        case 7715: // Doors in back of Orsinium throne room. It seems likely this is supposed to be TextID 7717:
-                                   // "A strong, orcish voice in the back of the hall snarls "All who enter must face the trial by arms.""
-                                   // Unlike all the other door texts this one lacks a justify center line break.
-                                   // Rather than implement text wrapping for just this message, two replacement strings are being used here.
-                            {
-                                const string Text7717First = "A strong, orcish voice in the back of the";
-                                const string Text7717Second = "hall snarls \"All who enter must face the trial by arms.\"";
-                                DaggerfallUI.AddHUDText(Text7717First, 2.0f);
-                                DaggerfallUI.AddHUDText(Text7717Second, 2.0f);
-                                return;
-                            }
-                        case 7719: // This is on the doors to a room near the start of the Orsinium dungeon area with a long table lined with chairs and a fireplace.
-                                   // Soon after this room is a large open room.
-                                   // "Bold, brash male voices echo from behind the door. Faint clatters of metal, obviously made by men in armor moving about, can be heard."
-                                   // was maybe supposed to be used here, but not sure.
-                            {
-                                return;
-                            }
-                    }
-
-                    TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(DoorTextID);
-                    if (tokens != null)
-                    {
-                        DaggerfallUI.AddHUDText(tokens, 2.0f);
-                    }
-                    else
-                    {
-                        throw new System.Exception(string.Format("DaggerfallAction: Bad DoorTextID requested: {0}.", DoorTextID));
-                    }
+                    DaggerfallUI.AddHUDText(tokens, 2.0f);
+                }
+                else
+                {
+                    throw new System.Exception(string.Format("DaggerfallAction: Bad DoorTextID requested: {0}.", DoorTextID));
                 }
             }
             else

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -227,6 +227,9 @@ namespace DaggerfallWorkshop
                         ToggleDoor(true);
                     }
                 }
+
+                if (Game.GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeonCastle)
+                    Game.GameManager.Instance.MakeEnemiesHostile();
             }
         }
 

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -263,6 +263,19 @@ namespace DaggerfallWorkshop
 
         private void Open(float duration, bool ignoreLocks = false, bool activatedByPlayer = false)
         {
+            // Handle DoorText actions. On first activation, show the text but don't try to open the door.
+            DaggerfallAction action = GetComponent<DaggerfallAction>();
+            if (action != null
+                && action.ActionFlag == DFBlock.RdbActionFlags.DoorText
+                && (action.TriggerFlag == DFBlock.RdbTriggerFlags.Door || action.TriggerFlag == DFBlock.RdbTriggerFlags.Direct) // Door to Mynisera's room has a "Direct" trigger flag
+                && action.activationCount == 0
+                && activatedByPlayer)
+            {
+                ExecuteActionOnToggle();
+                if (!action.ActionEnabled) // ActionEnabled will still be false if there was valid text to display. In that case, don't open the door for this first activation.
+                    return;
+            }
+
             // Do nothing if door cannot be opened right now
             if ((IsLocked && !ignoreLocks) || IsOpen)
             {
@@ -270,6 +283,9 @@ namespace DaggerfallWorkshop
                     LookAtLock();
                 return;
             }
+
+            if (activatedByPlayer)
+                ExecuteActionOnToggle();
 
             //// Tween rotation
             //Hashtable rotateParams = __ExternalAssets.iTween.Hash(
@@ -300,12 +316,6 @@ namespace DaggerfallWorkshop
                 if (dfAudioSource != null)
                     dfAudioSource.PlayOneShot(OpenSound);
             }
-
-            // For doors that are also action objects, execute action when door opened / closed
-            // Only doing so if player was the activator, to keep DoorText actions from running
-            // when enemies open doors.
-            if (activatedByPlayer)
-                ExecuteActionOnToggle();
 
             // Set flag
             //IsMagicallyHeld = false;
@@ -367,7 +377,6 @@ namespace DaggerfallWorkshop
             DaggerfallAction action = GetComponent<DaggerfallAction>();
             if(action != null)
                 action.Receive(gameObject, DaggerfallAction.TriggerTypes.Door);
-
         }
 
         #endregion


### PR DESCRIPTION
This implements castle guards going hostile. The main thing I was aiming for was finishing up the "DoorText" action I worked on earlier. Guards will go hostile now when you open the doors to restricted areas in the castles, like in classic. Also, guards will go hostile when you attack any one of them that was passive. All guards in the area will be set to hostile. I think in classic it might just be those that are within loaded range or something, but this behavior seems fine to me, rather than potentially having some guards standing around and ignoring the fight.

As for the DoorText trespassing action, the classic behavior is emulated, but it is somewhat broken IMO.
- The descriptive messages that warns you about areas being off limits are only seen if you click the doors in info mode, so they are easy to miss.
- If you click the door in info mode, it leads to an exploit, because the door opens but the trespassing check doesn't trigger.

You know I in general want to copy classic, but I think broken game mechanics like this should be fixed. What do you think about doing these:
- Always show the descriptive messages. This makes sense since they include things like guards issuing you warnings not to enter.
- On first click, the message is shown. After that, regardless of interaction mode, the door will be opened, and trespassing check performed.

I've gathered over the time watching your work, Interkarma, that you like avoiding extra clicks wherever possible, so maybe you won't like that second suggestion, since it would mean two clicks to open these doors. These doors aren't very common, but if you have another suggestion, maybe we could do that.