### PR TITLE
More work on guards and crime

### DIFF
--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
@@ -273,7 +273,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   OpenDoorDistance: 2
-  GiveUpTime: 4
 --- !u!114 &11470552
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -342,6 +341,7 @@ MonoBehaviour:
       Weight: 0
     EnemyState: 0
     StateAnims: []
+    AnimStateRecord: 0
 --- !u!114 &11492232
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -380,9 +380,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9fd446a55d098ca4f826c3c9bc93563a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SightRadius: 16
+  SightRadius: 102.4
   HearingRadius: 8
-  FieldOfView: 120
+  FieldOfView: 180
 --- !u!143 &14323946
 CharacterController:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
@@ -329,6 +329,7 @@ MonoBehaviour:
       Weight: 0
     EnemyState: 0
     StateAnims: []
+    AnimStateRecord: 0
 --- !u!114 &11492232
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -367,8 +368,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9fd446a55d098ca4f826c3c9bc93563a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SightRadius: 25
-  HearingRadius: 25
+  SightRadius: 102.4
+  HearingRadius: 8
   FieldOfView: 180
 --- !u!143 &14323946
 CharacterController:

--- a/Assets/Scripts/API/Save/SaveVars.cs
+++ b/Assets/Scripts/API/Save/SaveVars.cs
@@ -36,7 +36,7 @@ namespace DaggerfallConnect.Save
         const int globalVarsCount = 64;
 
         const int isDayOffset = 0x391;
-        const int typeOfCrimeCommittedOffset = 0x3A3;
+        const int crimeCommittedOffset = 0x3A3;
         const int inDungeonWaterOffset = 0x3A6;
         const int breathRemainingOffset = 0x3AB;
         const int climateWeathersOffset = 0x3B7;
@@ -83,7 +83,7 @@ namespace DaggerfallConnect.Save
         short lastSpellCost = 0; // The cost of the last spell that was readied. If the spell is aborted, these spell points are returned.
 
         bool isDay = false;
-        byte typeOfCrimeCommitted = 0;
+        byte crimeCommitted = 0;
         bool inDungeonWater = false;
         int breathRemaining = 0;
         byte[] climateWeathers; // Weather in each of the six weather climates
@@ -258,9 +258,9 @@ namespace DaggerfallConnect.Save
         /// <summary>
         /// Gets type of crime committed by player from savevars.
         /// </summary>
-        public byte TypeOfCrimeCommitted
+        public byte CrimeCommitted
         {
-            get { return typeOfCrimeCommitted; }
+            get { return crimeCommitted; }
         }
 
         /// <summary>
@@ -416,7 +416,7 @@ namespace DaggerfallConnect.Save
             ReadGlobalVars(reader);
             ReadLastSpellCost(reader);
             ReadIsDay(reader);
-            ReadTypeOfCrimeCommitted(reader);
+            ReadCrimeCommitted(reader);
             ReadInDungeonWater(reader);
             ReadClimateWeathers(reader);
             ReadWeaponDrawn(reader);
@@ -490,10 +490,10 @@ namespace DaggerfallConnect.Save
                 isDay = true;
         }
 
-        void ReadTypeOfCrimeCommitted(BinaryReader reader)
+        void ReadCrimeCommitted(BinaryReader reader)
         {
-            reader.BaseStream.Position = typeOfCrimeCommittedOffset;
-            typeOfCrimeCommitted = reader.ReadByte();
+            reader.BaseStream.Position = crimeCommittedOffset;
+            crimeCommitted = reader.ReadByte();
         }
 
         void ReadInDungeonWater(BinaryReader reader)

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -14,6 +14,7 @@ using System.Collections;
 using DaggerfallConnect;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Formulas;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -184,6 +185,8 @@ namespace DaggerfallWorkshop.Game
 
         private int ApplyDamageToPlayer()
         {
+            const int doYouSurrenderToGuardsTextID = 15;
+
             int damage = 0;
             EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
@@ -195,9 +198,33 @@ namespace DaggerfallWorkshop.Game
             playerEntity.TallySkill(DFCareer.Skills.Dodging, 1);
 
             if (damage > 0)
+            {
+                // If hit by a guard, show the surrender dialogue
+                if (!playerEntity.HaveShownSurrenderToGuardsDialogue && entity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
+                {
+                    DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.UIManager);
+                    messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(doYouSurrenderToGuardsTextID));
+                    messageBox.ParentPanel.BackgroundColor = Color.clear;
+                    messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
+                    messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No);
+                    messageBox.OnButtonClick += SurrenderToGuardsDialogue_OnButtonClick;
+                    messageBox.Show();
+
+                    playerEntity.HaveShownSurrenderToGuardsDialogue = true;
+                }
                 GameManager.Instance.PlayerObject.SendMessage("RemoveHealth", damage);
