### PR TITLE
Guild mod hooks

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -15,6 +15,9 @@ using DaggerfallWorkshop.Game.Weather;
 using DaggerfallWorkshop.Game.Questing;
 using DaggerfallWorkshop.Game.Effects;
 using DaggerfallWorkshop.Game.UserInterface;
+using DaggerfallConnect;
+using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace Wenzil.Console
 {
@@ -73,6 +76,64 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(StartQuest.name, StartQuest.usage, StartQuest.description, StartQuest.Execute);
 
             ConsoleCommandsDatabase.RegisterCommand(CastEffect.name, CastEffect.usage, CastEffect.description, CastEffect.Execute);
+
+            ConsoleCommandsDatabase.RegisterCommand(DumpBlock.name, DumpBlock.description, DumpBlock.usage, DumpBlock.Execute);
+            ConsoleCommandsDatabase.RegisterCommand(DumpBuilding.name, DumpBuilding.description, DumpBuilding.usage, DumpBuilding.Execute);
+        }
+
+        private static class DumpBlock
+        {
+            public static readonly string name = "dumpblock";
+            public static readonly string error = "Failed to dump block";
+            public static readonly string usage = "dumpblock blockName";
+            public static readonly string description = "Dump a block to json file";
+
+            public static string Execute(params string[] args)
+            {
+                if (args.Length == 0)
+                {
+                    return HelpCommand.Execute(DumpBlock.name);
+                }
+                else
+                {
+                    DFBlock blockData;
+                    if (RMBLayout.GetBlockData(args[0], out blockData))
+                    {
+                        string blockJson = SaveLoadManager.Serialize(blockData.GetType(), blockData);
+                        File.WriteAllText(Path.Combine(Application.persistentDataPath, args[0]), blockJson);
+                        return "Block data json written to " + Path.Combine(Application.persistentDataPath, args[0]);
+                    }
+                    return error;
+                }
+            }
+        }
+
+        private static class DumpBuilding
+        {
+            public static readonly string name = "dumpbuilding";
+            public static readonly string error = "Failed to dump building";
+            public static readonly string usage = "dumpbuilding";
+            public static readonly string description = "Dump the current building player is inside to json file";
+
+            public static string Execute(params string[] args)
+            {
+                DaggerfallInterior interior = GameManager.Instance.PlayerEnterExit.Interior;
+                int blockIndex = interior.EntryDoor.blockIndex;
+                int recordIndex = interior.EntryDoor.recordIndex;
+
+                DFBlock blockData = DaggerfallUnity.Instance.ContentReader.BlockFileReader.GetBlock(blockIndex);
+                if (blockData.Type == DFBlock.BlockTypes.Rmb)
+                {
+                    string fileName = WorldDataReplacement.GetBuildingReplacementFilename(blockData.Name, blockIndex, recordIndex);
+                    BuildingReplacementData buildingData = new BuildingReplacementData() {
+                        rmbSubRecord = blockData.RmbBlock.SubRecords[recordIndex]
+                    };
+                    string buildingJson = SaveLoadManager.Serialize(buildingData.GetType(), buildingData);
+                    File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), buildingJson);
+                    return "Building data written to " + Path.Combine(Application.persistentDataPath, fileName);
+                }
+                return error;
+            }
         }
 
         private static class GodCommand

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -195,7 +195,7 @@ namespace Wenzil.Console
                 {
                     string fileName = WorldDataReplacement.GetBuildingReplacementFilename(blockData.Name, blockIndex, recordIndex);
                     BuildingReplacementData buildingData = new BuildingReplacementData() {
-                        rmbSubRecord = blockData.RmbBlock.SubRecords[recordIndex]
+                        RmbSubRecord = blockData.RmbBlock.SubRecords[recordIndex]
                     };
                     string buildingJson = SaveLoadManager.Serialize(buildingData.GetType(), buildingData);
                     File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), buildingJson);

