### PR TITLE
Add TG and DB bribing judge, and fixes

### DIFF
--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -107,6 +107,9 @@ namespace DaggerfallWorkshop.Game.Entity
                 return;
             }
 
+            if (careerIndex == (int)MobileTypes.Knight_CityWatch)
+                level += UnityEngine.Random.Range(3, 7);
+
             this.mobileEnemy = mobileEnemy;
             this.entityType = entityType;
             name = career.Name;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1288,7 +1288,7 @@ namespace DaggerfallWorkshop.Game.Entity
             FactionData.ChangeReputation(peopleFaction.id, -(reputationLossPerCrime[(int)crimeCommitted] / 2));
         }
 
-        public void RaiseLegalRepForDoingSentence()
+        public void RaiseReputationForDoingSentence()
         {
             int regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
             regionData[regionIndex].LegalRep += (short)(halfOfLegalRepPlayerLostFromCrime - 1);

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -602,13 +602,13 @@ namespace DaggerfallWorkshop.Game
             {
                 DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
                 if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
-                    Destroy(entityBehaviour);
+                    Destroy(entityBehaviour.gameObject);
             }
 
             // Also check for enemy spawners that might emit an enemy
             FoeSpawner[] spawners = FindObjectsOfType<FoeSpawner>();
             for (int i = 0; i < spawners.Length; i++)
-                Destroy(spawners[i]);
+                Destroy(spawners[i].gameObject);
         }
 
         /// <summary>


### PR DESCRIPTION
- Adds Thieves Guild and Dark Brotherhood bribing judge.
- Fixes enemy-clearing method I added last time (it should have been destroying the game objects)
- Addressed a couple oversights in classic. The player should always be healed and get their reputation partly repaired if they are found not guilty now.