### PR TITLE
Asset injection: Import terrain textures from mods

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
@@ -111,10 +111,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.VerticalAlignment = VerticalAlignment.Middle;
             mainPanel.Size = mainPanelSize;
             mainPanel.Outline.Enabled = true;
-            if (TextureReplacement.CustomTextureExist("mainPanelBackgroundColor"))
-                mainPanel.BackgroundTexture = TextureReplacement.LoadCustomTexture("mainPanelBackgroundColor");
-            else
-                mainPanel.BackgroundColor = mainPanelBackgroundColor;
+            SetBackground(mainPanel, mainPanelBackgroundColor, "mainPanelBackgroundColor");
             NativePanel.Components.Add(mainPanel);
 
             // Prompt
@@ -127,10 +124,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             namePanel.Position = new Vector2(4, 12);
             namePanel.Size = new Vector2(272, 9);
             namePanel.Outline.Enabled = true;
-            if (TextureReplacement.CustomTextureExist("namePanelBackgroundColor"))
-                namePanel.BackgroundTexture = TextureReplacement.LoadCustomTexture("namePanelBackgroundColor");
-            else
-                namePanel.BackgroundColor = namePanelBackgroundColor;
+            SetBackground(namePanel, namePanelBackgroundColor, "namePanelBackgroundColor");
             mainPanel.Components.Add(namePanel);
 
             // Name input
@@ -150,10 +144,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             savesList.Position = new Vector2(2, 2);
             savesList.Size = new Vector2(91, 129);
             savesList.TextColor = savesListTextColor;
-            if (TextureReplacement.CustomTextureExist("savesListBackgroundColor"))
-                savesList.BackgroundTexture = TextureReplacement.LoadCustomTexture("savesListBackgroundColor");
-            else
-                savesList.BackgroundColor = savesListBackgroundColor;
+            SetBackground(savesList, savesListBackgroundColor, "savesListBackgroundColor");
             savesList.ShadowPosition = Vector2.zero;
             savesList.RowsDisplayed = 16;
             savesList.OnScroll += SavesList_OnScroll;
@@ -172,10 +163,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             goButton.Position = new Vector2(108, 150);
             goButton.Size = new Vector2(40, 16);
             goButton.Label.ShadowColor = Color.black;
-            if (TextureReplacement.CustomTextureExist("saveButtonBackgroundColor"))
-                TextureReplacement.SetCustomButton(ref goButton, "saveButtonBackgroundColor");
-            else
-                goButton.BackgroundColor = saveButtonBackgroundColor;
+            SetBackground(goButton, saveButtonBackgroundColor, "saveButtonBackgroundColor");
             goButton.Outline.Enabled = true;
             goButton.OnMouseClick += SaveLoadEventHandler;
             mainPanel.Components.Add(goButton);
@@ -186,10 +174,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             switchClassicButton.Label.Text = "Classic";
             //switchClassicButton.Label.TextColor = new Color(0.6f, 0.3f, 0.6f);
             switchClassicButton.Label.ShadowColor = Color.black;
-            if (TextureReplacement.CustomTextureExist("switchClassicButtonBackgroundColor"))
-                TextureReplacement.SetCustomButton(ref switchClassicButton, "switchClassicButtonBackgroundColor");
-            else
-                switchClassicButton.BackgroundColor = new Color(0.2f, 0.2f, 0);
+            SetBackground(switchClassicButton, new Color(0.2f, 0.2f, 0), "switchClassicButtonBackgroundColor");
             switchClassicButton.Outline.Enabled = true;
             switchClassicButton.OnMouseClick += SwitchClassicButton_OnMouseClick;
             mainPanel.Components.Add(switchClassicButton);
@@ -200,10 +185,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             cancelButton.Size = new Vector2(40, 16);
             cancelButton.Label.Text = "Cancel";
             cancelButton.Label.ShadowColor = Color.black;
-            if (TextureReplacement.CustomTextureExist("cancelButtonBackgroundColor"))
-                TextureReplacement.SetCustomButton(ref cancelButton, "cancelButtonBackgroundColor");
-            else
-                cancelButton.BackgroundColor = cancelButtonBackgroundColor;
+            SetBackground(cancelButton, cancelButtonBackgroundColor, "cancelButtonBackgroundColor");
             cancelButton.Outline.Enabled = true;
             cancelButton.OnMouseClick += CancelButton_OnMouseClick;
             mainPanel.Components.Add(cancelButton);
