### PR TITLE
Talkwindow - progress, support for texture replacement talkwindow, interior and exterior automap 

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -755,10 +755,10 @@ namespace DaggerfallWorkshop.Game
             return newPanel;
         }
 
-        public static Texture2D GetTextureFromImg(string name, TextureFormat format = TextureFormat.ARGB32)
+        public static Texture2D GetTextureFromImg(string name, TextureFormat format = TextureFormat.ARGB32, bool readOnly = true)
         {
             DFPosition offset;
-            Texture2D texture = GetTextureFromImg(name, out offset, format);
+            Texture2D texture = GetTextureFromImg(name, out offset, format, readOnly);
 
             return texture;
         }
@@ -767,9 +767,9 @@ namespace DaggerfallWorkshop.Game
         /// Loads IMG file to texture using a subrect of source image.
         /// Origin of source image (0,0) is bottom-left corner.
         /// </summary>
-        public static Texture2D GetTextureFromImg(string name, Rect subRect, TextureFormat format = TextureFormat.ARGB32)
+        public static Texture2D GetTextureFromImg(string name, Rect subRect, TextureFormat format = TextureFormat.ARGB32, bool readOnly = true)
         {
-            ImgFile imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, name), FileUsage.UseMemory, true);
+            ImgFile imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, name), FileUsage.UseMemory, readOnly);
             imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
 
             DFBitmap bitmap = imgFile.GetDFBitmap();
@@ -796,7 +796,7 @@ namespace DaggerfallWorkshop.Game
             return texture;
         }
 
-        public static Texture2D GetTextureFromImg(string name, out DFPosition offset, TextureFormat format = TextureFormat.ARGB32)
+        public static Texture2D GetTextureFromImg(string name, out DFPosition offset, TextureFormat format = TextureFormat.ARGB32, bool readOnly = true)
         {
             offset = new DFPosition();
 
@@ -804,7 +804,7 @@ namespace DaggerfallWorkshop.Game
             if (!dfUnity.IsReady)
                 return null;
 
-            ImgFile imgFile = new ImgFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, true);            
+            ImgFile imgFile = new ImgFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, readOnly);            
             Texture2D texture = null;
  
             // Custom texture
@@ -814,7 +814,7 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 imgFile.LoadPalette(Path.Combine(dfUnity.Arena2Path, imgFile.PaletteName));
-                texture = GetTextureFromImg(imgFile, format);
+                texture = GetTextureFromImg(imgFile, format, readOnly);
             }
                 
             texture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
@@ -823,12 +823,12 @@ namespace DaggerfallWorkshop.Game
             return texture;
         }
 
-        public static Texture2D GetTextureFromImg(ImgFile img, TextureFormat format = TextureFormat.ARGB32)
+        public static Texture2D GetTextureFromImg(ImgFile img, TextureFormat format = TextureFormat.ARGB32, bool readOnly = true)
         {
             DFBitmap bitmap = img.GetDFBitmap();
             Texture2D texture = new Texture2D(bitmap.Width, bitmap.Height, format, false);
             texture.SetPixels32(img.GetColor32(bitmap, 0));
-            texture.Apply(false, true);
+            texture.Apply(false, readOnly);
             texture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
 
             return texture;

--- a/Assets/Scripts/Game/TalkManagerMCP.cs
+++ b/Assets/Scripts/Game/TalkManagerMCP.cs
@@ -9,6 +9,7 @@ using System;
 using DaggerfallWorkshop.Utility;
 using DaggerfallConnect.Arena2;
 using System.Collections.Generic;
+using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using UnityEngine;
 using DaggerfallConnect.FallExe;
@@ -17,9 +18,34 @@ namespace DaggerfallWorkshop.Game
 {
     public partial class TalkManager : IMacroContextProvider
     {
+        /// <summary>
+        /// Oaths by race.
+        /// </summary>
+        enum RacialOaths
+        {
+            None = 0,
+            Nord = 201,
+            Khajiit = 202,
+            Redguard = 203,
+            Breton = 204,
+            Argonian = 205,
+            Bosmer = 206,
+            Altmer = 207,
+            Dunmer = 208,
+        }
+
+        public class TalkManagerContext
+        {
+            public ListItem currentQuestionListItem;
+            public Races npcRace;
+        }
+
         public MacroDataSource GetMacroDataSource()
         {
-            return new TalkManagerDataSource(this.currentQuestionListItem);
+            TalkManagerContext context = new TalkManagerContext();
+            context.currentQuestionListItem = this.currentQuestionListItem;
+            context.npcRace = this.npcData.race;
+            return new TalkManagerDataSource(context);
         }
 
         /// <summary>
@@ -28,10 +54,10 @@ namespace DaggerfallWorkshop.Game
         private class TalkManagerDataSource : MacroDataSource
         {
 
-            private TalkManager.ListItem parent;
-            public TalkManagerDataSource(TalkManager.ListItem item)
+            private TalkManagerContext parent;
+            public TalkManagerDataSource(TalkManagerContext context)
             {
-                this.parent = item;
+                this.parent = context;
             }
 
             public override string LocationDirection()
@@ -41,7 +67,7 @@ namespace DaggerfallWorkshop.Game
                 //    return GameManager.Instance.TalkManager.GetQuestLocationDirection();
                 //}
                 //else if (parent.questionType == QuestionType.LocalBuilding)
-                if (parent.questionType == QuestionType.LocalBuilding)
+                if (parent.currentQuestionListItem.questionType == QuestionType.LocalBuilding)
                 {
                     return GameManager.Instance.TalkManager.GetKeySubjectLocationDirection();
                 }
@@ -50,28 +76,67 @@ namespace DaggerfallWorkshop.Game
 
             public override string DialogHint()
             {
-                if (parent.questionType == QuestionType.LocalBuilding)
+                if (parent.currentQuestionListItem.questionType == QuestionType.LocalBuilding)
                 {
                     return GameManager.Instance.TalkManager.GetKeySubjectLocationHint();
                 }
-                else if (parent.questionType == QuestionType.QuestLocation || parent.questionType == QuestionType.QuestPerson || parent.questionType == QuestionType.QuestItem)
+                else if (parent.currentQuestionListItem.questionType == QuestionType.QuestLocation || parent.currentQuestionListItem.questionType == QuestionType.QuestPerson || parent.currentQuestionListItem.questionType == QuestionType.QuestItem)
                 {
-                    return GameManager.Instance.TalkManager.GetDialogHint(parent);
+                    return GameManager.Instance.TalkManager.GetDialogHint(parent.currentQuestionListItem);
                 }
                 return "never mind...";
             }
 
             public override string DialogHint2()
             {
-                if (parent.questionType == QuestionType.LocalBuilding)
+                if (parent.currentQuestionListItem.questionType == QuestionType.LocalBuilding)
                 {
                     return GameManager.Instance.TalkManager.GetKeySubjectLocationHint();
                 }
-                else if (parent.questionType == QuestionType.QuestLocation || parent.questionType == QuestionType.QuestPerson || parent.questionType == QuestionType.QuestItem)
+                else if (parent.currentQuestionListItem.questionType == QuestionType.QuestLocation || parent.currentQuestionListItem.questionType == QuestionType.QuestPerson || parent.currentQuestionListItem.questionType == QuestionType.QuestItem)
                 {
-                    return GameManager.Instance.TalkManager.GetDialogHint2(parent);
+                    return GameManager.Instance.TalkManager.GetDialogHint2(parent.currentQuestionListItem);
                 }
                 return "never mind...";
+            }
+            public override string Oath()
+            {
+                RacialOaths whichOath = RacialOaths.None;
+                switch (parent.npcRace)
+                {
+                    case Races.Argonian:
+                        whichOath = RacialOaths.Argonian;
+                        break;
+                    case Races.Breton:
+                        whichOath = RacialOaths.Breton;
+                        break;
+                    case Races.DarkElf:
+                        whichOath = RacialOaths.Dunmer;
+                        break;
+                    case Races.HighElf:
+                        whichOath = RacialOaths.Altmer;
+                        break;
+                    case Races.Khajiit:
+                        whichOath = RacialOaths.Khajiit;
+                        break;
+                    case Races.Nord:
+                        whichOath = RacialOaths.Nord;
+                        break;
+                    case Races.Redguard:
+                        whichOath = RacialOaths.Redguard;
+                        break;
+                    case Races.Vampire:
+                        whichOath = RacialOaths.Dunmer;
+                        break;
+                    case Races.Wereboar:
+                    case Races.Werewolf:
+                        whichOath = RacialOaths.None;
+                        break;
+                    case Races.WoodElf:
+                        whichOath = RacialOaths.Bosmer;
+                        break;
+                }
+                return DaggerfallUnity.Instance.TextProvider.GetRandomText((int)whichOath);
             }
         }
     }

--- a/Assets/Scripts/Game/UserInterface/TextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/TextLabel.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Michael Rauter (Nystul)
 // 
 // Notes:
 //

--- a/Assets/Scripts/Game/UserInterface/TextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/TextLabel.cs
@@ -54,11 +54,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         bool wrapText = false; // wrap text - but will tear words that are reaching
         bool wrapWords = false; // wrap words - no word tearing
 
-        bool makeTextureNoLongerReadable = true; // in pixel-wise scroll mode with restricted render area this flag is set to false since textures must be readable for this mode to work
-
-        // restricted render area can be used to force label rendering inside this rect (used for text rendering in window frames where text is larger than frame)
-        bool useRestrictedRenderArea = false;
-        Rect rectRestrictedRenderArea;
+        bool makeTextureNoLongerReadable = true; // in pixel-wise scroll mode with restricted render area this flag is set to false since textures must be readable for this mode to work        
 
         float textScale = 1.0f; // scale text 
 
@@ -176,13 +172,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// <summary>
         /// set a restricted render area for the textlabel - the textlabel's content will only be rendered inside the specified Rect's bounds
         /// </summary>
-        public Rect RectRestrictedRenderArea
+        new public Rect RectRestrictedRenderArea
         {
             get { return rectRestrictedRenderArea; }
             set
             {
-                rectRestrictedRenderArea = value;
-                useRestrictedRenderArea = true;
+                ((BaseScreenComponent)this).RectRestrictedRenderArea = value;
                 makeTextureNoLongerReadable = false;
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
@@ -214,6 +214,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         Texture2D nativeTexture; // background image will be stored in this Texture2D
 
+        Texture2D nativeTextureGrid2D;
+        Texture2D nativeTextureGrid3D;
+
         Color[] pixelsGrid2D; // grid button texture for 2D view image will be stored in here
         Color[] pixelsGrid3D; // grid button texture for 3D view image will be stored in here
 
@@ -221,6 +224,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Color[] backgroundAlternative1; // texture with first alternative background will be stored in here
         Color[] backgroundAlternative2; // texture with second alternative background will be stored in here
         Color[] backgroundAlternative3; // texture with third alternative background will be stored in here
+
+        Texture2D textureBackgroundAlternative1;
+        Texture2D textureBackgroundAlternative2;
+        Texture2D textureBackgroundAlternative3;
 
         HUDCompass compass = null;
 
@@ -253,42 +260,37 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// </summary>
         protected override void Setup()
         {           
-            ImgFile imgFile = null;
-            DFBitmap bitmap = null;
-
             if (isSetup) // don't setup twice!
                 return;
 
             initGlobalResources(); // initialize gameobjectAutomap, daggerfallAutomap and layerAutomap
 
             // Load native texture
-            imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, nativeImgName), FileUsage.UseMemory, false);
-            imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
-            bitmap = imgFile.GetDFBitmap();
-            nativeTexture = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.ARGB32, false);
-            nativeTexture.SetPixels32(imgFile.GetColor32(bitmap, 0));
-            nativeTexture.Apply(false, false); // make readable
+            nativeTexture = DaggerfallUI.GetTextureFromImg(nativeImgName, TextureFormat.ARGB32, false);
             nativeTexture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             if (!nativeTexture)
                 throw new Exception("DaggerfallAutomapWindow: Could not load native texture (AMAP00I0.IMG).");
-            
+
             // Load alternative Grid Icon (3D View Grid graphics)
-            imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, nativeImgNameGrid3D), FileUsage.UseMemory, false);
-            imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
-            bitmap = imgFile.GetDFBitmap();
-            Texture2D nativeTextureGrid3D = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.ARGB32, false);
-            nativeTextureGrid3D.SetPixels32(imgFile.GetColor32(bitmap, 0));
-            nativeTextureGrid3D.Apply(false, false); // make readable
+            nativeTextureGrid3D = DaggerfallUI.GetTextureFromImg(nativeImgNameGrid3D, TextureFormat.ARGB32, false);
             nativeTextureGrid3D.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             if (!nativeTextureGrid3D)
