### PR TITLE
Migrate Speed Changes from PlayerMotor to PlayerSpeedChanger

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -350,16 +350,16 @@ namespace Wenzil.Console
             public static string Execute(params string[] args)
             {
                 int speed;
-                PlayerMotor playerMotor = GameManager.Instance.PlayerMotor;//GameObject.FindObjectOfType<PlayerMotor>();
+                PlayerSpeedChanger speedChanger = GameManager.Instance.SpeedChanger;
 
-                if (playerMotor == null)
+                if (speedChanger == null)
                     return error;
 
                 if (args == null || args.Length < 1)
                 {
                     try
                     {
-                        Console.Log(string.Format("Current Walk Speed: {0}", playerMotor.GetWalkSpeed(GameManager.Instance.PlayerEntity)));
+                        Console.Log(string.Format("Current Walk Speed: {0}", speedChanger.GetWalkSpeed(GameManager.Instance.PlayerEntity)));
                         return HelpCommand.Execute(SetWalkSpeed.name);
 
                     }
@@ -373,13 +373,13 @@ namespace Wenzil.Console
                     return error;
                 else if (speed == -1)
                 {
-                    playerMotor.useWalkSpeedOverride = false;
+                    speedChanger.useWalkSpeedOverride = false;
                     return string.Format("Walk speed set to default.");
                 }
                 else
                 {
-                    playerMotor.useWalkSpeedOverride = true;
-                    playerMotor.walkSpeedOverride = speed;
+                    speedChanger.useWalkSpeedOverride = true;
+                    speedChanger.walkSpeedOverride = speed;
                     return string.Format("Walk speed set to: {0}", speed);
                 }
 
@@ -396,16 +396,16 @@ namespace Wenzil.Console
             public static string Execute(params string[] args)
             {
                 int speed;
-                PlayerMotor playerMotor = GameManager.Instance.PlayerMotor;//GameObject.FindObjectOfType<PlayerMotor>();
+                PlayerSpeedChanger speedChanger = GameManager.Instance.SpeedChanger;//GameObject.FindObjectOfType<PlayerMotor>();
 
-                if (playerMotor == null)
+                if (speedChanger == null)
                     return error;
 
                 if (args == null || args.Length < 1)
                 {
                     try
                     {
-                        Console.Log(string.Format("Current RunSpeed: {0}", playerMotor.GetRunSpeed(playerMotor.GetWalkSpeed(GameManager.Instance.PlayerEntity))));
+                        Console.Log(string.Format("Current RunSpeed: {0}", speedChanger.GetRunSpeed(speedChanger.GetWalkSpeed(GameManager.Instance.PlayerEntity))));
                         return HelpCommand.Execute(SetRunSpeed.name);
 
                     }
@@ -422,13 +422,13 @@ namespace Wenzil.Console
                 }
                 else if (speed == -1)
                 {
-                    playerMotor.useRunSpeedOverride = false;
+                    speedChanger.useRunSpeedOverride = false;
                     return string.Format("Run speed set to default.");
                 }
                 else
                 {
-                    playerMotor.runSpeedOverride = speed;
-                    playerMotor.useRunSpeedOverride = true;
+                    speedChanger.runSpeedOverride = speed;
+                    speedChanger.useRunSpeedOverride = true;
                     return string.Format("Run speed set to: {0}", speed);
                 }
             }

--- a/Assets/Prefabs/Player/PlayerAdvanced.prefab
+++ b/Assets/Prefabs/Player/PlayerAdvanced.prefab
@@ -34,6 +34,7 @@ GameObject:
   - component: {fileID: 114863256343619774}
   - component: {fileID: 114189154217185308}
   - component: {fileID: 114126215008192106}
+  - component: {fileID: 114232921892998986}
   m_Layer: 0
   m_Name: PlayerAdvanced
   m_TagString: Player
@@ -554,10 +555,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c9bfb03a8545a343883f7d2606b5814, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  walkSpeedOverride: 6
-  useWalkSpeedOverride: 0
-  runSpeedOverride: 11
-  useRunSpeedOverride: 0
   standingHeight: 1.78
   eyeHeight: 0.09
   crouchingHeight: 0.45
@@ -1061,6 +1058,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18474689034f2b543b96b936e271914b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &114232921892998986
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 923e44bd2b461494586a0930c79739f4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  walkSpeedOverride: 6
+  useWalkSpeedOverride: 0
+  runSpeedOverride: 11
+  useRunSpeedOverride: 0
 --- !u!114 &114338371543951144
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1227,6 +1239,8 @@ MonoBehaviour:
   bobSpeed: 0
   bobXAmount: 0
   bobYAmount: 0
+  nodXAmount: 0
+  nodYAmount: 0
   bobScalar: 0
 --- !u!198 &198237622866876544
 ParticleSystem:

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -109,7 +109,7 @@ namespace DaggerfallWorkshop.Game
             {
                 // Take the speed of movement during the attack animation and hit frame into account when calculating attack range
                 EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
-                float attackSpeed = ((entity.Stats.LiveSpeed + PlayerMotor.dfWalkBase) / PlayerMotor.classicToUnitySpeedUnitRatio) / EnemyMotor.AttackSpeedDivisor;
+                float attackSpeed = ((entity.Stats.LiveSpeed + PlayerSpeedChanger.dfWalkBase) / PlayerSpeedChanger.classicToUnitySpeedUnitRatio) / EnemyMotor.AttackSpeedDivisor;
                 float timeUntilHit = mobile.Summary.Enemy.HitFrame / DaggerfallWorkshop.Utility.EnemyBasics.PrimaryAttackAnimSpeed;
 
                 if (senses.DistanceToPlayer >= (MeleeDistance + (attackSpeed * timeUntilHit)))

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -203,19 +203,19 @@ namespace DaggerfallWorkshop.Game
             {
                 // Limit knockBackSpeed. This can be higher than what is actually used for the speed of motion,
                 // making it last longer and do more damage if the enemy collides with something.
-                if (knockBackSpeed > (40 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10)))
-                    knockBackSpeed = (40 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10));
+                if (knockBackSpeed > (40 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)))
+                    knockBackSpeed = (40 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10));
 
