### PR TITLE
Bugfix: save factionId with quest

### DIFF
--- a/Assets/Scripts/Game/Guilds/FightersGuild.cs
+++ b/Assets/Scripts/Game/Guilds/FightersGuild.cs
@@ -99,7 +99,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public override int ReducedRepairCost(int price)
         {
-            return ((10 - rank) / 10) * price;
+            return (((10 - rank) << 8) / 10 * price) >> 8;
         }
 
         #endregion

--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -211,12 +211,18 @@ namespace DaggerfallWorkshop.Game.Guilds
                 DaggerfallUI.MessageBox(NoArmorId);
             }
             else
-            {   // Give a random armor piece
-                Armor armor = (Armor) UnityEngine.Random.Range(102, 108);
+            {   // Give a random armor piece, allowing player to choose one out of 3-6
+                ItemCollection rewardArmor = new ItemCollection();
                 ArmorMaterialTypes material = ArmorMaterialTypes.Iron + rank;
-                playerEntity.Items.AddItem(ItemBuilder.CreateArmor(playerEntity.Gender, playerEntity.Race, armor, material));
+                for (int i = UnityEngine.Random.Range(3, 7); i >= 0; i--)
+                {
+                    Armor armor = (Armor) UnityEngine.Random.Range(102, 109);
+                    rewardArmor.AddItem(ItemBuilder.CreateArmor(playerEntity.Gender, playerEntity.Race, armor, material));
+                }
                 flags = flags | ArmorFlagMask;
                 DaggerfallUI.MessageBox(ArmorId);
+                DaggerfallUI.Instance.InventoryWindow.SetChooseOne(rewardArmor);
+                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
             }
         }
 

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -291,7 +291,12 @@ namespace DaggerfallWorkshop.Game.Questing
                     break;
 
                 case MacroTypes.FactionMacro:           // Faction macro
-                    result = false;
+                    // Want name of guild, not the person
+                    FactionFile.FactionData guildData;
+                    if (GameManager.Instance.PlayerEntity.FactionData.GetFactionData(ParentQuest.FactionId, out guildData))
+                        textOut = guildData.name;
+                    else
+                        result = false;
                     break;
 
                 default:                                // Macro not supported

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -745,6 +745,7 @@ namespace DaggerfallWorkshop.Game.Questing
             public bool questSuccess;
             public string questName;
             public string displayName;
+            public int factionId;
             public DaggerfallDateTime questStartTime;
             public bool questTombstoned;
             public DaggerfallDateTime questTombstoneTime;
@@ -764,6 +765,7 @@ namespace DaggerfallWorkshop.Game.Questing
             data.questSuccess = questSuccess;
             data.questName = questName;
             data.displayName = displayName;
+            data.factionId = factionId;
             data.questStartTime = questStartTime;
             data.questTombstoned = questTombstoned;
             data.questTombstoneTime = questTombstoneTime;
@@ -815,6 +817,7 @@ namespace DaggerfallWorkshop.Game.Questing
             questSuccess = data.questSuccess;
             questName = data.questName;
             displayName = data.displayName;
+            factionId = data.factionId;
             questStartTime = data.questStartTime;
             questTombstoned = data.questTombstoned;
             questTombstoneTime = data.questTombstoneTime;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -156,6 +156,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         DaggerfallLoot lootTarget = null;
         bool usingWagon = false;
         bool allowDungeonWagonAccess = false;
+        bool chooseOne = false;
         bool shopShelfStealing = false;
         int lootTargetStartCount = 0;
 
@@ -219,6 +220,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public void AllowDungeonWagonAccess()
         {
             allowDungeonWagonAccess = true;
+        }
+
+        public void SetChooseOne(ItemCollection items)
+        {
+            chooseOne = true;
+            remoteItems = items;
         }
 
         public void SetShopShelfStealing()
@@ -488,11 +495,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Start a new dropped items target
             droppedItems.Clear();
