### PR TITLE
Implement knocking back enemies

### DIFF
--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
@@ -217,7 +217,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MeleeAttackSpeed: 1.25
-  MeleeDistance: 2
+  MeleeDistance: 2.5
 --- !u!114 &11435454
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -339,6 +339,7 @@ MonoBehaviour:
       MapChance: 0
       LootTableKey: 
       HitFrame: 0
+      Weight: 0
     EnemyState: 0
     StateAnims: []
 --- !u!114 &11492232

--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
@@ -216,7 +216,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MeleeAttackSpeed: 1.25
-  MeleeDistance: 2
+  MeleeDistance: 2.5
 --- !u!114 &11435454
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -327,6 +327,7 @@ MonoBehaviour:
       MapChance: 0
       LootTableKey: 
       HitFrame: 0
+      Weight: 0
     EnemyState: 0
     StateAnims: []
 --- !u!114 &11492232

--- a/Assets/Scenes/DaggerfallUnityGame.unity
+++ b/Assets/Scenes/DaggerfallUnityGame.unity
@@ -2100,7 +2100,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22400016, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 11400006, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_Value

--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -204,6 +204,7 @@ namespace DaggerfallWorkshop
         public int MapChance;                       // Chance of having a map
         public string LootTableKey;                 // Key to use when generating loot
         public int HitFrame;                        // Frame of attack animation at which hit on target is attempted
+        public int Weight;                          // Weight of this enemy. Affects chance of being knocked back by a hit.
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -23,7 +23,7 @@ namespace DaggerfallWorkshop.Game
     public class EnemyAttack : MonoBehaviour
     {
         public float MeleeAttackSpeed = 1.25f;      // Number of seconds between melee attacks
-        public float MeleeDistance = 2f;          // Maximum distance for melee attack
+        public float MeleeDistance = 2.5f;          // Maximum distance for melee attack
 
         EnemyMotor motor;
         EnemySenses senses;

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -23,7 +23,7 @@ namespace DaggerfallWorkshop.Game
     public class EnemyAttack : MonoBehaviour
     {
         public float MeleeAttackSpeed = 1.25f;      // Number of seconds between melee attacks
-        public float MeleeDistance = 2.0f;          // Maximum distance for melee attack
+        public float MeleeDistance = 2f;          // Maximum distance for melee attack
 
         EnemyMotor motor;
         EnemySenses senses;
@@ -77,8 +77,16 @@ namespace DaggerfallWorkshop.Game
         private void MeleeAnimation()
         {
             // Are we in range and facing player? Then start attack.
-            if (senses.DistanceToPlayer < MeleeDistance && senses.PlayerInSight)
+            if (senses.PlayerInSight)
             {
+                // Take the speed of movement during the attack animation and hit frame into account when calculating attack range
+                EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
+                float attackSpeed = ((entity.Stats.LiveSpeed + PlayerMotor.dfWalkBase) / PlayerMotor.classicToUnitySpeedUnitRatio) / EnemyMotor.AttackSpeedDivisor;
+                float timeUntilHit = mobile.Summary.Enemy.HitFrame / DaggerfallWorkshop.Utility.EnemyBasics.PrimaryAttackAnimSpeed;
+
+                if (senses.DistanceToPlayer >= (MeleeDistance + (attackSpeed * timeUntilHit)))
+                    return;
+
                 // Don't attack if not hostile
                 if (!motor.IsHostile)
                     return;

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -26,6 +26,7 @@ namespace DaggerfallWorkshop.Game
     {
         public float OpenDoorDistance = 2f;         // Maximum distance to open door
         public float GiveUpTime = 4f;               // Time in seconds enemy will give up if target is unreachable
+        public const float AttackSpeedDivisor = 3f;       // How much to slow down during attack animations
 
         EnemySenses senses;
         Vector3 targetPos;
@@ -201,7 +202,7 @@ namespace DaggerfallWorkshop.Game
 
             // Reduced speed if playing a one-shot animation
             if (mobile.IsPlayingOneShot())
-                moveSpeed /= 3;
+                moveSpeed /= AttackSpeedDivisor;
 
             // Remain idle when player not acquired or not hostile
             if (senses.LastKnownPlayerPos == EnemySenses.ResetPlayerPos || !isHostile)

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -1,4 +1,4 @@
-// Project:         Daggerfall Tools For Unity
+﻿// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2017 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -336,6 +336,21 @@ namespace DaggerfallWorkshop.Game.Entity
             }
         }
 
+        public int GetWeightInClassicUnits()
+        {
+            int itemWeightsClassic = (int)(Items.GetWeight() * 4);
+            int baseWeight;
+
+            if (entityType == EntityTypes.EnemyMonster)
+                baseWeight = mobileEnemy.Weight;
+            else if (mobileEnemy.Gender == MobileGender.Female)
+                baseWeight = 240;
+            else
+                baseWeight = 350;
+
+            return itemWeightsClassic + baseWeight;
+        }
+
         #endregion
     }
 }

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -77,8 +77,8 @@ namespace DaggerfallWorkshop.Game.Entity
         public const int SwimmingFatigueLoss = 44;
 
         private float classicUpdateTimer = 0f;
-        private float classicUpdateInterval = 0.0625f; // Update every 1/16 of a second. An approximation of classic's update loop, which
-                                                       // varies with framerate.
+        public const float ClassicUpdateInterval = 0.0625f; // Update every 1/16 of a second. An approximation of classic's update loop, which
+                                                            // varies with framerate.
         private int breathUpdateTally = 0;
 
         private int JumpingFatigueLoss = 11;        // According to DF Chronicles and verified in classic
@@ -146,7 +146,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
             bool classicUpdate = false;
 
-            if (classicUpdateTimer < classicUpdateInterval)
+            if (classicUpdateTimer < ClassicUpdateInterval)
                 classicUpdateTimer += Time.deltaTime;
             else
             {

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -71,6 +71,10 @@ namespace DaggerfallWorkshop.Game.Items
                 // Horses, carts and arrows are not counted against encumbrance.
                 if (item.ItemGroup != ItemGroups.Transportation && item.TemplateIndex != (int)Weapons.Arrow)
                     weight += item.weightInKg * item.stackCount;
+
+                // Enemies carry around gold as an item, unlike the player
+                if (item.ItemGroup == ItemGroups.Currency)
+                    weight += item.stackCount / Banking.DaggerfallBankManager.gold1kg;
             }
             return weight;
         }

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -147,6 +147,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 HitFrame = 3,
+                Weight = 2,
             },
 
             // Imp
