### PR TITLE
Fix dying from fall damage when fast traveling

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -846,8 +846,8 @@ namespace DaggerfallWorkshop.Game
             Ray ray = new Ray(transform.position, Vector3.down);
             if (Physics.Raycast(ray, out hit, controller.height * 2f))
             {
-                // Cancel movement so player doesn't take falling damage if they transitioned into a dungeon while jumping
-                GameManager.Instance.PlayerMotor.CancelMovement = true;
+                // Clear falling damage so player doesn't take damage if they transitioned into a dungeon while jumping
+                GameManager.Instance.PlayerMotor.ClearFallingDamage();
                 // Position player at hit position plus just over half controller height up
                 Vector3 pos = hit.point;
                 pos.y += controller.height / 2f + 0.25f;

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -924,6 +924,8 @@ namespace DaggerfallWorkshop
             autoRepositionOffset = repositionOffset;
             autoRepositionMethod = autoReposition;
             InitWorld();
+            // Clear falling damage so player doesn't take damage if they were in the air before a transition
+            GameManager.Instance.PlayerMotor.ClearFallingDamage();
             RaiseOnTeleportToCoordinatesEvent(worldPos);
         }
 


### PR DESCRIPTION
In master branch it's possible to die from fast traveling if you hit the fast travel key while you were in the air (jumping for example) and the destination is lower elevation than the place you traveled from.

This fix works by clearing fall damage when teleporting. We might end up needing a different fix, because the player is also teleported to the correct position when loading a saved game, and you should still get fall damage if you saved mid-fall. You don't get any fall damage in master branch either, though, so this isn't a regression.

Or, if we can change the loading code to not use a teleport, maybe we can continue to use this fix.