### PR TITLE
House purchasing, ship models & player housing

### DIFF
--- a/Assets/Scenes/DaggerfallUnityGame.unity
+++ b/Assets/Scenes/DaggerfallUnityGame.unity
@@ -740,6 +740,34 @@ MonoBehaviour:
   ShowEditorFlats: 0
   NoWorld: 0
   GodMode: 0
+--- !u!1 &392839675
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 392839676}
+  m_Layer: 0
+  m_Name: BankPurchase
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &392839676
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 392839675}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &401895382 stripped
 MonoBehaviour:
   m_PrefabParentObject: {fileID: 11466528, guid: bbe5e15c9f6b3dc47bb9485a437750a0,
@@ -2141,7 +2169,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22400016, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 11400006, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_Value

--- a/Assets/Scripts/Game/BuildingDirectory.cs
+++ b/Assets/Scripts/Game/BuildingDirectory.cs
@@ -139,6 +139,15 @@ namespace DaggerfallWorkshop.Game
             return buildings;
         }
 
+        public List<BuildingSummary> GetHousesForSale()
+        {
+            List<BuildingSummary> forSale = new List<BuildingSummary>();
+            foreach (BuildingSummary building in buildingDict.Values)
+                if (building.BuildingType == DFLocation.BuildingTypes.HouseForSale)
+                    forSale.Add(building);
+            return forSale;
+        }
+
         #endregion
 
         #region Public Static Methods

--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -77,6 +77,7 @@ namespace DaggerfallWorkshop.Game.Banking
 
         private static int[] shipPrices = new int[] { 100000, 200000 };
         private static uint[] shipModelIds = new uint[] { 910, 909 };
+        private static float[] shipCameraDist = new float[] { -30, -50 };
         private static DFPosition[] shipCoords = new DFPosition[] { new DFPosition(2, 2), new DFPosition(5, 5) };
         private static string[] shipInteriorSceneNames = new string[] {
             DaggerfallInterior.GetSceneName(1050578, 0),
@@ -98,6 +99,8 @@ namespace DaggerfallWorkshop.Game.Banking
         public static int GetShipSellPrice(ShipType ship) { return (int)(GetShipPrice(ship) * deedSellMult); }
 
         public static uint GetShipModelId(ShipType ship) { return ship >= 0 ? shipModelIds[(int)ship] : 0; }
+
+        public static float GetShipCameraDist(ShipType ship) { return ship >= 0 ? shipCameraDist[(int)ship] : 0; }
 
         public static DFPosition GetShipCoords() { return OwnsShip ? shipCoords[(int)ownedShip] : null; }
 

--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -141,7 +141,7 @@ namespace DaggerfallWorkshop.Game.Banking
             ModelData modelData;
             DaggerfallUnity.Instance.MeshReader.GetModelData(house.ModelID, out modelData);
             float houseRadius = modelData.DFMesh.Radius;
-            return (int) (houseRadius * 1280); //1436.6);
+            return (int) (houseRadius * 1280);
         }
 
         public static void SetupHouses()

--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -76,6 +76,7 @@ namespace DaggerfallWorkshop.Game.Banking
         private const float deedSellMult = 0.85f;
 
         private static int[] shipPrices = new int[] { 100000, 200000 };
