### PR TITLE
Talkwindow - progress and fixes

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -345,13 +345,14 @@ namespace DaggerfallWorkshop.Game
             public Dictionary<ulong, QuestResources> dictQuestInfo;
             public List<RumorMillEntry> listRumorMill;
             public Dictionary<ulong, TextFile.Token[]> dictQuestorPostQuestMessage;
+            public Dictionary<int, NpcWorkEntry> npcsWithWork;
         }
 
         // faction IDs for factions listed in "tell me about"
         int[] infoFactionIDs = { 42, 40, 108, 129, 306, 353, 41, 67, 82, 84, 88, 92, 94, 106, 36, 83, 85, 89, 93, 95, 99, 107, 37, 368, 408, 409, 410, 411, 413, 414, 415, 416, 417, 98 };
 
         // Data for NPC "work" quests in the current town
-        struct NpcWorkEntry
+        public struct NpcWorkEntry
         {
             public StaticNPC.NPCData npc;
             public FactionFile.SocialGroups socialGroup;            
@@ -1603,6 +1604,7 @@ namespace DaggerfallWorkshop.Game
             saveDataConversation.dictQuestInfo = dictQuestInfo;
             saveDataConversation.listRumorMill = listRumorMill;
             saveDataConversation.dictQuestorPostQuestMessage = dictQuestorPostQuestMessage;
+            saveDataConversation.npcsWithWork = npcsWithWork;
             return saveDataConversation;
         }
 
@@ -1669,6 +1671,9 @@ namespace DaggerfallWorkshop.Game
             {
                 dictQuestorPostQuestMessage = new Dictionary<ulong, TextFile.Token[]>();
             }
+
+            if (data.npcsWithWork != null)
+                npcsWithWork = data.npcsWithWork;
 
             // update topic list
             AssembleTopiclistTellMeAbout();

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -564,6 +564,8 @@ namespace DaggerfallWorkshop.Game
             npcData.race = targetMobileNPC.Race;
 
             this.reactionToPlayer = reactionToPlayer;
+
+            AssembleTopicListPerson(); // update "Where Is" -> "Person" list since this list may hide the questor (if talking to the questor)
         }
 
         public void SetTargetNPC(StaticNPC targetNPC, int reactionToPlayer, ref bool sameTalkTargetAsBefore)
@@ -622,8 +624,6 @@ namespace DaggerfallWorkshop.Game
             const int likePlayerGreetingTextId = 7208;
             const int veryLikePlayerGreetingTextId = 7209;
 
-            string greetingString = "";
-
             if (currentNPCType == NPCType.Static)
             {
                 foreach(KeyValuePair<ulong, TextFile.Token[]> entry in dictQuestorPostQuestMessage)
@@ -644,35 +644,21 @@ namespace DaggerfallWorkshop.Game
                                 // expand tokens and reveal dialog-linked resources
                                 QuestMacroHelper macroHelper = new QuestMacroHelper();
                                 macroHelper.ExpandQuestMessage(GameManager.Instance.QuestMachine.GetQuest(questID), ref tokens, true);
-                                greetingString = TokensToString(tokens);
-
-                                return (greetingString);                                
+                                return TokensToString(tokens);                              
                             }
                         }
                     }
                 }
             }
 
-            if (reactionToPlayer >= 0)
-            {
-                if (reactionToPlayer >= 10)
-                {
-                    if (reactionToPlayer >= 30)
-                        greetingString = expandRandomTextRecord(veryLikePlayerGreetingTextId);
-                    else
-                        greetingString = expandRandomTextRecord(likePlayerGreetingTextId);
-                }
-                else
-                {
-                    greetingString = expandRandomTextRecord(neutralToPlayerGreetingTextId);
-                }
-            }
-            else
-            {
-                greetingString = expandRandomTextRecord(dislikePlayerGreetingTextId);
-            }
-            
-            return (greetingString);
+            if (reactionToPlayer >= 30)
+                return expandRandomTextRecord(veryLikePlayerGreetingTextId);
+            else if (reactionToPlayer >= 10)
+                return expandRandomTextRecord(likePlayerGreetingTextId);
+            else if (reactionToPlayer >= 0)
+                return expandRandomTextRecord(neutralToPlayerGreetingTextId);
+            else            
+                return expandRandomTextRecord(dislikePlayerGreetingTextId);
         }
 
         public string GetPCGreetingText(DaggerfallTalkWindow.TalkTone talkTone)