@@ -212,10 +194,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             screenshotPanel.Position = new Vector2(108, 25);
             screenshotPanel.Size = new Vector2(168, 95);
             screenshotPanel.BackgroundTextureLayout = BackgroundLayout.ScaleToFit;
-            if (TextureReplacement.CustomTextureExist("screenshotPanelBackgroundColor"))
-                screenshotPanel.BackgroundTexture = TextureReplacement.LoadCustomTexture("screenshotPanelBackgroundColor");
-            else
-                screenshotPanel.BackgroundColor = savesListBackgroundColor;
+            SetBackground(screenshotPanel, savesListBackgroundColor, "screenshotPanelBackgroundColor");
             screenshotPanel.Outline.Enabled = true;
             mainPanel.Components.Add(screenshotPanel);
 
@@ -254,10 +233,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             deleteSaveButton.HorizontalAlignment = HorizontalAlignment.Center;
             deleteSaveButton.Label.Text = "Delete Save";
             deleteSaveButton.Label.ShadowColor = Color.black;
-            if (TextureReplacement.CustomTextureExist("deleteSaveButtonBackgroundColor"))
-                TextureReplacement.SetCustomButton(ref deleteSaveButton, "deleteSaveButtonBackgroundColor");
-            else
-                deleteSaveButton.BackgroundColor = namePanelBackgroundColor;
+            SetBackground(deleteSaveButton, namePanelBackgroundColor, "deleteSaveButtonBackgroundColor");
             deleteSaveButton.Outline.Enabled = false;
             deleteSaveButton.OnMouseClick += DeleteSaveButton_OnMouseClick;
             savesPanel.Components.Add(deleteSaveButton);
@@ -267,10 +243,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             switchCharButton.Size = new Vector2(60, 8);
             switchCharButton.Label.Text = "Switch Char";
             switchCharButton.Label.ShadowColor = Color.black;
-            if (TextureReplacement.CustomTextureExist("switchCharButtonBackgroundColor"))
-                TextureReplacement.SetCustomButton(ref switchCharButton, "switchCharButtonBackgroundColor");
-            else
-                switchCharButton.BackgroundColor = saveButtonBackgroundColor;
+            SetBackground(switchCharButton, saveButtonBackgroundColor, "switchCharButtonBackgroundColor");
             switchCharButton.OnMouseClick += SwitchCharButton_OnMouseClick;
             mainPanel.Components.Add(switchCharButton);
         }
@@ -436,6 +409,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 else
                     switchCharButton.Enabled = false;
             }