+            }
 
             return damage;
+        }
+
+        private void SurrenderToGuardsDialogue_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
+        {
+            sender.CloseWindow();
+            if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
+            {
+                DaggerfallUI.MessageBox("Not implemented yet.");
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -199,9 +199,11 @@ namespace DaggerfallWorkshop.Game
 
             if (damage > 0)
             {
-                // If hit by a guard, show the surrender dialogue
+                // If hit by a guard, lower reputation and show the surrender dialogue
                 if (!playerEntity.HaveShownSurrenderToGuardsDialogue && entity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
                 {
+                    playerEntity.LowerRepForCrime();
+
                     DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.UIManager);
                     messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(doYouSurrenderToGuardsTextID));
                     messageBox.ParentPanel.BackgroundColor = Color.clear;

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -25,7 +25,7 @@ namespace DaggerfallWorkshop.Game
     {
         public static readonly Vector3 ResetPlayerPos = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
 
-        public float SightRadius = 25f;         // Range of enemy sight
+        public float SightRadius = 4096 * MeshReader.GlobalScale;         // Range of enemy sight
         public float HearingRadius = 25f;       // Range of enemy hearing
         public float FieldOfView = 180f;        // Enemy field of view
 

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1271,6 +1271,21 @@ namespace DaggerfallWorkshop.Game.Entity
             Treason = 14,
         }
 
+        // Values after index 0 are from FALL.EXE. It does not seem to have a valid value for the last crime "Treason," so just using half of "High Treason" value here.
+        short[] reputationLossPerCrime = { 0x00, 0x0A, 0x05, 0x0A, 0x08, 0x14, 0x0A, 0x02, 0x01, 0x02, 0x02, 0x4B, 0x02, 0x08, 0x24 };
+
+        public void LowerRepForCrime()
+        {
+            int regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
+
+            // Lower legal reputation
+            regionData[regionIndex].LegalRep -= reputationLossPerCrime[(int)crimeCommitted];
+
+            // TODO: Faction reputation adjustments
+            //FactionFile.FactionData peopleFaction;
+            //FactionData.FindFactionByTypeAndRegion(15, regionIndex + 1, out peopleFaction);
+        }
+
         #endregion
 
         #region Event Handlers

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -84,7 +84,8 @@ namespace DaggerfallWorkshop.Game.Entity
 
         protected RegionDataRecord[] regionData = new RegionDataRecord[62];
 
-        protected Crimes crimeCommitted = 0;
+        protected Crimes crimeCommitted = 0; // TODO: Save/load
+        protected bool haveShownSurrenderToGuardsDialogue = false; // TODO: Save/load
 
         private List<RoomRental_v1> rentedRooms = new List<RoomRental_v1>();
 
@@ -148,6 +149,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public List<RoomRental_v1> RentedRooms { get { return rentedRooms; } set { rentedRooms = value; } }
         public List<DaggerfallDisease> Diseases { get { return diseases; } set { diseases = value; } }
         public Crimes CrimeCommitted { get { return crimeCommitted; } set { crimeCommitted = value; } }
+        public bool HaveShownSurrenderToGuardsDialogue { get { return haveShownSurrenderToGuardsDialogue; } set { haveShownSurrenderToGuardsDialogue = value; } }
 
         #endregion
 
@@ -358,6 +360,13 @@ namespace DaggerfallWorkshop.Game.Entity
                 isResting = false;
 
             HandleStartingCrimeGuildQuests();
+
+            // Reset surrender to guards dialogue if no guards are nearby
+            if (haveShownSurrenderToGuardsDialogue == true)
+            {
+                if (GameManager.Instance.HowManyEnemiesOfType(MobileTypes.Knight_CityWatch, true) == 0)
+                    haveShownSurrenderToGuardsDialogue = false;
+            }
         }
 
         public bool IntermittentEnemySpawn(uint Minutes)
@@ -435,8 +444,8 @@ namespace DaggerfallWorkshop.Game.Entity
 
         public void SpawnCityGuards(bool forceSpawn)
         {
-            // Don't spawn if more than 10 enemies are already in the area
-            if (UnityEngine.Object.FindObjectsOfType<DaggerfallEntityBehaviour>().Length > 10)
+            // Don't spawn if more than 10 guards are already in the area
+            if (GameManager.Instance.HowManyEnemiesOfType(MobileTypes.Knight_CityWatch) > 10)
                 return;
 
             if (forceSpawn)

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -84,6 +84,8 @@ namespace DaggerfallWorkshop.Game.Entity
 
         protected RegionDataRecord[] regionData = new RegionDataRecord[62];
 
+        protected Crimes crimeCommitted = 0;
+
         private List<RoomRental_v1> rentedRooms = new List<RoomRental_v1>();
 
         // Fatigue loss per in-game minute
@@ -145,6 +147,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public uint LastGameMinutes { get { return lastGameMinutes; } set { lastGameMinutes = value; } }
         public List<RoomRental_v1> RentedRooms { get { return rentedRooms; } set { rentedRooms = value; } }
         public List<DaggerfallDisease> Diseases { get { return diseases; } set { diseases = value; } }
+        public Crimes CrimeCommitted { get { return crimeCommitted; } set { crimeCommitted = value; } }
 
         #endregion
 
@@ -442,7 +445,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 // if out of player view.
                 // If none spawned, proceed with below
                 int randomNumber = UnityEngine.Random.Range(2, 5 + 1);
-                GameObjectHelper.CreateFoeSpawner(true, MobileTypes.Knight_CityWatch, randomNumber);
+                GameObjectHelper.CreateFoeSpawner(true, MobileTypes.Knight_CityWatch, randomNumber, (int)(1032 * MeshReader.GlobalScale), (int)(3096 * MeshReader.GlobalScale));
             }
             // TODO: If !forceSpawn, check for LOS from nearby guard townspeople and spawn from them if they see player.
             // Otherwise, check for LOS from non-guard townspeople. If they see player, random countdown is set, after which guards will spawn.
@@ -1234,6 +1237,29 @@ namespace DaggerfallWorkshop.Game.Entity
                 else if (factionData.FactionDict[key].rep > 0)
                     factionData.ChangeReputation(factionData.FactionDict[key].id, -1);
             }
+        }
+
+        #endregion
+
+        #region Crime
+
+        public enum Crimes
+        {
+            None = 0,
+            Attempted_Breaking_And_Entering = 1,
+            Trespassing = 2,
+            Breaking_And_Entering = 3,
+            Assault = 4,
+            Murder = 5,
+            Tax_Evasion = 6,
+            Criminal_Conspiracy = 7,
+            Vagrancy = 8,
+            Smuggling = 9,
+            Piracy = 10,
+            High_Treason = 11,
+            Pickpocketing = 12,
+            Theft = 13,
+            Treason = 14,
         }
 
         #endregion

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -503,7 +503,7 @@ namespace DaggerfallWorkshop.Game
         /// Determines if enemies are nearby. Uses include whether player is able to rest or not.
         /// Based on minimum distance to nearest monster, and if monster can actually sense player.
         /// </summary>
