### PR TITLE
Implement classic tavern room costs

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -79,6 +79,7 @@ namespace DaggerfallConnect.Save
             doc.startingLevelUpSkillSum = parsedData.startingLevelUpSkillSum;
             doc.minMetalToHit = parsedData.minMetalToHit;
             doc.armorValues = parsedData.armorValues;
+            doc.lastTimePlayerAteOrDrankAtTavern = parsedData.lastTimePlayerAteOrDrankAtTavern;
             doc.lastTimePlayerBoughtTraining = parsedData.lastTimePlayerBoughtTraining;
             doc.timeForThievesGuildLetter = parsedData.timeForThievesGuildLetter;
             doc.timeForDarkBrotherhoodLetter = parsedData.timeForDarkBrotherhoodLetter;
@@ -171,7 +172,8 @@ namespace DaggerfallConnect.Save
             reader.BaseStream.Position = 0x1fd;
             parsedData.timeStamp = reader.ReadUInt32();
 
-            reader.BaseStream.Position = 0x209;
+            reader.BaseStream.Position = 0x205;
+            parsedData.lastTimePlayerAteOrDrankAtTavern = reader.ReadUInt32();
             parsedData.lastTimePlayerBoughtTraining = reader.ReadUInt32();
 
             reader.BaseStream.Position = 0x211;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -73,6 +73,8 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int thievesGuildRequirementTally = 0;
         protected int darkBrotherhoodRequirementTally = 0;
 
+        protected uint lastTimePlayerAteOrDrankAtTavern = 0;
+
         protected RegionDataRecord[] regionData = new RegionDataRecord[62];
 
         private List<RoomRental_v1> rentedRooms = new List<RoomRental_v1>();
@@ -127,6 +129,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public uint TimeForDarkBrotherhoodLetter { get { return timeForDarkBrotherhoodLetter; } set { timeForDarkBrotherhoodLetter = value; } }
         public int ThievesGuildRequirementTally { get { return thievesGuildRequirementTally; } set { thievesGuildRequirementTally = value; } }
         public int DarkBrotherhoodRequirementTally { get { return darkBrotherhoodRequirementTally; } set { darkBrotherhoodRequirementTally = value; } }
+        public uint LastTimePlayerAteOrDrankAtTavern { get { return lastTimePlayerAteOrDrankAtTavern; } set { lastTimePlayerAteOrDrankAtTavern = value; } }
         public float CarriedWeight { get { return Items.GetWeight() + ((float)goldPieces / DaggerfallBankManager.gold1kg); } }
         public float WagonWeight { get { return WagonItems.GetWeight(); } }
         public RegionDataRecord[] RegionData { get { return regionData; } set { regionData = value; } }
@@ -346,6 +349,7 @@ namespace DaggerfallWorkshop.Game.Entity
             this.startingLevelUpSkillSum = character.startingLevelUpSkillSum;
             this.minMetalToHit = (WeaponMaterialTypes)character.minMetalToHit;
             this.armorValues = character.armorValues;
+            this.lastTimePlayerAteOrDrankAtTavern = character.lastTimePlayerAteOrDrankAtTavern;
             this.timeOfLastSkillTraining = character.lastTimePlayerBoughtTraining;
             this.timeForThievesGuildLetter = character.timeForThievesGuildLetter;
             this.timeForDarkBrotherhoodLetter = character.timeForDarkBrotherhoodLetter;

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -660,10 +660,24 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         #region Commerce
 
-        public static int CalculateRoomCost(int shopQuality)
+        public static int CalculateRoomCost(int daysToRent)
         {
-            // TODO: Awaiting the binary wizard, Allofich!
-            return 4;
+            int cost = 0;
+            int dayOfYear = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.DayOfYear;
+            if (dayOfYear <= 46 && dayOfYear + daysToRent > 46)
+                cost = 7 * (daysToRent - 1);  // No charge for Heart's Day
+            else
+                cost = 7 * daysToRent;
+
+            // If player is member of region's knightly order, or rank 4 or higher in any knightly order
+            // DaggerfallUI.MessageBox(UserInterfaceWindows.HardStrings.roomFreeForKnightSuchAsYou);
+            // cost = 0;
+            if (cost == 0) // Only renting for Heart's Day
+            {
+                DaggerfallUI.MessageBox(UserInterfaceWindows.HardStrings.roomFreeDueToHeartsDay);
+            }
+
+            return cost;
         }
 
         public static int CalculateCost(int baseItemValue, int shopQuality)

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -52,6 +52,7 @@ namespace DaggerfallWorkshop.Game.Player
         public uint timeForDarkBrotherhoodLetter;
         public byte darkBrotherhoodRequirementTally;
         public byte thievesGuildRequirementTally;