-                throw new Exception("DaggerfallAutomapWindow: Could not load native texture (AMAP01I0.IMG).");
-            pixelsGrid3D = nativeTextureGrid3D.GetPixels(0, 0, 27, 19);
+                throw new Exception("DaggerfallAutomapWindow: Could not load native texture (AMAP01I0.IMG).");            
+            pixelsGrid3D = nativeTextureGrid3D.GetPixels((int)(0), (int)((200 - 0 - 19) * (nativeTextureGrid3D.height / 200f)), (int)(27 * (nativeTextureGrid3D.width / 320f)), (int)(19 * (nativeTextureGrid3D.height / 200f)));
 
-            // Cut out 2D View Grid graphics from background image
-            pixelsGrid2D = nativeTexture.GetPixels(78, nativeTexture.height - 171 - 19, 27, 19);
+            // Cut out 2D View Grid graphics from background image            
+            int width = (int)(27 * (nativeTexture.width / 320f));
+            int height = (int)(19 * (nativeTexture.height / 200f));
+            pixelsGrid2D = nativeTexture.GetPixels((int)(78 * (nativeTexture.width / 320f)), (int)((200 - 171 - 19) * (nativeTexture.height / 200f)), width, height);
+            nativeTextureGrid2D = new Texture2D(width, height, TextureFormat.ARGB32, false);
+            nativeTextureGrid2D.SetPixels(pixelsGrid2D);
+            nativeTextureGrid2D.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            nativeTextureGrid2D.Apply(false, false);
 
-            // store background graphics from from background image
-            backgroundOriginal = nativeTexture.GetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29);
+            // store background graphics from from background image            
+            width = (int)(320 * (nativeTexture.width / 320f));
+            height = (int)((200 - 29) * (nativeTexture.height / 200f));
+            backgroundOriginal = nativeTexture.GetPixels((int)(0 * (nativeTexture.width / 320f)), (int)(29 * (nativeTexture.height / 200f)), width, height);
 
             backgroundAlternative1 = new Color[backgroundOriginal.Length];
             for (int i = 0; i < backgroundOriginal.Length; ++i)
@@ -298,6 +300,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 backgroundAlternative1[i].b = 0.0f;
                 backgroundAlternative1[i].a = 1.0f;
             }
+            textureBackgroundAlternative1 = new Texture2D(width, height, TextureFormat.ARGB32, false);
+            textureBackgroundAlternative1.SetPixels(backgroundAlternative1);
+            textureBackgroundAlternative1.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureBackgroundAlternative1.Apply(false, true);
 
             backgroundAlternative2 = new Color[backgroundOriginal.Length];
             for (int i = 0; i < backgroundOriginal.Length; ++i)
@@ -307,6 +313,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 backgroundAlternative2[i].b = 0.3f;
                 backgroundAlternative2[i].a = 1.0f;
             }
+            textureBackgroundAlternative2 = new Texture2D(width, height, TextureFormat.ARGB32, false);
+            textureBackgroundAlternative2.SetPixels(backgroundAlternative2);
+            textureBackgroundAlternative2.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureBackgroundAlternative2.Apply(false, true);
 
             backgroundAlternative3 = new Color[backgroundOriginal.Length];
             for (int i = 0; i < backgroundOriginal.Length; ++i)
@@ -316,6 +326,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 backgroundAlternative3[i].b = 0.2f;
                 backgroundAlternative3[i].a = 1.0f;
             }
+            textureBackgroundAlternative3 = new Texture2D(width, height, TextureFormat.ARGB32, false);
+            textureBackgroundAlternative3.SetPixels(backgroundAlternative3);
+            textureBackgroundAlternative3.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureBackgroundAlternative3.Apply(false, true);
 
             // Always dim background
             ParentPanel.BackgroundColor = ScreenDimColor;
@@ -1540,8 +1554,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// </summary>
         private void ActionSwitchToAutomapBackgroundOriginal()
         {
-            nativeTexture.SetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29, backgroundOriginal);
-            nativeTexture.Apply(false);
+            dummyPanelAutomap.BackgroundTexture = null;
             updateAutomapView();
         }
 