-                if (knockBackSpeed > (5 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10)) &&
+                if (knockBackSpeed > (5 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)) &&
                     mobile.Summary.EnemyState != MobileStates.PrimaryAttack)
                     mobile.ChangeEnemyState(MobileStates.Hurt);
 
                 // Actual speed of motion is limited
                 Vector3 motion;
-                if (knockBackSpeed <= (25 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10)))
+                if (knockBackSpeed <= (25 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)))
                     motion = knockBackDirection * knockBackSpeed;
                 else
-                    motion = knockBackDirection * (25 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10));
+                    motion = knockBackDirection * (25 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10));
 
                 if (swims)
                 {
@@ -228,8 +228,8 @@ namespace DaggerfallWorkshop.Game
 
                 if (classicUpdate)
                 {
-                    knockBackSpeed -= (5 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10));
-                    if (knockBackSpeed <= (5 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10)) &&
+                    knockBackSpeed -= (5 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10));
+                    if (knockBackSpeed <= (5 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)) &&
                         mobile.Summary.EnemyState != MobileStates.PrimaryAttack)
                         mobile.ChangeEnemyState(MobileStates.Move);
                 }
@@ -239,7 +239,7 @@ namespace DaggerfallWorkshop.Game
 
             // Monster speed of movement follows the same formula as for when the player walks
             EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
-            float moveSpeed = ((entity.Stats.LiveSpeed + PlayerMotor.dfWalkBase) / PlayerMotor.classicToUnitySpeedUnitRatio);
+            float moveSpeed = ((entity.Stats.LiveSpeed + PlayerSpeedChanger.dfWalkBase) / PlayerSpeedChanger.classicToUnitySpeedUnitRatio);
 
             // Reduced speed if playing a one-shot animation
             if (mobile.IsPlayingOneShot())

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -63,6 +63,7 @@ namespace DaggerfallWorkshop.Game
         GameObject streamingTarget = null;
         SaveLoadManager saveLoadManager = null;
         PlayerMotor playerMotor = null;
