### PR TITLE
Implement classic cure disease cost (WIP)

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -79,6 +79,7 @@ namespace DaggerfallConnect.Save
             doc.startingLevelUpSkillSum = parsedData.startingLevelUpSkillSum;
             doc.minMetalToHit = parsedData.minMetalToHit;
             doc.armorValues = parsedData.armorValues;
+            doc.timeToBecomeVampireOrWerebeast = parsedData.timeToBecomeVampireOrWerebeast;
             doc.lastTimePlayerAteOrDrankAtTavern = parsedData.lastTimePlayerAteOrDrankAtTavern;
             doc.lastTimePlayerBoughtTraining = parsedData.lastTimePlayerBoughtTraining;
             doc.timeForThievesGuildLetter = parsedData.timeForThievesGuildLetter;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -73,6 +73,7 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int thievesGuildRequirementTally = 0;
         protected int darkBrotherhoodRequirementTally = 0;
 
+        protected uint timeToBecomeVampireOrWerebeast = 0;
         protected uint lastTimePlayerAteOrDrankAtTavern = 0;
 
         protected DaggerfallDisease disease = new DaggerfallDisease();
@@ -131,6 +132,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public uint TimeForDarkBrotherhoodLetter { get { return timeForDarkBrotherhoodLetter; } set { timeForDarkBrotherhoodLetter = value; } }
         public int ThievesGuildRequirementTally { get { return thievesGuildRequirementTally; } set { thievesGuildRequirementTally = value; } }
         public int DarkBrotherhoodRequirementTally { get { return darkBrotherhoodRequirementTally; } set { darkBrotherhoodRequirementTally = value; } }
+        public uint TimeToBecomeVampireOrWerebeast { get { return timeToBecomeVampireOrWerebeast; } set { timeToBecomeVampireOrWerebeast = value; } }
         public uint LastTimePlayerAteOrDrankAtTavern { get { return lastTimePlayerAteOrDrankAtTavern; } set { lastTimePlayerAteOrDrankAtTavern = value; } }
         public float CarriedWeight { get { return Items.GetWeight() + ((float)goldPieces / DaggerfallBankManager.gold1kg); } }
         public float WagonWeight { get { return WagonItems.GetWeight(); } }
@@ -360,6 +362,7 @@ namespace DaggerfallWorkshop.Game.Entity
             this.startingLevelUpSkillSum = character.startingLevelUpSkillSum;
             this.minMetalToHit = (WeaponMaterialTypes)character.minMetalToHit;
             this.armorValues = character.armorValues;
+            this.timeToBecomeVampireOrWerebeast = character.timeToBecomeVampireOrWerebeast;
             this.lastTimePlayerAteOrDrankAtTavern = character.lastTimePlayerAteOrDrankAtTavern;
             this.timeOfLastSkillTraining = character.lastTimePlayerBoughtTraining;
             this.timeForThievesGuildLetter = character.timeForThievesGuildLetter;

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1075,9 +1075,16 @@ namespace DaggerfallWorkshop.Game.Formulas
             return amount;
         }
 
-        public static int CalculateCuringCost()
+        public static int CalculateCuringCost(int numberOfDiseases, int templeQuality, int templeRank)
         {
-            return 100;  // TODO - how is this worked out? what params?
+            int baseCost = 250 * numberOfDiseases;
+            int costBeforeBartering = CalculateCost(baseCost, templeQuality);
+            int costAfterBartering = CalculateTradePrice(costBeforeBartering, templeQuality, false);
+            int rankModifier = ((10 - templeRank) << 8) / 10;
+
+            // TODO: Discount for Arkay
+
+            return (rankModifier * costAfterBartering) >> 8;
         }
 
         public static int ApplyRegionalPriceAdjustment(int cost)

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1075,18 +1075,6 @@ namespace DaggerfallWorkshop.Game.Formulas
             return amount;
         }
 
