### PR TITLE
ConversationData.txt - fixes for old savegame format issues - should fix most of the problems

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -786,6 +786,16 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 TalkManager.ListItem item = listTopic[i];
                 ListBox.ListItem listboxItem;
+                if (item.caption == null) // this is a check to detect problems arising from old save data - where caption end up as null
+                {
+                    item.caption = item.key; //  just try to take key as caption then (answers might still be broken)
+                    if (item.caption == String.Empty)
+                        item.caption = TextManager.Instance.GetText(TalkManager.TextDatabase, "resolvingError");
+                }
+                else if (item.caption == String.Empty)
+                {
+                    item.caption = TextManager.Instance.GetText(TalkManager.TextDatabase, "resolvingError");
+                }
                 listboxTopic.AddItem(item.caption, out listboxItem);
                 if (item.type == TalkManager.ListItemType.NavigationBack)
                 {


### PR DESCRIPTION
RestoreConversationData now checks for quest resource entries and rumors of orphaned quests (that are no longer running) and removes them

additional checks should prevent some issues I found when above mechanism would not be in place (double net mechanism)