### PR TITLE
Implement normalization of reputations

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -15,6 +15,7 @@ using DaggerfallConnect;
 using DaggerfallWorkshop.Game.Guilds;
 using DaggerfallWorkshop.Game.Entity;
 using System.Collections.Generic;
+using DaggerfallConnect.Arena2;
 
 namespace DaggerfallWorkshop.Game.Formulas
 {
@@ -1096,22 +1097,22 @@ namespace DaggerfallWorkshop.Game.Formulas
             return adjustedCost;
         }
 
-        public static void RandomizeInitialPriceAdjustments(ref PlayerEntity.RegionDataRecord[] regionData)
+        public static void RandomizeInitialRegionalPrices(ref PlayerEntity.RegionDataRecord[] regionData)
         {
             for (int i = 0; i < regionData.Length; i++)
                 regionData[i].PriceAdjustment = (ushort)(UnityEngine.Random.Range(0, 501) + 750);
         }
 
-        public static void ModifyPriceAdjustmentByRegion(ref PlayerEntity.RegionDataRecord[] regionData, int times)
+        public static void UpdateRegionalPrices(ref PlayerEntity.RegionDataRecord[] regionData, int times)
         {
             PlayerEntity player = GameManager.Instance.PlayerEntity;
-            DaggerfallConnect.Arena2.FactionFile.FactionData merchantsFaction;
+            FactionFile.FactionData merchantsFaction;
             if (!player.FactionData.GetFactionData(510, out merchantsFaction))
                 return;
 
             for (int i = 0; i < regionData.Length; ++i)
             {
-                DaggerfallConnect.Arena2.FactionFile.FactionData regionFaction;
+                FactionFile.FactionData regionFaction;
                 if (player.FactionData.FindFactionByTypeAndRegion(7, i + 1, out regionFaction))
                 {
                     for (int j = 0; j < times; ++j)

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -29,7 +29,6 @@ namespace DaggerfallWorkshop.Game.Player
     {
         #region Fields
 
-        const int legalReputationCount = 62;
         const int minReputation = -100;
         const int maxReputation = 100;
 
@@ -39,7 +38,6 @@ namespace DaggerfallWorkshop.Game.Player
 
         Dictionary<int, FactionFile.FactionData> factionDict = new Dictionary<int, FactionFile.FactionData>();
         Dictionary<string, int> factionNameToIDDict = new Dictionary<string, int>();
-        List<LegalReputation> legalReputationList = new List<LegalReputation>();
 
         #endregion
 
@@ -55,20 +53,6 @@ namespace DaggerfallWorkshop.Game.Player
         {
             get { return factionNameToIDDict; }
             set { factionNameToIDDict = value; }
-        }
-
-        #endregion
-
-        #region Structs & Enums
-
-        /// <summary>
-        /// Legal reputation for regions.
-        /// </summary>
-        public struct LegalReputation
-        {
-            public int index;
-            public int value;
-            public string name;
         }
 
         #endregion
@@ -111,42 +95,6 @@ namespace DaggerfallWorkshop.Game.Player
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Gets legal reputation by region index.
-        /// </summary>
-        /// <param name="regionIndex">Region index 0 to 61.</param>
-        /// <returns>Legal reputation for that region.</returns>
-        public LegalReputation GetLegalReputation(int regionIndex)
-        {
-            if (regionIndex < 0 || regionIndex >= legalReputationCount)
-                throw new IndexOutOfRangeException("GetLegalReputation regionIndex out of range");
-
-            // Reset if no legal reputation data available
-            if (legalReputationList.Count != legalReputationCount)
-                ResetLegalReputation();
-
-            return legalReputationList[regionIndex];
-        }
-
-        /// <summary>
-        /// Change legal reputation value by amount.
-        /// </summary>
-        public int ChangeLegalReputation(int regionIndex, int amount)
-        {
-            if (regionIndex < 0 || regionIndex >= legalReputationCount)
-                throw new IndexOutOfRangeException("ChangeLegalReputation regionIndex out of range");
-
-            // Reset if no legal reputation data available
-            if (legalReputationList.Count != legalReputationCount)
-                ResetLegalReputation();
-
-            LegalReputation lr = legalReputationList[regionIndex];
-            lr.value = Mathf.Clamp(lr.value + amount, minReputation, maxReputation);
-            legalReputationList[regionIndex] = lr;
-
-            return lr.value;
         }
 
         /// <summary>
@@ -266,25 +214,6 @@ namespace DaggerfallWorkshop.Game.Player
             Debug.Log("PersistentFactionData.Reset() loaded fresh faction data.");
         }
 
-        /// <summary>
-        /// Resets legal reputation for all regions back to 0.
-        /// Not fully implemented yet, still needs to be imported from SAVEVARS.DAT.
-        /// Might move to own class later, but here is a good spot for now.
-        /// </summary>
-        public void ResetLegalReputation()
-        {
-            // Clear legal reputation across all regions
-            legalReputationList.Clear();
-            for (int i = 0; i < legalReputationCount; i++)
-            {
-                LegalReputation lr = new LegalReputation();
-                lr.index = i;
-                lr.value = 0;
-                lr.name = DaggerfallUnity.Instance.ContentReader.MapFileReader.GetRegionName(i);
-                legalReputationList.Add(lr);
-            }
-        }
-
         #endregion
 
         #region Reputation
@@ -357,8 +286,15 @@ namespace DaggerfallWorkshop.Game.Player
         /// </summary>
         public void ZeroAllReputations()
         {
+            // Reset faction reputations
             Reset();
-            ResetLegalReputation();
+
+            // Reset legal reputations
+            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            for (int i = 0; i < player.RegionData.Length; i++)
+            {
+                player.RegionData[i].LegalRep = 0;
+            }
         }
 
         #endregion


### PR DESCRIPTION
Implements gradual return of reputations to 0, matched to classic.

Also some cleanup, comments, etc.

I removed the unused stuff for legal reputation in PersistentFactionData.cs, trying to keep the mess of all this WIP stuff under control a bit, since legal reputation all being done in the playerEntity's regionData array at the moment. If you want to refactor this stuff later, Interkarma, to make it all more tidy or fit some code organization you have in mind, that's OK with me.

I'm looking into guard spawning, btw, which ties into legal reputation work.