@@ -1082,46 +1068,26 @@ namespace DaggerfallWorkshop.Game
             if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)
             {
                 // messages if npc does not know
-                if (reactionToPlayer >= 0)
-                {
-                    if (reactionToPlayer >= 10)
-                    {
-                        if (reactionToPlayer >= 30)
-                            return getRecordIdByNpcsSocialGroup(veryLikePlayerDoesNotKnowWhereIsDefault, veryLikePlayerDoesNotKnowWhereIsGuildMembers, veryLikePlayerDoesNotKnowWhereIsMerchants, veryLikePlayerDoesNotKnowWhereIsScholars, veryLikePlayerDoesNotKnowWhereIsNobility, veryLikePlayerDoesNotKnowWhereIsUnderworld);
-                        else
-                            return getRecordIdByNpcsSocialGroup(likePlayerDoesNotKnowWhereIsDefault, likePlayerDoesNotKnowWhereIsGuildMembers, likePlayerDoesNotKnowWhereIsMerchants, likePlayerDoesNotKnowWhereIsScholars, likePlayerDoesNotKnowWhereIsNobility, likePlayerDoesNotKnowWhereIsUnderworld);
-                    }
-                    else
-                    {
-                        return getRecordIdByNpcsSocialGroup(neutralToPlayerDoesNotKnowWhereIsDefault, neutralToPlayerDoesNotKnowWhereIsGuildMembers, neutralToPlayerDoesNotKnowWhereIsMerchants, neutralToPlayerDoesNotKnowWhereIsScholars, neutralToPlayerDoesNotKnowWhereIsNobility, neutralToPlayerDoesNotKnowWhereIsUnderworld);
-                    }
-                }
+                if (reactionToPlayer >= 30)
+                    return getRecordIdByNpcsSocialGroup(veryLikePlayerDoesNotKnowWhereIsDefault, veryLikePlayerDoesNotKnowWhereIsGuildMembers, veryLikePlayerDoesNotKnowWhereIsMerchants, veryLikePlayerDoesNotKnowWhereIsScholars, veryLikePlayerDoesNotKnowWhereIsNobility, veryLikePlayerDoesNotKnowWhereIsUnderworld);
+                else if (reactionToPlayer >= 10)
+                    return getRecordIdByNpcsSocialGroup(likePlayerDoesNotKnowWhereIsDefault, likePlayerDoesNotKnowWhereIsGuildMembers, likePlayerDoesNotKnowWhereIsMerchants, likePlayerDoesNotKnowWhereIsScholars, likePlayerDoesNotKnowWhereIsNobility, likePlayerDoesNotKnowWhereIsUnderworld);
+                else if (reactionToPlayer >= 0)
+                    return getRecordIdByNpcsSocialGroup(neutralToPlayerDoesNotKnowWhereIsDefault, neutralToPlayerDoesNotKnowWhereIsGuildMembers, neutralToPlayerDoesNotKnowWhereIsMerchants, neutralToPlayerDoesNotKnowWhereIsScholars, neutralToPlayerDoesNotKnowWhereIsNobility, neutralToPlayerDoesNotKnowWhereIsUnderworld);
                 else
-                {
                     return getRecordIdByNpcsSocialGroup(dislikePlayerDoesNotKnowWhereIsDefault, dislikePlayerDoesNotKnowWhereIsGuildMembers, dislikePlayerDoesNotKnowWhereIsMerchants, dislikePlayerDoesNotKnowWhereIsScholars, dislikePlayerDoesNotKnowWhereIsNobility, dislikePlayerDoesNotKnowWhereIsUnderworld);
-                }
             }
             else
             {
                 // location related messages if npc knows
-                if (reactionToPlayer >= 0)
-                {
-                    if (reactionToPlayer >= 10)
-                    {
-                        if (reactionToPlayer >= 30)
-                            return getRecordIdByNpcsSocialGroup(veryLikePlayerAnswerWhereIsDefault, veryLikePlayerAnswerWhereIsGuildMembers, veryLikePlayerAnswerWhereIsMerchants, veryLikePlayerAnswerWhereIsScholars, veryLikePlayerAnswerWhereIsNobility, veryLikePlayerAnswerWhereIsUnderworld);
-                        else
-                            return getRecordIdByNpcsSocialGroup(likePlayerAnswerWhereIsDefault, likePlayerAnswerWhereIsGuildMembers, likePlayerAnswerWhereIsMerchants, likePlayerAnswerWhereIsScholars, likePlayerAnswerWhereIsNobility, likePlayerAnswerWhereIsUnderworld);
-                    }
-                    else
-                    {
-                        return getRecordIdByNpcsSocialGroup(neutralToPlayerAnswerWhereIsDefault, neutralToPlayerAnswerWhereIsGuildMembers, neutralToPlayerAnswerWhereIsMerchants, neutralToPlayerAnswerWhereIsScholars, neutralToPlayerAnswerWhereIsNobility, neutralToPlayerAnswerWhereIsUnderworld);
-                    }
-                }
+                if (reactionToPlayer >= 30)
+                    return getRecordIdByNpcsSocialGroup(veryLikePlayerAnswerWhereIsDefault, veryLikePlayerAnswerWhereIsGuildMembers, veryLikePlayerAnswerWhereIsMerchants, veryLikePlayerAnswerWhereIsScholars, veryLikePlayerAnswerWhereIsNobility, veryLikePlayerAnswerWhereIsUnderworld);
+                else if (reactionToPlayer >= 10)
+                    return getRecordIdByNpcsSocialGroup(likePlayerAnswerWhereIsDefault, likePlayerAnswerWhereIsGuildMembers, likePlayerAnswerWhereIsMerchants, likePlayerAnswerWhereIsScholars, likePlayerAnswerWhereIsNobility, likePlayerAnswerWhereIsUnderworld);
+                else if (reactionToPlayer >= 0)
+                    return getRecordIdByNpcsSocialGroup(neutralToPlayerAnswerWhereIsDefault, neutralToPlayerAnswerWhereIsGuildMembers, neutralToPlayerAnswerWhereIsMerchants, neutralToPlayerAnswerWhereIsScholars, neutralToPlayerAnswerWhereIsNobility, neutralToPlayerAnswerWhereIsUnderworld);
                 else
-                {
                     return getRecordIdByNpcsSocialGroup(dislikePlayerAnswerWhereIsDefault, dislikePlayerAnswerWhereIsGuildMembers, dislikePlayerAnswerWhereIsMerchants, dislikePlayerAnswerWhereIsScholars, dislikePlayerAnswerWhereIsNobility, dislikePlayerAnswerWhereIsUnderworld);
-                }
             }
         }
 
