### PR TITLE
Import guild memberships from classic

### DIFF
--- a/Assets/Scripts/API/Save/DiseaseOrPoisonRecord.cs
+++ b/Assets/Scripts/API/Save/DiseaseOrPoisonRecord.cs
@@ -92,7 +92,7 @@ namespace DaggerfallConnect.Save
             // Copy base record data
             base.CopyTo(other);
 
-            // Copy item data
+            // Copy parsed data
             other.parsedData = this.parsedData;
         }
 

--- a/Assets/Scripts/API/Save/GuildMembershipRecord.cs
+++ b/Assets/Scripts/API/Save/GuildMembershipRecord.cs
@@ -1,0 +1,114 @@
+﻿// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Allofich
+// Contributors:
+//
+// Notes:
+//
+
+using System;
+using System.IO;
+
+namespace DaggerfallConnect.Save
+{
+    /// <summary>
+    /// Guild membership record.
+    /// SaveTreeRecordTypes = 0x0A
+    /// </summary>
+    public class GuildMembershipRecord : SaveTreeBaseRecord
+    {
+        #region Fields
+
+        GuildMembershipRecordData parsedData;
+
+        #endregion
+
+        #region Properties
+
+        public GuildMembershipRecordData ParsedData
+        {
+            get { return parsedData; }
+            set { parsedData = value; }
+        }
+
+        #endregion
+
+        #region Structures and Enumerations
+
+        /// <summary>
+        /// Stores native data exactly as read from save file.
+        /// </summary>
+        public struct GuildMembershipRecordData
+        {
+            public Byte rank;                       // Rank in guild, starting at 0
+            public Byte notedByGuild;               // Under research. Increased by doing quests? Related to rewards, promotions.
+            public Byte guildType;                  // Guild type. Used in classic for %gdd, %lev and %pct macros, choosing guild quest filename prefix, and blessings (not used in classic)
+            public UInt16 factionID;
+            public UInt32 timeOfLastRankChange;     // Time of joining guild or last promotion or demotion
+            public Byte unused;                     // Seems to be unused
+            public Byte blessingMagnitude;          // Amount of blessing (not used in classic)
+            public UInt16 unused2;                  // Seems to be unused
+        }
+
+        #endregion
+
+        #region Constructors
+
+        public GuildMembershipRecord()
+        {
+        }
+
+        public GuildMembershipRecord(BinaryReader reader, int length)
+            : base(reader, length)
+        {
+            ReadNativeGuildMembershipData();
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void CopyTo(GuildMembershipRecord other)
+        {
+            // Copy base record data
+            base.CopyTo(other);
+
+            // Copy parsed data
+            other.parsedData = this.parsedData;
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        void ReadNativeGuildMembershipData()
+        {
+            // Must be a guild membership type
+            if (recordType != RecordTypes.GuildMembership)
+                return;
+
+            // Prepare stream
+            MemoryStream stream = new MemoryStream(RecordData);
+            BinaryReader reader = new BinaryReader(stream);
+
+            // Read native data
+            parsedData = new GuildMembershipRecordData();
+            parsedData.rank = reader.ReadByte();
+            parsedData.notedByGuild = reader.ReadByte();
+            parsedData.guildType = reader.ReadByte();
+            parsedData.factionID = reader.ReadUInt16();
+            parsedData.timeOfLastRankChange = reader.ReadUInt32();
+            parsedData.unused = reader.ReadByte();
+            parsedData.blessingMagnitude = reader.ReadByte();
+            parsedData.unused2 = reader.ReadUInt16();
+
+            // Close stream
+            reader.Close();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/API/Save/GuildMembershipRecord.cs.meta
+++ b/Assets/Scripts/API/Save/GuildMembershipRecord.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d9bcad2bbbbec584bb73b362fa89b0d3
+timeCreated: 1526740379
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/API/Save/SaveTree.cs
+++ b/Assets/Scripts/API/Save/SaveTree.cs
@@ -242,6 +242,9 @@ namespace DaggerfallConnect.Save
                     case RecordTypes.Spell:
                         record = new SpellRecord(reader, length);
                         break;
+                    case RecordTypes.GuildMembership:
+                        record = new GuildMembershipRecord(reader, length);
+                        break;
                     case RecordTypes.DiseaseOrPoison:
                         record = new DiseaseOrPoisonRecord(reader, length);
                         break;

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -58,6 +58,8 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public int Rank { get { return rank; } set { rank = value; } }
 
+        public int LastRankChange { get { return lastRankChange; } set { lastRankChange = value; } }
+
         public virtual TextFile.Token[] UpdateRank(PlayerEntity playerEntity)
         {
             TextFile.Token[] tokens = null;
@@ -115,7 +117,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             }
         }
 
-        private static int CalculateDaySinceZero(DaggerfallDateTime date)
+        public static int CalculateDaySinceZero(DaggerfallDateTime date)
         {
             return (date.Year * DaggerfallDateTime.DaysPerYear) + date.DayOfYear;
         }

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -127,7 +127,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             return CreateGuildObj(guildGroup, buildingFactionId);
         }
 
-        private Guild CreateGuildObj(FactionFile.GuildGroups guildGroup, int variant = 0)
+        public Guild CreateGuildObj(FactionFile.GuildGroups guildGroup, int variant = 0)
         {
             switch (guildGroup)
             {
@@ -206,7 +206,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                 return GetGuild(guildGroup, factionId);
         }
 
-        private FactionFile.GuildGroups GetGuildGroup(int factionId)
+        public FactionFile.GuildGroups GetGuildGroup(int factionId)
         {
             PersistentFactionData persistentFactionData = GameManager.Instance.PlayerEntity.FactionData;
             FactionFile.GuildGroups guildGroup = FactionFile.GuildGroups.None;

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -541,6 +541,9 @@ namespace DaggerfallWorkshop.Game.Utility
             // Assign items to player entity
             playerEntity.AssignItems(saveTree);
 
+            // Assign guild memberships
+            playerEntity.AssignGuildMemberships(saveTree);
+
             // Assign diseases and poisons to player entity
             playerEntity.AssignDiseasesAndPoisons(saveTree);
 


### PR DESCRIPTION
Imports guilds from classic, including rank and time of last rank change.

The only used guild value I know of that is not imported is one that seems to be involved in guild promotions and rewards.

@ajrb I had to make a couple guild-related methods public so I could access them, I hope that's alright with you. Also I had to do some conversion work to match to the days-since-promotion that you're using. Classic goes by minutes. (As far as I have seen classic always uses minutes for game time related calculations)