### PR TITLE
talkmanager now can handle multiple resources with same name, fix remote quest locations talk stuff

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/AddDialog.cs
+++ b/Assets/Scripts/Game/Questing/Actions/AddDialog.cs
@@ -67,23 +67,18 @@ namespace DaggerfallWorkshop.Game.Questing
             // Get related Item resource
             Item item = ParentQuest.GetItem(itemSymbol);
 
-            string namePlace = "", namePerson = "", nameItem = "";
-
             // add dialog for resources
             if (place != null)
             {
-                namePlace = place.SiteDetails.locationName;
-                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, namePlace, TalkManager.QuestInfoResourceType.Location, false);
+                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, place.Symbol.Name, TalkManager.QuestInfoResourceType.Location, false);
             }
             if (person != null)
             {
-                namePerson = person.DisplayName;
-                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, namePerson, TalkManager.QuestInfoResourceType.Person, false);
+                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, person.Symbol.Name, TalkManager.QuestInfoResourceType.Person, false);
             }
             if (item != null)
             {
-                nameItem = item.DaggerfallUnityItem.ItemName;
-                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, nameItem, TalkManager.QuestInfoResourceType.Thing, false);
+                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, item.Symbol.Name, TalkManager.QuestInfoResourceType.Thing, false);
             }
 
             SetComplete();

--- a/Assets/Scripts/Game/Questing/Actions/DialogLink.cs
+++ b/Assets/Scripts/Game/Questing/Actions/DialogLink.cs
@@ -72,21 +72,22 @@ namespace DaggerfallWorkshop.Game.Questing
             // first create dialog link for just the separated resources (which will hide them)
             if (place != null)
             {
+                /*
                 namePlace = place.SiteDetails.buildingName; // use building name as default
                 if (namePlace == null) // no building?
                     namePlace = place.SiteDetails.locationName; // use dungeon name
-
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, namePlace, TalkManager.QuestInfoResourceType.Location);
+                */
+                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, place.Symbol.Name, TalkManager.QuestInfoResourceType.Location);
             }
             if (person != null)
             {
                 namePerson = person.DisplayName;
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, namePerson, TalkManager.QuestInfoResourceType.Person);
+                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, person.Symbol.Name, TalkManager.QuestInfoResourceType.Person);
             }
             if (item != null)
             {
                 nameItem = item.DaggerfallUnityItem.ItemName;
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, nameItem, TalkManager.QuestInfoResourceType.Thing);
+                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, item.Symbol.Name, TalkManager.QuestInfoResourceType.Thing);
             }
 
             // then create dialog links between the resources

--- a/Assets/Scripts/Game/Questing/Item.cs
+++ b/Assets/Scripts/Game/Questing/Item.cs
@@ -370,7 +370,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 }                
             }
 
-            string key = this.Symbol.Name; //this.Symbol.Name + "[" + this.item.ItemName + "]";
+            string key = this.Symbol.Name;
             GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, key, TalkManager.QuestInfoResourceType.Thing, anyInfoAnswers, anyRumorsAnswers);
         }
 

--- a/Assets/Scripts/Game/Questing/Item.cs
+++ b/Assets/Scripts/Game/Questing/Item.cs
@@ -370,7 +370,8 @@ namespace DaggerfallWorkshop.Game.Questing
                 }                
             }
 
-            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, this.item.ItemName, TalkManager.QuestInfoResourceType.Thing, anyInfoAnswers, anyRumorsAnswers);
+            string key = this.Symbol.Name; //this.Symbol.Name + "[" + this.item.ItemName + "]";
+            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, key, TalkManager.QuestInfoResourceType.Thing, anyInfoAnswers, anyRumorsAnswers);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -558,8 +558,8 @@ namespace DaggerfallWorkshop.Game.Questing
                 }                
             }
 
-            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, this.displayName, TalkManager.QuestInfoResourceType.Person, anyInfoAnswers, anyRumorsAnswers);
-            //GameManager.Instance.TalkManager.AddPersonTopic(this.ParentQuest.UID, this);
+            string key = this.Symbol.Name; // this.Symbol.Name + "["+ this.displayName + "]";
+            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, key, TalkManager.QuestInfoResourceType.Person, anyInfoAnswers, anyRumorsAnswers);
         }
 
         Genders GetGender(string genderName)

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -558,7 +558,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 }                
             }
 
-            string key = this.Symbol.Name; // this.Symbol.Name + "["+ this.displayName + "]";
+            string key = this.Symbol.Name;
             GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, key, TalkManager.QuestInfoResourceType.Person, anyInfoAnswers, anyRumorsAnswers);
         }
 

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -1024,7 +1024,7 @@ namespace DaggerfallWorkshop.Game.Questing
             this.ExpandMacro(MacroTypes.NameMacro1, out captionString); // first try to resolve building name (if this fails it is a dungeon...)
             if (captionString == null) // if building name resolving failed
                 this.ExpandMacro(MacroTypes.NameMacro3, out captionString); // resolve dungeon name
-            string key = this.Symbol.Name; //siteDetails.regionName + "_" + siteDetails.locationName + captionString;
+            string key = this.Symbol.Name;
             GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, key, TalkManager.QuestInfoResourceType.Location, anyInfoAnswers, anyRumorsAnswers);
         }
 

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -1024,7 +1024,8 @@ namespace DaggerfallWorkshop.Game.Questing
             this.ExpandMacro(MacroTypes.NameMacro1, out captionString); // first try to resolve building name (if this fails it is a dungeon...)
             if (captionString == null) // if building name resolving failed
                 this.ExpandMacro(MacroTypes.NameMacro3, out captionString); // resolve dungeon name
