### PR TITLE
Add GetSubTexture() overload for relative subrects

### DIFF
--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -7,6 +7,7 @@
 
 using UnityEngine;
 using System.Collections.Generic;
+using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Items;
 
@@ -29,6 +30,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         };
         Rect upArrowRect = new Rect(0, 0, 9, 16);
         Rect downArrowRect = new Rect(0, 136, 9, 16);
+        DFSize arrowsFullSize = new DFSize(9, 152);
 
         Texture2D redUpArrow;
         Texture2D greenUpArrow;
@@ -400,20 +402,20 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             // Cut out red up/down arrows
             Texture2D redArrowsTexture = ImageReader.GetTexture(redArrowsTextureName);
-            redUpArrow = ImageReader.GetSubTexture(redArrowsTexture, upArrowRect);
-            redDownArrow = ImageReader.GetSubTexture(redArrowsTexture, downArrowRect);
+            redUpArrow = ImageReader.GetSubTexture(redArrowsTexture, upArrowRect, arrowsFullSize);
+            redDownArrow = ImageReader.GetSubTexture(redArrowsTexture, downArrowRect, arrowsFullSize);
 
             // Cut out green up/down arrows
             Texture2D greenArrowsTexture = ImageReader.GetTexture(greenArrowsTextureName);
-            greenUpArrow = ImageReader.GetSubTexture(greenArrowsTexture, upArrowRect);
-            greenDownArrow = ImageReader.GetSubTexture(greenArrowsTexture, downArrowRect);
+            greenUpArrow = ImageReader.GetSubTexture(greenArrowsTexture, upArrowRect, arrowsFullSize);
+            greenDownArrow = ImageReader.GetSubTexture(greenArrowsTexture, downArrowRect, arrowsFullSize);
 
             if (enhanced)
             {
                 itemListTextures = new Texture2D[listDisplayUnits];
                 Texture2D baseInvTexture = ImageReader.GetTexture(baseInvTextureName);
                 for (int i = 0; i < itemCutoutRects16.Length; i++)
-                    itemListTextures[i] = ImageReader.GetSubTexture(baseInvTexture, itemCutoutRects16[i]);
+                    itemListTextures[i] = ImageReader.GetSubTexture(baseInvTexture, itemCutoutRects16[i], new DFSize(320, 200));
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
@@ -11,6 +11,7 @@ using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Banking;
 using System.Collections.Generic;
 using DaggerfallConnect;
+using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
@@ -24,6 +25,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Rect exitButtonRect = new Rect(150, 106, 40, 19);
         Rect upArrowRect = new Rect(0, 0, 9, 16);
         Rect downArrowRect = new Rect(0, 64, 9, 16);
+        DFSize arrowsFullSize = new DFSize(9, 80);
 
         #endregion
 
@@ -356,13 +358,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Cut out red up/down arrows
             Texture2D redArrowsTexture = ImageReader.GetTexture(redArrowsTextureName);
-            redUpArrow = ImageReader.GetSubTexture(redArrowsTexture, upArrowRect);
-            redDownArrow = ImageReader.GetSubTexture(redArrowsTexture, downArrowRect);
+            redUpArrow = ImageReader.GetSubTexture(redArrowsTexture, upArrowRect, arrowsFullSize);
+            redDownArrow = ImageReader.GetSubTexture(redArrowsTexture, downArrowRect, arrowsFullSize);
 
             // Cut out green up/down arrows
             Texture2D greenArrowsTexture = ImageReader.GetTexture(greenArrowsTextureName);
-            greenUpArrow = ImageReader.GetSubTexture(greenArrowsTexture, upArrowRect);
-            greenDownArrow = ImageReader.GetSubTexture(greenArrowsTexture, downArrowRect);
+            greenUpArrow = ImageReader.GetSubTexture(greenArrowsTexture, upArrowRect, arrowsFullSize);
+            greenDownArrow = ImageReader.GetSubTexture(greenArrowsTexture, downArrowRect, arrowsFullSize);
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -13,6 +13,7 @@ using UnityEngine;
 using System;
 using System.Collections.Generic;
 using DaggerfallConnect.Arena2;
+using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Entity;
@@ -890,36 +891,37 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Load source textures
             baseTexture = ImageReader.GetTexture(baseTextureName);
             goldTexture = ImageReader.GetTexture(goldTextureName);
+            DFSize baseSize = new DFSize(320, 200);
 
             // Cut out tab page not selected button textures
-            weaponsAndArmorNotSelected = ImageReader.GetSubTexture(baseTexture, weaponsAndArmorRect);
-            magicItemsNotSelected = ImageReader.GetSubTexture(baseTexture, magicItemsRect);
-            clothingAndMiscNotSelected = ImageReader.GetSubTexture(baseTexture, clothingAndMiscRect);
-            ingredientsNotSelected = ImageReader.GetSubTexture(baseTexture, ingredientsRect);
+            weaponsAndArmorNotSelected = ImageReader.GetSubTexture(baseTexture, weaponsAndArmorRect, baseSize);
+            magicItemsNotSelected = ImageReader.GetSubTexture(baseTexture, magicItemsRect, baseSize);
+            clothingAndMiscNotSelected = ImageReader.GetSubTexture(baseTexture, clothingAndMiscRect, baseSize);
+            ingredientsNotSelected = ImageReader.GetSubTexture(baseTexture, ingredientsRect, baseSize);
 
             // Cut out tab page selected button textures
-            weaponsAndArmorSelected = ImageReader.GetSubTexture(goldTexture, weaponsAndArmorRect);
-            magicItemsSelected = ImageReader.GetSubTexture(goldTexture, magicItemsRect);
-            clothingAndMiscSelected = ImageReader.GetSubTexture(goldTexture, clothingAndMiscRect);
-            ingredientsSelected = ImageReader.GetSubTexture(goldTexture, ingredientsRect);
+            weaponsAndArmorSelected = ImageReader.GetSubTexture(goldTexture, weaponsAndArmorRect, baseSize);
+            magicItemsSelected = ImageReader.GetSubTexture(goldTexture, magicItemsRect, baseSize);
+            clothingAndMiscSelected = ImageReader.GetSubTexture(goldTexture, clothingAndMiscRect, baseSize);
+            ingredientsSelected = ImageReader.GetSubTexture(goldTexture, ingredientsRect, baseSize);
 
             // Cut out action mode not selected buttons
-            wagonNotSelected = ImageReader.GetSubTexture(baseTexture, wagonButtonRect);
-            infoNotSelected = ImageReader.GetSubTexture(baseTexture, infoButtonRect);
-            equipNotSelected = ImageReader.GetSubTexture(baseTexture, equipButtonRect);
-            removeNotSelected = ImageReader.GetSubTexture(baseTexture, removeButtonRect);
-            useNotSelected = ImageReader.GetSubTexture(baseTexture, useButtonRect);
+            wagonNotSelected = ImageReader.GetSubTexture(baseTexture, wagonButtonRect, baseSize);
+            infoNotSelected = ImageReader.GetSubTexture(baseTexture, infoButtonRect, baseSize);
+            equipNotSelected = ImageReader.GetSubTexture(baseTexture, equipButtonRect, baseSize);
+            removeNotSelected = ImageReader.GetSubTexture(baseTexture, removeButtonRect, baseSize);
+            useNotSelected = ImageReader.GetSubTexture(baseTexture, useButtonRect, baseSize);
 
             // Cut out action mode selected buttons
-            wagonSelected = ImageReader.GetSubTexture(goldTexture, wagonButtonRect);
-            infoSelected = ImageReader.GetSubTexture(goldTexture, infoButtonRect);
-            equipSelected = ImageReader.GetSubTexture(goldTexture, equipButtonRect);
-            removeSelected = ImageReader.GetSubTexture(goldTexture, removeButtonRect);
-            useSelected = ImageReader.GetSubTexture(goldTexture, useButtonRect);
+            wagonSelected = ImageReader.GetSubTexture(goldTexture, wagonButtonRect, baseSize);
+            infoSelected = ImageReader.GetSubTexture(goldTexture, infoButtonRect, baseSize);
+            equipSelected = ImageReader.GetSubTexture(goldTexture, equipButtonRect, baseSize);
+            removeSelected = ImageReader.GetSubTexture(goldTexture, removeButtonRect, baseSize);
+            useSelected = ImageReader.GetSubTexture(goldTexture, useButtonRect, baseSize);
 
             // Cut out info panel texture from item maker
             Texture2D infoBaseTexture = ImageReader.GetTexture(infoTextureName);
-            infoTexture = ImageReader.GetSubTexture(infoBaseTexture, infoCutoutRect);
+            infoTexture = ImageReader.GetSubTexture(infoBaseTexture, infoCutoutRect, baseSize);
 
             // Load coins animation textures
             coinsAnimation = ImageReader.GetImageData(coinsAnimTextureName, 6, 0, true, false, true);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -195,6 +195,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         int toneLastUsed = -1;
 
         // position rect of arrow images is src image
+        DFSize arrowsFullSize = new DFSize(9, 152);
         Rect upArrowRectInSrcImg = new Rect(0, 0, 9, 16);
         Rect downArrowRectInSrcImg = new Rect(0, 136, 9, 16);
 
@@ -485,13 +486,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             // Cut out red up/down arrows (topic)
             Texture2D redArrowsTexture = ImageReader.GetTexture(redArrowsTextureName);
-            arrowTopicUpRed = ImageReader.GetSubTexture(redArrowsTexture, upArrowRectInSrcImg);
-            arrowTopicDownRed = ImageReader.GetSubTexture(redArrowsTexture, downArrowRectInSrcImg);
+            arrowTopicUpRed = ImageReader.GetSubTexture(redArrowsTexture, upArrowRectInSrcImg, arrowsFullSize);
+            arrowTopicDownRed = ImageReader.GetSubTexture(redArrowsTexture, downArrowRectInSrcImg, arrowsFullSize);
 
             // Cut out green up/down arrows (topic)
             Texture2D greenArrowsTexture = ImageReader.GetTexture(greenArrowsTextureName);
-            arrowTopicUpGreen = ImageReader.GetSubTexture(greenArrowsTexture, upArrowRectInSrcImg);
-            arrowTopicDownGreen = ImageReader.GetSubTexture(greenArrowsTexture, downArrowRectInSrcImg);
+            arrowTopicUpGreen = ImageReader.GetSubTexture(greenArrowsTexture, upArrowRectInSrcImg, arrowsFullSize);
+            arrowTopicDownGreen = ImageReader.GetSubTexture(greenArrowsTexture, downArrowRectInSrcImg, arrowsFullSize);
 
             Color32[] colors;
             Color32[] rotated;
@@ -524,12 +525,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             arrowTopicRightGreen.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
 
             // Cut out red up/down arrows (conversation)           
-            arrowConversationUpRed = ImageReader.GetSubTexture(redArrowsTexture, upArrowRectInSrcImg);
-            arrowConversationDownRed = ImageReader.GetSubTexture(redArrowsTexture, downArrowRectInSrcImg);
+            arrowConversationUpRed = ImageReader.GetSubTexture(redArrowsTexture, upArrowRectInSrcImg, arrowsFullSize);
+            arrowConversationDownRed = ImageReader.GetSubTexture(redArrowsTexture, downArrowRectInSrcImg, arrowsFullSize);
 
             // Cut out green up/down arrows (conversation)
-            arrowConversationUpGreen = ImageReader.GetSubTexture(greenArrowsTexture, upArrowRectInSrcImg);
-            arrowConversationDownGreen = ImageReader.GetSubTexture(greenArrowsTexture, downArrowRectInSrcImg);
+            arrowConversationUpGreen = ImageReader.GetSubTexture(greenArrowsTexture, upArrowRectInSrcImg, arrowsFullSize);
+            arrowConversationDownGreen = ImageReader.GetSubTexture(greenArrowsTexture, downArrowRectInSrcImg, arrowsFullSize);
 
             listboxConversation = new ListBox();
             listboxConversation.OnScroll += ListBoxConversation_OnScroll;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -11,13 +11,14 @@
 using UnityEngine;
 using System;
 using System.Collections.Generic;
+using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
+using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.Banking;
-using DaggerfallConnect;
 using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
@@ -501,8 +502,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 actionButtonsTexture = ImageReader.GetTexture(identifyButtonsTextureName);
             }
             actionButtonsGoldTexture = ImageReader.GetTexture(sellButtonsGoldTextureName);
