### PR TITLE
Move next/previous control from PresetPicker to its own class, implement also in ModSettingsWindow

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
@@ -58,6 +58,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         Color saveButtonColor         = new Color(0.0f, 0.5f, 0.0f, 0.4f);  // green with alpha
         Color cancelButtonColor       = new Color(0.2f, 0.2f, 0.2f, 0.4f);  // grey with alpha
         Color sectionTitleColor       = new Color(0.53f, 0.81f, 0.98f, 1);  // light blue
+        Color sectionTitleShadow      = new Color(0.3f, 0.45f, 0.54f, 1);
         Color backgroundTitleColor    = new Color(0, 0.8f, 0, 0.1f);        // green
 
         readonly Mod mod;
@@ -328,8 +329,10 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         {
             // Title
             TextLabel titleLabel = new TextLabel();
-            titleLabel.Text = mod.Title + " settings";
-            titleLabel.Position = new Vector2(0, 6);
+            titleLabel.Text = mod.Title; // + " settings";
+            titleLabel.Font = DaggerfallUI.Instance.Font2;
+            titleLabel.TextScale = 0.75f;
+            titleLabel.Position = new Vector2(0, 3);
             titleLabel.HorizontalAlignment = HorizontalAlignment.Center;
             modSettingsPanel.Components.Add(titleLabel);
             currentPanel = modSettingsPanel;
@@ -349,10 +352,16 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             // Presets button
             if (presets.Count > 0)
             {
-                Button presetButton = GetButton("Presets", HorizontalAlignment.Right, saveButtonColor);
-                presetButton.VerticalAlignment = VerticalAlignment.Top;
+                Button presetButton = new Button();
                 presetButton.Size = new Vector2(35, 9);
+                presetButton.Position = new Vector2(currentPanel.Size.x - 37, 2);
+                presetButton.Label.Text = "Presets";
+                presetButton.Label.Font = DaggerfallUI.Instance.Font3;
+                presetButton.Label.TextScale = 0.8f;
+                presetButton.Label.TextColor = sectionTitleColor;
+                presetButton.Label.ShadowColor = sectionTitleShadow;
                 presetButton.OnMouseClick += PresetButton_OnMouseClick;
+                currentPanel.Components.Add(presetButton);
             }
 
             // Create first page and load settings
@@ -382,7 +391,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
                         paginator.TextColor = Color.yellow;
                         paginator.ArrowColor = Color.green;
                         paginator.DisabledArrowColor = new Color(0.18f, 0.55f, 0.34f);
-                        paginator.Position = new Vector2(startX + 3, 3);
+                        paginator.Position = new Vector2(startX + 3, 3.5f);
                         paginator.Size = new Vector2(35, 6);
                         paginator.OnSelected += Paginator_OnSelected;
                         modSettingsPanel.Components.Add(paginator);
@@ -441,7 +450,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             TextLabel textLabel = new TextLabel(DaggerfallUI.Instance.Font5);
             textLabel.Text = FormattedName(title);
             textLabel.TextColor = sectionTitleColor;
-            textLabel.ShadowColor = new Color(0.3f, 0.45f, 0.54f, 1);
+            textLabel.ShadowColor = sectionTitleShadow;
             textLabel.TextScale = 0.9f;
             textLabel.Position = new Vector2(0, 0.5f);
             textLabel.HorizontalAlignment = HorizontalAlignment.Center;

--- a/Assets/Game/Addons/ModSupport/ModSettings/PresetPicker.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/PresetPicker.cs
@@ -51,7 +51,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         TextLabel descriptionLabel      = new TextLabel();
         TextLabel authorLabel           = new TextLabel();
         TextLabel versionLabel          = new TextLabel();
-        TextLabel indicator             = new TextLabel();
+        Paginator paginator             = new Paginator();
         TextBox creatorTitle            = new TextBox();
         TextBox creatorDescription      = new TextBox();
 
@@ -62,7 +62,6 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         Color selectedTitleColor        = Color.blue;
         Color warningColor              = new Color(1, 0, 0, 0.4f);
 
-        bool isInit = true;
         bool creationMode = false;
 
         #endregion
@@ -136,35 +135,14 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             controlPanel.Size = new Vector2(mainPanel.Size.x, 20);
             mainPanel.Components.Add(controlPanel);
 
-            var leftButton = new Button();
-            leftButton.Size = new Vector2(5, 5);
-            leftButton.Position = new Vector2(10, 0);
-            leftButton.VerticalAlignment = VerticalAlignment.Middle;
-            leftButton.Label.Text = "<";
-            leftButton.Label.Font = DaggerfallUI.Instance.Font3;
-            leftButton.Label.ShadowColor = Color.clear;
-            leftButton.Label.TextColor = Color.blue;
-            leftButton.OnMouseClick += LeftButton_OnMouseClick;
-            controlPanel.Components.Add(leftButton);
-
-            var rightButton = new Button();
-            rightButton.Size = new Vector2(5, 5);
-            rightButton.Position = new Vector2(40, 0);
-            rightButton.VerticalAlignment = VerticalAlignment.Middle;
-            rightButton.Label.Text = ">";
-            rightButton.Label.Font = DaggerfallUI.Instance.Font3;
-            rightButton.Label.ShadowColor = Color.clear;
-            rightButton.Label.TextColor = Color.blue;
-            rightButton.OnMouseClick += RightButton_OnMouseClick;
-            controlPanel.Components.Add(rightButton);
-
-            indicator.Font = DaggerfallUI.Instance.Font3;
-            indicator.ShadowColor = Color.clear;
-            indicator.TextColor = titleColor;
-            indicator.Size = new Vector2(25, 5);
-            indicator.Position = new Vector2(20, 0);
-            indicator.VerticalAlignment = VerticalAlignment.Middle;
-            controlPanel.Components.Add(indicator);
+            paginator.Size = new Vector2(30, 5);
+            paginator.VerticalAlignment = VerticalAlignment.Middle;
+            paginator.Position = new Vector2(10, 0);
+            paginator.TextColor = titleColor;
+            paginator.ArrowColor = Color.blue;
+            paginator.DisabledArrowColor = new Color(0.28f, 0.24f, 0.55f);
+            paginator.OnSelected += Paginator_OnSelected;
+            controlPanel.Components.Add(paginator);
 
             var cancelButton = new Button();
             cancelButton.Size = new Vector2(30, 10);
@@ -224,18 +202,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             itemOut.selectedTextColor = selectedTitleColor;
             itemOut.shadowColor = Color.clear;
 
-            listBox.SelectIndex(0);
-        }
-
-        public override void Update()
-        {
-            base.Update();
-
-            if (isInit)
-            {
-                ListBox_OnSelectItem();
-                isInit = false;
-            }
+            ListBox_OnSelectItem();
         }
 
         #endregion