-            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, captionString, TalkManager.QuestInfoResourceType.Location, anyInfoAnswers, anyRumorsAnswers);
+            string key = this.Symbol.Name; //siteDetails.regionName + "_" + siteDetails.locationName + captionString;
+            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, key, TalkManager.QuestInfoResourceType.Location, anyInfoAnswers, anyRumorsAnswers);
         }
 
         #endregion

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2217,7 +2217,7 @@ namespace DaggerfallWorkshop.Game
             AssembleTopicListLocation();
             AssembleTopicListPerson();
             AssembleTopicListThing();
-            DaggerfallUI.Instance.TalkWindow.UpdateListBoxTopic();
+            DaggerfallUI.Instance.TalkWindow.UpdateListboxTopic();
         }
 
         private void AssembleTopiclistTellMeAbout()
@@ -2562,7 +2562,6 @@ namespace DaggerfallWorkshop.Game
                         if (!dialogPartnerIsSamePersonAsPersonResource &&   // dialog partner is not the same person as the person resource talked about
                             questResourceInfo.Value.availableForDialog &&   // it is not "hidden" by dialog link command
                             questResourceInfo.Value.hasEntryInWhereIs &&    // it is meant to have an entry in the where is section (currently this is always true, TODO: check if we can get rid of this)
-                            !person.IsHidden &&                             // if person resource is not hidden
                             IsPlayerInSameLocationWorldCell)                // if person resource is in same world map location as player
                         {
                             listTopicPerson.Add(item);

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1732,24 +1732,23 @@ namespace DaggerfallWorkshop.Game
                     for (int i = 0; i < questResources.Length; i++)
                     {
                         Questing.Place place = (Questing.Place)(questResources[i]);
-                        int key = place.SiteDetails.buildingKey;
-                        string name = place.SiteDetails.buildingName;
+                        string key = place.Symbol.Name;
 
-                        if (key != buildingKey)
+                        if (place.SiteDetails.buildingKey != buildingKey)
                             continue;
 
-                        if (questInfo.resourceInfo.ContainsKey(name))
+                        if (questInfo.resourceInfo.ContainsKey(key))
                         {
-                            if (questInfo.resourceInfo[name].availableForDialog) 
+                            if (questInfo.resourceInfo[key].availableForDialog) 
                                 pcLearnedAboutExistence = true;
 
-                            if (questInfo.resourceInfo[name].questPlaceResourceHintTypeReceived >= QuestResourceInfo.BuildingLocationHintTypeGiven.ReceivedDirectionalHints)
+                            if (questInfo.resourceInfo[key].questPlaceResourceHintTypeReceived >= QuestResourceInfo.BuildingLocationHintTypeGiven.ReceivedDirectionalHints)
                                 receivedDirectionalHints = true;
 
-                            if (questInfo.resourceInfo[name].questPlaceResourceHintTypeReceived == QuestResourceInfo.BuildingLocationHintTypeGiven.LocationWasMarkedOnMap)
+                            if (questInfo.resourceInfo[key].questPlaceResourceHintTypeReceived == QuestResourceInfo.BuildingLocationHintTypeGiven.LocationWasMarkedOnMap)
                                 locationWasMarkedOnMapByNPC = true;
 
-                            overrideBuildingName = name;
+                            overrideBuildingName = place.SiteDetails.buildingName;
 
                             return true;
                         }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2217,6 +2217,7 @@ namespace DaggerfallWorkshop.Game
             AssembleTopicListLocation();
             AssembleTopicListPerson();
             AssembleTopicListThing();
+            DaggerfallUI.Instance.TalkWindow.UpdateListBoxTopic();
         }
 
         private void AssembleTopiclistTellMeAbout()

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2245,7 +2245,10 @@ namespace DaggerfallWorkshop.Game
                         case QuestInfoResourceType.Location:
                             itemQuestTopic.questionType = QuestionType.QuestLocation;
                             Questing.Place place = (Questing.Place)questResourceInfo.Value.questResource;
-                            captionString = place.SiteDetails.buildingName;
+                            if (place.SiteDetails.buildingName != null)
+                                captionString = place.SiteDetails.buildingName;
+                            else
+                                captionString = place.SiteDetails.locationName;
                             break;
                         case QuestInfoResourceType.Person:
                             itemQuestTopic.questionType = QuestionType.QuestPerson;

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -328,7 +328,7 @@ namespace DaggerfallWorkshop.Game
         List<ListItem> listTopicPerson;
         List<ListItem> listTopicThing;
 
-        int numQuestionsAsked = 0;
+        int numQuestionsAsked = 0; // used to determine if greetings text or follow up text needs to be used (not to mix up with npcData.numAnswersGivenTellMeAboutOrRumors)
         string questionOpeningText = ""; // randomize PC opening text only once for every new question so save it in this string after creating it (so opening text does not change when picking different questions/topics)
 
         bool markLocationOnMap = false; // flag to guide the macrohelper (macro resolving) to either give directional hints or mark buildings on the map
@@ -954,7 +954,7 @@ namespace DaggerfallWorkshop.Game
         public string GetNewsOrRumors()
         {
             const int outOfNewsRecordIndex = 1457;
-            if (npcData.numAnswersGivenTellMeAboutOrRumors < maxNumAnswersNpcGivesTellMeAboutOrRumors)
+            if (npcData.numAnswersGivenTellMeAboutOrRumors < maxNumAnswersNpcGivesTellMeAboutOrRumors || npcData.isSpyMaster)
             {
                 string news = TextManager.Instance.GetText(textDatabase, "resolvingError");
                 int randomIndex = UnityEngine.Random.Range(0, listRumorMill.Count);
@@ -1463,13 +1463,13 @@ namespace DaggerfallWorkshop.Game
             {
                 // decide here if npcs knows question's answer (spymaster always knows)
                 float randomFloat = UnityEngine.Random.Range(0.0f, 1.0f);
-                if (npcData.isSpyMaster ||(randomFloat < chanceNPCknowsSomthing && npcData.numAnswersGivenTellMeAboutOrRumors < maxNumAnswersNpcGivesTellMeAboutOrRumors))
+                if (randomFloat < chanceNPCknowsSomthing || npcData.isSpyMaster)
                     listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.KnowsAboutItem;
                 else
                     listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.DoesNotKnowAboutItem;
             }
 
-            if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)
+            if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem || (npcData.numAnswersGivenTellMeAboutOrRumors >= maxNumAnswersNpcGivesTellMeAboutOrRumors && !npcData.isSpyMaster))
             {
                 // messages if npc does not know
                 if (reactionToPlayer >= 30)
@@ -1483,6 +1483,8 @@ namespace DaggerfallWorkshop.Game
             }
             else
             {
+                npcData.numAnswersGivenTellMeAboutOrRumors++;
+
                 // location related messages if npc knows
                 if (reactionToPlayer >= 30)
                     return getRecordIdByNpcsSocialGroup(veryLikePlayerAnswerTellMeAboutDefault, veryLikePlayerAnswerTellMeAboutGuildMembers, veryLikePlayerAnswerTellMeAboutMerchants, veryLikePlayerAnswerTellMeAboutScholars, veryLikePlayerAnswerTellMeAboutNobility, veryLikePlayerAnswerTellMeAboutUnderworld);

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2557,11 +2557,15 @@ namespace DaggerfallWorkshop.Game
                             }
                         }
 
