### PR TITLE
Modsettings: Minor tweaks

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModSettings/Editor/ModSettingsConfigurationEditor.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/Editor/ModSettingsConfigurationEditor.cs
@@ -33,6 +33,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         int selectionGridSelected = 0;
         int parseFormat = 0;
 
+        ReorderableList presets;
+        bool presetsListExpanded;
+
         ReorderableList sections;
         Dictionary<int, bool> sectionExpanded = new Dictionary<int, bool>();
         int currentSection;
@@ -112,7 +115,17 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
                 EditorGUILayout.PropertyField(_presetSettings, new GUIContent("Info"), true);
             }
             else
-                EditorGUILayout.PropertyField(_presets, true);
+            {
+                if (presets == null)
+                {
+                    presets = new ReorderableList(serializedObject, _presets, true, true, true, true);
+                    presets.drawHeaderCallback = Presets_DrawHeaderCallback;
+                    presets.drawElementCallback = Presets_DrawElementCallback;
+                }
+                EditorGUI.indentLevel++;
+                presets.DoLayoutList();
+                EditorGUI.indentLevel--;
+            }
 
             EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
 
@@ -196,6 +209,18 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         #endregion
 
         #region Callbacks
+
+        private void Presets_DrawHeaderCallback(Rect rect)
+        {
+            presetsListExpanded = EditorGUI.Foldout(LineRect(rect), presetsListExpanded, "Preset Names");
+            presets.elementHeight = presetsListExpanded ? lineHeight : 0;
+        }
+
+        private void Presets_DrawElementCallback(Rect rect, int index, bool isActive, bool isFocused)
+        {
+            if (presetsListExpanded)
+                EditorGUI.PropertyField(LineRect(rect), _presets.GetArrayElementAtIndex(index), GUIContent.none, false);
+        }
 
         private void Sections_DrawHeaderCallback(Rect rect)
         {

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettings.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettings.cs
@@ -10,6 +10,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using UnityEngine;
@@ -24,9 +25,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
     public class ModSettings
     {
         // Fields
-        Mod Mod;
+        Mod mod;
         IniData userSettings;
-        IniData defaultSettings;
+        ModSettingsConfiguration config;
 
         #region Public Methods
 
@@ -36,37 +37,60 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         /// <param name="mod">Mod to load settings for.</param>
         public ModSettings(Mod mod)
         {
-            Mod = mod;
+            if (!mod.HasSettings)
+                throw new ArgumentException(string.Format("{0} has no settings.", mod.Title), "mod");
 
-            ModSettingsReader.GetSettings(mod, out userSettings, out defaultSettings);
+            this.mod = mod;
+            ModSettingsReader.GetSettings(mod, out userSettings, out config);
         }
 
         /// <summary>
         /// Get string from user settings or, as fallback, from default settings.
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
-        public string GetString (string section, string name)
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
+        public string GetString(string section, string name)
         {
-            return GetValue(section, name);
+            string text = GetValue(section, name);
+            if (text != null)
+                return text;
+
+            ModSettingsKey key;
+            if (config.Key(section, name, ModSettingsKey.KeyType.Text, out key))
+                return key.text.text;
+
+            throw NewMissingKeyException(section, name);
         }
 
         /// <summary>
         /// Get integer from user settings or, as fallback, from default settings.
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
         public int GetInt(string section, string name)
         {
-            return int.Parse(GetValue(section, name));
+            int value;
+            if (int.TryParse(GetValue(section, name), out value))
+                return value;
+
+            ModSettingsKey key;
+            if (config.Key(section, name, out key))
+            {
+                if (key.type == ModSettingsKey.KeyType.Slider)
+                    return key.slider.value;
+                if (key.type == ModSettingsKey.KeyType.MultipleChoice)
+                    return key.multipleChoice.selected;
+            }
+
+            throw NewMissingKeyException(section, name);
         }
 
         /// <summary>
         /// Get integer from user settings or, as fallback, from default settings.
         /// Value is at least equal to min.
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
         /// <param name="min">Minimum accepted value.</param>
         public int GetInt(string section, string name, int min)
         {
@@ -77,8 +101,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         /// Get integer from user settings or, as fallback, from default settings.
         /// Value is clamped in range (min-max).
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
         /// <param name="min">Minimum accepted value.</param>
         /// <param name="max">Maximum accepted value.</param>
         public int GetInt(string section, string name, int min, int max)
@@ -89,19 +113,27 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         /// <summary>
         /// Get float from user settings or, as fallback, from default settings.
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
         public float GetFloat(string section, string name)
         {
-            return float.Parse(GetValue(section, name), NumberStyles.Float, CultureInfo.InvariantCulture);
+            float value;
+            if (float.TryParse(GetValue(section, name), NumberStyles.Float, CultureInfo.InvariantCulture, out value))
+                return value;
+
+            ModSettingsKey key;
+            if (config.Key(section, name, ModSettingsKey.KeyType.FloatSlider, out key))
+                return key.floatSlider.value;
+
+            throw NewMissingKeyException(section, name);
         }
 
         /// <summary>
         /// Get float from user settings or, as fallback, from default settings.
         /// Value is at least equal to min.
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
         /// <param name="min">Minimum accepted value.</param>
         public float GetFloat(string section, string name, float min)
         {
@@ -112,8 +144,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         /// Get float from user settings or, as fallback, from default settings.
         /// Value is clamped in range (min-max).
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
         /// <param name="min">Minimum accepted value.</param>
         /// <param name="max">Maximum accepted value.</param>
         public float GetFloat(string section, string name, float min, float max)
@@ -124,93 +156,75 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         /// <summary>
         /// Get bool from user settings or, as fallback, from default settings.
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
         public bool GetBool(string section, string name)
         {
-            return bool.Parse(GetValue(section, name));
+            bool value;
+            if (bool.TryParse(GetValue(section, name), out value))
+                return value;
+
+            ModSettingsKey key;
+            if (config.Key(section, name, ModSettingsKey.KeyType.Toggle, out key))
+                return key.toggle.value;
+
+            throw NewMissingKeyException(section, name);
         }
 
         /// <summary>
         /// Get color from user settings or, as fallback, from default settings.
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
         public Color GetColor(string section, string name)
         {
-            string colorString = GetValue(section, name);
-            int hexColor = 0;
-            if (int.TryParse(colorString, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out hexColor))
-                return ModSettingsReader.ColorFromString(colorString);
+            Color color;
+            if (ColorUtility.TryParseHtmlString("#" + GetValue(section, name), out color))
+                return color;
 
-            Debug.LogError(colorString + " from " + Mod.FileName + ".ini is not a valid color. Using default color.");
-            return ModSettingsReader.ColorFromString(defaultSettings[section][name]);
+            ModSettingsKey key;
+            if (config.Key(section, name, ModSettingsKey.KeyType.Color, out key))
+                return key.color.color;
+
+            throw NewMissingKeyException(section, name);
         }
 
         /// <summary>
         /// Get Tuple from user settings or, as fallback, from default settings.
-        /// Format: {First}{delimiter}{Second}
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
-        /// <param name="delimiter">Char between First and Second.</param>
-        public Tuple<string, string> GetTupleString (string section, string name, string delimiter = ModSettingsReader.tupleDelimiterChar)
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
+        public Tuple<int, int> GetTupleInt(string section, string name)
         {
-            try
-            {
-                string text = GetString(section, name);
-                int index = text.IndexOf(delimiter);
-                return new Tuple<string, string>(text.Substring(0, index), text.Substring(index + delimiter.Length));
-            }
-            catch (Exception e)
-            {
-                Debug.LogError(string.Format("Failed to get {0},{1} from {2} settings!\n{2}", section, name, Mod.Title, e.Message));
-                return new Tuple<string, string>("", "");
-            }
+            int first, second;
+            var tuple = GetTuple(section, name);
+            if (int.TryParse(tuple.First, out first) && int.TryParse(tuple.Second, out second))
+                return new Tuple<int, int>(first, second);
+
+            ModSettingsKey key;
+            if (config.Key(section, name, ModSettingsKey.KeyType.Tuple, out key))
+                return new Tuple<int, int>(key.tuple.first, key.tuple.second);
+
+            throw NewMissingKeyException(section, name);
         }
 
         /// <summary>
         /// Get Tuple from user settings or, as fallback, from default settings.
-        /// Format: {First}{delimiter}{Second}
         /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
-        /// <param name="delimiter">Char between First and Second.</param>
-        public Tuple<int, int> GetTupleInt(string section, string name, string delimiter = ModSettingsReader.tupleDelimiterChar)
+        /// <param name="section">Name of section.</param>
+        /// <param name="name">Name of key.</param>
+        public Tuple<float, float> GetTupleFloat(string section, string name)
         {
-            try
-            {
-                var tuple = GetTupleString(section, name, delimiter);
-                return new Tuple<int, int>(int.Parse(tuple.First), int.Parse(tuple.Second));
-            }
-            catch (Exception e)
-            {
-                Debug.LogError(string.Format("Failed to get {0},{1} from {2} settings!\n{2}", section, name, Mod.Title, e.Message));
-                return new Tuple<int, int>(0, 0);
-            }
-        }
-
-        /// <summary>
-        /// Get Tuple from user settings or, as fallback, from default settings.
-        /// Format: {First}{delimiter}{Second}
-        /// </summary>
-        /// <param name="section">Name of section inside .ini</param>
-        /// <param name="name">Name of key inside .ini</param>
-        /// <param name="delimiter">Char between First and Second.</param>
-        public Tuple<float, float> GetTupleFloat(string section, string name, string delimiter = ModSettingsReader.tupleDelimiterChar)
-        {
-            try
-            {
-                var tuple = GetTupleString(section, name, delimiter);
-                float first = float.Parse(tuple.First, NumberStyles.Float, CultureInfo.InvariantCulture);
-                float second = float.Parse(tuple.Second, NumberStyles.Float, CultureInfo.InvariantCulture);
+            float first, second;
+            var tuple = GetTuple(section, name);
+            if (float.TryParse(tuple.First, out first) && float.TryParse(tuple.Second, out second))
                 return new Tuple<float, float>(first, second);
-            }
-            catch (Exception e)
-            {
-                Debug.LogError(string.Format("Failed to get {0},{1} from {2} settings!\n{2}", section, name, Mod.Title, e.Message));
-                return new Tuple<float, float>(0, 0);
-            }
+
+            ModSettingsKey key;
+            if (config.Key(section, name, ModSettingsKey.KeyType.FloatTuple, out key))
+                return new Tuple<float, float>(key.tuple.first, key.tuple.second);
+
+            throw NewMissingKeyException(section, name);
         }
 
         /// <summary>
@@ -223,7 +237,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         {
             if (!userSettings.Sections.ContainsSection(section))
             {
-                Debug.LogErrorFormat("Failed to parse section {0} for mod {1}", section, Mod.Title);
+                Debug.LogErrorFormat("Failed to parse section {0} for mod {1}", section, mod.Title);
                 return;
             }
 
@@ -241,7 +255,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
                 }
                 catch (Exception e)
                 {
-                    Debug.LogErrorFormat("Failed to parse section {0} for mod {1}\n{2}", section, Mod.Title, e.ToString());
+                    Debug.LogErrorFormat("Failed to parse section {0} for mod {1}\n{2}", section, mod.Title, e.ToString());
                 }
             }
         }
@@ -251,29 +265,20 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         #region Private Methods
 
         /// <summary>
-        /// Get value from user settings or, as fallback, 
-        /// from default settings.
+        /// Get value from user settings.
         /// </summary>
         private string GetValue(string section, string name)
         {
-            try
+            KeyDataCollection keyDataCollection = userSettings[section];
+            if (keyDataCollection != null)
             {
-                return userSettings[section][name];
+                string key = keyDataCollection[name];
+                if (key != null)
+                    return key;
             }
-            catch
-            {
-                Debug.LogErrorFormat("Failed to get ({0},{1}) for mod {2}. Using default value.", section, name, Mod.Title);
 
-                try
-                {
-                    return defaultSettings[section][name];
-                }
-                catch
-                {
-                    Debug.LogErrorFormat("Failed to get ({0},{1}) from default settings of mod {2}.", section, name, Mod.Title);
-                    return null;
-                }
-            }
+            Debug.LogErrorFormat("Failed to get ({0},{1}) for mod {2}.", section, name, mod.Title);
+            return null;
         }
 
         /// <summary>
@@ -297,6 +302,25 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
                 return GetColor(section, name);
 
             return null;
+        }
+
+        private Tuple<string, string> GetTuple(string section, string name)
+        {
+            try
+            {
+                string text = GetValue(section, name);
+                int index = text.IndexOf(ModSettingsReader.tupleDelimiterChar);
+                return new Tuple<string, string>(text.Substring(0, index), text.Substring(index + ModSettingsReader.tupleDelimiterChar.Length));
+            }
+            catch { return new Tuple<string, string>(string.Empty, string.Empty); }
+        }
+
+        /// <summary>
+        /// Helper that create and return a new KeyNotFoundException exception with a message.
+        /// </summary>
+        private Exception NewMissingKeyException(string section, string name)
+        {
+            return new KeyNotFoundException(string.Format("The key ({0},{1}) was not present in {2} settings.", section, name, mod.Title));
         }
 
         #endregion

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsConfiguration.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsConfiguration.cs
@@ -58,6 +58,25 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
 
 #endif
 
+        /// <summary>
+        /// Get all sections shown on GUI.
+        /// </summary>
+        public IEnumerable<Section> VisibleSections
+        {
+            get { return sections.Where(x => x.name != ModSettingsReader.internalSection); }
+        }
+
+        /// <summary>
+        /// Get section hidden from GUI. Can be null.
+        /// </summary>
+        public Section HiddenSection
+        {
+            get { return sections.FirstOrDefault(x => x.name == ModSettingsReader.internalSection); }
+        }
+
+        /// <summary>
+        /// Get a section with the given name.
+        /// </summary>
         public Section this[string sectionName]
         {
             get { return sections.FirstOrDefault(x => x.name == sectionName); }
@@ -84,25 +103,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             return false;
         }
 
-        public KeyType GetKeyType(string sectionName, string keyName)
+        public bool Key(string sectionName, string keyName, KeyType keyType, out ModSettingsKey keyOut)
         {
-            ModSettingsKey key;
-            if (Key(sectionName, keyName, out key))
-                return key.type;
-
-            return (KeyType)(-1);
-        }
-
-        public bool IsSlider(string sectionName, string keyName)
-        {
-            KeyType type = GetKeyType(sectionName, keyName);
-            return type == KeyType.Slider || type == KeyType.FloatSlider;
-        }
-
-        public bool IsTuple(string sectionName, string keyName)
-        {
-            KeyType type = GetKeyType(sectionName, keyName);
-            return type == KeyType.Tuple || type == KeyType.FloatTuple;
+            return Key(sectionName, keyName, out keyOut) && keyOut.type == keyType;
         }
 
         #endregion

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsConfiguration.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsConfiguration.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 using FullSerializer;
+using IniParser;
 using KeyType = DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.ModSettingsKey.KeyType;
 
 namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
@@ -200,6 +201,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         {
             if (!Serialize(this))
                 Debug.LogError("Failed to export mod settings");
+        }
+
+        public void ImportFromIni()
+        {
+            ModSettingsReader.ParseIniToConfig((new FileIniDataParser()).ReadFile(ParsedIniPath), this);
         }
 
         public void ExportToIni()

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsConfiguration.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsConfiguration.cs
@@ -21,19 +21,10 @@ using KeyType = DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.ModSettin
 namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
 {
     [CreateAssetMenu(fileName = "modsettings", menuName = "Mods/Settings", order = 0)]
+    [HelpURL("http://www.dfworkshop.net/projects/daggerfall-unity/modding/")]
     public class ModSettingsConfiguration : ScriptableObject
     {
-        #region Fields & Properties
-
-        static string SerializedFile
-        {
-            get { return Path.Combine(Path.Combine(Application.dataPath, "Untracked"), "modsettings.json"); }
-        }
-
-        static string ParsedIniPath
-        {
-            get { return Path.Combine(Path.Combine(Application.dataPath, "Untracked"), "modsettings.ini"); }
-        }
+        #region Fields
 
         [Tooltip("Version of settings config file. This is not the version of mod or preset.")]
         public string version = "1.0";
@@ -48,6 +39,24 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         public string[] presets;
 
         public Section[] sections = new Section[1];
+
+        #endregion
+
+        #region Properties
+
+#if UNITY_EDITOR
+
+        static string JsonPath
+        {
+            get { return Path.Combine(Path.Combine(Application.dataPath, "Untracked"), "modsettings.json"); }
+        }
+
+        static string IniPath
+        {
+            get { return Path.Combine(Path.Combine(Application.dataPath, "Untracked"), "modsettings.ini"); }
+        }
+
+#endif
 
         public Section this[string sectionName]
         {
@@ -205,20 +214,20 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
 
         public void ImportFromIni()
         {
-            ModSettingsReader.ParseIniToConfig((new FileIniDataParser()).ReadFile(ParsedIniPath), this);
+            ModSettingsReader.ParseIniToConfig((new FileIniDataParser()).ReadFile(IniPath), this);
         }
 
         public void ExportToIni()
         {
-            File.WriteAllText(ParsedIniPath, ModSettingsReader.ParseConfigToIni(this).ToString());
+            File.WriteAllText(IniPath, ModSettingsReader.ParseConfigToIni(this).ToString());
         }
 
         private static bool Deserialize(ModSettingsConfiguration config)
         {
             fsSerializer fsSerializer = new fsSerializer();
-            if (File.Exists(SerializedFile))
+            if (File.Exists(JsonPath))
             {
-                string serializedData = File.ReadAllText(SerializedFile);
+                string serializedData = File.ReadAllText(JsonPath);
                 fsData data = fsJsonParser.Parse(serializedData);
                 return fsSerializer.TryDeserialize(data, ref config).Succeeded;
             }
@@ -232,7 +241,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             fsData data;
             if (fsSerializer.TrySerialize(typeof(fsSerializer), config, out data).Succeeded)
             {
-                File.WriteAllText(SerializedFile, fsJsonPrinter.PrettyJson(data));
+                File.WriteAllText(JsonPath, fsJsonPrinter.PrettyJson(data));
                 return true;
             }
 

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsKey.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsKey.cs
@@ -88,6 +88,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             public string HexColor
             {
                 get { return ColorUtility.ToHtmlStringRGBA(color); }
+                set
+                {
+                    Color color;
+                    if (ColorUtility.TryParseHtmlString("#" + value, out color))
+                        this.color = color;
+                }
             }
 
             public Color32 color;

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsReader.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsReader.cs
@@ -9,9 +9,11 @@
 // Notes:
 //
 
-using System.IO;
-using System.Globalization;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
 using UnityEngine;
 using IniParser;
 using IniParser.Model;
@@ -441,6 +443,15 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             byte a = byte.Parse(colorStr.Substring(6, 2), NumberStyles.HexNumber);
 
             return new Color32(r, g, b, a);
+        }
+
+        /// <summary>
+        /// Make a displayable name for a key or section.
+        /// </summary>
+        public static string FormattedName(string name)
+        {
+            return string.Concat((name.First().ToString().ToUpper() + name.Substring(1))
+                .Select(x => Char.IsUpper(x) ? " " + x : x.ToString()).ToArray()).TrimStart(' ');
         }
 
         #endregion

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsReader.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsReader.cs
@@ -352,7 +352,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         public static ModSettingsConfiguration ParseIniToConfig(IniData iniData)
         {
             var config = ScriptableObject.CreateInstance(typeof(ModSettingsConfiguration)) as ModSettingsConfiguration;
+            ParseIniToConfig(iniData, config);
+            return config;
+        }
 
+        public static void ParseIniToConfig(IniData iniData, ModSettingsConfiguration config)
+        {
             var configSections = new List<ModSettingsConfiguration.Section>();
             foreach (SectionData section in iniData.Sections)
             {
@@ -406,8 +411,6 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
                 configSections.Add(configSection);
             }
             config.sections = configSections.ToArray();
-
-            return config;
         }
 
         public static bool IsHexColor(string stringColor)

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
@@ -396,7 +396,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             currentPanel.Components.Add(background);
 
             TextLabel textLabel = new TextLabel(DaggerfallUI.Instance.Font5);
-            textLabel.Text = FormattedName(title);
+            textLabel.Text = ModSettingsReader.FormattedName(title);
             textLabel.TextColor = sectionTitleColor;
             textLabel.ShadowColor = sectionTitleShadow;
             textLabel.TextScale = 0.9f;
@@ -408,22 +408,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         private TextLabel AddKeyName(string name)
         {
             TextLabel textLabel = new TextLabel();
-            textLabel.Text = FormattedName(name);
+            textLabel.Text = ModSettingsReader.FormattedName(name);
             textLabel.ShadowColor = Color.clear;
             textLabel.TextScale = textScale;
             textLabel.Position = new Vector2(x, y);
             textLabel.HorizontalAlignment = HorizontalAlignment.None;
             currentPanel.Components.Add(textLabel);
             return textLabel;
-        }
-
-        /// <summary>
-        /// Add a space before uppercase chars.
-        /// </summary>
-        private string FormattedName(string name)
-        {
-            var chars = name.Select(x => Char.IsUpper(x) ? " " + x : x.ToString());
-            return string.Concat(chars.ToArray()).TrimStart(' ');
         }
 
         /// <summary>

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
@@ -64,7 +64,6 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         readonly Mod mod;
 
         IniData data;
-        IniData defaultSettings;
         ModSettingsConfiguration config;
         List<IniData> presets = new List<IniData>();
 
@@ -92,8 +91,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         protected override void Setup()
         {
             // Get settings
-            ModSettingsReader.GetSettings(mod, out data, out defaultSettings);
-            config = ModSettingsReader.GetConfig(mod);
+            ModSettingsReader.GetSettings(mod, out data, out config);
             presets = ModSettingsReader.GetPresets(mod);
 
             // Setup base panel
@@ -129,110 +127,86 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         /// <summary>
         /// Load settings from IniData.
         /// </summary>
-        private void LoadSettings ()
+        private void LoadSettings()
         {
-            // Read settings
-            foreach (SectionData section in data.Sections.Where(x => x.SectionName != ModSettingsReader.internalSection))
+            foreach (var section in config.sections)
             {
-                // Section title
-                AddSectionTitle(section.SectionName);
+                // Add section title to window
+                AddSectionTitle(section.name);
                 MovePosition(spacing);
-                List<string> comments = section.Comments;
-                int comment = 0;
 
-                foreach (KeyData key in section.Keys)
+                // Get section from collection
+                SectionDataCollection sectionDataCollection = data.Sections;
+                if (!sectionDataCollection.ContainsSection(section.name))
+                    sectionDataCollection.AddSection(section.name);
+                SectionData sectionData = sectionDataCollection.GetSectionData(section.name);
+
+                foreach (var key in section.keys)
                 {
-                    // Setting label
-                    TextLabel settingName = AddKeyName(key.KeyName);
+                    // Get key from collection
+                    KeyDataCollection keyDataCollection = sectionData.Keys;
+                    if (!keyDataCollection.ContainsKey(key.name))
+                        keyDataCollection.AddKey(key.name);
+                    KeyData keyData = keyDataCollection.GetKeyData(key.name);
 
-                    // Setting field
-                    ModSettingsKey configKey;
-                    if (config && config.Key(section.SectionName, key.KeyName, out configKey))
+                    // Add key to window with corrispective control
+                    TextLabel settingName = AddKeyName(key.name);
+                    settingName.ToolTip = defaultToolTip;
+                    settingName.ToolTipText = key.description;
+
+                    switch (key.type)
                     {
-                        settingName.ToolTip = defaultToolTip;
-                        settingName.ToolTipText = configKey.description;
+                        case ModSettingsKey.KeyType.Toggle:
+                            bool toggle;
+                            AddCheckBox((bool.TryParse(keyData.Value, out toggle) && toggle) || key.toggle.value);
+                            break;
 
-                        // Use config file
-                        switch (configKey.type)
-                        {
-                            case ModSettingsKey.KeyType.Toggle:
-                                bool toggle;
-                                AddCheckBox((bool.TryParse(key.Value, out toggle) && toggle) || configKey.toggle.value);
-                                break;
+                        case ModSettingsKey.KeyType.MultipleChoice:
+                            int selected;
+                            if (!int.TryParse(keyData.Value, out selected))
+                                selected = key.multipleChoice.selected;
+                            var multipleChoice = GetSlider();
+                            multipleChoice.SetIndicator(key.multipleChoice.choices, selected);
+                            SetSliderIndicator(multipleChoice);
+                            break;
 
-                            case ModSettingsKey.KeyType.MultipleChoice:
-                                int selected;
-                                if (!int.TryParse(key.Value, out selected))
-                                    selected = configKey.multipleChoice.selected;
-                                var multipleChoice = GetSlider();
-                                multipleChoice.SetIndicator(configKey.multipleChoice.choices, selected);
-                                SetSliderIndicator(multipleChoice);
-                                break;
+                        case ModSettingsKey.KeyType.Slider:
+                            var sliderKey = key.slider;
+                            int startValue;
+                            if (!int.TryParse(keyData.Value, out startValue))
+                                startValue = key.slider.value;
+                            var slider = GetSlider();
+                            slider.SetIndicator(sliderKey.min, sliderKey.max, startValue);
+                            SetSliderIndicator(slider);
+                            break;
 
-                            case ModSettingsKey.KeyType.Slider:
-                                var sliderKey = configKey.slider;
-                                int startValue;
-                                if (!int.TryParse(key.Value, out startValue))
-                                    startValue = configKey.slider.value;
-                                var slider = GetSlider();
-                                slider.SetIndicator(sliderKey.min, sliderKey.max, startValue);
-                                SetSliderIndicator(slider);
-                                break;
+                        case ModSettingsKey.KeyType.FloatSlider:
+                            var floatSliderKey = key.floatSlider;
+                            float floatStartValue;
+                            if (!float.TryParse(keyData.Value, out floatStartValue))
+                                floatStartValue = key.floatSlider.value;
+                            var floatSlider = GetSlider();
+                            floatSlider.SetIndicator(floatSliderKey.min, floatSliderKey.max, floatStartValue);
+                            SetSliderIndicator(floatSlider);
+                            break;
 
-                            case ModSettingsKey.KeyType.FloatSlider:
-                                var floatSliderKey = configKey.floatSlider;
-                                float floatStartValue;
-                                if (!float.TryParse(key.Value, out floatStartValue))
-                                    floatStartValue = configKey.floatSlider.value;
-                                var floatSlider = GetSlider();
-                                floatSlider.SetIndicator(floatSliderKey.min, floatSliderKey.max, floatStartValue);
-                                SetSliderIndicator(floatSlider);
-                                break;
+                        case ModSettingsKey.KeyType.Tuple:
+                            var tuple = AddTuple(keyData.Value);
+                            tuple.First.Numeric = tuple.Second.Numeric = true;
+                            break;
 
-                            case ModSettingsKey.KeyType.Tuple:
-                                var tuple = AddTuple(key.Value);
-                                tuple.First.Numeric = tuple.Second.Numeric = true;
-                                break;
+                        case ModSettingsKey.KeyType.FloatTuple:
+                            AddTuple(keyData.Value); // TextBox.Numeric doesn't allow dot
+                            break;
 
-                            case ModSettingsKey.KeyType.FloatTuple:
-                                AddTuple(key.Value); // TextBox.Numeric doesn't allow dot
-                                break;
-
-                            case ModSettingsKey.KeyType.Text:
-                                TextBox textBox = GetTextbox(95, 40, key.Value);
-                                modTextBoxes.Add(textBox);
-                                break;
-
-                            case ModSettingsKey.KeyType.Color:
-                                AddColorPicker(key.Value, configKey);
-                                break;
-                        }
-                    }
-                    else
-                    {
-                        // Legacy support
-                        if (comment < comments.Count)
-                        {
-                            settingName.ToolTip = defaultToolTip;
-                            settingName.ToolTipText = comments[comment];
-                            comment++;
-                        }
-
-                        if (key.Value == "True")
-                            AddCheckBox(true);
-                        else if (key.Value == "False")
-                            AddCheckBox(false);
-                        else if (key.Value.Contains(ModSettingsReader.tupleDelimiterChar))
-                            AddTuple(key.Value);
-                        else if (ModSettingsReader.IsHexColor(key.Value))
-                        {
-                            AddColorPicker(key.Value);
-                        }
-                        else
-                        {
-                            TextBox textBox = GetTextbox(95, 40, key.Value);
+                        case ModSettingsKey.KeyType.Text:
+                            TextBox textBox = GetTextbox(95, 40, keyData.Value);
                             modTextBoxes.Add(textBox);
-                        }
+                            break;
+
+                        case ModSettingsKey.KeyType.Color:
+                            AddColorPicker(keyData.Value, key);
+                            break;
                     }
 
                     MovePosition(spacing);
@@ -248,68 +222,42 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         {
             // Set new values
             int checkBox = 0, textBox = 0, tuple = 0, slider = 0, colorPicker = 0;
-            foreach (SectionData section in data.Sections.Where(x => x.SectionName != ModSettingsReader.internalSection))
+            foreach (var section in config.sections)
             {
-                foreach (KeyData key in section.Keys)
+                foreach (var key in section.keys)
                 {
-                    ModSettingsKey configKey;
-                    if (config && config.Key(section.SectionName, key.KeyName, out configKey))
+                    switch (key.type)
                     {
-                        switch(configKey.type)
-                        {
-                            case ModSettingsKey.KeyType.Toggle:
-                                data[section.SectionName][key.KeyName] = modCheckboxes[checkBox].IsChecked.ToString();
-                                checkBox++;
-                                break;
+                        case ModSettingsKey.KeyType.Toggle:
+                            data[section.name][key.name] = modCheckboxes[checkBox].IsChecked.ToString();
+                            checkBox++;
+                            break;
 
-                            case ModSettingsKey.KeyType.MultipleChoice:
-                            case ModSettingsKey.KeyType.Slider:
-                            case ModSettingsKey.KeyType.FloatSlider:
-                                data[section.SectionName][key.KeyName] = modSliders[slider].GetValue().ToString();
-                                slider++;
-                                break;
+                        case ModSettingsKey.KeyType.MultipleChoice:
+                        case ModSettingsKey.KeyType.Slider:
+                        case ModSettingsKey.KeyType.FloatSlider:
+                            data[section.name][key.name] = modSliders[slider].GetValue().ToString();
+                            slider++;
+                            break;
 
-                            case ModSettingsKey.KeyType.Tuple:
-                            case ModSettingsKey.KeyType.FloatTuple:
-                                string value = modTuples[tuple].First.ResultText + ModSettingsReader.tupleDelimiterChar + modTuples[tuple].Second.ResultText;
-                                data[section.SectionName][key.KeyName] = value;
-                                tuple++;
-                                break;
+                        case ModSettingsKey.KeyType.Tuple:
+                        case ModSettingsKey.KeyType.FloatTuple:
+                            string value = modTuples[tuple].First.ResultText + ModSettingsReader.tupleDelimiterChar + modTuples[tuple].Second.ResultText;
+                            data[section.name][key.name] = value;
+                            tuple++;
+                            break;
 
-                            case ModSettingsKey.KeyType.Text:
-                                data[section.SectionName][key.KeyName] = modTextBoxes[textBox].ResultText;
-                                textBox++;
-                                break;
+                        case ModSettingsKey.KeyType.Text:
+                            data[section.name][key.name] = modTextBoxes[textBox].ResultText;
+                            textBox++;
+                            break;
 
-                            case ModSettingsKey.KeyType.Color:
-                                string hexColor = ColorUtility.ToHtmlStringRGBA(modColorPickers[colorPicker].BackgroundColor);
-                                data[section.SectionName][key.KeyName] = hexColor;
-                                colorPicker++;
-                                break;
-                        }
+                        case ModSettingsKey.KeyType.Color:
+                            string hexColor = ColorUtility.ToHtmlStringRGBA(modColorPickers[colorPicker].BackgroundColor);
+                            data[section.name][key.name] = hexColor;
+                            colorPicker++;
+                            break;
                     }
-                    else if (key.Value == "True" || key.Value == "False")
-                    {
-                        data[section.SectionName][key.KeyName] = modCheckboxes[checkBox].IsChecked.ToString();
-                        checkBox++;
-                    }
-                    else if (key.Value.Contains(ModSettingsReader.tupleDelimiterChar))
-                    {
-                        string value = modTuples[tuple].First.ResultText + ModSettingsReader.tupleDelimiterChar + modTuples[tuple].Second.ResultText;
-                        data[section.SectionName][key.KeyName] = value;
-                        tuple++;
-                    }
-                    else if (ModSettingsReader.IsHexColor(key.Value))
-                    {
-                        string hexColor = ColorUtility.ToHtmlStringRGBA(modColorPickers[colorPicker].BackgroundColor);
-                        data[section.SectionName][key.KeyName] = hexColor;
-                        colorPicker++;
-                    }
-                    else
-                    {
-                        data[section.SectionName][key.KeyName] = modTextBoxes[textBox].ResultText;
-                        textBox++;
-                    }     
                 }
             }
 
@@ -663,7 +611,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         {
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
             {
-                ModSettingsReader.ResetSettings(mod, ref data, defaultSettings);
+                ModSettingsReader.ResetSettings(mod, ref data, config);
                 CloseWindow();
                 RestartSettingsWindow();
             }

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
@@ -129,7 +129,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         /// </summary>
         private void LoadSettings()
         {
-            foreach (var section in config.sections)
+            foreach (var section in config.VisibleSections)
             {
                 // Add section title to window
                 AddSectionTitle(section.name);
@@ -158,7 +158,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
                     {
                         case ModSettingsKey.KeyType.Toggle:
                             bool toggle;
-                            AddCheckBox((bool.TryParse(keyData.Value, out toggle) && toggle) || key.toggle.value);
+                            AddCheckBox(bool.TryParse(keyData.Value, out toggle) ? toggle : key.toggle.value);
                             break;
 
                         case ModSettingsKey.KeyType.MultipleChoice:
@@ -222,7 +222,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         {
             // Set new values
             int checkBox = 0, textBox = 0, tuple = 0, slider = 0, colorPicker = 0;
-            foreach (var section in config.sections)
+            foreach (var section in config.VisibleSections)
             {
                 foreach (var key in section.keys)
                 {
@@ -520,7 +520,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             return tuple;
         }
 
-        private void AddColorPicker(string hexColor, ModSettingsKey key = null)
+        private void AddColorPicker(string hexColor, ModSettingsKey key)
         {
             Button colorPicker = new Button()
             {
@@ -530,9 +530,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             };
             colorPicker.Outline.Enabled = true;
 
-            if (!ModSettingsReader.IsHexColor(hexColor))
-                hexColor = key != null ? key.color.HexColor : "FFFFFFFF";
-            colorPicker.BackgroundColor = ModSettingsReader.ColorFromString(hexColor);
+            Color color;
+            if (ColorUtility.TryParseHtmlString("#" + hexColor, out color))
+                colorPicker.BackgroundColor = color;
+            else
+                colorPicker.BackgroundColor = key.color.color;
 
             colorPicker.OnMouseClick += ColorPicker_OnMouseClick;
             modColorPickers.Add(colorPicker);


### PR DESCRIPTION
No notable new features, just some little improvements. Editor UI in particular is now more confortable to use since i implemented ReorderableList, which allows keys to be dragged and change position without destroying the list. I'm going to provide more details on forum.

Changes:
* Add missing keys when reading file from disk.
* Improved usability of modsettings asset in inspector with ReorderableList, which allow keys to be dragged isnide a section.
* Import a ini file from inspector to create a basic settings asset. This is helpful when upgrading old mods to the new UI system.
* Graphical improvements in inspector view.
* Allow Copy/paste options for multiplechoices between keys.
* Use a red color for sections called "Internal" in inspector (keys hidden from gui).
* Reorganized fallbacks in ModSettings. Default value is always returned if serialized value is missing or can't be parsed to the correct type.