### PR TITLE
TextureReplacement: some size fixes

### DIFF
--- a/Assets/Scripts/Game/UserInterface/PaperDoll.cs
+++ b/Assets/Scripts/Game/UserInterface/PaperDoll.cs
@@ -21,7 +21,6 @@ using DaggerfallConnect.Utility;
 using DaggerfallConnect.FallExe;
 using DaggerfallWorkshop;
 using DaggerfallWorkshop.Utility;
-using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Player;
 using DaggerfallWorkshop.Game.Entity;
@@ -40,6 +39,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         const int paperDollHeight = 184;
         const int waistHeight = 40;
 
+        DFSize backgroundFullSize = new DFSize(125, 198);
         Rect backgroundSubRect = new Rect(8, 7, paperDollWidth, paperDollHeight);
 
         #endregion
@@ -223,21 +223,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             if (lastBackgroundName != entity.RaceTemplate.PaperDollBackground)
             {
-                Texture2D texture;
-                if (TextureReplacement.TryImportImage(entity.RaceTemplate.PaperDollBackground, out texture))
-                {
-                    // Import custom image. We assume the image provided is already wihout borders
-                    backgroundPanel.Size = new Vector2(paperDollWidth, paperDollHeight);
-                }
-                else
-                {
-                    // Use vanilla Daggerfall image and remove borders
-                    ImageData data = ImageReader.GetImageData(entity.RaceTemplate.PaperDollBackground, 0, 0, false, false);
-                    texture = ImageReader.GetSubTexture(data, backgroundSubRect);
-                    backgroundPanel.Size = new Vector2(texture.width, texture.height);
-                }
-
-                backgroundPanel.BackgroundTexture = texture;
+                Texture2D texture = ImageReader.GetTexture(entity.RaceTemplate.PaperDollBackground, 0, 0, false);
+                backgroundPanel.BackgroundTexture = ImageReader.GetSubTexture(texture, backgroundSubRect, backgroundFullSize);
+                backgroundPanel.Size = new Vector2(paperDollWidth, paperDollHeight);
                 lastBackgroundName = entity.RaceTemplate.PaperDollBackground;
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankPurchasePopUp.cs
@@ -123,7 +123,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.VerticalAlignment = VerticalAlignment.Middle;
             mainPanel.BackgroundTexture = baseTexture;
             mainPanel.Position = new Vector2(0, 50);
-            mainPanel.Size = new Vector2(baseTexture.width, baseTexture.height);
+            mainPanel.Size = new Vector2(225, 129);
 
             // Buy button
             buyButton = DaggerfallUI.AddButton(buyButtonRect, mainPanel);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
@@ -70,7 +70,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             mainPanel                       = DaggerfallUI.AddPanel(NativePanel, AutoSizeModes.None);
             mainPanel.BackgroundTexture     = background;
-            mainPanel.Size                  = new Vector2(background.width, background.height);
+            mainPanel.Size                  = new Vector2(225, 181);
             mainPanel.HorizontalAlignment   = HorizontalAlignment.Center;
             mainPanel.VerticalAlignment     = VerticalAlignment.Middle;
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -147,7 +147,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.VerticalAlignment = VerticalAlignment.Middle;
             mainPanel.BackgroundTexture = baseTexture;
             mainPanel.Position = new Vector2(0, 50);
-            mainPanel.Size = new Vector2(baseTexture.width, baseTexture.height);
+            mainPanel.Size = new Vector2(130, 51);
 
             // Join Guild button
             if (!member)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantRepairPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantRepairPopupWindow.cs
@@ -71,7 +71,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.VerticalAlignment = VerticalAlignment.Middle;
             mainPanel.BackgroundTexture = baseTexture;
             mainPanel.Position = new Vector2(0, 50);
-            mainPanel.Size = new Vector2(baseTexture.width, baseTexture.height);
+            mainPanel.Size = new Vector2(130, 51);
 
             // Repair button
             repairButton = DaggerfallUI.AddButton(repairButtonRect, mainPanel);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantServicePopupWindow.cs
@@ -83,7 +83,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.VerticalAlignment = VerticalAlignment.Middle;
             mainPanel.BackgroundTexture = baseTexture;
             mainPanel.Position = new Vector2(0, 50);
-            mainPanel.Size = new Vector2(baseTexture.width, baseTexture.height);
+            mainPanel.Size = new Vector2(130, 42);
 
             // Talk button
             talkButton = DaggerfallUI.AddButton(talkButtonRect, mainPanel);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -82,7 +82,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             mainPanel                       = new Panel();
             mainPanel.BackgroundTexture     = nativeTexture;
-            mainPanel.Size                  = new Vector2(nativeTexture.width, nativeTexture.height);
+            mainPanel.Size                  = new Vector2(259, 164);
             mainPanel.HorizontalAlignment   = HorizontalAlignment.Center;
             mainPanel.VerticalAlignment     = VerticalAlignment.Middle;
             mainPanel.Name                  = "main_panel";


### PR DESCRIPTION
Fixed a few windows reported on forums. Also removed a workaround for paperdoll background which is not necessary anymore since we can cut imported textures now.