### PR TITLE
Add dungeon texture options

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -14,6 +14,7 @@ ShadowResolutionMode=1
 UseLegacyDeferred=False
 DungeonLightShadows=False
 EnableTextureArrays=True
+RandomDungeonTextures=0
 
 [ChildGuard]
 PlayerNudity=False

--- a/Assets/Scripts/DungeonTextureTables.cs
+++ b/Assets/Scripts/DungeonTextureTables.cs
@@ -9,6 +9,7 @@
 // Notes:
 //
 
+using UnityEngine;
 using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
 
@@ -16,28 +17,38 @@ namespace DaggerfallWorkshop
 {
     public static class DungeonTextureTables
     {
+        public const int TableLength = 6;
         // Default dungeon texture table at linear offset 0x28617C
         public static int[] DefaultTextureTable = new int[] { 119, 120, 122, 123, 124, 168 };
 
-        // Generates dungeon texture table from random seed
-        public static int[] RandomTextureTable(int seed)
+        public static int[] RandomTextureTableClassic(int seed, int randomDungeonTextures = 0)
         {
             byte[] climateTextureArchiveIndices = { 0, 0, 1, 4, 4, 0, 3, 3, 3, 0 };
-            short[] climateTextureArchives = { 19, 119, 319, 419, 119 };
+            short[] climateTextureArchives;
+            if (randomDungeonTextures == 0)
+                climateTextureArchives = new short[] { 19, 119, 319, 419, 119 }; // Values from classic, used in classic algorithm
+            else
+                climateTextureArchives = new short[] { 19, 119, 119, 319, 419 }; // Values for climate-based algorithm. Index 2 (unused) is a dummy value.
 
             int climate = Game.GameManager.Instance.PlayerGPS.CurrentClimateIndex;
             if (climate == (int)MapsFile.Climates.Ocean)
                 climate = (int)MapsFile.Climates.Swamp;
 
-            int climateTextureArchiveIndicesIndex = Game.Utility.TravelTimeCalculator.climateIndices[climate - (int)MapsFile.Climates.Ocean];
-            int climateTextureArchiveIndex = climateTextureArchiveIndices[climateTextureArchiveIndicesIndex];
+            int classicIndexValue = Game.Utility.TravelTimeCalculator.climateIndices[climate - (int)MapsFile.Climates.Ocean];
+            int climateBasedIndexValue = climate - (int)MapsFile.Climates.Desert;
+
+            int climateTextureArchiveIndex;
+            if (randomDungeonTextures == 0) // classic algorithm
+                climateTextureArchiveIndex = climateTextureArchiveIndices[classicIndexValue];
+            else // climate-based algorithm
+                climateTextureArchiveIndex = climateTextureArchiveIndices[climateBasedIndexValue];
 
             int textureArchiveOffset;
             DFRandom.srand(seed);
 
             int[] textureTable = (int[])DefaultTextureTable.Clone();
 
-            if (climateTextureArchiveIndex != 1)
+            if (randomDungeonTextures != 0 || climateTextureArchiveIndex != 1) // classic algorithm skips on index 1
             {
                 for (int i = 0; i < 5; ++i)
                 {
@@ -48,8 +59,34 @@ namespace DaggerfallWorkshop
                 }
             }
 
-            int sewerTextureArchiveIndex = climate - (int)MapsFile.Climates.Desert;
-            textureTable[5] = (int)DFLocation.ClimateTextureSet.Interior_Sewer + 100 * climateTextureArchiveIndices[sewerTextureArchiveIndex];
+            textureTable[5] = (int)DFLocation.ClimateTextureSet.Interior_Sewer + 100 * climateTextureArchiveIndices[climateBasedIndexValue];
+            return textureTable;
+        }
+
+        // Randomly pick from all dungeon texture tables. This is a DF Unity implementation different from classic.
+        public static int[] RandomTextureTableAlternate(int seed)
+        {
+            // Valid dungeon textures table indices
+            int[] valids = new int[]
+            {
+                019, 020, 022, 023, 024, 068,
+                119, 120, 122, 123, 124, 168,
+                319, 320, 322, 323, 324, 368,
+                419, 420, 422, 423, 424, 468,
+            };
+
+            Random.InitState(seed);
+            int[] textureTable = new int[TableLength];
+            for (int i = 0; i < TableLength; i++)
+            {
+                textureTable[i] = valids[Random.Range(0, valids.Length)];
+            }
+
+            // Make sure sewer textures are used for last slot, or errors can occur because sewer archives have more records than the others
+            int[] validSewerArchives = { 68, 168, 368, 468 };
+            if ((textureTable[5] % 100) != 68)
+                textureTable[5] = validSewerArchives[Random.Range(0, validSewerArchives.Length)];
+
             return textureTable;
         }
     }

--- a/Assets/Scripts/DungeonTextureTables.cs
+++ b/Assets/Scripts/DungeonTextureTables.cs
@@ -45,18 +45,18 @@ namespace DaggerfallWorkshop
 
             int textureArchiveOffset;
             DFRandom.srand(seed);
+            int[] textureTable = new int[TableLength];
 
-            int[] textureTable = (int[])DefaultTextureTable.Clone();
-
-            if (randomDungeonTextures != 0 || climateTextureArchiveIndex != 1) // classic algorithm skips on index 1
+            // In classic, if climateTextureArchiveIndex is 1 here (only happens with rainforest climate), the following loop is skipped and
+            // a dungeon in that climate will have the texture table of the last visited dungeon or, if no dungeons
+            // had been visited since starting the program, the default dungeon textures. This seems like it must just be a bug, so the
+            // recreation of the classic algorithm here assigns textures even if climateTextureArchiveIndex is 1.
+            for (int i = 0; i < 5; ++i)
             {
-                for (int i = 0; i < 5; ++i)
-                {
-                    textureArchiveOffset = DFRandom.random_range_inclusive(0, 4);
-                    if (textureArchiveOffset == 2) // invalid
-                        textureArchiveOffset = 4;
-                    textureTable[i] = climateTextureArchives[climateTextureArchiveIndex] + textureArchiveOffset;
-                }
+                textureArchiveOffset = DFRandom.random_range_inclusive(0, 4);
+                if (textureArchiveOffset == 2) // invalid
+                    textureArchiveOffset = 4;
+                textureTable[i] = climateTextureArchives[climateTextureArchiveIndex] + textureArchiveOffset;
             }
 
             textureTable[5] = (int)DFLocation.ClimateTextureSet.Interior_Sewer + 100 * climateTextureArchiveIndices[climateBasedIndexValue];

--- a/Assets/Scripts/Internal/DaggerfallDungeon.cs
+++ b/Assets/Scripts/Internal/DaggerfallDungeon.cs
@@ -123,14 +123,52 @@ namespace DaggerfallWorkshop
 
         public void RandomiseDungeonTextureTable()
         {
-            DungeonTextureTable = DungeonTextureTables.RandomTextureTable(UnityEngine.Random.Range(int.MinValue, int.MaxValue));
+            DungeonTextureTable = DungeonTextureTables.RandomTextureTableAlternate(UnityEngine.Random.Range(int.MinValue, int.MaxValue));
             ApplyDungeonTextureTable();
         }
 
         public void UseLocationDungeonTextureTable()
         {
-            // Dungeon textures are gotten in same manner as classic
-            DungeonTextureTable = DungeonTextureTables.RandomTextureTable(Summary.LocationData.Dungeon.RecordElement.Header.LocationId);
+            // Generates dungeon texture table from random seed
+            // RandomDungeonTextures are read from settings.ini. Values are
+            // 0 : Classic textures (swamp and woodland texture sets unused)
+            // 1 : Textures by climate + classic textures for main story dungeons
+            // 2 : Textures by climate for all dungeons
+            // 3 : Randomized + classic textures for main story dungeons (method used in earlier DF Unity builds)
+            // 4 : Randomized for all dungeons
+            bool mainStoryDungeon = false;
+            switch (Summary.ID)
+            {
+                case 187853213:         // Daggerfall/Privateer's Hold
+                case 630439035:         // Wayrest/Wayrest
+                case 1291010263:        // Daggerfall/Daggerfall
+                case 6634853:           // Sentinel/Sentinel
+                case 19021260:          // Orsinium Area/Orsinium
+                case 728811286:         // Wrothgarian Mountains/Shedungent
+                case 701948302:         // Dragontail Mountains/Scourg Barrow
+                case 83032363:          // Wayrest/Woodborne Hall
+                case 1001:              // High Rock sea coast/Mantellan Crux
+                case 207828842:         // Menevia/Lysandus' Tomb
+                case 9570447:           // Daggerfall/Castle Necromoghan
+                case 2352284:           // Betony/Tristore Laboratory
+                case 336619236:         // Ykalon/Castle Llugwych
+                     mainStoryDungeon = true;
+                     break;
+                  default:
+                     break;
+            }
+
+            int randomDungeonTextures = DaggerfallUnity.Settings.RandomDungeonTextures;
+            // If not overriding with other textures (modes 2 and 4), use classic algorithm for main story dungeons
+            if (mainStoryDungeon && randomDungeonTextures != 2 && randomDungeonTextures != 4)
+                DungeonTextureTable = DungeonTextureTables.RandomTextureTableClassic(Summary.LocationData.Dungeon.RecordElement.Header.LocationId);
+            else // Otherwise, use a random texture according to the mode set in settings.ini
+            {
+                if (randomDungeonTextures < 3)
+                    DungeonTextureTable = DungeonTextureTables.RandomTextureTableClassic(Summary.LocationData.Dungeon.RecordElement.Header.LocationId, DaggerfallUnity.Settings.RandomDungeonTextures);
+                else
+                    DungeonTextureTable = DungeonTextureTables.RandomTextureTableAlternate(Summary.ID);
+            }
             ApplyDungeonTextureTable();
         }
 

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -73,6 +73,7 @@ namespace DaggerfallWorkshop
         public bool UseLegacyDeferred { get; set; }
         public bool DungeonLightShadows { get; set; }
         public bool EnableTextureArrays { get; set; }
+        public int RandomDungeonTextures { get; set; }
 
         // [ChildGuard]
         public bool PlayerNudity { get; set; }
@@ -147,6 +148,7 @@ namespace DaggerfallWorkshop
             UseLegacyDeferred = GetBool(sectionVideo, "UseLegacyDeferred");
             DungeonLightShadows = GetBool(sectionVideo, "DungeonLightShadows");
             EnableTextureArrays = GetBool(sectionVideo, "EnableTextureArrays");
+            RandomDungeonTextures = GetInt(sectionVideo, "RandomDungeonTextures", 0, 4);
             PlayerNudity = GetBool(sectionChildGuard, "PlayerNudity");
             ShowOptionsAtStart = GetBool(sectionGUI, "ShowOptionsAtStart");
             GUIFilterMode = GetInt(sectionGUI, "GUIFilterMode", 0, 2);
@@ -203,6 +205,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionVideo, "UseLegacyDeferred", UseLegacyDeferred);
             SetBool(sectionVideo, "DungeonLightShadows", DungeonLightShadows);
             SetBool(sectionVideo, "EnableTextureArrays", EnableTextureArrays);
+            SetInt(sectionVideo, "RandomDungeonTextures", RandomDungeonTextures);
             SetBool(sectionChildGuard, "PlayerNudity", PlayerNudity);
             SetBool(sectionGUI, "ShowOptionsAtStart", ShowOptionsAtStart);
             SetInt(sectionGUI, "GUIFilterMode", GUIFilterMode);


### PR DESCRIPTION
Adds settings.ini options for dungeon textures.

0 = classic textures
1 = climate-based textures, using classic algorithm for picking among them. Main story dungeons have classic textures.
2 = climate-based textures for all dungeons
3 = Random selection from all textures (DF Unity implementation from before). Main story dungeons have classic textures. Sewer texture fix added so out-of-range textures shouldn't be used.
4 = Random selection from all textures (DF Unity implementation from before) for all dungeons. Sewer texture fix.