@@ -1313,46 +1279,26 @@ namespace DaggerfallWorkshop.Game
             if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)
             {
                 // messages if npc does not know
-                if (reactionToPlayer >= 0)
-                {
-                    if (reactionToPlayer >= 10)
-                    {
-                        if (reactionToPlayer >= 30)
-                            return getRecordIdByNpcsSocialGroup(veryLikePlayerDoesNotKnowWhereIsDefault, veryLikePlayerDoesNotKnowWhereIsGuildMembers, veryLikePlayerDoesNotKnowWhereIsMerchants, veryLikePlayerDoesNotKnowWhereIsScholars, veryLikePlayerDoesNotKnowWhereIsNobility, veryLikePlayerDoesNotKnowWhereIsUnderworld);
-                        else
-                            return getRecordIdByNpcsSocialGroup(likePlayerDoesNotKnowWhereIsDefault, likePlayerDoesNotKnowWhereIsGuildMembers, likePlayerDoesNotKnowWhereIsMerchants, likePlayerDoesNotKnowWhereIsScholars, likePlayerDoesNotKnowWhereIsNobility, likePlayerDoesNotKnowWhereIsUnderworld);
-                    }
-                    else
-                    {
-                        return getRecordIdByNpcsSocialGroup(neutralToPlayerDoesNotKnowWhereIsDefault, neutralToPlayerDoesNotKnowWhereIsGuildMembers, neutralToPlayerDoesNotKnowWhereIsMerchants, neutralToPlayerDoesNotKnowWhereIsScholars, neutralToPlayerDoesNotKnowWhereIsNobility, neutralToPlayerDoesNotKnowWhereIsUnderworld);
-                    }
-                }
+                if (reactionToPlayer >= 30)
+                    return getRecordIdByNpcsSocialGroup(veryLikePlayerDoesNotKnowWhereIsDefault, veryLikePlayerDoesNotKnowWhereIsGuildMembers, veryLikePlayerDoesNotKnowWhereIsMerchants, veryLikePlayerDoesNotKnowWhereIsScholars, veryLikePlayerDoesNotKnowWhereIsNobility, veryLikePlayerDoesNotKnowWhereIsUnderworld);
+                else if (reactionToPlayer >= 10)
+                    return getRecordIdByNpcsSocialGroup(likePlayerDoesNotKnowWhereIsDefault, likePlayerDoesNotKnowWhereIsGuildMembers, likePlayerDoesNotKnowWhereIsMerchants, likePlayerDoesNotKnowWhereIsScholars, likePlayerDoesNotKnowWhereIsNobility, likePlayerDoesNotKnowWhereIsUnderworld);
+                else if (reactionToPlayer >= 0)
+                    return getRecordIdByNpcsSocialGroup(neutralToPlayerDoesNotKnowWhereIsDefault, neutralToPlayerDoesNotKnowWhereIsGuildMembers, neutralToPlayerDoesNotKnowWhereIsMerchants, neutralToPlayerDoesNotKnowWhereIsScholars, neutralToPlayerDoesNotKnowWhereIsNobility, neutralToPlayerDoesNotKnowWhereIsUnderworld);
                 else
-                {
                     return getRecordIdByNpcsSocialGroup(dislikePlayerDoesNotKnowWhereIsDefault, dislikePlayerDoesNotKnowWhereIsGuildMembers, dislikePlayerDoesNotKnowWhereIsMerchants, dislikePlayerDoesNotKnowWhereIsScholars, dislikePlayerDoesNotKnowWhereIsNobility, dislikePlayerDoesNotKnowWhereIsUnderworld);
-                }
             }
             else
             {
                 // location related messages if npc knows
-                if (reactionToPlayer >= 0)
-                {
-                    if (reactionToPlayer >= 10)
-                    {
-                        if (reactionToPlayer >= 30)
-                            return getRecordIdByNpcsSocialGroup(veryLikePlayerAnswerWhereIsDefault, veryLikePlayerAnswerWhereIsGuildMembers, veryLikePlayerAnswerWhereIsMerchants, veryLikePlayerAnswerWhereIsScholars, veryLikePlayerAnswerWhereIsNobility, veryLikePlayerAnswerWhereIsUnderworld);
-                        else
-                            return getRecordIdByNpcsSocialGroup(likePlayerAnswerWhereIsDefault, likePlayerAnswerWhereIsGuildMembers, likePlayerAnswerWhereIsMerchants, likePlayerAnswerWhereIsScholars, likePlayerAnswerWhereIsNobility, likePlayerAnswerWhereIsUnderworld);
-                    }
-                    else
-                    {
-                        return getRecordIdByNpcsSocialGroup(neutralToPlayerAnswerWhereIsDefault, neutralToPlayerAnswerWhereIsGuildMembers, neutralToPlayerAnswerWhereIsMerchants, neutralToPlayerAnswerWhereIsScholars, neutralToPlayerAnswerWhereIsNobility, neutralToPlayerAnswerWhereIsUnderworld);
-                    }
-                }
+                if (reactionToPlayer >= 30)
+                    return getRecordIdByNpcsSocialGroup(veryLikePlayerAnswerWhereIsDefault, veryLikePlayerAnswerWhereIsGuildMembers, veryLikePlayerAnswerWhereIsMerchants, veryLikePlayerAnswerWhereIsScholars, veryLikePlayerAnswerWhereIsNobility, veryLikePlayerAnswerWhereIsUnderworld);
+                else if (reactionToPlayer >= 10)
+                    return getRecordIdByNpcsSocialGroup(likePlayerAnswerWhereIsDefault, likePlayerAnswerWhereIsGuildMembers, likePlayerAnswerWhereIsMerchants, likePlayerAnswerWhereIsScholars, likePlayerAnswerWhereIsNobility, likePlayerAnswerWhereIsUnderworld);
+                else if (reactionToPlayer >= 0)
+                    return getRecordIdByNpcsSocialGroup(neutralToPlayerAnswerWhereIsDefault, neutralToPlayerAnswerWhereIsGuildMembers, neutralToPlayerAnswerWhereIsMerchants, neutralToPlayerAnswerWhereIsScholars, neutralToPlayerAnswerWhereIsNobility, neutralToPlayerAnswerWhereIsUnderworld);
                 else
-                {
                     return getRecordIdByNpcsSocialGroup(dislikePlayerAnswerWhereIsDefault, dislikePlayerAnswerWhereIsGuildMembers, dislikePlayerAnswerWhereIsMerchants, dislikePlayerAnswerWhereIsScholars, dislikePlayerAnswerWhereIsNobility, dislikePlayerAnswerWhereIsUnderworld);
-                }
             }
         }
 
