### PR TITLE
Implement map item

### DIFF
--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -61,6 +61,8 @@ namespace DaggerfallWorkshop
         int lastClimateIndex;
         int lastPoliticIndex;
 
+        string locationRevealedByMapItem;
+
         Dictionary<int, DiscoveredLocation> discoveredLocations = new Dictionary<int, DiscoveredLocation>();
 
         #endregion
@@ -217,6 +219,14 @@ namespace DaggerfallWorkshop
         public RectOffset LocationRect
         {
             get { return new RectOffset(locationWorldRectMinX, locationWorldRectMaxX, locationWorldRectMinZ, locationWorldRectMaxZ); }
+        }
+
+        /// <summary>
+        /// The name of the last location revealed by a map item. Used for %map macro.
+        /// </summary>
+        public string LocationRevealedByMapItem
+        {
+            get { return locationRevealedByMapItem; } set { locationRevealedByMapItem = value; }
         }
 
         #endregion

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -122,7 +122,7 @@ namespace DaggerfallWorkshop.Utility
             { "%lt1", null }, // Title of _fl1
             { "%ltn", LocalReputation }, // In the eyes of the law you are.......
             { "%luc", Luck }, // Luck
-            { "%map", null }, // ?
+            { "%map", LocationRevealedByMapItem }, // Name of location revealed by a map item
             { "%mad", MagicResist }, // Resistance
             { "%mat", Material }, // Material
             { "%mit", null }, // Item
@@ -626,6 +626,12 @@ namespace DaggerfallWorkshop.Utility
             if (GameManager.Instance.TalkManager.MarkLocationOnMap)
                 GameManager.Instance.TalkManager.MarkKeySubjectLocationOnMap();
             return GameManager.Instance.TalkManager.CurrentKeySubject;
+        }
+
+        private static string LocationRevealedByMapItem(IMacroContextProvider mcp)
+        {
+            // %map
+            return GameManager.Instance.PlayerGPS.LocationRevealedByMapItem;
         }
 
         #endregion


### PR DESCRIPTION
Works basically like classic. Although UESP says that map items reveal a large undiscovered dungeon, it's actually any undiscovered location, including small dungeons and covens, which I confirmed through testing.

Since I found the flag in my earlier PR that determines whether a location starts the game discovered (not counting some of the graveyard locations which are still a mystery), we now have "discovered" data in two places, that flag in the map tables, and a discovered locations dictionary. Maybe we could get by just using the bit in the map tables? Also there's what feels like a little bit roundabout code in this PR in order to discover the location using the region and location names, which are the parameters for the to be the DiscoverLocation function, but it works fine. If you would like to reorganize anything, please go ahead.

