### PR TITLE
Implement animal sounds

### DIFF
--- a/Assets/Scripts/DaggerfallUnityEnums.cs
+++ b/Assets/Scripts/DaggerfallUnityEnums.cs
@@ -439,11 +439,12 @@ namespace DaggerfallWorkshop
     /// </summary>
     public enum AudioPresets
     {
-        None,                   // No changes to AudioSource
-        OnDemand,               // PlayOnAwake=false, Loop=false
-        LoopOnAwake,            // PlayOnAwake=true, Loop=true
-        LoopOnDemand,           // PlayOnAwake=false, Loop=true
-        LoopIfPlayerNear,       // PlayOnAwake=true, Loop=true, distanceCheck=true
+        None,                       // No changes to AudioSource
+        OnDemand,                   // PlayOnAwake=false, Loop=false
+        LoopOnAwake,                // PlayOnAwake=true, Loop=true
+        LoopOnDemand,               // PlayOnAwake=false, Loop=true
+        LoopIfPlayerNear,           // PlayOnAwake=true, Loop=true, distanceCheck=true
+        PlayRandomlyIfPlayerNear,   // PlayOnAwake=false, Loop=false, distanceCheck=true, playRandomly=true
     }
 
     /// <summary>

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -54,6 +54,11 @@ namespace DaggerfallWorkshop
         // Can only be flagged using LoopOnDistance preset.
         private bool playerCheck = false;
 
+        // Sets looping sound to only play randomly and on a slower update matched to classic.
+        // Only used for animal sounds.
+        private bool playRandomly = false;
+        private float classicUpdateTimer = 0f;
+
         public bool IsReady
         {
             get { return ReadyCheck(); }
@@ -83,8 +88,26 @@ namespace DaggerfallWorkshop
             // Handle player checks
             if (playerCheck && audioSource && player)
             {
-                bool playerInRange = (Vector3.Distance(transform.position, player.transform.position) < audioSource.maxDistance);
+                bool playerInRange = (Vector3.Distance(transform.position, player.transform.position) <= audioSource.maxDistance);
+
                 audioSource.enabled = playerInRange;
+
+                // Handle random play
+                if (audioSource.enabled && playRandomly)
+                {
+                    bool classicUpdate = false;
+
+                    if (classicUpdateTimer < Game.Entity.PlayerEntity.ClassicUpdateInterval)
+                        classicUpdateTimer += Time.deltaTime;
+                    else
+                    {
+                        classicUpdateTimer = 0;
+                        classicUpdate = true;
+                    }
+
+                    if (classicUpdate && DFRandom.rand() <= 100)
+                        audioSource.Play();
+                }
             }
         }
 
@@ -247,21 +270,31 @@ namespace DaggerfallWorkshop
                     audioSource.playOnAwake = false;
                     audioSource.loop = false;
                     playerCheck = false;
+                    playRandomly = false;
                     break;
                 case AudioPresets.LoopOnAwake:
                     audioSource.playOnAwake = true;
                     audioSource.loop = true;
                     playerCheck = false;
+                    playRandomly = false;
                     break;
                 case AudioPresets.LoopOnDemand:
                     audioSource.playOnAwake = false;
                     audioSource.loop = true;
                     playerCheck = false;
+                    playRandomly = false;
                     break;
                 case AudioPresets.LoopIfPlayerNear:
                     audioSource.playOnAwake = true;
                     audioSource.loop = true;
                     playerCheck = true;
+                    playRandomly = false;
+                    break;
+                case AudioPresets.PlayRandomlyIfPlayerNear:
+                    audioSource.playOnAwake = false;
+                    audioSource.loop = false;
+                    playerCheck = true;
+                    playRandomly = true;
                     break;
                 default:
                     break;

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -38,6 +38,9 @@ namespace DaggerfallWorkshop.Utility
         public const uint CityGateOpenModelID = 446;
         public const uint CityGateClosedModelID = 447;
 
+        // Animal sounds range. Matched to classic.
+        const float animalSoundMaxDistance = 768 * MeshReader.GlobalScale;
+
         #region Structures
 
         struct BuildingPoolItem
@@ -337,16 +340,19 @@ namespace DaggerfallWorkshop.Utility
                 }
 
                 // Add to batch where available
-                if (obj.TextureArchive == TextureReader.AnimalsTextureArchive && animalsBillboardBatch != null)
-                {
-                    animalsBillboardBatch.AddItem(obj.TextureRecord, billboardPosition);
-                    continue;
-                }
+                //if (obj.TextureArchive == TextureReader.AnimalsTextureArchive && animalsBillboardBatch != null)
+                //{
+                //    animalsBillboardBatch.AddItem(obj.TextureRecord, billboardPosition);
+                //    continue;
+                //}
 
                 // Add standalone billboard gameobject
                 GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(obj.TextureArchive, obj.TextureRecord, flatsParent);
                 go.transform.position = billboardPosition;
                 AlignBillboardToBase(go);
+                // Add animal sound
+                if (obj.TextureArchive == TextureReader.AnimalsTextureArchive)
+                    AddAnimalAudioSource(go);
             }
         }
 
@@ -808,6 +814,43 @@ namespace DaggerfallWorkshop.Utility
                 return true;
             else
                 return false;
+        }
+
+        private static void AddAnimalAudioSource(GameObject go)
+        {
+            DaggerfallAudioSource source = go.AddComponent<DaggerfallAudioSource>();
+            source.AudioSource.maxDistance = animalSoundMaxDistance;
+
+            DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+            SoundClips sound = SoundClips.None;
+            switch(dfBillboard.Summary.Record)
+            {
+                case 0:
+                case 1:
+                    sound = SoundClips.AnimalHorse;
+                    break;
+                case 3:
+                case 4:
+                    sound = SoundClips.AnimalCow;
+                    break;
+                case 5:
+                case 6:
+                    sound = SoundClips.AnimalPig;
+                    break;
+                case 7:
+                case 8:
+                    sound = SoundClips.AnimalCat;
+                    break;
+                case 9:
+                case 10:
+                    sound = SoundClips.AnimalDog;
+                    break;
+                default:
+                    sound = SoundClips.None;
+                    break;
+            }
+
+            source.SetSound(sound, AudioPresets.PlayRandomlyIfPlayerNear);
         }
 
         #endregion


### PR DESCRIPTION
Implements animal sounds. Range and frequency should match or be close to matching classic.

One thing though, is that I don't know exactly what's going on with the billboard batching. It looked like I needed to (or it at least be simplest to) remove animal flats from billboard batching so I could add audioSources to them, but maybe they can still be batched? If not, we could remove the animal batch code.