@@ -2019,8 +1965,6 @@ namespace DaggerfallWorkshop.Game
                     ulong questID = questInfo.Key;
                     itemQuestTopic.questID = questID;
                     string captionString = questResourceInfo.Key;
-                    //QuestMacroHelper macroHelper = new QuestMacroHelper();
-                    //macroHelper.ExpandQuestString(GameManager.Instance.QuestMachine.GetQuest(questID), ref captionString);
                     itemQuestTopic.caption = captionString;
 
                     if (questResourceInfo.Value.availableForDialog && questResourceInfo.Value.hasEntryInTellMeAbout) // only make it available for talk if it is not "hidden" by dialog link command
@@ -2106,10 +2050,6 @@ namespace DaggerfallWorkshop.Game
                             item.questID = questID;
 
                             string captionString = questResourceInfo.Key;
-                            // Questing.Place place = (Questing.Place)questResourceInfo.Value.questResource;
-                            // string buildingName = place.SiteDetails.buildingName;
-                            // captionString = buildingName;
-
                             item.caption = captionString;
                             item.buildingKey = place.SiteDetails.buildingKey;
 
@@ -2281,7 +2221,7 @@ namespace DaggerfallWorkshop.Game
                         }
                         else
                         {
-                            /*
+                            /* - note: found a different way to do it via mapId
                             try
                             {
                                 IsPlayerInSameLocationWorldCell = ((Questing.Person)questResourceInfo.Value.questResource).IsPlayerInSameLocationWorldCell();
@@ -2315,16 +2255,6 @@ namespace DaggerfallWorkshop.Game
         private void AssembleTopicListThing()
         {            
             listTopicThing = new List<ListItem>();
-            /*
-            for (int i = 0; i < 30; i++)
-            {
-                ListItem item = new ListItem();
-                item.type = ListItemType.Item;
-                item.questionType = QuestionType.Thing;
-                item.caption = "thing " + i;
-                listTopicThing.Add(item);
-            }
-            */
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -92,6 +92,64 @@ namespace DaggerfallWorkshop.Game
         #region Fields
 
         const string textDatabase = "ConversationText";
+
+        // dislike answer set (doesn't tell)
+        const int dislikePlayerAnswerWhereIsDefault = 7256;
+        const int dislikePlayerAnswerWhereIsGuildMembers = 7255;
+        const int dislikePlayerAnswerWhereIsMerchants = 7256;
+        const int dislikePlayerAnswerWhereIsNobility = 7258;
+        const int dislikePlayerAnswerWhereIsScholars = 7257;
+        const int dislikePlayerAnswerWhereIsUnderworld = 7259;
+        // neutral answer set
+        const int neutralToPlayerAnswerWhereIsDefault = 7271;
+        const int neutralToPlayerAnswerWhereIsGuildMembers = 7270;
+        const int neutralToPlayerAnswerWhereIsMerchants = 7271;
+        const int neutralToPlayerAnswerWhereIsScholars = 7272;
+        const int neutralToPlayerAnswerWhereIsNobility = 7273;
+        const int neutralToPlayerAnswerWhereIsUnderworld = 7274;
+        // like answer set
+        const int likePlayerAnswerWhereIsDefault = 7291;
+        const int likePlayerAnswerWhereIsGuildMembers = 7290;
+        const int likePlayerAnswerWhereIsMerchants = 7291;
+        const int likePlayerAnswerWhereIsScholars = 7292;
+        const int likePlayerAnswerWhereIsNobility = 7293;
+        const int likePlayerAnswerWhereIsUnderworld = 7294;
+        // very like answer set
+        const int veryLikePlayerAnswerWhereIsDefault = 7286;
+        const int veryLikePlayerAnswerWhereIsGuildMembers = 7285;
+        const int veryLikePlayerAnswerWhereIsMerchants = 7286;
+        const int veryLikePlayerAnswerWhereIsScholars = 7287;
+        const int veryLikePlayerAnswerWhereIsNobility = 7288;
+        const int veryLikePlayerAnswerWhereIsUnderworld = 7289;
+
+        // dislike does not know set
+        const int dislikePlayerDoesNotKnowWhereIsDefault = 7251;
+        const int dislikePlayerDoesNotKnowWhereIsGuildMembers = 7250;
+        const int dislikePlayerDoesNotKnowWhereIsMerchants = 7251;
+        const int dislikePlayerDoesNotKnowWhereIsNobility = 7252;
+        const int dislikePlayerDoesNotKnowWhereIsScholars = 7253;
+        const int dislikePlayerDoesNotKnowWhereIsUnderworld = 7251; // no matching underworld set (7254 is empty), use 7251 instead
+        // neutral does not know set
+        const int neutralToPlayerDoesNotKnowWhereIsDefault = 7266;
+        const int neutralToPlayerDoesNotKnowWhereIsGuildMembers = 7265;
+        const int neutralToPlayerDoesNotKnowWhereIsMerchants = 7266;
+        const int neutralToPlayerDoesNotKnowWhereIsScholars = 7267;
+        const int neutralToPlayerDoesNotKnowWhereIsNobility = 7268;
+        const int neutralToPlayerDoesNotKnowWhereIsUnderworld = 7269;
+        // like does not know set
+        const int likePlayerDoesNotKnowWhereIsDefault = 7281;
+        const int likePlayerDoesNotKnowWhereIsGuildMembers = 7280;
+        const int likePlayerDoesNotKnowWhereIsMerchants = 7281;
+        const int likePlayerDoesNotKnowWhereIsScholars = 7282;
+        const int likePlayerDoesNotKnowWhereIsNobility = 7283;
+        const int likePlayerDoesNotKnowWhereIsUnderworld = 7284;
+        // very like does not know set
+        const int veryLikePlayerDoesNotKnowWhereIsDefault = 7281;
+        const int veryLikePlayerDoesNotKnowWhereIsGuildMembers = 7280;
+        const int veryLikePlayerDoesNotKnowWhereIsMerchants = 7281;
+        const int veryLikePlayerDoesNotKnowWhereIsScholars = 7282;
+        const int veryLikePlayerDoesNotKnowWhereIsNobility = 7283;
+        const int veryLikePlayerDoesNotKnowWhereIsUnderworld = 7284;
      
         // specifies entry type of list item in topic lists
         public enum ListItemType
@@ -502,7 +560,7 @@ namespace DaggerfallWorkshop.Game
             }
             else
             {
-                DaggerfallUI.MessageBox(youGetNoResponseTextId);
+                DaggerfallUI.MessageBox(youGetNoResponseTextId); // TODO: rejection text handling (vanilla gives different texts)
             }
         }
 
