### PR TITLE
Implement regional building answers

### DIFF
--- a/Assets/Scripts/API/DFRegion.cs
+++ b/Assets/Scripts/API/DFRegion.cs
@@ -240,8 +240,8 @@ namespace DaggerfallConnect
             /// <summary>Whether or not this location is discovered.</summary>
             public Boolean Discovered;
 
-            /// <summary>Last 4 bytes appear to be unused.</summary>
-            public UInt32 Unused;
+            /// <summary>A key for the contents of the location.</summary>
+            public UInt32 Key;
         }
 
         #endregion

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -976,7 +976,7 @@ namespace DaggerfallConnect.Arena2
                 regions[region].DFRegion.MapTable[i].Discovered = ((bitfield >> 24) & 0x40) != 0;
                 regions[region].DFRegion.MapTable[i].Latitude = (reader.ReadInt32() & 0xFFFFFF) >> 8;
                 regions[region].DFRegion.MapTable[i].DungeonType = (DFRegion.DungeonTypes)reader.ReadByte();
-                regions[region].DFRegion.MapTable[i].Unused = reader.ReadUInt32();
+                regions[region].DFRegion.MapTable[i].Key = reader.ReadUInt32();
 
                 // Add to dictionary
                 if (!regions[region].DFRegion.MapIdLookup.ContainsKey(regions[region].DFRegion.MapTable[i].MapId))

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -76,7 +76,7 @@ namespace DaggerfallWorkshop.Utility
             { "%ef", null },  // Local shop name
             { "%enc", EncumbranceMax }, // Encumbrance
             { "%end", End }, // Amount of Endurance
-            { "%fcn", null }, // Another city
+            { "%fcn", LocationOfRegionalBuilding }, // Location with regional building asked about
             { "%fe", null },  // ?
             { "%fea", null }, // ?
             { "%fl1", null }, // Lord of _fx1
@@ -632,6 +632,12 @@ namespace DaggerfallWorkshop.Utility
         {
             // %map
             return GameManager.Instance.PlayerGPS.LocationRevealedByMapItem;
+        }
+
+        private static string LocationOfRegionalBuilding(IMacroContextProvider mcp)
+        {
+            // %fcn
+            return GameManager.Instance.TalkManager.LocationOfRegionalBuilding;
         }
 
         #endregion


### PR DESCRIPTION
Turns out there's keys in the mapTable records for which types of buildings exist in each location.

In classic asking for armorer is bugged and always returns 0, but there was a gap in the flags and it seems to match for armorer, so this PR uses it.

The question text is still unimplemented.