-        /// <param name="minMonsterDistance">Monsters must be at least this far away.</param>
+        /// <param name="minMonsterDistance">Monsters must be at least this close.</param>
         /// <returns>True if enemies are nearby.</returns>
         public bool AreEnemiesNearby(float minMonsterDistance = 12f)
         {
@@ -547,6 +547,47 @@ namespace DaggerfallWorkshop.Game
             }
 
             return areEnemiesNearby;
+        }
+
+        /// <summary>
+        /// Gets how many enemies of a given type exist.
+        /// </summary>
+        /// <param name="type">Enemy type to search for.</param>
+        /// <param name="stopLookingIfFound">Return as soon as an enemy of given type is found.</param>
+        /// <returns>Number of this enemy type.</returns>
+        public int HowManyEnemiesOfType(MobileTypes type, bool stopLookingIfFound = false)
+        {
+            int numberOfEnemies = 0;
+            DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
+            for (int i = 0; i < entityBehaviours.Length; i++)
+            {
+                DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
+                if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
+                {
+                    EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
+                    if (entity.MobileEnemy.ID == (int)type)
+                    {
+                        numberOfEnemies++;
+                        if (stopLookingIfFound)
+                            return numberOfEnemies;
+                    }
+                }
+            }
+
+            // Also check for enemy spawners that might emit an enemy
+            FoeSpawner[] spawners = FindObjectsOfType<FoeSpawner>();
+            for (int i = 0; i < spawners.Length; i++)
+            {
+                // Is a spawner inside min distance?
+                if (spawners[i].FoeType == type)
+                {
+                    numberOfEnemies++;
+                    if (stopLookingIfFound)
+                        return numberOfEnemies;
+                }
+            }
+
+            return numberOfEnemies;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -1031,6 +1031,13 @@ namespace DaggerfallWorkshop.Game
                 string notSuccessfulMessage = HardStrings.youAreNotSuccessful;
                 DaggerfallUI.Instance.PopupMessage(notSuccessfulMessage);
 
+                // Register crime and start spawning guards.
+                if (target == null) // target is a townsperson
+                {
+                    player.CrimeCommitted = PlayerEntity.Crimes.Pickpocketing;
+                    player.SpawnCityGuards(true);
+                }
+
                 // Make enemies in an area aggressive if player failed to pickpocket a non-hostile one.
                 EnemyMotor enemyMotor = null;
                 if (target != null)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -407,6 +407,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 CloseWindow();
                 DaggerfallUI.MessageBox(cityCampingIllegal);
+
+                // Register crime and start spawning guards
+                playerEntity.CrimeCommitted = PlayerEntity.Crimes.Vagrancy;
+                playerEntity.SpawnCityGuards(true);
+
                 return false;
             }
             else if ((inTown || !playerGPS.HasCurrentLocation) && playerEnterExit.IsPlayerInsideBuilding)

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -566,6 +566,9 @@ namespace DaggerfallWorkshop.Game.Utility
             // TODO: Import classic spellbook
             playerEntity.DeserializeSpellbook(null);
 
