### PR TITLE
Progress on diseases

### DIFF
--- a/Assets/Scripts/API/Save/SaveTree.cs
+++ b/Assets/Scripts/API/Save/SaveTree.cs
@@ -382,6 +382,7 @@ namespace DaggerfallConnect.Save
         NPCFlat = 0x08,
         Spell = 0x09,
         GuildMembership = 0x0a,
+        DiseaseOrPoison = 0x0b,
         QBNData = 0x0e,
         QuestTree = 0x10,                           // Fixsave calls this "quest tree".
         EnemyMobile = 0x12,

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -1043,7 +1043,7 @@ namespace DaggerfallWorkshop.Game
         public DaggerfallMessageBox CreateHealthStatusBox(IUserInterfaceWindow previous = null)
         {
             DaggerfallMessageBox healthBox = new DaggerfallMessageBox(uiManager, previous);
-            healthBox.SetTextTokens(GameManager.Instance.PlayerEntity.Disease.GetMessageId());    // TODO: Various diseases are in msgs 100-117
+            healthBox.SetTextTokens(GameManager.Instance.PlayerEntity.Disease.GetMessageId());
             healthBox.ClickAnywhereToClose = true;
             return healthBox;
         }

--- a/Assets/Scripts/Game/Entities/DaggerfallDisease.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallDisease.cs
@@ -15,15 +15,83 @@ namespace DaggerfallWorkshop.Game.Entity
 {
     public class DaggerfallDisease
     {
+        public struct DiseaseData
+        {
+            // Affected stats
+            public byte STR;
+            public byte INT;
+            public byte WIL;
+            public byte AGI;
+            public byte END;
+            public byte PER;
+            public byte SPD;
+            public byte LUC;
+            public byte HEA;
+            public byte FAT;
+            public byte SPL;
+            public byte minDamage;
+            public byte maxDamage;
+            public byte daysOfSymptomsMin; // 0xFF means never-ending
+            public byte daysOfSymptomsMax;
+
+            // Constructor
+            public DiseaseData(byte STRp, byte INTp,
+                byte WILp, byte AGIp, byte ENDp, byte PERp,
+                byte SPDp, byte LUCp, byte HEAp, byte FATp,
+                byte SPLp, byte minDamagep, byte maxDamagep,
+                byte daysOfSymptomsMinp, byte daysOfSymptomsMaxp)
+            {
+                STR = STRp;
+                INT = INTp;
+                WIL = WILp;
+                AGI = AGIp;
+                END = ENDp;
+                PER = PERp;
+                SPD = SPDp;
+                LUC = LUCp;
+                HEA = HEAp;
+                FAT = FATp;
+                SPL = SPLp;
+                minDamage = minDamagep;
+                maxDamage = maxDamagep;
+                daysOfSymptomsMin = daysOfSymptomsMinp;
+                daysOfSymptomsMax = daysOfSymptomsMaxp;
+            }
+        }
+
+        // Disease data. Found in FALL.EXE (1.07.213) from offset 0x1C0053.
+        public DiseaseData[] diseaseData = new DiseaseData[]
+        {              //  STR  INT  WIL  AGI  END  PER  SPD  LUC  HEA  FAT  SPL MIND  MAXD  MINS  MAXS
+            new DiseaseData( 1,   0,   0,   0,   1,   0,   0,   0,   1,   0,   0,   2,   10, 0xFF, 0xFF), // Witches' Pox
+            new DiseaseData( 1,   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   3,   30, 0xFF, 0xFF), // Plague
+            new DiseaseData( 0,   0,   1,   0,   1,   0,   0,   0,   1,   0,   0,   5,   10, 0xFF, 0xFF), // Yellow Fever
+            new DiseaseData( 0,   0,   0,   0,   0,   0,   0,   0,   1,   0,   0,   1,    5, 0xFF, 0xFF), // Stomach Rot
+            new DiseaseData( 1,   0,   1,   1,   0,   0,   0,   0,   0,   0,   0,   2,   10, 0xFF, 0xFF), // Consumption
+            new DiseaseData( 0,   0,   1,   0,   0,   1,   0,   0,   1,   0,   0,   1,    5, 0xFF, 0xFF), // Brain Fever
+            new DiseaseData( 1,   0,   1,   1,   0,   0,   0,   0,   0,   0,   0,   2,   10, 0xFF, 0xFF), // Swamp Rot
+            new DiseaseData( 1,   0,   0,   1,   0,   0,   1,   0,   0,   0,   0,   5,   10,    3,   18), // Caliron's Curse
+            new DiseaseData( 1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   5,   30, 0xFF, 0xFF), // Cholera
+            new DiseaseData( 1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   0,   5,   30, 0xFF, 0xFF), // Leprosy
+            new DiseaseData( 1,   0,   0,   0,   1,   0,   0,   0,   1,   0,   0,   2,    4, 0xFF, 0xFF), // Wound Rot
+            new DiseaseData( 0,   0,   0,   0,   1,   1,   0,   0,   0,   1,   0,   2,   10, 0xFF, 0xFF), // Red Death
+            new DiseaseData( 0,   0,   1,   0,   0,   1,   0,   0,   1,   0,   0,   5,   10,    3,   18), // Blood Rot
+            new DiseaseData( 0,   1,   0,   0,   1,   0,   0,   0,   1,   0,   0,   2,   10, 0xFF, 0xFF), // Typhoid Fever
+            new DiseaseData( 0,   1,   1,   0,   0,   1,   0,   0,   0,   0,   0,   2,   10, 0xFF, 0xFF), // Dementia
+            new DiseaseData( 0,   1,   0,   0,   0,   0,   0,   0,   0,   0,   1,   5,   10, 0xFF, 0xFF), // Chrondiasis
+            new DiseaseData( 0,   1,   0,   0,   0,   0,   0,   0,   0,   0,   1,   2,    4,    3,   18), // Wizard Fever
+        };
+
         Diseases diseaseType = Diseases.None;
         ulong contractedTime = 0;
         uint incubationTime = 0;
+        public byte daysOfSymptoms = 0;
+        public int totalDamage = 0;
 
         private const uint baseIncubation = 60 * 60 * 16;    // 16 hours
 
         private WorldTime worldTime;
 
-        private static List<Diseases> affectsHealth = new List<Diseases>
+        /*private static List<Diseases> affectsHealth = new List<Diseases>
             { Diseases.BloodRot, Diseases.BrainFever };
 
         private static Dictionary<Diseases, List<DFCareer.Stats>> affectedStats = new Dictionary<Diseases, List<DFCareer.Stats>>
@@ -31,7 +99,7 @@ namespace DaggerfallWorkshop.Game.Entity
             { Diseases.BloodRot, new List<DFCareer.Stats>() { DFCareer.Stats.Personality, DFCareer.Stats.Willpower } },
             { Diseases.BrainFever, new List<DFCareer.Stats>() { DFCareer.Stats.Personality, DFCareer.Stats.Willpower } },
             { Diseases.CalironsCurse, new List<DFCareer.Stats>() { DFCareer.Stats.Strength, DFCareer.Stats.Speed, DFCareer.Stats.Agility } },
-        };
+        };*/
 
         public DaggerfallDisease()
         {
@@ -44,8 +112,106 @@ namespace DaggerfallWorkshop.Game.Entity
             diseaseType = disease;
             contractedTime = worldTime.Now.ToSeconds();
             incubationTime = CalculateIncubationTime();
-            Debug.Log("Contracted " + disease);
 
+            // Get index to disease data
+            byte index = (byte)((byte)disease - 100);
+
+            // Get length of stat-worsening if not cured.
+            // If the minimum length of the disease is set to 0xFF, this means stats never stop falling until cured. Otherwise, get a random length.
+            daysOfSymptoms = diseaseData[index].daysOfSymptomsMin;
+
+            if (daysOfSymptoms != 0xFF)
+                daysOfSymptoms = (byte)Random.Range(diseaseData[index].daysOfSymptomsMin, diseaseData[index].daysOfSymptomsMax + 1);
+
+            Debug.Log("Contracted " + disease);
+        }
+
+        public void ApplyDiseaseEffects(PlayerEntity player)
+        {
+            // Get index to disease data
+            byte index = (byte)((byte)diseaseType - 100);
+
+            // A value of 0xFE for remaining days is used in classic for a disease that has run its course and is no longer
+            // damaging stats
+            if (daysOfSymptoms == 0xFE)
+                return;
+
+            // Count down remaining days for diseases with limited time.
+            if (daysOfSymptoms != 0xFF && (--daysOfSymptoms == 0))
+            {
+                daysOfSymptoms = 0xFE;
+                // Classic returns here, which is probably a mistake, since it would shave off the final day from the expected number of days
+            }
+
+            int damageAmount = Random.Range(diseaseData[index].minDamage, diseaseData[index].maxDamage + 1);
+
+            // Tally damage total. A tally like this seems to be used in classic for reversing stat damage when the disease is cured.
+            totalDamage += damageAmount;
+
+            if (diseaseData[index].STR != 0)
+            {
+                // TODO: lower by damageAmount
+                if (player.Stats.LiveStrength <= 0)
+                    player.SetHealth(0);
+            }
+            if (diseaseData[index].INT != 0)
+            {
+                // TODO: lower by damageAmount
+                if (player.Stats.LiveIntelligence <= 0)
+                    player.SetHealth(0);
+            }
+            if (diseaseData[index].WIL != 0)
+            {
+                // TODO: lower by damageAmount
+                if (player.Stats.LiveWillpower <= 0)
+                    player.SetHealth(0);
+            }
+            if (diseaseData[index].AGI != 0)
+            {
+                // TODO: lower by damageAmount
+                if (player.Stats.LiveAgility <= 0)
+                    player.SetHealth(0);
+            }
+            if (diseaseData[index].END != 0)
+            {
+                // TODO: lower by damageAmount
+                if (player.Stats.LiveEndurance <= 0)
+                    player.SetHealth(0);
+            }
+            if (diseaseData[index].PER != 0)
+            {
+                // TODO: lower by damageAmount
+                if (player.Stats.LivePersonality <= 0)
+                    player.SetHealth(0);
+            }
+            if (diseaseData[index].SPD != 0)
+            {
+                // TODO: lower by damageAmount
+                if (player.Stats.LiveSpeed <= 0)
+                    player.SetHealth(0);
+            }
+            if (diseaseData[index].LUC != 0)
+            {
+                // TODO: lower by damageAmount
+                if (player.Stats.LiveLuck <= 0)
+                    player.SetHealth(0);
+            }
+            if (diseaseData[index].HEA != 0)
+                player.CurrentHealth -= damageAmount;
+            if (diseaseData[index].FAT != 0)
+                player.CurrentFatigue -= damageAmount;
+            if (diseaseData[index].SPL != 0)
+                player.CurrentMagicka -= damageAmount;
+
+            DaggerfallUI.AddHUDText(UserInterfaceWindows.HardStrings.youFeelSomewhatBad);
+        }
+
+        public bool HasFinishedIncubation()
+        {
+            if (contractedTime + incubationTime <= DaggerfallUnity.Instance.WorldTime.Now.ToSeconds())
+                return true;
+            else
+                return false;
         }
 
         public Diseases Type { get { return diseaseType; } }
@@ -54,7 +220,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
         public int GetMessageId()
         {
-            if (diseaseType == Diseases.None) // || contractedTime + incubationTime > worldTime.Now.ToSeconds())
+            if (diseaseType == Diseases.None || !HasFinishedIncubation())
                 return 18;
             else
                 return (int) diseaseType;
@@ -67,6 +233,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 disease = diseaseType,
                 diseaseContractedTime = contractedTime,
                 diseaseInclubationTime = incubationTime,
+                diseaseDaysOfSymptoms = daysOfSymptoms,
             };
         }
 
@@ -77,6 +244,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 diseaseType = data.disease;
                 contractedTime = data.diseaseContractedTime;
                 incubationTime = data.diseaseInclubationTime;
+                daysOfSymptoms = data.diseaseDaysOfSymptoms;
             }
             else
             {

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -278,7 +278,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 }
             }
 