+        }
+
+        void SetBackground(BaseScreenComponent panel, Color color, string textureName)
+        {
+            Texture2D tex;
+            if (TextureReplacement.TryImportTexture(textureName, out tex))
+                panel.BackgroundTexture = tex;
+            else
+                panel.BackgroundColor = color;
+        }
+
+        void SetBackground(Button button, Color color, string textureName)
+        {
+            if (!TextureReplacement.TryCustomizeButton(ref button, textureName))
+                button.BackgroundColor = color;
         }
 
         #endregion

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -308,6 +308,7 @@ namespace DaggerfallWorkshop
                 TextureReplacement.TryImportMaterial(archive, record, frame, out material))
             {
                 results = TextureReplacement.MakeResults(material, archive, record);
+                TextureReplacement.AssignFiltermode(material);
             }
             else
             {

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -304,7 +304,7 @@ namespace DaggerfallWorkshop
 
             // Try to import a material from mods, otherwise create a standard material
             // and import textures from Daggerfall files and loose files.
-            if (!TextureReplacement.CustomTextureExist(archive, record, frame) &&
+            if (!TextureReplacement.TextureExistsAmongLooseFiles(archive, record, frame) &&
                 TextureReplacement.TryImportMaterial(archive, record, frame, out material))
             {
                 results = TextureReplacement.MakeResults(material, archive, record);
@@ -343,7 +343,7 @@ namespace DaggerfallWorkshop
                 material.mainTexture.filterMode = MainFilterMode;
 
                 // Setup normal map
-                bool importedNormals = TextureReplacement.CustomNormalExist(settings.archive, settings.record, settings.frame);
+                bool importedNormals = TextureReplacement.TextureExistsAmongLooseFiles(settings.archive, settings.record, settings.frame, TextureMap.Normal);
                 if ((GenerateNormals || importedNormals) && results.normalMap != null)
                 {
                     results.normalMap.filterMode = MainFilterMode;

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -305,7 +305,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                         // Override Daggerfall material with textures from loose files
                         int archive, record;
                         if (TextureReplacement.IsDaggerfallTexture(materials[i].name, out archive, out record)
-                            && TextureReplacement.CustomTextureExist(archive, record, 0))
+                            && TextureReplacement.TextureExistsAmongLooseFiles(archive, record, 0))
                         {
                             CachedMaterial cachedMaterialOut;
                             if (materialReader.GetCachedMaterial(archive, record, 0, out cachedMaterialOut))

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -10,7 +10,6 @@
 //
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 using Random = UnityEngine.Random;
@@ -27,14 +26,6 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     public static class MeshReplacement
     {
         #region Fields
-
-        static readonly int[] Uniforms = new int[]
-        {
-            Shader.PropertyToID("_MainTex"),
-            Shader.PropertyToID("_BumpMap"),
-            Shader.PropertyToID("_EmissionMap"),
-            Shader.PropertyToID("_MetallicGlossMap")
-        };
 
         static Func<float> getTreeScaleCallback = () => Random.Range(0.6f, 1.4f);
         static Func<Color32> getTreeColorCallback = () => Color.Lerp(Color.white, Color.grey, Random.value);
@@ -316,12 +307,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                         }
 
                         // Assign filtermode to textures
-                        FilterMode filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
-                        foreach (var property in Uniforms.Where(x => materials[i].HasProperty(x)))
-                        {
-                            Texture tex = materials[i].GetTexture(property);
-                            if (tex) tex.filterMode = filterMode;
-                        }
+                        TextureReplacement.AssignFiltermode(materials[i]);
                     }
                     else
                     {

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -13,7 +13,6 @@
  * TODO:
  * - PaperDoll CharacterLayer textures works only if resolution is the same as vanilla 
  *        (http://forums.dfworkshop.net/viewtopic.php?f=22&p=3547&sid=6a99dbcffad1a15b08dd5e157274b772#p3547)
- * - Import terrain textures from mods
  */
 
 //#define DEBUG_TEXTURE_FORMAT
@@ -29,6 +28,8 @@ using DaggerfallWorkshop.Game.Utility.ModSupport;
 
 namespace DaggerfallWorkshop.Utility.AssetInjection
 {
+    #region Enums and Structs
+
     /// <summary>
     /// Supported textures maps.
     /// </summary>
@@ -55,11 +56,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         public List<List<Texture2D>> Textures;      // Textures for all records and frames.
     }
 
+    #endregion
+
     /// <summary>
-    /// Handles import and injection of custom textures and images
-    /// with the purpose of providing modding support.
+    /// Handles import and injection of custom textures and images with the purpose of providing modding support.
+    /// Import materials from mods and textures from mods and loose files.
     /// </summary>
-    static public class TextureReplacement
+    public static class TextureReplacement
     {
         #region Fields
 
@@ -126,55 +129,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Search for image files on disk to use as textures on models or billboards
-        /// (archive_record-frame.png, for example '86_3-0.png').
-        /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index. It's different than zero only for animated billboards.</param>
-        /// <returns>True if texture exists.</returns>
-        static public bool CustomTextureExist(int archive, int record, int frame = 0)
-        {
-            return TextureFileExist(texturesPath, GetName(archive, record, frame));
-        }
-
-        /// <summary>
-        /// Search for image files on disk to use as textures on models or billboards
-        /// (name.png).
-        /// </summary>
-        /// <param name="name">Name of texture without extension.</param>
-        /// <returns>True if texture exists.</returns>
-        static public bool CustomTextureExist(string name)
-        {
-            return TextureFileExist(texturesPath, name);
-        }
-
-        /// <summary>
-        /// Import image from disk as texture2D
-        /// (archive_record-frame.png, for example '86_3-0.png').
-        /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index. It's different than zero only for animated billboards</param>
-        /// <returns>Texture.</returns>
-        static public Texture2D LoadCustomTexture(int archive, int record, int frame)
-        {
-            return ImportTextureFile(texturesPath, GetName(archive, record, frame), true);
-        }
-
-        /// <summary>
-        /// Import image from disk as texture2D
-        /// (name.png).
-        /// </summary>
-        /// <param name="name">Name of texture without extension.</param>
-        /// <returns>Texture.</returns>
-        static public Texture2D LoadCustomTexture(string name)
-        {
-            return ImportTextureFile(texturesPath, name, true);
-        }
-
-        /// <summary>
-        /// Seek animated texture from mods with all frames.
+        /// Seek animated texture from modding locations with all frames.
         /// </summary>
         /// <param name="archive">Texture archive.</param>
         /// <param name="record">Record index.</param>
@@ -186,7 +141,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Seek texture from mods.
+        /// Seek texture from modding locations.
         /// </summary>
         /// <param name="archive">Texture archive.</param>
         /// <param name="record">Record index.</param>
@@ -199,7 +154,21 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Seek texture from mods with a specific dye.
+        /// Seek texture from modding locations.
+        /// </summary>
+        /// <param name="archive">Texture archive.</param>
+        /// <param name="record">Record index.</param>
+        /// <param name="frame">Animation frame index.</param>
+        /// <param name="textureMap">Texture type.</param>
+        /// <param name="tex">Imported texture.</param>
+        /// <returns>True if texture imported.</returns>
+        public static bool TryImportTexture(int archive, int record, int frame, TextureMap textureMap, out Texture2D tex)
+        {
+            return TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap), out tex);
+        }
+
+        /// <summary>
+        /// Seek texture from modding locations with a specific dye.
         /// </summary>
         /// <param name="archive">Texture archive.</param>
         /// <param name="record">Record index.</param>
@@ -213,7 +182,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Seek texture from mods.
+        /// Seek texture from modding locations.
         /// </summary>
         /// <param name="name">Texture name.</param>
         /// <param name="tex">Imported texture.</param>
@@ -224,7 +193,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Seek image from mods.
+        /// Seek image from modding locations.
         /// </summary>
         /// <param name="name">Image name.</param>
         /// <param name="tex">Imported image as texture.</param>
@@ -235,7 +204,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Seek CifRci from mods.
+        /// Seek CifRci from modding locations.
         /// </summary>
         /// <param name="name">Image name.</param>
         /// <param name="record">Record index.</param>
@@ -248,7 +217,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Seek CifRci with a specific metaltype from mods.
+        /// Seek CifRci with a specific metaltype from modding locations.
         /// </summary>
         /// <param name="name">Image name.</param>
         /// <param name="record">Record index.</param>
@@ -262,199 +231,59 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Search for image file on disk to use as normal map
-        /// (archive_record-frame_Normal.png, for example '112_3-0_Normal.png').
+        /// Seek texture from loose files.
         /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
+        /// <param name="archive">Texture archive.</param>
         /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index.</param>
-        /// <returns>True if normal map exists.</returns>
-        static public bool CustomNormalExist(int archive, int record, int frame)
-        {
-            return TextureFileExist(texturesPath, GetName(archive, record, frame, TextureMap.Normal));
-        }
-
-        /// <summary>
-        /// Search for image file on disk to use as normal map
-        /// (name_Normal.png).
-        /// </summary>
-        /// <param name="name">Name of texture.</param>
-        /// <returns>True if normal map exists.</returns>
-        static public bool CustomNormalExist(string name)
-        {
-            return TextureFileExist(texturesPath, name + "_" + TextureMap.Normal);
-        }
-
-        /// <summary>
-        /// Import image file from disk to use as normal map.
-        /// (archive_record-frame_Normal.png, for example '112_3-0_Normal.png').
-        /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index.</param> 
-        /// <returns>Normal map.</returns>
-        static public Texture2D LoadCustomNormal(int archive, int record, int frame)
-        {
-            return ImportNormalMap(texturesPath, GetName(archive, record, frame, TextureMap.Normal));
-        }
-
-        /// <summary>
-        /// Import image file from disk to use as normal map
-        /// (name_Normal.png).
-        /// </summary>
-        /// <param name="name">Name of texture.</param>
-        /// <returns>Normal map.</returns>
-        static public Texture2D LoadCustomNormal(string name)
-        {
-            return ImportNormalMap(texturesPath, name + "_" + TextureMap.Normal);
-        }
-
-        /// <summary>
-        /// Search for image file on disk to use as emission map
-        /// (archive_record-frame_Emission.png, for example '112_3-0_Emission.png).
-        /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index. It's different than zero only for animated billboards.</param>
-        /// <returns>True if emission map exists.</returns>
-        static public bool CustomEmissionExist(int archive, int record, int frame)
-        {
-            return TextureFileExist(texturesPath, GetName(archive, record, frame, TextureMap.Emission));
-        }
-
-        /// <summary>
-        /// Search for image file on disk to use as emission map
-        /// (name_Emission.png)
-        /// </summary>
-        /// <param name="name">Name of texture.</param>
-        /// <returns>True if emission map exists.</returns>
-        static public bool CustomEmissionExist(string name)
-        {
-            return TextureFileExist(texturesPath, name + "_" + TextureMap.Emission);
-        }
-
-        /// <summary>
-        /// Import image file from disk to use as emission map
-        /// (archive_record-frame_Emission.png, for example '112_3-0_Emission.png').
-        /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index. It's different than zero only for animated billboards</param>
-        /// <returns>Emission map.</returns>
-        static public Texture2D LoadCustomEmission(int archive, int record, int frame)
-        {
-            return ImportTextureFile(texturesPath, GetName(archive, record, frame, TextureMap.Emission), true);
-        }
-
-        /// <summary>
-        /// Import image file from disk to use as emission map
-        /// (name_Emission.png)
-        /// </summary>
-        /// <param name="name">Name of texture.</param>
-        /// <returns>Emission map.</returns>
-        static public Texture2D LoadCustomEmission(string name)
-        {
-            return ImportTextureFile(texturesPath, name + "_" + TextureMap.Emission, true);
-        }
-
-        /// <summary>
-        /// Search for image file on disk to use as metallic map
-        /// (archive_record-frame_MetallicGloss.png).
-        /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index.</param> 
-        /// <returns>True if MetallicGloss map exist.</returns>
-        static public bool CustomMetallicGlossExist(int archive, int record, int frame)
-        {
-            return TextureFileExist(texturesPath, GetName(archive, record, frame, TextureMap.MetallicGloss));
-        }
-
-        /// <summary>
-        /// Search for image file on disk to use as metallic map
-        /// (name_MetallicGloss.png).
-        /// </summary>
-        /// <param name="name">Name of texture.</param> 
-        /// <returns>True if MetallicGloss map exist.</returns>
-        static public bool CustomMetallicGlossExist(string name)
-        {
-            return TextureFileExist(texturesPath, name + "_" + TextureMap.MetallicGloss);
-        }
-
-        /// <summary>
-        /// Import image file from disk to use as metallic map.
-        /// (archive_record-frame_MetallicGloss.png).
-        /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index.</param> 
-        /// <returns>MetallicGloss map.</returns>
-        static public Texture2D LoadCustomMetallicGloss(int archive, int record, int frame)
-        {
-            return ImportTextureFile(texturesPath, GetName(archive, record, frame, TextureMap.MetallicGloss), true);
-        }
-
-        /// <summary>
-        /// Import image file from disk to use as MetallicGloss map
-        /// (name_MetallicGloss.png).
-        /// </summary>
-        /// <param name="name">Name of texture.</param>
-        /// <returns>MetallicGloss map.</returns>
-        static public Texture2D LoadCustomMetallicGloss(string name)
-        {
-            return ImportTextureFile(texturesPath, name + "_" + TextureMap.Emission, true);
-        }
-
-        /// <summary>
-        /// Import a png file from loose files following arguments requirements.
-        /// This is a helper method for mods and should not be used in core.
-        /// </summary>
-        /// <param name="relPath">Relative path to png file inside Textures folder.</param>
-        /// <param name="textureMap">Require modifications for specific texture maps</param>
-        /// <param name="mipMaps">Enable mipmaps?</param>
+        /// <param name="frame">Animation index.</param>
+        /// <param name="textureMap">Texture type.</param>
         /// <param name="tex">Imported texture.</param>
         /// <returns>True if texture imported.</returns>
-        public static bool TryImportTextureFromLooseFiles(string relPath, TextureMap textureMap, bool mipMaps, out Texture2D tex)
+        public static bool TryImportTextureFromLooseFiles(int archive, int record, int frame, TextureMap textureMap, out Texture2D tex)
         {
-            return TryImportTextureFromDisk(texturesPath, relPath, textureMap, mipMaps, out tex);  
+            string path = Path.Combine(texturesPath, GetName(archive, record, frame, textureMap));
+            if (DaggerfallUnity.Settings.MeshAndTextureReplacement)
+                return TryImportTextureFromDisk(path, textureMap == TextureMap.Normal, true, out tex);
+
+            tex = null;
+            return false;           
         }
 
         /// <summary>
-        /// Import a png file from given location following arguments requirements.
-        /// This is a helper method for mods and should not be used in core.
+        /// Seek texture from loose files using a relative path from <see cref="TexturesPath"/>.
         /// </summary>
-        /// <param name="directory">Folder on disk.</param>
-        /// <param name="fileName">Name of png file without extension.</param>
-        /// <param name="textureMap">Require modifications for specific texture maps</param>
+        /// <param name="relPath">Relative path to file from <see cref="TexturesPath"/>.</param>
         /// <param name="mipMaps">Enable mipmaps?</param>
+        /// <param name="encodeAsNormalMap">Convert from RGB to DTXnm.</param>
         /// <param name="tex">Imported texture.</param>
-        /// <returns>True if texture imported.</returns>
-        public static bool TryImportTextureFromDisk(string directory, string fileName, TextureMap textureMap, bool mipMaps, out Texture2D tex)
+        /// <returns>True if texture exists and has been imported.</returns>
+        public static bool TryImportTextureFromLooseFiles(string relPath, bool mipMaps, bool encodeAsNormalMap, out Texture2D tex)
         {
-            if (File.Exists(Path.Combine(directory, fileName + extension)))
+            return TryImportTextureFromDisk(Path.Combine(texturesPath, relPath), mipMaps, encodeAsNormalMap, out tex);
+        }
+
+        /// <summary>
+        /// Seek texture from disk using a full path.
+        /// </summary>
+        /// <param name="directory">Full path to texture file.</param>
+        /// <param name="fileName">Name of texture file.</param>
+        /// <param name="mipMaps">Enable mipmaps?</param>
+        /// <param name="encodeAsNormalMap">Convert from RGB to DTXnm.</param>
+        /// <param name="tex">Imported texture.</param>
+        /// <returns>True if texture exists and has been imported.</returns>
+        public static bool TryImportTextureFromDisk(string path, bool mipMaps, bool encodeAsNormalMap, out Texture2D tex)
+        {
+            if (!path.EndsWith(extension))
+                path += extension;
+
+            if (File.Exists(path))
             {
-                if (textureMap == TextureMap.Normal)
-                    tex = ImportNormalMap(directory, fileName);
-                else
-                    tex = ImportTextureFile(directory, fileName, mipMaps);
+                tex = ImportTextureFromDisk(path, mipMaps, encodeAsNormalMap);
                 return true;
             }
 
             tex = null;
             return false;
-        }
-
-        /// <summary>
-        /// Import png file from disk as Texture2D.
-        /// </summary>
-        /// <param name="path">Path where image file is located.</param>
-        /// <param name="name">Name of image file without extension.</param>
-        /// <param name="texture">Texture.</param>
-        /// <param name="mapTag">Texture map.</param>
-        [Obsolete("Use 'TryImportTextureFromDisk' with more options")]
-        static public bool ImportTextureFromDisk(string path, string name, out Texture2D texture, TextureMap map = TextureMap.Albedo)
-        {
-            return TryImportTextureFromDisk(path, name, map, true, out texture);
         }
 
         #endregion
@@ -471,10 +300,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static public void CustomizeMaterial(int archive, int record, int frame, Material material)
         {
             // MetallicGloss map
-            if (CustomMetallicGlossExist(archive, record, frame))
+            Texture2D metallicGloss;
+            if (TryImportTextureFromLooseFiles(archive, record, frame, TextureMap.MetallicGloss, out metallicGloss))
             {
                 material.EnableKeyword("_METALLICGLOSSMAP");
-                material.SetTexture("_MetallicGlossMap", LoadCustomMetallicGloss(archive, record, frame));
+                material.SetTexture("_MetallicGlossMap", metallicGloss);
             }
 
             // Properties
@@ -618,10 +448,14 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// </summary>
         /// <param name="button">Button</param>
         /// <param name="colorName">Name of texture</param>
-        static public void SetCustomButton(ref Button button, string colorName)
+        static public bool TryCustomizeButton(ref Button button, string colorName)
         {
+            Texture2D tex;
+            if (!TryImportTexture(colorName, out tex))
+                return false;
+
             // Load texture
-            button.BackgroundTexture = LoadCustomTexture(colorName);
+            button.BackgroundTexture = tex;
             button.BackgroundTexture.filterMode = (FilterMode)DaggerfallUnity.Settings.GUIFilterMode;
 
             // Load settings from Xml
@@ -638,12 +472,14 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     else if (value == "notext") // Disable text. This is useful if text is drawn on texture
                         button.Label.Text = string.Empty;
                 }
-            }            
+            }
+
+            return true;
         }
 
         #endregion
 
-        #region Utilities
+        #region Public Helpers
 
         /// <summary>
         /// Get name for a texture.
@@ -761,6 +597,20 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
+        /// Seek a texture on disk inside <see cref="TexturesPath"/> without importing it.
+        /// </summary>
+        /// <param name="archive">Texture archive.</param>
+        /// <param name="record">Record index.</param>
+        /// <param name="frame">Frame index.</param>
+        /// <param name="textureMap">Texture type.</param>
+        /// <returns>True if texture is found.</returns>
+        public static bool TextureExistsAmongLooseFiles(int archive, int record, int frame = 0, TextureMap textureMap = TextureMap.Albedo)
+        {
+            return DaggerfallUnity.Settings.MeshAndTextureReplacement
+                && File.Exists(Path.Combine(texturesPath, GetName(archive, record, frame, textureMap) + extension));
+        }
+
+        /// <summary>
         /// Get a safe size for a control based on resolution of img.
         /// </summary>
         public static Vector2 GetSize(Texture2D texture, string textureName, bool allowXml = false)
@@ -829,61 +679,6 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         #region Private Methods
 
         /// <summary>
-        /// True if image file is found inside loose files and settings allow import.
-        /// </summary>
-        /// <param name="path">Path to file on disk.</param>
-        /// <param name="fileName">Name of file without extension.</param>
-        private static bool TextureFileExist (string path, string name)
-        {
-            return DaggerfallUnity.Settings.MeshAndTextureReplacement
-                && File.Exists(Path.Combine(path, name + extension));
-        }
-
-        /// <summary>
-        /// Import image file as texture2D from loose files.
-        /// </summary>
-        /// <param name="path">Path to file on disk.</param>
-        /// <param name="fileName">Name of file without extension.</param>
-        /// <param name="mipMaps">Enable MipMaps?</param>
-        private static Texture2D ImportTextureFile (string path, string fileName, bool mipMaps = false)
-        {
-            // Create empty texture, size will be the actual size of .png file
-            Texture2D tex = new Texture2D(4, 4, TextureFormat, mipMaps);
-
-            // Load image as Texture2D
-            tex.LoadImage(File.ReadAllBytes(Path.Combine(path, fileName + extension)));
-
-#if DEBUG_TEXTURE_FORMAT    
-            Debug.LogFormat("{0}: {1} - mipmaps requested: {2}, mipmaps count : {3}", fileName, tex.format, mipMaps, tex.mipmapCount);
-#endif
-
-            return tex;
-        }
-
-        /// <summary>
-        /// Import image file as Normal Map texture2D from loose files.
-        /// </summary>
-        /// <param name="path">Path to file on disk.</param>
-        /// <param name="fileName">Name of file without extension.</param>
-        private static Texture2D ImportNormalMap (string path, string fileName)
-        {
-            // Get texture
-            Texture2D tex = ImportTextureFile(path, fileName, true);
-
-            // RGBA to DXTnm
-            Color32[] colours = tex.GetPixels32();
-            for (int i = 0; i < colours.Length; i++)
-            {
-                colours[i].a = colours[i].r;
-                colours[i].r = colours[i].b = colours[i].g;
-            }
-            tex.SetPixels32(colours);
-            tex.Apply();
-
-            return tex;
-        }
-
-        /// <summary>
         /// Seek material from mods.
         /// </summary>
         /// <param name="name">Name of material.</param>
@@ -914,11 +709,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             if (DaggerfallUnity.Settings.MeshAndTextureReplacement)
             {
                 // Seek from loose files
-                if (File.Exists(Path.Combine(path, name + extension)))
-                {
-                    tex = ImportTextureFile(path, name);
+                if (TryImportTextureFromDisk(Path.Combine(path, name), false, false, out tex))
                     return true;
-                }
 
                 // Seek from mods
                 if (ModManager.Instance != null)
@@ -951,6 +743,41 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
             texFrames = null;
             return false;
+        }
+
+        /// <summary>
+        /// Import data from a file on disk as a texture.
+        /// </summary>
+        /// <param name="path">Location of texture file.</param>
+        /// <param name="fileName">Name of texture file.</param>
+        /// <param name="mipMaps">Enable mipmaps?</param>
+        /// <param name="encodeAsNormalMap">Convert from RGB to DTXnm.</param>
+        /// <returns>Imported texture2D.</returns>
+        private static Texture2D ImportTextureFromDisk(string path, bool mipMaps = false, bool encodeAsNormalMap = false)
+        {
+            // Load texture file
+            Texture2D tex = new Texture2D(4, 4, TextureFormat, mipMaps);
+            if (!tex.LoadImage(File.ReadAllBytes(path)))
+                Debug.LogErrorFormat("Failed to import texture data at {0}", path);
+
+            if (encodeAsNormalMap)
+            {
+                // RGBA to DXTnm
+                Color32[] colours = tex.GetPixels32();
+                for (int i = 0; i < colours.Length; i++)
+                {
+                    colours[i].a = colours[i].r;
+                    colours[i].r = colours[i].b = colours[i].g;
+                }
+                tex.SetPixels32(colours);
+                tex.Apply();
+            }
+
+#if DEBUG_TEXTURE_FORMAT
+            Debug.LogFormat("{0}: {1} - mipmaps requested: {2}, mipmaps count : {3}", fileName, tex.format, mipMaps, tex.mipmapCount);
+#endif
+
+            return tex;
         }
 
         /// <summary>
@@ -1004,7 +831,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 emission = cachedMaterial.emissionMap;
                 return true;
             }
-            else if (TryImportTexture(texturesPath, GetName(archive, record, frame), out albedo))
+            else if (TryImportTexture(archive, record, frame, out albedo))
             {
                 var filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
 
@@ -1013,7 +840,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
                 if (isEmissive)
                 {
-                    if (!TryImportTexture(texturesPath, GetName(archive, record, frame++, TextureMap.Emission), out emission))
+                    if (!TryImportTexture(archive, record, frame++, TextureMap.Emission, out emission))
                         emission = albedo;
                     emission.filterMode = filterMode;
                     cachedMaterial.emissionMap = emission;


### PR DESCRIPTION
* Terrain textures can be shipped in a single dfmod file.
* Removed some old methods for loose files import which are not needed anymore.

I'm using Shader.PropertyToID() because methods for access to shader properties have an int overload, which is faster than the string one (i believe the string method just call PropertyToID everytime).  I wrote a static class to holds all these values like the post processing stack does. What do you think of moving it to MaterialReader and use it project wide?