@@ -271,11 +238,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             presets.Add(preset);
 
             listBox.AddItem(preset.Title, out itemOut);
-        }
-
-        private void UpdateIndicator()
-        {
-            indicator.Text = string.Format("{0}/{1}", listBox.SelectedIndex + 1, listBox.Count);
+            paginator.Total = listBox.Count;
         }
 
         private void SetCreationMode(bool toggle)
@@ -291,18 +254,6 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         #endregion
 
         #region Event Handlers
-
-        private void LeftButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
-        {
-            listBox.SelectPrevious();
-            UpdateIndicator();
-        }
-
-        private void RightButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
-        {
-            listBox.SelectNext();
-            UpdateIndicator();
-        }
 
         private void ListBox_OnSelectItem()
         {
@@ -324,8 +275,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
                 else
                     versionLabel.Text = string.Empty;
             }
+            paginator.Sync(listBox.SelectedIndex);
+        }
 
-            UpdateIndicator();
+        private void Paginator_OnSelected(int previous, int selected)
+        {
+            listBox.SelectedIndex = paginator.Selected;
         }
 
         private void CancelButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterface/Paginator.cs
+++ b/Assets/Scripts/Game/UserInterface/Paginator.cs
@@ -1,0 +1,280 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2017 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: TheLacus
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using UnityEngine;
+
+namespace DaggerfallWorkshop.Game.UserInterface
+{
+    /// <summary>
+    /// Navigation controls for pages or listed items.
+    /// </summary>
+    public class Paginator : Panel
+    {
+        #region UI Controls
+
+        TextLabel indicator     = new TextLabel();
+        Button leftButton       = new Button();
+        Button rightButton      = new Button();
+
+        #endregion
+
+        #region Fields
+
+        const string leftArrow = "<";
+        const string rightArrow = ">";
+
+        int previous, selected, total;
+
+        Color arrowColor            = Color.white;
+        Color disabledArrowColor    = Color.grey;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Number of positions.
+        /// </summary>
+        public int Total
+        {
+            get { return total; }
+            set { SetTotal(value); }
+        }
+
+        /// <summary>
+        /// Selected index.
+        /// </summary>
+        public int Selected
+        {
+            get { return selected; }
+            set { SetSelected(value); }
+        }
+
+        /// <summary>
+        /// Is first selected?
+        /// </summary>
+        public bool IsFirst { get { return selected == 0; } }
+
+        /// <summary>
+        /// Is last selected?
+        /// </summary>
+        public bool IsLast { get { return total - selected == 1; } }
+
+        /// <summary>
+        /// Color of previous/next arrows.
+        /// </summary>
+        public Color ArrowColor
+        {
+            get { return arrowColor; }
+            set { arrowColor = value;
+                UpdateArrowsColor(); }
+        }
+
+        /// <summary>
+        /// Color of previous/next arrows on first/last position.
+        /// </summary>
+        public Color DisabledArrowColor
+        {
+            get { return disabledArrowColor; }
+            set { disabledArrowColor = value;
+                UpdateArrowsColor(); }
+        }
+
+        /// <summary>
+        /// Color of index label.
+        /// </summary>
+        public Color TextColor
+        {
+            get { return indicator.TextColor; }
+            set { indicator.TextColor = value; }
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Create a control for pages or listed items.
+        /// </summary>
+        public Paginator(int total = 1)
+        {
+            leftButton.Size = new Vector2(5, 5);
+            leftButton.VerticalAlignment = VerticalAlignment.Middle;
+            leftButton.Label.Text = leftArrow;
+            leftButton.Label.ShadowColor = Color.clear;
+            leftButton.OnMouseClick += LeftButton_OnMouseClick;
+            Components.Add(leftButton);
+
+            rightButton.Size = new Vector2(5, 5);
+            rightButton.VerticalAlignment = VerticalAlignment.Middle;
+            rightButton.Label.Text = rightArrow;
+            rightButton.Label.ShadowColor = Color.clear;
+            rightButton.OnMouseClick += RightButton_OnMouseClick;
+            Components.Add(rightButton);
+
+            indicator.Font = DaggerfallUI.Instance.Font3;
+            indicator.ShadowColor = Color.clear;
+            indicator.Size = new Vector2(25, 5);
+            indicator.VerticalAlignment = VerticalAlignment.Middle;
+            Components.Add(indicator);
+
+            this.total = total;
+            ConfirmSelection();
+            SetScale();
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Set text scale and distance between arrows. 
+        /// </summary>
+        /// <param name="textScale">Scale factor of text.</param>
+        /// <param name="arrowSpacing">Distance between arrows.</param>
+        public void SetScale(float textScale = 1, float arrowSpacing = 30)
+        {
+            // Assign text scale
+            leftButton.Label.TextScale = textScale;
+            rightButton.Label.TextScale = textScale;
+            indicator.TextScale = textScale;
+
+            // Move right arrow
+            float rightArrowPosX = Mathf.Max(0, arrowSpacing) + leftButton.Position.x;
+            rightButton.Position = new Vector2(rightArrowPosX, rightButton.Position.y);
+
+            // Move position indicator between arrows
+            float indicatorPosX = (float)(leftButton.Position.x + rightButton.Position.x) / 2;
+            indicatorPosX -= indicator.Size.x / 2;
+            indicator.Position = new Vector2(indicatorPosX, indicator.Position.y);
+        }
+
+        /// <summary>
+        /// Move to previous position.
+        /// </summary>
+        public void Previous()
+        {
+            if (!IsFirst)
+            {
+                previous = selected--;
+                ConfirmSelection();
+            }         
+        }
+
+        /// <summary>
+        /// Move to next position.
+        /// </summary>
+        public void Next()
+        {
+            if (!IsLast)
+            {
+                previous = selected++;
+                ConfirmSelection();
+            }
+        }
+
+        /// <summary>
+        /// Move to first position.
+        /// </summary>
+        public void First()
+        {
+            SetSelected(0);
+        }
+
+        /// <summary>
+        /// Move to last position.
+        /// </summary>
+        public void Last()
+        {
+            SetSelected(total - 1);
+        }
+
+        /// <summary>
+        /// Select position without raising events.
+        /// </summary>
+        public void Sync(int selected)
+        {
+            SetSelected(selected, false);
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private void SetTotal(int total)
+        {
+            if (total <= 0)
+                throw new ArgumentOutOfRangeException("total", total, "Total must be a positive number.");
+
+            // Assign total and move selected in new range.
+            this.total = total;
+            if (selected >= total)
+                selected = total - 1;
+
+            ConfirmSelection(false);
+        }
+
+        private void SetSelected(int selected, bool raiseEvent = true)
+        {
+            if (this.selected == selected)
+                return;
+
+            if (selected < 0 || selected >= total)
+                throw new ArgumentOutOfRangeException("selected", selected, "Selected must be positive and lower than total.");
+
+            previous = this.selected;
+            this.selected = selected;
+
+            ConfirmSelection(raiseEvent);
+        }
+
+        private void ConfirmSelection(bool raiseEvent = true)
+        {
+            indicator.Text = string.Format("{0}/{1}", selected + 1, total);
+
+            UpdateArrowsColor();
+
+            if (raiseEvent)
+                RaiseOnSelected();
+        }
+
+        private void UpdateArrowsColor()
+        {
+            leftButton.Label.TextColor = IsFirst ? disabledArrowColor : arrowColor;
+            rightButton.Label.TextColor =  IsLast ? disabledArrowColor : arrowColor;
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        private void LeftButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            Previous();
+        }
+
+        private void RightButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            Next();
+        }
+
+        public delegate void OnSelectedHandler(int previous, int selected);
+        public event OnSelectedHandler OnSelected;
+        void RaiseOnSelected()
+        {
+            if (OnSelected != null)
+                OnSelected(previous, selected);
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Game/UserInterface/Paginator.cs.meta
+++ b/Assets/Scripts/Game/UserInterface/Paginator.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: acb8b26025d89e544ab725719b840599
+timeCreated: 1513287836
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I moved the left/right control used in PresetPicker window to its own class, so i could also implement it in ModSettingsWindow.  [picture](https://i.imgur.com/VOZiMBB.png)