### PR TITLE
Fixes to FPS weapon animations

### DIFF
--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -236,7 +236,7 @@ namespace DaggerfallWorkshop.Game
             if (!ShowWeapon || WeaponType == WeaponTypes.None)
             {
                 weaponState = WeaponStates.Idle;
-                return;
+                currentFrame = 0;
             }
 
             // Store rect and anim
@@ -378,6 +378,8 @@ namespace DaggerfallWorkshop.Game
 
                 if (weaponAnims != null && ShowWeapon)
                 {
+                    int frameBeforeStepping = currentFrame;
+
                     // Special animation for unarmed attack to left
                     if ((WeaponType == WeaponTypes.Melee || WeaponType == WeaponTypes.Werecreature)
                         && WeaponState == WeaponStates.StrikeLeft)
@@ -410,7 +412,9 @@ namespace DaggerfallWorkshop.Game
                         }
                     }
 
-                    UpdateWeapon();
+                    // Only update if the frame actually changed
+                    if (frameBeforeStepping != currentFrame)
+                        UpdateWeapon();
                 }
 
                 yield return new WaitForSeconds(time);


### PR DESCRIPTION
Fixes a problem with the FPS weapon looking glitched when you change weapons because the old weapon's animation data remained. Also put in an optimization to not run UpdateWeapon() from the weapon animation subroutine when there is no reason to.