@@ -1031,24 +1089,60 @@ namespace DaggerfallWorkshop.Game
 
         public string GetAnswerWhereIs(TalkManager.ListItem listItem)
         {
-            string answer;
-
             if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.NotSet)
             {
-                // chances unknown - so there is a 50% chance for now that npc knows
+                // chances unknown - so there is a 50% chance for now that npc knows - TODO: apply correct chances here
                 int randomNum = UnityEngine.Random.Range(0, 2);
                 if (randomNum == 0)
                     listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.DoesNotKnowAboutItem;
                 else
                     listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.KnowsAboutItem;
             }
-
-            // TODO: take into account if npc likes you for answers here as well (use different sets here depending on how much npc likes you)
-            if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)                
-                answer = getRecordIdByNpcsSocialGroup(7281, 7280, 7280, 7283, 7282, 7284); // messages if npc does not know
+            
+            if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)
+            {
+                // messages if npc does not know
+                if (reactionToPlayer >= 0)
+                {
+                    if (reactionToPlayer >= 10)
+                    {
+                        if (reactionToPlayer >= 30)
+                            return getRecordIdByNpcsSocialGroup(veryLikePlayerDoesNotKnowWhereIsDefault, veryLikePlayerDoesNotKnowWhereIsGuildMembers, veryLikePlayerDoesNotKnowWhereIsMerchants, veryLikePlayerDoesNotKnowWhereIsScholars, veryLikePlayerDoesNotKnowWhereIsNobility, veryLikePlayerDoesNotKnowWhereIsUnderworld);
+                        else
+                            return getRecordIdByNpcsSocialGroup(likePlayerDoesNotKnowWhereIsDefault, likePlayerDoesNotKnowWhereIsGuildMembers, likePlayerDoesNotKnowWhereIsMerchants, likePlayerDoesNotKnowWhereIsScholars, likePlayerDoesNotKnowWhereIsNobility, likePlayerDoesNotKnowWhereIsUnderworld);
+                    }
+                    else
+                    {
+                        return getRecordIdByNpcsSocialGroup(neutralToPlayerDoesNotKnowWhereIsDefault, neutralToPlayerDoesNotKnowWhereIsGuildMembers, neutralToPlayerDoesNotKnowWhereIsMerchants, neutralToPlayerDoesNotKnowWhereIsScholars, neutralToPlayerDoesNotKnowWhereIsNobility, neutralToPlayerDoesNotKnowWhereIsUnderworld);
+                    }
+                }
+                else
+                {
+                    return getRecordIdByNpcsSocialGroup(dislikePlayerDoesNotKnowWhereIsDefault, dislikePlayerDoesNotKnowWhereIsGuildMembers, dislikePlayerDoesNotKnowWhereIsMerchants, dislikePlayerDoesNotKnowWhereIsScholars, dislikePlayerDoesNotKnowWhereIsNobility, dislikePlayerDoesNotKnowWhereIsUnderworld);
+                }
+            }
             else
