### PR TITLE
Spawn random encounters

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -347,11 +347,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         if (timeOfDay < 360 || timeOfDay > 1080) // night
                         {
                             if (UnityEngine.Random.Range(0, 24) == 0)
-                            {
-                                MobileTypes enemy = RandomEncounters.ChooseRandomEnemy(false);
-                                // TODO: Spawn enemy
-                                //SpawnEnemyNearPlayerInLocation(enemy);
-                            }
+                                GameObjectHelper.CreateFoeSpawner(RandomEncounters.ChooseRandomEnemy(false), 1);
                         }
                     }
                     else
@@ -364,9 +360,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         else // night
                             if (UnityEngine.Random.Range(0, 24) != 0)
                             return;
-                        MobileTypes enemy = RandomEncounters.ChooseRandomEnemy(false);
-                        // TODO: Spawn enemy
-                        //SpawnEnemyNearPlayerInWilderness(enemy);
+                        GameObjectHelper.CreateFoeSpawner(RandomEncounters.ChooseRandomEnemy(false), 1);
                     }
                 } // in interior
                 else
@@ -376,12 +370,8 @@ namespace DaggerfallWorkshop.Game.Entity
                         if (isResting)
                         {
                             if (UnityEngine.Random.Range(0, 36) == 0)
-                            {
                                 // TODO: Not sure how enemy type is chosen here.
-                                MobileTypes enemy = RandomEncounters.ChooseRandomEnemy(false);
-                                // TODO: Spawn enemy
-                                //SpawnEnemyNearPlayerInLocation(enemy);
-                            }
+                                GameObjectHelper.CreateFoeSpawner(RandomEncounters.ChooseRandomEnemy(false), 1);
                         }
                     }
                 }

--- a/Assets/Scripts/Utility/RandomEncounters.cs
+++ b/Assets/Scripts/Utility/RandomEncounters.cs
@@ -1346,7 +1346,7 @@ namespace DaggerfallWorkshop.Utility
             if (chooseUnderWaterEnemy)
                 encounterTableIndex = 19;
             else if (playerEnterExit.IsPlayerInsideDungeon)
-                encounterTableIndex = ((int)playerGPS.CurrentLocationType);
+                encounterTableIndex = ((int)playerEnterExit.Dungeon.Summary.DungeonType);
             else if (playerEnterExit.IsPlayerInsideBuilding)
             {
                 DFLocation.BuildingTypes buildingType = playerEnterExit.BuildingType;


### PR DESCRIPTION
Random encounters spawn now. Thanks for the FoeSpawner, Interkarma.

I don't know if adding a FoeSpawner to the "options" part of DaggerfallUnity prefab is correct style-wise, I just followed the example of existing uses of InstantiatePrefab.

In game it works fine. While in the wilderness in classic enemies actually spawn from a little farther away, but currently at that distance enemies don't react to the player in DF Unity nor does the "There are enemies nearby" message appear, so for now I just have it using the default FoeSpawner distances.