@@ -175,8 +176,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 3,
                 ParrySounds = false,
                 MapChance = 1,
-                LootTableKey = "D",
                 HitFrame = 3,
+                Weight = 40,
+                LootTableKey = "D",
             },
 
             // Spriggan
@@ -208,8 +210,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = -4,
                 ParrySounds = false,
                 MapChance = 0,
-                LootTableKey = "B",
                 HitFrame = 3,
+                Weight = 240,
+                LootTableKey = "B",
             },
 
             // Giant Bat
@@ -238,6 +241,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 HitFrame = 2,
+                Weight = 80,
             },
 
             // Grizzly Bear
@@ -270,6 +274,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 HitFrame = 3,
+                Weight = 1000,
             },
 
             // Sabertooth Tiger
@@ -302,6 +307,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 HitFrame = 3,
+                Weight = 1000,
             },
 
             // Spider
@@ -330,6 +336,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 HitFrame = 3,
+                Weight = 400,
             },
 
             // Orc
@@ -358,8 +365,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 7,
                 ParrySounds = true,
                 MapChance = 0,
-                LootTableKey = "A",
                 HitFrame = 3,
+                Weight = 600,
+                LootTableKey = "A",
             },
 
             // Centaur
@@ -388,8 +396,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = true,
                 MapChance = 1,
-                LootTableKey = "C",
                 HitFrame = 3,
