### PR TITLE
thieves guild and dark brotherhood guild buildings are revealed again 

### DIFF
--- a/Assets/Scripts/Game/DaggerfallExteriorAutomap.cs
+++ b/Assets/Scripts/Game/DaggerfallExteriorAutomap.cs
@@ -27,6 +27,7 @@ using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.Questing;
+using DaggerfallWorkshop.Game.Guilds;
 using Wenzil.Console;
 
 namespace DaggerfallWorkshop.Game
@@ -764,7 +765,7 @@ namespace DaggerfallWorkshop.Game
                             if (GameManager.Instance.PlayerGPS.GetDiscoveredBuilding(buildingSummary.buildingKey, out discoveredBuilding))
                             {
                                 
-                                if (!RMBLayout.IsResidence(buildingSummary.BuildingType)) // guilds, shops, taverns, palace (general case)
+                                if (!RMBLayout.IsResidence(buildingSummary.BuildingType) || buildingSummary.FactionId == Guilds.ThievesGuild.FactionId || buildingSummary.FactionId == Guilds.DarkBrotherhood.FactionId) // guilds, shops, taverns, palace (general case)
                                 {
                                     newBuildingNameplate.name = discoveredBuilding.displayName;
                                 }

--- a/Assets/Scripts/Game/DaggerfallExteriorAutomap.cs
+++ b/Assets/Scripts/Game/DaggerfallExteriorAutomap.cs
@@ -764,8 +764,10 @@ namespace DaggerfallWorkshop.Game
                             PlayerGPS.DiscoveredBuilding discoveredBuilding;
                             if (GameManager.Instance.PlayerGPS.GetDiscoveredBuilding(buildingSummary.buildingKey, out discoveredBuilding))
                             {
-                                
-                                if (!RMBLayout.IsResidence(buildingSummary.BuildingType) || buildingSummary.FactionId == Guilds.ThievesGuild.FactionId || buildingSummary.FactionId == Guilds.DarkBrotherhood.FactionId) // guilds, shops, taverns, palace (general case)
+                                // show guilds, shops, taverns, palace (general case), show thieves guild and dark brotherhood guild halls if member
+                                if (!RMBLayout.IsResidence(buildingSummary.BuildingType) ||
+                                    (buildingSummary.FactionId == Guilds.ThievesGuild.FactionId && GameManager.Instance.GuildManager.HasJoined(FactionFile.GuildGroups.GeneralPopulace)) ||
+                                    (buildingSummary.FactionId == Guilds.DarkBrotherhood.FactionId && GameManager.Instance.GuildManager.HasJoined(FactionFile.GuildGroups.DarkBrotherHood)))
                                 {
                                     newBuildingNameplate.name = discoveredBuilding.displayName;
                                 }

--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -179,6 +179,12 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Joining
 
+        override public void Join()
+        {
+            base.Join();
+            RevealGuildHallOnMap();
+        }
+
         public override TextFile.Token[] TokensIneligible(PlayerEntity playerEntity)
         {
             throw new NotImplementedException();
@@ -198,6 +204,15 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)
         {
+            RevealGuildHallOnMap();
+        }
+
+        #endregion
+
+        #region Private Functions
+
+        private void RevealGuildHallOnMap()
+        {
             BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();
             if (buildingDirectory)
                 foreach (BuildingSummary building in buildingDirectory.GetBuildingsOfFaction(factionId))
@@ -205,7 +220,6 @@ namespace DaggerfallWorkshop.Game.Guilds
         }
 
         #endregion
-
 
         #region Macro Handling
 

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -164,6 +164,12 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Joining
 
+        override public void Join()
+        {
+            base.Join();
+            RevealGuildHallOnMap();
+        }
+
         public override TextFile.Token[] TokensIneligible(PlayerEntity playerEntity)
         {
             throw new NotImplementedException();
@@ -183,6 +189,15 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)
         {
+            RevealGuildHallOnMap();
+        }
+
+        #endregion
+
+        #region Private Functions
+
+        private void RevealGuildHallOnMap()
+        {
             BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();
             if (buildingDirectory)
                 foreach (BuildingSummary building in buildingDirectory.GetBuildingsOfFaction(factionId))
@@ -190,7 +205,6 @@ namespace DaggerfallWorkshop.Game.Guilds
         }
 
         #endregion
-
 
         #region Macro Handling
 


### PR DESCRIPTION
now filtering by factionId of building to show them when player is in guild and thus have them marked on the map
map marking also happens now directly when joining guild in same town - you don't have to reenter the city/town

only shows the tg, dbh guild nameplate when player has joined them
due to the new filtering this had to be handled specially