### PR TITLE
Progress court screen

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -189,7 +189,7 @@ namespace DaggerfallWorkshop.Game
                 if (entity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
                 {
                     // If hit by a guard, lower reputation and show the surrender dialogue
-                    if (!playerEntity.HaveShownSurrenderToGuardsDialogue)
+                    if (!playerEntity.HaveShownSurrenderToGuardsDialogue && playerEntity.CrimeCommitted != PlayerEntity.Crimes.None)
                     {
                         playerEntity.LowerRepForCrime();
 

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1308,7 +1308,7 @@ namespace DaggerfallWorkshop.Game.Entity
             if (CurrentHealth <= 0)
                 return false;
 
-            //SetHealth(1);
+            SetHealth(1);
             if (legalRep < -20 && !voluntarySurrender)
                 return false;
             else if (legalRep < -20 || legalRep > 0)

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -593,6 +593,25 @@ namespace DaggerfallWorkshop.Game
         }
 
         /// <summary>
+        /// Clears the area of enemies.
+        /// </summary>
+        public void ClearEnemies()
+        {
+            DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
+            for (int i = 0; i < entityBehaviours.Length; i++)
+            {
+                DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
+                if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
+                    Destroy(entityBehaviour);
+            }
+
+            // Also check for enemy spawners that might emit an enemy
+            FoeSpawner[] spawners = FindObjectsOfType<FoeSpawner>();
+            for (int i = 0; i < spawners.Length; i++)
+                Destroy(spawners[i]);
+        }
+
+        /// <summary>
         /// Make all enemies in an area go hostile.
         /// </summary>
         public void MakeEnemiesHostile()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -15,6 +15,7 @@ using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
+using DaggerfallConnect;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -27,7 +28,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int courtTextStart = 8050;
         const int courtTextFoundGuilty = 8055;
         const int courtTextExecuted = 8060;
+        const int courtTextFreeToGo = 8062;
         const int courtTextBanished = 8063;
+        const int courtTextHowConvince = 8064;
 
         Texture2D nativeTexture;
         Panel courtPanel = new Panel();
@@ -74,7 +77,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (state == 0)
+            if (state == 0) // Starting
             {
                 regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
 
@@ -147,44 +150,56 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 messageBox.OnButtonClick += GuiltyNotGuilty_OnButtonClick;
                 messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
                 uiManager.PushWindow(messageBox);
-                state = 1;
+                state = 1; // Done with initial message
             }
-            else if (state == 2)
+            else if (state == 2) // Found guilty
             {
-                DaggerfallUI.MessageBox(courtTextFoundGuilty);
+                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this, false, 149);
+                messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextFoundGuilty));
+                messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
+                messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                uiManager.PushWindow(messageBox);
                 state = 3;
             }
-            else if (state == 3)
+            else if (state == 3) // Serve prison sentence
             {
                 PositionPlayerAtLocationEntrance();
-                //ServeTime(daysInPrison);
-                //HealPlayer();
+                ServeTime(daysInPrison);
                 playerEntity.RaiseLegalRepForDoingSentence();
                 state = 100;
             }
-            else if (state == 5)
+            else if (state == 4) // Banished
             {
-                DaggerfallUI.MessageBox(courtTextBanished);
-                //playerEntity.SetHeavyPunishmentFlags(currentRegionID, 1);
+                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this, false, 149);
+                messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextBanished));
+                messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
+                messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                uiManager.PushWindow(messageBox);
+                playerEntity.RegionData[regionIndex].SeverePunishmentFlags |= 1;
                 PositionPlayerAtLocationEntrance();
                 state = 100;
             }
-            else if (state == 6)
+            // Note: Seems like an execution sentence can't be given in classic. It can't be given here, either.
+            else if (state == 5) // Execution
             {
-                DaggerfallUI.MessageBox(courtTextExecuted);
-                //playerEntity.SetHeavyPunishmentFlags(currentRegionID, 2);
-                state = 7;
+                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this, false, 149);
+                messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextExecuted));
+                messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
+                messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                uiManager.PushWindow(messageBox);
+                playerEntity.RegionData[regionIndex].SeverePunishmentFlags |= 2;
+                state = 6;
             }
-            else if (state == 7)
+            else if (state == 6) // Reposition player at entrance
             {
                 PositionPlayerAtLocationEntrance();
                 state = 100;
             }
-            else if (state == 100)
+            else if (state == 100) // Done
             {
                 ReleaseFromJail();
             }
-    }
+        }
 
         private void GuiltyNotGuilty_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
         {
@@ -194,7 +209,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (punishmentType != 0)
                 {
                     if (punishmentType == 1)
-                        state = 6;
+                        state = 5;
                     else
                     {
                         fine >>= 1;
@@ -214,10 +229,76 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     }
                 }
                 else
-                    state = 5;
+                    state = 4;
+            }
+            else // Pleading not guilty
+            {
+                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this, false, 127);
+                messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextHowConvince));
+                messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
+                messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Debate);
+                messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Lie);
+                messageBox.OnButtonClick += DebateLie_OnButtonClick;
+                messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                uiManager.PushWindow(messageBox);
+            }
+        }
+
+        private void DebateLie_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
+        {
+            sender.CloseWindow();
+            int playerSkill = 0;
+            if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Debate)
+            {
+                playerSkill = playerEntity.Skills.GetLiveSkillValue(DFCareer.Skills.Etiquette);
+                playerEntity.TallySkill(DFCareer.Skills.Etiquette, 1);
             }
             else
