### PR TITLE
Fix enemies shooting bow too much

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -302,7 +302,7 @@ namespace DaggerfallWorkshop.Game
                     if (mobile.Summary.Enemy.HasRangedAttack1 && mobile.Summary.Enemy.ID > 129 && mobile.Summary.Enemy.ID != 132)
                     {
                         // Random chance to shoot bow
-                        if (DFRandom.rand() < 1000)
+                        if (classicUpdate && DFRandom.rand() < 1000)
                         {
                             if (mobile.Summary.Enemy.HasRangedAttack1 && !mobile.Summary.Enemy.HasRangedAttack2
                                 && mobile.Summary.EnemyState != MobileStates.RangedAttack1)


### PR DESCRIPTION
My earlier fix in https://github.com/Interkarma/daggerfall-unity/pull/657 included removing a limiter on the AI decision code that timed it to classic's slower update rate, but doing so made bow attacks way too rapid. This fixes it by putting it back for the ranged attack (while also avoiding the earlier problem that was the reason I removed it).