-            selectNotSelected = ImageReader.GetSubTexture(actionButtonsTexture, selectButtonRect);
-            selectSelected = ImageReader.GetSubTexture(actionButtonsGoldTexture, selectButtonRect);
+            DFSize actionButtonsFullSize = new DFSize(39, 190);
+            selectNotSelected = ImageReader.GetSubTexture(actionButtonsTexture, selectButtonRect, actionButtonsFullSize);
+            selectSelected = ImageReader.GetSubTexture(actionButtonsGoldTexture, selectButtonRect, actionButtonsFullSize);
 
             costPanelTexture = ImageReader.GetTexture(costPanelTextureName);
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -6,6 +6,7 @@
 // Original Author: Hazelnut
 
 using UnityEngine;
+using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Items;
@@ -87,6 +88,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.BackgroundTexture = baseTexture;
             mainPanel.Position = new Vector2(0, 50);
             mainPanel.Size = baseSize;
+            DFSize disabledTextureSize = new DFSize(122, 36);
 
             // Foot button
             footButton = DaggerfallUI.AddButton(footButtonRect, mainPanel);
@@ -97,21 +99,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (hasHorse) {
                 horseButton.OnMouseClick += HorseButton_OnMouseClick;
             } else {
-                horseButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, horseDisabledRect);
+                horseButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, horseDisabledRect, disabledTextureSize);
             }
             // Cart button
             cartButton = DaggerfallUI.AddButton(cartButtonRect, mainPanel);
             if (hasCart) {
                 cartButton.OnMouseClick += CartButton_OnMouseClick;
             } else {
-                cartButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, cartDisabledRect);
+                cartButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, cartDisabledRect, disabledTextureSize);
             }
             // Ship button
             shipButton = DaggerfallUI.AddButton(shipButtonRect, mainPanel);
             if (hasShip) {
                 shipButton.OnMouseClick += ShipButton_OnMouseClick;
             } else {
-                shipButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, shipDisabledRect);
+                shipButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, shipDisabledRect, disabledTextureSize);
             }
 
             // Exit button

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -478,28 +478,31 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             Texture2D baselocationFilterButtonEnabledText = ImageReader.GetTexture(locationFilterButtonEnabledImgName);
             Texture2D baselocationFilterButtonDisabledText = ImageReader.GetTexture(locationFilterButtonDisabledImgName);