-        public static int CalculateCuringCost(int numberOfDiseases, int templeQuality, int templeRank)
-        {
-            int baseCost = 250 * numberOfDiseases;
-            int costBeforeBartering = CalculateCost(baseCost, templeQuality);
-            int costAfterBartering = CalculateTradePrice(costBeforeBartering, templeQuality, false);
-            int rankModifier = ((10 - templeRank) << 8) / 10;
-
-            // TODO: Discount for Arkay
-
-            return (rankModifier * costAfterBartering) >> 8;
-        }
-
         public static int ApplyRegionalPriceAdjustment(int cost)
         {
             Formula_1i del;

--- a/Assets/Scripts/Game/Guilds/Temple.cs
+++ b/Assets/Scripts/Game/Guilds/Temple.cs
@@ -407,11 +407,12 @@ namespace DaggerfallWorkshop.Game.Guilds
         }
 
         public override int ReducedCureCost(int price)
-        {// TEST
+        {
+            double mult = ((double)(10 - rank) / 10);
             if (deity == Divines.Arkay)
-                return ((10 - rank) / 10) * price;
+                return (int) (mult * mult * price);
             else
-                return price;
+                return (int) (mult * price);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Guilds/Temple.cs
+++ b/Assets/Scripts/Game/Guilds/Temple.cs
@@ -408,11 +408,10 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public override int ReducedCureCost(int price)
         {
-            double mult = ((double)(10 - rank) / 10);
             if (deity == Divines.Arkay)
-                return (int) (mult * mult * price);
+                return (((10 - rank) << 8) / 10 * price) >> 8;
             else
-                return (int) (mult * price);
+                return price;
         }
 
         #endregion

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -52,6 +52,7 @@ namespace DaggerfallWorkshop.Game.Player
         public uint timeForDarkBrotherhoodLetter;
         public byte darkBrotherhoodRequirementTally;
         public byte thievesGuildRequirementTally;
+        public uint timeToBecomeVampireOrWerebeast;
         public uint lastTimePlayerAteOrDrankAtTavern;
         public sbyte biographyReactionMod;
 

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -181,6 +181,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public uint timeForDarkBrotherhoodLetter;
         public int thievesGuildRequirementTally;
         public int darkBrotherhoodRequirementTally;
+        public uint timeToBecomeVampireOrWerebeast;
         public uint lastTimePlayerAteOrDrankAtTavern;
         public uint timeOfLastSkillTraining;
         public PlayerEntity.RegionDataRecord[] regionData;

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -136,6 +136,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             data.playerEntity.timeForDarkBrotherhoodLetter = entity.TimeForDarkBrotherhoodLetter;
             data.playerEntity.thievesGuildRequirementTally = entity.ThievesGuildRequirementTally;
             data.playerEntity.darkBrotherhoodRequirementTally = entity.DarkBrotherhoodRequirementTally;
+            data.playerEntity.timeToBecomeVampireOrWerebeast = entity.TimeToBecomeVampireOrWerebeast;
             data.playerEntity.lastTimePlayerAteOrDrankAtTavern = entity.LastTimePlayerAteOrDrankAtTavern;
 
             data.playerEntity.regionData = entity.RegionData;
@@ -246,6 +247,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.TimeForDarkBrotherhoodLetter = data.playerEntity.timeForDarkBrotherhoodLetter;
             entity.ThievesGuildRequirementTally = data.playerEntity.thievesGuildRequirementTally;
             entity.DarkBrotherhoodRequirementTally = data.playerEntity.darkBrotherhoodRequirementTally;
+            entity.TimeToBecomeVampireOrWerebeast = data.playerEntity.timeToBecomeVampireOrWerebeast;
             entity.LastTimePlayerAteOrDrankAtTavern = data.playerEntity.lastTimePlayerAteOrDrankAtTavern;
             entity.SetCurrentLevelUpSkillSum();
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -613,12 +613,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void CureDiseaseService()
         {
+            const int tradeMessageBaseId = 260; // TODO: Message based on bargaining result
+            int msgOffset = 0;
             CloseWindow();
             if (playerEntity.Disease.IsDiseased())
             {
-                // Offer curing price
+                // Offer curing price. TODO: Message not showing correct amount.
                 DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, uiManager.TopWindow);
-                TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(TrainingOfferId);
+                TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(tradeMessageBaseId + msgOffset);
                 messageBox.SetTextTokens(tokens, guild);
                 messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
                 messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No);
@@ -634,9 +636,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void ConfirmCuring_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
         {
             CloseWindow();
+            int templeQuality = GameManager.Instance.PlayerEnterExit.BuildingDiscoveryData.quality;
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
             {
-                int curingPrice = FormulaHelper.CalculateCuringCost();
+                int curingPrice = FormulaHelper.CalculateCuringCost(1, templeQuality, 0); // TODO: Support multiple diseases + curing lycanthropy and vampirism/pass in temple rank parameter
                 if (playerEntity.GetGoldAmount() >= curingPrice)
                 {
                     playerEntity.DeductGoldAmount(curingPrice);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -622,20 +622,24 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             int numberOfDiseases = 1;   // TODO: Support multiple diseases
             if (playerEntity.Disease.IsDiseased())
             {
-                // Calculate curing cost, and trade price after haggling
+                // Get base cost
                 int baseCost = 250 * numberOfDiseases;
-                int cost = FormulaHelper.CalculateCost(baseCost, buildingDiscoveryData.quality);
-                int tradePrice = FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, false);
 
-                // Apply reduced cost due to guild rank or membership benefit (e.g. Arkay)
-                curingCost = guild.ReducedCureCost(tradePrice);
+                // Apply rank-based discount if this is an Arkay temple
+                baseCost = guild.ReducedCureCost(baseCost);
+
+                // Apply temple quality and regional price modifiers
+                int costBeforeBargaining = FormulaHelper.CalculateCost(baseCost, buildingDiscoveryData.quality);
+
+                // Apply bargaining to get final price
+                curingCost = FormulaHelper.CalculateTradePrice(costBeforeBargaining, buildingDiscoveryData.quality, false);
 
                 // Index correct message
                 const int tradeMessageBaseId = 260;
                 int msgOffset = 0;
-                if (cost >> 1 <= tradePrice)
+                if (costBeforeBargaining >> 1 <= curingCost)
                 {
-                    if (cost - (cost >> 2) <= tradePrice)
+                    if (costBeforeBargaining - (costBeforeBargaining >> 2) <= curingCost)
                         msgOffset = 2;
                     else
                         msgOffset = 1;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -617,10 +617,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void CureDiseaseService()
         {
-            // TODO: curing lycanthropy and vampirism
             CloseWindow();
-            int numberOfDiseases = 1;   // TODO: Support multiple diseases
+            int numberOfDiseases = 0;
             if (playerEntity.Disease.IsDiseased())
+                numberOfDiseases++; // TODO: Support multiple diseases
+
+            if (playerEntity.TimeToBecomeVampireOrWerebeast != 0)
+                numberOfDiseases++;
+
+            if (numberOfDiseases > 0)
             {
                 // Get base cost
                 int baseCost = 250 * numberOfDiseases;
@@ -668,6 +673,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     playerEntity.DeductGoldAmount(curingCost);
                     playerEntity.Disease = new DaggerfallDisease();
+                    playerEntity.TimeToBecomeVampireOrWerebeast = 0;
                     DaggerfallUI.MessageBox("You are cured.");
                 }
                 else


### PR DESCRIPTION
Implements classic cost for cure diseases.

Some additional work needs to be done. @ajrb, I need your help to figure out some stuff. The main thing, which I think should be fixed before this is merged, is displaying the correct cost amount in the dialogue. Temple healers use the same "bartering dialogue" as shopkeepers. However right now the amount given in the dialogue doesn't reflect the actual amount that curing the disease costs. These messages have a `%a` macro that is used in classic, but in DF Unity it looks like this macro is unimplemented. Why do the shopkeepers show the correct value? We need it for this dialogue, too, and the cure calculation will need to be figured out before the message shows, not after as it is now.

Otherwise, this doesn't have to be in right now, but the cure service gives a discount based on rank. It wasn't obvious to me where to get the player's rank in the temple.