### PR TITLE
Refinements to court screen/arresting

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -87,6 +87,7 @@ namespace DaggerfallWorkshop.Game.Entity
         protected Crimes crimeCommitted = 0; // TODO: Save/load
         protected bool haveShownSurrenderToGuardsDialogue = false; // TODO: Save/load
         protected bool arrested = false;
+        protected short halfOfLegalRepPlayerLostFromCrime = 0;
 
         private List<RoomRental_v1> rentedRooms = new List<RoomRental_v1>();
 
@@ -1279,13 +1280,24 @@ namespace DaggerfallWorkshop.Game.Entity
         public void LowerRepForCrime()
         {
             int regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
-
-            // Lower legal reputation
             regionData[regionIndex].LegalRep -= reputationLossPerCrime[(int)crimeCommitted];
 
             FactionFile.FactionData peopleFaction;
             FactionData.FindFactionByTypeAndRegion(15, regionIndex + 1, out peopleFaction);
+
             FactionData.ChangeReputation(peopleFaction.id, -(reputationLossPerCrime[(int)crimeCommitted] / 2));
+        }
+
+        public void RaiseLegalRepForDoingSentence()
+        {
+            int regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
+            regionData[regionIndex].LegalRep += (short)(halfOfLegalRepPlayerLostFromCrime - 1);
+
+            FactionFile.FactionData peopleFaction;
+            FactionData.FindFactionByTypeAndRegion(15, regionIndex + 1, out peopleFaction);
+
+            // Classic changes reputation here by (1 - halfOfLegalRepPlayerLostFromCrime) / 2). Probably a bug.
+            FactionData.ChangeReputation(peopleFaction.id, (halfOfLegalRepPlayerLostFromCrime - 1) / 2);
         }
 
         public bool SurrenderToCityGuards(bool voluntarySurrender)
@@ -1312,6 +1324,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public void CourtWindow()
         {
             arrested = true;
+            halfOfLegalRepPlayerLostFromCrime = (short)(reputationLossPerCrime[(int)crimeCommitted] / 2);
             DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenCourtWindow);
         }
 

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1288,20 +1288,25 @@ namespace DaggerfallWorkshop.Game.Entity
             FactionData.ChangeReputation(peopleFaction.id, -(reputationLossPerCrime[(int)crimeCommitted] / 2));
         }
 
-        public void SurrenderToCityGuards(bool voluntarySurrender)
+        public bool SurrenderToCityGuards(bool voluntarySurrender)
         {
             int regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
             short legalRep = regionData[regionIndex].LegalRep;
 
+            if (CurrentHealth <= 0)
+                return false;
+
             //SetHealth(1);
             if (legalRep < -20 && !voluntarySurrender)
-                SetHealth(0);
+                return false;
             else if (legalRep < -20 || legalRep > 0)
                 CourtWindow();
             else if ((DFRandom.rand() & 1) != 0 && !voluntarySurrender)
-                SetHealth(0);
+                return false;
             else
                 CourtWindow();
+
+            return true;
         }
 
         public void CourtWindow()

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -190,6 +190,8 @@ namespace DaggerfallWorkshop.Game.Serialization
         public DaggerfallDisease[] diseases;
         public EffectBundleSettings[] spellbook;
         public EntityEffectManager.EffectBundleSaveData_v1[] instancedEffectBundles;
+        public PlayerEntity.Crimes crimeCommitted;
+        public bool haveShownSurrenderToGuardsDialogue;
     }
 
     [fsObject("v1")]

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -140,6 +140,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             data.playerEntity.timeToBecomeVampireOrWerebeast = entity.TimeToBecomeVampireOrWerebeast;
             data.playerEntity.lastTimePlayerAteOrDrankAtTavern = entity.LastTimePlayerAteOrDrankAtTavern;
             data.playerEntity.spellbook = entity.SerializeSpellbook();