+            DFSize baseSize = new DFSize(179, 22);
 
             // Dungeons toggle button
-            dungeonFilterButtonEnabled = ImageReader.GetSubTexture(baselocationFilterButtonEnabledText, dungeonsFilterButtonSrcRect);
-            dungeonFilterButtonDisabled = ImageReader.GetSubTexture(baselocationFilterButtonDisabledText, dungeonsFilterButtonSrcRect);
+            dungeonFilterButtonEnabled = ImageReader.GetSubTexture(baselocationFilterButtonEnabledText, dungeonsFilterButtonSrcRect, baseSize);
+            dungeonFilterButtonDisabled = ImageReader.GetSubTexture(baselocationFilterButtonDisabledText, dungeonsFilterButtonSrcRect, baseSize);
 
             // Dungeons toggle button
-            templesFilterButtonEnabled = ImageReader.GetSubTexture(baselocationFilterButtonEnabledText, templesFilterButtonSrcRect);
-            templesFilterButtonDisabled = ImageReader.GetSubTexture(baselocationFilterButtonDisabledText, templesFilterButtonSrcRect);
+            templesFilterButtonEnabled = ImageReader.GetSubTexture(baselocationFilterButtonEnabledText, templesFilterButtonSrcRect, baseSize);
+            templesFilterButtonDisabled = ImageReader.GetSubTexture(baselocationFilterButtonDisabledText, templesFilterButtonSrcRect, baseSize);
 
             // Homes toggle button