@@ -1550,8 +1563,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// </summary>
         private void ActionSwitchToAutomapBackgroundAlternative1()
         {
-            nativeTexture.SetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29, backgroundAlternative1);
-            nativeTexture.Apply(false);
+            dummyPanelAutomap.BackgroundTexture = textureBackgroundAlternative1;
             updateAutomapView();
         }
 
@@ -1560,8 +1572,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// </summary>
         private void ActionSwitchToAutomapBackgroundAlternative2()
         {
-            nativeTexture.SetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29, backgroundAlternative2);
-            nativeTexture.Apply(false);
+            dummyPanelAutomap.BackgroundTexture = textureBackgroundAlternative2;
             updateAutomapView();
         }
 
@@ -1570,8 +1581,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// </summary>
         private void ActionSwitchToAutomapBackgroundAlternative3()
         {
-            nativeTexture.SetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29, backgroundAlternative3);
-            nativeTexture.Apply(false);
+            dummyPanelAutomap.BackgroundTexture = textureBackgroundAlternative3;
             updateAutomapView();
         }
 
@@ -1588,8 +1598,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 case AutomapViewMode.View2D:
                     // update grid graphics
-                    nativeTexture.SetPixels(78, nativeTexture.height - 171 - 19, 27, 19, pixelsGrid2D);
-                    nativeTexture.Apply(false);
+                    gridButton.BackgroundTexture = nativeTextureGrid2D;
                     saveCameraTransformView3D();
                     restoreOldCameraTransformViewFromTop();
                     cameraAutomap.fieldOfView = fieldOfViewCameraMode2D;
@@ -1598,8 +1607,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
                 case AutomapViewMode.View3D:
                     // update grid graphics
-                    nativeTexture.SetPixels(78, nativeTexture.height - 171 - 19, 27, 19, pixelsGrid3D);
-                    nativeTexture.Apply(false);
+                    gridButton.BackgroundTexture = nativeTextureGrid3D;
                     saveCameraTransformViewFromTop();
                     restoreOldCameraTransformView3D();
                     cameraAutomap.fieldOfView = fieldOfViewCameraMode3D;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -162,6 +162,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         Panel dummyPanelCompass = null; // used to determine correct compass position
 
+        Panel panelCaption = null; // used to place and show caption label
+
         // these boolean flags are used to indicate which mouse button was pressed over which gui button/element - these are set in the event callbacks
 #pragma warning disable 414
         bool leftMouseClickedOnPanelAutomap = false; // used for debug teleport mode clicks
@@ -202,6 +204,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         RenderTexture renderTextureExteriorAutomap = null; // render texture in which exterior automap camera will render into
         Texture2D textureExteriorAutomap = null; // render texture will converted to this texture so that it can be drawn in panelRenderExteriorAutomap
 
+        Texture2D textureBackgroundAlternative1;
+        Texture2D textureBackgroundAlternative2;
+        Texture2D textureBackgroundAlternative3;
+
         int renderTextureExteriorAutomapDepth = 16;
         int oldRenderTextureExteriorAutomapWidth; // used to store previous width of exterior automap render texture to react to changes to NativePanel's size and react accordingly by setting texture up with new widht and height again
         int oldRenderTextureExteriorAutomapHeight; // used to store previous height of exterior automap render texture to react to changes to NativePanel's size and react accordingly by setting texture up with new widht and height again
@@ -236,34 +242,29 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             gameobjectExteriorAutomap.transform.rotation = Quaternion.Euler(Vector3.zero);
 
             // Load native texture
-            imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, nativeImgName), FileUsage.UseMemory, false);
-            imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
-            bitmap = imgFile.GetDFBitmap();
-            nativeTexture = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.ARGB32, false);
-            nativeTexture.SetPixels32(imgFile.GetColor32(bitmap, 0));
-            nativeTexture.Apply(false, false); // make readable
+            nativeTexture = DaggerfallUI.GetTextureFromImg(nativeImgName, TextureFormat.ARGB32, false);
             nativeTexture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             if (!nativeTexture)
                 throw new Exception("DaggerfallExteriorAutomapWindow: Could not load native texture (AMAP00I0.IMG).");
-            
+
             // Load caption line
-            imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, nativeImgNameCaption), FileUsage.UseMemory, false);
-            imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
-            bitmap = imgFile.GetDFBitmap();
-            Texture2D nativeTextureCaption = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.ARGB32, false);
-            nativeTextureCaption.SetPixels32(imgFile.GetColor32(bitmap, 0));
-            nativeTextureCaption.Apply(false, false); // make readable
+            Texture2D nativeTextureCaption = DaggerfallUI.GetTextureFromImg(nativeImgNameCaption, TextureFormat.ARGB32, true);
             nativeTextureCaption.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             if (!nativeTextureCaption)
                 throw new Exception("DaggerfallExteriorAutomapWindow: Could not load native texture (TOWN00I0.IMG).");
-            pixelsCaption = nativeTextureCaption.GetPixels(0, 0, 320, 10);
+
+            Rect rectPanelCaption = new Rect();
+            rectPanelCaption.position = new Vector2(0, 200 - 10);
+            rectPanelCaption.size = new Vector2(320, 10);
+            panelCaption = DaggerfallUI.AddPanel(rectPanelCaption, NativePanel);
 
             // set caption line in bottom part of exterior automap window background image texture
-            nativeTexture.SetPixels(0, 0, 320, 10, pixelsCaption);
-            nativeTexture.Apply(false);
+            panelCaption.BackgroundTexture = nativeTextureCaption;
 
-            // store background graphics from from background image
-            backgroundOriginal = nativeTexture.GetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29);
+            // store background graphics from from background image            
+            int width = (int)(320 * (nativeTexture.width / 320f));
+            int height = (int)((200 - 29) * (nativeTexture.height / 200f));
+            backgroundOriginal = nativeTexture.GetPixels((int)(0 * (nativeTexture.width / 320f)), (int)(29 * (nativeTexture.height / 200f)), width, height);
 
             backgroundAlternative1 = new Color[backgroundOriginal.Length];
             for (int i = 0; i < backgroundOriginal.Length; ++i)
@@ -273,6 +274,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 backgroundAlternative1[i].b = 0.0f;
                 backgroundAlternative1[i].a = 1.0f;
             }
+            textureBackgroundAlternative1 = new Texture2D(width, height, TextureFormat.ARGB32, false);
+            textureBackgroundAlternative1.SetPixels(backgroundAlternative1);
+            textureBackgroundAlternative1.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureBackgroundAlternative1.Apply(false, true);
 
             backgroundAlternative2 = new Color[backgroundOriginal.Length];
             for (int i = 0; i < backgroundOriginal.Length; ++i)
@@ -282,6 +287,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 backgroundAlternative2[i].b = 0.3f;
                 backgroundAlternative2[i].a = 1.0f;
             }
+            textureBackgroundAlternative2 = new Texture2D(width, height, TextureFormat.ARGB32, false);
+            textureBackgroundAlternative2.SetPixels(backgroundAlternative2);
+            textureBackgroundAlternative2.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureBackgroundAlternative2.Apply(false, true);
 
             backgroundAlternative3 = new Color[backgroundOriginal.Length];
             for (int i = 0; i < backgroundOriginal.Length; ++i)
@@ -291,6 +300,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 backgroundAlternative3[i].b = 0.18f;
                 backgroundAlternative3[i].a = 1.0f;
             }
+            textureBackgroundAlternative3 = new Texture2D(width, height, TextureFormat.ARGB32, false);
+            textureBackgroundAlternative3.SetPixels(backgroundAlternative3);
+            textureBackgroundAlternative3.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureBackgroundAlternative3.Apply(false, true);
 
             // Always dim background
             ParentPanel.BackgroundColor = ScreenDimColor;
@@ -1103,8 +1116,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// </summary>
         private void ActionSwitchToExteriorAutomapBackgroundOriginal()
         {
-            nativeTexture.SetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29, backgroundOriginal);
-            nativeTexture.Apply(false);
+            dummyPanelAutomap.BackgroundTexture = null;
             updateAutomapView();
         }
 
@@ -1113,8 +1125,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// </summary>
         private void ActionSwitchToExteriorAutomapBackgroundAlternative1()
         {
-            nativeTexture.SetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29, backgroundAlternative1);
-            nativeTexture.Apply(false);
+            dummyPanelAutomap.BackgroundTexture = textureBackgroundAlternative1;
             updateAutomapView();
         }
 