-                        if (!dialogPartnerIsSamePersonAsPersonResource && // only make it available for talk if dialog partner is not the same person as the person resource talked about
-                            questResourceInfo.Value.availableForDialog && // only make it available for talk if it is not "hidden" by dialog link command
-                            questResourceInfo.Value.hasEntryInWhereIs &&
-                            IsPlayerInSameLocationWorldCell) // only make it available for talk if person resource is in same world map location as player
+                        // only make it available for talk if...
+                        if (!dialogPartnerIsSamePersonAsPersonResource &&   // dialog partner is not the same person as the person resource talked about
+                            questResourceInfo.Value.availableForDialog &&   // it is not "hidden" by dialog link command
+                            questResourceInfo.Value.hasEntryInWhereIs &&    // it is meant to have an entry in the where is section (currently this is always true, TODO: check if we can get rid of this)
+                            !person.IsHidden &&                             // if person resource is not hidden
+                            IsPlayerInSameLocationWorldCell)                // if person resource is in same world map location as player
+                        {
                             listTopicPerson.Add(item);
+                        }
                     }
 
                 }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -983,7 +983,7 @@ namespace DaggerfallWorkshop.Game
                     {
                         TextFile.Token[] tokens = entry.listRumorVariants[0];
                         MacroHelper.ExpandMacros(ref tokens, this);
-                        news = tokens[0].text;
+                        news = TokensToString(tokens, false);
                     }
                 }
                 else if (entry.rumorType == RumorType.QuestRumorMill || entry.rumorType == RumorType.QuestProgressRumor)
@@ -1256,12 +1256,17 @@ namespace DaggerfallWorkshop.Game
             return TextManager.Instance.GetText(textDatabase, "resolvingError");
         }
 
-        public string getHonoric()
+        public string GetHonoric()
         {
             if (GameManager.Instance.PlayerEntity.Gender == Genders.Male)
                 return TextManager.Instance.GetText(textDatabase, "Sir");
             else
                 return TextManager.Instance.GetText(textDatabase, "Ma'am");
+        }
+
+        public string GetOldLeaderFateString(int index)
+        {
+            return TextManager.Instance.GetText(textDatabase, String.Format("oldLeaderFate{0}", index));
         }
 
         public string GetAnswerWhereIs(TalkManager.ListItem listItem)
@@ -2015,12 +2020,14 @@ namespace DaggerfallWorkshop.Game
                     RumorMillEntry entry = new RumorMillEntry();
 
                     TextFile.Token[] tokens;
-                    int randomNum = UnityEngine.Random.Range(0, 12);
+                    int randomNum = UnityEngine.Random.Range(0, 20);
                     if (randomNum >= 0 && randomNum <= 9)
                         tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(1400 + randomNum);
                     else if (randomNum == 10)
                         tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(1456);
-                    else if (randomNum == 11)
+                    else if (randomNum >= 11 && randomNum <= 15)
+                        tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(1480);
+                    else if (randomNum >= 16 && randomNum <= 20)
                         tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(1481);
                     else
                         tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(1457);
@@ -2774,21 +2781,23 @@ namespace DaggerfallWorkshop.Game
 
         }
 
