### PR TITLE
status info messagebox fix, hotkey window toggling for remaining windows implemented

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -1157,10 +1157,12 @@ namespace DaggerfallWorkshop.Game
         {
             // Setup status info as the first message box.
             DaggerfallMessageBox statusBox = new DaggerfallMessageBox(Instance.uiManager, Instance.uiManager.TopWindow);
+            statusBox.ExtraProceedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Status); // set proceed binding for statusBox to key binding for status window
             statusBox.SetTextTokens(22);
 
             // Setup health info as the second message box.
             DaggerfallMessageBox healthBox = CreateHealthStatusBox(statusBox);
+            healthBox.ExtraProceedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Status); // set proceed binding for healthBox to key binding for status window
             statusBox.AddNextMessageBox(healthBox);
 
             statusBox.Show();

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -474,7 +474,7 @@ namespace DaggerfallWorkshop.Game
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiStatusInfo);
             }
 
-            if (InputManager.Instance.ActionStarted(InputManager.Actions.AutoMap))
+            if (InputManager.Instance.ActionComplete(InputManager.Actions.AutoMap))
             {
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenAutomap);
             }

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -440,7 +440,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Handle in-game windows
-            if (InputManager.Instance.ActionStarted(InputManager.Actions.CharacterSheet))
+            if (InputManager.Instance.ActionComplete(InputManager.Actions.CharacterSheet))
             {
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenCharacterSheetWindow);
             }

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -448,7 +448,7 @@ namespace DaggerfallWorkshop.Game
             {
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
             }
-            else if (InputManager.Instance.ActionStarted(InputManager.Actions.TravelMap))
+            else if (InputManager.Instance.ActionComplete(InputManager.Actions.TravelMap))
             {
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenTravelMapWindow);
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
@@ -128,7 +128,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button upstairsButton;
         Button downstairsButton;
 
-        // definitions of hotkey sequences      
+        // definitions of hotkey sequences  
         readonly HotkeySequence HotkeySequence_SwitchAutomapGridMode = new HotkeySequence(KeyCode.Space, HotkeySequence.KeyModifiers.None);
         readonly HotkeySequence HotkeySequence_ResetView = new HotkeySequence(KeyCode.Backspace, HotkeySequence.KeyModifiers.None);
         readonly HotkeySequence HotkeySequence_ResetRotationPivotAxisView = new HotkeySequence(KeyCode.Backspace, HotkeySequence.KeyModifiers.LeftControl | HotkeySequence.KeyModifiers.RightControl);
@@ -163,6 +163,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         readonly HotkeySequence HotkeySequence_ZoomOut = new HotkeySequence(KeyCode.KeypadMinus, HotkeySequence.KeyModifiers.None);
         readonly HotkeySequence HotkeySequence_IncreaseCameraFieldOfFiew = new HotkeySequence(KeyCode.KeypadMultiply, HotkeySequence.KeyModifiers.None);
         readonly HotkeySequence HotkeySequence_DecreaseCameraFieldOfFiew = new HotkeySequence(KeyCode.KeypadDivide, HotkeySequence.KeyModifiers.None);
+
+        KeyCode toggleClosedBinding;
 
         const string nativeImgName = "AMAP00I0.IMG";
         const string nativeImgNameGrid3D = "AMAP01I0.IMG";
@@ -478,6 +480,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             compass.Scale = scale;
             NativePanel.Components.Add(compass);
 
+            // Store toggle closed binding for this window
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.AutoMap);
+
             isSetup = true;
         }
 
@@ -626,6 +631,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
             resizeGUIelementsOnDemand();
+
+            // Toggle window closed with same hotkey used to open it
+            if (Input.GetKeyUp(toggleClosedBinding))
+                CloseWindow();
 
             HotkeySequence.KeyModifiers keyModifiers = HotkeySequence.getKeyModifiers(Input.GetKey(KeyCode.LeftControl), Input.GetKey(KeyCode.RightControl), Input.GetKey(KeyCode.LeftShift), Input.GetKey(KeyCode.RightShift), Input.GetKey(KeyCode.LeftAlt), Input.GetKey(KeyCode.RightAlt));
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
@@ -128,8 +128,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button upstairsButton;
         Button downstairsButton;
 
-        // definitions of hotkey sequences
-        readonly HotkeySequence HotkeySequence_CloseMap = new HotkeySequence(KeyCode.M, HotkeySequence.KeyModifiers.None);        
+        // definitions of hotkey sequences      
         readonly HotkeySequence HotkeySequence_SwitchAutomapGridMode = new HotkeySequence(KeyCode.Space, HotkeySequence.KeyModifiers.None);
         readonly HotkeySequence HotkeySequence_ResetView = new HotkeySequence(KeyCode.Backspace, HotkeySequence.KeyModifiers.None);
         readonly HotkeySequence HotkeySequence_ResetRotationPivotAxisView = new HotkeySequence(KeyCode.Backspace, HotkeySequence.KeyModifiers.LeftControl | HotkeySequence.KeyModifiers.RightControl);
