### PR TITLE
Enable player interaction with shelves

### DIFF
--- a/Assets/Scripts/DaggerfallUnityEnums.cs
+++ b/Assets/Scripts/DaggerfallUnityEnums.cs
@@ -536,6 +536,7 @@ namespace DaggerfallWorkshop
         RandomTreasure,
         CorpseMarker,
         DroppedLoot,
+        Shelves
     }
 
     /// <summary>

--- a/Assets/Scripts/DaggerfallUnityEnums.cs
+++ b/Assets/Scripts/DaggerfallUnityEnums.cs
@@ -536,7 +536,6 @@ namespace DaggerfallWorkshop
         RandomTreasure,
         CorpseMarker,
         DroppedLoot,
-        Geometry,
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -121,7 +121,7 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
-        #region Private Methods
+        #region Public Methods
 
         public bool StealthCheck()
         {
@@ -153,6 +153,25 @@ namespace DaggerfallWorkshop.Game
 
             return Random.Range(1, 101) > stealthRoll;
         }
+
+        public bool TargetIsWithinYawAngle(float targetAngle)
+        {
+            Vector3 directionToPlayer2D = directionToPlayer;
+            directionToPlayer2D.y = 0;
+
+            Vector3 enemyDirection2D = transform.forward;
+            enemyDirection2D.y = 0;
+
+            float angle = Vector3.Angle(directionToPlayer2D, enemyDirection2D);
+            if (angle < targetAngle)
+                return true;
+            else
+                return false;
+        }
+
+        #endregion
+
+        #region Private Methods
 
         private bool CanSeePlayer()
         {

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -104,180 +104,83 @@ namespace DaggerfallWorkshop.Game
 
                     #region Hit Checks
 
-                        // Trigger quest resource behaviour click on anything but NPCs
-                        QuestResourceBehaviour questResourceBehaviour;
-                        if (QuestResourceBehaviourCheck(hit, out questResourceBehaviour))
+                    // Trigger quest resource behaviour click on anything but NPCs
+                    QuestResourceBehaviour questResourceBehaviour;
+                    if (QuestResourceBehaviourCheck(hit, out questResourceBehaviour))
+                    {
+                        if (!(questResourceBehaviour.TargetResource is Person))
                         {
-                            if (!(questResourceBehaviour.TargetResource is Person))
+                            if (hit.distance > (DefaultActivationDistance * MeshReader.GlobalScale))
                             {
-                                if (hit.distance > (DefaultActivationDistance * MeshReader.GlobalScale))
-                                {
-                                    DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
-                                    return;
-                                }
+                                DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
+                                return;
+                            }
 
-                                // Only trigger click when not in info mode
-                                if (currentMode != PlayerActivateModes.Info)
-                                {
-                                    TriggerQuestResourceBehaviourClick(questResourceBehaviour);
-                                }
+                            // Only trigger click when not in info mode
+                            if (currentMode != PlayerActivateModes.Info)
+                            {
+                                TriggerQuestResourceBehaviourClick(questResourceBehaviour);
                             }
                         }
+                    }
 
-                        // Check for a static building hit
-                        Transform buildingOwner;
-                        DaggerfallStaticBuildings buildings = GetBuildings(hit.transform, out buildingOwner);
-                        if (buildings)
+                    // Check for a static building hit
+                    Transform buildingOwner;
+                    DaggerfallStaticBuildings buildings = GetBuildings(hit.transform, out buildingOwner);
+                    if (buildings)
+                    {
+                        if (buildings.HasHit(hit.point, out building))
                         {
-                            if (buildings.HasHit(hit.point, out building))
+                            hitBuilding = true;
+
+                            // Get building directory for location
+                            BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();
+                            if (!buildingDirectory)
+                                return;
+
+                            // Get detailed building data from directory
+                            BuildingSummary buildingSummary;
+                            if (!buildingDirectory.GetBuildingSummary(building.buildingKey, out buildingSummary))
+                                return;
+
+                            // Check if door is unlocked
+                            buildingUnlocked = BuildingIsUnlocked(buildingSummary);
+
+                            // Store building type
+                            buildingType = buildingSummary.BuildingType;
+
+                            if (currentMode == PlayerActivateModes.Info)
                             {
-                                hitBuilding = true;
+                                // Discover building
+                                GameManager.Instance.PlayerGPS.DiscoverBuilding(building.buildingKey);
 
-                                // Get building directory for location
-                                BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();
-                                if (!buildingDirectory)
-                                    return;
-
-                                // Get detailed building data from directory
-                                BuildingSummary buildingSummary;
-                                if (!buildingDirectory.GetBuildingSummary(building.buildingKey, out buildingSummary))
-                                    return;
-
-                                // Check if door is unlocked
-                                buildingUnlocked = BuildingIsUnlocked(buildingSummary);
-
-                                // Store building type
-                                buildingType = buildingSummary.BuildingType;
-
-                                if (currentMode == PlayerActivateModes.Info)
+                                // Get discovered building
+                                PlayerGPS.DiscoveredBuilding db;
+                                if (GameManager.Instance.PlayerGPS.GetDiscoveredBuilding(building.buildingKey, out db))
                                 {
-                                    // Discover building
-                                    GameManager.Instance.PlayerGPS.DiscoverBuilding(building.buildingKey);
+                                    // TODO: Check against quest system for an overriding quest-assigned display name for this building
+                                    DaggerfallUI.AddHUDText(db.displayName);
 
-                                    // Get discovered building
-                                    PlayerGPS.DiscoveredBuilding db;
-                                    if (GameManager.Instance.PlayerGPS.GetDiscoveredBuilding(building.buildingKey, out db))
+                                    if (!buildingUnlocked && buildingType < DFLocation.BuildingTypes.Temple
+                                        && buildingType != DFLocation.BuildingTypes.HouseForSale)
                                     {
-                                        // TODO: Check against quest system for an overriding quest-assigned display name for this building
-                                        DaggerfallUI.AddHUDText(db.displayName);
-
-                                        if (!buildingUnlocked && buildingType < DFLocation.BuildingTypes.Temple
-                                            && buildingType != DFLocation.BuildingTypes.HouseForSale)
-                                        {
-                                            string storeClosedMessage = HardStrings.storeClosed;
-                                            storeClosedMessage = storeClosedMessage.Replace("%d1", openHours[(int)buildingType].ToString());
-                                            storeClosedMessage = storeClosedMessage.Replace("%d2", closeHours[(int)buildingType].ToString());
-                                            DaggerfallUI.Instance.PopupMessage(storeClosedMessage);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        // Check for a static door hit
-                        Transform doorOwner;
-                        DaggerfallStaticDoors doors = GetDoors(hit.transform, out doorOwner);
-                        if (doors && playerEnterExit)
-                        {
-                            StaticDoor door;
-                            if (doors.HasHit(hit.point, out door))
-                            {
-                                // Check if close enough to activate
-                                if (hit.distance > (DoorActivationDistance * MeshReader.GlobalScale))
-                                {
-                                    DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
-                                    return;
-                                }
-
-                                if (door.doorType == DoorTypes.Building && !playerEnterExit.IsPlayerInside)
-                                {
-                                    // Discover building
-                                    GameManager.Instance.PlayerGPS.DiscoverBuilding(building.buildingKey);
-
-                                    // TODO: Implement lockpicking and door bashing for exterior doors
-                                    // For now, any locked building door can be entered by using steal mode
-                                    if (!buildingUnlocked)
-                                    {
-                                        if (currentMode != PlayerActivateModes.Steal)
-                                        {
-                                            string Locked = "Locked.";
-                                            DaggerfallUI.Instance.PopupMessage(Locked);
-                                            return;
-                                        }
-                                        else // Breaking into building
-                                        {
-                                            PlayerEntity player = GameManager.Instance.PlayerEntity;
-                                            //player.TallyCrimeGuildRequirements(true, 1);
-                                        }
-                                    }
-
-                                    // If entering a shop let player know the quality level
-                                    // If entering an open home, show greeting
-                                    if (hitBuilding)
-                                    {
-                                        const int houseGreetingsTextId = 256;
-
-                                        DaggerfallMessageBox mb;
-
-                                        if (buildingUnlocked && buildingType >= DFLocation.BuildingTypes.House1
-                                            && buildingType <= DFLocation.BuildingTypes.House4)
-                                        {
-                                            string greetingText = DaggerfallUnity.Instance.TextProvider.GetRandomText(houseGreetingsTextId);
-                                            mb = DaggerfallUI.MessageBox(greetingText);
-                                        }
-                                        else
-                                            mb = PresentShopQuality(building);
-
-                                        if (mb != null)
-                                        {
-                                            // Defer transition to interior to after user closes messagebox
-                                            deferredInteriorDoorOwner = doorOwner;
-                                            deferredInteriorDoor = door;
-                                            mb.OnClose += Popup_OnClose;
-                                            return;
-                                        }
-                                    }
-                                    
-                                    // Hit door while outside, transition inside
-                                    TransitionInterior(doorOwner, door, true);
-                                    return;
-                                }
-                                else if (door.doorType == DoorTypes.Building && playerEnterExit.IsPlayerInside)
-                                {
-                                    // Hit door while inside, transition outside
-                                    playerEnterExit.TransitionExterior(true);
-                                    return;
-                                }
-                                else if (door.doorType == DoorTypes.DungeonEntrance && !playerEnterExit.IsPlayerInside)
-                                {
-                                    if (playerGPS)
-                                    {
-                                        // Hit dungeon door while outside, transition inside
-                                        playerEnterExit.TransitionDungeonInterior(doorOwner, door, playerGPS.CurrentLocation, true);
-                                        return;
-                                    }
-                                }
-                                else if (door.doorType == DoorTypes.DungeonExit && playerEnterExit.IsPlayerInside)
-                                {
-                                    // Hit dungeon exit while inside, ask if access wagon or transition outside
-                                    if (GameManager.Instance.PlayerEntity.Items.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart))
-                                    {
-                                        DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.UIManager, DaggerfallMessageBox.CommonMessageBoxButtons.YesNo, 38, DaggerfallUI.UIManager.TopWindow);
-                                        messageBox.OnButtonClick += DungeonWagonAccess_OnButtonClick;
-                                        DaggerfallUI.UIManager.PushWindow(messageBox);
-                                        return;
-                                    }
-                                    else
-                                    {
-                                        playerEnterExit.TransitionDungeonExterior(true);
+                                        string storeClosedMessage = HardStrings.storeClosed;
+                                        storeClosedMessage = storeClosedMessage.Replace("%d1", openHours[(int)buildingType].ToString());
+                                        storeClosedMessage = storeClosedMessage.Replace("%d2", closeHours[(int)buildingType].ToString());
+                                        DaggerfallUI.Instance.PopupMessage(storeClosedMessage);
                                     }
                                 }
                             }
                         }
+                    }
 
-                        // Check for an action door hit
-                        DaggerfallActionDoor actionDoor;
-                        if (ActionDoorCheck(hit, out actionDoor))
+                    // Check for a static door hit
+                    Transform doorOwner;
+                    DaggerfallStaticDoors doors = GetDoors(hit.transform, out doorOwner);
+                    if (doors && playerEnterExit)
+                    {
+                        StaticDoor door;
+                        if (doors.HasHit(hit.point, out door))
                         {
                             // Check if close enough to activate
                             if (hit.distance > (DoorActivationDistance * MeshReader.GlobalScale))
@@ -286,27 +189,140 @@ namespace DaggerfallWorkshop.Game
                                 return;
                             }
 
-                            if (currentMode == PlayerActivateModes.Steal && actionDoor.IsLocked && !actionDoor.IsOpen)
+                            if (door.doorType == DoorTypes.Building && !playerEnterExit.IsPlayerInside)
                             {
-                                actionDoor.AttemptLockpicking();
-                            }
-                            else
-                                actionDoor.ToggleDoor(true);
-                        }
+                                // Discover building
+                                GameManager.Instance.PlayerGPS.DiscoverBuilding(building.buildingKey);
 
-                        // Check for action record hit
-                        DaggerfallAction action;
-                        if (ActionCheck(hit, out action))
+                                // TODO: Implement lockpicking and door bashing for exterior doors
+                                // For now, any locked building door can be entered by using steal mode
+                                if (!buildingUnlocked)
+                                {
+                                    if (currentMode != PlayerActivateModes.Steal)
+                                    {
+                                        string Locked = "Locked.";
+                                        DaggerfallUI.Instance.PopupMessage(Locked);
+                                        return;
+                                    }
+                                    else // Breaking into building
+                                    {
+                                        PlayerEntity player = GameManager.Instance.PlayerEntity;
+                                        //player.TallyCrimeGuildRequirements(true, 1);
+                                    }
+                                }
+
+                                // If entering a shop let player know the quality level
+                                // If entering an open home, show greeting
+                                if (hitBuilding)
+                                {
+                                    const int houseGreetingsTextId = 256;
+
+                                    DaggerfallMessageBox mb;
+
+                                    if (buildingUnlocked && buildingType >= DFLocation.BuildingTypes.House1
+                                        && buildingType <= DFLocation.BuildingTypes.House4)
+                                    {
+                                        string greetingText = DaggerfallUnity.Instance.TextProvider.GetRandomText(houseGreetingsTextId);
+                                        mb = DaggerfallUI.MessageBox(greetingText);
+                                    }
+                                    else
+                                        mb = PresentShopQuality(building);
+
+                                    if (mb != null)
+                                    {
+                                        // Defer transition to interior to after user closes messagebox
+                                        deferredInteriorDoorOwner = doorOwner;
+                                        deferredInteriorDoor = door;
+                                        mb.OnClose += Popup_OnClose;
+                                        return;
+                                    }
+                                }
+                                    
+                                // Hit door while outside, transition inside
+                                TransitionInterior(doorOwner, door, true);
+                                return;
+                            }
+                            else if (door.doorType == DoorTypes.Building && playerEnterExit.IsPlayerInside)
+                            {
+                                // Hit door while inside, transition outside
+                                playerEnterExit.TransitionExterior(true);
+                                return;
+                            }
+                            else if (door.doorType == DoorTypes.DungeonEntrance && !playerEnterExit.IsPlayerInside)
+                            {
+                                if (playerGPS)
+                                {
+                                    // Hit dungeon door while outside, transition inside
+                                    playerEnterExit.TransitionDungeonInterior(doorOwner, door, playerGPS.CurrentLocation, true);
+                                    return;
+                                }
+                            }
+                            else if (door.doorType == DoorTypes.DungeonExit && playerEnterExit.IsPlayerInside)
+                            {
+                                // Hit dungeon exit while inside, ask if access wagon or transition outside
+                                if (GameManager.Instance.PlayerEntity.Items.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart))
+                                {
+                                    DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.UIManager, DaggerfallMessageBox.CommonMessageBoxButtons.YesNo, 38, DaggerfallUI.UIManager.TopWindow);
+                                    messageBox.OnButtonClick += DungeonWagonAccess_OnButtonClick;
+                                    DaggerfallUI.UIManager.PushWindow(messageBox);
+                                    return;
+                                }
+                                else
+                                {
+                                    playerEnterExit.TransitionDungeonExterior(true);
+                                }
+                            }
+                        }
+                    }
+
+                    // Check for an action door hit
+                    DaggerfallActionDoor actionDoor;
+                    if (ActionDoorCheck(hit, out actionDoor))
+                    {
+                        // Check if close enough to activate
+                        if (hit.distance > (DoorActivationDistance * MeshReader.GlobalScale))
                         {
-                            if (hit.distance <= (DefaultActivationDistance * MeshReader.GlobalScale))
-                            {
-                                action.Receive(this.gameObject, DaggerfallAction.TriggerTypes.Direct);
-                            }
+                            DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
+                            return;
                         }
 
-                        // Check for lootable object hit
-                        DaggerfallLoot loot;
-                        if (LootCheck(hit, out loot))
+                        if (currentMode == PlayerActivateModes.Steal && actionDoor.IsLocked && !actionDoor.IsOpen)
+                        {
+                            actionDoor.AttemptLockpicking();
+                        }
+                        else
+                            actionDoor.ToggleDoor(true);
+                    }
+
+                    // Check for action record hit
+                    DaggerfallAction action;
+                    if (ActionCheck(hit, out action))
+                    {
+                        if (hit.distance <= (DefaultActivationDistance * MeshReader.GlobalScale))
+                        {
+                            action.Receive(this.gameObject, DaggerfallAction.TriggerTypes.Direct);
+                        }
+                    }
+
+                    // Check for lootable object hit
+                    DaggerfallLoot loot;
+                    if (LootCheck(hit, out loot))
+                    {
+                        if (hit.distance > TreasureActivationDistance * MeshReader.GlobalScale)
+                        {
+                            DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
+                            return;
+                        }
+                        // Handle shop shelves. (mode not relevant)
+                        if (loot.ContainerType == LootContainerTypes.Shelves)
+                        {
+                            // Open trade window with activated loot container as remote target.
+                            UserInterfaceManager uiManager = DaggerfallUI.Instance.UserInterfaceManager;
+                            DaggerfallTradeWindow tradeWindow = new DaggerfallTradeWindow(uiManager, DaggerfallTradeWindow.WindowModes.Buy);
+                            tradeWindow.MerchantItems = loot.Items;
+                            uiManager.PushWindow(tradeWindow);
+                        }
+                        else
                         {
                             switch (currentMode)
                             {
@@ -328,146 +344,148 @@ namespace DaggerfallWorkshop.Game
                                 case PlayerActivateModes.Talk:
                                 case PlayerActivateModes.Steal:
                                     // Check if close enough to activate
-                                    if (loot.ContainerType == LootContainerTypes.CorpseMarker)
-                                    {
-                                        if (hit.distance > CorpseActivationDistance * MeshReader.GlobalScale)
-                                        {
-                                            DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
-                                            break;
-                                        }
-                                    }
-                                    else if (hit.distance > TreasureActivationDistance * MeshReader.GlobalScale)
+                                    if (loot.ContainerType == LootContainerTypes.CorpseMarker &&
+                                        hit.distance > CorpseActivationDistance * MeshReader.GlobalScale)
                                     {
                                         DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
                                         break;
                                     }
-
-                                    // For bodies, check has treasure first
-                                    if (loot.ContainerType == LootContainerTypes.CorpseMarker && loot.Items.Count == 0)
+                                    // For bodies, check has treasure
+                                    else if (loot.ContainerType == LootContainerTypes.CorpseMarker && loot.Items.Count == 0)
                                     {
                                         DaggerfallUI.AddHUDText(HardStrings.theBodyHasNoTreasure);
                                         break;
                                     }
-
-                                    // Open inventory window with loot as remote target
+                                    // Open inventory window with activated loot container as remote target.
                                     DaggerfallUI.Instance.InventoryWindow.LootTarget = loot;
                                     DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
                                     break;
                             }
                         }
+                    }
 