+            data.playerEntity.crimeCommitted = entity.CrimeCommitted;
+            data.playerEntity.haveShownSurrenderToGuardsDialogue = entity.HaveShownSurrenderToGuardsDialogue;
 
             data.playerEntity.regionData = entity.RegionData;
             data.playerEntity.rentedRooms = entity.RentedRooms.ToArray();
@@ -254,6 +256,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.DarkBrotherhoodRequirementTally = data.playerEntity.darkBrotherhoodRequirementTally;
             entity.TimeToBecomeVampireOrWerebeast = data.playerEntity.timeToBecomeVampireOrWerebeast;
             entity.LastTimePlayerAteOrDrankAtTavern = data.playerEntity.lastTimePlayerAteOrDrankAtTavern;
+            entity.CrimeCommitted = data.playerEntity.crimeCommitted;
+            entity.HaveShownSurrenderToGuardsDialogue = data.playerEntity.haveShownSurrenderToGuardsDialogue;
             entity.SetCurrentLevelUpSkillSum();
 
             entity.RentedRooms = (data.playerEntity.rentedRooms != null) ? data.playerEntity.rentedRooms.ToList() : new List<RoomRental_v1>();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -134,12 +134,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 // TODO: Chance to free player if in Dark Brotherhood or Thieves Guild
 
-                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
+                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this, false, 105);
                 messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextID1));
-                messageBox.ParentPanel.BackgroundColor = Color.clear;
+                messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
                 messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Guilty);
                 messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.NotGuilty);
                 messageBox.OnButtonClick += GuiltyNotGuilty_OnButtonClick;
+                messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
                 uiManager.PushWindow(messageBox);
                 state = 1;
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -37,6 +37,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         MessageBoxButtons selectedButton = MessageBoxButtons.Cancel;
         bool clickAnywhereToClose = false;
         DaggerfallMessageBox nextMessageBox;
+        int customYPos = -1;
 
         /// <summary>
         /// Default message box buttons are indices into BUTTONS.RCI.
@@ -95,7 +96,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             set { clickAnywhereToClose = value; }
         }
 
-        public DaggerfallMessageBox(IUserInterfaceManager uiManager, IUserInterfaceWindow previous = null, bool wrapText = false)
+        public DaggerfallMessageBox(IUserInterfaceManager uiManager, IUserInterfaceWindow previous = null, bool wrapText = false, int posY = -1)
             : base(uiManager, previous)
         {
             if (wrapText)
@@ -105,6 +106,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // it is the widest text can be without making the parchment textures expand off the edges of the screen.
                 label.MaxTextWidth = 288;
             }
+
+            if (posY > -1)
+                customYPos = posY;
         }
 
         public DaggerfallMessageBox(IUserInterfaceManager uiManager, CommonMessageBoxButtons buttons, TextFile.Token[] tokens, IUserInterfaceWindow previous = null, IMacroContextProvider mcp = null)
@@ -133,7 +137,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             base.Setup();
 
             messagePanel.HorizontalAlignment = HorizontalAlignment.Center;
-            messagePanel.VerticalAlignment = VerticalAlignment.Middle;
+
+            if (customYPos > -1)
+            {
+                messagePanel.VerticalAlignment = VerticalAlignment.None;
+                messagePanel.Position = new Vector2(messagePanel.Position.x, customYPos);
+            }
+            else
+                messagePanel.VerticalAlignment = VerticalAlignment.Middle;
+
             DaggerfallUI.Instance.SetDaggerfallPopupStyle(DaggerfallUI.PopupStyle.Parchment, messagePanel);
             NativePanel.Components.Add(messagePanel);
 


### PR DESCRIPTION
Moved the message down and removed the background dimming. The court screen is already a dark screen and you can't see it clearly if it is dimmed.

Of course as I'm sure you know Interkarma there is no dimming for any pop-up messages in classic. I've been generally leaving it in place in DF Unity because I assume you put it in because you like it, but I don't know if you have anything decided about it. For this case at least I think it looks better without.