@@ -646,11 +645,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             
             // check hotkeys and assign actions
-            if (Input.GetKeyDown(HotkeySequence_CloseMap.keyCode) && HotkeySequence.checkSetModifiers(keyModifiers, HotkeySequence_CloseMap.modifiers))
-            {                
-                CloseWindow();
-                Input.ResetInputAxes(); // prevents automap window to reopen immediately after closing
-            }
             if (Input.GetKeyDown(HotkeySequence_SwitchAutomapGridMode.keyCode) && HotkeySequence.checkSetModifiers(keyModifiers, HotkeySequence_SwitchAutomapGridMode.modifiers))
             {
                 ActionChangeAutomapGridMode();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -26,8 +26,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     /// </summary>
     public class DaggerfallCharacterSheetWindow : DaggerfallPopupWindow
     {
+        #region Fields
         const string nativeImgName = "INFO00I0.IMG";
         private const int noAffiliationsMsgId = 19;
+
+        StatsRollout statsRollout;
+
+        bool leveling = false;
+
+        const int minBonusPool = 4;        // The minimum number of free points to allocate on level up
+        const int maxBonusPool = 6;        // The maximum number of free points to allocate on level up
+        SoundClips levelUpSound = SoundClips.LevelUp;
+
+        KeyCode toggleClosedBinding;
+
+        #endregion
 
         #region UI Controls
 
@@ -49,20 +62,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         #region UI Textures
 
         Texture2D nativeTexture;
-
-        #endregion
-
-        #region Fields
-
-        StatsRollout statsRollout;
-
-        bool leveling = false;
-
-        const int minBonusPool = 4;        // The minimum number of free points to allocate on level up
-        const int maxBonusPool = 6;        // The maximum number of free points to allocate on level up
-        SoundClips levelUpSound = SoundClips.LevelUp;
-
-        KeyCode toggleClosedBinding;
 
         #endregion
 
@@ -189,6 +188,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Store toggle closed binding for this window
             toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.CharacterSheet);
         }
+
+        #endregion
+
+        #region Overrides
 
         public override void Update()
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -29,7 +29,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const string nativeImgName = "INFO00I0.IMG";
         private const int noAffiliationsMsgId = 19;
 
-        Texture2D nativeTexture;
+        #region UI Controls
+
         PlayerEntity playerEntity;
         TextLabel nameLabel = new TextLabel();
         TextLabel raceLabel = new TextLabel();
@@ -43,6 +44,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         TextLabel[] statLabels = new TextLabel[DaggerfallStats.Count];
         PaperDoll characterPortrait = new PaperDoll();
 
+        #endregion
+
+        #region UI Textures
+
+        Texture2D nativeTexture;
+
+        #endregion
+
+        #region Fields
+
         StatsRollout statsRollout;
 
         bool leveling = false;
@@ -51,15 +62,29 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int maxBonusPool = 6;        // The maximum number of free points to allocate on level up
         SoundClips levelUpSound = SoundClips.LevelUp;
 
+        KeyCode toggleClosedBinding;
+
+        #endregion
+
+        #region Properties
+
         PlayerEntity PlayerEntity
         {
             get { return (playerEntity != null) ? playerEntity : playerEntity = GameManager.Instance.PlayerEntity; }
         }
 
+        #endregion
+
+        #region Constructors
+
         public DaggerfallCharacterSheetWindow(IUserInterfaceManager uiManager)
             : base(uiManager)
         {
         }
+
+        #endregion
+
+        #region Setup Methods
 
         protected override void Setup()
         {
@@ -160,6 +185,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Update player paper doll for first time
             UpdatePlayerValues();
             characterPortrait.Refresh();
+
+            // Store toggle closed binding for this window
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.CharacterSheet);
+        }
+
+        public override void Update()
+        {
+            base.Update();
+
+            // Toggle window closed with same hotkey used to open it
+            if (Input.GetKeyUp(toggleClosedBinding))
+                CloseWindow();
         }
 
         public override void OnPush()
@@ -181,6 +218,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             base.CancelWindow();
         }
+
+        #endregion
 
         #region Private Methods
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -114,7 +114,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button downstairsButton;
 
         // definitions of hotkey sequences
-        readonly HotkeySequence HotkeySequence_CloseMap = new HotkeySequence(KeyCode.M, HotkeySequence.KeyModifiers.None);
         readonly HotkeySequence HotkeySequence_FocusPlayerPosition = new HotkeySequence(KeyCode.Tab, HotkeySequence.KeyModifiers.None);
         readonly HotkeySequence HotkeySequence_ResetView = new HotkeySequence(KeyCode.Backspace, HotkeySequence.KeyModifiers.None);      
         readonly HotkeySequence HotkeySequence_SwitchToNextExteriorAutomapViewMode = new HotkeySequence(KeyCode.Return, HotkeySequence.KeyModifiers.None);
