### PR TITLE
TextureReplacement: Simplification of Image size methods (including XmlManager), other improvements 

### DIFF
--- a/Assets/Scripts/Game/UserInterface/FacePicker.cs
+++ b/Assets/Scripts/Game/UserInterface/FacePicker.cs
@@ -104,9 +104,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (currentFaceTexture != null)
             {
                 if (raceGender == Genders.Male)
-                    facePanel.Size = TextureReplacement.GetSizeFromTexture(currentFaceTexture, raceTemplate.PaperDollHeadsMale, faceIndex);
+                    facePanel.Size = TextureReplacement.GetSize(currentFaceTexture, raceTemplate.PaperDollHeadsMale, faceIndex);
                 else if (raceGender == Genders.Female)
-                    facePanel.Size = TextureReplacement.GetSizeFromTexture(currentFaceTexture, raceTemplate.PaperDollHeadsFemale, faceIndex);
+                    facePanel.Size = TextureReplacement.GetSize(currentFaceTexture, raceTemplate.PaperDollHeadsFemale, faceIndex);
 
                 facePanel.BackgroundTexture = currentFaceTexture;
             }

--- a/Assets/Scripts/Game/UserInterface/HUDCompass.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCompass.cs
@@ -66,7 +66,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (Enabled)
             {
                 base.Update();
-                Size = TextureReplacement.GetSizeFromXml(compassBoxTexture, compassBoxFilename, Scale.x, Scale.y);
+                Size = TextureReplacement.GetSize(compassBoxTexture, compassBoxFilename, Scale, true);
             }
         }
 
@@ -109,12 +109,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             compassBoxRect.x = Position.x;
             compassBoxRect.y = Position.y;
 
-            Vector2 boxRectSize = TextureReplacement.GetSizeFromXml(compassBoxTexture, compassBoxFilename, Scale.x, Scale.y);
+            Vector2 boxRectSize = TextureReplacement.GetSize(compassBoxTexture, compassBoxFilename, Scale, true);
             compassBoxRect.width = boxRectSize.x;
             compassBoxRect.height = boxRectSize.y;
 
             // Get compassTexture size
-            Vector2 compassTextureSize = TextureReplacement.GetSizeFromXml(compassTexture, compassFilename);
+            Vector2 compassTextureSize = TextureReplacement.GetSize(compassTexture, compassFilename, true);
             float compassTextureWidth = compassTextureSize.x;
             float compassTextureHeight = compassTextureSize.y;
 

--- a/Assets/Scripts/Game/UserInterface/HUDCompass.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCompass.cs
@@ -24,7 +24,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         Camera compassCamera;
         Texture2D compassTexture;
+        Vector2 compassSize;
         Texture2D compassBoxTexture;
+        Vector2 compassBoxSize;
         float eulerAngle;
 
         /// <summary>
@@ -66,7 +68,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (Enabled)
             {
                 base.Update();
-                Size = TextureReplacement.GetSize(compassBoxTexture, compassBoxFilename, Scale, true);
+                Size = new Vector2(compassBoxSize.x * Scale.x, compassBoxSize.y * Scale.y);
             }
         }
 
@@ -82,7 +84,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         void LoadAssets()
         {
             compassTexture = DaggerfallUI.GetTextureFromImg(compassFilename);
+            compassSize = TextureReplacement.GetSize(compassTexture, compassFilename, true);
             compassBoxTexture = DaggerfallUI.GetTextureFromImg(compassBoxFilename);
+            compassBoxSize = TextureReplacement.GetSize(compassBoxTexture, compassBoxFilename, true);
         }
 
         void DrawCompass()
@@ -109,14 +113,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
             compassBoxRect.x = Position.x;
             compassBoxRect.y = Position.y;
 
-            Vector2 boxRectSize = TextureReplacement.GetSize(compassBoxTexture, compassBoxFilename, Scale, true);
+            Vector2 boxRectSize = new Vector2(compassBoxSize.x * Scale.x, compassBoxSize.y * Scale.y);
             compassBoxRect.width = boxRectSize.x;
             compassBoxRect.height = boxRectSize.y;
 
             // Get compassTexture size
-            Vector2 compassTextureSize = TextureReplacement.GetSize(compassTexture, compassFilename, true);
-            float compassTextureWidth = compassTextureSize.x;
-            float compassTextureHeight = compassTextureSize.y;
+            float compassTextureWidth = compassSize.x;
+            float compassTextureHeight = compassSize.y;
 
             // Compass strip source
             Rect compassSrcRect = new Rect();

