### PR TITLE
Get most pre-discovered locations like classic

### DIFF
--- a/Assets/Scripts/API/DFRegion.cs
+++ b/Assets/Scripts/API/DFRegion.cs
@@ -66,44 +66,36 @@ namespace DaggerfallConnect
         /// </summary>
         public enum LocationTypes
         {
-            /// <summary>Large dungeon.</summary>
-            DungeonLabyrinth = 132,
-            /// <summary>Medium dungeon.</summary>
-            DungeonKeep = 135,
-            /// <summary>Small dungeon.</summary>
-            DungeonRuin = 138,
-
-            /// <summary>Graveyard visible.</summary>
-            GraveyardCommon = 172,
-            /// <summary>Graveyard hidden.</summary>
-            GraveyardForgotten = 140,
-
-            /// <summary>Coven.</summary>
-            Coven = 141,
-
-            /// <summary>Farmhouse.</summary>
-            HomeFarms = 163,
-            /// <summary>Wealthy home.</summary>
-            HomeWealthy = 168,
-            /// <summary>Poor home.</summary>
-            HomePoor = 171,
-            /// <summary>Player ship.</summary>
-            HomeYourShips = 174,
-
-            /// <summary>Tavern</summary>
-            Tavern = 166,
-
-            /// <summary>Temple.</summary>
-            ReligionTemple = 165,
-            /// <summary>Cult.</summary>
-            ReligionCult = 169,
-
             /// <summary>Large settlement.</summary>
-            TownCity = 160,
+            TownCity = 0,
             /// <summary>Medium settlement.</summary>
-            TownHamlet = 161,
+            TownHamlet = 1,
             /// <summary>Small settlement.</summary>
-            TownVillage = 162,
+            TownVillage = 2,
+            /// <summary>Farmhouse.</summary>
+            HomeFarms = 3,
+            /// <summary>Large dungeon.</summary>
+            DungeonLabyrinth = 4,
+            /// <summary>Temple.</summary>
+            ReligionTemple = 5,
+            /// <summary>Tavern</summary>
+            Tavern = 6,
+            /// <summary>Medium dungeon.</summary>
+            DungeonKeep = 7,
+            /// <summary>Wealthy home.</summary>
+            HomeWealthy = 8,
+            /// <summary>Cult.</summary>
+            ReligionCult = 9,
+            /// <summary>Small dungeon.</summary>
+            DungeonRuin = 10,
+            /// <summary>Poor home.</summary>
+            HomePoor = 11,
+            /// <summary>Graveyard.</summary>
+            Graveyard = 12,
+            /// <summary>Coven.</summary>
+            Coven = 13,
+            /// <summary>Player ship.</summary>
+            HomeYourShips = 14,
         }
 
         /// <summary>
@@ -178,27 +170,26 @@ namespace DaggerfallConnect
         /// </summary>
         public enum DungeonTypes
         {
-            Crypt = 51,
-            OrcStronghold = 307,
-            HumanStronghold = 563,
-            Palace = 648,               // Palace also >> 8 to index 2 (HumanStronghold)
-            Prison = 819,
-            DesecratedTemple = 1075,
-            Mine = 1331,
-            NaturalCave = 1587,
-            Coven = 1843,
-            VampireHaunt = 2099,
-            Laboratory = 2355,
-            HarpyNest = 2611,
-            RuinedCastle = 2867,
-            SpiderNest = 3123,
-            GiantStronghold = 3379,
-            DragonsDen = 3635,
-            BarbarianStronghold = 3891,
-            VolcanicCaves = 4147,
-            ScorpionNest = 4403,
-            Cemetery = 4659,
-            NoDungeon = 65399,
+            Crypt = 0,
+            OrcStronghold = 1,
+            HumanStronghold = 2,
+            Prison = 3,
+            DesecratedTemple = 4,
+            Mine = 5,
+            NaturalCave = 6,
+            Coven = 7,
+            VampireHaunt = 8,
+            Laboratory = 9,
+            HarpyNest = 10,
+            RuinedCastle = 11,
+            SpiderNest = 12,
+            GiantStronghold = 13,
+            DragonsDen = 14,
+            BarbarianStronghold = 15,
+            VolcanicCaves = 16,
+            ScorpionNest = 17,
+            Cemetery = 18,
+            NoDungeon = 255,
         }
 
         /// <summary>