-                        // Check for static NPC hit
-                        StaticNPC npc;
-                        if (NPCCheck(hit, out npc))
+                    // Check for static NPC hit
+                    StaticNPC npc;
+                    if (NPCCheck(hit, out npc))
+                    {
+                        switch (currentMode)
                         {
-                            switch (currentMode)
-                            {
-                                case PlayerActivateModes.Info:
-                                    PresentNPCInfo(npc);
+                            case PlayerActivateModes.Info:
+                                PresentNPCInfo(npc);
+                                break;
+                            case PlayerActivateModes.Grab:
+                            case PlayerActivateModes.Talk:
+                            case PlayerActivateModes.Steal:
+                                if (hit.distance > (StaticNPCActivationDistance * MeshReader.GlobalScale))
+                                {
+                                    DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
                                     break;
-                                case PlayerActivateModes.Grab:
-                                case PlayerActivateModes.Talk:
-                                case PlayerActivateModes.Steal:
-                                    if (hit.distance > (StaticNPCActivationDistance * MeshReader.GlobalScale))
+                                }
+                                StaticNPCClick(npc);
+                                break;
+                        }
+                    }
+
+                    // Check for mobile NPC hit
+                    MobilePersonNPC mobileNpc = null;
+                    if (MobilePersonMotorCheck(hit, out mobileNpc))
+                    {
+                        switch (currentMode)
+                        {
+                            case PlayerActivateModes.Info:
+                            case PlayerActivateModes.Grab:
+                            case PlayerActivateModes.Talk:
+                                if (hit.distance > (MobileNPCActivationDistance * MeshReader.GlobalScale))
+                                {
+                                    DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
+                                    break;
+                                }
+                                GameManager.Instance.TalkManager.TalkToMobileNPC(mobileNpc);
+                                break;
+                            case PlayerActivateModes.Steal:
+                                if (!mobileNpc.PickpocketByPlayerAttempted)
+                                {
+                                    if (hit.distance > (PickpocketDistance * MeshReader.GlobalScale))
                                     {
                                         DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
                                         break;
                                     }
-                                    StaticNPCClick(npc);
-                                    break;
-                            }
+                                    mobileNpc.PickpocketByPlayerAttempted = true;
+                                    Pickpocket();
+                                }
+                                break;
                         }
+                    }
 
