### PR TITLE
Start implementation of regional conditions

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -1,4 +1,4 @@
-// Project:         Daggerfall Tools For Unity
+﻿// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -174,6 +174,7 @@ namespace DaggerfallConnect.Arena2
             public int maxf;
             public int vam;
             public int rank;
+            public int randomValue;
 
             public List<int> children;
         }

--- a/Assets/Scripts/API/Save/SaveVars.cs
+++ b/Assets/Scripts/API/Save/SaveVars.cs
@@ -609,7 +609,8 @@ namespace DaggerfallConnect.Save
                 faction.vam = reader.ReadInt16();
                 faction.flags = reader.ReadInt16();
 
-                reader.BaseStream.Position += 8;            // Skip 8 unknown bytes
+                reader.BaseStream.Position += 4;            // Skip 4 unknown bytes
+                faction.randomValue = reader.ReadInt32();
 
                 faction.flat1 = reader.ReadInt16();
                 faction.flat2 = reader.ReadInt16();

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -319,6 +319,14 @@ namespace DaggerfallWorkshop.Game.Entity
                     IntermittentEnemySpawn(l + lastGameMinutes + 1);
             }
 
+            // Update faction relationships, faction power levels and regional conditions (in progress)
+            uint minutesPassed = gameMinutes - lastGameMinutes;
+            for (int i = 0; i < minutesPassed; ++i)
+            {
+                if (((i + lastGameMinutes) % 40320) == 0) // 28 days
+                    FactionAndRegionConditionsUpdate();
+            }
+
             lastGameMinutes = gameMinutes;
 
             // Allow enemy spawns again if they have been disabled
@@ -918,9 +926,136 @@ namespace DaggerfallWorkshop.Game.Entity
             public ushort PriceAdjustment; // bytes 78 to 80
         }
 