@@ -1123,8 +1134,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// </summary>
         private void ActionSwitchToExteriorAutomapBackgroundAlternative2()
         {
-            nativeTexture.SetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29, backgroundAlternative2);
-            nativeTexture.Apply(false);
+            dummyPanelAutomap.BackgroundTexture = textureBackgroundAlternative2;
             updateAutomapView();
         }
 
@@ -1133,8 +1143,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// </summary>
         private void ActionSwitchToExteriorAutomapBackgroundAlternative3()
         {
-            nativeTexture.SetPixels(0, 29, nativeTexture.width, nativeTexture.height - 29, backgroundAlternative3);
-            nativeTexture.Apply(false);
+            dummyPanelAutomap.BackgroundTexture = textureBackgroundAlternative3;
             updateAutomapView();
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -109,7 +109,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         List<TalkManager.ListItem> listCurrentTopics; // current topic list metadata of displayed topic list in topic frame
 
-        Texture2D textureBackground;
+        Texture2D textureBackground;        
         Texture2D textureHighlightedOptions;
         Texture2D textureGrayedOutCategories;
         Texture2D texturePortrait;
@@ -117,25 +117,33 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Panel panelNameNPC;
         TextLabel labelNameNPC = null;
 
-        Color[] textureTellMeAboutNormal;
-        Color[] textureTellMeAboutHighlighted;
-        Color[] textureWhereIsNormal;
-        Color[] textureWhereIsHighlighted;
+        Texture2D textureTellMeAboutHighlighted;
+        Texture2D textureWhereIsHighlighted;
 
-        Color[] textureCategoryLocationHighlighted;
-        Color[] textureCategoryLocationGrayedOut;
-        Color[] textureCategoryPeopleHighlighted;
-        Color[] textureCategoryPeopleGrayedOut;
-        Color[] textureCategoryThingsHighlighted;
-        Color[] textureCategoryThingsGrayedOut;
-        Color[] textureCategoryWorkHighlighted;
-        Color[] textureCategoryWorkGrayedOut;
+        Texture2D textureCategoryLocationGrayedOut;
+        Texture2D textureCategoryPersonGrayedOut;
+        Texture2D textureCategoryThingGrayedOut;
+        Texture2D textureCategoryWorkGrayedOut;
+
+        Color[] colorsTellMeAboutHighlighted;
+        Color[] colorsWhereIsHighlighted;
+
+        Color[] colorsCategoryLocationGrayedOut;
+        Color[] colorsCategoryPeopleGrayedOut;
+        Color[] colorsCategoryThingGrayedOut;
+        Color[] colorsCategoryWorkGrayedOut;
+
 
         Panel mainPanel;
 
         TextLabel textlabelPlayerSays;
         string currentQuestion = "";
         int selectionIndexLastUsed = -1;
+
+        // alignment stuff for portrait
+        Panel panelPortrait = null;
+        Vector2 panelPortraitPos = new Vector2(119, 65);
+        Vector2 panelPortraitSize = new Vector2(64f, 64f);
 
         // alignment stuff for checkbox buttons
         Panel panelTone; // used as selection marker
@@ -154,7 +162,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Button buttonTellMeAbout;
         Button buttonWhereIs;
         Button buttonCategoryLocation;
-        Button buttonCategoryPeople;
+        Button buttonCategoryPerson;
         Button buttonCategoryThings;
         Button buttonCategoryWork;
         Button buttonTopicUp;
@@ -292,7 +300,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             }
 
-            UpdatePortrait();
+            if (panelPortrait != null)
+                panelPortrait.BackgroundTexture = texturePortrait;
         }
 
         public void UpdateNameNPC()
@@ -313,12 +322,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
             ParentPanel.BackgroundColor = ScreenDimColor;
 
             // Load background texture of talk window
-            imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, talkWindowImgName), FileUsage.UseMemory, false);
-            imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
-            bitmap = imgFile.GetDFBitmap();
-            textureBackground = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.ARGB32, false);
-            textureBackground.SetPixels32(imgFile.GetColor32(bitmap, 0));
-            textureBackground.Apply(false, false); // make readable
+            //imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, talkWindowImgName), FileUsage.UseMemory, false);
+            //imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
+            //bitmap = imgFile.GetDFBitmap();
+            textureBackground = DaggerfallUI.GetTextureFromImg(talkWindowImgName, TextureFormat.ARGB32, false);
+            //textureBackground = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.ARGB32, false);
+            //textureBackground.SetPixels32(imgFile.GetColor32(bitmap, 0));
+            //textureBackground.Apply(false, false); // make readable
             textureBackground.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             if (!textureBackground)
             {
@@ -329,14 +339,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             mainPanel = DaggerfallUI.AddPanel(NativePanel, AutoSizeModes.None);
             mainPanel.BackgroundTexture = textureBackground;
-            mainPanel.Size = new Vector2(textureBackground.width, textureBackground.height);
+            //mainPanel.Size = new Vector2(textureBackground.width, textureBackground.height);
+            mainPanel.Size = new Vector2(320, 200);
             mainPanel.HorizontalAlignment = HorizontalAlignment.Center;
             mainPanel.VerticalAlignment = VerticalAlignment.Middle;
 
-            if (texturePortrait)
-            {
-                UpdatePortrait();
-            }
+            panelPortrait = DaggerfallUI.AddPanel(new Rect(panelPortraitPos, panelPortraitSize), NativePanel);
+            panelPortrait.BackgroundTexture = texturePortrait;
 
             panelNameNPC = DaggerfallUI.AddPanel(mainPanel, AutoSizeModes.None);
             panelNameNPC.Position = new Vector2(117, 52);
@@ -382,20 +391,38 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 CloseWindow();
                 return;
             }
+            
+            colorsTellMeAboutHighlighted = textureHighlightedOptions.GetPixels(0, 10, 107, 10);            
+            colorsWhereIsHighlighted = textureHighlightedOptions.GetPixels(0, 0, 107, 10);
 
-            textureTellMeAboutNormal = textureBackground.GetPixels(4, textureBackground.height - 4 - 10, 107, 10);
-            textureTellMeAboutHighlighted = textureHighlightedOptions.GetPixels(0, 10, 107, 10);
-            textureWhereIsNormal = textureBackground.GetPixels(4, textureBackground.height - 14 - 10, 107, 10);
-            textureWhereIsHighlighted = textureHighlightedOptions.GetPixels(0, 0, 107, 10);
+            //colorsCategoryLocationHighlighted = textureBackground.GetPixels(4, textureBackground.height - 26 - 10, 107, 10);
+            colorsCategoryLocationGrayedOut = textureGrayedOutCategories.GetPixels(0, 30, 107, 10);
+            //colorsCategoryPeopleHighlighted = textureBackground.GetPixels(4, textureBackground.height - 36 - 10, 107, 10);
+            colorsCategoryPeopleGrayedOut = textureGrayedOutCategories.GetPixels(0, 20, 107, 10);
+            //colorsCategoryThingHighlighted = textureBackground.GetPixels(4, textureBackground.height - 46 - 10, 107, 10);
+            colorsCategoryThingGrayedOut = textureGrayedOutCategories.GetPixels(0, 10, 107, 10);
+            //colorsCategoryWorkHighlighted = textureBackground.GetPixels(4, textureBackground.height - 56 - 10, 107, 10);
+            colorsCategoryWorkGrayedOut = textureGrayedOutCategories.GetPixels(0, 0, 107, 10);
 