-            // Adjust regional prices and update climate weathers whenever the date has changed.
+            // Adjust regional prices and update climate weathers and diseases whenever the date has changed.
             uint lastDay = lastGameMinutes / 1440;
             uint currentDay = gameMinutes / 1440;
             int daysPast = (int)(currentDay - lastDay);
@@ -289,6 +289,12 @@ namespace DaggerfallWorkshop.Game.Entity
                 GameManager.Instance.WeatherManager.SetClimateWeathers();
                 GameManager.Instance.WeatherManager.UpdateWeatherFromClimateArray = true;
                 RemoveExpiredRentedRooms();
+
+                if (Disease.IsDiseased() && (Disease.HasFinishedIncubation()))
+                {
+                    for (int i = daysPast; i > 0; i--)
+                        Disease.ApplyDiseaseEffects(this);
+                }
             }
 
             lastGameMinutes = gameMinutes;

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -194,6 +194,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public Diseases disease;
         public ulong diseaseContractedTime;
         public uint diseaseInclubationTime;
+        public byte diseaseDaysOfSymptoms;
     }
 
     [fsObject("v1")]

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -346,6 +346,41 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public void BeginButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
         {
             Refresh();
+
+            // Warns player if they have an incubating disease
+            if (GameManager.Instance.PlayerEntity.Disease.IsDiseased() && !GameManager.Instance.PlayerEntity.Disease.HasFinishedIncubation())
+            {
+                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
+                TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(1010);
+                messageBox.SetTextTokens(tokens);
+                messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
+                messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No);
+                messageBox.OnButtonClick += ConfirmTravelPopupDiseasedButtonClick;
+                uiManager.PushWindow(messageBox);
+            }
+            else
+            {
+                CallFastTravelGoldCheck();
+            }
+        }
+
+        /// <summary>
+        /// Button handler for travel-with-incubating-disease confirmation pop up.
+        /// </summary>
+        void ConfirmTravelPopupDiseasedButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
+        {
+            sender.CloseWindow();
+
+            if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
+            {
+                CallFastTravelGoldCheck();
+            }
+            else
+                return;
+        }
+
+        void CallFastTravelGoldCheck()
+        {
             if (!enoughGoldCheck())
             {
                 showNotEnoughGoldPopup();

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -150,6 +150,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public const string exhaustedInWater = "Fatigue overcomes you and sends you to a watery grave...."; // Not in classic. Borrowed from Arena.
 
+        public const string youFeelSomewhatBad = "You feel somewhat bad.";
+
         // Words used by macro handlers:
 
         public const string pronounHe = "he";


### PR DESCRIPTION
Implements:
- Classic diseases' stats (which attributes they affect, etc.)
- Diseases that endlessly lower stats vs. those that don't. When a non-endlessly-lowering disease finishes, it sets its number of days left to 254 (0xFE) in classic. Doing it the same way, which should aid in importing diseases from classic saves.
- Length of disease and damage values gotten like in classic.
- Diseases lower stats in the same manner as classic and can kill the player.

Diseases are disabled now until a way to cure them is implemented.

I haven't figured out how classic does the incubation period yet. Also there is no "you may not survive" message for traveling. Length of disease period will need to be saved and loaded. Poisons aren't implemented yet. Neither are imported from classic saves yet.