-            remoteItems = droppedItems;
-            remoteTargetType = RemoteTargetTypes.Dropped;
-            dropIconArchive = DaggerfallLootDataTables.randomTreasureArchive;
-            dropIconTexture = -1;
-
+            if (chooseOne)
+            {
+                remoteTargetType = RemoteTargetTypes.Merchant;
+                dropIconArchive = DaggerfallLootDataTables.combatArchive;
+                dropIconTexture = 11;
+            }
+            else
+            {   // Set dropped items as default target
+                remoteItems = droppedItems;
+                remoteTargetType = RemoteTargetTypes.Dropped;
+                dropIconArchive = DaggerfallLootDataTables.randomTreasureArchive;
+                dropIconTexture = -1;
+            }
             // Use custom loot target if specified
             if (lootTarget != null)
             {
@@ -563,6 +578,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // Reset dungeon wagon access permission
             allowDungeonWagonAccess = false;
+
+            // Reset choose one mode
+            chooseOne = false;
 
             // Handle stealing and reset shop shelf stealing mode
             if (shopShelfStealing && remoteItems.Count < lootTargetStartCount)
@@ -1314,6 +1332,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             to.Transfer(item, from, order);
             Refresh(false);
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+
+            if (chooseOne)
+                CloseWindow();
         }
 
         protected void ShowInfoPopup(DaggerfallUnityItem item)