-            textureCategoryLocationHighlighted = textureBackground.GetPixels(4, textureBackground.height - 26 - 10, 107, 10);
-            textureCategoryLocationGrayedOut = textureGrayedOutCategories.GetPixels(0, 30, 107, 10);
-            textureCategoryPeopleHighlighted = textureBackground.GetPixels(4, textureBackground.height - 36 - 10, 107, 10);
-            textureCategoryPeopleGrayedOut = textureGrayedOutCategories.GetPixels(0, 20, 107, 10);
-            textureCategoryThingsHighlighted = textureBackground.GetPixels(4, textureBackground.height - 46 - 10, 107, 10);
-            textureCategoryThingsGrayedOut = textureGrayedOutCategories.GetPixels(0, 10, 107, 10);
-            textureCategoryWorkHighlighted = textureBackground.GetPixels(4, textureBackground.height - 56 - 10, 107, 10);
-            textureCategoryWorkGrayedOut = textureGrayedOutCategories.GetPixels(0, 0, 107, 10);
+            textureTellMeAboutHighlighted = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureTellMeAboutHighlighted.SetPixels(colorsTellMeAboutHighlighted);
+            textureTellMeAboutHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureWhereIsHighlighted = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureWhereIsHighlighted.SetPixels(colorsWhereIsHighlighted);
+            textureWhereIsHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+
+            textureCategoryLocationGrayedOut = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureCategoryLocationGrayedOut.SetPixels(colorsCategoryLocationGrayedOut);
+            textureCategoryLocationGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryPersonGrayedOut = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureCategoryPersonGrayedOut.SetPixels(colorsCategoryPeopleGrayedOut);
+            textureCategoryPersonGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryThingGrayedOut = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureCategoryThingGrayedOut.SetPixels(colorsCategoryThingGrayedOut);
+            textureCategoryThingGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryWorkGrayedOut = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureCategoryWorkGrayedOut.SetPixels(colorsCategoryWorkGrayedOut);
+            textureCategoryWorkGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
 
             textlabelPlayerSays = new TextLabel();
             textlabelPlayerSays.Position = new Vector2(123, 8);
@@ -552,12 +579,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             buttonCategoryLocation.OnMouseClick += ButtonCategoryLocation_OnMouseClick;
             mainPanel.Components.Add(buttonCategoryLocation);
 
-            buttonCategoryPeople = new Button();
-            buttonCategoryPeople.Position = new Vector2(4, 36);
-            buttonCategoryPeople.Size = new Vector2(107, 10);
-            buttonCategoryPeople.Name = "button_categoryPeople";
-            buttonCategoryPeople.OnMouseClick += ButtonCategoryPeople_OnMouseClick;
-            mainPanel.Components.Add(buttonCategoryPeople);
+            buttonCategoryPerson = new Button();
+            buttonCategoryPerson.Position = new Vector2(4, 36);
+            buttonCategoryPerson.Size = new Vector2(107, 10);
+            buttonCategoryPerson.Name = "button_categoryPeople";
+            buttonCategoryPerson.OnMouseClick += ButtonCategoryPeople_OnMouseClick;
+            mainPanel.Components.Add(buttonCategoryPerson);
 
             buttonCategoryThings = new Button();
             buttonCategoryThings.Position = new Vector2(4, 46);
@@ -751,15 +778,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             listboxTopic.MaxHorizontalScrollIndex = 0;
         }
 
-        void UpdatePortrait()
-        {
-            if (textureBackground)
-            {
-                textureBackground.SetPixels(119, textureBackground.height - 65 - 64, 64, 64, texturePortrait.GetPixels());
-                textureBackground.Apply(false);
-            }
-        }
-
         void UpdateLabels()
         {
 
@@ -793,13 +811,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             talkCategoryLastUsed = TalkCategory.None; // important so that category is enabled again when switching back to TalkOption.WhereIs
 
-            textureBackground.SetPixels(4, textureBackground.height - 4 - 10, 107, 10, textureTellMeAboutHighlighted);
-            textureBackground.SetPixels(4, textureBackground.height - 14 - 10, 107, 10, textureWhereIsNormal);
-            textureBackground.SetPixels(4, textureBackground.height - 26 - 10, 107, 10, textureCategoryLocationGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 36 - 10, 107, 10, textureCategoryPeopleGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 46 - 10, 107, 10, textureCategoryThingsGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 56 - 10, 107, 10, textureCategoryWorkGrayedOut);
-            textureBackground.Apply(false);
+            buttonTellMeAbout.BackgroundTexture = textureTellMeAboutHighlighted;
+            buttonWhereIs.BackgroundTexture = null;
+            buttonCategoryLocation.BackgroundTexture = null;
+            buttonCategoryPerson.BackgroundTexture = null;
+            buttonCategoryThings.BackgroundTexture = null;
+            buttonCategoryWork.BackgroundTexture = null;
 
             SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicTellMeAbout);
             listboxTopic.Update();
@@ -817,9 +834,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             talkOptionLastUsed = selectedTalkOption;
 
-            textureBackground.SetPixels(4, textureBackground.height - 4 - 10, 107, 10, textureTellMeAboutNormal);
-            textureBackground.SetPixels(4, textureBackground.height - 14 - 10, 107, 10, textureWhereIsHighlighted);            
-            textureBackground.Apply(false);
+            buttonTellMeAbout.BackgroundTexture = null;
+            buttonWhereIs.BackgroundTexture = textureWhereIsHighlighted;
 
             SetTalkCategory(selectedTalkCategory);
         }
@@ -854,11 +870,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             selectedTalkCategory = TalkCategory.None;
             talkCategoryLastUsed = TalkCategory.None;
 
-            textureBackground.SetPixels(4, textureBackground.height - 26 - 10, 107, 10, textureCategoryLocationGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 36 - 10, 107, 10, textureCategoryPeopleGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 46 - 10, 107, 10, textureCategoryThingsGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 56 - 10, 107, 10, textureCategoryWorkGrayedOut);
-            textureBackground.Apply(false);
+            buttonCategoryLocation.BackgroundTexture = null;
+            buttonCategoryPerson.BackgroundTexture = null;
+            buttonCategoryThings.BackgroundTexture = null;
+            buttonCategoryWork.BackgroundTexture = null;
 
             ClearListboxTopics();
             listboxTopic.Update();
@@ -874,11 +889,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             talkCategoryLastUsed = selectedTalkCategory;
 
-            textureBackground.SetPixels(4, textureBackground.height - 26 - 10, 107, 10, textureCategoryLocationHighlighted);
-            textureBackground.SetPixels(4, textureBackground.height - 36 - 10, 107, 10, textureCategoryPeopleGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 46 - 10, 107, 10, textureCategoryThingsGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 56 - 10, 107, 10, textureCategoryWorkGrayedOut);
-            textureBackground.Apply(false);
+            buttonCategoryLocation.BackgroundTexture = null;
+            buttonCategoryPerson.BackgroundTexture = textureCategoryPersonGrayedOut;
+            buttonCategoryThings.BackgroundTexture = textureCategoryThingGrayedOut;
+            buttonCategoryWork.BackgroundTexture = textureCategoryWorkGrayedOut;
 
             SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicLocation);
             listboxTopic.Update();
@@ -896,11 +910,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             talkCategoryLastUsed = selectedTalkCategory;
 
-            textureBackground.SetPixels(4, textureBackground.height - 26 - 10, 107, 10, textureCategoryLocationGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 36 - 10, 107, 10, textureCategoryPeopleHighlighted);
-            textureBackground.SetPixels(4, textureBackground.height - 46 - 10, 107, 10, textureCategoryThingsGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 56 - 10, 107, 10, textureCategoryWorkGrayedOut);
-            textureBackground.Apply(false);
+            buttonCategoryLocation.BackgroundTexture = textureCategoryLocationGrayedOut;
+            buttonCategoryPerson.BackgroundTexture = null;
+            buttonCategoryThings.BackgroundTexture = textureCategoryThingGrayedOut;
+            buttonCategoryWork.BackgroundTexture = textureCategoryWorkGrayedOut;
 
             SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicPerson);
             listboxTopic.Update();
@@ -918,11 +931,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             talkCategoryLastUsed = selectedTalkCategory;
 
-            textureBackground.SetPixels(4, textureBackground.height - 26 - 10, 107, 10, textureCategoryLocationGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 36 - 10, 107, 10, textureCategoryPeopleGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 46 - 10, 107, 10, textureCategoryThingsHighlighted);
-            textureBackground.SetPixels(4, textureBackground.height - 56 - 10, 107, 10, textureCategoryWorkGrayedOut);
-            textureBackground.Apply(false);
+            buttonCategoryLocation.BackgroundTexture = textureCategoryLocationGrayedOut;
+            buttonCategoryPerson.BackgroundTexture = textureCategoryPersonGrayedOut;
+            buttonCategoryThings.BackgroundTexture = null;
+            buttonCategoryWork.BackgroundTexture = textureCategoryWorkGrayedOut;
 
             SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicThings);
             listboxTopic.Update();
@@ -940,11 +952,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             talkCategoryLastUsed = selectedTalkCategory;
 