+        PlayerSpeedChanger speedChanger = null;
         FloatingOrigin floatingOrigin = null;
         FPSWeapon[] playerWeapons = new FPSWeapon[2];
         FPSSpellCasting playerSpellCasting = null;
@@ -225,6 +226,12 @@ namespace DaggerfallWorkshop.Game
         {
             get { return (saveLoadManager) ? saveLoadManager : saveLoadManager = GetMonoBehaviour<SaveLoadManager>(); }
             set { saveLoadManager = value; }
+        }
+        
+        public PlayerSpeedChanger SpeedChanger
+        {
+            get { return (speedChanger) ? speedChanger : speedChanger = GetMonoBehaviour<PlayerSpeedChanger>(); }
+            set { speedChanger = value; }
         }
 
         public PlayerMotor PlayerMotor

--- a/Assets/Scripts/Game/LevitateMotor.cs
+++ b/Assets/Scripts/Game/LevitateMotor.cs
@@ -24,6 +24,7 @@ namespace DaggerfallWorkshop.Game
         bool playerLevitating = false;
         bool playerSwimming = false;
         PlayerMotor playerMotor;
+        PlayerSpeedChanger speedChanger;
         Camera playerCamera;
         float moveSpeed = 4.0f;
         CollisionFlags collisionFlags = 0;
@@ -48,6 +49,7 @@ namespace DaggerfallWorkshop.Game
         private void Start()
         {
             playerMotor = GetComponent<PlayerMotor>();
+            speedChanger = GetComponent<PlayerSpeedChanger>();
             playerCamera = GameManager.Instance.MainCamera;
         }
 
@@ -88,13 +90,13 @@ namespace DaggerfallWorkshop.Game
                     direction.y = 0;
 
                 Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-                float baseSpeed = playerMotor.GetBaseSpeed();
-                moveSpeed = playerMotor.GetSwimSpeed(baseSpeed);
+                float baseSpeed = speedChanger.GetBaseSpeed();
+                moveSpeed = speedChanger.GetSwimSpeed(baseSpeed);
             }
 
             // There's a fixed speed for up/down movement
             if (upOrDown)
