### PR TITLE
Implement blood splash for townspeople and basic guard spawning

### DIFF
--- a/Assets/Prefabs/Scene/DaggerfallMobilePerson [Standalone].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallMobilePerson [Standalone].prefab
@@ -22,6 +22,7 @@ GameObject:
   - component: {fileID: 114102110313281098}
   - component: {fileID: 114040605119886728}
   - component: {fileID: 136715391349249406}
+  - component: {fileID: 114017295900129130}
   m_Layer: 0
   m_Name: DaggerfallMobilePerson [Standalone]
   m_TagString: Untagged
@@ -112,6 +113,17 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1779995961696246}
   m_Mesh: {fileID: 0}
+--- !u!114 &114017295900129130
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1534471568425466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1bf0109348ece14aa8bf1fc3afe830e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114040605119886728
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -135,8 +147,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5deea3c9f6717aa4484fe777b3986380, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  race: 1
-  gender: 0
+  raceToBeSet: 1
+  genderToBeSet: 0
+  outfitVariantToBeSet: -1
 --- !u!114 &114597381660483322
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -148,9 +161,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a1f4e1f7b3069e5408422bb490cd6527, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  race: 1
-  gender: 0
-  personVariant: -1
 --- !u!136 &136715391349249406
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -200,7 +200,7 @@ namespace DaggerfallWorkshop.Game
 
         private bool IgnoreHumanSounds()
         {
-            if (mobile.Summary.Enemy.ID > 127 && MuteHumanSounds)
+            if (mobile.Summary.Enemy.ID > 127 && mobile.Summary.Enemy.ID != 146 && MuteHumanSounds)
                 return true;
             else
                 return false;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -390,6 +390,24 @@ namespace DaggerfallWorkshop.Game.Entity
             }
         }
 
+        public void SpawnCityGuards(bool forceSpawn)
+        {
+            // Don't spawn if more than 10 enemies are already in the area
+            if (UnityEngine.Object.FindObjectsOfType<DaggerfallEntityBehaviour>().Length > 10)
+                return;
+
+            if (forceSpawn)
+            {
+                // TODO: First try to spawn guards from nearby townspeople. If townsperson is a guard spawn, or if is a non-guard 1/3 chance to spawn
+                // if out of player view.
+                // If none spawned, proceed with below
+                int randomNumber = UnityEngine.Random.Range(2, 5 + 1);
+                GameObjectHelper.CreateFoeSpawner(MobileTypes.Knight_CityWatch, randomNumber);
+            }
+            // TODO: If !forceSpawn, check for LOS from nearby guard townspeople and spawn from them if they see player.
+            // Otherwise, check for LOS from non-guard townspeople. If they see player, random countdown is set, after which guards will spawn.
+        }
+
         /// <summary>
         /// Resets entity to initial state.
         /// </summary>

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -706,6 +706,8 @@ namespace DaggerfallWorkshop.Game
                     }
                     mobileNpc.Motor.gameObject.SetActive(false);
                     GameManager.Instance.PlayerEntity.TallyCrimeGuildRequirements(false, 5);
+                    // TODO: LOS check from each townsperson. If seen, start spawning guards as below.
+                    GameManager.Instance.PlayerEntity.SpawnCityGuards(true);
                 }
             }
         }

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -699,7 +699,11 @@ namespace DaggerfallWorkshop.Game
                 MobilePersonNPC mobileNpc = hit.transform.GetComponent<MobilePersonNPC>();
                 if (mobileNpc)
                 {
-                    // TODO: Create blood splash.
+                    EnemyBlood blood = hit.transform.GetComponent<EnemyBlood>();
+                    if (blood)
+                    {
+                        blood.ShowBloodSplash(0, hit.point);
+                    }
                     mobileNpc.Motor.gameObject.SetActive(false);
                     GameManager.Instance.PlayerEntity.TallyCrimeGuildRequirements(false, 5);
                 }


### PR DESCRIPTION
This adds blood splashes for killing townspeople and basic guard spawning (only for killing townspeople for now).

I think that guard spawning behavior in classic involves LOS checking from townspeople, and nearby "townsperson guards" and regular townspeople (1/3 chance) are the first choices for spawning guards. The fallback behavior after that is what this PR uses. I may need some help from you Interkarma to do that. Basically I would want to be able to iterate through the townspeople, doing an LOS check from each of them to the player, and also to be able to use the location of a townsperson as a spawn point (not sure if we actually want to do that for regular townspeople, it may have been intended to simulate them "clearing the streets" but it may be more immersive to not do it that way, but for guards as townspeople at least we'll want the ability to spawn from their position).