### PR TITLE
Set player death sound by race and gender

### DIFF
--- a/Assets/Scripts/Game/PlayerDeath.cs
+++ b/Assets/Scripts/Game/PlayerDeath.cs
@@ -31,8 +31,6 @@ namespace DaggerfallWorkshop.Game
         public float FadeDuration = 2f;
         public float TimeBeforeReset = 3;
 
-        public SoundClips PlayerDeathSound = SoundClips.PlayerDeath;
-
         StartGameBehaviour startGameBehaviour;
         DaggerfallEntityBehaviour entityBehaviour;
         PlayerEntity playerEntity;
@@ -162,11 +160,42 @@ namespace DaggerfallWorkshop.Game
             currentCameraHeight = startCameraHeight;
             DaggerfallUI.Instance.FadeHUDToBlack(FadeDuration);
 
+            // There are 3 pain-like sounds for each race/gender. The third one, used here, sounds like
+            // it may have been meant for when the player dies.
+
+            PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+            SoundClips sound = GetRaceGenderPain3Sound((Races)playerEntity.RaceTemplate.ID, playerEntity.Gender);
+
             if (DaggerfallUI.Instance.DaggerfallAudioSource)
-                DaggerfallUI.Instance.DaggerfallAudioSource.PlayOneShot(PlayerDeathSound, 0);
+                DaggerfallUI.Instance.DaggerfallAudioSource.PlayOneShot(sound, 0);
 
             if (OnPlayerDeath != null)
                 OnPlayerDeath(this, null);
+        }
+
+        SoundClips GetRaceGenderPain3Sound(Races race, Genders gender)
+        {
+            switch (race)
+            {
+                case Races.Breton:
+                    return (playerEntity.Gender == Genders.Male) ? SoundClips.BretonMalePain3 : SoundClips.BretonFemalePain3;
+                case Races.Redguard:
+                    return (playerEntity.Gender == Genders.Male) ? SoundClips.RedguardMalePain3 : SoundClips.RedguardFemalePain3;
+                case Races.Nord:
+                    return (playerEntity.Gender == Genders.Male) ? SoundClips.NordMalePain3 : SoundClips.NordFemalePain3;
+                case Races.DarkElf:
+                    return (playerEntity.Gender == Genders.Male) ? SoundClips.DarkElfMalePain3 : SoundClips.DarkElfFemalePain3;
+                case Races.HighElf:
+                    return (playerEntity.Gender == Genders.Male) ? SoundClips.HighElfMalePain3 : SoundClips.HighElfFemalePain3;
+                case Races.WoodElf:
+                    return (playerEntity.Gender == Genders.Male) ? SoundClips.WoodElfMalePain3 : SoundClips.WoodElfFemalePain3;
+                case Races.Khajiit:
+                    return (playerEntity.Gender == Genders.Male) ? SoundClips.KhajiitMalePain3 : SoundClips.KhajiitFemalePain3;
+                case Races.Argonian:
+                    return (playerEntity.Gender == Genders.Male) ? SoundClips.ArgonianMalePain3 : SoundClips.ArgonianFemalePain3;
+                default:
+                    return SoundClips.None;
+            }
         }
 
         #endregion


### PR DESCRIPTION
This sets the death sound by race and gender.

Background:
There are 3 pain sounds for each race/gender combination in the sound files. Classic only uses one of these, the second in the Male Wood Elf set, for the player regardless of their race or gender in the original game.

By my judgment the sounds generally seem to sound like
1. Hurt/Exertion
2. Hurt/Exertion more
3. Dying

The "hurt" sounds might also be interpreted as exertion while attacking. For example the Breton Female "Hurt 1" is the same as the Nymph's attack. But generally across the board I think they sound more like being hurt than doing an attack. I think the 3rd one is pretty unambiguous across the board as a "dying" sound, so that's the only one I'm using for this so far. I'm thinking maybe the other two could be used as pain sounds for something like > 50% health and < 50% health.

I initially made this as a setting, and I still have that version locally, but this is pretty much going into the realm of bug fix I think, since you shouldn't get a male voice for a female character. If people are nostalgic for the voice used by classic, we could have the setting, but I think maybe we could just wait to see if anybody wants it first. 

