### PR TITLE
Asset injection: Import sound files from asset bundles

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -315,6 +315,48 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         }
 
         /// <summary>
+        /// Seek asset in all mods with load order.
+        /// </summary>
+        /// <param name="name">Name of asset to seek.</param>
+        /// <param name="clone">Make a copy of asset?</param>
+        /// <param name="asset">Loaded asset or null.</param>
+        /// <remarks>
+        /// If multiple mods contain an asset with given name, priority is defined by load order.
+        /// </remarks>
+        /// <returns>True if asset is found and loaded sucessfully.</returns>
+        public bool TryGetAsset<T>(string name, bool clone, out T asset) where T : UnityEngine.Object
+        {
+            var query = from mod in Mods where mod.AssetBundle != null
+                        orderby mod.LoadPriority descending
+                        where mod.AssetBundle.Contains(name)
+                        select mod.GetAsset<T>(name, clone);
+
+            return (asset = query.FirstOrDefault()) != null;
+        }
+
+        /// <summary>
+        /// Seek asset in all mods with load order.
+        /// Check all names for each mod with the given priority.
+        /// </summary>
+        /// <param name="names">Names of asset to seek ordered by priority.</param>
+        /// <param name="clone">Make a copy of asset?</param>
+        /// <param name="asset">Loaded asset or null.</param>
+        /// <remarks>
+        /// If multiple mods contain an asset with any of the given names, priority is defined by load order.
+        /// If chosen mod contains multiple assets, priority is defined by order of names list.
+        /// </remarks>
+        /// <returns>True if asset is found and loaded sucessfully.</returns>
+        public bool TryGetAsset<T>(string[] names, bool clone, out T asset) where T : UnityEngine.Object
+        {
+            var query = from mod in Mods where mod.AssetBundle != null
+                        orderby mod.LoadPriority descending
+                        from name in names where mod.AssetBundle.Contains(name)
+                        select mod.GetAsset<T>(name, clone);
+
+            return (asset = query.FirstOrDefault()) != null;
+        }
+
+        /// <summary>
         /// convert full relative path to just the asset name for example:
         /// /Assets/examples/myscript.cs to myscript.cs
         /// </summary>

--- a/Assets/Scripts/SoundReader.cs
+++ b/Assets/Scripts/SoundReader.cs
@@ -17,6 +17,7 @@ using System.IO;
 using DaggerfallConnect;
 using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop
 {
@@ -71,13 +72,9 @@ namespace DaggerfallWorkshop
             // Get clip
             AudioClip clip;
             string name = string.Format("DaggerfallClip [Index={0}, ID={1}]", soundIndex, (int)soundFile.BsaFile.GetRecordId(soundIndex));
-            if (Utility.AssetInjection.SoundReplacement.CustomSoundExist(soundIndex))
+            if (SoundReplacement.TryImportSound((SoundClips)soundIndex, out clip))
             {
-                // Get audio clip from sound file on disk
-                WWW customSoundFile = Utility.AssetInjection.SoundReplacement.LoadCustomSound(soundIndex);
-                clip = customSoundFile.audioClip;
                 clip.name = name;
-                StartCoroutine(WaitForSoundFile(customSoundFile, clip));
             }
             else
             {
@@ -154,21 +151,6 @@ namespace DaggerfallWorkshop
                 return -1;
 
             return soundFile.GetRecordIndex((uint)soundID);
-        }
-
-        /// <summary>
-        /// Load AudioClip from WWW to get custom sound.
-        /// </summary>
-        /// <param name="www">WWW object</param>
-        /// <param name="clip">Audio clip from WWW</param>
-        /// <returns></returns>
-        IEnumerator WaitForSoundFile(WWW www, AudioClip clip)
-        {
-            while (clip.loadState != AudioDataLoadState.Loaded)
-                yield return www;
-
-            if (clip.loadState == AudioDataLoadState.Failed)
-                Debug.LogError("Can't load custom clip audio " + clip.name);
         }
 
         #endregion


### PR DESCRIPTION
* Added a generic method to ModManager class to seek and import an asset of given type and name from all mods.
* Added support for sound import from mods. It was already possible to import them from disk, now they are also loaded from assetbundles with load order, like we discussed on forum for textures.

I did the same with videos but i prefer to test them a bit more before pushing.