### PR TITLE
TextureReplacement: add option for compressed textures

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -63,3 +63,4 @@ TerrainDistance=3
 LypyL_GameConsole=True
 LypyL_ModSystem=True
 MeshAndTextureReplacement=False
+CompressModdedTextures=True

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -88,6 +88,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox gameConsole;
         Checkbox modSystem;
         Checkbox assetImport;
+        Checkbox compressModdedTextures;
 
         // Video
         HorizontalSlider resolution;
@@ -186,6 +187,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             gameConsole = AddCheckbox(rightPanel, "Game Console", "Enable input for console commands", DaggerfallUnity.Settings.LypyL_GameConsole);
             modSystem = AddCheckbox(rightPanel, "Mod System", "Enable support for mods.", DaggerfallUnity.Settings.LypyL_ModSystem);
             assetImport = AddCheckbox(rightPanel, "Allow Custom Assets", "Import assets from enabled mods and loose files.", DaggerfallUnity.Settings.MeshAndTextureReplacement);
+            compressModdedTextures = AddCheckbox(rightPanel, "Compress Modded Textures", "Import textures with a compressed format which uses less graphics memory.", DaggerfallUnity.Settings.CompressModdedTextures);
         }
 
         private void Video(Panel leftPanel, Panel rightPanel)
@@ -248,6 +250,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.LypyL_GameConsole = gameConsole.IsChecked;
             DaggerfallUnity.Settings.LypyL_ModSystem = modSystem.IsChecked;
             DaggerfallUnity.Settings.MeshAndTextureReplacement = assetImport.IsChecked;
+            DaggerfallUnity.Settings.CompressModdedTextures = compressModdedTextures.IsChecked;
 
             /* Video */
 

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -224,6 +224,7 @@ namespace DaggerfallWorkshop.Game.Utility
 
             // Filter settings
             DaggerfallUnity.Instance.MaterialReader.MainFilterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
+            DaggerfallUnity.Instance.MaterialReader.CompressModdedTextures = DaggerfallUnity.Settings.CompressModdedTextures;
 
             // HUD settings
             DaggerfallHUD hud = DaggerfallUI.Instance.DaggerfallHUD;

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -38,6 +38,7 @@ namespace DaggerfallWorkshop
         // General settings
         public bool AtlasTextures = true;
         public bool CompressSkyTextures = false;
+        public bool CompressModdedTextures = true;
         public bool Sharpen = false;
         public bool GenerateNormals = false;
         public float NormalTextureStrength = 0.2f;

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -122,6 +122,7 @@ namespace DaggerfallWorkshop
         public bool LypyL_GameConsole { get; set; }
         public bool LypyL_ModSystem { get; set; }
         public bool MeshAndTextureReplacement { get; set; }
+        public bool CompressModdedTextures { get; set; }
 
         #endregion
 
@@ -186,6 +187,7 @@ namespace DaggerfallWorkshop
             LypyL_GameConsole = GetBool(sectionEnhancements, "LypyL_GameConsole");
             LypyL_ModSystem = GetBool(sectionEnhancements, "LypyL_ModSystem");
             MeshAndTextureReplacement = GetBool(sectionEnhancements, "MeshAndTextureReplacement");
+            CompressModdedTextures = GetBool(sectionEnhancements, "CompressModdedTextures");
         }
 
         /// <summary>
@@ -243,6 +245,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionEnhancements, "LypyL_GameConsole", LypyL_GameConsole);
             SetBool(sectionEnhancements, "LypyL_ModSystem", LypyL_ModSystem);
             SetBool(sectionEnhancements, "MeshAndTextureReplacement", MeshAndTextureReplacement);
+            SetBool(sectionEnhancements, "CompressModdedTextures", CompressModdedTextures);
 
             // Write settings to persistent file
             WriteSettingsFile();


### PR DESCRIPTION
Imported textures use DXT5 if requested by user settings.