-                moveSpeed = 80f / PlayerMotor.classicToUnitySpeedUnitRatio;
+                moveSpeed = 80f / PlayerSpeedChanger.classicToUnitySpeedUnitRatio;
 
             collisionFlags = playerMotor.controller.Move(direction * moveSpeed * Time.deltaTime);
             // Reset to levitate speed in case it has been changed by swimming

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -1,0 +1,83 @@
+﻿using DaggerfallConnect;
+using DaggerfallWorkshop.Game;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DaggerfallWorkshop.Game
+{
+    //Added the RequireComponent attribute to make sure that following components are indeed on this GameObject, since they are require to make this code work
+    [RequireComponent(typeof(PlayerMotor))]
+    [RequireComponent(typeof(CharacterController))]
+    public class PlayerSpeedChanger : MonoBehaviour
+    {
+        private PlayerMotor playerMotor;
+        private CharacterController controller;
+        private Camera mainCamera;
+
+        // Daggerfall base speed constants. (courtesy Allofich)
+        public const float classicToUnitySpeedUnitRatio = 39.5f; // was estimated from comparing a walk over the same distance in classic and DF Unity
+        public const float dfWalkBase = 150f;
+        private const float dfCrouchBase = 50f;
+        private const float dfRideBase = dfWalkBase + 225f;
+        private const float dfCartBase = dfWalkBase + 100f;
+
+        public float walkSpeedOverride = 6.0f;
+        public bool useWalkSpeedOverride = false;
+
+        public float runSpeedOverride = 11.0f;
+        public bool useRunSpeedOverride = false;
+
+        private void Start()
+        {
+            playerMotor = GameManager.Instance.PlayerMotor;//GetComponent<PlayerMotor>();
+            controller = GetComponent<CharacterController>();
+            mainCamera = GameManager.Instance.MainCamera;
+        }
+
+        private void Update()
+        {
+
+        }
+
+        public float GetBaseSpeed()
+        {
+            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            float baseSpeed = 0;
+            float playerSpeed = player.Stats.LiveSpeed;
+            if (playerMotor == null) // fixes null reference bug.
+                playerMotor = GameManager.Instance.PlayerMotor;
+            if (playerMotor.IsCrouching)
+                baseSpeed = (playerSpeed + dfCrouchBase) / classicToUnitySpeedUnitRatio;
+            else if (playerMotor.IsRiding)
+                baseSpeed = (playerSpeed + dfRideBase) / classicToUnitySpeedUnitRatio;
+            else
+                baseSpeed = GetWalkSpeed(player);
+            return baseSpeed;
+        }
+
+        public float GetWalkSpeed(Entity.PlayerEntity player)
+        {
+            if (useWalkSpeedOverride == true)
+                return walkSpeedOverride;
+            else
+                return (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
+        }
+
+        public float GetRunSpeed(float baseSpeed)
+        {
+            if (useRunSpeedOverride)
+                return runSpeedOverride;
+            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            float runSpeed = baseSpeed * (1.25f + (player.Skills.GetLiveSkillValue(DFCareer.Skills.Running) / 200f));
+            return runSpeed;
+        }
+
+        public float GetSwimSpeed(float baseSpeed)
+        {
+            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            float swimSpeed = (baseSpeed * (player.Skills.GetLiveSkillValue(DFCareer.Skills.Swimming) / 200f)) + (baseSpeed / 4);
+            return swimSpeed;
+        }
+    }
+}

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs.meta
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 923e44bd2b461494586a0930c79739f4
+timeCreated: 1525661293
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -16,13 +16,6 @@ namespace DaggerfallWorkshop.Game
     [RequireComponent(typeof(CharacterController))]
     public class PlayerMotor : MonoBehaviour
     {
-        // Daggerfall base speed constants. (courtesy Allofich)
-        public const float classicToUnitySpeedUnitRatio = 39.5f; // was estimated from comparing a walk over the same distance in classic and DF Unity
-        public const float dfWalkBase = 150f;
-        private const float dfCrouchBase = 50f;
-        private const float dfRideBase = dfWalkBase + 225f;
-        private const float dfCartBase = dfWalkBase + 100f;
-
         // Moving platform support
         Transform activePlatform;
         Vector3 activeLocalPlatformPoint;
@@ -30,12 +23,6 @@ namespace DaggerfallWorkshop.Game
         //Vector3 lastPlatformVelocity;
         Quaternion activeLocalPlatformRotation;
         Quaternion activeGlobalPlatformRotation;
-
-        public float walkSpeedOverride = 6.0f;
-        public bool useWalkSpeedOverride = false;
-
-        public float runSpeedOverride = 11.0f;
-        public bool useRunSpeedOverride = false;
 
         public float standingHeight = 1.78f;
         public float eyeHeight = 0.09f;         // Eye height is 9cm below top of capsule.
@@ -118,6 +105,7 @@ namespace DaggerfallWorkshop.Game
         private bool showClimbingModeMessage = true;
         private Vector2 lastHorizontalPosition = Vector2.zero;
         private Croucher myCroucher;
+        private PlayerSpeedChanger speedChanger;
 
         private CollisionFlags collisionFlags = 0;
 
@@ -133,7 +121,7 @@ namespace DaggerfallWorkshop.Game
 
         public bool IsRunning
         {
-            get { return speed == GetRunSpeed(GetBaseSpeed()); }
+            get { return speed == speedChanger.GetRunSpeed(speedChanger.GetBaseSpeed()); }
         }
 
         public bool IsStandingStill
@@ -174,9 +162,9 @@ namespace DaggerfallWorkshop.Game
                 }
                 if (isCrouching)
                 {
-                    return (GetWalkSpeed(GameManager.Instance.PlayerEntity) / 2) >= speed;
+                    return (speedChanger.GetWalkSpeed(GameManager.Instance.PlayerEntity) / 2) >= speed;
                 }
-                return (GetBaseSpeed() / 2) >= speed;
+                return (speedChanger.GetBaseSpeed() / 2) >= speed;
             }
         }
 