--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -703,9 +703,9 @@ namespace DaggerfallConnect.Arena2
             {
                 if (WorldDataReplacement.GetBuildingReplacementData(blocks[block].Name, block, i, out buildingReplacementData))
                 {
-                    blocks[block].DFBlock.RmbBlock.SubRecords[i] = buildingReplacementData.rmbSubRecord;
-                    blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].FactionId = buildingReplacementData.factionId;
-                    blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].BuildingType = (DFLocation.BuildingTypes) buildingReplacementData.buildingType;
+                    blocks[block].DFBlock.RmbBlock.SubRecords[i] = buildingReplacementData.RmbSubRecord;
+                    blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].FactionId = buildingReplacementData.FactionId;
+                    blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].BuildingType = (DFLocation.BuildingTypes) buildingReplacementData.BuildingType;
                 }
                 else
                 {
@@ -812,7 +812,7 @@ namespace DaggerfallConnect.Arena2
             blockData.BlockDoorRecords = new DFBlock.RmbBlockDoorRecord[numDoorRecords];
             for (int i = 0; i < numDoorRecords; i++)
             {
-                blockData.BlockDoorRecords[i].This = (Int32)reader.BaseStream.Position;
+                blockData.BlockDoorRecords[i].Position = (Int32)reader.BaseStream.Position;
                 blockData.BlockDoorRecords[i].XPos = reader.ReadInt32();
                 blockData.BlockDoorRecords[i].YPos = reader.ReadInt32();
                 blockData.BlockDoorRecords[i].ZPos = reader.ReadInt32();
@@ -944,7 +944,7 @@ namespace DaggerfallConnect.Arena2
             {
                 // Read object data
                 DFBlock.RdbUnknownObject obj = new DFBlock.RdbUnknownObject();
-                obj.This = (Int32)reader.BaseStream.Position;
+                obj.Position = (Int32)reader.BaseStream.Position;
                 obj.Next = reader.ReadInt32();
                 obj.Index = reader.ReadInt16();
                 obj.UnknownOffset = (UInt32)reader.ReadInt32();
@@ -1044,7 +1044,7 @@ namespace DaggerfallConnect.Arena2
             while (true)
             {
                 // Read object data
-                objectRoot.RdbObjects[index].This = (Int32)reader.BaseStream.Position;
+                objectRoot.RdbObjects[index].Position = (Int32)reader.BaseStream.Position;
                 objectRoot.RdbObjects[index].Next = reader.ReadInt32();
                 objectRoot.RdbObjects[index].Previous = reader.ReadInt32();
                 objectRoot.RdbObjects[index].Index = index;
@@ -1131,12 +1131,12 @@ namespace DaggerfallConnect.Arena2
             int index = 0;
             foreach (DFBlock.RdbObject obj in rdbObjects)
             {
-                if (obj.This ==
+                if (obj.Position ==
                     rdbObject.Resources.ModelResource.ActionResource.NextObjectOffset)
                 {
                     // Set target and and parent indices
                     rdbObject.Resources.ModelResource.ActionResource.NextObjectIndex = index;
-                    rdbObjects[index].Resources.ModelResource.ActionResource.PreviousObjectOffset = rdbObject.This;
+                    rdbObjects[index].Resources.ModelResource.ActionResource.PreviousObjectOffset = rdbObject.Position;
                     break;
                 }
                 index++;

--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -701,6 +701,7 @@ namespace DaggerfallConnect.Arena2
             BuildingReplacementData buildingReplacementData;
             for (int i = 0; i < recordCount; i++)
             {
+                // Check for replacement building data and use it if found
                 if (WorldDataReplacement.GetBuildingReplacementData(blocks[block].Name, block, i, out buildingReplacementData))
                 {
                     blocks[block].DFBlock.RmbBlock.SubRecords[i] = buildingReplacementData.RmbSubRecord;

--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -10,6 +10,7 @@
 //
 
 #region Using Statements
+using FullSerializer;
 using System;
 using System.Text;
 #endregion
@@ -248,6 +249,7 @@ namespace DaggerfallConnect
         /// <summary>
         /// Ground data to draw under a city block, such as ground textures, trees, rocks, etc.
         /// </summary>
+        [fsObject(MemberSerialization = fsMemberSerialization.OptIn)]   // FullSerializer can't do 2D arrays out of the box
         public struct RmbFldGroundData
         {
             /// <summary>Header with unknown data.</summary>
@@ -521,6 +523,7 @@ namespace DaggerfallConnect
         /// <summary>
         /// Doors the player can open and close.
         /// </summary>
+        [fsObject(MemberSerialization = fsMemberSerialization.OptOut)]  // Otherwise 'This' is ignored, maybe change to 'Position' like other records?
         public struct RmbBlockDoorRecord
         {
             /// <summary>Offset of this object from start of RMB record. Not required unless you are extending the block reader.</summary>

--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -523,11 +523,10 @@ namespace DaggerfallConnect
         /// <summary>
         /// Doors the player can open and close.
         /// </summary>
-        [fsObject(MemberSerialization = fsMemberSerialization.OptOut)]  // Otherwise 'This' is ignored, maybe change to 'Position' like other records?
         public struct RmbBlockDoorRecord
         {
             /// <summary>Offset of this object from start of RMB record. Not required unless you are extending the block reader.</summary>
-            internal Int32 This;
+            public Int32 Position;
 
             /// <summary>X position in 3D space.</summary>
             public Int32 XPos;
@@ -869,7 +868,7 @@ namespace DaggerfallConnect
         public struct RdbUnknownObject
         {
             /// <summary>Offset of this object from start of RDB record. Not required unless you are extending the block reader.</summary>
-            public Int32 This;
+            public Int32 Position;
 
             /// <summary>Offset to next object from start of RDB record. Not required unless you are extending the block reader.</summary>
             public Int32 Next;
@@ -899,7 +898,7 @@ namespace DaggerfallConnect
         public struct RdbObject
         {
             /// <summary>Offset of this object from start of RDB record. Not required unless you are extending the block reader.</summary>
-            internal Int32 This;
+            internal Int32 Position;
 
             /// <summary>Offset to next object from start of RDB record. Not required unless you are extending the block reader.</summary>
             internal Int32 Next;

--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -16,7 +16,7 @@ using System.Collections.Generic;
 using System.IO;
 using DaggerfallConnect.Utility;
 using DaggerfallConnect.Save;
-using UnityEngine;
+using DaggerfallWorkshop;
 #endregion
 
 namespace DaggerfallConnect.Arena2
@@ -213,7 +213,7 @@ namespace DaggerfallConnect.Arena2
         /// <returns>true if faction was registered, false if the faction id is already in use</returns>
         public static bool RegisterCustomFaction(int factionId, FactionData factionData)
         {
-            Debug.Log("RegisterCustomFaction: " + factionId);
+            DaggerfallUnity.LogMessage("RegisterCustomFaction: " + factionId, true);
             if (!customFactions.ContainsKey(factionId))
             {
                 customFactions.Add(factionId, factionData);

--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -195,6 +195,31 @@ namespace DaggerfallConnect.Arena2
             get { return "FACTION.TXT"; }
         }
 
+        public static Dictionary<int, FactionData> CustomFactions { get { return customFactions; } }
+
+        #endregion
+
+        #region Custom faction registration
+
+        // Registry for custom factions.
+        private static Dictionary<int, FactionData> customFactions = new Dictionary<int, FactionData>();
+
+        /// <summary>
+        /// Register a custom faction not in the DF FACTION.TXT file
+        /// </summary>
+        /// <param name="factionId">faction id for the new faction</param>
+        /// <param name="factionData">faction data struct for new faction, including child list</param>
+        /// <returns>true if faction was registered, false if the faction id is already in use</returns>
+        public static bool RegisterCustomFaction(int factionId, FactionData factionData)
+        {
+            if (!customFactions.ContainsKey(factionId))
+            {
+                customFactions.Add(factionId, factionData);
+                return true;
+            }
+            return false;
+        }
+
         #endregion
 
         #region Constructors

--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.IO;
 using DaggerfallConnect.Utility;
 using DaggerfallConnect.Save;
+using UnityEngine;
 #endregion
 
 namespace DaggerfallConnect.Arena2
@@ -212,6 +213,7 @@ namespace DaggerfallConnect.Arena2
         /// <returns>true if faction was registered, false if the faction id is already in use</returns>
         public static bool RegisterCustomFaction(int factionId, FactionData factionData)
         {
+            Debug.Log("RegisterCustomFaction: " + factionId);
             if (!customFactions.ContainsKey(factionId))
             {
                 customFactions.Add(factionId, factionData);

--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -120,8 +120,12 @@ namespace DaggerfallWorkshop.Game.Banking
 
         public static bool IsHouseOwned(int buildingKey)
         {
-            DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
-            return Houses[location.RegionIndex].buildingKey == buildingKey;
+            if (buildingKey > 0)
+            {
+                DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
+                return Houses[location.RegionIndex].buildingKey == buildingKey;
+            }
+            return false;
         }
 
         public static HouseData_v1[] Houses

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -244,7 +244,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     {
                         if (currentBreath == 0)
                         {
-                            currentBreath = GameManager.Instance.GuildManager.GetGuild(FactionFile.GuildGroups.HolyOrder).DeepBreath(MaxBreath);
+                            currentBreath = GameManager.Instance.GuildManager.DeepBreath(MaxBreath);
                         }
                         if (breathUpdateTally > 18)
                         {

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -471,8 +471,17 @@ namespace DaggerfallWorkshop.Game.Entity
         {
             if (godMode)
                 return currentHealth = MaxHealth;
-            else
-                return base.SetHealth(amount);
+
+            currentHealth = Mathf.Clamp(amount, 0, MaxHealth);
+            if (currentHealth <= 0)
+            {
+                // Players can have avoid death benefit from guild memberships
+                if (GameManager.Instance.GuildManager.AvoidDeath())
+                    return currentHealth = 1;
+                else
+                    RaiseOnDeathEvent();
+            }
+            return currentHealth;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -273,11 +273,14 @@ namespace DaggerfallWorkshop.Game.Formulas
                 chance += player.Stats.LivePersonality / 10;
             }
             chance += GameManager.Instance.WeaponManager.Sheathed ? 10 : -25;
-            chance += player.Stats.LiveLuck / 5;    // BCHG: luck is not part of formula on uesp, not checked in classic code
 
-            int roll = UnityEngine.Random.Range(0, 145);    // Max ~96.5% chance for 100% skill + per + luck and sheathed weapon.
-            Debug.LogFormat("Pacification {3} using {0} skill: chance= {1}  roll= {2}", languageSkill, chance, roll, (roll < chance) ? "success" : "failure");
-            return (roll < chance);
+            int roll = UnityEngine.Random.Range(0, 200);
+            bool success = (roll < chance);
+            if (success)
+                player.TallySkill(languageSkill, 1);
+
+            Debug.LogFormat("Pacification {3} using {0} skill: chance= {1}  roll= {2}", languageSkill, chance, roll, success ? "success" : "failure");
+            return success;
         }
 
         #endregion

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -278,6 +278,8 @@ namespace DaggerfallWorkshop.Game.Formulas
             bool success = (roll < chance);
             if (success)
                 player.TallySkill(languageSkill, 1);
+            else if (languageSkill != DFCareer.Skills.Etiquette && languageSkill != DFCareer.Skills.Streetwise)
+                player.TallySkill(languageSkill, 1);
 
             Debug.LogFormat("Pacification {3} using {0} skill: chance= {1}  roll= {2}", languageSkill, chance, roll, success ? "success" : "failure");
             return success;

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -14,50 +14,96 @@ using System;
 using DaggerfallConnect;
 using DaggerfallWorkshop.Game.Guilds;
 using DaggerfallWorkshop.Game.Entity;
+using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game.Formulas
 {
     /// <summary>
     /// Common formulas used throughout game.
     /// Where the exact formula is unknown, a "best effort" approximation will be used.
-    /// Will likely be migrated to a pluggable IFormulaProvider at a later date.
+    /// Most formula can be overridden by registering a new method matching the appropriate delegate signature.
+    /// Other signatures can be added upon demand.
     /// </summary>
     public static class FormulaHelper
     {
+        // Delegate method signatures for overriding default formula
+        public delegate int Formula_1i(int a);
+        public delegate int Formula_2i(int a, int b);
+        public delegate int Formula_3i(int a, int b, int c);
+        public delegate int Formula_1i_1f(int a, float b);
+        public delegate int Formula_2de(DaggerfallEntity de1, DaggerfallEntity de2);
+        public delegate bool Formula_1pe_1sk(PlayerEntity pe, DFCareer.Skills sk);
+
+        // Registries for overridden formula
+        public static Dictionary<string, Formula_1i>        formula_1i = new Dictionary<string, Formula_1i>();
+        public static Dictionary<string, Formula_2i>        formula_2i = new Dictionary<string, Formula_2i>();
+        public static Dictionary<string, Formula_3i>        formula_3i = new Dictionary<string, Formula_3i>();
+        public static Dictionary<string, Formula_1i_1f>     formula_1i_1f = new Dictionary<string, Formula_1i_1f>();
+        public static Dictionary<string, Formula_2de>       formula_2de = new Dictionary<string, Formula_2de>();
+        public static Dictionary<string, Formula_1pe_1sk>   formula_1pe_1sk = new Dictionary<string, Formula_1pe_1sk>();
+
         #region Basic Formulas
 
         public static int DamageModifier(int strength)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("DamageModifier", out del))
+                return del(strength);
+
             return (int)Mathf.Floor((float)(strength - 50) / 5f);
         }
 
         public static int MaxEncumbrance(int strength)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("MaxEncumbrance", out del))
+                return del(strength);
+
             return (int)Mathf.Floor((float)strength * 1.5f);
         }
 
         public static int SpellPoints(int intelligence, float multiplier)
         {
+            Formula_1i_1f del;
+            if (formula_1i_1f.TryGetValue("SpellPoints", out del))
+                return del(intelligence, multiplier);
+
             return (int)Mathf.Floor((float)intelligence * multiplier);
         }
 
         public static int MagicResist(int willpower)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("MagicResist", out del))
+                return del(willpower);
+
             return (int)Mathf.Floor((float)willpower / 10f);
         }
 
         public static int ToHitModifier(int agility)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("ToHitModifier", out del))
+                return del(agility);
+
             return (int)Mathf.Floor((float)agility / 10f) - 5;
         }
 
         public static int HitPointsModifier(int endurance)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("HitPointsModifier", out del))
+                return del(endurance);
+
             return (int)Mathf.Floor((float)endurance / 10f) - 5;
         }
 
         public static int HealingRateModifier(int endurance)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("HealingRateModifier", out del))
+                return del(endurance);
+
             // Original Daggerfall seems to have a bug where negative endurance modifiers on healing rate
             // are applied as modifier + 1. Not recreating that here.
             return (int)Mathf.Floor((float)endurance / 10f) - 5;
@@ -70,6 +116,10 @@ namespace DaggerfallWorkshop.Game.Formulas
         // Generates player health based on level and career hit points per level
         public static int RollMaxHealth(int level, int hitPointsPerLevel)
         {
+            Formula_2i del;
+            if (formula_2i.TryGetValue("RollMaxHealth", out del))
+                return del(level, hitPointsPerLevel);
+
             const int baseHealth = 25;
             int maxHealth = baseHealth + hitPointsPerLevel;
 
@@ -82,8 +132,12 @@ namespace DaggerfallWorkshop.Game.Formulas
         }
 
         // Calculate how much health the player should recover per hour of rest
-        public static int CalculateHealthRecoveryRate(Entity.PlayerEntity player)
+        public static int CalculateHealthRecoveryRate(PlayerEntity player)
         {
+            Formula_2de del;
+            if (formula_2de.TryGetValue("CalculateHealthRecoveryRate", out del))
+                return del(player, null);
+
             short medical = player.Skills.GetLiveSkillValue(DFCareer.Skills.Medical);
             int endurance = player.Stats.LiveEndurance;
             int maxHealth = player.MaxHealth;
@@ -111,18 +165,30 @@ namespace DaggerfallWorkshop.Game.Formulas
         // Calculate how much fatigue the player should recover per hour of rest
         public static int CalculateFatigueRecoveryRate(int maxFatigue)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("HealingRateModifier", out del))
+                return del(maxFatigue);
+
             return Mathf.Max((int)Mathf.Floor(maxFatigue / 8), 1);
         }
 
         // Calculate how many spell points the player should recover per hour of rest
         public static int CalculateSpellPointRecoveryRate(int maxSpellPoints)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("HealingRateModifier", out del))
+                return del(maxSpellPoints);
+
             return Mathf.Max((int)Mathf.Floor(maxSpellPoints / 8), 1);
         }
 
         // Calculate chance of successfully lockpicking a door in an interior (an animating door). If this is higher than a random number between 0 and 100 (inclusive), the lockpicking succeeds.
         public static int CalculateInteriorLockpickingChance(int level, int lockvalue, int lockpickingSkill)
         {
+            Formula_3i del;
+            if (formula_3i.TryGetValue("CalculateInteriorLockpickingChance", out del))
+                return del(level, lockvalue, lockpickingSkill);
+
             int chance = (5 * (level - lockvalue) + lockpickingSkill);
             return Mathf.Clamp(chance, 5, 95);
         }
@@ -130,13 +196,21 @@ namespace DaggerfallWorkshop.Game.Formulas
         // Calculate chance of successfully lockpicking a door in an exterior (a door that leads to an interior). If this is higher than a random number between 0 and 100 (inclusive), the lockpicking succeeds.
         public static int CalculateExteriorLockpickingChance(int lockvalue, int lockpickingSkill)
         {
+            Formula_2i del;
+            if (formula_2i.TryGetValue("CalculateExteriorLockpickingChance", out del))
+                return del(lockvalue, lockpickingSkill);
+
             int chance = lockpickingSkill - (5 * lockvalue);
             return Mathf.Clamp(chance, 5, 95);
         }
 
         // Calculate chance of successfully pickpocketing a target
-        public static int CalculatePickpocketingChance(Entity.PlayerEntity player, Entity.EnemyEntity target)
+        public static int CalculatePickpocketingChance(PlayerEntity player, EnemyEntity target)
         {
+            Formula_2de del;
+            if (formula_2de.TryGetValue("CalculatePickpocketingChance", out del))
+                return del(player, target);
+
             int chance = player.Skills.GetLiveSkillValue(DFCareer.Skills.Pickpocket);
             // If target is an enemy mobile, apply level modifier.
             if (target != null)
@@ -156,12 +230,20 @@ namespace DaggerfallWorkshop.Game.Formulas
         // Calculate player level.
         public static int CalculatePlayerLevel(int startingLevelUpSkillsSum, int currentLevelUpSkillsSum)
         {
+            Formula_2i del;
+            if (formula_2i.TryGetValue("CalculatePlayerLevel", out del))
+                return del(startingLevelUpSkillsSum, currentLevelUpSkillsSum);
+
             return (int)Mathf.Floor((currentLevelUpSkillsSum - startingLevelUpSkillsSum + 28) / 15);
         }
 
         // Calculate hit points player gains per level.
-        public static int CalculateHitPointsPerLevelUp(Entity.PlayerEntity player)
+        public static int CalculateHitPointsPerLevelUp(PlayerEntity player)
         {
+            Formula_2de del;
+            if (formula_2de.TryGetValue("CalculateHitPointsPerLevelUp", out del))
+                return del(player, null);
+
             int minRoll = player.Career.HitPointsPerLevel / 2;
             int maxRoll = player.Career.HitPointsPerLevel + 1; // Adding +1 as Unity Random.Range(int,int) is exclusive of maximum value
             int addHitPoints = UnityEngine.Random.Range(minRoll, maxRoll);
@@ -172,8 +254,12 @@ namespace DaggerfallWorkshop.Game.Formulas
         }
 
         // Calculate whether the player is successful at pacifying an enemy.
-        public static bool CalculateEnemyPacification(Entity.PlayerEntity player, DFCareer.Skills languageSkill)
+        public static bool CalculateEnemyPacification(PlayerEntity player, DFCareer.Skills languageSkill)
         {
+            Formula_1pe_1sk del;
+            if (formula_1pe_1sk.TryGetValue("CalculateEnemyPacification", out del))
+                return del(player, languageSkill);
+
             double chance = 0;
             if (languageSkill == DFCareer.Skills.Etiquette ||
                 languageSkill == DFCareer.Skills.Streetwise)
@@ -200,18 +286,26 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         public static int CalculateHandToHandMinDamage(int handToHandSkill)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("CalculateHandToHandMinDamage", out del))
+                return del(handToHandSkill);
+
             return (handToHandSkill / 10) + 1;
         }
 
         public static int CalculateHandToHandMaxDamage(int handToHandSkill)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("CalculateHandToHandMaxDamage", out del))
+                return del(handToHandSkill);
+
             // Daggerfall Chronicles table lists hand-to-hand skills of 80 and above (45 through 79 are omitted)
             // as if they give max damage of (handToHandSkill / 5) + 2, but the hand-to-hand damage display in the character sheet
             // in classic Daggerfall shows it as continuing to be (handToHandSkill / 5) + 1
             return (handToHandSkill / 5) + 1;
         }
 
-        public static int CalculateAttackDamage(Entity.DaggerfallEntity attacker, Entity.DaggerfallEntity target, int weaponEquipSlot, int enemyAnimStateRecord)
+        public static int CalculateAttackDamage(DaggerfallEntity attacker, DaggerfallEntity target, int weaponEquipSlot, int enemyAnimStateRecord)
         {
             if (attacker == null || target == null)
                 return 0;
@@ -222,7 +316,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             int damage = 0;
             int chanceToHitMod = 0;
             int backstabbingLevel = 0;
-            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            PlayerEntity player = GameManager.Instance.PlayerEntity;
             Items.DaggerfallUnityItem weapon = attacker.ItemEquipTable.GetItem((Items.EquipSlots)weaponEquipSlot);
             short skillID = 0;
 
@@ -232,7 +326,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             // For some enemies this gives lower damage than similar-tier monsters
             // and the weaponless values seems more appropriate, so here
             // enemies will choose to use their weaponless attack if it is more damaging.
-            Entity.EnemyEntity AIAttacker = attacker as Entity.EnemyEntity;
+            EnemyEntity AIAttacker = attacker as EnemyEntity;
             if (AIAttacker != null && weapon != null)
             {
                 int weaponAverage = ((minBaseDamage + maxBaseDamage) / 2);
@@ -268,10 +362,10 @@ namespace DaggerfallWorkshop.Game.Formulas
 
             chanceToHitMod = attacker.Skills.GetLiveSkillValue(skillID);
 
-            Entity.EnemyEntity AITarget = null;
+            EnemyEntity AITarget = null;
             if (target != player)
             {
-                AITarget = target as Entity.EnemyEntity;
+                AITarget = target as EnemyEntity;
             }
 
             if (attacker == player)
@@ -324,20 +418,20 @@ namespace DaggerfallWorkshop.Game.Formulas
                 // Apply racial bonuses
                 if (weapon != null)
                 {
-                    if (player.RaceTemplate.ID == (int)Entity.Races.DarkElf)
+                    if (player.RaceTemplate.ID == (int)Races.DarkElf)
                     {
                         damageModifiers += (attacker.Level / 4);
                         chanceToHitMod += (attacker.Level / 4);
                     }
                     else if (skillID == (short)DFCareer.Skills.Archery)
                     {
-                        if (player.RaceTemplate.ID == (int)Entity.Races.WoodElf)
+                        if (player.RaceTemplate.ID == (int)Races.WoodElf)
                         {
                             damageModifiers += (attacker.Level / 3);
                             chanceToHitMod += (attacker.Level / 3);
                         }
                     }
-                    else if (player.RaceTemplate.ID == (int)Entity.Races.Redguard)
+                    else if (player.RaceTemplate.ID == (int)Races.Redguard)
                     {
                         damageModifiers += (attacker.Level / 3);
                         chanceToHitMod += (attacker.Level / 3);
@@ -421,7 +515,7 @@ namespace DaggerfallWorkshop.Game.Formulas
                     damage += damageModifiers;
 
                     // Apply modifiers for Skeletal Warrior.
-                    if (AITarget != null && AITarget.CareerIndex == (int)Entity.MonsterCareers.SkeletalWarrior)
+                    if (AITarget != null && AITarget.CareerIndex == (int)MonsterCareers.SkeletalWarrior)
                     {
                         if (weapon.NativeMaterialValue == (int)Items.WeaponMaterialTypes.Silver)
                         {
@@ -490,14 +584,14 @@ namespace DaggerfallWorkshop.Game.Formulas
             return damage;
         }
 
-        public static bool CalculateSuccessfulHit(Entity.DaggerfallEntity attacker, Entity.DaggerfallEntity target, int chanceToHitMod, Items.DaggerfallUnityItem weapon, int struckBodyPart)
+        public static bool CalculateSuccessfulHit(DaggerfallEntity attacker, DaggerfallEntity target, int chanceToHitMod, Items.DaggerfallUnityItem weapon, int struckBodyPart)
         {
             if (attacker == null || target == null)
                 return false;
 
             int chanceToHit = chanceToHitMod;
-            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-            Entity.EnemyEntity AITarget = target as Entity.EnemyEntity;
+            PlayerEntity player = GameManager.Instance.PlayerEntity;
+            EnemyEntity AITarget = target as EnemyEntity;
 
             int armorValue = 0;
 
@@ -568,8 +662,12 @@ namespace DaggerfallWorkshop.Game.Formulas
                 return false;
         }
 
-        static int GetBonusOrPenaltyByEnemyType(Entity.DaggerfallEntity attacker, Entity.EnemyEntity AITarget)
+        static int GetBonusOrPenaltyByEnemyType(DaggerfallEntity attacker, EnemyEntity AITarget)
         {
+            Formula_2de del;
+            if (formula_2de.TryGetValue("GetBonusOrPenaltyByEnemyType", out del))
+                return del(attacker, AITarget);
+
             if (attacker == null || AITarget == null)
                 return 0;
 
@@ -630,6 +728,10 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         public static Diseases CalculateChanceOfDisease(EnemyEntity attacker)
         {
+            Formula_2de del;
+            if (formula_2de.TryGetValue("CalculateChanceOfDisease", out del))
+                return (Diseases) del(attacker, null);
+
             DFCareer.EnemyGroups group = attacker.GetEnemyGroup();
             if (group == DFCareer.EnemyGroups.Animals || group == DFCareer.EnemyGroups.Undead)
             {
@@ -642,6 +744,10 @@ namespace DaggerfallWorkshop.Game.Formulas
         // Generates health for enemy classes based on level and class
         public static int RollEnemyClassMaxHealth(int level, int hitPointsPerLevel)
         {
+            Formula_2i del;
+            if (formula_2i.TryGetValue("RollEnemyClassMaxHealth", out del))
+                return del(level, hitPointsPerLevel);
+
             const int baseHealth = 10;
             int maxHealth = baseHealth;
 
@@ -649,7 +755,6 @@ namespace DaggerfallWorkshop.Game.Formulas
             {
                 maxHealth += UnityEngine.Random.Range(1, hitPointsPerLevel + 1);
             }
-
             return maxHealth;
         }
 
@@ -698,6 +803,10 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         public static int CalculateRoomCost(int daysToRent)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("CalculateRoomCost", out del))
+                return del(daysToRent);
+
             int cost = 0;
             int dayOfYear = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.DayOfYear;
             if (dayOfYear <= 46 && dayOfYear + daysToRent > 46)
@@ -718,6 +827,10 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         public static int CalculateCost(int baseItemValue, int shopQuality)
         {
+            Formula_2i del;
+            if (formula_2i.TryGetValue("CalculateCost", out del))
+                return del(baseItemValue, shopQuality);
+
             int cost = baseItemValue;
 
             if (cost < 1)
@@ -750,7 +863,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return cost;
         }
 
-        public static int CalculateItemIdentifyCost(int baseItemValue)
+        public static int CalculateItemIdentifyCost(int baseItemValue, Guild guild)
         {
             // Free on Witches Festival
             uint minutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
@@ -761,14 +874,21 @@ namespace DaggerfallWorkshop.Game.Formulas
                 if (holidayId == (int)DFLocation.Holidays.Witches_Festival)
                     return 0;
             }
-
             int cost = (25 * baseItemValue) >> 8;
+
+            if (guild != null)
+                cost = guild.ReducedIdentifyCost(cost);
+
             return cost;
         }
 
         public static int CalculateTradePrice(int cost, int shopQuality, bool selling)
         {
-            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            Formula_3i del;
+            if (formula_3i.TryGetValue("CalculateTradePrice", out del))
+                return del(cost, shopQuality, selling ? 1 : 0);
+
+            PlayerEntity player = GameManager.Instance.PlayerEntity;
             int merchant_mercantile_level = 5 * (shopQuality - 10) + 50;
             int merchant_personality_level = 5 * (shopQuality - 10) + 50;
 
@@ -794,9 +914,13 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         public static int ApplyRegionalPriceAdjustment(int cost)
         {
+            Formula_1i del;
+            if (formula_1i.TryGetValue("ApplyRegionalPriceAdjustment", out del))
+                return del(cost);
+
             int adjustedCost;
             int currentRegionIndex;
-            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            PlayerEntity player = GameManager.Instance.PlayerEntity;
             PlayerGPS gps = GameManager.Instance.PlayerGPS;
             if (gps.HasCurrentLocation)
                 currentRegionIndex = gps.CurrentRegionIndex;
@@ -809,13 +933,13 @@ namespace DaggerfallWorkshop.Game.Formulas
             return adjustedCost;
         }
 
-        public static void RandomizeInitialPriceAdjustments(ref Entity.PlayerEntity.RegionDataRecord[] regionData)
+        public static void RandomizeInitialPriceAdjustments(ref PlayerEntity.RegionDataRecord[] regionData)
         {
             for (int i = 0; i < regionData.Length; i++)
                 regionData[i].PriceAdjustment = (ushort)(UnityEngine.Random.Range(0, 501) + 750);
         }
 
-        public static void ModifyPriceAdjustmentByRegion(ref Entity.PlayerEntity.RegionDataRecord[] regionData, int times)
+        public static void ModifyPriceAdjustmentByRegion(ref PlayerEntity.RegionDataRecord[] regionData, int times)
         {
             DaggerfallConnect.Arena2.FactionFile.FactionData merchantsFaction;
             if (!GameManager.Instance.PlayerEntity.FactionData.GetFactionData(510, out merchantsFaction))

--- a/Assets/Scripts/Game/Guilds/FightersGuild.cs
+++ b/Assets/Scripts/Game/Guilds/FightersGuild.cs
@@ -27,25 +27,23 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #endregion
 
-        #region Static Data
+        #region Properties & Data
 
-        static FightersGuild()
-        {
-            rankTitles = new string[] {
+        static string[] rankTitles = new string[] {
                 "Apprentice", "Journeyman", "Swordsman", "Protector", "Defender", "Warder", "Guardian", "Champion", "Warrior", "Master"
+        };
+
+        static List<DFCareer.Skills> guildSkills = new List<DFCareer.Skills>() {
+                DFCareer.Skills.Archery,
+                DFCareer.Skills.Axe,
+                DFCareer.Skills.BluntWeapon,
+                DFCareer.Skills.Giantish,
+                DFCareer.Skills.LongBlade,
+                DFCareer.Skills.Orcish,
+                DFCareer.Skills.ShortBlade,
             };
 
-            guildSkills = new List<DFCareer.Skills>() {
-                DFCareer.Skills.Archery,    // 14 melissa
-                DFCareer.Skills.Axe,        // 6
-                DFCareer.Skills.BluntWeapon,// 3
-                DFCareer.Skills.Giantish,   // 5
-                DFCareer.Skills.LongBlade,  // 30
-                DFCareer.Skills.Orcish,     // 6
-                DFCareer.Skills.ShortBlade, // 11
-            };
-
-            trainingSkills = new List<DFCareer.Skills>() {
+        static List<DFCareer.Skills> trainingSkills = new List<DFCareer.Skills>() {
                 DFCareer.Skills.Archery,
                 DFCareer.Skills.Axe,
                 DFCareer.Skills.BluntWeapon,
@@ -58,7 +56,12 @@ namespace DaggerfallWorkshop.Game.Guilds
                 DFCareer.Skills.ShortBlade,
                 DFCareer.Skills.Swimming
             };
-        }
+
+        public override string[] RankTitles { get { return rankTitles; } }
+
+        public override List<DFCareer.Skills> GuildSkills { get { return guildSkills; } }
+
+        public override List<DFCareer.Skills> TrainingSkills { get { return trainingSkills; } }
 
         #endregion
 
@@ -89,7 +92,8 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public override bool HallAccessAnytime()
         {
-            return (rank >= 6);        }
+            return (rank >= 6);
+        }
 
         public override int ReducedRepairCost(int price)
         {

--- a/Assets/Scripts/Game/Guilds/FightersGuild.cs
+++ b/Assets/Scripts/Game/Guilds/FightersGuild.cs
@@ -102,9 +102,6 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #endregion
 
-        #region Service: Training
-
-        #endregion
 
         #region Joining
 

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -9,7 +9,6 @@
 using UnityEngine;
 using System.Collections.Generic;
 using DaggerfallConnect;
-using System;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Utility;
@@ -24,6 +23,7 @@ namespace DaggerfallWorkshop.Game.Guilds
     {
         #region Constants
 
+        public const int defaultTrainingMax = 50;
         public const int memberTrainingCost = 100;
         public const int nonMemberTrainingCost = 400;
 
@@ -247,6 +247,11 @@ namespace DaggerfallWorkshop.Game.Guilds
         #endregion
 
         #region Service: Training
+
+        public virtual int GetTrainingMax(DFCareer.Skills skill)
+        {
+            return defaultTrainingMax;
+        }
 
         public virtual int GetTrainingPrice()
         {

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -190,18 +190,23 @@ namespace DaggerfallWorkshop.Game.Guilds
             return price;
         }
 
-        #endregion
-
-        #region Special temple benefits:
-
-        public virtual int FastTravel(int duration)
+        public virtual int ReducedIdentifyCost(int price)
         {
-            return duration;
+            return price;
         }
 
         public virtual int ReducedCureCost(int price)
         {
             return price;
+        }
+
+        #endregion
+
+        #region Special benefits:
+
+        public virtual int FastTravel(int duration)
+        {
+            return duration;
         }
 
         public virtual int DeepBreath(int duration)

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -34,22 +34,19 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Static Data
 
-        protected static string[] rankTitles;
-
         protected static int[] rankReqReputation = new int[] {  0, 10, 20, 30, 40, 50, 60, 70, 80, 90 };
         protected static int[] rankReqSkillHigh = new int[]  { 22, 23, 31, 39, 47, 55, 63, 71, 79, 87 };
         protected static int[] rankReqSkillLow = new int[]   {  4,  5,  9, 13, 17, 21, 25, 29, 33, 37 };
-
-        protected static List<DFCareer.Skills> guildSkills;
-        protected static List<DFCareer.Skills> trainingSkills;
 
         #endregion
 
         #region Properties
 
-        public virtual List<DFCareer.Skills> GuildSkills { get { return guildSkills; } }
+        public abstract string[] RankTitles { get; }
 
-        public virtual List<DFCareer.Skills> TrainingSkills { get { return trainingSkills; } }
+        public abstract List<DFCareer.Skills> GuildSkills { get; }
+
+        public abstract List<DFCareer.Skills> TrainingSkills { get; }
 
         #endregion
 
@@ -166,7 +163,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public virtual string GetTitle()
         {
-            return IsMember() ? rankTitles[rank] : "non-member";
+            return IsMember() ? RankTitles[rank] : "Expelled";
         }
 
         #endregion

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -210,6 +210,14 @@ namespace DaggerfallWorkshop.Game.Guilds
             return newDuration;
         }
 
+        public virtual bool AvoidDeath()
+        {
+            foreach (Guild guild in memberships.Values)
+                if (guild.AvoidDeath())
+                    return true;
+            return false;
+        }
+
         #endregion
 
     }

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -27,6 +27,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public static bool RegisterCustomGuild(FactionFile.GuildGroups guildGroup, Type guildType)
         {
+            Debug.Log("RegisterCustomGuild: " + guildGroup);
             if (!customGuilds.ContainsKey(guildGroup))
             {
                 customGuilds.Add(guildGroup, guildType);

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -8,7 +8,6 @@
 
 using UnityEngine;
 using System.Collections.Generic;
-using DaggerfallConnect;
 using System;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Player;
@@ -22,6 +21,19 @@ namespace DaggerfallWorkshop.Game.Guilds
         public static Guild guildNotMember = new NonMemberGuild();
         // A base temple class defining non-membership.
         public static Guild templeNotMember = new NonMemberGuild(true);
+
+        // Custom guild registry.
+        private static Dictionary<FactionFile.GuildGroups, Type> customGuilds = new Dictionary<FactionFile.GuildGroups, Type>();
+
+        public static bool RegisterCustomGuild(FactionFile.GuildGroups guildGroup, Type guildType)
+        {
+            if (!customGuilds.ContainsKey(guildGroup))
+            {
+                customGuilds.Add(guildGroup, guildType);
+                return true;
+            }
+            return false;
+        }
 
         private Dictionary<FactionFile.GuildGroups, Guild> memberships = new Dictionary<FactionFile.GuildGroups, Guild>();
 
@@ -69,8 +81,13 @@ namespace DaggerfallWorkshop.Game.Guilds
                     Temple.Divines deity = (Temple.Divines) buildingFactionId;
                     return new KnightlyOrder(region);
 */
+                default:
+                    Type guildType;
+                    if (customGuilds.TryGetValue(guildGroup, out guildType))
+                        return (Guild) Activator.CreateInstance(guildType);
+                    else
+                        return null;
             }
-            return null;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -27,7 +27,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public static bool RegisterCustomGuild(FactionFile.GuildGroups guildGroup, Type guildType)
         {
-            Debug.Log("RegisterCustomGuild: " + guildGroup);
+            DaggerfallUnity.LogMessage("RegisterCustomGuild: " + guildGroup, true);
             if (!customGuilds.ContainsKey(guildGroup))
             {
                 customGuilds.Add(guildGroup, guildType);

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -36,6 +36,8 @@ namespace DaggerfallWorkshop.Game.Guilds
             return false;
         }
 
+        #region Guild membership handling
+
         private Dictionary<FactionFile.GuildGroups, Guild> memberships = new Dictionary<FactionFile.GuildGroups, Guild>();
 
         public List<Guild> GetMemberships()
@@ -187,6 +189,28 @@ namespace DaggerfallWorkshop.Game.Guilds
                 }
             }
         }
+
+        #endregion
+
+        #region Special guild benefits
+
+        public virtual int FastTravel(int duration)
+        {
+            int newDuration = duration;
+            foreach (Guild guild in memberships.Values)
+                newDuration = guild.FastTravel(newDuration);
+            return newDuration;
+        }
+
+        public virtual int DeepBreath(int duration)
+        {
+            int newDuration = duration;
+            foreach (Guild guild in memberships.Values)
+                newDuration = guild.DeepBreath(newDuration);
+            return newDuration;
+        }
+
+        #endregion
 
     }
 }

--- a/Assets/Scripts/Game/Guilds/MagesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/MagesGuild.cs
@@ -27,15 +27,13 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #endregion
 
-        #region Static Data
+        #region Properties & Data
 
-        static MagesGuild()
-        {
-            rankTitles = new string[] {
+        static string[] rankTitles = new string[] {
                 "Apprentice", "Journeyman", "Evoker", "Conjurer", "Magician", "Enchanter", "Warlock", "Wizard", "Master Wizard", "Archmage"
-            };
+        };
 
-            guildSkills = new List<DFCareer.Skills>() {
+        static List<DFCareer.Skills> guildSkills = new List<DFCareer.Skills>() {
                 DFCareer.Skills.Alteration,
                 DFCareer.Skills.Destruction,
                 DFCareer.Skills.Illusion,
@@ -44,7 +42,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                 DFCareer.Skills.Thaumaturgy
             };
 
-            trainingSkills = new List<DFCareer.Skills>() {
+        static List<DFCareer.Skills> trainingSkills = new List<DFCareer.Skills>() {
                 DFCareer.Skills.Alteration,
                 DFCareer.Skills.Daedric,
                 DFCareer.Skills.Destruction,
@@ -58,7 +56,12 @@ namespace DaggerfallWorkshop.Game.Guilds
                 DFCareer.Skills.Spriggan,
                 DFCareer.Skills.Thaumaturgy
             };
-        }
+
+        public override string[] RankTitles { get { return rankTitles; } }
+
+        public override List<DFCareer.Skills> GuildSkills { get { return guildSkills; } }
+
+        public override List<DFCareer.Skills> TrainingSkills { get { return trainingSkills; } }
 
         #endregion
 

--- a/Assets/Scripts/Game/Guilds/NonMemberGuild.cs
+++ b/Assets/Scripts/Game/Guilds/NonMemberGuild.cs
@@ -9,12 +9,20 @@
 using System;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallConnect.Arena2;
+using System.Collections.Generic;
+using DaggerfallConnect;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
     public class NonMemberGuild : Guild
     {
         private bool canTrain = false;
+
+        public override string[] RankTitles { get { throw new NotImplementedException(); } }
+
+        public override List<DFCareer.Skills> GuildSkills { get { throw new NotImplementedException(); } }
+
+        public override List<DFCareer.Skills> TrainingSkills { get { throw new NotImplementedException(); } }
 
         public NonMemberGuild(bool canTrain = false)
         {

--- a/Assets/Scripts/Game/Guilds/Services.cs
+++ b/Assets/Scripts/Game/Guilds/Services.cs
@@ -9,6 +9,7 @@
 using System;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
@@ -153,6 +154,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public static bool RegisterGuildService(int npcFactionId, GuildServices service)
         {
+            Debug.Log("RegisterGuildService: " + npcFactionId);
             if (!guildNpcServices.ContainsKey(npcFactionId))
             {
                 guildNpcServices.Add(npcFactionId, service);
@@ -163,6 +165,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public static bool RegisterGuildService(int npcFactionId, CustomGuildService service, string serviceName)
         {
+            Debug.Log("RegisterGuildService: " + npcFactionId + " with service: " + serviceName);
             if (!customNpcServices.ContainsKey(npcFactionId))
             {
                 customNpcServices.Add(npcFactionId, service);

--- a/Assets/Scripts/Game/Guilds/Services.cs
+++ b/Assets/Scripts/Game/Guilds/Services.cs
@@ -9,7 +9,6 @@
 using System;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using System.Collections.Generic;
-using UnityEngine;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
@@ -154,7 +153,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public static bool RegisterGuildService(int npcFactionId, GuildServices service)
         {
-            Debug.Log("RegisterGuildService: " + npcFactionId);
+            DaggerfallUnity.LogMessage("RegisterGuildService: " + npcFactionId, true);
             if (!guildNpcServices.ContainsKey(npcFactionId))
             {
                 guildNpcServices.Add(npcFactionId, service);
@@ -165,7 +164,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public static bool RegisterGuildService(int npcFactionId, CustomGuildService service, string serviceName)
         {
-            Debug.Log("RegisterGuildService: " + npcFactionId + " with service: " + serviceName);
+            DaggerfallUnity.LogMessage("RegisterGuildService: " + npcFactionId + " with service: " + serviceName, true);
             if (!customNpcServices.ContainsKey(npcFactionId))
             {
                 customNpcServices.Add(npcFactionId, service);

--- a/Assets/Scripts/Game/Guilds/Temple.cs
+++ b/Assets/Scripts/Game/Guilds/Temple.cs
@@ -385,7 +385,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public override bool FreeHealing()
         {
-            return (rank > 0);
+            return (templeRankBenefits[deity].healing <= rank);
         }
 
         #endregion
@@ -399,8 +399,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                 Debug.LogFormat("Akatosh FastTravel= {0} -{1} less hours", duration, duration - (int)(((95f - rank) / 100) * duration));
                 return (int)(((95f - rank) / 100) * duration);
             }
-            else
-                return duration;
+            return duration;
         }
 
         public override int ReducedCureCost(int price)
@@ -418,12 +417,19 @@ namespace DaggerfallWorkshop.Game.Guilds
                 Debug.LogFormat("Kynareth DeepBreath= {0} +{1} extra seconds", duration, (int)((((10f + rank) / 10) - 1) * duration));
                 return (int)(((10f + rank) / 10) * duration);
             }
-            else
-                return duration;
+            return duration;
         }
 
         public override bool AvoidDeath()
-        {// TODO
+        {
+            if (deity == Divines.Stendarr &&
+                !GameManager.Instance.PlayerEnterExit.IsPlayerSubmerged &&
+                UnityEngine.Random.Range(1, 50) < rank)
+            {
+                Debug.LogFormat("Stendarr AvoidDeath= success");
+                // TODO: what is "weaker state" is it more than being left on 1 health?
+                return true;
+            }
             return false;
         }
 

--- a/Assets/Scripts/Game/Guilds/Temple.cs
+++ b/Assets/Scripts/Game/Guilds/Temple.cs
@@ -143,7 +143,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             { Divines.Zenithar, new RankBenefits(4, 1, 1, 6,-1,-1,-1,-1,-1, 8, 5288, 5243, 4056) },
         };
 
-        static new Dictionary<Divines, List<DFCareer.Skills>> guildSkills = new Dictionary<Divines, List<DFCareer.Skills>>()
+        static Dictionary<Divines, List<DFCareer.Skills>> guildSkills = new Dictionary<Divines, List<DFCareer.Skills>>()
         {
             { Divines.Akatosh, new List<DFCareer.Skills>() {
                 DFCareer.Skills.Alteration,
@@ -231,7 +231,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             } },
         };
 
-        static new Dictionary<Divines, List<DFCareer.Skills>> trainingSkills = new Dictionary<Divines, List<DFCareer.Skills>>()
+        static Dictionary<Divines, List<DFCareer.Skills>> trainingSkills = new Dictionary<Divines, List<DFCareer.Skills>>()
         {
             { Divines.Akatosh, new List<DFCareer.Skills>() {
                 DFCareer.Skills.Alteration, DFCareer.Skills.Archery, DFCareer.Skills.Daedric,
@@ -267,16 +267,15 @@ namespace DaggerfallWorkshop.Game.Guilds
                 DFCareer.Skills.Pickpocket, DFCareer.Skills.Spriggan, DFCareer.Skills.Streetwise, DFCareer.Skills.Thaumaturgy } },
         };
 
-        static Temple()
-        {
-            rankTitles = new string[] {
-                "Novice", "Initiate", "Acolyte", "Adept", "Curate", "Disciple", "Brother", "Diviner", "Master", "Patriarch"
-            };
-        }
-
         #endregion
 
-        #region Properties
+        #region Properties & Data
+
+        string[] rankTitles = new string[] {
+                "Novice", "Initiate", "Acolyte", "Adept", "Curate", "Disciple", "Brother", "Diviner", "Master", "Patriarch"
+        };
+
+        public override string[] RankTitles { get { return rankTitles; } }
 
         public override List<DFCareer.Skills> GuildSkills { get { return guildSkills[deity]; } }
 

--- a/Assets/Scripts/Game/Guilds/Temple.cs
+++ b/Assets/Scripts/Game/Guilds/Temple.cs
@@ -390,13 +390,13 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #endregion
 
-        #region Special temple benefits:
+        #region Special guild benefits:
 
         public override int FastTravel(int duration)
         {
             if (deity == Divines.Akatosh)
             {
-                Debug.LogFormat("Akatosh FastTravel= {0} -{1} less days", duration, (duration - (int)(((95f - rank) / 100) * duration)) / 1440);
+                Debug.LogFormat("Akatosh FastTravel= {0} -{1} less hours", duration, duration - (int)(((95f - rank) / 100) * duration));
                 return (int)(((95f - rank) / 100) * duration);
             }
             else

--- a/Assets/Scripts/Game/Guilds/Temple.cs
+++ b/Assets/Scripts/Game/Guilds/Temple.cs
@@ -388,9 +388,17 @@ namespace DaggerfallWorkshop.Game.Guilds
             return (templeRankBenefits[deity].healing <= rank);
         }
 
+        public override int ReducedCureCost(int price)
+        {// TEST
+            if (deity == Divines.Arkay)
+                return ((10 - rank) / 10) * price;
+            else
+                return price;
+        }
+
         #endregion
 
-        #region Special guild benefits:
+        #region Special benefits:
 
         public override int FastTravel(int duration)
         {
@@ -400,14 +408,6 @@ namespace DaggerfallWorkshop.Game.Guilds
                 return (int)(((95f - rank) / 100) * duration);
             }
             return duration;
-        }
-
-        public override int ReducedCureCost(int price)
-        {// TEST
-            if (deity == Divines.Arkay)
-                return ((10 - rank) / 10) * price;
-            else
-                return price;
         }
 
         public override int DeepBreath(int duration)

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -74,6 +74,21 @@ namespace DaggerfallWorkshop.Game.Player
         #endregion
 
         #region Public Methods
+
+        /// <summary>
+        /// Adds any registered custom factions into existing save data or new games
+        /// </summary>
+        public void AddCustomFactions()
+        {
+            foreach (int id in FactionFile.CustomFactions.Keys)
+            {
+                if (!factionDict.ContainsKey(id))
+                {
+                    factionDict.Add(id, FactionFile.CustomFactions[id]);
+                    factionNameToIDDict.Add(FactionFile.CustomFactions[id].name, id);
+                }
+            }
+        }
 
         /// <summary>
         /// Gets faction data from faction ID.
@@ -246,6 +261,9 @@ namespace DaggerfallWorkshop.Game.Player
             // Get dictionaries
             factionDict = factionFile.FactionDict;
             factionNameToIDDict = factionFile.FactionNameToIDDict;
+
+            // Add any registered custom factions
+            AddCustomFactions();
 
             // Log message to see when faction data reset
             Debug.Log("PersistentFactionData.Reset() loaded fresh faction data.");

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -941,7 +941,7 @@ namespace DaggerfallWorkshop.Game
                     npc.Data.factionID, (FactionFile.SocialGroups)factionData.sgroup, (FactionFile.GuildGroups)factionData.ggroup, (FactionFile.GuildGroups)buildingFactionData.ggroup);
 
                 // Check if the NPC offers a guild service.
-                if (Enum.IsDefined(typeof(GuildNpcServices), npc.Data.factionID))
+                if (Services.HasGuildService(npc.Data.factionID))
                 {
                     FactionFile.GuildGroups guildGroup = (FactionFile.GuildGroups) buildingFactionData.ggroup;
                     if (guildGroup == FactionFile.GuildGroups.None)

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -1127,7 +1127,7 @@ namespace DaggerfallWorkshop.Game.Questing
                     foreach (DFBlock.RdbObject obj in group.RdbObjects)
                     {
                         // Get marker ID
-                        ulong markerID = (ulong)(blockData.Position + obj.This);
+                        ulong markerID = (ulong)(blockData.Position + obj.Position);
 
                         // Look for editor flats
                         Vector3 position = new Vector3(obj.XPos, -obj.YPos, obj.ZPos) * MeshReader.GlobalScale;

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -198,6 +198,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             PlayerEntity entity = playerEntityBehaviour.Entity as PlayerEntity;
             entity.FactionData.FactionDict = factionData.factionDict;
             entity.FactionData.FactionNameToIDDict = factionData.factionNameToIDDict;
+            // Add any registered custom factions
+            entity.FactionData.AddCustomFactions();
         }
 
         public void RestoreSaveData(object dataIn)

--- a/Assets/Scripts/Game/StaticNPC.cs
+++ b/Assets/Scripts/Game/StaticNPC.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -133,13 +133,13 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Sets NPC data from RMB layout.
         /// </summary>
-        public void SetLayoutData(DFBlock.RmbBlockPeopleRecord obj)
+        public void SetLayoutData(DFBlock.RmbBlockPeopleRecord obj, int buildingKey = 0)
         {
             // Store common layout data
             npcData.hash = GetPositionHash(obj.XPos, obj.YPos, obj.ZPos);
             npcData.flags = obj.Flags;
             npcData.factionID = obj.FactionID;
-            npcData.nameSeed = (int)obj.Position;
+            npcData.nameSeed = (int) obj.Position ^ buildingKey;
             npcData.gender = ((npcData.flags & 32) == 32) ? Genders.Female : Genders.Male;
             npcData.context = Context.Building;
             npcData.billboardArchiveIndex = obj.TextureArchive;

--- a/Assets/Scripts/Game/TalkManagerMCP.cs
+++ b/Assets/Scripts/Game/TalkManagerMCP.cs
@@ -45,9 +45,9 @@ namespace DaggerfallWorkshop.Game
         public MacroDataSource GetMacroDataSource()
         {
             TalkManagerContext context = new TalkManagerContext();
-            context.currentQuestionListItem = this.currentQuestionListItem;
+            context.currentQuestionListItem = currentQuestionListItem;
             context.npcRace = this.npcData.race;
-            if (this.currentQuestionListItem.questionType == QuestionType.Work)
+            if (currentQuestionListItem != null && currentQuestionListItem.questionType == QuestionType.Work)
             {
                 context.potentialQuestorGender = TalkManager.Instance.GetQuestorGender();
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -321,7 +321,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     tokens.Add(TextFile.CreateTextToken(guild.GetAffiliation()));
                     tokens.Add(tab);
                     tokens.Add(TextFile.CreateTextToken(guild.GetTitle() //)); DEBUG rep:
-                        + " rep:" + guild.GetReputation(playerEntity).ToString()));
+                        + " (rep:" + guild.GetReputation(playerEntity).ToString() + ")"));
                     tokens.Add(TextFile.NewLineToken);
                 }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -228,7 +228,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 case GuildServices.Identify:
                     CloseWindow();
-                    uiManager.PushWindow(new DaggerfallTradeWindow(uiManager, DaggerfallTradeWindow.WindowModes.Identify, this));
+                    uiManager.PushWindow(new DaggerfallTradeWindow(uiManager, DaggerfallTradeWindow.WindowModes.Identify, this, guild));
                     break;
 
                 case GuildServices.Repair:

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -219,7 +219,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
                 return;
             }
-            // Handle service
+            // Handle known service
             switch (service)
             {
                 case GuildServices.Quests:
@@ -253,13 +253,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     uiManager.PushWindow(DaggerfallUI.Instance.DfTravelMapWindow);
                     break;
 
-                case GuildServices.BuySpells:
+                //case GuildServices.BuySpells:
                     //uiManager.PushWindow(new DaggerfallBankingWindow(uiManager, this));
                     //break;
 
                 default:
                     CloseWindow();
-                    DaggerfallUI.MessageBox("Guild service not yet implemented.");
+                    Services.CustomGuildService customService;
+                    if (Services.GetCustomGuildService((int)service, out customService))
+                        customService();
+                    else
+                        DaggerfallUI.MessageBox("Guild service not yet implemented.");
                     break;
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -549,11 +549,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             List<DFCareer.Skills> trainingSkills = GetTrainingSkills();
             DFCareer.Skills skillToTrain = trainingSkills[index];
 
-            int maxTraining = 50;
-            if (DaggerfallSkills.IsLanguageSkill(skillToTrain))     // BCHG: Language skill training is capped by char intelligence instead of 50%
-                maxTraining = playerEntity.Stats.PermanentIntelligence;
-
-            if (playerEntity.Skills.GetPermanentSkillValue(skillToTrain) > maxTraining)
+            if (playerEntity.Skills.GetPermanentSkillValue(skillToTrain) > guild.GetTrainingMax(skillToTrain))
             {
                 // Inform player they're too skilled to train
                 TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(TrainingTooSkilledId);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -147,6 +147,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             : base(uiManager, previous)
         {
             this.windowMode = windowMode;
+            this.guild = guild;
         }
 
         #endregion
@@ -347,7 +348,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                             break;
                         case WindowModes.Identify:
                             if (!item.IsIdentified)
-                                cost += FormulaHelper.CalculateItemIdentifyCost(item.value);
+                                cost += FormulaHelper.CalculateItemIdentifyCost(item.value, guild);
                             break;
                     }
                 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -237,8 +237,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             availableGoldLabel.Text = GameManager.Instance.PlayerEntity.GoldPieces.ToString();
             travelTimeMinutes = travelTimeCalculator.CalculateTravelTime(endPos, speedCautious, sleepModeInn, travelShip, hasHorse, hasCart);
 
-            // Players can have fast travel benefit from temple membership
-            travelTimeMinutes = GameManager.Instance.GuildManager.GetGuild(FactionFile.GuildGroups.HolyOrder).FastTravel(travelTimeMinutes);
+            // Players can have fast travel benefit from guild memberships
+            travelTimeMinutes = GameManager.Instance.GuildManager.FastTravel(travelTimeMinutes);
 
             int travelTimeDaysTotal = (travelTimeMinutes / 1440);
 

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -773,7 +773,7 @@ namespace DaggerfallWorkshop
 
                 // Add StaticNPC behaviour
                 StaticNPC npc = go.AddComponent<StaticNPC>();
-                npc.SetLayoutData(obj);
+                npc.SetLayoutData(obj, entryDoor.buildingKey);
 
                 // Disable people if shop or building is closed
                 DFLocation.BuildingTypes buildingType = buildingData.buildingType;
@@ -799,7 +799,7 @@ namespace DaggerfallWorkshop
             foreach (DFBlock.RmbBlockDoorRecord obj in recordData.Interior.BlockDoorRecords)
             {
                 // Create unique LoadID for save sytem
-                ulong loadID = (ulong)(blockData.Position + obj.This);
+                ulong loadID = (ulong)(blockData.Position + obj.Position);
 
                 // Get model transform
                 Vector3 modelRotation = new Vector3(0, -obj.YRotation / BlocksFile.RotationDivisor, 0);

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -1,0 +1,100 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Hazelnut
+// Contributors:
+//
+
+using System.IO;
+using UnityEngine;
+using DaggerfallConnect;
+using DaggerfallWorkshop.Game.Serialization;
+using System.Collections.Generic;
+
+namespace DaggerfallWorkshop.Utility.AssetInjection
+{
+    public struct BlockRecordId
+    {
+        public int blockIndex;
+        public int recordIndex;
+    }
+
+    public struct BuildingReplacementData
+    {
+        public ushort factionId;
+        public int buildingType;
+        public DFBlock.RmbSubRecord rmbSubRecord;
+        // TODO: autoMapData for coloured map?
+    }
+
+    /// <summary>
+    /// Handles import and injection of custom block data with the purpose of providing modding support.
+    /// Block data is imported from mod bundles with load order or loaded directly from disk.
+    /// </summary>
+    public class WorldDataReplacement
+    {
+        #region Singleton
+
+        private static readonly WorldDataReplacement instance = new WorldDataReplacement();
+
+        private WorldDataReplacement() { }
+
+        public static WorldDataReplacement Instance { get { return instance; } }
+
+        #endregion
+
+
+        #region Fields & Properties
+
+        static readonly string worldDataPath = Path.Combine(Application.streamingAssetsPath, "WorldData");
+
+        private Dictionary<BlockRecordId, BuildingReplacementData> buildings = new Dictionary<BlockRecordId, BuildingReplacementData>();
+
+        private static Dictionary<BlockRecordId, BuildingReplacementData> Buildings { get { return Instance.buildings; } }
+
+        /// <summary>
+        /// Path to custom world data on disk.
+        /// </summary>
+        public static string WorldDataPath { get { return worldDataPath; } }
+
+        #endregion
+
+        #region Public Methods
+
+        public static string GetBuildingReplacementFilename(string blockName, int blockIndex, int recordIndex)
+        {
+            return string.Format("{0}-{1}-building{2}.json", blockName, blockIndex, recordIndex);
+        }
+
+        public static bool GetBuildingReplacementData(string blockName, int blockIndex, int recordIndex, out BuildingReplacementData buildingData)
+        {
+            if (DaggerfallUnity.Settings.MeshAndTextureReplacement)
+            {
+                BlockRecordId blockRecordId = new BlockRecordId() { blockIndex = blockIndex, recordIndex = recordIndex };
+                if (!Buildings.ContainsKey(blockRecordId))
+                {
+                    if (File.Exists(Path.Combine(worldDataPath, GetBuildingReplacementFilename(blockName, blockIndex, recordIndex))))
+                    {
+                        string fileName = GetBuildingReplacementFilename(blockName, blockIndex, recordIndex);
+                        string buildingReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
+                        buildingData = (BuildingReplacementData) SaveLoadManager.Deserialize(typeof(BuildingReplacementData), buildingReplacementJson);
+                        Buildings.Add(blockRecordId, buildingData);
+                        return true;
+                    }
+                }
+                else
+                {
+                    buildingData = Buildings[blockRecordId];
+                    return true;
+                }
+            }
+            buildingData = new BuildingReplacementData();
+            return false;
+        }
+
+        #endregion
+
+    }
+}

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -88,7 +88,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     string fileName = GetBuildingReplacementFilename(blockName, blockIndex, recordIndex);
 
                     // Seek from loose files
-                    if (File.Exists(Path.Combine(worldDataPath, GetBuildingReplacementFilename(blockName, blockIndex, recordIndex))))
+                    if (File.Exists(Path.Combine(worldDataPath, fileName)))
                     {
                         string buildingReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
                         buildingData = (BuildingReplacementData)SaveLoadManager.Deserialize(typeof(BuildingReplacementData), buildingReplacementJson);

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -23,9 +23,10 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
     public struct BuildingReplacementData
     {
-        public ushort factionId;
-        public int buildingType;
-        public DFBlock.RmbSubRecord rmbSubRecord;
+        public ushort FactionId;
+        public int BuildingType;
+        public byte Quality;
+        public DFBlock.RmbSubRecord RmbSubRecord;
         // TODO: autoMapData for coloured map?
     }
 
@@ -80,7 +81,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                         string fileName = GetBuildingReplacementFilename(blockName, blockIndex, recordIndex);
                         string buildingReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
                         buildingData = (BuildingReplacementData) SaveLoadManager.Deserialize(typeof(BuildingReplacementData), buildingReplacementJson);
+#if !UNITY_EDITOR       // Cache building replacement data unless in editor
                         Buildings.Add(blockRecordId, buildingData);
+#endif
                         return true;
                     }
                 }
@@ -94,7 +97,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return false;
         }
 
-        #endregion
+#endregion
 
     }
 }

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs.meta
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8a323be53a121884591258c7df0bcb40
+timeCreated: 1519741653
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -237,7 +237,7 @@ namespace DaggerfallWorkshop.Utility
                         // Create unique LoadID for save sytem
                         ulong loadID = 0;
                         if (serialize)
-                            loadID = (ulong)(blockData.Position + obj.This);
+                            loadID = (ulong)(blockData.Position + obj.Position);
 
                         // Look for action doors
                         int modelReference = obj.Resources.ModelResource.ModelIndex;
@@ -347,19 +347,19 @@ namespace DaggerfallWorkshop.Utility
                             // Add special marker component for quest and item markers
                             if (record == 11 || record == 18)
                             {
-                                ulong markerID = (ulong)(blockData.Position + obj.This);
+                                ulong markerID = (ulong)(blockData.Position + obj.Position);
                                 DaggerfallMarker marker = flatObject.AddComponent<DaggerfallMarker>();
                                 marker.MarkerID = markerID;
                             }
 
                             //add editor flats to actionLinkDict
-                            if (!actionLinkDict.ContainsKey(obj.This))
+                            if (!actionLinkDict.ContainsKey(obj.Position))
                             {
                                 ActionLink link;
                                 link.gameObject = flatObject;
                                 link.nextKey = obj.Resources.FlatResource.NextObjectOffset;
                                 link.prevKey = -1;
-                                actionLinkDict.Add(obj.This, link);
+                                actionLinkDict.Add(obj.Position, link);
                             }
                         }
 
@@ -835,20 +835,20 @@ namespace DaggerfallWorkshop.Utility
                     triggerFlag = (DFBlock.RdbTriggerFlags)obj.TriggerFlag_StartingLock;
 
                 // Add action node to actionLink dictionary
-                if (!actionLinkDict.ContainsKey(rdbObj.This))
+                if (!actionLinkDict.ContainsKey(rdbObj.Position))
                 {
                     ActionLink link;
                     link.nextKey = obj.ActionResource.NextObjectOffset;
                     link.prevKey = obj.ActionResource.PreviousObjectOffset;
                     link.gameObject = go;
-                    actionLinkDict.Add(rdbObj.This, link);
+                    actionLinkDict.Add(rdbObj.Position, link);
                 }
             }
 
             // Create unique LoadID for save sytem
             ulong loadID = 0;
             if (serialize)
-                loadID = (ulong)(blockData.Position + rdbObj.This);
+                loadID = (ulong)(blockData.Position + rdbObj.Position);
 
             AddAction(go, description, soundID_Index, duration, magnitude, axis, triggerFlag, actionFlag, loadID);
 
@@ -883,19 +883,19 @@ namespace DaggerfallWorkshop.Utility
                 triggerFlag = (DFBlock.RdbTriggerFlags)obj.Flags;
 
             //add action node to actionLink dictionary
-            if (!actionLinkDict.ContainsKey(rdbObj.This))
+            if (!actionLinkDict.ContainsKey(rdbObj.Position))
             {
                 ActionLink link;
                 link.nextKey = obj.NextObjectOffset;
                 link.prevKey = -1;
                 link.gameObject = go;
-                actionLinkDict.Add(rdbObj.This, link);
+                actionLinkDict.Add(rdbObj.Position, link);
             }
 
             // Create unique LoadID for save sytem
             ulong loadID = 0;
             if (serialize)
-                loadID = (ulong)(blockData.Position + rdbObj.This);
+                loadID = (ulong)(blockData.Position + rdbObj.Position);
 
             AddAction(go, description, soundID_Index, duration, magnitude, axis, triggerFlag, actionFlag, loadID);
         }
@@ -1321,7 +1321,7 @@ namespace DaggerfallWorkshop.Utility
                 // Create unique LoadID for save sytem
                 ulong loadID = 0;
                 if (serialize)
-                    loadID = (ulong)(blockData.Position + obj.This);
+                    loadID = (ulong)(blockData.Position + obj.Position);
 
                 // Add enemy
                 AddEnemy(obj, type, parent, loadID);
@@ -1342,7 +1342,7 @@ namespace DaggerfallWorkshop.Utility
             // Create unique LoadID for save sytem
             ulong loadID = 0;
             if (serialize)
-                loadID = (ulong)(blockData.Position + obj.This);
+                loadID = (ulong)(blockData.Position + obj.Position);
 
             // Cast to enum
             MobileTypes type = (MobileTypes)(obj.Resources.FlatResource.FactionOrMobileId & 0xff);
@@ -1405,7 +1405,7 @@ namespace DaggerfallWorkshop.Utility
             // Create unique LoadID for save sytem
             ulong loadID = 0;
             if (serialize)
-                loadID = (ulong)(blockData.Position + obj.This);
+                loadID = (ulong)(blockData.Position + obj.Position);
 
             // Randomise container texture
             int iconIndex = UnityEngine.Random.Range(0, DaggerfallLootDataTables.randomTreasureIconIndices.Length);

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -11,11 +11,8 @@
 
 using UnityEngine;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using DaggerfallConnect;
-using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game;
@@ -513,11 +510,23 @@ namespace DaggerfallWorkshop.Utility
                         throw new Exception("GetCompleteBuildingData() could not read block " + blockName);
 
                     // Assign building data for this block
+                    BuildingReplacementData buildingReplacementData;
                     for (int i = 0; i < block.RmbBlock.SubRecords.Length; i++)
                     {
                         DFLocation.BuildingData building = block.RmbBlock.FldHeader.BuildingDataList[i];
                         if (IsNamedBuilding(building.BuildingType))
                         {
+                            if (WorldDataReplacement.GetBuildingReplacementData(blockName, block.Index, i, out buildingReplacementData))
+                            {
+                                BuildingPoolItem bpi = new BuildingPoolItem();
+                                bpi.buildingData = new DFLocation.BuildingData()
+                                {
+                                    FactionId = buildingReplacementData.factionId,
+                                    BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.buildingType,
+                                };
+                                bpi.used = false;
+                                namedBuildingPool.Add(bpi);
+                            }
                             // Try to find next building and merge data
                             BuildingPoolItem item;
                             if (!GetNextBuildingFromPool(namedBuildingPool, building.BuildingType, out item))
@@ -689,6 +698,17 @@ namespace DaggerfallWorkshop.Utility
                     if (modelData.Doors != null)
                         doorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, recordCount, modelMatrix));
 
+/*                    if (obj.ModelIdNum == 324)
+                    {
+                        for (int i=0; i < modelData.SubMeshes.Length; i++)
+                        {
+                            ModelData.SubMeshData subData = modelData.SubMeshes[i];
+                            Debug.LogFormat("Tex arch: {0}  rec: {1}", subData.TextureArchive, subData.TextureRecord);
+                            if (subData.TextureArchive == 126)
+                                subData.TextureArchive = 133;
+                        }
+                    }
+*/
                     // Store building information for first model of record
                     // First model is main record structure, others are attachments like posts
                     // Only main structure is needed to resolve building after hit-test

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -516,8 +516,10 @@ namespace DaggerfallWorkshop.Utility
                         DFLocation.BuildingData building = block.RmbBlock.FldHeader.BuildingDataList[i];
                         if (IsNamedBuilding(building.BuildingType))
                         {
+                            // Check for replacement building data and use it if found
                             if (WorldDataReplacement.GetBuildingReplacementData(blockName, block.Index, i, out buildingReplacementData))
                             {
+                                // Use custom building values from replacement data, don't use pool or maps file
                                 building.NameSeed = location.Exterior.Buildings[0].NameSeed;
                                 building.FactionId = buildingReplacementData.FactionId;
                                 building.BuildingType = (DFLocation.BuildingTypes) buildingReplacementData.BuildingType;
@@ -697,17 +699,6 @@ namespace DaggerfallWorkshop.Utility
                     if (modelData.Doors != null)
                         doorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, recordCount, modelMatrix));
 
-/*                    if (obj.ModelIdNum == 324)
-                    {
-                        for (int i=0; i < modelData.SubMeshes.Length; i++)
-                        {
-                            ModelData.SubMeshData subData = modelData.SubMeshes[i];
-                            Debug.LogFormat("Tex arch: {0}  rec: {1}", subData.TextureArchive, subData.TextureRecord);
-                            if (subData.TextureArchive == 126)
-                                subData.TextureArchive = 133;
-                        }
-                    }
-*/
                     // Store building information for first model of record
                     // First model is main record structure, others are attachments like posts
                     // Only main structure is needed to resolve building after hit-test

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -518,31 +518,30 @@ namespace DaggerfallWorkshop.Utility
                         {
                             if (WorldDataReplacement.GetBuildingReplacementData(blockName, block.Index, i, out buildingReplacementData))
                             {
-                                BuildingPoolItem bpi = new BuildingPoolItem();
-                                bpi.buildingData = new DFLocation.BuildingData()
-                                {
-                                    FactionId = buildingReplacementData.factionId,
-                                    BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.buildingType,
-                                };
-                                bpi.used = false;
-                                namedBuildingPool.Add(bpi);
-                            }
-                            // Try to find next building and merge data
-                            BuildingPoolItem item;
-                            if (!GetNextBuildingFromPool(namedBuildingPool, building.BuildingType, out item))
-                            {
-                                Debug.LogFormat("End of city building list reached without finding building type {0} in location {1}.{2}", building.BuildingType, location.RegionName, location.Name);
+                                building.NameSeed = location.Exterior.Buildings[0].NameSeed;
+                                building.FactionId = buildingReplacementData.FactionId;
+                                building.BuildingType = (DFLocation.BuildingTypes) buildingReplacementData.BuildingType;
+                                building.LocationId = location.Exterior.Buildings[0].LocationId;
+                                building.Quality = buildingReplacementData.Quality;
                             }
                             else
                             {
-                                // Copy found city building data to block level
-                                building.NameSeed = item.buildingData.NameSeed;
-                                building.FactionId = item.buildingData.FactionId;
-                                building.Sector = item.buildingData.Sector;
-                                building.LocationId = item.buildingData.LocationId;
-                                building.Quality = item.buildingData.Quality;
+                                // Try to find next building and merge data
+                                BuildingPoolItem item;
+                                if (!GetNextBuildingFromPool(namedBuildingPool, building.BuildingType, out item))
+                                {
+                                    Debug.LogFormat("End of city building list reached without finding building type {0} in location {1}.{2}", building.BuildingType, location.RegionName, location.Name);
+                                }
+                                else
+                                {
+                                    // Copy found city building data to block level
+                                    building.NameSeed = item.buildingData.NameSeed;
+                                    building.FactionId = item.buildingData.FactionId;
+                                    building.Sector = item.buildingData.Sector;
+                                    building.LocationId = item.buildingData.LocationId;
+                                    building.Quality = item.buildingData.Quality;
+                                }
                             }
-
                             // Set whatever building data we could find
                             block.RmbBlock.FldHeader.BuildingDataList[i] = building;
                         }

--- a/Assets/StreamingAssets/WorldData.meta
+++ b/Assets/StreamingAssets/WorldData.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 261bd662859a4ce40bc8121ec0c5ac34
+folderAsset: yes
+timeCreated: 1519765983
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/WorldData/.gitignore
+++ b/Assets/StreamingAssets/WorldData/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything in this directory
+*
+# Except these files
+!.gitignore
+!readme.txt
+!readme.txt.meta


### PR DESCRIPTION
1. Fixes to guild foundations.
2. Guild mod hooks:
2.1 Building replacement functionality in WorldDataReplacement reads building json from loose files or mods (also caches it when not running in editor in a non-sparse cache so abort calls early since block data is loaded a LOT - please check the code here @Interkarma & @TheLacus )
2.2 Register new custom factions, guilds, and services from mods
3. Fix NPC nameseeds
4. Three dump data commands

To test this you will need to do the following (after checking it hasn't broken anything first) to add my custom guild mod:

1. Download the mod file from my mod repo (https://github.com/ajrb/dfunity-mods/raw/master/build/StandaloneWindows/archaeologists.dfmod)
2. Place in StreamingAssets/Mods and ensure is activated
3. Load game and travel to Oxbeth
4. Look at map and find the large irregularly shaped building (actually is 2 separate buildings) get close to one
5. Use info mode and click on building - should say Archaeologists guild
6. Enter both buildings and interact with NPCs
7 Grin! :-D

Let me know if you find any issues. Hope you have some time to look at it this weekend.

 