### PR TITLE
Prevent exception in SmoothFollower

### DIFF
--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -511,7 +511,7 @@ namespace DaggerfallWorkshop.Game
                 }
             }
 
-            if (smoothFollower != null)
+            if (smoothFollower != null && controller != null)
             {
                 float distanceMoved = Vector3.Distance(smoothFollowerPrevWorldPos, smoothFollower.position);        // Assuming the follower is a child of this motor transform we can get the distance travelled.
                 float maxPossibleDistanceByMotorVelocity = controller.velocity.magnitude * 2.0f * Time.deltaTime;   // Theoretically the max distance the motor can carry the player with a generous margin.

--- a/Assets/Scripts/Game/Utility/TravelTimeCalculator.cs
+++ b/Assets/Scripts/Game/Utility/TravelTimeCalculator.cs
@@ -150,10 +150,10 @@ namespace DaggerfallWorkshop.Game.Utility
 
         public int CalculateTripCost(int travelTimeInMinutes, bool sleepModeInn, bool hasShip, bool travelShip)
         {
-            int travelTimeInDays = (travelTimeInMinutes + 59) / 60;
+            int travelTimeInHours = (travelTimeInMinutes + 59) / 60;
             int cost = 0;
             if (sleepModeInn)
-                cost = 5 * ((travelTimeInDays - pixelsTraveledOnOcean) / 24) + 5;
+                cost = 5 * ((travelTimeInHours - pixelsTraveledOnOcean) / 24) + 5;
             if ((pixelsTraveledOnOcean > 0) && !hasShip && travelShip)
                 cost += 25 * (pixelsTraveledOnOcean / 24 + 1);
             return cost;


### PR DESCRIPTION
For quite a while now, probably ever since the SmoothFollower stuff was added, I've had a problem with an exception occurring on the line

`float maxPossibleDistanceByMotorVelocity = controller.velocity.magnitude * 2.0f * Time.deltaTime;`

in PlayerMotor.cs when I try to start the game from the editor. It seems like it always happens the first time I try to run the game from the editor after getting the latest update to the master branch.

Has anyone else had the same issue? This check should keep the exception from happening.

BTW, on the topic of fixing issues with the code...

I've noticed that when loading a game, "OnMapPixelChanged" happens twice. Nystul, in TalkManager.cs, AssembleTopicLists() is called 3 times when you load a game, twice from the OnMapPixelChanged event, then once for OnLoadEvent. I know it's a work in progress, but I'm letting you know in case you didn't already. It should only need to be called once, right?