### PR TITLE
Minor adjustments to enemies

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -391,7 +391,7 @@ namespace DaggerfallWorkshop.Game
 
         private void TurnToTarget(Vector3 targetDirection)
         {
-            const float turnSpeed = 30f;
+            const float turnSpeed = 20f;
             //const float turnSpeed = 11.25f;
 
             if (classicUpdate)

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -355,10 +355,7 @@ namespace DaggerfallWorkshop.Game
             if (!senses.TargetIsWithinYawAngle(5.625f))
             {
                 TurnToTarget(direction.normalized);
-                // Returning here is closer to classic behavior but disabling
-                // it provides an easy trick to make enemies harder to outmaneuver,
-                // since the enemy will resume moving. May revisit this later.
-                //return;
+                return;
             }
 
             var motion = transform.forward * moveSpeed;

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -535,22 +535,17 @@ namespace DaggerfallWorkshop.Game.Formulas
                     damage = UnityEngine.Random.Range(weapon.GetBaseDamageMin(), weapon.GetBaseDamageMax() + 1);
                     damage += damageModifiers;
 
-                    // Apply damage modifier for Skeletal Warrior. Damage halved if using an edged weapon
-                    // rather than a blunt weapon.
-                    if (AITarget != null && AITarget.CareerIndex == (int)MonsterCareers.SkeletalWarrior
-                        && (weapon.flags & 0x10) == 0)
+                    if (AITarget != null && AITarget.CareerIndex == (int)MonsterCareers.SkeletalWarrior)
                     {
-                        damage /= 2;
-                    }
+                        // Apply edged-weapon damage modifier for Skeletal Warrior
+                        if ((weapon.flags & 0x10) == 0)
+                            damage /= 2;
 
-                    // Apply modifier for werebeasts. In classic, this applies to the Skeletal Warrior, but this is
-                    // probably a mistake. The Skeletal Warrior ID is 15, just 1 off from the Wereboar ID of 14, and
-                    // silver = anti-werebeast is something used elsewhere in the TES series.
-                    if (AITarget != null && (AITarget.CareerIndex == (int)MonsterCareers.Wereboar
-                        || AITarget.CareerIndex == (int)MonsterCareers.Werewolf)
-                        && weapon.NativeMaterialValue == (int)Items.WeaponMaterialTypes.Silver)
-                    {
-                        damage *= 2;
+                        // Apply silver weapon damage modifier for Skeletal Warrior
+                        // Arena applies a silver weapon damage bonus for undead enemies, which
+                        // is probably where this comes from.
+                        if (weapon.NativeMaterialValue == (int)Items.WeaponMaterialTypes.Silver)
+                            damage *= 2;
                     }
 
                     // TODO: Apply strength bonus from Mace of Molag Bal


### PR DESCRIPTION
- Change silver damage bonus back to Skeletal Warrior.

Recently someone working on OpenTESArena found that original Arena gives silver weapon damage bonuses against undead, so I no longer think this was a mistake. However, it might be a mistake or oversight that it only applies to the Skeletal Warrior and not other undead types. Changing that might affect gameplay too much, though, if it made undead enemies too easy, so I just put it back on the Skeletal Warrior like in classic.

- Make enemies stop when turning while pursuing again (not needed because of the faster turning now). This will remove the odd-looking behavior of dashing off to the side when you approach enemies from behind, etc.

About the turning, though, I think it may be too fast at the moment. Specifically, if an enemy goes from facing sideways to looking towards you the turn looks instantaneous. I think it should be slow enough that you see all the in-between animation frames.