-            textureBackground.SetPixels(4, textureBackground.height - 26 - 10, 107, 10, textureCategoryLocationGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 36 - 10, 107, 10, textureCategoryPeopleGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 46 - 10, 107, 10, textureCategoryThingsGrayedOut);
-            textureBackground.SetPixels(4, textureBackground.height - 56 - 10, 107, 10, textureCategoryWorkHighlighted);
-            textureBackground.Apply(false);
+            buttonCategoryLocation.BackgroundTexture = textureCategoryLocationGrayedOut;
+            buttonCategoryPerson.BackgroundTexture = textureCategoryPersonGrayedOut;
+            buttonCategoryThings.BackgroundTexture = textureCategoryThingGrayedOut;
+            buttonCategoryWork.BackgroundTexture = null;
 
             ClearListboxTopics();
             listboxTopic.Update();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -321,14 +321,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             ParentPanel.BackgroundColor = ScreenDimColor;
 
-            // Load background texture of talk window
-            //imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, talkWindowImgName), FileUsage.UseMemory, false);
-            //imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
-            //bitmap = imgFile.GetDFBitmap();
             textureBackground = DaggerfallUI.GetTextureFromImg(talkWindowImgName, TextureFormat.ARGB32, false);
-            //textureBackground = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.ARGB32, false);
-            //textureBackground.SetPixels32(imgFile.GetColor32(bitmap, 0));
-            //textureBackground.Apply(false, false); // make readable
             textureBackground.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             if (!textureBackground)
             {
@@ -340,7 +333,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             mainPanel = DaggerfallUI.AddPanel(NativePanel, AutoSizeModes.None);
             mainPanel.BackgroundTexture = textureBackground;
             //mainPanel.Size = new Vector2(textureBackground.width, textureBackground.height);
-            mainPanel.Size = new Vector2(320, 200);
+            mainPanel.Size = new Vector2(320, 200); // reference size is always vanilla df resolution
             mainPanel.HorizontalAlignment = HorizontalAlignment.Center;
             mainPanel.VerticalAlignment = VerticalAlignment.Middle;
 
@@ -363,12 +356,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             UpdateNameNPC();
 
             // Load talk options highlight texture
-            imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, highlightedOptionsImgName), FileUsage.UseMemory, false);
-            imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
-            bitmap = imgFile.GetDFBitmap();
-            textureHighlightedOptions = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.ARGB32, false);
-            textureHighlightedOptions.SetPixels32(imgFile.GetColor32(bitmap, 0));
-            textureHighlightedOptions.Apply(false, false); // make readable
+            textureHighlightedOptions = DaggerfallUI.GetTextureFromImg(highlightedOptionsImgName, TextureFormat.ARGB32, false);
             textureHighlightedOptions.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             if (!textureHighlightedOptions)
             {
@@ -378,12 +366,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             }
 
             // Load talk categories highlight texture
-            imgFile = new ImgFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, talkCategoriesImgName), FileUsage.UseMemory, false);
-            imgFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imgFile.PaletteName));
-            bitmap = imgFile.GetDFBitmap();
-            textureGrayedOutCategories = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.ARGB32, false);
-            textureGrayedOutCategories.SetPixels32(imgFile.GetColor32(bitmap, 0));
-            textureGrayedOutCategories.Apply(false, false); // make readable
+
+            textureGrayedOutCategories = DaggerfallUI.GetTextureFromImg(talkCategoriesImgName, TextureFormat.ARGB32, false);
             textureGrayedOutCategories.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             if (!textureGrayedOutCategories)
             {
@@ -391,36 +375,33 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 CloseWindow();
                 return;
             }
-            
-            colorsTellMeAboutHighlighted = textureHighlightedOptions.GetPixels(0, 10, 107, 10);            
-            colorsWhereIsHighlighted = textureHighlightedOptions.GetPixels(0, 0, 107, 10);
 
-            //colorsCategoryLocationHighlighted = textureBackground.GetPixels(4, textureBackground.height - 26 - 10, 107, 10);
-            colorsCategoryLocationGrayedOut = textureGrayedOutCategories.GetPixels(0, 30, 107, 10);
-            //colorsCategoryPeopleHighlighted = textureBackground.GetPixels(4, textureBackground.height - 36 - 10, 107, 10);
-            colorsCategoryPeopleGrayedOut = textureGrayedOutCategories.GetPixels(0, 20, 107, 10);
-            //colorsCategoryThingHighlighted = textureBackground.GetPixels(4, textureBackground.height - 46 - 10, 107, 10);
-            colorsCategoryThingGrayedOut = textureGrayedOutCategories.GetPixels(0, 10, 107, 10);
-            //colorsCategoryWorkHighlighted = textureBackground.GetPixels(4, textureBackground.height - 56 - 10, 107, 10);
-            colorsCategoryWorkGrayedOut = textureGrayedOutCategories.GetPixels(0, 0, 107, 10);
+            colorsTellMeAboutHighlighted = textureHighlightedOptions.GetPixels(0, textureHighlightedOptions.height/2, textureHighlightedOptions.width, textureHighlightedOptions.height/2);            
+            colorsWhereIsHighlighted = textureHighlightedOptions.GetPixels(0, 0, textureHighlightedOptions.width, textureHighlightedOptions.height/2);
 
-            textureTellMeAboutHighlighted = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            colorsCategoryLocationGrayedOut = textureGrayedOutCategories.GetPixels(0, textureGrayedOutCategories.height * 3 / 4, textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4);
+            colorsCategoryPeopleGrayedOut = textureGrayedOutCategories.GetPixels(0, textureGrayedOutCategories.height * 2 / 4, textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4);
+            colorsCategoryThingGrayedOut = textureGrayedOutCategories.GetPixels(0, textureGrayedOutCategories.height / 4, textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4);
+            colorsCategoryWorkGrayedOut = textureGrayedOutCategories.GetPixels(0, 0, textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4);
+
+
+            textureTellMeAboutHighlighted = new Texture2D(textureHighlightedOptions.width, textureHighlightedOptions.height/2, TextureFormat.ARGB32, false);
             textureTellMeAboutHighlighted.SetPixels(colorsTellMeAboutHighlighted);
             textureTellMeAboutHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
-            textureWhereIsHighlighted = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureWhereIsHighlighted = new Texture2D(textureHighlightedOptions.width, textureHighlightedOptions.height / 2, TextureFormat.ARGB32, false);
             textureWhereIsHighlighted.SetPixels(colorsWhereIsHighlighted);
             textureWhereIsHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
 
-            textureCategoryLocationGrayedOut = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureCategoryLocationGrayedOut = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryLocationGrayedOut.SetPixels(colorsCategoryLocationGrayedOut);
             textureCategoryLocationGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
-            textureCategoryPersonGrayedOut = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureCategoryPersonGrayedOut = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryPersonGrayedOut.SetPixels(colorsCategoryPeopleGrayedOut);
             textureCategoryPersonGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
-            textureCategoryThingGrayedOut = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureCategoryThingGrayedOut = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryThingGrayedOut.SetPixels(colorsCategoryThingGrayedOut);
             textureCategoryThingGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
-            textureCategoryWorkGrayedOut = new Texture2D(107, 10, TextureFormat.ARGB32, false);
+            textureCategoryWorkGrayedOut = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryWorkGrayedOut.SetPixels(colorsCategoryWorkGrayedOut);
             textureCategoryWorkGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
 
@@ -813,10 +794,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             buttonTellMeAbout.BackgroundTexture = textureTellMeAboutHighlighted;
             buttonWhereIs.BackgroundTexture = null;
-            buttonCategoryLocation.BackgroundTexture = null;
-            buttonCategoryPerson.BackgroundTexture = null;
-            buttonCategoryThings.BackgroundTexture = null;
-            buttonCategoryWork.BackgroundTexture = null;
+            buttonCategoryLocation.BackgroundTexture = textureCategoryLocationGrayedOut;
+            buttonCategoryPerson.BackgroundTexture = textureCategoryPersonGrayedOut;
+            buttonCategoryThings.BackgroundTexture = textureCategoryThingGrayedOut;
+            buttonCategoryWork.BackgroundTexture = textureCategoryWorkGrayedOut;
 
             SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicTellMeAbout);
             listboxTopic.Update();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -49,7 +49,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Color textcolorQuestionHighlighted = new Color(0.8f, 0.9f, 1.0f);
         Color textcolorHighlighted = Color.white;
 