@@ -521,11 +520,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             HotkeySequence.KeyModifiers keyModifiers = HotkeySequence.getKeyModifiers(Input.GetKey(KeyCode.LeftControl), Input.GetKey(KeyCode.RightControl), Input.GetKey(KeyCode.LeftShift), Input.GetKey(KeyCode.RightShift), Input.GetKey(KeyCode.LeftAlt), Input.GetKey(KeyCode.RightAlt));
             
             // check hotkeys and assign actions
-            if (Input.GetKeyDown(HotkeySequence_CloseMap.keyCode) && HotkeySequence.checkSetModifiers(keyModifiers, HotkeySequence_CloseMap.modifiers))
-            {                
-                CloseWindow();
-                Input.ResetInputAxes(); // prevents automap window to reopen immediately after closing
-            }
             if (Input.GetKeyDown(HotkeySequence_FocusPlayerPosition.keyCode) && HotkeySequence.checkSetModifiers(keyModifiers, HotkeySequence_FocusPlayerPosition.modifiers))
             {
                 ActionFocusPlayerPosition();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -145,6 +145,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         readonly HotkeySequence HotkeySequence_MinZoom2 = new HotkeySequence(KeyCode.KeypadPlus, HotkeySequence.KeyModifiers.LeftControl | HotkeySequence.KeyModifiers.RightControl);
         readonly HotkeySequence HotkeySequence_MaxZoom2 = new HotkeySequence(KeyCode.KeypadMinus, HotkeySequence.KeyModifiers.LeftControl | HotkeySequence.KeyModifiers.RightControl);
 
+        KeyCode toggleClosedBinding;
+
         const string nativeImgName = "AMAP00I0.IMG";
         const string nativeImgNameCaption = "TOWN00I0.IMG";
 
@@ -209,7 +211,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         int oldRenderTextureExteriorAutomapWidth; // used to store previous width of exterior automap render texture to react to changes to NativePanel's size and react accordingly by setting texture up with new widht and height again
         int oldRenderTextureExteriorAutomapHeight; // used to store previous height of exterior automap render texture to react to changes to NativePanel's size and react accordingly by setting texture up with new widht and height again
 		
-        bool isSetup = false;
+        bool isSetup = false;        
 
         public Panel PanelRenderAutomap
         {
@@ -443,6 +445,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             compass.Scale = scale;
             NativePanel.Components.Add(compass);
 
+            // Store toggle closed binding for this window
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.AutoMap);
+
             isSetup = true;
         }
 
@@ -516,6 +521,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
             resizeGUIelementsOnDemand();
+
+            // Toggle window closed with same hotkey used to open it
+            if (Input.GetKeyUp(toggleClosedBinding))
+                CloseWindow();
 
             HotkeySequence.KeyModifiers keyModifiers = HotkeySequence.getKeyModifiers(Input.GetKey(KeyCode.LeftControl), Input.GetKey(KeyCode.RightControl), Input.GetKey(KeyCode.LeftShift), Input.GetKey(KeyCode.RightShift), Input.GetKey(KeyCode.LeftAlt), Input.GetKey(KeyCode.RightAlt));
             

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -39,6 +39,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         DaggerfallMessageBox nextMessageBox;
         int customYPos = -1;
 
+        KeyCode extraProceedBinding = KeyCode.None;
+
         /// <summary>
         /// Default message box buttons are indices into BUTTONS.RCI.
         /// </summary>
@@ -95,6 +97,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             get { return clickAnywhereToClose; }
             set { clickAnywhereToClose = value; }
+        }
+
+        public KeyCode ExtraProceedBinding
+        {
+            get { return extraProceedBinding; }
+            set { extraProceedBinding = value; }
         }
 
         public DaggerfallMessageBox(IUserInterfaceManager uiManager, IUserInterfaceWindow previous = null, bool wrapText = false, int posY = -1)