-            homesFilterButtonEnabled = ImageReader.GetSubTexture(baselocationFilterButtonEnabledText, homesFilterButtonSrcRect);
-            homesFilterButtonDisabled = ImageReader.GetSubTexture(baselocationFilterButtonDisabledText, homesFilterButtonSrcRect);
+            homesFilterButtonEnabled = ImageReader.GetSubTexture(baselocationFilterButtonEnabledText, homesFilterButtonSrcRect, baseSize);
+            homesFilterButtonDisabled = ImageReader.GetSubTexture(baselocationFilterButtonDisabledText, homesFilterButtonSrcRect, baseSize);
 
             // Towns toggle button
-            townsFilterButtonEnabled = ImageReader.GetSubTexture(baselocationFilterButtonEnabledText, townsFilterButtonSrcRect);
-            townsFilterButtonDisabled = ImageReader.GetSubTexture(baselocationFilterButtonDisabledText, townsFilterButtonSrcRect);
+            townsFilterButtonEnabled = ImageReader.GetSubTexture(baselocationFilterButtonEnabledText, townsFilterButtonSrcRect, baseSize);
+            townsFilterButtonDisabled = ImageReader.GetSubTexture(baselocationFilterButtonDisabledText, townsFilterButtonSrcRect, baseSize);
+
+            DFSize buttonsFullSize = new DFSize(45, 22);
 
             findButtonTexture = ImageReader.GetTexture(findAtButtonImgName);
