### PR TITLE
Court screen updates

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -49,6 +49,8 @@ namespace DaggerfallWorkshop.Game
         public static Color DaggerfallUnityDefaultToolTipTextColor = new Color32(230, 230, 200, 255);
         public static Color DaggerfallUnityDefaultCheckboxToggleColor = new Color32(146, 12, 4, 255);
         public static Color DaggerfallUnityNotImplementedColor = new Color(1, 0, 0, 0.5f);
+        public static Color DaggerfallPrisonDaysUntilFreedomColor = new Color32(232, 196, 76, 255);
+        public static Color DaggerfallPrisonDaysUntilFreedomShadowColor = new Color32(48, 36, 20, 255);
         public static Vector2 DaggerfallDefaultShadowPos = Vector2.one;
 
         public FilterMode globalFilterMode = FilterMode.Point;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -36,6 +36,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
         bool godMode = false;
         bool preventEnemySpawns = false;
+        bool preventNormalizingReputations = false;
         bool isResting = false;
 
         const int testPlayerLevel = 1;
@@ -113,6 +114,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
         public bool GodMode { get { return godMode; } set { godMode = value; } }
         public bool PreventEnemySpawns { get { return preventEnemySpawns; } set { preventEnemySpawns = value; } }
+        public bool PreventNormalizingReputations { get { return preventNormalizingReputations; } set { preventNormalizingReputations = value; } }
         public bool IsResting { get { return isResting; } set { isResting = value; } }
         public Races Race { get { return (Races)RaceTemplate.ID; } }
         public RaceTemplate RaceTemplate { get { return raceTemplate; } set { raceTemplate = value; } }
@@ -316,7 +318,7 @@ namespace DaggerfallWorkshop.Game.Entity
             for (int i = 0; i < minutesPassed; ++i)
             {
                 // Normalize legal reputations towards 0
-                if (((i + lastGameMinutes) % 161280) == 0) // 112 days
+                if (((i + lastGameMinutes) % 161280) == 0 && !preventNormalizingReputations) // 112 days
                     NormalizeReputations();
 
                 // Update faction relationships, faction power levels and regional conditions (in progress)
@@ -363,6 +365,10 @@ namespace DaggerfallWorkshop.Game.Entity
             // Allow enemy spawns again if they have been disabled
             if (preventEnemySpawns)
                 preventEnemySpawns = false;
+
+            // Allow normalizing reputations again if it was disabled
+            if (preventNormalizingReputations)
+                preventNormalizingReputations = false;
 
             // Reset isResting flag. If still resting DaggerfallRestWindow will set it to true again for the next update.
             if (isResting)

--- a/Assets/Scripts/Game/Player/CameraRecoiler.cs
+++ b/Assets/Scripts/Game/Player/CameraRecoiler.cs
@@ -14,6 +14,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -60,6 +61,7 @@ namespace DaggerfallWorkshop.Game
             // Use events to capture a couple of edge cases
             StreamingWorld.OnInitWorld += StreamingWorld_OnInitWorld;
             SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
+            DaggerfallCourtWindow.OnCourtScreen += DaggerfallCourtWindow_OnCourtScreen;
         }
 
         void Update()
@@ -208,6 +210,12 @@ namespace DaggerfallWorkshop.Game
             // Loading a character with same MaxHealth but lower current health
             // would also trigger a sway on load
             // This resets on any load so sway is cleared for incoming character
+            ResetRecoil();
+        }
+
+        private void DaggerfallCourtWindow_OnCourtScreen()
+        {
+            // Clear sway when player goes to court screen
             ResetRecoil();
         }
     }

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -124,6 +124,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string youPinchedGoldPieces = "You pinched %d gold pieces.";
         public const string youAreNotSuccessful = "You are not successful...";
 
+        public const string daysUntilFreedom = "%d days until freedom.";
+
         public const string skillImprove = "Your %s skill has improved.";
         public const string mustDistributeBonusPoints = "You must distribute all bonus points.";
         public const string affiliation = "Affiliation";


### PR DESCRIPTION
- Prison screen implemented
- Fix to not allow using ESC key to cancel court window or court message boxes, which would mess things up as it wasn't set up to handle it
- Fix to prevent camera recoil when leaving court screen

Also, although it's not in classic, I added a "cheat" key to speed up the day countdown by holding down ESC, which is nice to have while testing if nothing else. I don't know how hardcore people want to be about actually having to wait through the prison sentence.

Interkarma, is there a good way to change the color of text? The text on the prison screen should be different from the default color, as in this screenshot.
![prisonscreen](https://user-images.githubusercontent.com/19624336/40277306-d271e498-5c57-11e8-872c-f5f9dbcc60e1.png)
