### PR TITLE
Remove no longer needed bit shifts

### DIFF
--- a/Assets/Scripts/API/DFRegion.cs
+++ b/Assets/Scripts/API/DFRegion.cs
@@ -166,7 +166,6 @@ namespace DaggerfallConnect
 
         /// <summary>
         /// Describes dungeon types based on Daggerfall Chronicles.
-        /// (value >> 8) = index of type.
         /// </summary>
         public enum DungeonTypes
         {

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1239,7 +1239,7 @@ namespace DaggerfallWorkshop.Utility
                 return;
 
             // Get dungeon type index
-            int dungeonIndex = (int)dungeonType >> 8;
+            int dungeonIndex = (int)dungeonType;
             if (dungeonIndex < RandomEncounters.EncounterTables.Length)
             {
                 // Get encounter table
@@ -1390,7 +1390,7 @@ namespace DaggerfallWorkshop.Utility
             }
 
             // Get dungeon type index
-            int dungeonIndex = (int)dungeonType >> 8;
+            int dungeonIndex = (int)dungeonType;
 
             string[] lootTableKeys = {
             "K", // Crypt


### PR DESCRIPTION
I missed this in my PR on the map data. A leftover shift was causing all dungeons to have crypt monsters.