### PR TITLE
Dungeon water sound progress

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -35,11 +35,13 @@ namespace DaggerfallWorkshop.Game
         bool isPlayerInsideDungeon = false;
         bool isPlayerInsideDungeonCastle = false;
         bool isPlayerInsideSpecialArea = false;
+        bool isPlayerInDungeonWater = false;
         bool isRespawning = false;
         DaggerfallInterior interior;
         DaggerfallDungeon dungeon;
         StreamingWorld world;
         PlayerGPS playerGPS;
+        Entity.DaggerfallEntityBehaviour player;
 
         List<StaticDoor> exteriorDoors = new List<StaticDoor>();
 
@@ -184,6 +186,7 @@ namespace DaggerfallWorkshop.Game
             dfUnity = DaggerfallUnity.Instance;
             playerGPS = GetComponent<PlayerGPS>();
             world = FindObjectOfType<StreamingWorld>();
+            player = GameManager.Instance.PlayerEntityBehaviour;
         }
 
         void Start()
@@ -216,6 +219,16 @@ namespace DaggerfallWorkshop.Game
             {
                 holidayTextPrimed = false;
                 ShowHolidayText();
+            }
+
+            // NOTE: Player's y value in DF unity is 0.95 units off from classic, so subtracting it to get correct comparison
+            if (blockWaterLevel == 10000 || (player.transform.position.y + (50 * MeshReader.GlobalScale) - 0.95f) >= (blockWaterLevel * -1 * MeshReader.GlobalScale))
+                isPlayerInDungeonWater = false;
+            else
+            {
+                if (!isPlayerInDungeonWater)
+                    SendMessage("PlayLargeSplash", SendMessageOptions.DontRequireReceiver);
+                isPlayerInDungeonWater = true;
             }
         }
 

--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -31,6 +31,7 @@ namespace DaggerfallWorkshop.Game
         public SoundClips FootstepSoundSnow = SoundClips.PlayerFootstepSnow;
         public SoundClips FallHardSound = SoundClips.FallHard;
         public SoundClips FallDamageSound = SoundClips.FallDamage;
+        public SoundClips SplashLargeSound = SoundClips.SplashLarge;
 
         DaggerfallUnity dfUnity;
         PlayerEnterExit playerEnterExit;
@@ -175,6 +176,13 @@ namespace DaggerfallWorkshop.Game
             // Play hard fall one-shot through normal audio source
             if (dfAudioSource)
                 dfAudioSource.PlayOneShot((int)FallHardSound, 0, FootstepVolumeScale);
+        }
+
+        // Capture this message so we can play large splash sound
+        public void PlayLargeSplash()
+        {
+            if (dfAudioSource)
+                dfAudioSource.PlayOneShot((int)SplashLargeSound, 0, FootstepVolumeScale);
         }
 
         #endregion


### PR DESCRIPTION
See comments in https://github.com/Interkarma/daggerfall-unity/pull/543.

Makes water environmental sound 2D and distance-based. I tried to roughly match classic's sound dropoff. Also adds water splash when entering, according to same criteria as classic (player.y + 50 classic units is < dungeon water. It's opposite in classic actually, since negative y is up there), with unit conversion as needed.