-        Color textcolorQuestionBackgroundModernConversationStyle = new Color(0.23f, 0.27f, 0.33f);
+        Color textcolorQuestionBackgroundModernConversationStyle = new Color(0.3f, 0.35f, 0.43f); // new Color(0.23f, 0.27f, 0.33f);
         Color textcolorAnswerBackgroundModernConversationStyle = new Color(0.32f, 0.31f, 0.06f); //  default text r: 243 (0.95f), g: 239 (0.93f), b: 44 (0.17)
 
         Color textcolorCaptionGotoParentList = new Color(0.698f, 0.812f, 1.0f);
@@ -522,7 +522,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 {
                     textLabelNPCGreeting.textLabel.TextScale = textScaleModernConversationStyle;
                     textLabelNPCGreeting.textLabel.MaxWidth = (int)(textLabelNPCGreeting.textLabel.MaxWidth * textBlockSizeModernConversationStyle);
-                    //textLabelNPCGreeting.textLabel.BackgroundColor = textcolorAnswerBackgroundModernConversationStyle;
+                    textLabelNPCGreeting.textLabel.BackgroundColor = textcolorAnswerBackgroundModernConversationStyle;
                 }
             }
 
@@ -1121,7 +1121,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 textLabelQuestion.textLabel.TextScale = textScaleModernConversationStyle;
                 textLabelQuestion.textLabel.MaxWidth = (int)(textLabelQuestion.textLabel.MaxWidth * textBlockSizeModernConversationStyle);
-                //textLabelQuestion.textLabel.BackgroundColor = textcolorQuestionBackgroundModernConversationStyle;
+                textLabelQuestion.textLabel.BackgroundColor = textcolorQuestionBackgroundModernConversationStyle;
             }
             listboxConversation.AddItem(answer, out textLabelAnswer);
             textLabelAnswer.selectedTextColor = textcolorHighlighted;            
@@ -1132,7 +1132,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 textLabelAnswer.textLabel.TextScale = textScaleModernConversationStyle;
                 textLabelAnswer.textLabel.MaxWidth = (int)(textLabelAnswer.textLabel.MaxWidth * textBlockSizeModernConversationStyle);
-                //textLabelAnswer.textLabel.BackgroundColor = textcolorAnswerBackgroundModernConversationStyle;
+                textLabelAnswer.textLabel.BackgroundColor = textcolorAnswerBackgroundModernConversationStyle;
             }
 
             listboxConversation.SelectedIndex = listboxConversation.Count - 1; // always highlight the new answer

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -328,9 +328,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             base.Setup();
 
-            ImgFile imgFile = null;
-            DFBitmap bitmap = null;
-
             ParentPanel.BackgroundColor = ScreenDimColor;
 
             textureBackground = DaggerfallUI.GetTextureFromImg(talkWindowImgName, TextureFormat.ARGB32, false);
@@ -407,42 +404,54 @@ namespace DaggerfallWorkshop.Game.UserInterface
             textureTellMeAboutGrayedOut = new Texture2D(textureHighlightedOptions.width, textureHighlightedOptions.height / 2, TextureFormat.ARGB32, false);
             textureTellMeAboutGrayedOut.SetPixels(colorsTellMeAboutGrayedOut);
             textureTellMeAboutGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureTellMeAboutGrayedOut.Apply(false, false);
             textureWhereIsGrayedOut = new Texture2D(textureHighlightedOptions.width, textureHighlightedOptions.height / 2, TextureFormat.ARGB32, false);
             textureWhereIsGrayedOut.SetPixels(colorsWhereIsGrayedOut);
             textureWhereIsGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureWhereIsGrayedOut.Apply(false, false);
 
             textureTellMeAboutHighlighted = new Texture2D(textureHighlightedOptions.width, textureHighlightedOptions.height/2, TextureFormat.ARGB32, false);
             textureTellMeAboutHighlighted.SetPixels(colorsTellMeAboutHighlighted);
             textureTellMeAboutHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureTellMeAboutHighlighted.Apply(false, false);
             textureWhereIsHighlighted = new Texture2D(textureHighlightedOptions.width, textureHighlightedOptions.height / 2, TextureFormat.ARGB32, false);
             textureWhereIsHighlighted.SetPixels(colorsWhereIsHighlighted);
             textureWhereIsHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureWhereIsHighlighted.Apply(false, false);
 
             textureCategoryLocationGrayedOut = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryLocationGrayedOut.SetPixels(colorsCategoryLocationGrayedOut);
             textureCategoryLocationGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryLocationGrayedOut.Apply(false, false);
             textureCategoryPersonGrayedOut = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryPersonGrayedOut.SetPixels(colorsCategoryPeopleGrayedOut);
             textureCategoryPersonGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryPersonGrayedOut.Apply(false, false);
             textureCategoryThingGrayedOut = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryThingGrayedOut.SetPixels(colorsCategoryThingGrayedOut);
             textureCategoryThingGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryThingGrayedOut.Apply(false, false);
             textureCategoryWorkGrayedOut = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryWorkGrayedOut.SetPixels(colorsCategoryWorkGrayedOut);
             textureCategoryWorkGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryWorkGrayedOut.Apply(false, false);
 
             textureCategoryLocationHighlighted = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryLocationHighlighted.SetPixels(colorsCategoryLocationHighlighted);
             textureCategoryLocationHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryLocationHighlighted.Apply(false, false);
             textureCategoryPersonHighlighted = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryPersonHighlighted.SetPixels(colorsCategoryPeopleHighlighted);
             textureCategoryPersonHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryPersonHighlighted.Apply(false, false);
             textureCategoryThingHighlighted = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryThingHighlighted.SetPixels(colorsCategoryThingHighlighted);
             textureCategoryThingHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryThingHighlighted.Apply(false, false);
             textureCategoryWorkHighlighted = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryWorkHighlighted.SetPixels(colorsCategoryWorkHighlighted);
             textureCategoryWorkHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryWorkHighlighted.Apply(false, false);
 
             textlabelPlayerSays = new TextLabel();
             textlabelPlayerSays.Position = new Vector2(123, 8);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -117,6 +117,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Panel panelNameNPC;
         TextLabel labelNameNPC = null;
 
+        Texture2D textureTellMeAboutGrayedOut; // tried without this texture by just setting button background to null, but then pixel-perfect fit is no longer achieved
+        Texture2D textureWhereIsGrayedOut; // tried without this texture by just setting button background to null, but then pixel-perfect fit is no longer achieved
         Texture2D textureTellMeAboutHighlighted;
         Texture2D textureWhereIsHighlighted;
 
@@ -124,7 +126,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Texture2D textureCategoryPersonGrayedOut;
         Texture2D textureCategoryThingGrayedOut;
         Texture2D textureCategoryWorkGrayedOut;
+        Texture2D textureCategoryLocationHighlighted; // tried without this texture by just setting button background to null, but then pixel-perfect fit is no longer achieved
+        Texture2D textureCategoryPersonHighlighted; // tried without this texture by just setting button background to null, but then pixel-perfect fit is no longer achieved
+        Texture2D textureCategoryThingHighlighted; // tried without this texture by just setting button background to null, but then pixel-perfect fit is no longer achieved
+        Texture2D textureCategoryWorkHighlighted; // tried without this texture by just setting button background to null, but then pixel-perfect fit is no longer achieved
 
+        Color[] colorsTellMeAboutGrayedOut;
+        Color[] colorsWhereIsGrayedOut;
         Color[] colorsTellMeAboutHighlighted;
         Color[] colorsWhereIsHighlighted;
 
@@ -132,6 +140,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Color[] colorsCategoryPeopleGrayedOut;
         Color[] colorsCategoryThingGrayedOut;
         Color[] colorsCategoryWorkGrayedOut;
+        Color[] colorsCategoryLocationHighlighted;
+        Color[] colorsCategoryPeopleHighlighted;
+        Color[] colorsCategoryThingHighlighted;
+        Color[] colorsCategoryWorkHighlighted;
 
 
         Panel mainPanel;
@@ -376,6 +388,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             }
 
+            colorsTellMeAboutGrayedOut = textureBackground.GetPixels((int)(4 * (textureBackground.width / 320f)), (int)((200 - 4 - 10) * (textureBackground.height / 200f)), (int)(107 * (textureBackground.width / 320f)), (int)(10 * (textureBackground.height / 200f)));
+            colorsWhereIsGrayedOut = textureBackground.GetPixels((int)(4 * (textureBackground.width / 320f)), (int)((200 - 14 - 10) * (textureBackground.height / 200f)), (int)(107 * (textureBackground.width / 320f)), (int)(10 * (textureBackground.height / 200f)));
+
             colorsTellMeAboutHighlighted = textureHighlightedOptions.GetPixels(0, textureHighlightedOptions.height/2, textureHighlightedOptions.width, textureHighlightedOptions.height/2);            
             colorsWhereIsHighlighted = textureHighlightedOptions.GetPixels(0, 0, textureHighlightedOptions.width, textureHighlightedOptions.height/2);
 
