### PR TITLE
Implement backstabbing and rewrite damage formula

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -187,7 +187,7 @@ namespace DaggerfallWorkshop.Game
             EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
 
             // Calculate damage
-            damage = Game.Formulas.FormulaHelper.CalculateWeaponDamage(entity, GameManager.Instance.PlayerEntity, null);
+            damage = Formulas.FormulaHelper.CalculateAttackDamage(entity, GameManager.Instance.PlayerEntity, (int)(Items.EquipSlots.RightHand), -1);
 
             // Tally player's dodging skill
             GameManager.Instance.PlayerEntity.TallySkill(DFCareer.Skills.Dodging, 1);

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -88,6 +88,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string theNamedResidence = "The %s Residence";
 
         public const string materialIneffective = "The material of the weapon you are using is ineffective.";
+        public const string successfulBackstab = "Successful backstab!";
 
         public const string lockpickingSuccess = "The lock clicks open.";
         public const string lockpickingFailure = "It does not unlock.";

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -655,6 +655,7 @@ namespace DaggerfallWorkshop.Game
 
                 // Check if hit an entity and remove health
                 DaggerfallEntityBehaviour entityBehaviour = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
+                DaggerfallMobileUnit entityMobileUnit = hit.transform.GetComponentInChildren<DaggerfallMobileUnit>();
                 if (entityBehaviour)
                 {
                     if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
@@ -662,7 +663,11 @@ namespace DaggerfallWorkshop.Game
                         EnemyEntity enemyEntity = entityBehaviour.Entity as EnemyEntity;
 
                         // Calculate damage
-                        int damage = FormulaHelper.CalculateWeaponDamage(playerEntity, enemyEntity, weapon);
+                        int damage;
+                        if (usingRightHand)
+                            damage = FormulaHelper.CalculateAttackDamage(playerEntity, enemyEntity, (int)(EquipSlots.RightHand), entityMobileUnit.Summary.AnimStateRecord);
+                        else
+                            damage = FormulaHelper.CalculateAttackDamage(playerEntity, enemyEntity, (int)(EquipSlots.LeftHand), entityMobileUnit.Summary.AnimStateRecord);
 
                         EnemyMotor enemyMotor = hit.transform.GetComponent<EnemyMotor>();
                         EnemySounds enemySounds = hit.transform.GetComponent<EnemySounds>();

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -80,6 +80,7 @@ namespace DaggerfallWorkshop
             public MobileAnimation[] StateAnims;                // Animation frames for this state
             public TextureReplacement.CustomEnemyMaterial 
                 CustomMaterial;                                 // Custom material
+            public int AnimStateRecord;                         // Record number of animation state
         }
 
         void Start()
@@ -303,6 +304,7 @@ namespace DaggerfallWorkshop
             
             // Get enemy size and scale for this state
             int record = summary.StateAnims[orientation].Record;
+            summary.AnimStateRecord = record;
             Vector2 size = summary.RecordSizes[record];
 
             // Ensure walking enemies keep their feet aligned between states


### PR DESCRIPTION
This implements backstabbing in the same manner as classic and also has a rewrite of the damage calculation function, including adding a part of the formula I had missed regarding the hit chances for enemies. This actually depends on the reflexes setting but this PR matches the default reflexes setting.