### PR TITLE
Merge quest dispensing into guild service code

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -936,8 +936,8 @@ namespace DaggerfallWorkshop.Game
             DaggerfallGuildPopupWindow.TempGuilds guild;
             if (npc.Data.factionID == PersistentFactionData.fightersGuildQuestorFactionID)
                 guild = DaggerfallGuildPopupWindow.TempGuilds.Fighter;
-            else if (npc.Data.factionID == PersistentFactionData.magesGuildQuestorFactionID)
-                guild = DaggerfallGuildPopupWindow.TempGuilds.Mage;
+//            else if (npc.Data.factionID == PersistentFactionData.magesGuildQuestorFactionID)
+//                guild = DaggerfallGuildPopupWindow.TempGuilds.Mage;
             else
                 guild = DaggerfallGuildPopupWindow.TempGuilds.None;
 

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -859,8 +859,8 @@ namespace DaggerfallWorkshop.Game
 
             // Check if this NPC is a quest giver and show temp guild quest popup
             // This will be changed later when temp guild system replaced with real thing
-            if (QuestorCheck(npc))
-                return;
+//            if (QuestorCheck(npc))
+//                return;
 
             // Handle quest NPC click and exit if linked to a Person resource
             QuestResourceBehaviour questResourceBehaviour = npc.gameObject.GetComponent<QuestResourceBehaviour>();
@@ -936,8 +936,8 @@ namespace DaggerfallWorkshop.Game
             DaggerfallGuildPopupWindow.TempGuilds guild;
             if (npc.Data.factionID == PersistentFactionData.fightersGuildQuestorFactionID)
                 guild = DaggerfallGuildPopupWindow.TempGuilds.Fighter;
-//            else if (npc.Data.factionID == PersistentFactionData.magesGuildQuestorFactionID)
-//                guild = DaggerfallGuildPopupWindow.TempGuilds.Mage;
+            else if (npc.Data.factionID == PersistentFactionData.magesGuildQuestorFactionID)
+                guild = DaggerfallGuildPopupWindow.TempGuilds.Mage;
             else
                 guild = DaggerfallGuildPopupWindow.TempGuilds.None;
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -54,10 +54,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         DB_Training = 839,
         DB_Make_Potions = 840,
         DB_Buy_Potions = 841,
-        DB_Spymaster = 841,
+        DB_Spymaster = 842,
         DB_Buy_Soulgems = 843,
 
-        // Temples:
+        // Temples, generic:
         T_Quests = 240,
         T_Make_Donation = 810,
         T_Cure_Diseases = 813,
@@ -144,23 +144,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
                 ItemCollection items = new ItemCollection();
