### PR TITLE
Fixed a talk window bug

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -174,6 +174,8 @@ namespace DaggerfallWorkshop.Game
         int currentKeySubjectBuildingKey = -1;
         int reactionToPlayer = 0;
 
+
+        //The lists that contain the topics to select
         List<ListItem> listTopicTellMeAbout;
         List<ListItem> listTopicLocation;
         List<ListItem> listTopicPerson;
@@ -973,7 +975,7 @@ namespace DaggerfallWorkshop.Game
             if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)
                 answer = getRecordIdByNpcsSocialGroup(7281, 7280, 7280, 7283, 7282, 7284); // messages if npc does not know
             else
-            {                
+            {
                 answer = getRecordIdByNpcsSocialGroup(7271, 7270, 7270, 7273, 7272, 7274); // location related messages if npc knows
             }
             return answer;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -1197,10 +1197,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // inListboxTopicContentUpdate to false again before!)
             if (inListboxTopicContentUpdate)
                 return;
+
+            if (index < 0 || index >= listboxTopic.Count) 
+                return;
+
             inListboxTopicContentUpdate = true;
 
-            if (index < 0 || index >= listboxTopic.Count)
-                return;
 
             TalkManager.ListItem listItem = listCurrentTopics[index];
             if (listItem.type == TalkManager.ListItemType.NavigationBack)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Michael Rauter (Nystul)
-// Contributors:    
+// Contributors:    Kenny Stepney (TheExceptionist)
 // 
 // Notes:
 //


### PR DESCRIPTION
I noticed a dialogue bug when switching from the "Where is -> Person" to "Where is -> Location". The root cause the variable "inListboxTopicContentUpdate" remaining true after the player asked "Where is -> Person". I rearranged when the variable is set to true to solve this issue.

Relatively small fix, but I'm still getting used to the codebase :)