### PR TITLE
Use a few more faction enums

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -196,7 +196,7 @@ namespace DaggerfallConnect.Arena2
 
             Random_Noble = 242,
 
-            Teahers_of_Zen = 243,
+            Teachers_of_Zen = 243,
 
             Court_of_Balfiera = 244,
 

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1164,10 +1164,10 @@ namespace DaggerfallWorkshop.Game.Entity
                         //--item.power;
 
                     FactionFile.FactionData thievesGuild;
-                    FactionData.GetFactionData(42, out thievesGuild);
+                    FactionData.GetFactionData((int)FactionFile.FactionIDs.The_Thieves_Guild, out thievesGuild);
 
                     FactionFile.FactionData darkBrotherhood;
-                    FactionData.GetFactionData(108, out darkBrotherhood);
+                    FactionData.GetFactionData((int)FactionFile.FactionIDs.The_Dark_Brotherhood, out darkBrotherhood);
 
                     if (UnityEngine.Random.Range(0, 101) >= ((thievesGuild.power + darkBrotherhood.power) / 2 - item.power + 5) / 5)
                         TurnOffConditionFlag(item.region - 1, RegionDataFlags.CrimeWave);

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -1003,15 +1003,15 @@ namespace DaggerfallWorkshop.Game.Questing
             else if (stage == 5)
             {
                 GameManager.Instance.PlayerEntity.Level = 8;
-                GameManager.Instance.PlayerEntity.FactionData.ChangeReputation(510, 60);    // Merchants +60
+                GameManager.Instance.PlayerEntity.FactionData.ChangeReputation((int)FactionFile.FactionIDs.The_Merchants, 60);
                 InstantiateQuest("__MQSTAGE05");
                 InstantiateQuest("S0000977");
             }
             else if (stage == 6)
             {
                 GameManager.Instance.PlayerEntity.Level = 10;
-                GameManager.Instance.PlayerEntity.FactionData.ChangeReputation(363, 20);    // Medora +20
-                GameManager.Instance.PlayerEntity.FactionData.ChangeReputation(305, 20);    // King of Worms +20
+                GameManager.Instance.PlayerEntity.FactionData.ChangeReputation((int)FactionFile.FactionIDs.Medora, 20);
+                GameManager.Instance.PlayerEntity.FactionData.ChangeReputation((int)FactionFile.FactionIDs.King_of_Worms, 20);
                 GameManager.Instance.PlayerEntity.GlobalVars.SetGlobalVar(29, true);        // MyniseraSatisfied globalvar
                 GameManager.Instance.PlayerEntity.GlobalVars.SetGlobalVar(31, true);        // MetLadyBrisienna globalvar
                 GameManager.Instance.PlayerEntity.GlobalVars.SetGlobalVar(33, true);        // KingOfWormsSatisfied globalvar


### PR DESCRIPTION
Very minor PR. Just fixes a spelling error and uses the faction enums in a few more spots.

I started to go through the code looking for anywhere that faction IDs were used as numbers, but I wasn't sure of an effective way to search for that, and I came across usage of faction IDs defined within guild files, such as the factionID defined within the `ThievesGuild` class. I just left that alone, but I'm using the enums for the code I write.