-                        // Check for mobile NPC hit
-                        MobilePersonNPC mobileNpc = null;
-                        if (MobilePersonMotorCheck(hit, out mobileNpc))
+                    // Check for mobile enemy hit
+                    DaggerfallEntityBehaviour mobileEnemyBehaviour;
+                    if (MobileEnemyCheck(hit, out mobileEnemyBehaviour))
+                    {
+                        EnemyEntity enemyEntity = mobileEnemyBehaviour.Entity as EnemyEntity;
+                        switch (currentMode)
                         {
-                            switch (currentMode)
-                            {
-                                case PlayerActivateModes.Info:
-                                case PlayerActivateModes.Grab:
-                                case PlayerActivateModes.Talk:
-                                    if (hit.distance > (MobileNPCActivationDistance * MeshReader.GlobalScale))
+                            case PlayerActivateModes.Info:
+                            case PlayerActivateModes.Grab:
+                            case PlayerActivateModes.Talk:
+                                if (enemyEntity != null)
+                                {
+                                    MobileEnemy mobileEnemy = enemyEntity.MobileEnemy;
+                                    bool startsWithVowel = "aeiouAEIOU".Contains(mobileEnemy.Name[0].ToString());
+                                    string message;
+                                    if (startsWithVowel)
+                                        message = HardStrings.youSeeAn;
+                                    else
+                                        message = HardStrings.youSeeA;
+                                    message = message.Replace("%s", mobileEnemy.Name);
+                                    DaggerfallUI.Instance.PopupMessage(message);
+                                }
+                                break;
+                            case PlayerActivateModes.Steal:
+                                // Classic allows pickpocketing of NPC mobiles and enemy mobiles.
+                                // In early versions the only enemy mobiles that can be pickpocketed are classes,
+                                // but patch 1.07.212 allows pickpocketing of creatures.
+                                // For now, the only enemy mobiles being allowed by DF Unity are classes.
+                                if (mobileEnemyBehaviour && (mobileEnemyBehaviour.EntityType != EntityTypes.EnemyClass))
+                                    break;
+                                // Classic doesn't set any flag when pickpocketing enemy mobiles, so infinite attempts are possible
+                                if (enemyEntity != null && !enemyEntity.PickpocketByPlayerAttempted)
+                                {
+                                    if (hit.distance > (PickpocketDistance * MeshReader.GlobalScale))
                                     {
                                         DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
                                         break;
                                     }
-                                    GameManager.Instance.TalkManager.TalkToMobileNPC(mobileNpc);
-                                    break;
-                                case PlayerActivateModes.Steal:
-                                    if (!mobileNpc.PickpocketByPlayerAttempted)
-                                    {
-                                        if (hit.distance > (PickpocketDistance * MeshReader.GlobalScale))
-                                        {
-                                            DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
-                                            break;
-                                        }
-                                        mobileNpc.PickpocketByPlayerAttempted = true;
-                                        Pickpocket();
-                                    }
-                                    break;
-                            }
+                                    enemyEntity.PickpocketByPlayerAttempted = true;
+                                    Pickpocket(mobileEnemyBehaviour);
+                                }
+                                break;
                         }
+                    }
 
