### PR TITLE
Implement stealth basics

### DIFF
--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
@@ -261,7 +261,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   OpenDoorDistance: 2
-  GiveUpTime: 4
 --- !u!114 &11470552
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -368,9 +367,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9fd446a55d098ca4f826c3c9bc93563a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SightRadius: 16
-  HearingRadius: 8
-  FieldOfView: 120
+  SightRadius: 25
+  HearingRadius: 25
+  FieldOfView: 180
 --- !u!143 &14323946
 CharacterController:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -52,6 +52,8 @@ namespace DaggerfallWorkshop.Game.Entity
         protected uint timeOfLastSkillIncreaseCheck = 0;
         protected uint timeOfLastSkillTraining = 0;
 
+        protected uint timeOfLastStealthCheck = 0;
+
         protected int startingLevelUpSkillSum = 0;
         protected int currentLevelUpSkillSum = 0;
         protected bool readyToLevelUp = false;
@@ -107,6 +109,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public short[] SkillUses { get { return skillUses; } set { skillUses = value; } }
         public uint TimeOfLastSkillIncreaseCheck { get { return timeOfLastSkillIncreaseCheck; } set { timeOfLastSkillIncreaseCheck = value; } }
         public uint TimeOfLastSkillTraining { get { return timeOfLastSkillTraining; } set { timeOfLastSkillTraining = value; } }
+        public uint TimeOfLastStealthCheck { get { return timeOfLastStealthCheck; } set { timeOfLastStealthCheck = value; } }
         public int StartingLevelUpSkillSum { get { return startingLevelUpSkillSum; } set { startingLevelUpSkillSum = value; } }
         public int CurrentLevelUpSkillSum {  get { return currentLevelUpSkillSum; } }
         public bool ReadyToLevelUp { get { return readyToLevelUp; } set { readyToLevelUp = value; } }

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -142,6 +142,22 @@ namespace DaggerfallWorkshop.Game
             set { isRiding = value; }
         }
 
+        public bool IsMovingLessThanHalfSpeed
+        {
+            get
+            {
+                if (IsStandingStill)
+                {
+                    return true;
+                }
+                if (isCrouching)
+                {
+                    return (GetWalkSpeed(GameManager.Instance.PlayerEntity) / 2) >= speed;
+                }
+                return (GetBaseSpeed() / 2) >= speed;
+            }
+        }
+
         public Transform ActivePlatform
         {
             get { return activePlatform; }
@@ -281,6 +297,13 @@ namespace DaggerfallWorkshop.Game
                     {
                         speed = GetRunSpeed(speed);
                     }
+                }
+
+                // Handle sneak key. Reduces movement speed to half, then subtracts 1 in classic speed units
+                if (InputManager.Instance.HasAction(InputManager.Actions.Sneak))
+                {
+                    speed /= 2;
+                    speed -= (1 / classicToUnitySpeedUnitRatio);
                 }
 
                 // If sliding (and it's allowed), or if we're on an object tagged "Slide", get a vector pointing down the slope we're on

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -52,7 +52,8 @@ namespace DaggerfallWorkshop.Game
         const float animFrameTime = 0.125f;  // Time between animation frames in seconds.
 
         const SoundClips horseSound = SoundClips.AnimalHorse;
-        const SoundClips horseRidingSound = SoundClips.HorseClop2;
+        const SoundClips horseRidingSound1 = SoundClips.HorseClop;
+        const SoundClips horseRidingSound2 = SoundClips.HorseClop2;
         const SoundClips cartRidingSound = SoundClips.HorseAndCart;
 
         // TODO: Move into ImageHelper? (duplicated in FPSWeapon & DaggerfallVidPlayerWindow)
@@ -69,7 +70,7 @@ namespace DaggerfallWorkshop.Game
 
         AudioClip neighClip;
         float neighTime = 0;
-
+        bool wasMovingLessThanHalfSpeed = true;
 
         // Use this for initialization
         void Start()
@@ -126,7 +127,21 @@ namespace DaggerfallWorkshop.Game
                         frameIdx = (frameIdx == 3) ? 0 : frameIdx + 1;
                         ridingTexure = ridingTexures[frameIdx];
                     }
-                    // Play hoof-fall (clip-clop) sounds.
+                    // Get appropriate hoof sound for horse
+                    if (mode == TransportModes.Horse)
+                    {
+                        if (!wasMovingLessThanHalfSpeed && playerMotor.IsMovingLessThanHalfSpeed)
+                        {
+                            wasMovingLessThanHalfSpeed = true;
+                            ridingAudioSource.clip = dfAudioSource.GetAudioClip((int)horseRidingSound1);
+                        }
+                        else if (wasMovingLessThanHalfSpeed && !playerMotor.IsMovingLessThanHalfSpeed)
+                        {
+                            wasMovingLessThanHalfSpeed = false;
+                            ridingAudioSource.clip = dfAudioSource.GetAudioClip((int)horseRidingSound2);
+                        }
+                    }
+
                     if (!ridingAudioSource.isPlaying)
                         ridingAudioSource.Play();
                 }
@@ -173,7 +188,7 @@ namespace DaggerfallWorkshop.Game
                 playerMotor.IsRiding = true;
 
                 // Setup appropriate riding sounds.
-                SoundClips sound = (mode == TransportModes.Horse) ? horseRidingSound : cartRidingSound;
+                SoundClips sound = (mode == TransportModes.Horse) ? horseRidingSound2 : cartRidingSound;
                 ridingAudioSource.clip = dfAudioSource.GetAudioClip((int) sound);
 
                 // Setup appropriate riding textures.

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -216,8 +216,6 @@ namespace DaggerfallWorkshop
                 // Cannot bash magically held doors
                 if (!IsMagicallyHeld)
                 {
-                    PlayerEntity player = Game.GameManager.Instance.PlayerEntity;
-                    player.TallySkill(DFCareer.Skills.Stealth, 1);
                     // Roll for chance to open
                     int chance = 20 - CurrentLockValue;
                     int roll = UnityEngine.Random.Range(1, 101);


### PR DESCRIPTION
Implements stealth basics, as well as general tweaking of enemy detection AI.

- The basics of the stealth check in classic are recreated (check every in-game minute, tally player skill, detection formula). There's a bit more that's involved but we need to implement the sneak key first.
- Enemy FOV matched to classic. Vision and hearing range (I don't think enemies have "hearing" in classic) matched to range of stealth check
- Hearing is only active when the player has been detected by that enemy, since otherwise it would interfere with stealth and not allow sneaking up on enemies. The stealth check in classic basically doubles as "hearing" simulation. Since I've increased the hearing range I also force a "false" hearing check when statics are between the enemy and the player, to try to reduce enemies walking against walls because they hear the player behind it.

Right now enemy AI behavior in general is a mixture of classic and DF Unity behavior. I'm trying to first get in classic behavior (this, the ranged attacks) while preserving the improvements of DF Unity. IMO things are working pretty well with this PR. Later maybe we can have a toggle between classic behavior and enhanced AI.

This PR should also open the way to implementing backstabbing.