+                Weight = 1200,
+                LootTableKey = "C",
             },
 
             // Werewolf
@@ -423,6 +432,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 ParrySounds = false,
                 HitFrame = 2,
+                Weight = 480,
             },
 
             // Nymph
@@ -451,8 +461,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 0,
                 ParrySounds = false,
                 MapChance = 1,
-                LootTableKey = "C",
                 HitFrame = 5,
+                Weight = 200,
+                LootTableKey = "C",
             },
 
             // Slaughterfish
@@ -478,9 +489,10 @@ namespace DaggerfallWorkshop.Utility
                 MaxHealth = 50,
                 Level = 7,
                 ArmorValue = 6,
-                MapChance = 0,
                 ParrySounds = false,
+                MapChance = 0,
                 HitFrame = 5,
+                Weight = 400,
             },
 
             // Orc Sergeant
@@ -509,8 +521,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 5,
                 ParrySounds = true,
                 MapChance = 1,
-                LootTableKey = "A",
                 HitFrame = 2,
+                Weight = 600,
+                LootTableKey = "A",
             },
 
             // Harpy
@@ -538,8 +551,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 2,
                 ParrySounds = false,
                 MapChance = 0,
-                LootTableKey = "D",
                 HitFrame = 3,
+                Weight = 200,
+                LootTableKey = "D",
             },
 
             // Wereboar
@@ -573,6 +587,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 ParrySounds = false,
                 HitFrame = 3,
+                Weight = 560,
             },
 
             // Skeletal Warrior
@@ -602,8 +617,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 2,
                 ParrySounds = true,
                 MapChance = 1,
-                LootTableKey = "H",
                 HitFrame = 4,
+                Weight = 80,
+                LootTableKey = "H",
             },
 
             // Giant
@@ -634,6 +650,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 1,
                 LootTableKey = "F",
                 HitFrame = 3,
+                Weight = 3000,
             },
 
             // Zombie
@@ -661,8 +678,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 0,
                 ParrySounds = false,
                 MapChance = 1,
-                LootTableKey = "G",
                 HitFrame = 3,
+                Weight = 4000,
+                LootTableKey = "G",
             },
 
             // Ghost
@@ -691,8 +709,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 0,
                 ParrySounds = false,
                 MapChance = 1,
-                LootTableKey = "I",
                 HitFrame = 3,
+                Weight = 0,
+                LootTableKey = "I",
             },
 
             // Mummy
@@ -721,8 +740,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 2,
                 ParrySounds = false,
                 MapChance = 1,
-                LootTableKey = "E",
                 HitFrame = 4,
+                Weight = 300,
+                LootTableKey = "E",
             },
 
             // Giant Scorpion
@@ -747,10 +767,11 @@ namespace DaggerfallWorkshop.Utility
                 MinHealth = 18,
                 MaxHealth = 74,
                 Level = 12,
+                ParrySounds = false,
                 ArmorValue = 0,
                 MapChance = 0,
-                ParrySounds = false,
                 HitFrame = 3,
+                Weight = 600,
             },
 
             // Orc Shaman
@@ -779,8 +800,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 7,
                 ParrySounds = true,
                 MapChance = 3,
-                LootTableKey = "U",
                 HitFrame = 3,
+                Weight = 400,
+                LootTableKey = "U",
             },
 
             // Gargoyle
@@ -810,6 +832,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 ParrySounds = false,
                 HitFrame = 3,
+                Weight = 300,
             },
 
             // Wraith
@@ -838,8 +861,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 0,
                 ParrySounds = false,
                 MapChance = 1,
-                LootTableKey = "I",
                 HitFrame = 3,
+                Weight = 0,
+                LootTableKey = "I",
             },
 
             // Orc Warlord
@@ -868,8 +892,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 0,
                 ParrySounds = true,
                 MapChance = 2,
-                LootTableKey = "T",
                 HitFrame = 3,
+                Weight = 700,
+                LootTableKey = "T",
             },
 
             // Frost Daedra