-        private string TokensToString(TextFile.Token[] tokens)
+        private string TokensToString(TextFile.Token[] tokens, bool addSpaceAtTokenEnd = true)
         {
             // create return string from expanded tokens
             string returnString = "";
+            string seperatorString = " ";
+            if (!addSpaceAtTokenEnd)
+                seperatorString = "";
             for (int i = 0; i < tokens.Length; i++)
             {
                 string textFragment = tokens[i].text;
                 if (textFragment != null && textFragment.Length > 0 && i < textFragment.Length)
                     returnString += textFragment;
                 else
-                    returnString += " ";
+                    returnString += seperatorString;
             }
             return returnString;
         }
-
 
         private string expandRandomTextRecord(int recordIndex)
         {

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -211,6 +211,36 @@ namespace DaggerfallWorkshop.Game
         const int veryLikePlayerDoesNotKnowTellMeAboutNobility = 7283;
         const int veryLikePlayerDoesNotKnowTellMeAboutUnderworld = 7284;
 
+        public static List<FactionFile.FactionIDs> factionsUsedForFactionInNews = new List<FactionFile.FactionIDs>()
+        {
+            FactionFile.FactionIDs.Abibon_Gora, FactionFile.FactionIDs.Alcaire, FactionFile.FactionIDs.Alikra, FactionFile.FactionIDs.Anticlere,
+            FactionFile.FactionIDs.Antiphyllos, FactionFile.FactionIDs.Ayasofya, FactionFile.FactionIDs.Bergama, FactionFile.FactionIDs.Betony,
+            FactionFile.FactionIDs.Bhoraine, FactionFile.FactionIDs.Cybiades, FactionFile.FactionIDs.Daenia, FactionFile.FactionIDs.Daggerfall,
+            FactionFile.FactionIDs.Dakfron, FactionFile.FactionIDs.Dragontail, FactionFile.FactionIDs.Dwynnen, FactionFile.FactionIDs.Ephesus,
+            FactionFile.FactionIDs.Gavaudon, FactionFile.FactionIDs.Glenpoint, FactionFile.FactionIDs.Ilessan_Hills, FactionFile.FactionIDs.Isle_of_Balfiera,
+            FactionFile.FactionIDs.Kairou, FactionFile.FactionIDs.Kambria, FactionFile.FactionIDs.Koegria, FactionFile.FactionIDs.Kozanset,
+            FactionFile.FactionIDs.Lainlyn, FactionFile.FactionIDs.Menevia, FactionFile.FactionIDs.Mournoth, FactionFile.FactionIDs.Myrkwasa,
+            FactionFile.FactionIDs.Northmoor, FactionFile.FactionIDs.Orsinium, FactionFile.FactionIDs.Phrygia, FactionFile.FactionIDs.Pothago,
+            FactionFile.FactionIDs.Santaki, FactionFile.FactionIDs.Satakalaam, FactionFile.FactionIDs.Sentinel, FactionFile.FactionIDs.Shalgora,
+            FactionFile.FactionIDs.Tigonus, FactionFile.FactionIDs.Totambu, FactionFile.FactionIDs.Tulune, FactionFile.FactionIDs.Urvaius,
+            FactionFile.FactionIDs.Wayrest, FactionFile.FactionIDs.Wrothgaria, FactionFile.FactionIDs.Ykalon
+        };
+
+        public static List<FactionFile.FactionIDs> factionsUsedForRulers = new List<FactionFile.FactionIDs>()
+        {
+            FactionFile.FactionIDs.Abibon_Gora, FactionFile.FactionIDs.Alcaire, FactionFile.FactionIDs.Alikra,
+            FactionFile.FactionIDs.Antiphyllos, FactionFile.FactionIDs.Ayasofya, FactionFile.FactionIDs.Bergama, FactionFile.FactionIDs.Betony,
+            FactionFile.FactionIDs.Bhoraine, FactionFile.FactionIDs.Cybiades, FactionFile.FactionIDs.Daenia,
+            FactionFile.FactionIDs.Dakfron, FactionFile.FactionIDs.Dragontail, FactionFile.FactionIDs.Dwynnen, FactionFile.FactionIDs.Ephesus,
+            FactionFile.FactionIDs.Gavaudon, FactionFile.FactionIDs.Glenpoint, FactionFile.FactionIDs.Ilessan_Hills,
+            FactionFile.FactionIDs.Kairou, FactionFile.FactionIDs.Kambria, FactionFile.FactionIDs.Koegria, FactionFile.FactionIDs.Kozanset,
+            FactionFile.FactionIDs.Lainlyn, FactionFile.FactionIDs.Menevia, FactionFile.FactionIDs.Mournoth, FactionFile.FactionIDs.Myrkwasa,
+            FactionFile.FactionIDs.Northmoor, FactionFile.FactionIDs.Phrygia, FactionFile.FactionIDs.Pothago,
+            FactionFile.FactionIDs.Santaki, FactionFile.FactionIDs.Satakalaam, FactionFile.FactionIDs.Shalgora,
+            FactionFile.FactionIDs.Tigonus, FactionFile.FactionIDs.Totambu, FactionFile.FactionIDs.Tulune, FactionFile.FactionIDs.Urvaius,
+            FactionFile.FactionIDs.Wrothgaria, FactionFile.FactionIDs.Ykalon
+        };
+
         const float DefaultChanceKnowsSomethingAboutWhereIs = 0.5f; // chances unknown
         const float DefaultChanceKnowsSomethingAboutQuest = 0.5f; // chances unknown
         const float DefaultChanceKnowsSomethingAboutOrganizationsStaticNPC = 0.5f; // chances unknown
@@ -982,7 +1012,9 @@ namespace DaggerfallWorkshop.Game
                     if (entry.listRumorVariants != null)
                     {
                         TextFile.Token[] tokens = entry.listRumorVariants[0];
+                        MacroHelper.ResetFactionAndRulerIds(); // reset so that a new set of rulers and factions can be generated
                         MacroHelper.ExpandMacros(ref tokens, this);
+                        MacroHelper.ResetFactionAndRulerIds(); // reset again so %reg macro may resolve to current region if needed
                         news = TokensToString(tokens, false);
                     }
                 }