+            // Get last type of crime committed
+            playerEntity.CrimeCommitted = (PlayerEntity.Crimes)saveVars.CrimeCommitted;
+
             // Get weather
             byte[] climateWeathers = saveVars.ClimateWeathers;
 

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -705,9 +705,10 @@ namespace DaggerfallWorkshop.Game
                         blood.ShowBloodSplash(0, hit.point);
                     }
                     mobileNpc.Motor.gameObject.SetActive(false);
-                    GameManager.Instance.PlayerEntity.TallyCrimeGuildRequirements(false, 5);
-                    // TODO: LOS check from each townsperson. If seen, start spawning guards as below.
-                    GameManager.Instance.PlayerEntity.SpawnCityGuards(true);
+                    playerEntity.TallyCrimeGuildRequirements(false, 5);
+                    // TODO: LOS check from each townsperson. If seen, register crime and start spawning guards as below.
+                    playerEntity.CrimeCommitted = PlayerEntity.Crimes.Murder;
+                    playerEntity.SpawnCityGuards(true);
                 }
             }
         }


### PR DESCRIPTION
- Added crime enum and variable to track player's crime to playerEntity, and import this value from classic saves.
- Set the crime variable for the easy cases (murder, pickpocketing, vagrancy). The others will take a little more work to get right.
- Guards spawn further away (max distance should be equal to classic). Enemy sight increased (also FOV, which hadn't been properly updated before. I think I only changed the prefab for the Standalone Enemy and not the Serializable one). I believe the FOV matches classic and the sight matches the maximum distance an enemy can exist in classic (in outdoors environments) before being despawned, which may or may not be the same as sight range. Regardless, pursuing by guards or other monsters works much better.

A couple notes:
- Using the foe spawner, when multiple enemies spawn at once they always seem to be at the same distance. Is this intended? This isn't necessarily a bad thing but I think when multiple guards spawn in classic they each get their own random distance. I tried creating multiple 1 enemy FoeSpawners in a loop but the result was the same.
- Classic only stores a single "type of crime committed" variable for the player. We should probably sum together all crimes instead, but that can come later. We'd have to figure out how to adjust the court screen to handle multiple crimes, though.