### PR TITLE
Crimes modify faction reputations

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -175,6 +175,10 @@ namespace DaggerfallConnect.Arena2
             public int vam;
             public int rank;
             public int randomValue;
+            public int randomPowerBonus;
+            public int ptrToNextFactionAtSameHierarchyLevel;
+            public int ptrToFirstChildFaction;
+            public int ptrToParentFaction;
 
             public List<int> children;
         }

--- a/Assets/Scripts/API/Save/SaveVars.cs
+++ b/Assets/Scripts/API/Save/SaveVars.cs
@@ -609,8 +609,8 @@ namespace DaggerfallConnect.Save
                 faction.vam = reader.ReadInt16();
                 faction.flags = reader.ReadInt16();
 
-                reader.BaseStream.Position += 4;            // Skip 4 unknown bytes
-                faction.randomValue = reader.ReadInt32();
+                faction.randomValue = reader.ReadInt32();           // Completely random value
+                faction.randomPowerBonus = reader.ReadInt32();      // Random(0, 50) + 20
 
                 faction.flat1 = reader.ReadInt16();
                 faction.flat2 = reader.ReadInt16();
@@ -630,7 +630,9 @@ namespace DaggerfallConnect.Save
                 faction.enemy2 = reader.ReadInt32();
                 faction.enemy3 = reader.ReadInt32();
 
-                reader.BaseStream.Position += 12;           // Skip 12 unknown bytes
+                faction.ptrToNextFactionAtSameHierarchyLevel = reader.ReadInt32();
+                faction.ptrToFirstChildFaction = reader.ReadInt32();
+                faction.ptrToParentFaction = reader.ReadInt32();
 
                 factions.Add(faction);
             }

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -97,6 +97,7 @@ namespace DaggerfallWorkshop.Game
         DaggerfallQuestJournalWindow dfQuestJournalWindow;
         DaggerfallSpellBookWindow dfSpellBookWindow;
         DaggerfallSpellMakerWindow dfSpellMakerWindow;
+        DaggerfallCourtWindow dfCourtWindow;
         QuestMachineInspectorWindow dfQuestInspector;
 
         DaggerfallFontPlus fontPetrock32;
@@ -248,6 +249,7 @@ namespace DaggerfallWorkshop.Game
             dfTalkWindow = new DaggerfallTalkWindow(uiManager);
             dfSpellBookWindow = new DaggerfallSpellBookWindow(uiManager);
             dfSpellMakerWindow = new DaggerfallSpellMakerWindow(uiManager);
+            dfCourtWindow = new DaggerfallCourtWindow(uiManager);
 
             dfExteriorAutomapWindow = new DaggerfallExteriorAutomapWindow(uiManager);
 
@@ -380,6 +382,9 @@ namespace DaggerfallWorkshop.Game
                 case DaggerfallUIMessages.dfuiOpenSpellBookWindow:
                     if (!GameManager.Instance.PlayerSpellCasting.IsPlayingAnim)
                         uiManager.PushWindow(dfSpellBookWindow);
+                    break;
+                case DaggerfallUIMessages.dfuiOpenCourtWindow:
+                    uiManager.PushWindow(dfCourtWindow);
                     break;
                 case DaggerfallUIMessages.dfuiOpenSpellMakerWindow:
                     uiManager.PushWindow(dfSpellMakerWindow);

--- a/Assets/Scripts/Game/DaggerfallUIMessages.cs
+++ b/Assets/Scripts/Game/DaggerfallUIMessages.cs
@@ -58,6 +58,9 @@ namespace DaggerfallWorkshop.Game
         // Status info messages
         public const string dfuiStatusInfo = "dfuiStatusInfo";
 
+        // Court messages
+        public const string dfuiOpenCourtWindow = "dfuiOpenCourtWindow";
+
         // "Debug" window messages
         public const string dfuiOpenQuestInspector = "dfuiOpenQuestInspector";
     }

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -192,7 +192,7 @@ namespace DaggerfallWorkshop.Game
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
 
             // Calculate damage
-            damage = FormulaHelper.CalculateAttackDamage(entity, GameManager.Instance.PlayerEntity, (int)(Items.EquipSlots.RightHand), -1);
+            damage = FormulaHelper.CalculateAttackDamage(entity, playerEntity, (int)(Items.EquipSlots.RightHand), -1);
 
             // Tally player's dodging skill
             playerEntity.TallySkill(DFCareer.Skills.Dodging, 1);
@@ -214,7 +214,11 @@ namespace DaggerfallWorkshop.Game
 
                     playerEntity.HaveShownSurrenderToGuardsDialogue = true;
                 }
-                GameManager.Instance.PlayerObject.SendMessage("RemoveHealth", damage);
+
+                if (entity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch && playerEntity.CurrentHealth <= damage)
+                    playerEntity.SurrenderToCityGuards(false);
+                else
+                    GameManager.Instance.PlayerObject.SendMessage("RemoveHealth", damage);
             }
 
             return damage;
