### PR TITLE
Implement classic weather selection

### DIFF
--- a/Assets/Scripts/API/Save/SaveVars.cs
+++ b/Assets/Scripts/API/Save/SaveVars.cs
@@ -39,7 +39,7 @@ namespace DaggerfallConnect.Save
         const int typeOfCrimeCommittedOffset = 0x3A3;
         const int inDungeonWaterOffset = 0x3A6;
         const int breathRemainingOffset = 0x3AB;
-        const int weatherTypesOffset = 0x3B7;
+        const int climateWeathersOffset = 0x3B7;
         const int weaponDrawnOffset = 0x3BF;
         const int gameTimeOffset = 0x3C9;
         const int maleOrFemaleClothingOffset = 0x3D1; // 6 for male clothing or 12 for female clothing, matching player gender. Not bothering to read right now.
@@ -47,6 +47,7 @@ namespace DaggerfallConnect.Save
         const int currentRegionIdOffset = 0x173A; // Not bothering to read right now.
         const int cheatFlagsOffset = 0x173B;
         const int lastSkillCheckTimeOffset = 0x179A;
+        const int climateWeathersDuplicateOffset = 0x17A2; // Same data as other climateWeathers
         const int dungeonWaterLevelOffset = 0x17A8; // Not bothering to read right now.
 
         const int regionDataOffset = 0x3DA;
@@ -85,7 +86,7 @@ namespace DaggerfallConnect.Save
         byte typeOfCrimeCommitted = 0;
         bool inDungeonWater = false;
         int breathRemaining = 0;
-        byte[] weatherTypes; // Probably the possible weather types for the player's location
+        byte[] climateWeathers; // Weather in each of the six weather climates
         bool weaponDrawn = false;
         uint gameTime = 0;
         bool usingLeftHandWeapon = false;
@@ -279,11 +280,11 @@ namespace DaggerfallConnect.Save
         }
 
         /// <summary>
-        /// Gets current possible weather types?
+        /// Gets weathers in the six weather climates
         /// </summary>
-        public byte[] WeatherTypes
+        public byte[] ClimateWeathers
         {
-            get { return weatherTypes; }
+            get { return climateWeathers; }
         }
 
         /// <summary>
@@ -417,7 +418,7 @@ namespace DaggerfallConnect.Save
             ReadIsDay(reader);
             ReadTypeOfCrimeCommitted(reader);
             ReadInDungeonWater(reader);
-            ReadWeatherTypes(reader);
+            ReadClimateWeathers(reader);
             ReadWeaponDrawn(reader);
             ReadGameTime(reader);
             ReadUsingLeftHandWeapon(reader);
@@ -508,10 +509,11 @@ namespace DaggerfallConnect.Save
             breathRemaining = reader.ReadInt32();
         }
 
-        void ReadWeatherTypes(BinaryReader reader)
+        void ReadClimateWeathers(BinaryReader reader)
         {
-            reader.BaseStream.Position = weatherTypesOffset;
-            weatherTypes = reader.ReadBytes(6);
+            // Classic reads from both the first and then overwrites with the duplicate, so effectively the duplicate is what is used
+            reader.BaseStream.Position = climateWeathersDuplicateOffset;
+            climateWeathers = reader.ReadBytes(6);
         }
 
         void ReadWeaponDrawn(BinaryReader reader)

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -229,13 +229,17 @@ namespace DaggerfallWorkshop.Game.Entity
                 }
             }
 
-            // Adjust regional prices each time a day passes.
+            // Adjust regional prices and update climate weathers whenever the date has changed.
             uint lastDay = lastGameMinutes / 1440;
             uint currentDay = gameMinutes / 1440;
             int daysPast = (int)(currentDay - lastDay);
 
             if (daysPast > 0)
+            {
                 FormulaHelper.ModifyPriceAdjustmentByRegion(ref regionData, daysPast);
+                GameManager.Instance.WeatherManager.SetClimateWeathers();
+                GameManager.Instance.WeatherManager.UpdateWeatherFromClimateArray = true;
+            }
 
             lastGameMinutes = gameMinutes;
 

