### PR TITLE
Make it easier to max out volume

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
@@ -112,6 +112,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         #region Event Handlers
         private void SoundBar_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            // make it easier to max out volume
+            if ((position.x / barMaxLength) > 0.99f)
+                position.x = barMaxLength;
             // resize panel to where user clicked
             soundBar.Size = new Vector2(position.x, 3.5f);
             DaggerfallUnity.Settings.SoundVolume = (position.x / barMaxLength);
@@ -119,6 +122,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
         private void MusicBar_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            // make it easier to max out volume
+            if ((position.x / barMaxLength) > 0.99f)
+                position.x = barMaxLength;
             // resize panel to where user clicked
             musicBar.Size = new Vector2(position.x, 3.5f);
             DaggerfallUnity.Settings.MusicVolume = (position.x / barMaxLength);


### PR DESCRIPTION
Makes it easier to max out the volume bar on sound and music

I want to add more fixes to this branch before it gets merged to master, but I wanted to create it to discuss some potential fixes to making all the sounds scale with the audio volume setting.

PlayerFootsteps uses an AudioSource called customAudioSource and a DaggerfallAudioSource called dfAudioSource.  The former is used for default footsteps and the latter is used for other footsteps. 

TransportManager does something similar for keeping the horse whinny sound separate from riding sounds.

In addition to horse and footstep sounds, it seems like dungeon ambient sounds and enemy sounds aren't being affected.