@@ -2791,7 +2823,7 @@ namespace DaggerfallWorkshop.Game
             for (int i = 0; i < tokens.Length; i++)
             {
                 string textFragment = tokens[i].text;
-                if (textFragment != null && textFragment.Length > 0 && i < textFragment.Length)
+                if (textFragment != null && textFragment != string.Empty)
                     returnString += textFragment;
                 else
                     returnString += seperatorString;

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2010,7 +2010,7 @@ namespace DaggerfallWorkshop.Game
                 listRumorMill = new List<RumorMillEntry>();
             if (listRumorMill.Count == 0)
             {
-                for (int i = 0; i < 10; i++) // setup 10 random comman rumors (this is very early work in progress)
+                for (int i = 0; i < 10; i++) // setup 10 random common rumors (this is very early work in progress)
                 {
                     RumorMillEntry entry = new RumorMillEntry();
 

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1530,14 +1530,12 @@ namespace DaggerfallWorkshop.Game
 
             dictQuestInfo[questID] = questResources;
 
-            /*
             if (questResourceInfo.resourceType == QuestInfoResourceType.Location)
             {
                 // undiscover residences when they are a quest resource (named residence) when creating quest resource
                 // otherwise previously discovered residences will automatically show up on the automap when used in a quest            
                 UndiscoverQuestResidence(questID, resourceName, questResourceInfo);
             }
-            */
 
             // update topic lists
             rebuildTopicLists = true;
@@ -1636,6 +1634,13 @@ namespace DaggerfallWorkshop.Game
                 }
 
                 questResourceInfo.availableForDialog = true;
+
+                if (questResourceInfo.resourceType == QuestInfoResourceType.Location)
+                {
+                    // undiscover residences when they are a quest resource (named residence) when "add dialog" is done for this quest resource
+                    // otherwise previously discovered residences will automatically show up on the automap when used in a quest
+                    UndiscoverQuestResidence(questID, resourceName, questResourceInfo);
+                }
             }
 
             // update topic lists

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2301,8 +2301,8 @@ namespace DaggerfallWorkshop.Game
                     {
                         Questing.Place place = (Questing.Place)questResourceInfo.Value.questResource;
                         // (fix bug reports http://forums.dfworkshop.net/viewtopic.php?f=24&t=996, http://forums.dfworkshop.net/viewtopic.php?f=24&t=997)
-                        // only build entries for place quest resources that are local and in same location
-                        if (place.Scope != Place.Scopes.Local || GameManager.Instance.PlayerGPS.CurrentLocation.MapTableData.MapId != place.SiteDetails.mapId)
+                        // only build entries for place quest resources that are in same location as pc
+                        if (GameManager.Instance.PlayerGPS.CurrentLocation.MapTableData.MapId != place.SiteDetails.mapId)
                             continue;
                         DFLocation.BuildingTypes buildingType = GameManager.Instance.TalkManager.GetBuildingTypeForBuildingKey(place.SiteDetails.buildingKey);
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -308,8 +308,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicPerson);
                     else if (selectedTalkCategory == TalkCategory.Things)
                         SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicThings);
-                }
-                SelectTopicFromTopicList(listboxTopic.FindIndex(oldTopic), true);
+                }                
+                listboxTopic.SelectedIndex = listboxTopic.FindIndex(oldTopic);
+                UpdateQuestion(listboxTopic.SelectedIndex);
             }                
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -289,8 +289,26 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public override void Update()
         {
             base.Update();
+        }
 
-            UpdateLabels();
+        public void UpdateListBoxTopic()
+        {
+            if (listboxTopic != null)
+            {
+                if (selectedTalkOption == TalkOption.TellMeAbout)
+                {
+                    SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicTellMeAbout);
+                }
+                else if (selectedTalkOption == TalkOption.WhereIs)
+                {
+                    if (selectedTalkCategory == TalkCategory.Location)
+                        SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicLocation);
+                    else if (selectedTalkCategory == TalkCategory.People)
+                        SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicPerson);
+                    else if (selectedTalkCategory == TalkCategory.Things)
+                        SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicThings);
+                }
+            }
         }
 
         public void SetNPCPortrait(FacePortraitArchive facePortraitArchive, int recordId)
@@ -561,8 +579,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             UpdateScrollBarConversation();
             UpdateScrollButtonsConversation();
 
-            UpdateLabels();
-
             isSetup = true;
         }
 
@@ -808,11 +824,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             //lengthOfLongestItemInListBox = 0;
             widthOfLongestItemInListBox = 0;
             listboxTopic.MaxHorizontalScrollIndex = 0;
-        }
-
-        void UpdateLabels()
-        {
-
         }
 
         void UpdateCheckboxes()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Michael Rauter (Nystul)
-// Contributors:    Kenny Stepney (TheExceptionist)
+// Contributors:
 // 
 // Notes:
 //
@@ -291,10 +291,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
             base.Update();
         }
 
