### PR TITLE
Add "already defaulted" bank behavior

### DIFF
--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -34,7 +34,7 @@ namespace DaggerfallWorkshop.Game.Banking
         NOT_PORT_TOWN           = 0285,
         ALREADY_OWN_HOUSE       = 0286,
         NO_HOUSES_FOR_SALE      = 0287,
-        ALREADY_DEFAULTED       = 0288,    // not used in game?
+        ALREADY_DEFAULTED       = 0288,
         ALREADY_HAVE_LOAN       = 0289,
         NOT_ENOUGH_ACCOUNT      = 0290,
         DEPOSIT_LOC             = 0291,
@@ -198,6 +198,14 @@ namespace DaggerfallWorkshop.Game.Banking
                 return false;
 
             return BankAccounts[regionIndex].loanTotal > 0;
+        }
+
+        public static bool HasDefaulted(int regionIndex)
+        {
+            if (!ValidateRegion(regionIndex))
+                return false;
+
+            return BankAccounts[regionIndex].hasDefaulted;
         }
 
         public static void SetupAccounts()
@@ -481,9 +489,7 @@ namespace DaggerfallWorkshop.Game.Banking
         private static TransactionResult BorrowLoan(int amount, int regionIndex)
         {
             TransactionResult result = TransactionResult.NONE;
-            if (HasLoan(regionIndex))
-                result = TransactionResult.ALREADY_HAVE_LOAN;
-            else if (amount < 100)
+            if (amount < 100)
                 result = TransactionResult.LOAN_REQUEST_TOO_LOW;
             else if (amount > CalculateMaxLoan())
                 result = TransactionResult.LOAN_REQUEST_TOO_HIGH;
@@ -538,7 +544,7 @@ namespace DaggerfallWorkshop.Game.Banking
                 record.accountGold      = reader.ReadInt32();
                 record.loanTotal        = reader.ReadInt32();
                 record.loanDueDate      = reader.ReadUInt32();
-                reader.BaseStream.Position++;   //skip over unused byte in each record
+                record.hasDefaulted     = reader.ReadBoolean();
                 record.regionIndex = count;
 
                 if (record.regionIndex >= BankAccounts.Length)

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -422,6 +422,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public int loanTotal;
         public uint loanDueDate;
         public int regionIndex;
+        public bool hasDefaulted;
     }
 
     #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
@@ -198,6 +198,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             base.OnPush();
             DaggerfallBankManager.OnTransaction += this.OnTransactionEventHandler;
             regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
+            uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+            uint paymentDueMinutes = DaggerfallBankManager.BankAccounts[regionIndex].loanDueDate;
+
+            // Set hasDefaulted flag (Note: Does not seem to ever be set in classic)
+            if (paymentDueMinutes != 0 && paymentDueMinutes < gameMinutes)
+                DaggerfallBankManager.BankAccounts[regionIndex].hasDefaulted = true;
         }
 
         public override void OnPop()
@@ -385,7 +391,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         void LoanBorrowButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            if (DaggerfallBankManager.HasLoan(regionIndex))
+            if (DaggerfallBankManager.HasDefaulted(regionIndex))
+            {
+                GeneratePopup(TransactionResult.ALREADY_DEFAULTED);
+                ToggleTransactionInput(TransactionType.None);
+            }
+            else if (DaggerfallBankManager.HasLoan(regionIndex))
             {
                 GeneratePopup(TransactionResult.ALREADY_HAVE_LOAN);
                 ToggleTransactionInput(TransactionType.None);


### PR DESCRIPTION
Just a note, I started to add behavior for reading classic's bank records because it wasn't in what I thought was the "usual" spot, in ReadRecords() in SaveTree.cs. It seems like that should be consistent. But at least it meant the work of converting the read data to DF Unity was already done.

Maybe Interkarma though the same thing when he made this bug report?
http://forums.dfworkshop.net/viewtopic.php?f=24&t=788
Or maybe he made that before the code to read the data was added? Anyway the boolean that was being skipped is now read and used, so that report can be closed.