+        public uint lastTimePlayerAteOrDrankAtTavern;
         public sbyte biographyReactionMod;
 
         public CharacterDocument()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTavernWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTavernWindow.cs
@@ -51,6 +51,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int howManyAdditionalDaysId = 5100;
         const int howManyDaysId = 5102;
 
+        readonly string[] tavernMenu =
+        {"Ale (1 gold)", "Beer (1 gold)", "Mead (2 gold)", "Wine (3 gold)",
+         "Bread (1 gold)", "Broth (1 gold)", "Cheese (2 gold)", "Fowl (3 gold)",
+         "Gruel (2 gold)", "Pie (2 gold)", "Stew (3 gold)"};
+        byte[] tavernFoodAndDrinkPrices = { 1, 1, 2, 3, 1, 1, 2, 3, 2, 2, 3 };
+
         StaticNPC merchantNPC;
         PlayerGPS.DiscoveredBuilding buildingData;
         RoomRental_v1 rentedRoom;
@@ -212,6 +218,53 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void FoodButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             CloseWindow();
+            uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+
+            if ((gameMinutes - (GameManager.Instance.PlayerEntity.LastTimePlayerAteOrDrankAtTavern)) >= 240)
+            {
+                DaggerfallListPickerWindow foodAndDrinkPicker = new DaggerfallListPickerWindow(uiManager, this);
+                foodAndDrinkPicker.OnItemPicked += FoodAndDrink_OnItemPicked;
+
+                foreach (string menuItem in tavernMenu)
+                    foodAndDrinkPicker.ListBox.AddItem(menuItem);
+
+                uiManager.PushWindow(foodAndDrinkPicker);
+            }
+            else
+            {
+                DaggerfallUI.MessageBox(HardStrings.youAreNotHungry);
+            }
+        }
+
+        public void FoodAndDrink_OnItemPicked(int index, string foodOrDrinkName)
+        {
+            CloseWindow();
+            int price = tavernFoodAndDrinkPrices[index];
+            uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+            int holidayID = FormulaHelper.GetHolidayId(gameMinutes, 0);
+            PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+
+            // Note: In-game holiday description for both New Life Festival and Harvest's End say they offer free drinks.
+            //       Below is what they actually do (New Life Festival = everything free,
+            //       Harvest's End = everything half-price but at least 1 gold).
+
+            if (holidayID == (int)DaggerfallConnect.DFLocation.Holidays.Harvest_End)
+            {
+                price >>= 1;
+                if (price == 0)
+                    price = 1;
+            }
+            if (holidayID != (int)DaggerfallConnect.DFLocation.Holidays.New_Life && playerEntity.GetGoldAmount() < price)
+            {
+                DaggerfallUI.MessageBox(notEnoughGoldId);
+            }
+            else
+            {
+                if (holidayID != (int)DaggerfallConnect.DFLocation.Holidays.New_Life)
+                    playerEntity.DeductGoldAmount(price);
+                playerEntity.SetHealth(playerEntity.CurrentHealth + 2 * price);
+                playerEntity.LastTimePlayerAteOrDrankAtTavern = gameMinutes;
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -130,6 +130,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string serviceCure = "Cure Disease";
         public const string serviceDenied = "You need to be a member to access this.";
 
+        public const string roomFreeForKnightSuchAsYou = "The room is free for a knight such as you.";
+        public const string roomFreeDueToHeartsDay = "Room is free due to Heart's Day.";
+
         public const string doesntNeedIdentifying = "This does not need to be identified.";
 
         public const string pronounHe = "he";

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -132,6 +132,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public const string roomFreeForKnightSuchAsYou = "The room is free for a knight such as you.";
         public const string roomFreeDueToHeartsDay = "Room is free due to Heart's Day.";
+        public const string youAreNotHungry = "You are not hungry.";
 
         public const string doesntNeedIdentifying = "This does not need to be identified.";
 


### PR DESCRIPTION
This implements the following, matched to classic:

1) Same cost formula, including free for Heart's Day
2) Commented out code for free lodging for knights, once we have guilds implemented
3) Different messages depending on how well player bargained
4) Limit on renting days into the future includes days already rented.

Regarding 3, @ajrb, this causes code duplication with the trade window. Classic uses the same function for the display of the Yes/No bartering window. Since you wrote both the trade and tavern windows, maybe you can look at combining them. I started to play with doing so but it looked like it could get messy and I think you'd have a better idea of how to do it.

Btw there's a bug/oversight here in classic. The way the bartering message works is that you get one depending on how low the price after bargaining is compared to the original cost, but it seems classic doesn't set the "before bargaining" cost for the tavern room dialog, so what message you get depends on what the original cost value of your last trade negotiation was (or is 0, I assume, if you're starting off of a freshly loaded game). For this PR I properly set the cost for the tavern dialog.