### PR TITLE
Climbing Control Changes

### DIFF
--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -248,7 +248,7 @@ namespace DaggerfallWorkshop.Game
 
             // Climbing
             uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
-            if (!InputManager.Instance.HasAction(InputManager.Actions.MoveForwards)
+            if (InputManager.Instance.HasAction(InputManager.Actions.Jump)
                 || (collisionFlags & CollisionFlags.Sides) == 0
                 || failedClimbingCheck
                 || fakeLevitate.IsLevitating
@@ -495,7 +495,10 @@ namespace DaggerfallWorkshop.Game
 
         private void ClimbMovement()
         {
-            controller.Move(Vector3.up * Time.deltaTime);
+            if (InputManager.Instance.HasAction(InputManager.Actions.MoveForwards))
+                controller.Move(Vector3.up * Time.deltaTime);
+            if (InputManager.Instance.HasAction(InputManager.Actions.MoveBackwards))
+                controller.Move(-Vector3.up * Time.deltaTime);
             if (climbingContinueTimer <= (systemTimerUpdatesPerSecond * 15))
                 climbingContinueTimer += Time.deltaTime;
             else


### PR DESCRIPTION
Made changes to the PlayerMotor script to give the player more control while climbing. However, these changes deviate from the original game's climbing mechanics.

Basically you can now let go of the movement controls in order to stop while climbing, press the key to move backwards in order to climb down, and cancel climbing by pressing the jump key.