@@ -223,8 +211,9 @@ namespace DaggerfallWorkshop.Game
         void Start()
         {
             controller = GetComponent<CharacterController>();
+            speedChanger = GetComponent<PlayerSpeedChanger>();
             myTransform = transform;
-            speed = GetBaseSpeed();
+            speed = speedChanger.GetBaseSpeed();
             rayDistance = controller.height * .5f + controller.radius;
             slideLimit = controller.slopeLimit - .1f;
             jumpTimer = antiBunnyHopFactor;
@@ -382,7 +371,7 @@ namespace DaggerfallWorkshop.Game
                 }
 
                 // Get walking/crouching/riding speed
-                speed = GetBaseSpeed();
+                speed = speedChanger.GetBaseSpeed();
 
                 if (!riding)
                 {
@@ -393,11 +382,11 @@ namespace DaggerfallWorkshop.Game
                     {
                         // If running isn't on a toggle, then use the appropriate speed depending on whether the run button is down
                         if (!toggleRun && InputManager.Instance.HasAction(InputManager.Actions.Run))
-                            speed = GetRunSpeed(speed);
+                            speed = speedChanger.GetRunSpeed(speed);
                     }
                     catch
                     {
-                        speed = GetRunSpeed(speed);
+                        speed = speedChanger.GetRunSpeed(speed);
                     }
                 }
 
@@ -405,7 +394,7 @@ namespace DaggerfallWorkshop.Game
                 if (InputManager.Instance.HasAction(InputManager.Actions.Sneak))
                 {
                     speed /= 2;
-                    speed -= (1 / classicToUnitySpeedUnitRatio);
+                    speed -= (1 / PlayerSpeedChanger.classicToUnitySpeedUnitRatio);
                 }
 
                 // If sliding (and it's allowed), or if we're on an object tagged "Slide", get a vector pointing down the slope we're on
@@ -634,13 +623,13 @@ namespace DaggerfallWorkshop.Game
                     // If the run button is set to toggle, then switch between walk/run speed. (We use Update for this...
                     // FixedUpdate is a poor place to use GetButtonDown, since it doesn't necessarily run every frame and can miss the event)
                     if (toggleRun && grounded && InputManager.Instance.HasAction(InputManager.Actions.Run))
-                        speed = (speed == GetBaseSpeed() ? GetRunSpeed(speed) : GetBaseSpeed());
+                        speed = (speed == speedChanger.GetBaseSpeed() ? speedChanger.GetRunSpeed(speed) : speedChanger.GetBaseSpeed());
                     //if (toggleRun && grounded && Input.GetButtonDown("Run"))
                     //    speed = (speed == walkSpeed ? runSpeed : walkSpeed);
                 }
                 catch
                 {
-                    speed = GetRunSpeed(speed);
+                    speed = speedChanger.GetRunSpeed(speed);
                 }
 
                 // Toggle crouching