-                items.AddItem(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
-                items.AddItem(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
-                items.AddItem(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
-                DaggerfallUnityItem magic = ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
-                magic.legacyMagic = new int[] { 1, 87, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535 };
-                items.AddItem(magic);
-                items.AddItem(ItemBuilder.CreateRandomBook());
-                items.AddItem(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
-                items.AddItem(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
-                items.AddItem(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
-                items.AddItem(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
-                items.AddItem(ItemBuilder.CreateRandomIngredient());
-                items.AddItem(ItemBuilder.CreateItem(ItemGroups.MiscItems, 274));
-                items.AddItem(ItemBuilder.CreateRandomReligiousItem());
-                items.AddItem(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
-                items.AddItem(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
-                items.AddItem(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
+                DaggerfallUnityItem magicArm = ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
+                magicArm.legacyMagic = new int[] { 1, 87, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535 };
+                items.AddItem(magicArm);
+                DaggerfallUnityItem magicWeap = ItemBuilder.CreateRandomWeapon(playerEntity.Level);
+                magicWeap.legacyMagic = new int[] { 1, 87, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535 };
+                items.AddItem(magicWeap);
                 merchantItems = items;
             }
             return merchantItems;
@@ -211,23 +200,35 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             switch (service)
             {
+                case GuildServices.FG_Quests:
                 case GuildServices.MG_Quests:
+                case GuildServices.TG_Quests:
+                case GuildServices.DB_Quests:
+                case GuildServices.T_Quests:
                     return HardStrings.serviceQuests;
+
                 case GuildServices.MG_Identify:
                     return HardStrings.serviceIdentify;
+
                 case GuildServices.MG_Buy_Spells:
                 case GuildServices.TKy_Buy_Spells:
                     return HardStrings.serviceBuySpells;
+
                 case GuildServices.MG_Buy_Magic_Items:
                     return HardStrings.serviceBuyMagicItems;
+
                 case GuildServices.MG_Make_Spells:
                     return HardStrings.serviceMakeSpells;
+
                 case GuildServices.MG_Make_Magic_Items:
                     return HardStrings.serviceMakeMagicItems;
+
                 case GuildServices.MG_Daedra_Summoning:
                     return HardStrings.serviceDaedraSummon;
+
                 case GuildServices.MG_Teleportation:
                     return HardStrings.serviceTeleport;
+
                 case GuildServices.MG_Training:
                 case GuildServices.FG_Training:
                 case GuildServices.TG_Training:
@@ -241,12 +242,32 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 case GuildServices.TSt_Training:
                 case GuildServices.TZe_Training:
                     return HardStrings.serviceTraining;
+
                 case GuildServices.FG_Repairs:
                     return HardStrings.serviceRepairs;
-                case GuildServices.T_Cure_Diseases:
-                    return HardStrings.serviceCure;
+
+                case GuildServices.TG_Sell_Magic_Items:
+                    return HardStrings.serviceBuyMagicItems;
+
+                case GuildServices.TG_Spymaster:
+                case GuildServices.DB_Spymaster:
+                    return HardStrings.serviceSpymaster;
+
+                case GuildServices.DB_Make_Potions:
+                    return HardStrings.serviceMakePotions;
+
+                case GuildServices.DB_Buy_Potions:
+                    return HardStrings.serviceBuyPotions;
+
+                case GuildServices.DB_Buy_Soulgems:
+                    return HardStrings.serviceBuySoulgems;
+
                 case GuildServices.T_Make_Donation:
                     return HardStrings.serviceDonate;
+
+                case GuildServices.T_Cure_Diseases:
+                    return HardStrings.serviceCure;
+
                 default:
                     return "?";
             }
@@ -273,15 +294,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ServiceButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            CloseWindow();
             switch (service)
             {
+                case GuildServices.FG_Quests:
                 case GuildServices.MG_Quests:
-                    OfferQuest();
+                case GuildServices.TG_Quests:
+                case GuildServices.DB_Quests:
+                case GuildServices.T_Quests:
+                    GetQuest();
                     break;
+
                 case GuildServices.MG_Identify:
+                    CloseWindow();
                     uiManager.PushWindow(new DaggerfallTradeWindow(uiManager, DaggerfallTradeWindow.WindowModes.Identify, this));
                     break;
+
                 case GuildServices.MG_Training:
                 case GuildServices.FG_Training:
                 case GuildServices.TG_Training:
@@ -296,20 +323,26 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 case GuildServices.TZe_Training:
                     TrainingService();
                     break;
+
                 case GuildServices.MG_Buy_Magic_Items:
+                    CloseWindow();
                     DaggerfallTradeWindow tradeWindow = new DaggerfallTradeWindow(uiManager, DaggerfallTradeWindow.WindowModes.Buy, this);
                     tradeWindow.MerchantItems = GetMerchantItems();
                     uiManager.PushWindow(tradeWindow);
                     break;
+
                 case GuildServices.MG_Teleportation:
+                    CloseWindow();
                     DaggerfallUI.Instance.DfTravelMapWindow.ActivateTeleportationTravel();
                     uiManager.PushWindow(DaggerfallUI.Instance.DfTravelMapWindow);
                     break;
+
                 case GuildServices.MG_Buy_Spells:
                     //uiManager.PushWindow(new DaggerfallBankingWindow(uiManager, this));
                     //break;
 
                 default:
+                    CloseWindow();
                     DaggerfallUI.MessageBox("Guild service not yet implemented.");
                     break;
             }
@@ -330,25 +363,28 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             { GuildServices.MG_Quests, tempMagesQuestsFilename },
         };
 
-        void OfferQuest()
+        void GetQuest()
         {
             // Just exit if this NPC already involved in an active quest
             // If quest conditions are complete the quest system should pickup ending
             if (QuestMachine.Instance.IsLastNPCClickedAnActiveQuestor())
             {
                 CloseWindow();
+                return;
             }
-            else if (guildQuestTables.ContainsKey(service))
+
+            if (guildQuestTables.ContainsKey(service))
             {
-                OfferCuratedGuildQuest();
+                OfferGuildQuest();
             }
             else
             {
+                CloseWindow();
                 DaggerfallUI.MessageBox("Guild quests not yet implemented.");
             }
         }
 
-        void OfferCuratedGuildQuest()
+        void OfferGuildQuest()
         {
             // Load quests table each time so player can edit their local file at runtime
             Table table = null;
@@ -370,7 +406,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
 
             // Log offered quest
-            Debug.LogFormat("Offering quest {0} from TempGuild {1}", questName, guild);
+            Debug.LogFormat("Offering quest {0} from Guild {1}", questName, guild);
 
             // Parse quest
             try
@@ -505,6 +541,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void TrainingService()
         {
+            CloseWindow();
             // Check enough time has passed since last trained
             DaggerfallDateTime now = DaggerfallUnity.Instance.WorldTime.Now;
             if ((now.ToClassicDaggerfallTime() - playerEntity.TimeOfLastSkillTraining) < 720)

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -123,11 +123,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string serviceTeleport = "Teleportation";
         public const string serviceMakeSpells = "Make Spells";
         public const string serviceBuyMagicItems = "Buy Magic Items";
+        public const string serviceSellMagicItems = "Buy Magic Items";
         public const string serviceDaedraSummon = "Daedra Summoning";
         public const string serviceMakeMagicItems = "Make Magic Items";
         public const string serviceRepairs = "Repairs";
         public const string serviceDonate = "Make Donation";
         public const string serviceCure = "Cure Disease";
+        public const string serviceSpymaster = "Spymaster";
+        public const string serviceMakePotions = "Make Potions";
+        public const string serviceBuyPotions = "Buy Potions";
+        public const string serviceBuySoulgems = "Buy Soulgems";
         public const string serviceDenied = "You need to be a member to access this.";
 
         public const string roomFreeForKnightSuchAsYou = "The room is free for a knight such as you.";


### PR DESCRIPTION
Finish merging quest dispensing into guild service code now that we're onto 0.5. 
Should appear completely unchanged to players.
Disabled old code, but leaving in for now so can switch back if issues found.

One thing that that is changed is that in PlayerActivate lines 860-880 the trigger of quest resource behaviour and quest listener check are both now done before the quest dispensing is activated, rather than after. This doesn't seem to affect anything as far as I can see, but I may have missed something so please let me know if I need to preserve the ordering for any reason.