@@ -384,6 +399,17 @@ namespace DaggerfallWorkshop.Game.UserInterface
             colorsCategoryThingGrayedOut = textureGrayedOutCategories.GetPixels(0, textureGrayedOutCategories.height / 4, textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4);
             colorsCategoryWorkGrayedOut = textureGrayedOutCategories.GetPixels(0, 0, textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4);
 
+            colorsCategoryLocationHighlighted = textureBackground.GetPixels((int)(4 * (textureBackground.width / 320f)), (int)((200 - 26 - 10) * (textureBackground.height / 200f)), (int)(107 * (textureBackground.width / 320f)), (int)(10 * (textureBackground.height / 200f)));
+            colorsCategoryPeopleHighlighted = textureBackground.GetPixels((int)(4 * (textureBackground.width / 320f)), (int)((200 - 36 - 10) * (textureBackground.height / 200f)), (int)(107 * (textureBackground.width / 320f)), (int)(10 * (textureBackground.height / 200f)));
+            colorsCategoryThingHighlighted = textureBackground.GetPixels((int)(4 * (textureBackground.width / 320f)), (int)((200 - 46 - 10) * (textureBackground.height / 200f)), (int)(107 * (textureBackground.width / 320f)), (int)(10 * (textureBackground.height / 200f)));
+            colorsCategoryWorkHighlighted = textureBackground.GetPixels((int)(4 * (textureBackground.width / 320f)), (int)((200 - 56 - 10) * (textureBackground.height / 200f)), (int)(107 * (textureBackground.width / 320f)), (int)(10 * (textureBackground.height / 200f)));
+
+            textureTellMeAboutGrayedOut = new Texture2D(textureHighlightedOptions.width, textureHighlightedOptions.height / 2, TextureFormat.ARGB32, false);
+            textureTellMeAboutGrayedOut.SetPixels(colorsTellMeAboutGrayedOut);
+            textureTellMeAboutGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureWhereIsGrayedOut = new Texture2D(textureHighlightedOptions.width, textureHighlightedOptions.height / 2, TextureFormat.ARGB32, false);
+            textureWhereIsGrayedOut.SetPixels(colorsWhereIsGrayedOut);
+            textureWhereIsGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
 
             textureTellMeAboutHighlighted = new Texture2D(textureHighlightedOptions.width, textureHighlightedOptions.height/2, TextureFormat.ARGB32, false);
             textureTellMeAboutHighlighted.SetPixels(colorsTellMeAboutHighlighted);
@@ -404,6 +430,19 @@ namespace DaggerfallWorkshop.Game.UserInterface
             textureCategoryWorkGrayedOut = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
             textureCategoryWorkGrayedOut.SetPixels(colorsCategoryWorkGrayedOut);
             textureCategoryWorkGrayedOut.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+
+            textureCategoryLocationHighlighted = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
+            textureCategoryLocationHighlighted.SetPixels(colorsCategoryLocationHighlighted);
+            textureCategoryLocationHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryPersonHighlighted = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
+            textureCategoryPersonHighlighted.SetPixels(colorsCategoryPeopleHighlighted);
+            textureCategoryPersonHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryThingHighlighted = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
+            textureCategoryThingHighlighted.SetPixels(colorsCategoryThingHighlighted);
+            textureCategoryThingHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
+            textureCategoryWorkHighlighted = new Texture2D(textureGrayedOutCategories.width, textureGrayedOutCategories.height / 4, TextureFormat.ARGB32, false);
+            textureCategoryWorkHighlighted.SetPixels(colorsCategoryWorkHighlighted);
+            textureCategoryWorkHighlighted.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
 
             textlabelPlayerSays = new TextLabel();
             textlabelPlayerSays.Position = new Vector2(123, 8);
@@ -793,7 +832,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             talkCategoryLastUsed = TalkCategory.None; // important so that category is enabled again when switching back to TalkOption.WhereIs
 
             buttonTellMeAbout.BackgroundTexture = textureTellMeAboutHighlighted;
-            buttonWhereIs.BackgroundTexture = null;
+            buttonWhereIs.BackgroundTexture = textureWhereIsGrayedOut;
             buttonCategoryLocation.BackgroundTexture = textureCategoryLocationGrayedOut;
             buttonCategoryPerson.BackgroundTexture = textureCategoryPersonGrayedOut;
             buttonCategoryThings.BackgroundTexture = textureCategoryThingGrayedOut;
@@ -815,7 +854,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             talkOptionLastUsed = selectedTalkOption;
 
-            buttonTellMeAbout.BackgroundTexture = null;
+            buttonTellMeAbout.BackgroundTexture = textureTellMeAboutGrayedOut;
             buttonWhereIs.BackgroundTexture = textureWhereIsHighlighted;
 
             SetTalkCategory(selectedTalkCategory);
@@ -851,10 +890,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             selectedTalkCategory = TalkCategory.None;
             talkCategoryLastUsed = TalkCategory.None;
 
-            buttonCategoryLocation.BackgroundTexture = null;
-            buttonCategoryPerson.BackgroundTexture = null;
-            buttonCategoryThings.BackgroundTexture = null;
-            buttonCategoryWork.BackgroundTexture = null;
+            buttonCategoryLocation.BackgroundTexture = textureCategoryLocationGrayedOut;
+            buttonCategoryPerson.BackgroundTexture = textureCategoryPersonGrayedOut;
+            buttonCategoryThings.BackgroundTexture = textureCategoryThingGrayedOut;
+            buttonCategoryWork.BackgroundTexture = textureCategoryWorkGrayedOut;
 
             ClearListboxTopics();
             listboxTopic.Update();
@@ -870,7 +909,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             talkCategoryLastUsed = selectedTalkCategory;
 
-            buttonCategoryLocation.BackgroundTexture = null;
+            buttonCategoryLocation.BackgroundTexture = textureCategoryLocationHighlighted;
             buttonCategoryPerson.BackgroundTexture = textureCategoryPersonGrayedOut;
             buttonCategoryThings.BackgroundTexture = textureCategoryThingGrayedOut;
             buttonCategoryWork.BackgroundTexture = textureCategoryWorkGrayedOut;
@@ -892,7 +931,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             talkCategoryLastUsed = selectedTalkCategory;
 
             buttonCategoryLocation.BackgroundTexture = textureCategoryLocationGrayedOut;
-            buttonCategoryPerson.BackgroundTexture = null;
+            buttonCategoryPerson.BackgroundTexture = textureCategoryPersonHighlighted;
             buttonCategoryThings.BackgroundTexture = textureCategoryThingGrayedOut;
             buttonCategoryWork.BackgroundTexture = textureCategoryWorkGrayedOut;
 
@@ -914,7 +953,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             buttonCategoryLocation.BackgroundTexture = textureCategoryLocationGrayedOut;
             buttonCategoryPerson.BackgroundTexture = textureCategoryPersonGrayedOut;
-            buttonCategoryThings.BackgroundTexture = null;
+            buttonCategoryThings.BackgroundTexture = textureCategoryThingHighlighted;
             buttonCategoryWork.BackgroundTexture = textureCategoryWorkGrayedOut;
 
             SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicThings);
@@ -936,7 +975,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             buttonCategoryLocation.BackgroundTexture = textureCategoryLocationGrayedOut;
             buttonCategoryPerson.BackgroundTexture = textureCategoryPersonGrayedOut;
             buttonCategoryThings.BackgroundTexture = textureCategoryThingGrayedOut;
-            buttonCategoryWork.BackgroundTexture = null;
+            buttonCategoryWork.BackgroundTexture = textureCategoryWorkHighlighted;
 
             ClearListboxTopics();
             listboxTopic.Update();


### PR DESCRIPTION
progress:
%oath macro resolved
BaseScreenComponent now supports restricted render area

support for texture replacement (some stuff will not work right now):
what should work: background and topic/mode selection
what will not work right now: portrait and navigation stuff

support for interior automap texture replacement added
support for exterior automap texture replacement added