### PR TITLE
tg and dbh guild halls discovered when loading a interior savegame and getting promoted

### DIFF
--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -82,6 +82,14 @@ namespace DaggerfallWorkshop.Game.Guilds
         {
             // Register for location entry events so can auto discover guild houses.
             PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+        }
+
+        ~DarkBrotherhood()
+        {
+            // Unregister events
+            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
         }
 
         public static int FactionId { get { return factionId; } }
@@ -203,6 +211,11 @@ namespace DaggerfallWorkshop.Game.Guilds
         #region Event handlers
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)
+        {
+            RevealGuildHallOnMap();
+        }
+
+        private void StreamingWorld_OnAvailableLocationGameObject()
         {
             RevealGuildHallOnMap();
         }

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -79,6 +79,14 @@ namespace DaggerfallWorkshop.Game.Guilds
         {
             // Register for location entry events so can auto discover guild houses.
             PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+        }
+
+        ~ThievesGuild()
+        {
+            // Unregister events
+            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
         }
 
         public static int FactionId { get { return factionId; } }
@@ -188,6 +196,11 @@ namespace DaggerfallWorkshop.Game.Guilds
         #region Event handlers
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)
+        {
+            RevealGuildHallOnMap();
+        }
+
+        private void StreamingWorld_OnAvailableLocationGameObject()
         {
             RevealGuildHallOnMap();
         }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2301,7 +2301,8 @@ namespace DaggerfallWorkshop.Game
                     {
                         Questing.Place place = (Questing.Place)questResourceInfo.Value.questResource;
                         // (fix bug reports http://forums.dfworkshop.net/viewtopic.php?f=24&t=996, http://forums.dfworkshop.net/viewtopic.php?f=24&t=997)
-                        if (place.Scope != Place.Scopes.Local) // only build entries for place quest resources that are local
+                        // only build entries for place quest resources that are local and in same location
+                        if (place.Scope != Place.Scopes.Local || GameManager.Instance.PlayerGPS.CurrentLocation.MapTableData.MapId != place.SiteDetails.mapId)
                             continue;
                         DFLocation.BuildingTypes buildingType = GameManager.Instance.TalkManager.GetBuildingTypeForBuildingKey(place.SiteDetails.buildingKey);
 

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -612,6 +612,9 @@ namespace DaggerfallWorkshop
 
             // Update current player location object once location update complete
             currentPlayerLocationObject = GetPlayerLocationObject();
+
+            // Raise event
+            RaiseOnAvailableLocationGameObjectEvent();
         }
 
         private IEnumerator UpdateLocation(int index, bool allowYield)
@@ -1571,6 +1574,15 @@ namespace DaggerfallWorkshop
         {
             if (OnCreateLocationGameObject != null)
                 OnCreateLocationGameObject(dfLocation);
+        }
+
+        // OnAvailableLocationGameObject
+        public delegate void OnAvailableLocationGameObjectHandler();
+        public static event OnAvailableLocationGameObjectHandler OnAvailableLocationGameObject;
+        protected virtual void RaiseOnAvailableLocationGameObjectEvent()
+        {
+            if (OnAvailableLocationGameObject != null)
+                OnAvailableLocationGameObject();
         }
 
         #endregion


### PR DESCRIPTION
tg and dbh guild halls are now also correctly discovered when loading a interior savegame and getting promotion in interior and then leaving building

had to introduce new event in StreamingWorld class:  OnAvailableLocationGameObject so that GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory() will return the building directory and not null
initially I though existing OnCreateLocationGameObject(dfLocation) event would work but it turned out that it is fired too early (inside the function creating the gameobject, but gameobject is assigned outside afterward)
not sure if OnCreateLocationGameObject should do what OnAvailableLocationGameObject does now but I didn't want to break existing stuff.
