### PR TITLE
nameplate filtering mechanism reworked

### DIFF
--- a/Assets/Scripts/Game/ExteriorAutomap.cs
+++ b/Assets/Scripts/Game/ExteriorAutomap.cs
@@ -765,9 +765,7 @@ namespace DaggerfallWorkshop.Game
                             if (GameManager.Instance.PlayerGPS.GetDiscoveredBuilding(buildingSummary.buildingKey, out discoveredBuilding))
                             {
                                 // show guilds, shops, taverns, palace (general case), show thieves guild and dark brotherhood guild halls if member
-                                if (!RMBLayout.IsResidence(buildingSummary.BuildingType) ||
-                                    (buildingSummary.FactionId == Guilds.ThievesGuild.FactionId && GameManager.Instance.GuildManager.HasJoined(FactionFile.GuildGroups.GeneralPopulace)) ||
-                                    (buildingSummary.FactionId == Guilds.DarkBrotherhood.FactionId && GameManager.Instance.GuildManager.HasJoined(FactionFile.GuildGroups.DarkBrotherHood)))
+                                if (!RMBLayout.IsResidence(buildingSummary.BuildingType) || discoveredBuilding.isOverrideName)
                                 {
                                     newBuildingNameplate.name = discoveredBuilding.displayName;
                                 }

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -85,6 +85,8 @@ namespace DaggerfallWorkshop
         {
             public int buildingKey;
             public string displayName;
+            public string oldDisplayName;
+            public bool isOverrideName;
             public int factionID;
             public int quality;
             public DFLocation.BuildingTypes buildingType;
@@ -718,7 +720,16 @@ namespace DaggerfallWorkshop
 
             // Add the building and store back to discovered location, overriding name if requested
             if (overrideName != null)
+            {
+                if (!db.isOverrideName)
+                    db.oldDisplayName = db.displayName;
                 db.displayName = overrideName;
+                db.isOverrideName = true;
+            }
+
+            if (db.oldDisplayName == db.displayName)
+                db.isOverrideName = false;
+
             dl.discoveredBuildings[db.buildingKey] = db;
             discoveredLocations[mapPixelID] = dl;
         }


### PR DESCRIPTION
exterior automap nameplate filtering mechanism is now working as before when we checked for "Residence" string but now via "isOverrideName" field in DiscoveredBuilding struct (translation safe)

check is: 
`if (!RMBLayout.IsResidence(buildingSummary.BuildingType) || discoveredBuilding.isOverrideName)`

only thing to know is that player has to leave and enter town when loading an old savegame to make the new mechanism work with old savegames. no problem with newly created savegames though