@@ -224,9 +228,7 @@ namespace DaggerfallWorkshop.Game
         {
             sender.CloseWindow();
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
-            {
-                DaggerfallUI.MessageBox("Not implemented yet.");
-            }
+                GameManager.Instance.PlayerEntity.SurrenderToCityGuards(true);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1095,14 +1095,14 @@ namespace DaggerfallWorkshop.Game.Entity
                         TurnOffConditionFlag(item.region - 1, RegionDataFlags.FamineEnding);
                     else if (regionData[item.region - 1].Flags[(int)RegionDataFlags.FamineOngoing] == true)
                     {
-                        if (UnityEngine.Random.Range(0, 100 + 1) < item.randomValue / 5 + alliesPowerMod + item.power / 5)
+                        if (UnityEngine.Random.Range(0, 100 + 1) < item.randomPowerBonus / 5 + alliesPowerMod + item.power / 5)
                             TurnOnConditionFlag(item.region - 1, RegionDataFlags.FamineEnding);
                     }
                     else if (regionData[item.region - 1].Flags[(int)RegionDataFlags.FamineBeginning] == true)
                         TurnOnConditionFlag(item.region - 1, RegionDataFlags.FamineOngoing);
                     else if (UnityEngine.Random.Range(1, 100 + 1) <= 2)
                     {
-                        if (UnityEngine.Random.Range(0, 100 + 1) > item.randomValue + alliesPowerMod)
+                        if (UnityEngine.Random.Range(0, 100 + 1) > item.randomPowerBonus + alliesPowerMod)
                             TurnOnConditionFlag(item.region - 1, RegionDataFlags.FamineBeginning);
                     }
 
@@ -1117,7 +1117,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         //if (temple.id != 0)
                             //--temple.power;
                         //--item.power;
-                        if (UnityEngine.Random.Range(0, 100 + 1) < item.power / 5 + item.randomValue / 5 + alliesPowerMod)
+                        if (UnityEngine.Random.Range(0, 100 + 1) < item.power / 5 + item.randomPowerBonus / 5 + alliesPowerMod)
                             TurnOnConditionFlag(item.region - 1, RegionDataFlags.PlagueEnding);
                     }
                     else if (regionData[item.region - 1].Flags[(int)RegionDataFlags.PlagueBeginning] == true)
@@ -1129,7 +1129,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     }
                     else if (UnityEngine.Random.Range(1, 100 + 1) <= 2)
                     {
-                        if (UnityEngine.Random.Range(0, 100 + 1) > item.randomValue + alliesPowerMod)
+                        if (UnityEngine.Random.Range(0, 100 + 1) > item.randomPowerBonus + alliesPowerMod)
                         {
                             //if (temple.id != 0)
                                 //--temple.power;
@@ -1281,9 +1281,9 @@ namespace DaggerfallWorkshop.Game.Entity
             // Lower legal reputation
             regionData[regionIndex].LegalRep -= reputationLossPerCrime[(int)crimeCommitted];
 
-            // TODO: Faction reputation adjustments
-            //FactionFile.FactionData peopleFaction;
-            //FactionData.FindFactionByTypeAndRegion(15, regionIndex + 1, out peopleFaction);
+            FactionFile.FactionData peopleFaction;
+            FactionData.FindFactionByTypeAndRegion(15, regionIndex + 1, out peopleFaction);
+            FactionData.ChangeReputation(peopleFaction.id, -(reputationLossPerCrime[(int)crimeCommitted] / 2));
         }
 
         #endregion

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1286,6 +1286,27 @@ namespace DaggerfallWorkshop.Game.Entity
             FactionData.ChangeReputation(peopleFaction.id, -(reputationLossPerCrime[(int)crimeCommitted] / 2));
         }
 
+        public void SurrenderToCityGuards(bool voluntarySurrender)
+        {
+            int regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
+            short legalRep = regionData[regionIndex].LegalRep;
+
+            //SetHealth(1);
+            if (legalRep < -20 && !voluntarySurrender)
+                SetHealth(0);
+            else if (legalRep < -20 || legalRep > 0)
+                CourtWindow(CrimeCommitted);
+            else if ((DFRandom.rand() & 1) != 0 && !voluntarySurrender)
+                SetHealth(0);
+            else
+                CourtWindow(CrimeCommitted);
+        }
+
+        public void CourtWindow(Crimes crimeCommitted)
+        {
+            DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenCourtWindow);
+        }
+
         #endregion
 
         #region Event Handlers

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -1,0 +1,51 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Allofich
+// Contributors:
+//
+// Notes:
+//
+
+using UnityEngine;
+using System;
+using DaggerfallWorkshop.Game.UserInterface;
+using DaggerfallWorkshop.Utility.AssetInjection;
+
+namespace DaggerfallWorkshop.Game.UserInterfaceWindows
+{
+    /// <summary>
+    /// Implements popup window for when player is in court for a crime.
+    /// </summary>
+    public class DaggerfallCourtWindow : DaggerfallPopupWindow
+    {
+        const string nativeImgName = "CORT01I0.img";
+
+        Texture2D nativeTexture;
+        Panel courtPanel = new Panel();
+        private float timer = 0f;
+
+        public DaggerfallCourtWindow(IUserInterfaceManager uiManager, IUserInterfaceWindow previousWindow = null)
+            : base(uiManager, previousWindow)
+        {
+        }
+
+        protected override void Setup()
+        {
+            // Load native texture
+            nativeTexture = DaggerfallUI.GetTextureFromImg(nativeImgName);
+            if (!nativeTexture)
+                throw new Exception("DaggerfallCourtWindow: Could not load native texture.");
+
+            // Native court panel
+            courtPanel.HorizontalAlignment = HorizontalAlignment.Center;
+            courtPanel.Size = TextureReplacement.GetSize(nativeTexture, nativeImgName);
+            courtPanel.BackgroundTexture = nativeTexture;
+            NativePanel.Components.Add(courtPanel);
+
+            DaggerfallUI.MessageBox("Not implemented yet. Press ESC to exit.");
+        }
+    }
+}

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs.meta
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 53659b10412bc8b4a862a060d36191e3
+timeCreated: 1524304448
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Crimes now modify player's reputation with "people" factions in the same manner as classic.

Also identified the parts of the faction records in `SAVEVARS.DAT` that were unidentified. If we wanted to it's probably possible to create the parent-child relationships of factions just by reading in and using the 3 pointers at the end of each faction data record from `SAVEVARS.DAT`, rather than creating them by reading `FACTION.TXT`, but of course what we have already works.