--- a/Assets/Scripts/Game/UserInterface/HUDCrosshair.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCrosshair.cs
@@ -21,6 +21,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
     {
         const string defaultCrosshairFilename = "Crosshair";
 
+        Vector2 crosshairSize;
+
         public Texture2D CrosshairTexture;
         public float CrosshairScale = 1.0f;
 
@@ -37,7 +39,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (CrosshairTexture && Enabled)
             {
                 BackgroundTexture = CrosshairTexture;
-                Size = TextureReplacement.GetSize(CrosshairTexture, defaultCrosshairFilename, CrosshairScale, true);
+                Size = crosshairSize * CrosshairScale;
 
                 base.Update();
             }
@@ -49,6 +51,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 CrosshairTexture = TextureReplacement.LoadCustomTexture(defaultCrosshairFilename);
             else
                 CrosshairTexture = Resources.Load<Texture2D>(defaultCrosshairFilename);
+
+            crosshairSize = TextureReplacement.GetSize(CrosshairTexture, defaultCrosshairFilename, true);
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterface/HUDCrosshair.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCrosshair.cs
@@ -39,7 +39,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 BackgroundTexture = CrosshairTexture;
 
                 if (TextureReplacement.CustomTextureExist(defaultCrosshairFilename))
-                    Size = XMLManager.GetSize(defaultCrosshairFilename, TextureReplacement.TexturesPath, CrosshairScale, CrosshairScale);
+                    Size = TextureReplacement.GetSize(defaultCrosshairFilename, TextureReplacement.TexturesPath, CrosshairScale, CrosshairScale);
                 else
                     Size = new Vector2(CrosshairTexture.width * CrosshairScale, CrosshairTexture.height * CrosshairScale);
 

--- a/Assets/Scripts/Game/UserInterface/HUDCrosshair.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCrosshair.cs
@@ -37,11 +37,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (CrosshairTexture && Enabled)
             {
                 BackgroundTexture = CrosshairTexture;
-
-                if (TextureReplacement.CustomTextureExist(defaultCrosshairFilename))
-                    Size = TextureReplacement.GetSize(defaultCrosshairFilename, TextureReplacement.TexturesPath, CrosshairScale, CrosshairScale);
-                else
-                    Size = new Vector2(CrosshairTexture.width * CrosshairScale, CrosshairTexture.height * CrosshairScale);
+                Size = TextureReplacement.GetSize(CrosshairTexture, defaultCrosshairFilename, CrosshairScale, true);
 
                 base.Update();
             }

--- a/Assets/Scripts/Game/UserInterface/LeftRightSpinner.cs
+++ b/Assets/Scripts/Game/UserInterface/LeftRightSpinner.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -54,7 +54,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             nativeTexture.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
 
             // Setup spinner panel
-            Size = TextureReplacement.GetSizeFromTexture(nativeTexture, nativeImgName);
+            Size = TextureReplacement.GetSize(nativeTexture, nativeImgName);
             backgroundTexture = nativeTexture;
 
             // Add up/down buttons

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallListPickerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallListPickerWindow.cs
@@ -55,7 +55,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 throw new Exception("DaggerfallClassSelectWindow: Could not load native texture.");
 
             // Create panel for picker
-            pickerPanel.Size = TextureReplacement.GetSizeFromTexture(nativeTexture, nativeImgName);
+            pickerPanel.Size = TextureReplacement.GetSize(nativeTexture, nativeImgName);
             pickerPanel.HorizontalAlignment = HorizontalAlignment.Center;
             pickerPanel.VerticalAlignment = VerticalAlignment.Middle;
             pickerPanel.BackgroundTexture = nativeTexture;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -199,7 +199,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             Texture2D background = DaggerfallUI.GetTextureFromCifRci(buttonsFilename, (int)messageBoxButton);
             Button button = DaggerfallUI.AddButton(Vector2.zero, 
-                TextureReplacement.GetSizeFromTexture(background, buttonsFilename, (int)messageBoxButton), buttonPanel);
+                TextureReplacement.GetSize(background, buttonsFilename, (int)messageBoxButton), buttonPanel);
             button.BackgroundTexture = background;
             button.BackgroundTextureLayout = BackgroundLayout.StretchToFill;
             button.Tag = messageBoxButton;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
@@ -54,7 +54,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Native options panel
             optionsPanel.HorizontalAlignment = HorizontalAlignment.Center;
             optionsPanel.Position = new Vector2(0, 40);
-            optionsPanel.Size = TextureReplacement.GetSizeFromTexture(nativeTexture, nativeImgName);
+            optionsPanel.Size = TextureReplacement.GetSize(nativeTexture, nativeImgName);
             optionsPanel.BackgroundTexture = nativeTexture;
             NativePanel.Components.Add(optionsPanel);
 

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -460,13 +460,9 @@ namespace DaggerfallWorkshop
                 finalSize.x = (size.Width + xChange);
                 finalSize.y = (size.Height + yChange);
                 
-                // Get eventual custom scale
-                if ((summary.CustomMaterial.isCustom) && (XMLManager.XmlFileExist(archive, i)))
-                {
-                    Vector2 enemyScale = XMLManager.GetScale(TextureReplacement.GetName(archive, i), TextureReplacement.TexturesPath);
-                    finalSize.x *= enemyScale.x;
-                    finalSize.y *= enemyScale.y;
-                }
+                // Set optional scale
+                if (summary.CustomMaterial.isCustom)
+                    TextureReplacement.SetEnemyScale(archive, i, ref finalSize);
  
                 // Store final size and frame count
                 summary.RecordSizes[i] = finalSize * MeshReader.GlobalScale;

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -145,7 +145,7 @@ namespace DaggerfallWorkshop
                         textureReader.MiscFlatsTextureArchives,
                         2,
                         true,
-                        2048,
+                        DaggerfallUnity.Settings.MeshAndTextureReplacement ? 4096 : 2048,
                         AlphaTextureFormat,
                         NonAlphaTextureFormat);
 

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -76,8 +76,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         // Enemy will use custom textures if [archive, enemyDefaultRecord, enemyDefaultFrame] is found.
-        public const int enemyDefaultRecord = 0;          
-        public const int enemyDefaultFrame = 0;
+        const int enemyDefaultRecord = 0;          
+        const int enemyDefaultFrame = 0;
 
         /// <summary>
         /// Custom textures for enemies.