-            findButtonTexture = ImageReader.GetSubTexture(findButtonTexture, findButtonRect);
+            findButtonTexture = ImageReader.GetSubTexture(findButtonTexture, findButtonRect, buttonsFullSize);
 
             atButtonTexture = ImageReader.GetTexture(findAtButtonImgName);
-            atButtonTexture = ImageReader.GetSubTexture(atButtonTexture, atButtonRect);
+            atButtonTexture = ImageReader.GetSubTexture(atButtonTexture, atButtonRect, buttonsFullSize);
 
 
             // Arrows

--- a/Assets/Scripts/Utility/ImageReader.cs
+++ b/Assets/Scripts/Utility/ImageReader.cs
@@ -96,6 +96,23 @@ namespace DaggerfallWorkshop.Utility
         }
 
         /// <summary>
+        /// Cuts out a sub-texture from source texture using a virtual rect in a resolution-independent manner.
+        /// </summary>
+        /// <param name="texture">Source texture. Must be readable.</param>
+        /// <param name="subRect">Input rect using pixel coordinates into classic texture.</param>
+        /// <param name="srcSize">Full size of classic source texture.</param>
+        /// <returns>New Texture2D containing sub-texture.</returns>
+        public static Texture2D GetSubTexture(Texture2D texture, Rect subRect, DFSize srcSize)
+        {
+            // Cut classic textures with full rect to avoid rounding errors
+            if (texture.width == srcSize.Width && texture.height == srcSize.Height)
+                return GetSubTexture(texture, subRect, false);
+
+            // Support imported textures with a relative rect
+            return GetSubTexture(texture, ConvertToRelativeSubRect(subRect, srcSize.Width, srcSize.Height), true);
+        }
+
+        /// <summary>
         /// Cuts out a sub-texture from source texture.
         /// Useful for slicing up native UI elements into smaller functional units.
         /// </summary>


### PR DESCRIPTION
This follows #629. Native panel size is only used in inventory window, so i wrote a single method that accepts a DFSize argument. A few classic textures were off by one pixel (which is visible at classic resolution) so relative rect is used only when necessary. Tell me if you have any suggestions or requests :)