@@ -679,7 +668,7 @@ namespace DaggerfallWorkshop.Game
             {
                 float distanceMoved = Vector3.Distance(smoothFollowerPrevWorldPos, smoothFollower.position);        // Assuming the follower is a child of this motor transform we can get the distance travelled.
                 float maxPossibleDistanceByMotorVelocity = controller.velocity.magnitude * 2.0f * Time.deltaTime;   // Theoretically the max distance the motor can carry the player with a generous margin.
-                float speedThreshold = GetRunSpeed(speed) * Time.deltaTime;                                         // Without question any distance travelled less than the running speed is legal.
+                float speedThreshold = speedChanger.GetRunSpeed(speed) * Time.deltaTime;                                         // Without question any distance travelled less than the running speed is legal.
 
                 // NOTE: Maybe the min distance should also include the height different between crouching / standing.
                 if (distanceMoved > speedThreshold && distanceMoved > maxPossibleDistanceByMotorVelocity)
@@ -732,44 +721,6 @@ namespace DaggerfallWorkshop.Game
         {
             falling = false;
             fallStartLevel = transform.position.y;
-        }
-
-        public float GetBaseSpeed()
-        {
-            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-            float baseSpeed = 0;
-            float playerSpeed = player.Stats.LiveSpeed;
-            if (isCrouching)
-                baseSpeed = (playerSpeed + dfCrouchBase) / classicToUnitySpeedUnitRatio;
-            else if (riding)
-                baseSpeed = (playerSpeed + dfRideBase) / classicToUnitySpeedUnitRatio;
-            else
-                baseSpeed = GetWalkSpeed(player);
-            return baseSpeed;
-        }
-
-        public float GetWalkSpeed(Entity.PlayerEntity player)
-        {
-            if (useWalkSpeedOverride == true)
-                return walkSpeedOverride;
-            else
-                return (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
-        }
-
-        public float GetRunSpeed(float baseSpeed)
-        {
-            if (useRunSpeedOverride)
-                return runSpeedOverride;
-            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-            float runSpeed = baseSpeed * (1.25f + (player.Skills.GetLiveSkillValue(DFCareer.Skills.Running) / 200f));
-            return runSpeed;
-        }
-
-        public float GetSwimSpeed(float baseSpeed)
-        {
-            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-            float swimSpeed = (baseSpeed * (player.Skills.GetLiveSkillValue(DFCareer.Skills.Swimming) / 200f)) + (baseSpeed / 4);
-            return swimSpeed;
         }
 
         #region Private Methods

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -658,7 +658,7 @@ namespace DaggerfallWorkshop.Game
                             // Knock back enemy based on damage and enemy weight
                             if (enemyMotor)
                             {
-                                if (enemyMotor.KnockBackSpeed <= (5 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10)) &&
+                                if (enemyMotor.KnockBackSpeed <= (5 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)) &&
                                     entityBehaviour.EntityType == EntityTypes.EnemyClass ||
                                     enemyEntity.MobileEnemy.Weight > 0)
                                 {
@@ -668,10 +668,10 @@ namespace DaggerfallWorkshop.Game
 
                                     float knockBackAmount = ((tenTimesDamage - enemyWeight) * 256) / (enemyWeight + tenTimesDamage) * twoTimesDamage;
                                     float knockBackSpeed = (tenTimesDamage / enemyWeight) * (twoTimesDamage - (knockBackAmount / 256));
-                                    knockBackSpeed /= (PlayerMotor.classicToUnitySpeedUnitRatio / 10);
+                                    knockBackSpeed /= (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10);
 
-                                    if (knockBackSpeed < (15 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10)))
-                                        knockBackSpeed = (15 / (PlayerMotor.classicToUnitySpeedUnitRatio / 10));
+                                    if (knockBackSpeed < (15 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)))
+                                        knockBackSpeed = (15 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10));
                                     enemyMotor.KnockBackSpeed = knockBackSpeed;
                                     enemyMotor.KnockBackDirection = mainCamera.transform.forward;
                                 }


### PR DESCRIPTION
In this commit, all the code related to changing the player's speed is migrated to a separate class PlayerSpeedChanger.  All references to the module-level variables, constants, properties, constants, and methods have been copied and pasted to the new class.   All classes that reference the speed-related members and methods of PlayerMotor.cs (including code within PlayerMotor itself) have been updated to use PlayerSpeedChanger.  I tested it and fixed all null references.

I didn't notice any difference in gameplay with this commit.  Was wondering if it will make your task of rewriting PlayerMotor simpler?

This commit doesn't include the changes from the HeightChanger.  I used Github to see if the branches could be automatically merged and it showed no conflicts so I assume this won't conflict with the changes in HeightChanger pull request.

EDIT: after switching to Unity, and then switching to Github Desktop, it appears to have generated a playerAdvanced.prefab.  I included that file in another commit to this PR.