@@ -898,8 +923,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = -5,
                 ParrySounds = true,
                 MapChance = 0,
-                LootTableKey = "J",
                 HitFrame = 3,
+                Weight = 800,
+                LootTableKey = "J",
             },
 
             // Fire Daedra
@@ -928,8 +954,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 1,
                 ParrySounds = true,
                 MapChance = 0,
-                LootTableKey = "J",
                 HitFrame = 2,
+                Weight = 800,
+                LootTableKey = "J",
             },
 
             // Daedroth
@@ -957,8 +984,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 1,
                 ParrySounds = true,
                 MapChance = 0,
-                LootTableKey = "E",
                 HitFrame = 3,
+                Weight = 400,
+                LootTableKey = "E",
             },
 
             // Vampire
@@ -987,8 +1015,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = -2,
                 ParrySounds = false,
                 MapChance = 3,
-                LootTableKey = "Q",
                 HitFrame = 4,
+                Weight = 400,
+                LootTableKey = "Q",
             },
 
             // Daedra Seducer
@@ -1017,8 +1046,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 1,
                 ParrySounds = false,
                 MapChance = 1,
-                LootTableKey = "Q",
                 HitFrame = 2,
+                Weight = 200,
+                LootTableKey = "Q",
             },
 
             // Vampire Ancient
@@ -1047,8 +1077,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = -5,
                 ParrySounds = false,
                 MapChance = 3,
-                LootTableKey = "Q",
                 HitFrame = 3,
+                Weight = 400,
+                LootTableKey = "Q",
             },
 
             // Daedra Lord
@@ -1077,8 +1108,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = -10,
                 ParrySounds = true,
                 MapChance = 0,
-                LootTableKey = "S",
                 HitFrame = 3,
+                Weight = 1000,
+                LootTableKey = "S",
             },
 
             // Lich
@@ -1108,8 +1140,9 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = -10,
                 ParrySounds = false,
                 MapChance = 4,
-                LootTableKey = "S",
                 HitFrame = 3,
+                Weight = 300,
+                LootTableKey = "S",
             },
 
             // Ancient Lich
@@ -1139,9 +1172,12 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = -12,
                 ParrySounds = false,
                 MapChance = 4,
-                LootTableKey = "S",
                 HitFrame = 3,
+                Weight = 300,
+                LootTableKey = "S",
             },
+
+            // TODO: Figure out weights for monsters from here onward.
 
             // Dragonling
             new MobileEnemy()
@@ -1169,6 +1205,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 HitFrame = 2,
+                Weight = 10000,
             },
 
             // Fire Atronach
@@ -1197,6 +1234,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 HitFrame = 3,
+                Weight = 1000,
             },
 
             // Iron Atronach
@@ -1225,6 +1263,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 HitFrame = 3,
+                Weight = 1000,
             },
 
             // Flesh Atronach
@@ -1253,6 +1292,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 HitFrame = 3,
+                Weight = 1000,
             },
 
             // Ice Atronach
@@ -1281,6 +1321,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = true,
                 MapChance = 0,
                 HitFrame = 3,
+                Weight = 1000,
             },
 
             // Dragonling
@@ -1336,8 +1377,8 @@ namespace DaggerfallWorkshop.Utility
                 ArmorValue = 6,
                 ParrySounds = false,
                 MapChance = 0,
-                LootTableKey = "R",
                 HitFrame = 3,
+                LootTableKey = "R",
             },
 
             // Lamia


### PR DESCRIPTION
Implements knocking back enemies. Should be close to classic behavior.

This may give the player a bit of advantage for now. If we implement the player's view getting thrown off when they take a heavy hit, and also correct weapon speeds (the player swings fast now), it will hopefully even out.

I think having this in somewhat alleviates the "enemy constantly pressing forward while you backpedal" feeling of combat.

One thing that is happening in this PR that I don't understand is that sometimes an enemy will resume moving toward the player while still in the hurt animation. I can't see why this happens. The state should always have been reset to "Move" before an enemy gets out of being knocked back. Any idea?