### PR TITLE
Implement classic weapon animation timing

### DIFF
--- a/Assets/Scripts/Utility/WeaponBasics.cs
+++ b/Assets/Scripts/Utility/WeaponBasics.cs
@@ -84,7 +84,7 @@ namespace DaggerfallWorkshop.Utility
         // Animations for bow
         public static WeaponAnimation[] BowWeaponAnims = new WeaponAnimation[]
         {
-            new WeaponAnimation() {Record = 0, NumFrames = 1, FramePerSecond = IdleAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
+            new WeaponAnimation() {Record = 0, NumFrames = 4, FramePerSecond = IdleAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
             new WeaponAnimation() {Record = 0, NumFrames = 7, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
             new WeaponAnimation() {Record = 0, NumFrames = 7, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
             new WeaponAnimation() {Record = 0, NumFrames = 7, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},


### PR DESCRIPTION
This implements classic fps weapon animation timing that should be very close to classic. The speed attribute is used to determine weapon swing speed and cooldown between bow shots.

Also the special animation sequence for sideways left strikes with hand-to-hand/werecreature is implemented. After playing through normally it plays back the initial frames in reverse.

There is also a general cleanup of the weapon manager code. To me at least, it cleaner and makes more sense now. Its no longer possible to sheathe/unsheathe or switch hands mid-swing, although its possible in classic, because it looks weird and buggy.

Interkarma can I have your feedback on a few things?
1- The attack swing may seem too slow for characters without a high speed attribute. I'm a little worried it could give a poor impression to people who are playing DF Unity for the first time. This is how classic is and it doesn't bother me, but maybe we should have an option to play with faster swings?

2- Bow animations play like classic, with the idle at the arrow-knocked frame. Again, I am fine with this but I can see that people may not like it for covering up a lot of the screen. I think maybe this would include you Interkarma, since you don't like the original interface that covers part of the screen. Shall we have an option to idle the bow at frame 0?

If we have the options for 1 and 2, do you think they should be on by default, or should classic be the default?