### PR TITLE
Identify dungeon water level and castle block data

### DIFF
--- a/Assets/Scripts/API/DFLocation.cs
+++ b/Assets/Scripts/API/DFLocation.cs
@@ -642,6 +642,12 @@ namespace DaggerfallConnect
 
             /// <summary>Name of RDB block.</summary>
             public String BlockName;
+
+            /// <summary>Height level of dungeon water. 10000 means no water.</summary>
+            public Int16 WaterLevel;
+
+            /// <summary>Whether this block is a main story castle area.</summary>
+            public Boolean CastleBlock;
         }
 
         #endregion

--- a/Assets/Scripts/API/Save/SaveVars.cs
+++ b/Assets/Scripts/API/Save/SaveVars.cs
@@ -46,6 +46,7 @@ namespace DaggerfallConnect.Save
         const int currentRegionIdOffset = 0x173A; // Not bothering to read right now.
         const int cheatFlagsOffset = 0x173B;
         const int lastSkillCheckTimeOffset = 0x179A;
+        const int dungeonWaterLevelOffset = 0x17A8; // Not bothering to read right now.
 
         const int regionDataOffset = 0x3DA;
         const int regionDataLength = 80;

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -50,6 +50,7 @@ namespace DaggerfallWorkshop.Game
 
         int lastPlayerDungeonBlockIndex = -1;
         DFLocation.DungeonBlock playerDungeonBlockData = new DFLocation.DungeonBlock();
+        public short blockWaterLevel = 10000;
 
         DFLocation.BuildingTypes buildingType;
         ushort factionID = 0;
@@ -201,7 +202,8 @@ namespace DaggerfallWorkshop.Game
                 {
                     dungeon.GetBlockData(playerBlockIndex, out playerDungeonBlockData);
                     lastPlayerDungeonBlockIndex = playerBlockIndex;
-                    CastleCheck();
+                    blockWaterLevel = playerDungeonBlockData.WaterLevel;
+                    isPlayerInsideDungeonCastle = playerDungeonBlockData.CastleBlock;
                     SpecialAreaCheck();
                     //Debug.Log(string.Format("Player is now inside block {0}", playerDungeonBlockData.BlockName));
                 }
@@ -276,6 +278,7 @@ namespace DaggerfallWorkshop.Game
             isPlayerInside = false;
             isPlayerInsideDungeon = false;
             isPlayerInsideDungeonCastle = false;
+            blockWaterLevel = 10000;
 
             // Set player GPS coordinates
             playerGPS.WorldX = worldX;
@@ -763,31 +766,6 @@ namespace DaggerfallWorkshop.Game
         #endregion
 
         #region Private Methods
-
-        // Check if current block is a castle block
-        private void CastleCheck()
-        {
-            if (!isPlayerInsideDungeon)
-            {
-                isPlayerInsideDungeonCastle = false;
-                return;
-            }
-
-            switch (playerDungeonBlockData.BlockName)
-            {
-                case "S0000040.RDB":    // Sentinel castle area
-                case "S0000041.RDB":
-                case "S0000042.RDB":
-                case "S0000080.RDB":    // Wayrest castle area
-                case "S0000081.RDB":
-                case "S0000160.RDB":    // Daggerfall castle area
-                    isPlayerInsideDungeonCastle = true;
-                    break;
-                default:
-                    isPlayerInsideDungeonCastle = false;
-                    break;
-            }
-        }
 
         private void SpecialAreaCheck()
         {

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -77,6 +77,8 @@ namespace DaggerfallWorkshop
             public int FactionOrMobileID;                       // FactionID for NPCs, Mobile ID for monsters
             public int NameSeed;                                // NPC name seed
             public MobileTypes FixedEnemyType;                  // Type for fixed enemy marker
+            public short WaterLevel;                            // Dungeon water level
+            public bool CastleBlock;                            // Non-hostile area of main story castle dungeons
             public TextureReplacement.CustomBillboard 
                 CustomBillboard;                                // Custom textures
         }
@@ -221,11 +223,23 @@ namespace DaggerfallWorkshop
             summary.NameSeed = (int)resource.Position;
 
             // Set data of fixed mobile types (e.g. non-random enemy spawn)
-            if (resource.TextureArchive == 199 && resource.TextureRecord == 16)
+            if (resource.TextureArchive == 199)
             {
-                summary.IsMobile = true;
-                summary.EditorFlatType = EditorFlatTypes.FixedMobile;
-                summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID & 0xff);
+                if (resource.TextureRecord == 16)
+                {
+                    summary.IsMobile = true;
+                    summary.EditorFlatType = EditorFlatTypes.FixedMobile;
+                    summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID & 0xff);
+                }
+                else if (resource.TextureRecord == 10) // Start marker. Holds data for dungeon block water level and castle block status.
+                {
+                    if (resource.SoundIndex != 0)
+                        summary.WaterLevel = (short)(-8 * resource.SoundIndex);
+                    else
+                        summary.WaterLevel = 10000; // no water
+
+                    summary.CastleBlock = (resource.Magnitude != 0);
+                }
             }
         }
 


### PR DESCRIPTION
This identifies the dungeon water level value, which is contained in the "SoundIndex" value of a block's start marker.

I don't know if I'm propagating the value up in a way you would like, Interkarma, so feel free to change that. I just poked around at it until I found a way to get it through the various data structures up to the PlayerEnterExit class, which is where I suppose it is wanted.

Start markers also contain the value that determines whether a dungeon block is a main story castle block with NPCs, initially non-hostile guards, etc. Since we can use that I put that in and removed the check based on block name, but functionally it should be the same. If you would prefer it continue to be done by block name that is fine.