-        public void InitializeRegionPrices()
+        public enum RegionDataFlags
         {
+            Condition0 = 0,
+            Condition1 = 1,
+            Condition2 = 2,
+            Condition3 = 3,
+            PlagueBeginning = 4,
+            PlagueOngoing = 5,
+            PlagueEnding = 6,
+            FamineBeginning = 7,
+            FamineOngoing = 8,
+            FamineEnding = 9,
+            WitchBurnings = 10,
+            CrimeWave = 11,
+            Condition12 = 12,
+            Condition13 = 13,
+            Condition14 = 14,
+            Condition15 = 15,
+            Condition16 = 16,
+            Condition17 = 17,
+            PersecutedTemple = 18,
+            PricesHigh = 19,
+            PricesLow = 20,
+            Condition21 = 21,
+            Condition22 = 22,
+            Condition23 = 23,
+            Condition24 = 24,
+            Condition25 = 25,
+            Condition26 = 26,
+            Condition27 = 27,
+            Condition28 = 28,
+            Condition29 = 29,
+        }
+
+        public void FactionAndRegionConditionsUpdate()
+        {
+            foreach (FactionFile.FactionData item in FactionData.FactionDict.Values)
+            {
+                /*
+                if (item.type == (int)FactionFile.FactionTypes.Province ||
+                    item.type == (int)FactionFile.FactionTypes.Group ||
+                    item.type == (int)FactionFile.FactionTypes.Subgroup)
+                {
+                    //TODO: Faction power changes
+                }*/
+
+                // Handle famine condition
+                if (item.region != -1  && item.type == (int)FactionFile.FactionTypes.Province)
+                {
+                    int alliesPower = 0;
+                    FactionFile.FactionData ally;
+                    if (item.ally1 != 0)
+                    {
+                        FactionData.GetFactionData(item.ally1, out ally);
+                        alliesPower += ally.power;
+                    }
+                    if (item.ally2 != 0)
+                    {
+                        FactionData.GetFactionData(item.ally1, out ally);
+                        alliesPower += ally.power;
+                    }
+                    if (item.ally3 != 0)
+                    {
+                        FactionData.GetFactionData(item.ally1, out ally);
+                        alliesPower += ally.power;
+                    }
+
+                    int alliesPowerMod = alliesPower / 10;
+
+                    if (regionData[item.region - 1].Flags[(int)RegionDataFlags.FamineEnding] == true)
+                        TurnOffConditionFlag(item.region, RegionDataFlags.FamineEnding);
+                    else if (regionData[item.region - 1].Flags[(int)RegionDataFlags.FamineOngoing] == true)
+                    {
+                        int powerLevel = item.randomValue / 5 + alliesPowerMod + item.power / 5;
+                        if (UnityEngine.Random.Range(0, 100 + 1) < powerLevel)
+                        {
+                            TurnOnConditionFlag(item.region, RegionDataFlags.FamineEnding);
+                        }
+                    }
+                    else if (regionData[item.region - 1].Flags[(int)RegionDataFlags.FamineBeginning] == true)
+                    {
+                        TurnOnConditionFlag(item.region, RegionDataFlags.FamineOngoing);
+                    }
+                    else if (UnityEngine.Random.Range(1, 100 + 1) <= 2)
+                    {
+                        int powerLevel = item.randomValue + alliesPowerMod;
+                        if (UnityEngine.Random.Range(0, 100 + 1) > powerLevel)
+                            TurnOnConditionFlag(item.region, RegionDataFlags.FamineBeginning);
+                    }
+                }
+                // TODO: Handle plague
+                // TODO: Handle temple persecution
+                // TODO: Handle crime wave
+                // TODO: Handle witch burnings
+            }
+        }
+
+        public void TurnOffConditionFlag(int regionID, RegionDataFlags flagID)
+        {
+            Debug.Log(DaggerfallUnity.Instance.ContentReader.MapFileReader.RegionNames[regionID - 1] + " turned off " + flagID);
+            regionData[regionID - 1].Flags[(int)flagID] = false;
+        }
+
+        public void TurnOnConditionFlag(int regionID, RegionDataFlags flagID)
+        {
+            Debug.Log(DaggerfallUnity.Instance.ContentReader.MapFileReader.RegionNames[regionID - 1] + " turned on " + flagID);
+            regionData[regionID = 1].Flags[(int)flagID] = true;
+        }
+
+        public void InitializeRegionData()
+        {
+            Debug.Log("Initializing region data");
             FormulaHelper.RandomizeInitialPriceAdjustments(ref regionData);
+
+            // TODO: Randomize values and flags. Their relationships are not fully understood yet so for now just initializing all to 0 and false.
+            for (int i = 0; i < regionData.Length; i++)
+            {
+                regionData[i].Values = new byte[29];
+
+                for (int j = 0; j < 29; j++)
+                    regionData[i].Values[j] = 0;
+
+                regionData[i].Flags = new bool[29];
+                for (int j = 0; j < 29; j++)
+                    regionData[i].Flags[j] = false;
+
+                regionData[i].Flags2 = new bool[14];
+                for (int j = 0; j < 14; j++)
+                    regionData[i].Flags2[j] = false;
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -254,15 +254,17 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.RentedRooms = (data.playerEntity.rentedRooms != null) ? data.playerEntity.rentedRooms.ToList() : new List<RoomRental_v1>();
             entity.Disease.RestoreSaveData(data.playerEntity.disease);
 
-            if (data.playerEntity.regionData != null)
-                entity.RegionData = data.playerEntity.regionData;
-            else // If data doesn't exist, initialize to random values
-                entity.InitializeRegionPrices();
-
             // Set time tracked in player entity
             entity.LastGameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
 
-            // Fill in missing data for saves
+            // Fill in missing data for saves.
+            // Older saves may have regionData non-null but Values, Flags and Flags2 are uninitialized.
+            // Just checking that any one of these is null is enough. Initialize to 0 (no conditions) for now to avoid null references.
+            if (data.playerEntity.regionData != null && data.playerEntity.regionData[0].Values != null)
+                entity.RegionData = data.playerEntity.regionData;
+            else // If data doesn't exist, initialize it
+                entity.InitializeRegionData();
+
             if (entity.StartingLevelUpSkillSum <= 0)
                 entity.EstimateStartingLevelUpSkillSum();
             if (entity.SkillUses == null)

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -394,8 +394,8 @@ namespace DaggerfallWorkshop.Game.Utility
             Banking.DaggerfallBankManager.SetupAccounts();
             Banking.DaggerfallBankManager.SetupHouses();
 
-            // Randomize initial region prices
-            playerEntity.InitializeRegionPrices();
+            // Initialize region data
+            playerEntity.InitializeRegionData();
 
             // Randomize weathers
             GameManager.Instance.WeatherManager.SetClimateWeathers();
@@ -552,7 +552,7 @@ namespace DaggerfallWorkshop.Game.Utility
             Banking.DaggerfallBankManager.ReadNativeBankData(bankRecords);
 
             // Get regional data.
-            playerEntity.RegionData= saveVars.RegionData;
+            playerEntity.RegionData = saveVars.RegionData;
 
             // Set time tracked by playerEntity for game minute-based updates
             playerEntity.LastGameMinutes = saveVars.GameTime;


### PR DESCRIPTION
This is the start of implementing regional conditions. Only famine is handled now, and there are no in-game effects, only debug.log messages about the famine phases. As with randomEncounters, this is being handled in PlayerEntity for now but could be moved later. This is all matched to classic behavior.