--- a/Assets/Scripts/Game/PlayerWeather.cs
+++ b/Assets/Scripts/Game/PlayerWeather.cs
@@ -28,6 +28,7 @@ namespace DaggerfallWorkshop.Game
         public GameObject SnowParticles;
         public WeatherType WeatherType = WeatherType.Sunny;
         public PlayerGPS PlayerGps { get; private set; }
+        public byte[] ClimateWeathers;
 
         PlayerEnterExit playerEnterExit;
         WeatherType _currentWeatherType = WeatherType.Sunny;
@@ -40,6 +41,7 @@ namespace DaggerfallWorkshop.Game
             playerEnterExit = GetComponent<PlayerEnterExit>();
             if (RainParticles) RainParticles.SetActive(false);
             if (SnowParticles) SnowParticles.SetActive(false);
+            ClimateWeathers = new byte[6];
         }
 
         void Update()

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -388,6 +388,9 @@ namespace DaggerfallWorkshop.Game.Utility
             // Randomize initial region prices
             playerEntity.InitializeRegionPrices();
 
+            // Randomize weathers
+            GameManager.Instance.WeatherManager.SetClimateWeathers();
+
             // Start game
             GameManager.Instance.PauseGame(false);
             DaggerfallUI.Instance.FadeHUDFromBlack();
@@ -547,6 +550,22 @@ namespace DaggerfallWorkshop.Game.Utility
 
             // Get breath remaining if player was submerged (0 if they were not in the water)
             playerEntity.CurrentBreath = saveVars.BreathRemaining;
+
+            // Get weather
+            byte[] climateWeathers = saveVars.ClimateWeathers;
+
+            // Enums for thunder and snow are reversed in classic and Unity, so they are converted here.
+            for (int i = 0; i < climateWeathers.Length; i++)
+            {
+                // TODO: 0x80 flag can be set for snow or rain, to add fog to these weathers. This isn't in DF Unity yet, so
+                // temporarily removing the flag.
+                climateWeathers[i] &= 0x7f;
+                if (climateWeathers[i] == 5)
+                    climateWeathers[i] = 6;
+                else if (climateWeathers[i] == 6)
+                    climateWeathers[i] = 5;
+            }
+            GameManager.Instance.WeatherManager.PlayerWeather.ClimateWeathers = climateWeathers;
 
             // Start game
             DaggerfallUI.Instance.PopToHUD();

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -587,7 +587,7 @@ namespace DaggerfallWorkshop
             isPlayerInLocationRect = check;
         }
 
-        private bool ReadyCheck()
+        public bool ReadyCheck()
         {
             // Ensure we have a DaggerfallUnity reference
             if (dfUnity == null)


### PR DESCRIPTION
This re-introduces weather changes, which are currently disabled, using something close to the way classic does it, and imports weather from classic saves.

- In classic weathers are stored in a 6-byte array, which can be found in SaveVars, with the weather for the player's current climate the one that is used. DF Unity just tracks one weather.
- Thunder (which can be chosen in classic but has no visual or audio effects) and snow have their enums reversed in classic and Unity. This PR switches them when importing from classic.
- Classic changes weather when the date changes, or when the player crosses climate zones. Because of the game's accelerated time versus the speed of real time, I feel this looks OK, even though weathers only change on at a minimum of 24-hour increments. Also, since the changes happen at midnight game-time, the abruptness of them should be less than if it happened during the day. Still, it would be nice to have the possibility for transitions at any time of day as an improvement in the future. The abrupt changes when crossing climate zones look bad and I haven't tried to recreate them.
- In addition to the 7 weather types, if the 0x80 bit is set, I think rain and snow can have fog added to them. However, fog doesn't seem to be very noticeable in DF Unity currently, at least it doesn't create the same type of thick fog as classic. These "+fog" weather types aren't implemented yet. The 0x80 bit in classic has a chance of being set whenever rain or snow is chosen.
- The "MountainWoods" climate gets mountain weather chances in Unity, but woodland chances in classic. I don't know if we should change this, but for this "classic-like" implementation, the woodland chances are used.

At the moment the array of weathers isn't stored in DF Unity saves, as it's not necessary. It might not be necessary to have it in PlayerWeather, either, but for simplicity of importing from classic saves, it's there now. Maybe we can remove it.

We could replace this with a better selection method later, including with more weather transitions, but maybe we can keep this as an option for classic behavior. Also it will allow people to experience and test the weathers again, which are disabled now.