-                answer = getRecordIdByNpcsSocialGroup(7271, 7270, 7270, 7273, 7272, 7274); // location related messages if npc knows
-            return answer;
+            {
+                // location related messages if npc knows
+                if (reactionToPlayer >= 0)
+                {
+                    if (reactionToPlayer >= 10)
+                    {
+                        if (reactionToPlayer >= 30)
+                            return getRecordIdByNpcsSocialGroup(veryLikePlayerAnswerWhereIsDefault, veryLikePlayerAnswerWhereIsGuildMembers, veryLikePlayerAnswerWhereIsMerchants, veryLikePlayerAnswerWhereIsScholars, veryLikePlayerAnswerWhereIsNobility, veryLikePlayerAnswerWhereIsUnderworld);
+                        else
+                            return getRecordIdByNpcsSocialGroup(likePlayerAnswerWhereIsDefault, likePlayerAnswerWhereIsGuildMembers, likePlayerAnswerWhereIsMerchants, likePlayerAnswerWhereIsScholars, likePlayerAnswerWhereIsNobility, likePlayerAnswerWhereIsUnderworld);
+                    }
+                    else
+                    {
+                        return getRecordIdByNpcsSocialGroup(neutralToPlayerAnswerWhereIsDefault, neutralToPlayerAnswerWhereIsGuildMembers, neutralToPlayerAnswerWhereIsMerchants, neutralToPlayerAnswerWhereIsScholars, neutralToPlayerAnswerWhereIsNobility, neutralToPlayerAnswerWhereIsUnderworld);
+                    }
+                }
+                else
+                {
+                    return getRecordIdByNpcsSocialGroup(dislikePlayerAnswerWhereIsDefault, dislikePlayerAnswerWhereIsGuildMembers, dislikePlayerAnswerWhereIsMerchants, dislikePlayerAnswerWhereIsScholars, dislikePlayerAnswerWhereIsNobility, dislikePlayerAnswerWhereIsUnderworld);
+                }
+            }
         }
 
         public string GetAnswerAboutRegionalBuilding(TalkManager.ListItem listItem)
@@ -1181,7 +1275,6 @@ namespace DaggerfallWorkshop.Game
             {
                 case QuestionType.NoQuestion:
                 default:
-                    answer = getRecordIdByNpcsSocialGroup(7281, 7280, 7280, 7283, 7282, 7284); // messages if npc does not know
                     break;
                 case QuestionType.News:
                     answer = GetNewsOrRumors();
@@ -1209,13 +1302,13 @@ namespace DaggerfallWorkshop.Game
                 case QuestionType.Work:
                     if (!WorkAvailable)
                     {
-                        answer = expandRandomTextRecord(8078);
+                        answer = expandRandomTextRecord(8078); // TODO: find when 8075 should be used
                         break;
                     }
                     else
                     {
                         SetRandomQuestor(); // Pick a random Work questor from the pool
-                        answer = expandRandomTextRecord(8076);
+                        answer = expandRandomTextRecord(8076); // TODO: find when 8077 should be used
                         break;
                     }
             }
@@ -1238,9 +1331,49 @@ namespace DaggerfallWorkshop.Game
             }
 
             if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)
-                return getRecordIdByNpcsSocialGroup(7281, 7280, 7280, 7283, 7282, 7284); // messages if npc does not know
+            {
+                // messages if npc does not know
+                if (reactionToPlayer >= 0)
+                {
+                    if (reactionToPlayer >= 10)
+                    {
+                        if (reactionToPlayer >= 30)
+                            return getRecordIdByNpcsSocialGroup(veryLikePlayerDoesNotKnowWhereIsDefault, veryLikePlayerDoesNotKnowWhereIsGuildMembers, veryLikePlayerDoesNotKnowWhereIsMerchants, veryLikePlayerDoesNotKnowWhereIsScholars, veryLikePlayerDoesNotKnowWhereIsNobility, veryLikePlayerDoesNotKnowWhereIsUnderworld);
+                        else
+                            return getRecordIdByNpcsSocialGroup(likePlayerDoesNotKnowWhereIsDefault, likePlayerDoesNotKnowWhereIsGuildMembers, likePlayerDoesNotKnowWhereIsMerchants, likePlayerDoesNotKnowWhereIsScholars, likePlayerDoesNotKnowWhereIsNobility, likePlayerDoesNotKnowWhereIsUnderworld);
+                    }
+                    else
+                    {
+                        return getRecordIdByNpcsSocialGroup(neutralToPlayerDoesNotKnowWhereIsDefault, neutralToPlayerDoesNotKnowWhereIsGuildMembers, neutralToPlayerDoesNotKnowWhereIsMerchants, neutralToPlayerDoesNotKnowWhereIsScholars, neutralToPlayerDoesNotKnowWhereIsNobility, neutralToPlayerDoesNotKnowWhereIsUnderworld);
+                    }
+                }
+                else
+                {
+                    return getRecordIdByNpcsSocialGroup(dislikePlayerDoesNotKnowWhereIsDefault, dislikePlayerDoesNotKnowWhereIsGuildMembers, dislikePlayerDoesNotKnowWhereIsMerchants, dislikePlayerDoesNotKnowWhereIsScholars, dislikePlayerDoesNotKnowWhereIsNobility, dislikePlayerDoesNotKnowWhereIsUnderworld);
+                }
+            }
             else