+        private static uint[] shipModelIds = new uint[] { 910, 909 };
         private static DFPosition[] shipCoords = new DFPosition[] { new DFPosition(2, 2), new DFPosition(5, 5) };
         private static string[] shipInteriorSceneNames = new string[] {
             DaggerfallInterior.GetSceneName(1050578, 0),
@@ -95,6 +96,8 @@ namespace DaggerfallWorkshop.Game.Banking
         public static int GetShipPrice(ShipType ship) { return ship >= 0 ? shipPrices[(int) ship] : 0; }
 
         public static int GetShipSellPrice(ShipType ship) { return (int)(GetShipPrice(ship) * deedSellMult); }
+
+        public static uint GetShipModelId(ShipType ship) { return ship >= 0 ? shipModelIds[(int)ship] : 0; }
 
         public static DFPosition GetShipCoords() { return OwnsShip ? shipCoords[(int)ownedShip] : null; }
 

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -250,8 +250,10 @@ namespace DaggerfallWorkshop.Game
 
                                     DaggerfallMessageBox mb;
 
-                                    if (buildingUnlocked && buildingType >= DFLocation.BuildingTypes.House1
-                                        && buildingType <= DFLocation.BuildingTypes.House4)
+                                    if (buildingUnlocked &&
+                                        buildingType >= DFLocation.BuildingTypes.House1 &&
+                                        buildingType <= DFLocation.BuildingTypes.House4 &&
+                                        !DaggerfallBankManager.IsHouseOwned(building.buildingKey))
                                     {
                                         string greetingText = DaggerfallUnity.Instance.TextProvider.GetRandomText(houseGreetingsTextId);
                                         mb = DaggerfallUI.MessageBox(greetingText);
@@ -734,6 +736,10 @@ namespace DaggerfallWorkshop.Game
         // Check if non-house building is unlocked and enterable
         private bool BuildingIsUnlocked(BuildingSummary buildingSummary)
         {
+            // Player owned house is always unlocked
+            if (DaggerfallBankManager.IsHouseOwned(buildingSummary.buildingKey))
+                return true;
+
             bool unlocked = false;
 
             DFLocation.BuildingTypes type = buildingSummary.BuildingType;

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -19,6 +19,7 @@ using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using FullSerializer;
+using DaggerfallWorkshop.Game.Banking;
 
 namespace DaggerfallWorkshop.Game.Questing
 {
@@ -813,6 +814,8 @@ namespace DaggerfallWorkshop.Game.Questing
         /// </summary>
         SiteDetails[] CollectQuestSitesOfBuildingType(DFLocation location, DFLocation.BuildingTypes buildingType)
         {
+                Debug.LogFormat("quest sites for {0} id {1}", location.Name, location.MapTableData.MapId);
+
             // Valid building types for valid search
             int[] validBuildingTypes = { 0, 2, 3, 5, 6, 8, 9, 11, 12, 13, 14, 15, 17, 18, 19, 20 };
 
@@ -851,6 +854,10 @@ namespace DaggerfallWorkshop.Game.Questing
                         // Match building against required type
                         if (buildingSummary[i].BuildingType == buildingType || wildcardFound)
                         {
+                            // Building must not be a player owned house
+                            if (DaggerfallBankManager.IsHouseOwned(buildingSummary[i].buildingKey))
+                                continue;
+
                             // Building must be a valid quest site
                             QuestMarker[] questSpawnMarkers, questItemMarkers;
                             EnumerateBuildingQuestMarkers(blocks[index], i, out questSpawnMarkers, out questItemMarkers);

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -390,13 +390,15 @@ namespace DaggerfallWorkshop.Game.Serialization
     public class BankDeedData_v1
     {
         public int shipType;
-        public HouseDeedData_v1 houseDeed;
+        public HouseData_v1[] houses;
     }
 
     [fsObject("v1")]
-    public class HouseDeedData_v1
+    public class HouseData_v1
     {
-        public int houseId;
+        public int mapID;
+        public int buildingKey;
+        public int regionIndex;
     }
 
     [fsObject("v1")]

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
@@ -10,6 +10,7 @@ using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Banking;
 using System.Collections.Generic;
+using DaggerfallConnect;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -185,7 +186,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {   // List all the houses for sale in this location
                 foreach (BuildingSummary house in housesForSale)
                 {
-                    priceListBox.AddItem("Price : " + house.buildingKey + " gold");
+                    priceListBox.AddItem("Price : " + DaggerfallBankManager.GetHousePrice(house) + " gold");
                 }
                 /*
                 for (int i = 0; i < 20; i++)
@@ -241,6 +242,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             goModel = GameObjectHelper.CreateDaggerfallMeshGameObject(modelId, null);
             goModel.layer = layer;
             goModel.transform.SetParent(goBankPurchase.transform);
+
+            // Apply current climate
+            ClimateBases climateBase = ClimateSwaps.FromAPIClimateBase(GameManager.Instance.PlayerGPS.ClimateSettings.ClimateType);
+            ClimateSeason season = (DaggerfallUnity.WorldTime.Now.SeasonValue == DaggerfallDateTime.Seasons.Winter) ? ClimateSeason.Winter : ClimateSeason.Summer;
+            DaggerfallMesh dfMesh = goModel.GetComponent<DaggerfallMesh>();
+            dfMesh.SetClimate(climateBase, season, WindowStyle.Day);
         }
 
         private void RenderModel()
@@ -356,11 +363,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             if (priceListBox.SelectedIndex < 0)
                 return;
+
+            CloseWindow();
             if (housesForSale == null)
-            {
-                CloseWindow();
-                bankingWindow.GeneratePurchaseShipPopup((ShipType) priceListBox.SelectedIndex);
-            }
+                bankingWindow.GeneratePurchaseShipPopup((ShipType)priceListBox.SelectedIndex);
+            else
+                bankingWindow.GeneratePurchaseHousePopup(housesForSale[priceListBox.SelectedIndex]);
         }
 
         void PriceListBox_OnSelectItem()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
@@ -130,6 +130,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
+        private void Display3dModel(int selectedIdx)
+        {
+            if (housesForSale == null)
+            {
+                uint shipModelId = DaggerfallBankManager.GetShipModelId((ShipType) selectedIdx);
+                // Get model data
+                ModelData modelData;
+                DaggerfallUnity.MeshReader.GetModelData(shipModelId, out modelData);
+
+                GameObject go = GameObjectHelper.CreateDaggerfallMeshGameObject(shipModelId, null);
+
+                RenderTexture renderTexture = new RenderTexture((int) displayPanelRect.width, (int) displayPanelRect.height, 16);
+            }
+        }
+
         private void SetupPriceList()
         {
             priceListBox = new ListBox()
@@ -241,6 +256,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         void PriceListBox_OnSelectItem()
         {
             Debug.Log("Selected " + priceListBox.SelectedIndex);
+
         }
 
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
@@ -162,8 +162,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 lastRotTime = Time.realtimeSinceStartup;
                 if (goModel)
                 {
-                    goModel.transform.Rotate(Vector3.up, 1);
+                    // Render the model into display panel
                     RenderModel();
+                    // Rotate model
+                    goModel.transform.Rotate(Vector3.up, 1);
                 }
             }
         }
@@ -220,21 +222,25 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (goModel)
                 Object.Destroy(goModel);
 
+            uint modelId = 0;
             if (housesForSale == null)
             {
-                // Position camera
+                // Position camera and set model id
                 camera.transform.position = new Vector3(0, 12, DaggerfallBankManager.GetShipCameraDist((ShipType)selectedIdx));
-                // Get model data
-                ModelData modelData;
-                uint shipModelId = DaggerfallBankManager.GetShipModelId((ShipType)selectedIdx);
-                DaggerfallUnity.MeshReader.GetModelData(shipModelId, out modelData);
-                // Create mesh game object
-                goModel = GameObjectHelper.CreateDaggerfallMeshGameObject(shipModelId, null);
-                goModel.layer = layer;
-                goModel.transform.SetParent(goBankPurchase.transform);
-
-                RenderModel();
+                modelId = DaggerfallBankManager.GetShipModelId((ShipType)selectedIdx);
             }
+            else
+            {
+                // Position camera and set model id
+                camera.transform.position = new Vector3(0, 3, -16);
+                BuildingSummary house = housesForSale[selectedIdx];
+                modelId = house.ModelID;
+            }
+
+            // Create mesh game object for the model
+            goModel = GameObjectHelper.CreateDaggerfallMeshGameObject(modelId, null);
+            goModel.layer = layer;
+            goModel.transform.SetParent(goBankPurchase.transform);
         }
 
         private void RenderModel()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Banking;
+using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -54,20 +55,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Properties & Constants
 
-        DaggerfallBankingWindow bankingWindow;
+        protected DaggerfallBankingWindow bankingWindow;
+        private List<BuildingSummary> housesForSale;
         private const int listDisplayUnits = 10;  // Number of items displayed in scrolling area
         private const int scrollNum = 1;          // Number of items on each scroll tick
-        private bool ships;                       // True if purchasing ships, otherwise showing purchasable houses.
 
         #endregion
 
         #region Constructors
 
-        public DaggerfallBankPurchasePopUp(IUserInterfaceManager uiManager, DaggerfallBankingWindow previousWindow = null, bool ships = false)
+        public DaggerfallBankPurchasePopUp(IUserInterfaceManager uiManager, DaggerfallBankingWindow previousWindow = null, List<BuildingSummary> housesForSale = null)
             : base(uiManager, previousWindow)
         {
-            this.ships = ships;
-            this.bankingWindow = previousWindow;
+            this.housesForSale = housesForSale;
+            bankingWindow = previousWindow;
         }
 
         #endregion
@@ -110,17 +111,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void PopulatePriceList()
         {
-            if (ships)
+            if (housesForSale == null)
             {
                 for (int i = 0; i < 2; i++)
                     priceListBox.AddItem(HardStrings.bankPurchasePrice.Replace("%s", DaggerfallBankManager.GetShipPrice((ShipType) i).ToString()), i);
             }
             else
             {   // List all the houses for sale in this location
+                foreach (BuildingSummary house in housesForSale)
+                {
+                    priceListBox.AddItem("Price : " + house.buildingKey + " gold");
+                }
+                /*
                 for (int i = 0; i < 20; i++)
                 {
                     priceListBox.AddItem("Price : " + (100000 + i) + " gold");
-                }
+                }*/
             }
         }
 
@@ -225,7 +231,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             if (priceListBox.SelectedIndex < 0)
                 return;
-            if (ships)
+            if (housesForSale == null)
             {
                 CloseWindow();
                 bankingWindow.GeneratePurchaseShipPopup((ShipType) priceListBox.SelectedIndex);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
@@ -403,10 +403,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
             else
             {
                 BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();
-                List<BuildingSummary> housesForSale = buildingDirectory.GetHousesForSale();
-                // If houses are for sale, show them
-                if (housesForSale.Count > 0)
-                    uiManager.PushWindow(new DaggerfallBankPurchasePopUp(uiManager, this, housesForSale));
+                if (buildingDirectory)
+                {
+                    List<BuildingSummary> housesForSale = buildingDirectory.GetHousesForSale();
+                    // If houses are for sale, show them
+                    if (housesForSale.Count > 0)
+                        uiManager.PushWindow(new DaggerfallBankPurchasePopUp(uiManager, this, housesForSale));
+                    else
+                        GeneratePopup(TransactionResult.NO_HOUSES_FOR_SALE);
+                }
                 else
                     GeneratePopup(TransactionResult.NO_HOUSES_FOR_SALE);
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
@@ -14,6 +14,7 @@ using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Banking;
 using DaggerfallWorkshop.Utility;
+using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game.UserInterface
 {
@@ -397,11 +398,24 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             if (DaggerfallBankManager.OwnsHouse)
                 GeneratePopup(TransactionResult.ALREADY_OWN_HOUSE);
-            //else if no houses for sale
-            else    // Show houses for sale
-                uiManager.PushWindow(new DaggerfallBankPurchasePopUp(uiManager, this));
+            else
+            {
+                BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();
+                List<BuildingSummary> housesForSale = buildingDirectory.GetHousesForSale();
+                // If houses are for sale, show them
+                if (housesForSale.Count > 0)
+                    uiManager.PushWindow(new DaggerfallBankPurchasePopUp(uiManager, this, housesForSale));
+                else
+                    GeneratePopup(TransactionResult.NO_HOUSES_FOR_SALE);
+            }
         }
-
+/*
+        List<StaticBuilding> GetHousesForSale()
+        {
+            BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();
+            buildingDirectory.
+        }
+        */
         void sellHouseButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (!DaggerfallBankManager.OwnsHouse)
@@ -416,7 +430,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 GeneratePopup(TransactionResult.ALREADY_OWN_SHIP);
             //else if not port town
             else    // Show ships for sale
-                uiManager.PushWindow(new DaggerfallBankPurchasePopUp(uiManager, this, true));
+                uiManager.PushWindow(new DaggerfallBankPurchasePopUp(uiManager, this));
         }
 
         void sellShipButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
@@ -409,13 +409,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     GeneratePopup(TransactionResult.NO_HOUSES_FOR_SALE);
             }
         }
-/*
-        List<StaticBuilding> GetHousesForSale()
-        {
-            BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();
-            buildingDirectory.
-        }
-        */
+
         void sellHouseButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (!DaggerfallBankManager.OwnsHouse)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
@@ -106,77 +106,77 @@ namespace DaggerfallWorkshop.Game.UserInterface
             depoGoldButton.Position = new Vector2(120, 58);
             depoGoldButton.Size     = new Vector2(45, 8);
             depoGoldButton.Name     = "depo_gold_button";
-            depoGoldButton.OnMouseClick += depoGoldButton_OnMouseClick;
+            depoGoldButton.OnMouseClick += DepoGoldButton_OnMouseClick;
             mainPanel.Components.Add(depoGoldButton);
 
             drawGoldButton          = new Button();
             drawGoldButton.Position = new Vector2(172, 58);
             drawGoldButton.Size     = new Vector2(45, 8);
             drawGoldButton.Name     = "draw_gold_button";
-            drawGoldButton.OnMouseClick += drawGoldButton_OnMouseClick;
+            drawGoldButton.OnMouseClick += DrawGoldButton_OnMouseClick;
             mainPanel.Components.Add(drawGoldButton);
 
             depoLOCButton           = new Button();
             depoLOCButton.Position  = new Vector2(120, 76);
             depoLOCButton.Size      = new Vector2(45, 8);
             depoLOCButton.Name      = "depo_loc_button";
-            depoLOCButton.OnMouseClick += depoLOCButton_OnMouseClick;
+            depoLOCButton.OnMouseClick += DepoLOCButton_OnMouseClick;
             mainPanel.Components.Add(depoLOCButton);
 
             drawLOCButton           = new Button();
             drawLOCButton.Position  = new Vector2(172, 76);
             drawLOCButton.Size      = new Vector2(45, 8);
             drawLOCButton.Name      = "draw_LOC_button";
-            drawLOCButton.OnMouseClick += drawLOCButton_OnMouseClick;
+            drawLOCButton.OnMouseClick += DrawLOCButton_OnMouseClick;
             mainPanel.Components.Add(drawLOCButton);
 
             loanRepayButton         = new Button();
             loanRepayButton.Position= new Vector2(120, 94);
             loanRepayButton.Size    = new Vector2(45, 8);
             loanRepayButton.Name    = "loan_repay_button";
-            loanRepayButton.OnMouseClick += loanRepayButton_OnMouseClick;
+            loanRepayButton.OnMouseClick += LoanRepayButton_OnMouseClick;
             mainPanel.Components.Add(loanRepayButton);
 
             loanBorrowButton        = new Button();
             loanBorrowButton.Position = new Vector2(172, 94);
             loanBorrowButton.Size   = new Vector2(45, 8);
             loanBorrowButton.Name   = "loan_borrow_button";
-            loanBorrowButton.OnMouseClick += loanBorrowButton_OnMouseClick;
+            loanBorrowButton.OnMouseClick += LoanBorrowButton_OnMouseClick;
             mainPanel.Components.Add(loanBorrowButton);
 
             buyHouseButton          = new Button();
             buyHouseButton.Position = new Vector2(120, 112);
             buyHouseButton.Size     = new Vector2(45, 8);
             buyHouseButton.Name     = "buy_house_button";
-            buyHouseButton.OnMouseClick += buyHouseButton_OnMouseClick;
+            buyHouseButton.OnMouseClick += BuyHouseButton_OnMouseClick;
             mainPanel.Components.Add(buyHouseButton);
 
             sellHouseButton         = new Button();
             sellHouseButton.Position = new Vector2(172, 112);
             sellHouseButton.Size    = new Vector2(45, 8);
             sellHouseButton.Name    = "sell_house_button";
-            sellHouseButton.OnMouseClick += sellHouseButton_OnMouseClick;
+            sellHouseButton.OnMouseClick += SellHouseButton_OnMouseClick;
             mainPanel.Components.Add(sellHouseButton);
 
             buyShipButton           = new Button();
             buyShipButton.Position  = new Vector2(120, 130);
             buyShipButton.Size      = new Vector2(45, 8);
             buyShipButton.Name      = "buy_ship_button";
-            buyShipButton.OnMouseClick += buyShipButton_OnMouseClick;
+            buyShipButton.OnMouseClick += BuyShipButton_OnMouseClick;
             mainPanel.Components.Add(buyShipButton);
 
             sellShipButton          = new Button();
             sellShipButton.Position = new Vector2(172, 130);
             sellShipButton.Size     = new Vector2(45, 8);
             sellShipButton.Name     = "sell_ship_button";
-            sellShipButton.OnMouseClick += sellShipButton_OnMouseClick;
+            sellShipButton.OnMouseClick += SellShipButton_OnMouseClick;
             mainPanel.Components.Add(sellShipButton);
 
             exitButton              = new Button();
             exitButton.Position     = new Vector2(92, 159);
             exitButton.Size         = new Vector2(40, 19);
             exitButton.Name         = "exit_button";
-            exitButton.OnMouseClick += exitButton_OnMouseClick;
+            exitButton.OnMouseClick += ExitButton_OnMouseClick;
             mainPanel.Components.Add(exitButton);
 
             transactionInput           = new TextBox();
@@ -221,14 +221,16 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             UpdateButtons();
             UpdateLabels();
-
-            //if (transactionType != TransactionType.None)
-            //    Debug.Log(transactionType.ToString());
         }
 
         public void GeneratePurchaseShipPopup(ShipType shipType)
         {
             GeneratePopup(DaggerfallBankManager.PurchaseShip(shipType, regionIndex));
+        }
+
+        public void GeneratePurchaseHousePopup(BuildingSummary house)
+        {
+            GeneratePopup(DaggerfallBankManager.PurchaseHouse(house, regionIndex));
         }
 
         void UpdateLabels()
@@ -356,32 +358,32 @@ namespace DaggerfallWorkshop.Game.UserInterface
         }
 
         //bank window button handlers
-        void depoGoldButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void DepoGoldButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             ToggleTransactionInput(TransactionType.Depositing_gold);
         }
 
-        void drawGoldButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void DrawGoldButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             ToggleTransactionInput(TransactionType.Withdrawing_gold);
         }
 