-        public void UpdateListBoxTopic()
-        {
+        public void UpdateListboxTopic()
+        {               
             if (listboxTopic != null)
             {
+                string oldTopic = listboxTopic.SelectedItem;
                 if (selectedTalkOption == TalkOption.TellMeAbout)
                 {
                     SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicTellMeAbout);
@@ -308,7 +309,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     else if (selectedTalkCategory == TalkCategory.Things)
                         SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicThings);
                 }
-            }
+                SelectTopicFromTopicList(listboxTopic.FindIndex(oldTopic), true);
+            }                
         }
 
         public void SetNPCPortrait(FacePortraitArchive facePortraitArchive, int recordId)
@@ -1195,7 +1197,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             UpdateScrollButtonsConversation();
         }
 
-        void SelectTopicFromTopicList(int index)
+        void SelectTopicFromTopicList(int index, bool forceExecution = false)
         {
             // guard execution - this is important because I encountered a issue with listbox and double-click:
             // when changing listbox content and updating the listbox in the double click event callback the
@@ -1206,15 +1208,14 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // "previous" item on linked second list)
             // SIDE NOTE: don't use return inside this function (or if you do, don't forget to set
             // inListboxTopicContentUpdate to false again before!)
-            if (inListboxTopicContentUpdate)
+            if (inListboxTopicContentUpdate && !forceExecution)
                 return;
+            inListboxTopicContentUpdate = true;
 
             if (index < 0 || index >= listboxTopic.Count) 
                 return;
 
-            inListboxTopicContentUpdate = true;
-
-
+            listboxTopic.SelectedIndex = index;
             TalkManager.ListItem listItem = listCurrentTopics[index];
             if (listItem.type == TalkManager.ListItemType.NavigationBack)
             {
@@ -1237,7 +1238,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 string answer = TalkManager.Instance.GetAnswerText(listItem);
 
                 SetQuestionAnswerPairInConversationListbox(currentQuestion, answer);
-                
+
                 UpdateQuestion(listboxTopic.SelectedIndex); // and get new question text for textlabel
             }
             inListboxTopicContentUpdate = false;

--- a/Assets/Scripts/Utility/MacroDataSource.cs
+++ b/Assets/Scripts/Utility/MacroDataSource.cs
@@ -217,6 +217,16 @@ namespace DaggerfallWorkshop.Utility
             throw new NotImplementedException();
         }
 
+        public virtual string AFactionInNews()
+        {   // %fx1
+            throw new NotImplementedException();
+        }
+
+        public virtual string AnotherFactionInNews()
+        {   // %fx2
+            throw new NotImplementedException();
+        }
+
         public virtual string RoomHoursLeft()
         {   // %dwr
             throw new NotImplementedException();

--- a/Assets/Scripts/Utility/MacroDataSource.cs
+++ b/Assets/Scripts/Utility/MacroDataSource.cs
@@ -227,6 +227,31 @@ namespace DaggerfallWorkshop.Utility
             throw new NotImplementedException();
         }
 
+        public virtual string OldLordOfFaction1()
+        {   // %ol1
+            throw new NotImplementedException();
+        }
+
+        public virtual string LordOfFaction1()
+        {   // %fl1
+            throw new NotImplementedException();
+        }
+
+        public virtual string LordOfFaction2()
+        {   // %fl2
+            throw new NotImplementedException();
+        }
+
+        public virtual string TitleOfLordOfFaction1()
+        {   // %lt1
+            throw new NotImplementedException();
+        }
+
+        public virtual string OldLeaderFate()
+        {   // %olf
+            throw new NotImplementedException();
+        }
+
         public virtual string RoomHoursLeft()
         {   // %dwr
             throw new NotImplementedException();

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -81,8 +81,8 @@ namespace DaggerfallWorkshop.Utility
             { "%fcn", LocationOfRegionalBuilding }, // Location with regional building asked about
             { "%fe", null },  // ?
             { "%fea", null }, // ?
-            { "%fl1", null }, // Lord of _fx1
-            { "%fl2", null }, // Lord of _fx2
+            { "%fl1", LordOfFaction1 }, // Lord of _fx1
+            { "%fl2", LordOfFaction2 }, // Lord of _fx2
             { "%fn", null },  // Random first(?) name (Female?)
             { "%fn2", null }, // Same as _mn2 (?)
             { "%fnpc", GuildNPC }, // faction of npc that is dialog partner
@@ -123,7 +123,7 @@ namespace DaggerfallWorkshop.Utility
             { "%lp", LocalPalace },  //  Local / palace (?) dungeon
             { "%ln", null },  //  Random lastname
             { "%loc", MarkLocationOnMap }, // Location marked on map (comment Nystul: this seems to be context dependent - it is used both in direction dialogs (7333) and map reveal dialogs (7332) - it seems to return the name of the building and reveal the map only if a 7332 dialog was chosen
-            { "%lt1", null }, // Title of _fl1
+            { "%lt1", TitleOfLordOfFaction1 }, // Title of _fl1
             { "%ltn", LegalReputation }, // In the eyes of the law you are.......
             { "%luc", Luck }, // Luck
             { "%mad", MagicResist }, // Resistance
@@ -138,8 +138,8 @@ namespace DaggerfallWorkshop.Utility
             { "%nam", null }, // A random full name
             { "%nrn", null }, // Noble of the current region (used in: O0B00Y01)
             { "%nt", NearbyTavern },  // Nearby Tavern
-            { "%ol1", null }, // Old lord of _fx1
-            { "%olf", null }, // What happened to _ol1
+            { "%ol1", OldLordOfFaction1 }, // Old lord of _fx1
+            { "%olf", OldLeaderFate }, // What happened to _ol1
             { "%on", null },  // ?
             { "%oth", Oath }, // An oath (listed in TEXT.RSC)
             { "%pc", null },  // ?
@@ -637,7 +637,7 @@ namespace DaggerfallWorkshop.Utility
 
         private static string Honorific(IMacroContextProvider mcp)
         {   // %hnr
-            return GameManager.Instance.TalkManager.getHonoric();
+            return GameManager.Instance.TalkManager.GetHonoric();
         }
 
         private static string DmgMod(IMacroContextProvider mcp)
@@ -755,6 +755,32 @@ namespace DaggerfallWorkshop.Utility
                 id = tmpId + 1; // by just adding 1 to tmpIds >= idAFactionInNewsLastPicked -> so we will end up with an id in ranges [200, idAFactionInNewsLastPicked) union (idAFactionInNewsLastPicked, 236]
             factions.GetFactionData(id, out fd);
             return fd.name;
+        }
+
+        public static string OldLeaderFate(IMacroContextProvider mcp)
+        {   // %olf
+            int index = UnityEngine.Random.Range(0, 5);
+            return TalkManager.Instance.GetOldLeaderFateString(index);
+        }
+
+        public static string OldLordOfFaction1(IMacroContextProvider mcp)
+        {   // %ol1
+            return "[placeholder for an old lord]";
+        }
+
+        public static string LordOfFaction1(IMacroContextProvider mcp)
+        {   // %fl1
+            return "[placeholder for faction1 lord]";
+        }
+
+        public static string LordOfFaction2(IMacroContextProvider mcp)
+        {   // %fl2
+            return "[placeholder for faction2 lord]";
+        }
+
+        public static string TitleOfLordOfFaction1(IMacroContextProvider mcp)
+        {   // %lt1
+            return "[placeholder for title of faction1 lord]";
         }
 
         private static string DialogKeySubject(IMacroContextProvider mcp)

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -238,6 +238,9 @@ namespace DaggerfallWorkshop.Utility
             int multilineIdx = 0;
             TextFile.Token[] multilineTokens = null;
 
