### PR TITLE
Get door lock value like classic

### DIFF
--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -962,7 +962,7 @@ namespace DaggerfallConnect
             /// <summary>Index into ModelReferenceList array.</summary>
             public UInt16 ModelIndex;
 
-            /// <summary>Unknown.</summary>
+            /// <summary>Trigger flag and starting lock for doors.</summary>
             internal UInt32 TriggerFlag_StartingLock;
 
             /// <summary>ID of sound to play when action is executed. Also used for spell & text index.</summary>

--- a/Assets/Scripts/Internal/DaggerfallAction.cs
+++ b/Assets/Scripts/Internal/DaggerfallAction.cs
@@ -549,22 +549,6 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void OpenDoor(GameObject triggerObj, DaggerfallAction thisAction)
         {
-            // Try special action door
-            if (thisAction != null && thisAction.gameObject)
-            {
-                DaggerfallActionDoorSpecial specialDoor = thisAction.gameObject.GetComponent<DaggerfallActionDoorSpecial>();
-                if (specialDoor)
-                {
-                    if (specialDoor.IsOpen)
-                        return;
-                    else
-                    {
-                        specialDoor.ToggleDoor();
-                        return;
-                    }
-                }
-            }
-
             // Try regular action door
             DaggerfallActionDoor door;
             if (!GetDoor(thisAction.gameObject, out door))
@@ -577,6 +561,20 @@ namespace DaggerfallWorkshop
                 {
                     door.CurrentLockValue = 0;
                     door.ToggleDoor();
+                    return;
+                }
+            }
+
+            // Try special action door
+            if (thisAction != null && thisAction.gameObject)
+            {
+                DaggerfallActionDoorSpecial specialDoor = thisAction.gameObject.GetComponent<DaggerfallActionDoorSpecial>();
+                if (specialDoor)
+                {
+                    if (specialDoor.IsOpen)
+                        return;
+                    else
+                        specialDoor.ToggleDoor();
                 }
             }
         }
@@ -588,22 +586,6 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void CloseDoor(GameObject triggerObj, DaggerfallAction thisAction)
         {
-            // Try special action door
-            if (thisAction != null && thisAction.gameObject)
-            {
-                DaggerfallActionDoorSpecial specialDoor = thisAction.gameObject.GetComponent<DaggerfallActionDoorSpecial>();
-                if (specialDoor)
-                {
-                    if (specialDoor.IsClosed)
-                        return;
-                    else
-                    {
-                        specialDoor.ToggleDoor();
-                        return;
-                    }
-                }
-            }
-
             // Try regular action door
             DaggerfallActionDoor door;
             if (!GetDoor(thisAction.gameObject, out door))
@@ -616,9 +598,24 @@ namespace DaggerfallWorkshop
                 {
                     door.ToggleDoor();
                     door.CurrentLockValue = door.StartingLockValue;
+                    return;
                 }
 
             }
+
+            // Try special action door
+            if (thisAction != null && thisAction.gameObject)
+            {
+                DaggerfallActionDoorSpecial specialDoor = thisAction.gameObject.GetComponent<DaggerfallActionDoorSpecial>();
+                if (specialDoor)
+                {
+                    if (specialDoor.IsClosed)
+                        return;
+                    else
+                        specialDoor.ToggleDoor();
+                }
+            }
+
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1060,10 +1060,8 @@ namespace DaggerfallWorkshop.Utility
             DaggerfallActionDoor actionDoor = go.GetComponent<DaggerfallActionDoor>();
 
             // Set starting lock value
-            if (obj.Resources.ModelResource.TriggerFlag_StartingLock >= 16)
-            {
-                actionDoor.StartingLockValue = (int)obj.Resources.ModelResource.TriggerFlag_StartingLock / 8;
-            }
+            byte[] lockValues = { 0x00, 0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C, 0x0E, 0x10, 0x12, 0x14, 0x19, 0x1E, 0x32, 0x80, 0xFF };
+            actionDoor.StartingLockValue = lockValues[obj.Resources.ModelResource.TriggerFlag_StartingLock >> 4];
 
             // Set LoadID
             actionDoor.LoadID = loadID;


### PR DESCRIPTION
Gets the lock value for doors in the same manner as classic.

For regular locks the value will be the same, but apparently magical doors can have a few different values, which wouldn't be correct before this PR. Maybe those values matter when using lock-opening spells.