-        void depoLOCButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void DepoLOCButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             GeneratePopup(TransactionResult.DEPOSIT_LOC);
         }
 
-        void drawLOCButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void DrawLOCButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             ToggleTransactionInput(TransactionType.Withdrawing_Letter);
         }
 
-        void loanRepayButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void LoanRepayButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             ToggleTransactionInput(TransactionType.Repaying_loan);
         }
 
-        void loanBorrowButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void LoanBorrowButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (DaggerfallBankManager.HasLoan(regionIndex))
             {
@@ -394,7 +396,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             }
         }
 
-        void buyHouseButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void BuyHouseButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (DaggerfallBankManager.OwnsHouse)
                 GeneratePopup(TransactionResult.ALREADY_OWN_HOUSE);
@@ -410,7 +412,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             }
         }
 
-        void sellHouseButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void SellHouseButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (!DaggerfallBankManager.OwnsHouse)
                 return;
@@ -418,7 +420,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 GeneratePopup(TransactionResult.SELL_HOUSE_OFFER, 1234);  // Temp value 1234 for testing.
         }
 
-        void buyShipButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void BuyShipButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (DaggerfallBankManager.OwnsShip)
                 GeneratePopup(TransactionResult.ALREADY_OWN_SHIP);