-                return getRecordIdByNpcsSocialGroup(7276, 7275, 7275, 7278, 7277, 7279); // quest topic related messages if npc knows
+            {
+                // location related messages if npc knows
+                if (reactionToPlayer >= 0)
+                {
+                    if (reactionToPlayer >= 10)
+                    {
+                        if (reactionToPlayer >= 30)
+                            return getRecordIdByNpcsSocialGroup(veryLikePlayerAnswerWhereIsDefault, veryLikePlayerAnswerWhereIsGuildMembers, veryLikePlayerAnswerWhereIsMerchants, veryLikePlayerAnswerWhereIsScholars, veryLikePlayerAnswerWhereIsNobility, veryLikePlayerAnswerWhereIsUnderworld);
+                        else
+                            return getRecordIdByNpcsSocialGroup(likePlayerAnswerWhereIsDefault, likePlayerAnswerWhereIsGuildMembers, likePlayerAnswerWhereIsMerchants, likePlayerAnswerWhereIsScholars, likePlayerAnswerWhereIsNobility, likePlayerAnswerWhereIsUnderworld);
+                    }
+                    else
+                    {
+                        return getRecordIdByNpcsSocialGroup(neutralToPlayerAnswerWhereIsDefault, neutralToPlayerAnswerWhereIsGuildMembers, neutralToPlayerAnswerWhereIsMerchants, neutralToPlayerAnswerWhereIsScholars, neutralToPlayerAnswerWhereIsNobility, neutralToPlayerAnswerWhereIsUnderworld);
+                    }
+                }
+                else
+                {
+                    return getRecordIdByNpcsSocialGroup(dislikePlayerAnswerWhereIsDefault, dislikePlayerAnswerWhereIsGuildMembers, dislikePlayerAnswerWhereIsMerchants, dislikePlayerAnswerWhereIsScholars, dislikePlayerAnswerWhereIsNobility, dislikePlayerAnswerWhereIsUnderworld);
+                }
+            }
         }
 
 
@@ -2270,7 +2403,7 @@ namespace DaggerfallWorkshop.Game
             return (tokens[0].text);
         }
 
-        private string getRecordIdByNpcsSocialGroup(int textRecordIdDefault, int textRecordIdGuildMembers, int textRecordIdMerchants, int textRecordIdNobility, int textRecordIdScholars, int textRecordIdUnderworld)
+        private string getRecordIdByNpcsSocialGroup(int textRecordIdDefault, int textRecordIdGuildMembers, int textRecordIdMerchants, int textRecordIdScholars, int textRecordIdNobility, int textRecordIdUnderworld)
         {
             switch (npcData.socialGroup)
             {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -84,6 +84,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // may revisit this later)
                 GameManager.Instance.TalkManager.RemoveQuestInfoTopicsForSpecificQuest(offeredQuest.UID);
 
+                // remove quest rumors (rumor mill command) for this quest from talk manager
+                GameManager.Instance.TalkManager.RemoveQuestRumorsFromRumorMill(offeredQuest.UID);
+
+                // remove quest progress rumors for this quest from talk manager
+                GameManager.Instance.TalkManager.RemoveQuestProgressRumorsFromRumorMill(offeredQuest.UID);
+
                 // Show refuse message
                 sender.CloseWindow();
                 ShowQuestPopupMessage(offeredQuest, (int)QuestMachine.QuestMessages.RefuseQuest, false);

--- a/Assets/Scripts/Utility/MacroDataSource.cs
+++ b/Assets/Scripts/Utility/MacroDataSource.cs
@@ -29,6 +29,21 @@ namespace DaggerfallWorkshop.Utility
             throw new NotImplementedException();
         }
 
+        public virtual string FactionPC()
+        {   // %fpc
+            throw new NotImplementedException();
+        }
+
+        public virtual string GuildNPC()
+        {   // %fnpc
+            throw new NotImplementedException();
+        }
+
+        public virtual string FactionName()
+        {   // %fpa
+            throw new NotImplementedException();
+        }
+
         public virtual string Dungeon()
         {   // %dng
             throw new NotImplementedException();
@@ -154,6 +169,11 @@ namespace DaggerfallWorkshop.Utility
         }
         public virtual string Pronoun3()
         {   // %g3
+            throw new NotImplementedException();
+        }
+
+        public virtual string Honorific()
+        {   // %hnr
             throw new NotImplementedException();
         }
 

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -85,10 +85,10 @@ namespace DaggerfallWorkshop.Utility
             { "%fl2", null }, // Lord of _fx2
             { "%fn", null },  // Random first(?) name (Female?)
             { "%fn2", null }, // Same as _mn2 (?)
-            { "%fnpc", null }, // ?
+            { "%fnpc", GuildNPC }, // faction of npc that is dialog partner
             { "%fon", FactionOrderName }, // Faction order name
-            { "%fpa", null }, // ?
-            { "%fpc", null }, // ?
+            { "%fpa", FactionName }, // faction name? of dialog partner - should return "Kynareth" for npc that are members of "Temple of Kynareth"
+            { "%fpc", FactionPC }, // faction of pc that is from importance to dialog partner (same as his faction)
             { "%fx1", null }, // A faction in news
             { "%fx2", null }, // Another faction in news
             { "%g", Pronoun },   // He/She etc...
@@ -102,7 +102,7 @@ namespace DaggerfallWorkshop.Utility
             { "%gtp", GoldToPay }, // Amount of fine
             { "%hea", HpMod }, // HP Modifier
             { "%hmd", HealRateMod }, // Healing rate modifer
-            { "%hnr", null }, // Honorific in guild/faction
+            { "%hnr", Honorific }, // Honorific in guild/faction (note Nystul: vanilla resolved this for my male character to "Sir")
             { "%hnt", DialogHint }, // context "Tell Me About": anyInfo message, context place: Direction of location. (comment Nystul: it is either a location direction hint or a map reveal)
             { "%hnt2", DialogHint2 }, // context "Tell Me About": rumors message
             { "%hol", null }, // Holiday
@@ -611,6 +611,11 @@ namespace DaggerfallWorkshop.Utility
             return (GameManager.Instance.PlayerEntity.Gender == Genders.Female) ? HardStrings.pronounHers : HardStrings.pronounHis;
         }
 