-                        // Check for mobile enemy hit
-                        DaggerfallEntityBehaviour mobileEnemyBehaviour;
-                        if (MobileEnemyCheck(hit, out mobileEnemyBehaviour))
+                    // Check for functional interior furniture: Ladders, Bookshelves.
+                    DaggerfallLadder ladder = hit.transform.GetComponent<DaggerfallLadder>();
+                    DaggerfallBookshelf bookshelf = hit.transform.GetComponent<DaggerfallBookshelf>();
+
+                    if (ladder || bookshelf)
+                    {
+                        if (hit.distance > (DefaultActivationDistance * MeshReader.GlobalScale))
                         {
-                            EnemyEntity enemyEntity = mobileEnemyBehaviour.Entity as EnemyEntity;
-                            switch (currentMode)
-                            {
-                                case PlayerActivateModes.Info:
-                                case PlayerActivateModes.Grab:
-                                case PlayerActivateModes.Talk:
-                                    if (enemyEntity != null)
-                                    {
-                                        MobileEnemy mobileEnemy = enemyEntity.MobileEnemy;
-                                        bool startsWithVowel = "aeiouAEIOU".Contains(mobileEnemy.Name[0].ToString());
-                                        string message;
-                                        if (startsWithVowel)
-                                            message = HardStrings.youSeeAn;
-                                        else
-                                            message = HardStrings.youSeeA;
-                                        message = message.Replace("%s", mobileEnemy.Name);
-                                        DaggerfallUI.Instance.PopupMessage(message);
-                                    }
-                                    break;
-                                case PlayerActivateModes.Steal:
-                                    // Classic allows pickpocketing of NPC mobiles and enemy mobiles.
-                                    // In early versions the only enemy mobiles that can be pickpocketed are classes,
-                                    // but patch 1.07.212 allows pickpocketing of creatures.
-                                    // For now, the only enemy mobiles being allowed by DF Unity are classes.
-                                    if (mobileEnemyBehaviour && (mobileEnemyBehaviour.EntityType != EntityTypes.EnemyClass))
-                                        break;
-                                    // Classic doesn't set any flag when pickpocketing enemy mobiles, so infinite attempts are possible
-                                    if (enemyEntity != null && !enemyEntity.PickpocketByPlayerAttempted)
-                                    {
-                                        if (hit.distance > (PickpocketDistance * MeshReader.GlobalScale))
-                                        {
-                                            DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
-                                            break;
-                                        }
-                                        enemyEntity.PickpocketByPlayerAttempted = true;
-                                        Pickpocket(mobileEnemyBehaviour);
-                                    }
-                                    break;
-                            }
+                            DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
+                            return;
                         }
-
-                        // Trigger ladder hit
-                        DaggerfallLadder ladder = hit.transform.GetComponent<DaggerfallLadder>();
                         if (ladder)
-                        {
-                            if (hit.distance > (DefaultActivationDistance * MeshReader.GlobalScale))
-                            {
-                                DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
-                                return;
-                            }
-
+                        {   // Ladders:
                             ladder.ClimbLadder();
                         }
+                        else if (bookshelf)
+                        {   // Bookshelves:
+                            bookshelf.ReadBook();
+                        }
+                    }
+                    // Debug for identifying interior furniture model ids.
+                    Debug.Log(hit.transform);
 
-                        #endregion
+                    #endregion
                 }
             }
         }

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2017 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -451,7 +451,7 @@ namespace DaggerfallWorkshop.Game
             // If we fail for any reason, use that old chestnut "this house has nothing of value"
             try
             {
-                interior.DoLayout(doorOwner, door, climateBase);
+                interior.DoLayout(doorOwner, door, climateBase, buildingDiscoveryData);
             }
             catch
             {

--- a/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
@@ -84,7 +84,9 @@ namespace DaggerfallWorkshop.Game.Serialization
                 return;
 
             // Restore billboard only if this is a billboard-based loot container
-            if (loot.ContainerType != LootContainerTypes.Nothing && loot.ContainerType != LootContainerTypes.Geometry)
+            if (loot.ContainerType == LootContainerTypes.RandomTreasure ||
+                loot.ContainerType == LootContainerTypes.CorpseMarker ||
+                loot.ContainerType == LootContainerTypes.DroppedLoot)
             {
                 DaggerfallBillboard billboard = loot.GetComponent<DaggerfallBillboard>();
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -292,13 +292,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     tradeWindow.MerchantItems = GetMerchantItems();
                     uiManager.PushWindow(tradeWindow);
                     break;
-                case GuildServices.MG_Buy_Spells:
-                    //uiManager.PushWindow(new DaggerfallBankingWindow(uiManager, this));
-                    //break;
                 case GuildServices.MG_Teleportation:
                     DaggerfallUI.Instance.DfTravelMapWindow.ActivateTeleportationTravel();
                     uiManager.PushWindow(DaggerfallUI.Instance.DfTravelMapWindow);
                     break;
+                case GuildServices.MG_Buy_Spells:
+                    //uiManager.PushWindow(new DaggerfallBankingWindow(uiManager, this));
+                    //break;
 
                 default:
                     DaggerfallUI.MessageBox("Guild service not yet implemented.");

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallListPickerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallListPickerWindow.cs
@@ -35,7 +35,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected ListBox listBox = new ListBox();
         protected VerticalScrollBar scrollBar;
 
-        public DaggerfallListPickerWindow(IUserInterfaceManager uiManager, DaggerfallBaseWindow previous = null)
+        public DaggerfallListPickerWindow(IUserInterfaceManager uiManager, IUserInterfaceWindow previous = null)
             : base(uiManager, previous)
         {
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -105,7 +105,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             { DFLocation.BuildingTypes.Armorer, new List<ItemGroups>()
                 { ItemGroups.Armor, ItemGroups.Weapons } },
             { DFLocation.BuildingTypes.Bookseller, new List<ItemGroups>()   { ItemGroups.Books } },
-            { DFLocation.BuildingTypes.Library, new List<ItemGroups>()      { ItemGroups.Books } }, // Some bookshops are marked as libraries
             { DFLocation.BuildingTypes.ClothingStore, new List<ItemGroups>()
                 { ItemGroups.MensClothing, ItemGroups.WomensClothing } },
             { DFLocation.BuildingTypes.GemStore, new List<ItemGroups>()

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -128,6 +128,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string serviceRepairs = "Repairs";
         public const string serviceDonate = "Make Donation";
         public const string serviceCure = "Cure Disease";
+        public const string serviceDenied = "You need to be a member to access this.";
 
         public const string doesntNeedIdentifying = "This does not need to be identified.";
 

--- a/Assets/Scripts/Internal/DaggerfallBookshelf.cs
+++ b/Assets/Scripts/Internal/DaggerfallBookshelf.cs
@@ -1,0 +1,77 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2017 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Hazelnut
+
+using DaggerfallConnect;
+using DaggerfallWorkshop.Game;
+using DaggerfallWorkshop.Game.UserInterface;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DaggerfallWorkshop
+{
+    /// <summary>
+    /// Bookshelves in building interiors which allow reading books.
+    /// </summary>
+    public class DaggerfallBookshelf : MonoBehaviour
+    {
+        private List<int> books = null;
+
+        void Start()
+        {
+            if (books == null)
+            {
+                // Populate bookshelf with up to 10 random books.
+                books = new List<int>();
+                for (int i=0; i<10; i++)
+                {
+                    int bookNum = Random.Range(0, 111);
+                    string bookName = DaggerfallUnity.Instance.ItemHelper.getBookNameByID(bookNum, string.Empty);
+                    if (bookName != string.Empty)
+                        books.Add(bookNum);
+                }
+            }
+        }
+
+        public void ReadBook()
+        {
+            // Check permission to access bookshelf if inside a guild or temple
+            PlayerGPS.DiscoveredBuilding buildingData = GameManager.Instance.PlayerEnterExit.BuildingDiscoveryData;
+            // TODO: Faction membership check here when implemented, just check building type for now..
+            int factionID = buildingData.factionID;
+            Debug.Log("Faction ID = " + factionID);
+            if (buildingData.buildingType == DFLocation.BuildingTypes.GuildHall ||
+                buildingData.buildingType == DFLocation.BuildingTypes.Temple)
+            {
+                DaggerfallUI.MessageBox(HardStrings.serviceDenied);
+            }
+            else
+            {
+                // Show book picker loaded with list of books on this shelf
+                IUserInterfaceManager uiManager = DaggerfallUI.UIManager;
+                DaggerfallListPickerWindow bookPicker = new DaggerfallListPickerWindow(uiManager, uiManager.TopWindow);
+                bookPicker.OnItemPicked += BookShelf_OnItemPicked;
+
+                foreach (int bookNum in books)
+                {
+                    string bookName = DaggerfallUnity.Instance.ItemHelper.getBookNameByID(bookNum, string.Empty);
+                    if (bookName != string.Empty)
+                        bookPicker.ListBox.AddItem(bookName);
+                }
+
+                uiManager.PushWindow(bookPicker);
+            }
+        }
+
+        public void BookShelf_OnItemPicked(int index, string bookName)
+        {
+            DaggerfallUnity.Instance.TextProvider.OpenBook(books[index]);
+            DaggerfallUI.UIManager.PopWindow();
+            DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenBookReaderWindow);
+        }
+    }
+}

--- a/Assets/Scripts/Internal/DaggerfallBookshelf.cs.meta
+++ b/Assets/Scripts/Internal/DaggerfallBookshelf.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2f5f66a2e3668be48b5c8a9939e28468
+timeCreated: 1516564591
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2016 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -14,6 +14,7 @@ using System.Collections;
 using System.Collections.Generic;
 using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.Items;
+using DaggerfallConnect;
 
 namespace DaggerfallWorkshop
 {
@@ -59,6 +60,33 @@ namespace DaggerfallWorkshop
         public ItemCollection Items
         {
             get { return items; }
+        }
+
+        public static void StockItems(PlayerGPS.DiscoveredBuilding buildingData, ItemCollection items)
+        {
+            // TODO: Allofich to replace with shelf stocking code... using supplied building type and quality
+            DFLocation.BuildingTypes buildingType = buildingData.buildingType;
+            int shopQuality = buildingData.quality;
+
+            // Temp test code...
+            Game.Entity.PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+            items.AddItem(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
+            items.AddItem(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
+            items.AddItem(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
+            DaggerfallUnityItem magic = ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
+            magic.legacyMagic = new int[] { 1, 87, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535 };
+            items.AddItem(magic);
+            items.AddItem(ItemBuilder.CreateRandomBook());
+            items.AddItem(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
+            items.AddItem(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
+            items.AddItem(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
+            items.AddItem(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
+            items.AddItem(ItemBuilder.CreateRandomIngredient());
+            items.AddItem(ItemBuilder.CreateItem(ItemGroups.MiscItems, 274));
+            items.AddItem(ItemBuilder.CreateRandomReligiousItem());
+            items.AddItem(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
+            items.AddItem(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
+            items.AddItem(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -40,9 +40,9 @@ namespace DaggerfallWorkshop.Utility
             new MobileAnimation() {Record = 2, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing west
             new MobileAnimation() {Record = 3, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing north-west
             new MobileAnimation() {Record = 4, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing north (back facing player)
-            new MobileAnimation() {Record = 3, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing north-east
-            new MobileAnimation() {Record = 2, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing east
-            new MobileAnimation() {Record = 1, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing south-east
+            new MobileAnimation() {Record = 3, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},              // Facing north-east
+            new MobileAnimation() {Record = 2, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},              // Facing east
+            new MobileAnimation() {Record = 1, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},              // Facing south-east
         };
 
         // PrimaryAttack animations

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -711,26 +711,24 @@ namespace DaggerfallWorkshop.Utility
 
         /// <summary>
         /// Destroys/Disables a loot container.
-        /// Ignores LootContainerTypes.Nothing, .CorpseMarker, .Geometry.
+        /// Ignores unsupported or persistent container types.
         /// Custom drop containers will be destroyed from world.
         /// Fixed containers will be disabled so their empty state continues to be serialized.
         /// </summary>
         /// <param name="loot">DaggerfallLoot.</param>
         public static void RemoveLootContainer(DaggerfallLoot loot)
         {
-            // Some container types are not removed from world even if empty
-            if (loot.ContainerType == LootContainerTypes.Nothing ||
-                loot.ContainerType == LootContainerTypes.CorpseMarker ||
-                loot.ContainerType == LootContainerTypes.Geometry)
+            // Only certain container types can be removed from world
+            // Other container types (e.g. corpse markers and geometry-based containers) will persist
+            if (loot.ContainerType == LootContainerTypes.RandomTreasure ||
+                loot.ContainerType == LootContainerTypes.DroppedLoot)
             {
-                return;
+                // Destroy or disable based on custom flag
+                if (loot.customDrop)
+                    GameObject.Destroy(loot.gameObject);
+                else
+                    loot.gameObject.SetActive(false);
             }
-
-            // Destroy or disable based on custom flag
-            if (loot.customDrop)
-                GameObject.Destroy(loot.gameObject);
-            else
-                loot.gameObject.SetActive(false);
         }
 
         #endregion

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -618,7 +618,6 @@ namespace DaggerfallWorkshop.Utility
                 case DFLocation.BuildingTypes.FurnitureStore:
                 case DFLocation.BuildingTypes.GemStore:
                 case DFLocation.BuildingTypes.GeneralStore:
-                case DFLocation.BuildingTypes.Library:
                 case DFLocation.BuildingTypes.PawnShop:
                 case DFLocation.BuildingTypes.WeaponSmith:
                     return true;


### PR DESCRIPTION
Shop shelves have loot containers and initiate trade. (random items for now)
Libraries are not shops - reverted my previous 'correction' and corrected existing code instead
Library shelves are marked as bookshelves and implemented reading (temples & guilds too)
Moved shelf stocking to building interior layout to avoid restock when empty. 
Added member message for guilds and temple bookshelves

TODO: Serialization