### PR TITLE
Optionally allow TextBox to receive negative or floating point numbers

### DIFF
--- a/Assets/Scripts/Game/UserInterface/MultiTextBox.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiTextBox.cs
@@ -122,9 +122,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// </summary>
         /// <param name="size">Number of textboxes.</param>
         /// <param name="isNumeric">Accept only numeric chars.</param>
-        public void DoLayout(int size, bool isNumeric = false)
+        public void DoLayout(int size, bool isNumeric = false, NumericMode numericMode = NumericMode.Natural)
         {
-            DoLayout(Enumerable.Range(0, size).Select(x => string.Empty).ToArray(), isNumeric);
+            DoLayout(Enumerable.Range(0, size).Select(x => string.Empty).ToArray(), isNumeric, numericMode);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// <param name="defaultValues">Default values in the requested order.</param>
         public void DoLayout(params int[] defaultValues)
         {
-            DoLayout(defaultValues.Select(x => x.ToString()).ToArray(), true);
+            DoLayout(defaultValues.Select(x => x.ToString()).ToArray(), true, NumericMode.Integer);
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// <param name="defaultValues">Default values in the requested order.</param>
         public void DoLayout(params float[] defaultValues)
         {
-            DoLayout(defaultValues.Select(x => x.ToString()).ToArray(), false);
+            DoLayout(defaultValues.Select(x => x.ToString()).ToArray(), true, NumericMode.Float);
         }
 
         /// <summary>
@@ -197,14 +197,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// <summary>
         /// Gets all result values in the layout order.
         /// </summary>
-        /// <remarks>Numeric doesn't allow dot so we check for bad input for now.</remarks>
         public IEnumerable<float> GetFloatValues()
         {
-            foreach (string text in GetInput())
-            {
-                float value;
-                yield return float.TryParse(text, out value) ? value : 0;
-            }
+            return GetInput().Select(x => float.Parse(x));
         }
 
         /// <summary>
@@ -212,8 +207,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// </summary>
         public float GetFloatValue(int index)
         {
-            float value;
-            return float.TryParse(TextBoxes[index].ResultText, out value) ? value : 0;
+            return float.Parse(TextBoxes[index].ResultText);
         }
 
         /// <summary>
@@ -257,7 +251,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #region Private Methods
 
-        private void DoLayout(string[] defaultText, bool isNumeric)
+        private void DoLayout(string[] defaultText, bool isNumeric, NumericMode numericMode = NumericMode.Natural)
         {
             if (Components.Count > 0)
                 Components.Clear();
@@ -309,6 +303,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
                 TextBoxes[i] = DaggerfallUI.AddTextBoxWithFocus(new Rect(new Vector2(x, y), size), defaultText[i], this);
                 TextBoxes[i].Numeric = isNumeric;
+                TextBoxes[i].NumericMode = numericMode;
                 TextBoxes[i].UseFocus = true;
                 TextBoxes[i].Outline.Enabled = enableOutline;
                 if (OnAddTextBoxCallback != null)

--- a/Assets/Scripts/Game/UserInterface/TextBox.cs
+++ b/Assets/Scripts/Game/UserInterface/TextBox.cs
@@ -12,11 +12,14 @@
 using UnityEngine;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.IO;
 
 namespace DaggerfallWorkshop.Game.UserInterface
 {
+    public enum NumericMode { Natural, Integer, Float }
+
     /// <summary>
     /// Implements a single line text edit box.
     /// </summary>
@@ -35,6 +38,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Vector2 maxSize = Vector2.zero;
         bool readOnly = false;
         bool numeric = false;
+        NumericMode numericMode = NumericMode.Natural;
         bool upperOnly = false;
         bool fixedSize = false;
 
@@ -114,6 +118,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             set { numeric = value; }
         }
 
+        public NumericMode NumericMode
+        {
+            get { return numericMode; }
+            set { numericMode = value; }
+        }
+
         public bool UpperOnly
         {
             get { return upperOnly; }
@@ -188,12 +198,35 @@ namespace DaggerfallWorkshop.Game.UserInterface
             char character = DaggerfallUI.Instance.LastCharacterTyped;
             if (character != 0 && text.Length < maxCharacters)
             {
-                // For numeric only accept characters 0-9
                 if (numeric)
                 {
+                    const char minus = '-';
+                    const char dot = '.';
+
                     int value = (int)character;
                     if (value < 0x30 || value > 0x39)
-                        return;
+                    {
+                        if (character == minus)
+                        {
+                            // Allow negative numbers only if not natural
+                            if (numericMode == NumericMode.Natural)
+                                return;
+
+                            if (cursorPosition != 0 || (text.Length > 0 && text[0] == minus))
+                                return;
+                        }
+                        else if (character == dot)
+                        {
+                            // Allow dot for floats
+                            if (numericMode != NumericMode.Float || text.Contains(dot))
+                                return;
+                        }
+                        else
+                        {
+                            // For numeric only accept characters 0 - 9
+                            return;
+                        }
+                    }
                 }
 
                 // For upper only, force everything to caps


### PR DESCRIPTION
TextBox numeric mode only allows positive numbers (I assume this is what's required by classic) but mod settings have keys which allow user input for negative numbers and decimals (specifically _TupleFloatKey_ and _TupleIntKey_). 

So i added an enum property to texbox to safely receive also minus and decimal mark when required. Default option is _Natural_, which is current behaviour. Interkarma are you ok with this? If you prefer, i can replace entirely _isNumeric_ flag with a _None_ option.