@@ -202,9 +210,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public override void Update()
         {
             base.Update();
-        
-            if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter))
-              CloseWindow();
+
+            if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || Input.GetKeyUp(extraProceedBinding))
+            {
+                // if there is a nested next message box show it
+                if (this.nextMessageBox != null)
+                {
+                    nextMessageBox.Show();
+                }
+                else // or close window if there is no next message box to show
+                {
+                    CloseWindow();                    
+                }
+            }
         }
 
         public Button AddButton(MessageBoxButtons messageBoxButton)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -32,12 +32,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
     public class DaggerfallQuestJournalWindow : DaggerfallPopupWindow
     {
-        const string nativeImgName  = "LGBK00I0.IMG";
-        const int maxLines          = 19;
-        int lastMessageIndex        = -1;
-        int currentMessageIndex     = 0;
+        #region Fields
+
+        const string nativeImgName = "LGBK00I0.IMG";
+
+        const int maxLines = 19;
+        int lastMessageIndex = -1;
+        int currentMessageIndex = 0;
 
         List<Message> questMessages;
+
+        KeyCode toggleClosedBinding;
+
+        #endregion
+
+        #region UI Controls
 
         MultiFormatTextLabel questLogLabel;
 
@@ -48,11 +57,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button downArrowButton;
         Button exitButton;
 
+        #endregion
+
+        #region Constructors
 
         public DaggerfallQuestJournalWindow(UserInterfaceManager uiManager) : base(uiManager) 
         {
         }
 
+        #endregion
+
+        #region Setup Methods
 
         protected override void Setup()
         {
@@ -108,10 +123,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             questMessages = QuestMachine.Instance.GetAllQuestLogMessages();
             SetText();
 
+            // Store toggle closed binding for this window
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.LogBook);
+
 #if LAYOUT
             SetBackgroundColors();
 #endif
         }
+
+        #endregion
+
+        #region Overrides
 
         public override void OnPush()
         {
@@ -132,6 +154,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
+            // Toggle window closed with same hotkey used to open it
+            if (Input.GetKeyUp(toggleClosedBinding))
+                CloseWindow();
+
             if (lastMessageIndex != currentMessageIndex)
             {
                 lastMessageIndex = currentMessageIndex;
@@ -139,8 +165,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
+        #endregion
 
-#region events
+        #region events
 
         public void dialogButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
@@ -170,7 +197,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             CloseWindow();
         }
 
-#endregion
+        #endregion
+
+        #region region Private Methods
 
         private void SetText()
         {
@@ -241,5 +270,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 #endif
+        #endregion
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -78,6 +78,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         PlayerEntity playerEntity;
         DaggerfallHUD hud;
 
+        KeyCode toggleClosedBinding;
+
         #endregion
 
         #region Enums
@@ -143,6 +145,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Stop button
             stopButton = DaggerfallUI.AddButton(stopButtonRect, counterPanel);
             stopButton.OnMouseClick += StopButton_OnMouseClick;
+
+            // Store toggle closed binding for this window
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Rest);
         }
 
         #endregion
@@ -152,6 +157,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public override void Update()
         {
             base.Update();
+
+            // Toggle window closed with same hotkey used to open it
+            if (Input.GetKeyUp(toggleClosedBinding))
+                CloseWindow();
 
             // Update HUD
             if (hud != null)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -56,6 +56,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         Vector2 baseSize;
 
+        KeyCode toggleClosedBinding;
+
         #endregion
 
         #region Constructors
@@ -121,13 +123,29 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
 
             NativePanel.Components.Add(mainPanel);
+
+            // Store toggle closed binding for this window
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Transport);
         }
 
         #endregion
 
-        #region Private Methods
+        #region Overrides
 
-        void LoadTextures()
+        public override void Update()
+        {
+            base.Update();
+
+            // Toggle window closed with same hotkey used to open it
+            if (Input.GetKeyUp(toggleClosedBinding))
+                CloseWindow();
+        }
+
+        #endregion
+
+            #region Private Methods
+
+            void LoadTextures()
         {
             ImageData baseData = ImageReader.GetImageData(baseTextureName);
             baseTexture = baseData.texture;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -59,6 +59,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         DFRegion currentDFRegion;
         ContentReader.MapSummary locationSummary;
 
+        KeyCode toggleClosedBinding;
+
         Panel borderPanel;
         Panel regionTextureOverlayPanel;
 
@@ -284,6 +286,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
+            // Toggle window closed with same hotkey used to open it
+            if (Input.GetKeyUp(toggleClosedBinding))
+                CloseWindow();
+
             //input handling
 
             Vector2 currentMousePos = new Vector2((NativePanel.ScaledMousePosition.x), (NativePanel.ScaledMousePosition.y));
@@ -450,6 +456,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             NativePanel.Components.Add(verticalArrowButton);
             verticalArrowButton.Name = "verticalArrowButton";
             verticalArrowButton.OnMouseClick += ArrowButtonClickHandler;
+
+            // Store toggle closed binding for this window
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.TravelMap);
 
         }
 


### PR DESCRIPTION
according to your example I implemented all remaining windows that benefit from toggle behavior, hope you find this better now ;)

furthermore I fixed status info messagebox bug, status hot-key proceeds messagebox now as implemented in vanilla daggerfall, enter key will proceed, escape key will close messagebox immediately
also status hotkey will now proceed messagebox as convenience feature

hotkey toggling implemented for remaining windows:
- character sheet
- log book
- automaps
- travel map
- rest window
- transportation window