### PR TITLE
Add model id 13 to shop shelves and move 808 from house containers

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
@@ -119,7 +119,6 @@ namespace DaggerfallWorkshop.Game.Serialization
             loot.stockedDate = data.stockedDate;
             loot.playerOwned = data.playerOwned;
             loot.customDrop = data.customDrop;
-            loot.name = loot.ContainerType.ToString();
             loot.entityName = data.entityName;
             loot.isEnemyClass = data.isEnemyClass;
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -477,17 +477,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 remoteItems = lootTarget.Items;
                 remoteTargetType = RemoteTargetTypes.Loot;
                 lootTarget.OnInventoryOpen();
-                dropIconArchive = lootTarget.TextureArchive;
-                int[] iconIdxs;
-                DaggerfallLootDataTables.dropIconIdxs.TryGetValue(dropIconArchive, out iconIdxs);
-                if (iconIdxs != null)
+                if (lootTarget.TextureArchive > 0)
                 {
-                    for (int i = 0; i < iconIdxs.Length; i++)
+                    dropIconArchive = lootTarget.TextureArchive;
+                    int[] iconIdxs;
+                    DaggerfallLootDataTables.dropIconIdxs.TryGetValue(dropIconArchive, out iconIdxs);
+                    if (iconIdxs != null)
                     {
-                        if (iconIdxs[i] == lootTarget.TextureRecord)
+                        for (int i = 0; i < iconIdxs.Length; i++)
                         {
-                            dropIconTexture = i;
-                            break;
+                            if (iconIdxs[i] == lootTarget.TextureRecord)
+                            {
+                                dropIconTexture = i;
+                                break;
+                            }
                         }
                     }
                 }
@@ -539,7 +542,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             allowDungeonWagonAccess = false;
 
             // If icon has changed move items to dropped list so this loot is removed and a new one created
-            if (lootTarget != null && (lootTarget.TextureArchive != dropIconArchive || lootTarget.TextureRecord != dropIconTexture))
+            if (lootTarget != null && lootTarget.TextureArchive > 0 && (lootTarget.TextureArchive != dropIconArchive || lootTarget.TextureRecord != dropIconTexture))
                 droppedItems.TransferAll(lootTarget.Items);
 
             // Generate serializable loot pile in world for dropped items

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -31,8 +31,8 @@ namespace DaggerfallWorkshop
 
         const uint houseContainerObjectGroup = 418;
         const uint containerObjectGroupOffset = 41000;
-        static List<uint> shopShelvesObjectGroupIndices = new List<uint> { 5, 6, 11, 12, 15, 16, 17, 18, 19, 28, 29, 31, 35, 37, 40, 42, 44, 46, 47, 48, 49 };
-        static List<uint> houseContainerObjectGroupIndices = new List<uint> { 3, 4, 7, 8, 32, 33, 34, 35, 36, 37, 38, 50, 51 };
+        static List<uint> shopShelvesObjectGroupIndices = new List<uint> { 5, 6, 11, 12, 13, 15, 16, 17, 18, 19, 28, 29, 31, 35, 36, 37, 40, 42, 44, 46, 47, 48, 49, 808 };
+        static List<uint> houseContainerObjectGroupIndices = new List<uint> { 3, 4, 7, 32, 33, 34, 35, 37, 38, 50, 51 };
 
         // Building data for map layout, indicates no activation components needed.
         static PlayerGPS.DiscoveredBuilding mapBD = new PlayerGPS.DiscoveredBuilding {
@@ -406,8 +406,8 @@ namespace DaggerfallWorkshop
             }
             // Handle generic furniture as (private) house containers:
             // (e.g. shelves, boxes, wardrobes, drawers etc)
-            if (obj.ModelIdNum / 100 == houseContainerObjectGroup ||
-                houseContainerObjectGroupIndices.Contains(obj.ModelIdNum - containerObjectGroupOffset))
+            else if (obj.ModelIdNum / 100 == houseContainerObjectGroup ||
+                     houseContainerObjectGroupIndices.Contains(obj.ModelIdNum - containerObjectGroupOffset))
             {
                 DaggerfallLoot loot = go.AddComponent<DaggerfallLoot>();
                 if (loot)

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -233,7 +233,7 @@ namespace DaggerfallWorkshop
             items.Clear();
 
             DFLocation.BuildingTypes buildingType = buildingData.buildingType;
-            uint modelIndex = (uint)TextureRecord;
+            uint modelIndex = (uint) TextureRecord;
             int buildingQuality = buildingData.quality;
             byte[] privatePropertyList = null;
             DaggerfallUnityItem item = null;


### PR DESCRIPTION
Also fix bug with drop icon code

Model 41808 should be in house containers but classic has that model work as shop shelves in the shop from the bug report (http://forums.dfworkshop.net/viewtopic.php?f=24&t=852) so I've moved to shelves list.

This may cause wierdness if this model is in any non-shop buildings.. so we'll need to keep a lookout for that and move it back if any occurances are found.