+            // this dictionary is used check for previous resolving of a specific macro in the current call to ExpandMacros before expanding macros
+            // if macro (macro string used as dict key) has been expanded before use previous expanded string (value of this dict) as result
+            // this dict is newly created (and thus empty) for every new call to this function call so macros will be expanded in future calls to ExpandMacros
             Dictionary<string, string> macrosExpandedAlready = new Dictionary<string, string>();
 
             for (int tokenIdx = 0; tokenIdx < tokens.Length; tokenIdx++)
@@ -735,27 +738,22 @@ namespace DaggerfallWorkshop.Utility
         {   // %fx1
             PersistentFactionData factions = GameManager.Instance.PlayerEntity.FactionData;
             int id = UnityEngine.Random.Range(200, 236);
-            FactionFile.FactionData fd;            
-            factions.GetFactionData(GameManager.Instance.PlayerGPS.CurrentPoliticIndex, out fd);
-            for (int i = 0; i < 10; i++)
-                if (factions.GetFactionData(id, out fd))
-                    break;
-
+            FactionFile.FactionData fd;
+            factions.GetFactionData(id, out fd);
             idAFactionInNewsLastPicked = fd.id;
-
             return fd.name;
         }
 
         public static string AnotherFactionInNews(IMacroContextProvider mcp)
         {   // %fx2
             PersistentFactionData factions = GameManager.Instance.PlayerEntity.FactionData;
-            int id = UnityEngine.Random.Range(200, 236);
+            // get random number between 200 and 235 now since we might add a + 1 for an id >= idAFactionInNewsLastPicked later to prevent same faction as for %fx1
+            int tmpId = UnityEngine.Random.Range(200, 235);
             FactionFile.FactionData fd;
-            factions.GetFactionData(GameManager.Instance.PlayerGPS.CurrentPoliticIndex, out fd);
-            for (int i = 0; i < 100; i++)
-                if (factions.GetFactionData(id, out fd) && fd.id != idAFactionInNewsLastPicked)
-                    break;
-
+            int id = tmpId;
+            if (tmpId >= idAFactionInNewsLastPicked) // make sure to create an id != idAFactionInNewsLastPicked
+                id = tmpId + 1; // by just adding 1 to tmpIds >= idAFactionInNewsLastPicked -> so we will end up with an id in ranges [200, idAFactionInNewsLastPicked) union (idAFactionInNewsLastPicked, 236]
+            factions.GetFactionData(id, out fd);
             return fd.name;
         }
 

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -727,7 +727,10 @@ namespace DaggerfallWorkshop.Utility
                 case TalkManager.KeySubjectType.Work:
                     return GameManager.Instance.TalkManager.GetWorkString();
                 case TalkManager.KeySubjectType.QuestTopic:
-                    return GameManager.Instance.TalkManager.CurrentKeySubject;
+                    if (GameManager.Instance.TalkManager.CurrentQuestionListItem != null)
+                        return GameManager.Instance.TalkManager.CurrentQuestionListItem.caption;
+                    else
+                        return GameManager.Instance.TalkManager.CurrentKeySubject;
                 case TalkManager.KeySubjectType.Organization:
                     return GameManager.Instance.TalkManager.CurrentKeySubject;
             }