@@ -427,7 +429,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 uiManager.PushWindow(new DaggerfallBankPurchasePopUp(uiManager, this));
         }
 
-        void sellShipButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void SellShipButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (DaggerfallBankManager.OwnsShip)
                 GeneratePopup(TransactionResult.SELL_SHIP_OFFER, (int)(DaggerfallBankManager.GetShipPrice(DaggerfallBankManager.OwnedShip) * 0.85));
@@ -435,7 +437,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
         }
 
-        void exitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             CloseWindow();
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -16,6 +16,7 @@ using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallConnect;
+using DaggerfallWorkshop.Game.Banking;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -411,13 +412,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (SaveLoadManager.StateManager.ContainsPermanentScene(sceneName))
                 {
                     // Can rest if it's an player owned ship/house.
-                    if (playerEnterExit.BuildingType == DFLocation.BuildingTypes.Ship)
-                       // || TODO: house check
+                    int buildingKey = playerEnterExit.BuildingDiscoveryData.buildingKey;
+                    if (playerEnterExit.BuildingType == DFLocation.BuildingTypes.Ship || DaggerfallBankManager.IsHouseOwned(buildingKey))
                        return true;
 
                     // Find room rental record and get remaining time..
                     int mapId = playerGPS.CurrentLocation.MapTableData.MapId;
-                    int buildingKey = playerEnterExit.BuildingDiscoveryData.buildingKey;
                     RoomRental_v1 room = GameManager.Instance.PlayerEntity.GetRentedRoom(mapId, buildingKey);
                     remainingHoursRented = PlayerEntity.GetRemainingHours(room);
                     allocatedBed = room.allocatedBed;

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -86,6 +86,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string residence = "Residence";
         public const string youSee = "You see %s.";
         public const string theNamedResidence = "The %s Residence";
+        public const string playerResidence = "%s's house";
 
         public const string materialIneffective = "The material of the weapon you are using is ineffective.";
         public const string successfulBackstab = "Successful backstab!";

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -389,8 +389,9 @@ namespace DaggerfallWorkshop.Game.Utility
             // Assign starting gear to player entity
             DaggerfallUnity.Instance.ItemHelper.AssignStartingGear(playerEntity);
 
-            // Setup bank accounts
+            // Setup bank accounts and houses
             Banking.DaggerfallBankManager.SetupAccounts();
+            Banking.DaggerfallBankManager.SetupHouses();
 
             // Randomize initial region prices
             playerEntity.InitializeRegionPrices();

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -19,6 +19,7 @@ using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Items;
+using DaggerfallWorkshop.Game.Banking;
 
 namespace DaggerfallWorkshop
 {
@@ -774,6 +775,9 @@ namespace DaggerfallWorkshop
                 {
                     go.SetActive(false);
                 }
+                // Disable people if player owns this house
+                else if (DaggerfallBankManager.IsHouseOwned(buildingData.buildingKey))
+                    go.SetActive(false);
             }
         }
 

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -760,6 +760,12 @@ namespace DaggerfallWorkshop
             // Get discovery data for building
             discoveredBuildingOut = dl.discoveredBuildings[buildingKey];
 
+            // Check if name should be overridden (owned house / quest site)
+            PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+            if (DaggerfallBankManager.IsHouseOwned(buildingKey)) {
+                DaggerfallBankManager.IsHouseOwned(buildingKey);
+                discoveredBuildingOut.displayName = HardStrings.playerResidence.Replace("%s", playerEntity.Name);
+            }
             return true;
         }
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -20,7 +20,7 @@ TagManager:
   - WorldTerrain
   - Automap
   - Enemies
-  - 
+  - BankPurchase
   - 
   - 
   - 


### PR DESCRIPTION
Sorry, far too excited about this so I've just handled loading inside a bank by using the no houses for sale message. I'm happy to switch from using BuildingDirectory to datafiles, but not convinced it's worth it for this edge case. Turned out the radius was easy to get once I had model id. Didn't even need Allofich for the price multiplier.

TODO:
* Only listing buildings for sale - will need to add other houses in due course.
* Selling houses. (should be easy since the name is changed by overriding in PlayerGPS)

Anyway, this is so you can give it a spin when you need a break from magic! This was a while in the works as I gradually learned but it all came together today really nicely. Such a good feeling!

Oh, and you may want to check my changes to Place for preventing quests spawning in player houses.