@@ -229,7 +229,6 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         {
             return TextureFileExist(cifRciPath, GetNameCifRci(filename, record, frame, metalType));
         }
-
 
         /// <summary>
         /// Import image from disk to replace .CIFs and .RCIs. for a specific metalType
@@ -586,6 +585,14 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             }
         }
 
+        public static bool EnemyHasCustomMaterial(int archive)
+        {
+            // This is the first texture set on enemy. Enemies use all custom textures or all vanilla.
+            // If (archive, defaultRecord, defaultFrame) is present on disk all other textures are
+            // considered required, otherwise vanilla textures are used.
+            return TextureFileExist(texturesPath, GetName(archive, enemyDefaultRecord, enemyDefaultFrame));
+        }
+
         /// <summary>
         /// Import and set custom material on Enemy unit.
         /// </summary>
@@ -594,17 +601,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="textures">All textures for this enemy (except dead texture).</param>
         static public void SetupCustomEnemyMaterial(GameObject go, int archive, out List<List<Texture2D>> textures)
         {
-            // This is the first texture set on enemy. Enemies use all custom textures or all vanilla.
-            // If (archive, defaultRecord, defaultFrame) is present on disk all other textures are
-            // considered required, otherwise vanilla textures are used.
+            var meshRenderer = go.GetComponent<MeshRenderer>();
+            MaterialReader materialReader = DaggerfallUnity.Instance.MaterialReader;
             int record = enemyDefaultRecord, frame = enemyDefaultFrame;
 
             // Update UV map
             SetUv(go.GetComponent<MeshFilter>());
 
             // Get default texture from cache or import from disk
-            var meshRenderer = go.GetComponent<MeshRenderer>();
-            MaterialReader materialReader = DaggerfallUnity.Instance.MaterialReader;
+            meshRenderer.sharedMaterial = MaterialReader.CreateStandardMaterial(MaterialReader.CustomBlendMode.Cutout);
             CachedMaterial cachedMaterialOut;
             if (materialReader.GetCachedMaterialCustomBillboard(archive, record, frame, out cachedMaterialOut))
                 meshRenderer.material.mainTexture = cachedMaterialOut.albedoMap;

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -795,25 +795,6 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Get a safe size for a control based on resolution of img with a scale.
-        /// </summary>
-        public static Vector2 GetSize(Texture2D texture, string textureName, float scale, bool allowXml = false)
-        {
-            return GetSize(texture, textureName, allowXml) * scale;
-        }
-
-        /// <summary>
-        /// Get a safe size for a control based on resolution of img with a scale.
-        /// </summary>
-        public static Vector2 GetSize(Texture2D texture, string textureName, Vector2 scale, bool allowXml = false)
-        {
-            Vector2 size = GetSize(texture, textureName, allowXml);
-            size.x *= scale.x;
-            size.y *= scale.y;
-            return size;
-        }
-
-        /// <summary>
         /// Get a safe size for a control based on resolution of cif or rci.
         /// </summary>
         public static Vector2 GetSize(Texture2D texture, string textureName, int record, int frame = 0)

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -761,74 +761,67 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Get size of vanilla texture, even if using a custom one.
+        /// Get a safe size for a control based on resolution of img.
         /// </summary>
-        /// <param name="texture">Texture.</param>
-        /// <param name="textureName">Archive of texture.</param>
-        /// <param name="record">Record of texture.</param>
-        /// <param name="frame">Frame of texture.</param>
-        /// <returns>Vector2 with width and height</returns>
-        static public Vector2 GetSizeFromTexture(Texture2D texture, int archive, int record, int frame = 0)
+        public static Vector2 GetSize(Texture2D texture, string textureName, bool allowXml = false)
         {
-            if (CustomTextureExist(archive, record, frame))
+            if (allowXml)
             {
-                ImageData imageData = ImageReader.GetImageData("TEXTURE." + archive, createTexture: false);
-                return new Vector2(imageData.width, imageData.height);
+                // Get size from xml
+                string path = Path.Combine(imgPath, textureName);
+                if (XMLManager.XmlFileExists(path))
+                {
+                    var xml = new XMLManager(path);
+                    Vector2 size;
+                    if (xml.TryGetVector2("width", "height", out size))
+                        return size;
+                }
             }
-            else
-                return new Vector2(texture.width, texture.height);
-        }
 
-        /// <summary>
-        /// Get size of vanilla texture, even if using a custom one.
-        /// </summary>
-        /// <param name="texture">Texture.</param>
-        /// <param name="textureName">Name of texture file.</param>
-        /// <param name="record">Record of texture (CifRci only).</param>
-        /// <param name="frame">Frame of texture (CifRci only).</param>
-        /// <returns>Vector2 with width and height</returns>
-        static public Vector2 GetSizeFromTexture(Texture2D texture, string textureName, int record = 0, int frame = 0)
-        {
-            if (CustomImageExist(textureName) || CustomCifExist(textureName, record, frame))
+            // Get size from vanilla image
+            if (CustomImageExist(textureName))
             {
                 ImageData imageData = ImageReader.GetImageData(textureName, createTexture: false);
                 return new Vector2(imageData.width, imageData.height);
             }
-            else
-                return new Vector2(texture.width, texture.height);
+
+            // Get size from texture
+            return new Vector2(texture.width, texture.height);
         }
 
         /// <summary>
-        /// Get custom size or default size of texture.
+        /// Get a safe size for a control based on resolution of img with a scale.
         /// </summary>
-        static public Vector2 GetSizeFromXml(Texture2D texture, string textureName, float scaleWidth = 1, float scaleHeight = 1)
+        public static Vector2 GetSize(Texture2D texture, string textureName, float scale, bool allowXml = false)
         {
-            if (CustomImageExist(textureName))
-                return GetSize(textureName, imgPath, scaleWidth, scaleHeight);
-            else
-                return new Vector2(texture.width * scaleWidth, texture.height * scaleHeight);
+            return GetSize(texture, textureName, allowXml) * scale;
         }
 
-        public static Vector2 GetSize(string fileName, string path, float additionalScaleX = 1, float additionaScaleY = 1)
+        /// <summary>
+        /// Get a safe size for a control based on resolution of img with a scale.
+        /// </summary>
+        public static Vector2 GetSize(Texture2D texture, string textureName, Vector2 scale, bool allowXml = false)
         {
-            // Get size from xml
-            path = Path.Combine(path, fileName);
-            if (XMLManager.XmlFileExists(path))
-            {
-                var xml = new XMLManager(path);
+            Vector2 size = GetSize(texture, textureName, allowXml);
+            size.x *= scale.x;
+            size.y *= scale.y;
+            return size;
+        }
 
-                Vector2 size;
-                if (xml.TryGetVector2("width", "height", out size))
-                {
-                    size.x *= additionalScaleX;
-                    size.y *= additionaScaleY;
-                    return size;
-                }
+        /// <summary>
+        /// Get a safe size for a control based on resolution of cif or rci.
+        /// </summary>
+        public static Vector2 GetSize(Texture2D texture, string textureName, int record, int frame = 0)
+        {
+            // Get size from vanilla image
+            if (CustomCifExist(textureName, record, frame))
+            {
+                ImageData imageData = ImageReader.GetImageData(textureName, createTexture: false);
+                return new Vector2(imageData.width, imageData.height);
             }
 
-            // Fallback: get size from imagedata
-            ImageData imageData = ImageReader.GetImageData(fileName, createTexture: false);
-            return new Vector2(imageData.width * additionalScaleX, imageData.height * additionaScaleY);
+            // Get size from texture
+            return new Vector2(texture.width, texture.height);
         }
 
         #endregion

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -44,10 +44,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     {
         #region Fields & Structs
 
+        const string extension = ".png";
+
         // Paths
-        static private string texturesPath = Path.Combine(Application.streamingAssetsPath, "Textures");
-        static private string imgPath = Path.Combine(texturesPath, "Img");
-        static private string cifPath = Path.Combine(texturesPath, "CifRci");
+        static readonly string texturesPath = Path.Combine(Application.streamingAssetsPath, "Textures");
+        static readonly string imgPath = Path.Combine(texturesPath, "Img");
+        static readonly string cifRciPath = Path.Combine(texturesPath, "CifRci");
 
         /// <summary>
         /// Common tags for textures maps.
@@ -96,7 +98,6 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static public string TexturesPath
         {
             get { return texturesPath; }
-            internal set { texturesPath = value; }
         }
 
         /// <summary>
@@ -105,7 +106,6 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static public string ImagesPath
         {
             get { return imgPath; }
-            internal set { imgPath = value; }
         }
 
         /// <summary>
@@ -113,8 +113,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// </summary>
         static public string CifRciPath
         {
-            get { return cifPath; }
-            internal set { cifPath = value; }
+            get { return cifRciPath; }
         }
 
         #endregion
@@ -155,7 +154,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>Texture.</returns>
         static public Texture2D LoadCustomTexture(int archive, int record, int frame)
         {
-            return ImportTextureFile(texturesPath, GetName(archive, record, frame));
+            return ImportTextureFile(texturesPath, GetName(archive, record, frame), true);
         }
 
         /// <summary>
@@ -166,7 +165,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>Texture.</returns>
         static public Texture2D LoadCustomTexture(string name)
         {
-            return ImportTextureFile(texturesPath, name);
+            return ImportTextureFile(texturesPath, name, true);
         }
 
         /// <summary>
@@ -189,6 +188,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static public Texture2D LoadCustomImage(string filename)
         {
             return ImportTextureFile(imgPath, filename);
+
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if image exists.</returns>
         static public bool CustomCifExist(string filename, int record, int frame = 0)
         {
-            return TextureFileExist(cifPath, GetNameCifRci(filename, record, frame));
+            return TextureFileExist(cifRciPath, GetNameCifRci(filename, record, frame));
         }
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>Image.</returns>
         static public Texture2D LoadCustomCif(string filename, int record, int frame)
         {
-            return ImportTextureFile(cifPath, GetNameCifRci(filename, record, frame));
+            return ImportTextureFile(cifRciPath, GetNameCifRci(filename, record, frame));
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if generic or specific image exists.</returns>
         static public bool CustomCifExist(string filename, int record, int frame, MetalTypes metalType)
         {
-            return TextureFileExist(cifPath, GetNameCifRci(filename, record, frame, metalType));
+            return TextureFileExist(cifRciPath, GetNameCifRci(filename, record, frame, metalType));
         }
 
 
@@ -241,7 +241,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>Image for this metalType or generic image if metalType is None.</returns>
         static public Texture2D LoadCustomCif(string filename, int record, int frame, MetalTypes metalType)
         {
-            return ImportTextureFile(cifPath, GetNameCifRci(filename, record, frame, metalType));
+            return ImportTextureFile(cifRciPath, GetNameCifRci(filename, record, frame, metalType));
         }
 
         /// <summary>
@@ -326,7 +326,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>Emission map.</returns>
         static public Texture2D LoadCustomEmission(int archive, int record, int frame)
         {
-            return ImportTextureFile(texturesPath, GetName(archive, record, frame) + MapTags.Emission);
+            return ImportTextureFile(texturesPath, GetName(archive, record, frame) + MapTags.Emission, true);
         }
 
         /// <summary>
@@ -337,7 +337,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>Emission map.</returns>
         static public Texture2D LoadCustomEmission(string name)
         {
-            return ImportTextureFile(texturesPath, name + MapTags.Emission);
+            return ImportTextureFile(texturesPath, name + MapTags.Emission, true);
         }
 
         /// <summary>
@@ -374,7 +374,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>MetallicGloss map.</returns>
         static public Texture2D LoadCustomMetallicGloss(int archive, int record, int frame)
         {
-            return ImportTextureFile(texturesPath, GetName(archive, record, frame) + MapTags.MetallicGloss);
+            return ImportTextureFile(texturesPath, GetName(archive, record, frame) + MapTags.MetallicGloss, true);
         }
 
         /// <summary>
@@ -385,7 +385,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>MetallicGloss map.</returns>
         static public Texture2D LoadCustomMetallicGloss(string name)
         {
-            return ImportTextureFile(texturesPath, name + MapTags.MetallicGloss);
+            return ImportTextureFile(texturesPath, name + MapTags.MetallicGloss, true);
         }
 
         // General import methods for mods or other external code.
@@ -408,7 +408,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                         break;
 
                     default:
-                        texture = ImportTextureFile(path, name);
+                        texture = ImportTextureFile(path, name, true);
                         break;
                 }
 
@@ -496,7 +496,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             }
 
             // Update UV
-            UpdateUV(go.GetComponent<MeshFilter>(), uv.x, uv.y);
+            SetUv(go.GetComponent<MeshFilter>(), uv.x, uv.y);
 
             // Get material from cache or import from disk
             MaterialReader materialReader = DaggerfallUnity.Instance.MaterialReader;
@@ -600,7 +600,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             int record = enemyDefaultRecord, frame = enemyDefaultFrame;
 
             // Update UV map
-            UpdateUV(go.GetComponent<MeshFilter>());
+            SetUv(go.GetComponent<MeshFilter>());
 
             // Get default texture from cache or import from disk
             var meshRenderer = go.GetComponent<MeshRenderer>();
@@ -829,63 +829,45 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         #region Private Methods
 
         /// <summary>
-        /// Check if image file exist on disk.
+        /// True if image file exists and settings allow import.
         /// </summary>
-        /// <param name="path">Location of image file.</param>
-        /// <param name="name">Name of image file.</param>
-        /// <returns></returns>
-        static private bool TextureFileExist (string path, string name)
+        /// <param name="path">Path to file on disk.</param>
+        /// <param name="fileName">Name of file without extension.</param>
+        private static bool TextureFileExist (string path, string name)
         {
-            if (DaggerfallUnity.Settings.MeshAndTextureReplacement //check .ini setting
-                && File.Exists(Path.Combine(path, name + ".png")))
-                return true;
-
-            return false;
+            return DaggerfallUnity.Settings.MeshAndTextureReplacement
+                && File.Exists(Path.Combine(path, name + extension));
         }
 
         /// <summary>
-        /// Import image file with .png extension from disk,
-        /// to be used as a texture.
+        /// Import image file as texture2D.
         /// </summary>
-        /// <param name="path">Location of image file.</param>
-        /// <param name="name">Name of image file.</param>
-        /// <returns></returns>
-        static private Texture2D ImportTextureFile (string path, string name)
+        /// <param name="path">Path to file on disk.</param>
+        /// <param name="fileName">Name of file without extension.</param>
+        /// <param name="mipMaps">Enable MipMaps?</param>
+        private static Texture2D ImportTextureFile (string path, string fileName, bool mipMaps = false)
         {
             // Create empty texture, size will be the actual size of .png file
-            Texture2D tex = new Texture2D(2, 2);
+            Texture2D tex = new Texture2D(2, 2, TextureFormat.RGBA32, mipMaps);
 
             // Load image as Texture2D
-            tex.LoadImage(File.ReadAllBytes(Path.Combine(path, name + ".png")));
+            tex.LoadImage(File.ReadAllBytes(Path.Combine(path, fileName + extension)));
 
-            // Return imported texture
-            if (tex != null)
-                return tex;
-
-            Debug.LogError("Can't import custom texture " + name + ".png from " + path);
-            return null;
+            return tex;
         }
 
         /// <summary>
-        /// Import image file with .png extension from disk,
-        /// to be used as a normal map.
+        /// Import image file as Normal Map texture2D.
         /// </summary>
-        /// <param name="path">Location of image file.</param>
-        /// <param name="name">Name of image file.</param>
-        /// <returns>Normal map as Texture2D</returns>
-        static private Texture2D ImportNormalMap (string path, string name)
+        /// <param name="path">Path to file on disk.</param>
+        /// <param name="fileName">Name of file without extension.</param>
+        private static Texture2D ImportNormalMap (string path, string fileName)
         {
             //create empty texture, size will be the actual size of .png file
             Texture2D tex = new Texture2D(2, 2, TextureFormat.ARGB32, true);
 
             // Load image as Texture2D
-            tex.LoadImage(File.ReadAllBytes(Path.Combine(path, name + ".png")));
-
-            if (tex == null)
-            {
-                Debug.LogError("Can't import custom texture " + name + ".png from " + path);
-                return null;
-            }
+            tex.LoadImage(File.ReadAllBytes(Path.Combine(path, fileName + extension)));
 
             Color32[] colours = tex.GetPixels32();
             for (int i = 0; i < colours.Length; i++)
@@ -900,10 +882,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Update UV map
+        /// Set UV Map for a planar mesh.
         /// </summary>
-        /// <param name="meshFilter">MeshFilter of GameObject</param>
-        static private void UpdateUV (MeshFilter meshFilter, float x = 0, float y = 0)
+        /// <param name="x">Offset on X axis.</param>
+        /// <param name="y">Offset on Y axis.</param>
+        private static void SetUv(MeshFilter meshFilter, float x = 0, float y = 0)
         {
             Vector2[] uv = new Vector2[4];
             uv[0] = new Vector2(x, 1 - y);
@@ -914,18 +897,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Check all frames available on disk.
+        /// Get number of frames available on disk for a record.
         /// </summary>
         /// <param name="archive">Archive index.</param>
         /// <param name="record">Record index.</param>
-        /// <returns>Number of textures present on disk for this record</returns>
-        static private int NumberOfAvailableFrames(int archive, int record)
+        private static int NumberOfAvailableFrames(int archive, int record)
         {
             int frames = 0;
             while (CustomTextureExist(archive, record, frames))
-            {
                 frames++;
-            }
             return frames;
         }
 

--- a/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
+++ b/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
@@ -1,5 +1,5 @@
-﻿// Project:         Daggerfall Tools For Unity
-// Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2017 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
@@ -9,6 +9,7 @@
 // Notes:
 //
 
+using System.Globalization;
 using System.IO;
 using System.Xml.Linq;
 using UnityEngine;
@@ -18,334 +19,129 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     /// <summary>
     /// Read XML files from disk for modding purposes
     /// </summary>
-    static public class XMLManager
+    public class XMLManager
     {
-        #region Constants
+        #region Fields
 
-        // Files extension
         const string extension = ".xml";
-
-        // Keys
-        const string widthKey = "width";
-        const string heightKey = "height";
-        const string scaleXKey = "scaleX";
-        const string scaleYKey = "scaleY";
-        const string UvXKey = "uvX";
-        const string UvYKey = "uvY";
+        readonly XElement xml;
 
         #endregion
 
         #region Public Methods
 
-        /// <summary>
-        /// Search for xml file for specified texture.
-        /// </summary>
-        static public bool XmlFileExist(int archive, int record, int frame = 0)
+        public XMLManager(string path)
         {
-            return XmlFileExist(TextureReplacement.GetName(archive, record, frame), TextureReplacement.TexturesPath);
+            if (!path.EndsWith(extension))
+                path += extension;
+
+            this.xml = XElement.Load(path);
         }
 
-        /// <summary>
-        /// Search for xml file.
-        /// </summary>
-        /// <param name="fileName">Name of file without extension.</param>
-        /// <param name="path">Path.</param>
-        /// <returns></returns>
-        static public bool XmlFileExist(string fileName, string path)
+        public bool TryGetString(string key, out string value)
         {
-            path = Path.Combine(path, fileName);
-            return File.Exists(path + extension);
-        }
-
-        /// <summary>
-        /// Get a generic element from xml.
-        /// Return null if is not found.
-        /// </summary>
-        static public XElement GetElement(string fileName, string key, string path)
-        {
-            // Get XML file
-            XElement xml = GetXmlFile(fileName, path);
-            if (xml == null)
-                return null;
-
-            // Get Element 
-            return xml.Element(key);
-        }
-
-
-        /// <summary>
-        /// Get a float value from xml.
-        /// </summary>
-        /// <param name="defaultValue">Fallback value.</param>
-        /// <returns>Float from xml or fallback.</returns>
-        static public float GetFloat(string fileName, string key, string path, float defaultValue = 0)
-        {
-            var element = GetElement(fileName, key, path);
-            if (element != null)
-                return (float)element;
-            else
-                return defaultValue;
-        }
-
-        /// <summary>
-        /// Try to get a float value from xml.
-        /// </summary>
-        /// <returns>True if key is found.</returns>
-        static public bool TryGetFloat(string fileName, string key, out float value, string path)
-        {
-            var element = GetElement(fileName, key, path);
-            if (element != null)
-            {
-                value = (float)element;
-                return true;
-            }
-            else
-            {
-                value = 0;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Get a string from xml.
-        /// </summary>
-        /// <param name="defaultString">Fallback string.</param>
-        /// <returns>String from xml or fallback.</returns>
-        static public string GetString(string fileName, string key, string path, string defaultString = "")
-        {
-            var element = GetElement(fileName, key, path);
-            if (element != null)
-                return (string)element;
-            else
-                return defaultString;
-        }
-
-        /// <summary>
-        /// Try to get a string from xml.
-        /// </summary>
-        /// <returns>True if key is found.</returns>
-        static public bool TryGetString(string fileName, string key, out string value, string path)
-        {
-            var element = GetElement(fileName, key, path);
-            if (element != null)
+            XElement element;
+            if (TryGetElement(key, out element))
             {
                 value = (string)element;
                 return true;
             }
-            else
-            {
-                value = "";
-                return false;
-            }
+
+            value = null;
+            return false;
         }
 
-        /// <summary>
-        /// Create a new color from rgba value on xml file.
-        /// Default color will be used if xml file contains invalid data.
-        /// Alpha channel is set to A value from default color if omitted.
-        /// </summary>
-        /// <param name="fileName">Name of file.</param>
-        /// <param name="path">Path.</param>
-        /// <param name="defaultColor">Fallback color.</param>
-        /// <returns>Color from xml or fallback.</returns>
-        static public Color GetColor(string fileName, string path, Color defaultColor)
+        public bool TryGetFloat(string key, out float value)
         {
-            return (GetColor(fileName, path, defaultColor.r, defaultColor.g, defaultColor.b, defaultColor.a));
+            XElement element;
+            if (TryGetElement(key, out element))
+                return float.TryParse((string)element, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+
+            value = -1;
+            return false;
         }
 
-        /// <summary>
-        /// Create a new color from rgba value on xml file.
-        /// Alpha channel is set to full opacity if omitted.
-        /// Black color is used as fallback if xml file contains invalid data
-        /// </summary>
-        /// <param name="fileName">Name of file.</param>
-        /// <param name="path">Path.</param>
-        /// <returns>Color from xml or fallback.</returns>
-        static public Color GetColor(string fileName, string path, float R = 0, float G = 0, float B = 0, float A = 1)
+        public bool TryGetVector2(string keyX, string keyY, out Vector2 vector)
         {
-            // Fields
-            var defaultColor = new Color(R, G, B, A);
-            XElement r, g, b, a;
-            float alpha;
-            
-            // Get XML file
-            XElement xml = GetXmlFile(fileName, path);
-            if (xml == null)
-                return defaultColor;
-
-            // Alpha channel
-            a = xml.Element("a");
-            if (a != null)
-                alpha = (float)a;
-            else
-                alpha = defaultColor.a;
-
-            // Colors
-            r = xml.Element("r");
-            if (r != null)
-            {
-                g = xml.Element("g");
-                if (g != null)
-                {
-                    b = xml.Element("b");
-                    if (g != null)
-                        return new Color((float)r, (float)g, (float)b, alpha);
-                }
-            }
-
-            Debug.LogError("Failed to read color from " + Path.Combine(path, fileName + extension));
-            return defaultColor;
+            vector = new Vector2();
+            return TryGetFloat(keyX, out vector.x) && TryGetFloat(keyY, out vector.y);
         }
 
-        /// <summary>
-        /// Get (x,y,z) Vector3 from Xml file for a 2D scale,
-        /// setting a fallback scale.
-        /// </summary>
-        /// <param name="fileName"></param>
-        /// <param name="path"></param>
-        /// <param name="defaultScale"></param>
-        /// <returns></returns>
-        static public Vector3 GetScale(string fileName, string path, Vector3 defaultScale)
+        public Vector2 GetVector2(string keyX, string keyY, Vector2 baseVector)
         {
-            Vector3 scale = GetScale(fileName, path, defaultScale.x, defaultScale.y);
-            scale.z = defaultScale.z;
-            return scale;
-        }
-
-        /// <summary>
-        /// Get (x,y) scale from Xml file,
-        /// setting a fallback scale.
-        /// </summary>
-        /// <param name="fileName">Name of file.</param>
-        /// <param name="path">Path.</param>
-        /// <param name="defaultScale">Fallback scale.</param>
-        /// <returns>Scale from xml or fallback.</returns>
-        static public Vector2 GetScale(string fileName, string path, Vector2 defaultScale)
-        {
-            return GetScale(fileName, path, defaultScale.x, defaultScale.y);
-        }
-
-        /// <summary>
-        /// Get (x,y) scale from Xml file.
-        /// </summary>
-        /// <param name="fileName">Name of file.</param>
-        /// <param name="path">Path.</param>
-        /// <returns>Scale from xml or fallback.</returns>
-        static public Vector2 GetScale (string fileName, string path, float defaultX = 1, float defaultY = 1)
-        {
-            // Fields
-            XElement X, Y;
             float x, y;
 
-            // Get XML file
-            XElement xml = GetXmlFile(fileName, path);
-            if (xml == null)
-                return new Vector2(defaultX, defaultY);
-
-            // Get X
-            X = xml.Element(scaleXKey);
-            if (X != null)
-                x = (float)X;
-            else
-                x = defaultX;
-
-            // Get Y
-            Y = xml.Element(scaleYKey);
-            if (Y != null)
-                y = (float)Y;
-            else
-                y = defaultY;
-
-            return new Vector2(x, y);
+            return new Vector2(
+                TryGetFloat(keyX, out x) ? x : baseVector.x,
+                TryGetFloat(keyY, out y) ? y : baseVector.y
+                );
         }
 
-        /// <summary>
-        /// Get Uv from Xml file.
-        /// </summary>
-        /// <param name="fileName">Name of file.</param>
-        /// <param name="path">Path.</param>
-        /// <returns>Uv from xml or fallback.</returns>
-        static public Vector2 GetUv(string fileName, string path, float defaultX = 0, float defaultY = 0)
+        public Vector3 GetVector3(string keyX, string keyY, Vector3 baseVector)
         {
-            // Fields
-            XElement X, Y;
             float x, y;
 
-            // Get XML file
-            XElement xml = GetXmlFile(fileName, path);
-            if (xml == null)
-                return new Vector2(defaultX, defaultY);
-
-            // Get X
-            X = xml.Element(UvXKey);
-            if (X != null)
-                x = (float)X;
-            else
-                x = defaultX;
-
-            // Get Y
-            Y = xml.Element(UvYKey);
-            if (Y != null)
-                y = (float)Y;
-            else
-                y = defaultY;
-
-            return new Vector2(x, y);
+            return new Vector3(
+                TryGetFloat(keyX, out x) ? x : baseVector.x,
+                TryGetFloat(keyY, out y) ? y : baseVector.y,
+                baseVector.z
+                );
         }
 
-        /// <summary>
-        /// Get size from xml file for specified image.
-        /// </summary>
-        /// <returns>Size from xml or from original imagedata.</returns>
-        static public Vector2 GetSize(string fileName, string path, float additionalScaleX = 1, float additionaScaleY = 1)
+        public bool TryGetColor(out Color color)
         {
-            // Get size from xml
-            path = Path.Combine(path, fileName) + extension;
-            if (File.Exists(path))
+            color = new Color();
+            return TryGetFloat("r", out color.r) && TryGetFloat("g", out color.g)
+                && TryGetFloat("b", out color.b) && TryGetFloat("a", out color.a);
+        }
+
+        public bool TryGetColor(float defaultAlpha, out Color color)
+        {
+            color = new Color();
+
+            if (TryGetFloat("r", out color.r) && TryGetFloat("g", out color.g)
+                && TryGetFloat("b", out color.b))
             {
-                XElement xml = XElement.Load(path);
-                if (xml != null)
-                {
-                    XElement width = xml.Element(widthKey);
-                    if (width != null)
-                    {
-                        XElement height = xml.Element(heightKey);
-                        if (height != null)
-                            return new Vector2((float)width * additionalScaleX, (float)height * additionaScaleY);
-                    }
-                }
+                if (!TryGetFloat("a", out color.a))
+                    color.a = defaultAlpha;
+
+                return true;
             }
 
-            // Fallback: get size from imagedata
-            ImageData imageData = ImageReader.GetImageData(fileName, createTexture: false);
-            return new Vector2(imageData.width * additionalScaleX, imageData.height * additionaScaleY);
+            return false;
+        }
+
+        public Color GetColor(Color baseColor)
+        {
+            float r, g, b, a;
+
+            return new Color(
+                TryGetFloat("r", out r) ? r : baseColor.r,
+                TryGetFloat("g", out g) ? g : baseColor.g,
+                TryGetFloat("b", out b) ? b : baseColor.b,
+                TryGetFloat("a", out a) ? a : baseColor.a
+                );
         }
 
         #endregion
 
         #region Private Methods
 
-        /// <summary>
-        /// Get XML file.
-        /// </summary>
-        /// <param name="fileName">Name of file.</param>
-        /// <param name="path">Path.</param>
-        /// <returns>File as XElement.</returns>
-        static private XElement GetXmlFile(string fileName, string path)
+        private bool TryGetElement(string key, out XElement value)
         {
-            // Get path
-            path = Path.Combine(path, fileName) + extension;
+            return (value = xml.Element(key)) != null;
+        }
 
-            // Get XML file
-            if (File.Exists(path))
-            {
-                return XElement.Load(path);
-            }
-            else
-            {
-                Debug.LogError(path + " is missing");
-                return null;
-            }
+        #endregion
+
+        #region Static Methods
+
+        public static bool XmlFileExists(string path)
+        {
+            if (!path.EndsWith(extension))
+                path += extension;
+
+            return File.Exists(path);
         }
 
         #endregion

--- a/Assets/Scripts/Utility/TextureReader.cs
+++ b/Assets/Scripts/Utility/TextureReader.cs
@@ -252,7 +252,6 @@ namespace DaggerfallWorkshop.Utility
                 // Always import emission if present on disk
                 emissionMap = TextureReplacement.LoadCustomEmission(settings.archive, settings.record, settings.frame);
                 resultEmissive = true;
-                isWindow = false;
             }
             else
             {


### PR DESCRIPTION
* I simplified XmlManager as it was getting out of hand. Now TextureReplacement has all the methods that deals with size of UI images, which i refactored in the process.
There are a few lines which only differs for a method name, sorry for that.
* MipMaps is enabled for .XXX textures and disabled for img, cif and rci. Is this ok or there is something more specific i should consider?
* Size of MiscFlats atlas is 4096 instead of 2048 when asset import is enabled.
* Minor cleanup and optimization.
* Allow imported emission map to be tinted with window color.