@@ -235,26 +226,23 @@ namespace DaggerfallConnect
             /// <summary>Numeric ID of this location.</summary>
             public Int32 MapId;
 
-            /// <summary>Unknown.</summary>
-            public Byte Unknown1;
-
-            /// <summary>Longitude and Type compressed into a bitfield.</summary>
-            public UInt32 LongitudeTypeBitfield;
+            /// <summary>Latitude of this location.</summary>
+            public Int32 Latitude;
 
             /// <summary>Longitude value read from bitfield.</summary>
-            public UInt32 Longitude;
+            public Int32 Longitude;
 
-            /// <summary>Locaton type value read from bitfield.</summary>
+            /// <summary>Location type value read from bitfield.</summary>
             public LocationTypes LocationType;
-
-            /// <summary>Latitude of this location.</summary>
-            public UInt16 Latitude;
 
             /// <summary>Dungeon type (Crypt, Orc Stronghold, Human Stronghold, etc.).</summary>
             public DungeonTypes DungeonType;
 
-            /// <summary>Unknown.</summary>
-            public UInt32 Unknown3;
+            /// <summary>Whether or not this location is discovered.</summary>
+            public Boolean Discovered;
+
+            /// <summary>Last 4 bytes appear to be unused.</summary>
+            public UInt32 Unused;
         }
 
         #endregion

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -970,14 +970,13 @@ namespace DaggerfallConnect.Arena2
             {
                 // Read map table data
                 regions[region].DFRegion.MapTable[i].MapId = reader.ReadInt32();
-                regions[region].DFRegion.MapTable[i].Unknown1 = reader.ReadByte();
                 bitfield = reader.ReadUInt32();
-                regions[region].DFRegion.MapTable[i].LongitudeTypeBitfield = bitfield;
-                regions[region].DFRegion.MapTable[i].Longitude = bitfield & 0x1ffff;
-                regions[region].DFRegion.MapTable[i].LocationType = (DFRegion.LocationTypes)(bitfield >> 17);
-                regions[region].DFRegion.MapTable[i].Latitude = reader.ReadUInt16();
-                regions[region].DFRegion.MapTable[i].DungeonType = (DFRegion.DungeonTypes)reader.ReadUInt16();
-                regions[region].DFRegion.MapTable[i].Unknown3 = reader.ReadUInt32();
+                regions[region].DFRegion.MapTable[i].Longitude = (int)(bitfield & 0x1FFFFFF) >> 8;
+                regions[region].DFRegion.MapTable[i].LocationType = (DFRegion.LocationTypes)((4 * bitfield) >> 27);
+                regions[region].DFRegion.MapTable[i].Discovered = ((bitfield >> 24) & 0x40) != 0;
+                regions[region].DFRegion.MapTable[i].Latitude = (reader.ReadInt32() & 0xFFFFFF) >> 8;
+                regions[region].DFRegion.MapTable[i].DungeonType = (DFRegion.DungeonTypes)reader.ReadByte();
+                regions[region].DFRegion.MapTable[i].Unused = reader.ReadUInt32();
 
                 // Add to dictionary
                 if (!regions[region].DFRegion.MapIdLookup.ContainsKey(regions[region].DFRegion.MapTable[i].MapId))

--- a/Assets/Scripts/Editor/AtlasEditorWindow.cs
+++ b/Assets/Scripts/Editor/AtlasEditorWindow.cs
@@ -197,8 +197,7 @@ namespace DaggerfallWorkshop
                         }
                         break;
                     case SearchPatterns.Graveyards:
