### PR TITLE
Implement mastering skills, import more skill data

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -74,6 +74,8 @@ namespace DaggerfallConnect.Save
             doc.reputationUnderworld = parsedData.reputationUnderworld;
             doc.currentFatigue = parsedData.currentFatigue;
             doc.skillUses = parsedData.skillUses;
+            doc.skillsRaisedThisLevel1 = parsedData.skillsRaisedThisLevel1;
+            doc.skillsRaisedThisLevel2 = parsedData.skillsRaisedThisLevel2;
             doc.startingLevelUpSkillSum = parsedData.startingLevelUpSkillSum;
             doc.minMetalToHit = parsedData.minMetalToHit;
             doc.armorValues = parsedData.armorValues;
@@ -114,8 +116,8 @@ namespace DaggerfallConnect.Save
             }
             parsedData.armorValues = armorValues;
 
-            parsedData.skillUnknown1 = reader.ReadInt32();
-            parsedData.skillUnknown2 = reader.ReadInt32();
+            parsedData.skillsRaisedThisLevel1 = reader.ReadUInt32();
+            parsedData.skillsRaisedThisLevel2 = reader.ReadUInt32();
             parsedData.startingLevelUpSkillSum = reader.ReadInt32();
 
             parsedData.baseHealth = reader.ReadInt16();
@@ -296,8 +298,8 @@ namespace DaggerfallConnect.Save
             public byte minMetalToHit;
             public Races race;
             public sbyte[] armorValues;
-            public Int32 skillUnknown1; // Seems to be related to skills and leveling
-            public Int32 skillUnknown2; // Seems to be related to skills and leveling
+            public UInt32 skillsRaisedThisLevel1; // Flags for skills 0 through 31.
+            public UInt32 skillsRaisedThisLevel2; // Flags for skills 32 through 34.
             public Int32 startingLevelUpSkillSum; // The starting total of all the primary skills, the two top major skills and the top minor skill
             public Int16 baseHealth;
             public UInt32 timePlayerBecameWerebeast; // Needs confirming

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -42,6 +42,8 @@ namespace DaggerfallWorkshop.Game.Player
         public short reputationUnderworld;
         public int currentFatigue;
         public short[] skillUses;
+        public uint skillsRaisedThisLevel1;
+        public uint skillsRaisedThisLevel2;
         public int startingLevelUpSkillSum;
         public byte minMetalToHit;
         public sbyte[] armorValues = new sbyte[DaggerfallEntity.NumberBodyParts];

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -162,7 +162,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Check if any previous message boxes need to be closed as well.
             DaggerfallMessageBox prevWindow = PreviousWindow as DaggerfallMessageBox;
             if (prevWindow != null && prevWindow.nextMessageBox != null)
+            {
                 prevWindow.nextMessageBox.CloseWindow();
+                Debug.Log("OnPop Close");
+            }
         }
 
         #region Public Methods

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -198,8 +198,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             base.OnPop();
 
             Debug.Log(string.Format("Resting raised time by {0} hours total", totalHours));
-
-            playerEntity.RaiseSkills();
         }
 
         #endregion
@@ -414,6 +412,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void RestFinishedPopup_OnClose()
         {
             DaggerfallUI.Instance.PopToHUD();
+            playerEntity.RaiseSkills();
         }
 
         #endregion

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -179,7 +179,7 @@ namespace DaggerfallWorkshop.Utility
             { "%rn", null },  // Regent's Name
             { "%rt", null },  // Regent's Title
             { "%spc", Magicka }, // Current Spell Points
-            { "%ski", null }, // Skill
+            { "%ski", Skill }, // Mastered skill name
             { "%spd", Spd }, // Speed
             { "%spt", MagickaMax }, // Max spell points
             { "%str", Str }, // Amount of strength
@@ -532,6 +532,19 @@ namespace DaggerfallWorkshop.Utility
         private static string Magicka(IMacroContextProvider mcp)
         {   // %spt
             return GameManager.Instance.PlayerEntity.MaxMagicka.ToString();
+        }
+        private static string Skill(IMacroContextProvider mcp)
+        {   // %ski
+            List<DFCareer.Skills> primarySkills = GameManager.Instance.PlayerEntity.GetPrimarySkills();
+            foreach (DFCareer.Skills skill in primarySkills)
+            {
+                if (GameManager.Instance.PlayerEntity.Skills.GetPermanentSkillValue(skill) == 100)
+                {
+                    return DaggerfallUnity.Instance.TextProvider.GetSkillName(skill);
+                }
+            }
+
+            return "BLANK";
         }
 
         private static string MagicResist(IMacroContextProvider mcp)


### PR DESCRIPTION
Implements:

- Identifies and imports skill raised flags from classic saves. In classic these are set when a skill is raised for the current player level and cause the skill to be rendered in blue when looking at skill levels. This PR just imports the flags but doesn't do anything with them, nor are they saved/loaded between Unity saves yet.

- Implemented mastering a primary skill (reaching 100). You get the fanfare sound and the congratulatory message as in classic.
- Implemented %ski macro, which is used in the congratulatory message.

This PR just does things as classic does, but mastering a skill is actually a bit of a restriction, because until you do so you can raise any skill to 100%, but after you master a skill, you can no longer raise any skill over 95%.

What seems like a natural fix to me is that no skills can get past 95% except primary skills, and once you've raised a primary skill to 96%, it becomes the only one that can be raised over 95%. This might have been what was intended in classic. But people might like being able to max out various skills to 100%, so I'm not really in a rush to change it.