-                DaggerfallUI.MessageBox("Not implemented yet. Press ESC to exit.");
+            {
+                playerSkill = playerEntity.Skills.GetLiveSkillValue(DFCareer.Skills.Streetwise);
+                playerEntity.TallySkill(DFCareer.Skills.Streetwise, 1);
+            }
+
+            int chanceToGoFree = playerEntity.RegionData[regionIndex].LegalRep +
+                (playerSkill + playerEntity.Stats.GetLiveStatValue(DFCareer.Stats.Personality)) / 2;
+
+            if (chanceToGoFree > 95)
+                chanceToGoFree = 95;
+            else if (chanceToGoFree < 5)
+                chanceToGoFree = 5;
+
+            if (UnityEngine.Random.Range(1, 101) > chanceToGoFree)
+            {
+                // Banishment
+                if (punishmentType == 0)
+                    state = 4;
+                // Execution
+                else if (punishmentType == 1)
+                    state = 5;
+                // Prison/Fine
+                else
+                {
+                    int roll = playerEntity.RegionData[regionIndex].LegalRep + UnityEngine.Random.Range(1, 101);
+                    if (roll < 25)
+                        fine *= 2;
+                    else if (roll > 75)
+                        fine >>= 1;
+
+                    state = 2;
+                }
+            }
+            else
+            {
+                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this, false, 149);
+                messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextFreeToGo));
+                messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
+                messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                uiManager.PushWindow(messageBox);
+
+                // Oversight in classic: Does not refill vital signs unless prison time is served, so player is left with 1 health.
+                playerEntity.FillVitalSigns();
+                state = 6;
+            }
         }
 
         public override void OnPop()
@@ -237,6 +318,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 reposition = StreamingWorld.RepositionMethods.RandomStartMarker;
                 world.TeleportToCoordinates(mapPixel.X, mapPixel.Y, reposition);
             }
+        }
+
+        public void ServeTime(int daysInPrison)
+        {
+            // TODO
+            DaggerfallUnity.WorldTime.DaggerfallDateTime.RaiseTime(daysInPrison * 1440 * 60);
+            playerEntity.FillVitalSigns();
         }
 
         public void ReleaseFromJail()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -158,6 +158,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextFoundGuilty));
                 messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
                 messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                messageBox.ClickAnywhereToClose = true;
                 uiManager.PushWindow(messageBox);
                 state = 3;
             }
@@ -174,6 +175,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextBanished));
                 messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
                 messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                messageBox.ClickAnywhereToClose = true;
                 uiManager.PushWindow(messageBox);
                 playerEntity.RegionData[regionIndex].SeverePunishmentFlags |= 1;
                 PositionPlayerAtLocationEntrance();
@@ -186,6 +188,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextExecuted));
                 messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
                 messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                messageBox.ClickAnywhereToClose = true;
                 uiManager.PushWindow(messageBox);
                 playerEntity.RegionData[regionIndex].SeverePunishmentFlags |= 2;
                 state = 6;
@@ -224,6 +227,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         {
                             // Give the reputation raise here if no prison time will be served.
                             PositionPlayerAtLocationEntrance();
+
+                            // Oversight in classic: Does not refill vital signs when releasing in this case, so player is left with 1 health.
+                            playerEntity.FillVitalSigns();
                             ReleaseFromJail();
                         }
                     }
@@ -242,6 +248,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
                 uiManager.PushWindow(messageBox);
             }
+            Update();
         }
 
         private void DebateLie_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
@@ -293,12 +300,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(courtTextFreeToGo));
                 messageBox.ScreenDimColor = new Color32(0, 0, 0, 0);
                 messageBox.ParentPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                messageBox.ClickAnywhereToClose = true;
                 uiManager.PushWindow(messageBox);
 
-                // Oversight in classic: Does not refill vital signs unless prison time is served, so player is left with 1 health.
+                // Oversight in classic: Does not refill vital signs when releasing in this case, so player is left with 1 health.
                 playerEntity.FillVitalSigns();
                 state = 6;
             }
+            Update();
         }
 
         public override void OnPop()
@@ -322,15 +331,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public void ServeTime(int daysInPrison)
         {
-            // TODO
+            // TODO: Prison screen
+            playerEntity.PreventEnemySpawns = true;
             DaggerfallUnity.WorldTime.DaggerfallDateTime.RaiseTime(daysInPrison * 1440 * 60);
             playerEntity.FillVitalSigns();
         }
 
         public void ReleaseFromJail()
         {
+            playerEntity.PreventEnemySpawns = true;
             DaggerfallUnity.WorldTime.DaggerfallDateTime.RaiseTime(240 * 60);
             playerEntity.CrimeCommitted = Entity.PlayerEntity.Crimes.None;
+            GameManager.Instance.ClearEnemies();
             CancelWindow();
         }
     }


### PR DESCRIPTION
Player can now choose "Not Guilty" and try to debate or lie.
Time is now passed for prison sentence (still no prison screen).
Flags set for execution/banishment. (No effect yet. They are supposed to cause guards to spawn when player enters a settlement in that region from then on)
Messages positioned correctly.

Unfortunately, the pause at the end when returning the player from the court screen seems to be even longer now (perhaps because of raising time for the prison sentence). People will probably think the game has frozen so this needs to be fixed. Any ideas? 