--- a/Assets/Scripts/Utility/QuestMacroHelper.cs
+++ b/Assets/Scripts/Utility/QuestMacroHelper.cs
@@ -97,15 +97,15 @@ namespace DaggerfallWorkshop.Utility
                                 System.Type t = resource.GetType();
                                 if (t.Equals(typeof(DaggerfallWorkshop.Game.Questing.Place)))
                                 {
-                                        GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, result, TalkManager.QuestInfoResourceType.Location);
+                                        GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, macro.symbol, TalkManager.QuestInfoResourceType.Location);
                                 }
                                 else if (t.Equals(typeof(DaggerfallWorkshop.Game.Questing.Person)))
                                 {
-                                        GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, result, TalkManager.QuestInfoResourceType.Person);
+                                        GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, macro.symbol, TalkManager.QuestInfoResourceType.Person);
                                 }
                                 else if (t.Equals(typeof(DaggerfallWorkshop.Game.Questing.Item)))
                                 {
-                                        GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, result, TalkManager.QuestInfoResourceType.Thing);
+                                        GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, macro.symbol, TalkManager.QuestInfoResourceType.Thing);
                                 }
                             }
                         }

--- a/Assets/StreamingAssets/Quests/A0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y12.txt
@@ -189,20 +189,14 @@ _S.01_ task:
 _S.02_ task:
 	daily from 00:00 to 08:00 
 	pc at _house_ set _S.09_ 
-	place npc _thief_ at _house_
-	hide npc _thief_
 
 _S.03_ task:
 	daily from 16:02 to 23:59 
 	pc at _inn_ set _S.10_ 
-	place npc _thief_ at _inn_
-	hide npc _thief_
 
 _S.04_ task:
 	daily from 08:01 to 16:01 
-	pc at _store_ set _S.11_ 
-	place npc _thief_ at _store_
-	hide npc _thief_
+	pc at _store_ set _S.11_ _
 
 _S.05_ task:
 	clicked npc _informant_ say 1025 
@@ -221,7 +215,7 @@ _S.08_ task:
 	say 1030 
 
 _S.09_ task:
-	place foe thiefFoe at _house_ 
+	place foe thiefFoe at _house_
 
 _S.10_ task:
 	place foe thiefFoe at _inn_ 

--- a/Assets/StreamingAssets/Quests/A0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y12.txt
@@ -189,17 +189,20 @@ _S.01_ task:
 _S.02_ task:
 	daily from 00:00 to 08:00 
 	pc at _house_ set _S.09_ 
-	place npc _thief_ at _house_ 
+	place npc _thief_ at _house_
+	hide npc _thief_
 
 _S.03_ task:
 	daily from 16:02 to 23:59 
 	pc at _inn_ set _S.10_ 
-	place npc _thief_ at _inn_ 
+	place npc _thief_ at _inn_
+	hide npc _thief_
 
 _S.04_ task:
 	daily from 08:01 to 16:01 
 	pc at _store_ set _S.11_ 
-	place npc _thief_ at _store_ 
+	place npc _thief_ at _store_
+	hide npc _thief_
 
 _S.05_ task:
 	clicked npc _informant_ say 1025 
@@ -218,13 +221,10 @@ _S.08_ task:
 	say 1030 
 
 _S.09_ task:
-	hide npc _thief_ 
 	place foe thiefFoe at _house_ 
 
 _S.10_ task:
-	hide npc _thief_ 
 	place foe thiefFoe at _inn_ 
 
-_S.11_ task:
-	hide npc _thief_ 
+_S.11_ task: 
 	place foe thiefFoe at _store_ 

--- a/Assets/StreamingAssets/Text/ConversationText.txt
+++ b/Assets/StreamingAssets/Text/ConversationText.txt
@@ -29,12 +29,12 @@ Weaponsmiths,                   Weapon smiths
 Localtemples,                   Local temples
 Sir,                            Sir
 Ma'am,                          Ma'am
-oldLeaderFate0,					died of heart failure
-oldLeaderFate1,					fell and struck his head
-oldLeaderFate2,					died of the plague
-oldLeaderFate3,					stepped down under pressure
-oldLeaderFate4,					was overthrown
-oldLeaderFate5,					was found murdered in his bed
+oldLeaderFate0,                 died of heart failure
+oldLeaderFate1,                 fell and struck his head
+oldLeaderFate2,                 died of the plague
+oldLeaderFate3,                 stepped down under pressure
+oldLeaderFate4,                 was overthrown
+oldLeaderFate5,                 was found murdered in his bed
 toBeReplacedStringRegional,     Any
 replacementStringRegional,      any
 resolvingError,                 never mind...

--- a/Assets/StreamingAssets/Text/ConversationText.txt
+++ b/Assets/StreamingAssets/Text/ConversationText.txt
@@ -29,6 +29,12 @@ Weaponsmiths,                   Weapon smiths
 Localtemples,                   Local temples
 Sir,                            Sir
 Ma'am,                          Ma'am
+oldLeaderFate0,					died of heart failure
+oldLeaderFate1,					fell and struck his head
+oldLeaderFate2,					died of the plague
+oldLeaderFate3,					stepped down under pressure
+oldLeaderFate4,					was overthrown
+oldLeaderFate5,					was found murdered in his bed
 toBeReplacedStringRegional,     Any
 replacementStringRegional,      any
 resolvingError,                 never mind...


### PR DESCRIPTION
talkmanager now can handle multiple resources with same name (e.g. named residence in local and remote town sharing the same name, persons with same name) - the residence case indeed happened

fixed a bug where place quest resource would not show up in "Where Is"->"Location"->"General" group in talk window when quest place was in remote town

Note: running quests from savegames are likely broken since dictionary key is now Symbol.Name instead of caption name