-                        if (type == DFRegion.LocationTypes.GraveyardCommon ||
-                            type == DFRegion.LocationTypes.GraveyardForgotten)
+                        if (type == DFRegion.LocationTypes.Graveyard)
                         {
                             addName = true;
                         }

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -920,12 +920,13 @@ namespace DaggerfallWorkshop.Game
 
             if (playerGPS && !isPlayerInside)
             {
-                if (location.HasDungeon &&
-                    location.MapTableData.DungeonType != DFRegion.DungeonTypes.NoDungeon &&
-                    location.MapTableData.DungeonType != DFRegion.DungeonTypes.Palace)
+                if (location.MapTableData.LocationType == DFRegion.LocationTypes.DungeonLabyrinth ||
+                    location.MapTableData.LocationType == DFRegion.LocationTypes.DungeonKeep ||
+                    location.MapTableData.LocationType == DFRegion.LocationTypes.DungeonRuin ||
+                    location.MapTableData.LocationType == DFRegion.LocationTypes.Graveyard)
                 {
                     // Get text ID based on set start and dungeon type index
-                    int dungeonTypeIndex = (int)location.MapTableData.DungeonType >> 8;
+                    int dungeonTypeIndex = (int)location.MapTableData.DungeonType;
                     int set1ID = set1StartID + dungeonTypeIndex;
                     int set2ID = set2StartID + dungeonTypeIndex;
 
@@ -937,7 +938,8 @@ namespace DaggerfallWorkshop.Game
                     DaggerfallUI.AddHUDText(flavourText1, 3);
                     DaggerfallUI.AddHUDText(flavourText2, 3);
                 }
-                else
+                else if (location.MapTableData.LocationType != DFRegion.LocationTypes.Coven &&
+                    location.MapTableData.LocationType != DFRegion.LocationTypes.HomeYourShips)
                 {
                     // Show "You are entering %s"
                     string youAreEntering = HardStrings.youAreEntering;

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -798,8 +798,7 @@ namespace DaggerfallWorkshop.Game.Questing
             if (locationType == DFRegion.LocationTypes.DungeonKeep ||
                 locationType == DFRegion.LocationTypes.DungeonLabyrinth ||
                 locationType == DFRegion.LocationTypes.DungeonRuin ||
-                locationType == DFRegion.LocationTypes.GraveyardCommon ||
-                locationType == DFRegion.LocationTypes.GraveyardForgotten)
+                locationType == DFRegion.LocationTypes.Graveyard)
             {
                 return true;
             }
@@ -946,14 +945,14 @@ namespace DaggerfallWorkshop.Game.Questing
                 if (dungeonTypeIndex == -1)
                 {
                     // Limit range to indices 0-upperLimit
-                    int testIndex = ((int)regionData.MapTable[i].DungeonType >> 8);
+                    int testIndex = ((int)regionData.MapTable[i].DungeonType);
                     if (testIndex >= 0 && testIndex <= upperLimit)
                         foundLocationIndices.Add(i);
                 }
                 else
                 {
                     // Otherwise dungeon must be of specifed type
-                    if (((int)regionData.MapTable[i].DungeonType >> 8) == dungeonTypeIndex)
+                    if (((int)regionData.MapTable[i].DungeonType) == dungeonTypeIndex)
                         foundLocationIndices.Add(i);
                 }
             }

--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -308,8 +308,7 @@ namespace DaggerfallWorkshop.Game
                         case DFRegion.LocationTypes.HomePoor:
                             currentPlayerMusicEnvironment = PlayerMusicEnvironment.DungeonExterior;
                             break;
-                        case DFRegion.LocationTypes.GraveyardCommon:
-                        case DFRegion.LocationTypes.GraveyardForgotten:
+                        case DFRegion.LocationTypes.Graveyard:
                             currentPlayerMusicEnvironment = PlayerMusicEnvironment.Graveyard;
                             break;
                         case DFRegion.LocationTypes.HomeFarms:

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -25,11 +25,6 @@ using Wenzil.Console.Commands;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
-    ///TODO:
-    ///1. Betony
-    ///2. location filtering
-
-
     /// <summary>
     /// Implements Daggerfall's travel map.
     /// </summary>
