### PR TITLE
added demo quest showing off rumor mill in conjunction with dialog link

### DIFF
--- a/Assets/StreamingAssets/Quests/__DEMO14.txt
+++ b/Assets/StreamingAssets/Quests/__DEMO14.txt
@@ -1,0 +1,54 @@
+---- Example quest to demonstrate rumor mill and dialog link
+---- get information after (and only after) hearing the correct rumor
+---- !!this is extending vanilla daggerfall's behaviour!!
+---- once an npc talked about the rumor the linked dialog option
+---- will be available in the tell me about section
+---- rumor mill is using message 1020 here - one (and only one) of the
+---- two answers is revealing the person name in tell me about section
+---- (you have to switch dialog option and then it will show up in the
+---- tell me about section)
+---- you can then ask peasants for the correct place where the person
+---- can be found (todo: seems like the person does not show up,
+---- not sure why, but this is not related to talk mechanics)
+
+Quest: __DEMO14
+
+QRC:
+
+QuestorOffer:  [1000]
+<ce>            There is quite a talk lately about a mysterious person. Would you be willing to find out more about the rumors?
+
+RefuseQuest:  [1001]
+<ce>                I am sorry to hear that. I understand,
+<ce>                  of course, but it is disappointing.
+
+AcceptQuest:  [1002]
+<ce>             That's good to hear. You need to ask around for news and rumors...
+
+QuestLogEntry:  [1010]
+%qdt:
+ I need to ask around for news and rumors about a mysterious person
+
+Message:  1011
+_thief_ was said to be master thief.
+<--->
+_thief_ does all of the thieves guild footwork.
+<--->
+The _thief_ is that =thief_ down at _tavern_.
+
+Message:  1020
+_thief_ is in town. You should try to meet %g2. Just ask around where you can find _thief_.
+<--->
+There are rumors about a mysterious person in town, but unfortunately I cannot provide a name.
+
+QBN:
+
+Person _thief_ face 81 faction The_Thieves_Guild anyInfo 1011
+Place _tavern_ remote tavern
+
+--	Quest start-up:
+	dialog link for person _thief_ 
+	log 1010 step 0  
+	create npc _thief_ 
+	place npc _thief_ at _tavern_
+	rumor mill 1020 

--- a/Assets/StreamingAssets/Quests/__DEMO14.txt.meta
+++ b/Assets/StreamingAssets/Quests/__DEMO14.txt.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a4cd29c5c7d3364f82d51d28f1e79fa
+timeCreated: 1520262841
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
example quest to demonstrate rumor mill and dialog link:
get information after (and only after) hearing the correct rumor - this is extending vanilla daggerfall's behaviour - once an npc talked about the rumor the linked dialog option will be available in the tell me about section - rumor mill gives one of two possible answers (and you will have to try quite often, since these 2 answers only get added to the list of rumors) - only one of the two answers is revealing the person name in tell me about section (after getting the correct answer you still have to switch dialog option and then it will show up in the tell me about section) you can then ask peasants for the correct place where the person can be found (todo: seems like the quest person does not show up, not sure why, but this is not related to talk mechanics)