+        private static string Honorific(IMacroContextProvider mcp)
+        {   // %hnr
+            return GameManager.Instance.TalkManager.getHonoric();
+        }
+
         private static string DmgMod(IMacroContextProvider mcp)
         {   // %dam
             return GameManager.Instance.PlayerEntity.DamageModifier.ToString("+0;-0;0");
@@ -688,6 +693,21 @@ namespace DaggerfallWorkshop.Utility
         {
             // %n
             return GameManager.Instance.TalkManager.NameNPC;
+        }
+
+        private static string FactionPC(IMacroContextProvider mcp)
+        {   // %fpc
+            return GameManager.Instance.TalkManager.GetFactionPC();
+        }
+
+        private static string GuildNPC(IMacroContextProvider mcp)
+        {   // %fnpc
+            return GameManager.Instance.TalkManager.GetGuildNPC();
+        }
+
+        private static string FactionName(IMacroContextProvider mcp)
+        {   // %fpa
+            return GameManager.Instance.TalkManager.GetFactionName();
         }
 
         private static string DialogKeySubject(IMacroContextProvider mcp)

--- a/Assets/Scripts/Utility/QuestMacroHelper.cs
+++ b/Assets/Scripts/Utility/QuestMacroHelper.cs
@@ -75,6 +75,12 @@ namespace DaggerfallWorkshop.Utility
                     }
                     else
                     {
+                        // fix for bug when parent quest is no longer available (http://forums.dfworkshop.net/viewtopic.php?f=24&t=1002) in case
+                        // quest injected entries and rumors stay in list due to other bugs
+                        // so parentQuest is no longer available
+                        if (parentQuest == null)
+                            return;
+
                         // Ask resource to expand macro if possible
                         QuestResource resource = parentQuest.GetResource(macro.symbol);
                         if (resource != null)

--- a/Assets/StreamingAssets/Quests/A0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y12.txt
@@ -203,6 +203,7 @@ _S.04_ task:
 
 _S.05_ task:
 	clicked npc _informant_ say 1025 
+	add dialog for person _thief_ 
 	log 1035 step 1 
 
 _S.06_ task:

--- a/Assets/StreamingAssets/Text/ConversationText.txt
+++ b/Assets/StreamingAssets/Text/ConversationText.txt
@@ -27,6 +27,8 @@ Pawnshops,					Pawn shops
 Taverns,					Taverns
 Weaponsmiths,				Weapon smiths
 Localtemples,				Local temples
+Sir,						Sir
+Madam,						Madam
 toBeReplacedStringRegional,	Any
 replacementStringRegional,	any
 resolvingError,				never mind...


### PR DESCRIPTION
- rumors get removed correctly on quest decline now (one part of the bug report in http://forums.dfworkshop.net/viewtopic.php?f=24&t=1002&p=12092#p12092)
exception handling for the reported exception as well - TODO: still have to find out how "tell me about" entries could stay on the list after quest has finished
- npc reject message is now a random msg from text.rsc like in classic when first approaching npc, second time is "you get no response"
- question's answers take into account reputation with the npc now (similar to greeting msg)
- implemented guild member greetings, added macro handlers for %fnpc, %fpc, %fpa and %hnr
- work/questor list is now saved with conversation data
- fixed merchant missing book quest