@@ -1543,7 +1564,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             else if (selectedActionMode == ActionModes.Remove)
             {
                 // Transfer to remote items
-                if (remoteItems != null)
+                if (remoteItems != null && !chooseOne)
                 {
                     // Check wagon weight limit
                     if (!usingWagon || WagonCanHold(item))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -613,7 +613,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ModeActionButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            if (cost > 0)
+            if (cost > 0 || ((windowMode == WindowModes.Repair || windowMode == WindowModes.Identify) && remoteItems.Count > 0))
                 ShowTradePopup();
         }
 

--- a/Assets/StreamingAssets/Quests/B0B20Y07.txt
+++ b/Assets/StreamingAssets/Quests/B0B20Y07.txt
@@ -37,7 +37,7 @@ AcceptQuest:  [1002]
 <ce>                           leader, =monster_.
 <ce>                         I happen to know that
 <ce>                          they are holed up in
-<ce>                         ___dungeon_. If you're
+<ce>                         __dungeon_. If you're
 <ce>                     not back in =2dung_ days, I'll
 <ce>                        sing your praises at the
 <ce>                           funeral ceremony.
@@ -49,15 +49,15 @@ QuestComplete:  [1004]
 <ce>                     You are a credit to the Order.
 
 RumorsDuringQuest:  [1005]
-The orcs of ___dungeon_ are all but destroying normal caravan routes.
+The orcs of __dungeon_ are all but destroying normal caravan routes.
 <--->
-The ____dungeon_ orcs used to be fairly peaceful. They sure ain't anymore.
+The __dungeon_ orcs used to be fairly peaceful. They sure ain't anymore.
 
 RumorsPostfailure:  [1006]
 The orcs moved on, all on their own. But I bet that they'll be back.
 
 RumorsPostsuccess:  [1007]
-The %kno saved %reg from the ___dungeon_ orcs. The hero was a %ra knight.
+The %kno saved %reg from the __dungeon_ orcs. The hero was a %ra knight.
 
 QuestorPostsuccess:  [1008]
 I'd be happy to be of service, o Orc Destroyer.
@@ -71,7 +71,7 @@ QuestLogEntry:  [1010]
  ==qgiver_ in ___qgiver_
  gave me the task of wiping
  out an orc band that makes
- it's home in ___dungeon_.
+ it's home in __dungeon_.
  In particular I must get the
  leader, a certain _monster_.
  I need to get back to %g2
@@ -97,7 +97,7 @@ Message:  1011
 --           =2dung_ occurs 2 times.
 --         ==qgiver_ occurs 2 times.
 --         =monster_ occurs 2 times.
---      ____dungeon_ occurs 5 times.
+--      ___dungeon_ occurs 5 times.
 --        ___qgiver_ occurs 1 time.
 --         _monster_ occurs 1 time.
 --          _qgiver_ occurs 2 times.
@@ -107,7 +107,7 @@ QBN:
 Person _qgiver_ group Questor male
 Person _local_ face 1 group Resident2
 
-Place __dungeon_ remote dungeon1
+Place _dungeon_ remote dungeon
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 
@@ -115,9 +115,9 @@ Foe _monster_ is Orc_sergeant
 
 --	Quest start-up:
 	start timer _2dung_ 
-	reveal __dungeon_ 
+	reveal _dungeon_ 
 	log 1010 step 0 
-	place foe _monster_ at __dungeon_ 
+	place foe _monster_ at _dungeon_ 
 
 _2dung_ task:
 	end quest 

--- a/Assets/StreamingAssets/Quests/B0B60Y12.txt
+++ b/Assets/StreamingAssets/Quests/B0B60Y12.txt
@@ -123,7 +123,7 @@ Person _qgiver_ group Questor male
 Person _nobleman_ group Resident1 female
 Person _local_ face 1 group Resident2
 
-Place _dungeon_ remote dungeon4
+Place _dungeon_ remote dungeon
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Tables/QuestList-Classic.txt
+++ b/Assets/StreamingAssets/Tables/QuestList-Classic.txt
@@ -124,11 +124,11 @@ B0C00Y13, KnightlyOrder, N, 0, Passed.
 B0B00Y00, KnightlyOrder, M, 0, Passed. Undefined building variable name: __questgiver_.
 B0B00Y01, KnightlyOrder, M, 0, Passed. Undefined enemy name. Undefined building variable name: __questgiver_.
 B0B10Y04, KnightlyOrder, M, 10, Passed. 
--B0B20Y07, KnightlyOrder, M, 20, FAILED. Could not find Quest Place /
+B0B20Y07, KnightlyOrder, M, 20, Passed.
 B0B40Y08, KnightlyOrder, M, 40, Passed. Undefined variable: ==qgiver_.
 B0B40Y09, KnightlyOrder, M, 40, Passed.
 -B0B50Y11, KnightlyOrder, M, 50, FAILED. Requires GetCurrentRegionFaction(). Undefined variable: ==qgiver_.
--B0B60Y12, KnightlyOrder, M, 60, FAILED. Could not find Quest Place /
+B0B60Y12, KnightlyOrder, M, 60, Passed.
 B0B70Y14, KnightlyOrder, M, 70, Passed.
 B0B70Y16, KnightlyOrder, M, 70, Passed. Undefined variable: ==qgiver_.
 -B0B71Y03, KnightlyOrder, M, 71, FAILED. Lots of work to do. Undefined building variable name: __questgiver_.

--- a/Assets/StreamingAssets/Tables/QuestList-Classic.txt
+++ b/Assets/StreamingAssets/Tables/QuestList-Classic.txt
@@ -123,13 +123,13 @@ B0C00Y10, KnightlyOrder, N, 0, Passed.
 B0C00Y13, KnightlyOrder, N, 0, Passed.
 B0B00Y00, KnightlyOrder, M, 0, Passed. Undefined building variable name: __questgiver_.
 B0B00Y01, KnightlyOrder, M, 0, Passed. Undefined enemy name. Undefined building variable name: __questgiver_.
-B0B10Y04, KnightlyOrder, M, 10, Passed. Undefined building variable name: __questgiver_. Undefined variable %kno.
-B0B20Y07, KnightlyOrder, M, 20, Passed. Undefined variable: ==qgiver_.
+B0B10Y04, KnightlyOrder, M, 10, Passed. 
+-B0B20Y07, KnightlyOrder, M, 20, FAILED. Could not find Quest Place /
 B0B40Y08, KnightlyOrder, M, 40, Passed. Undefined variable: ==qgiver_.
 B0B40Y09, KnightlyOrder, M, 40, Passed.
 -B0B50Y11, KnightlyOrder, M, 50, FAILED. Requires GetCurrentRegionFaction(). Undefined variable: ==qgiver_.
-B0B60Y12, KnightlyOrder, M, 60, Passed. Undefined variable: ==qgiver_.
-B0B70Y14, KnightlyOrder, M, 70, Passed. Undefined variable: ==qgiver_.
+-B0B60Y12, KnightlyOrder, M, 60, FAILED. Could not find Quest Place /
+B0B70Y14, KnightlyOrder, M, 70, Passed.
 B0B70Y16, KnightlyOrder, M, 70, Passed. Undefined variable: ==qgiver_.
 -B0B71Y03, KnightlyOrder, M, 71, FAILED. Lots of work to do. Undefined building variable name: __questgiver_.
 B0B80Y17, KnightlyOrder, M, 80, Passed. Undefined variable: ==qgiver_.


### PR DESCRIPTION
This was a pretty bad and stupid oversight on my part! This fix stores the faction id so that the rep is changed correctly when the quest finishes. Currently it only changes the faction rep if you don't save and reload between taking the quest and completion which is pretty rare.

Would you please create a new build and remove the #102 build once this bugfix is merged and validated. I consider it that serious. (as in it breaks the whole guild system since you can't get promotions)