@@ -946,7 +941,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         bool checkLocationDiscovered(ContentReader.MapSummary summary)
         {
             if (GameManager.Instance.PlayerGPS.HasDiscoveredLocation(summary.ID) ||
-                PlayerGPS.checkIfLocationTypeAlwaysKnown(summary.LocationType) ||
+                summary.Discovered ||
                 revealUndiscoveredLocations == true)
             {
                 return true;
@@ -988,10 +983,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                             ContentReader.MapSummary summary;
                             if (DaggerfallUnity.Instance.ContentReader.HasLocation(originX + x, originY + y, out summary))
                             {
-                                // TEMP: Check if location discovered
-                                // This does not correctly account for locations that should always be shown
-                                // Purpose is only to test ID matching with discovery system
-                                // This is to be removed once proper discovery implemented
                                 if (!checkLocationDiscovered(summary))
                                     continue;
 
@@ -1205,10 +1196,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 case DFRegion.LocationTypes.DungeonRuin:
                     index = 2;
                     break;
-                case DFRegion.LocationTypes.GraveyardCommon:
-                    index = 3;
-                    break;
-                case DFRegion.LocationTypes.GraveyardForgotten:
+                case DFRegion.LocationTypes.Graveyard:
                     index = 3;
                     break;
                 case DFRegion.LocationTypes.Coven:

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -596,24 +596,6 @@ namespace DaggerfallWorkshop
 
         #region Location Discovery
 
-        public static bool checkIfLocationTypeAlwaysKnown(DFRegion.LocationTypes locationType)
-        {
-            if (locationType == DFRegion.LocationTypes.GraveyardCommon ||                
-                locationType == DFRegion.LocationTypes.HomeFarms ||
-                locationType == DFRegion.LocationTypes.HomePoor ||
-                locationType == DFRegion.LocationTypes.HomeWealthy ||
-                locationType == DFRegion.LocationTypes.ReligionCult ||
-                locationType == DFRegion.LocationTypes.ReligionTemple ||
-                locationType == DFRegion.LocationTypes.Tavern ||
-                locationType == DFRegion.LocationTypes.TownCity ||
-                locationType == DFRegion.LocationTypes.TownHamlet ||
-                locationType == DFRegion.LocationTypes.TownVillage)
-            {
-                return true;
-            }
-            return false;
-        }
-
         /// <summary>
         /// Discover current location.
         /// Does nothing if player in wilderness or location already dicovered.

--- a/Assets/Scripts/Utility/ContentReader.cs
+++ b/Assets/Scripts/Utility/ContentReader.cs
@@ -43,6 +43,7 @@ namespace DaggerfallWorkshop.Utility
             public int MapIndex;
             public DFRegion.LocationTypes LocationType;
             public DFRegion.DungeonTypes DungeonType;
+            public bool Discovered;
         }
 
         public bool IsReady
@@ -309,6 +310,10 @@ namespace DaggerfallWorkshop.Utility
                     summary.MapIndex = location;
                     summary.LocationType = mapTable.LocationType;
                     summary.DungeonType = mapTable.DungeonType;
+
+                    // TODO: This by itself doesn't account for DFRegion.LocationTypes.GraveyardForgotten locations that start the game discovered in classic
+                    summary.Discovered = mapTable.Discovered;
+
                     mapDict.Add(summary.ID, summary);
 
                     // Link locationId with mapId - adds ~25ms overhead


### PR DESCRIPTION
Gets most pre-discovered locations in the same manner as classic.

Some DFRegion.LocationTypes.GraveyardForgotten type locations that start the game known in classic are not gotten yet, but this is the same in the current implementation in master. I haven't been able to find how these are gotten yet.

As far as I know this is functionally identical to master, but it's a step toward correctly reading the map files and could be helpful as reference in figuring out how to import discovered location data from classic saves or how to get the remaining locations that start the game known so I think it's worth merging, but I'll leave the call to you Interkarma.

I also removed what looked like a couple out-of-date TODO comments.