### PR TITLE
escape key now closes travel map window correctly

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -231,9 +231,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Populate the offset dict
             PopulateRegionOffsetDict();
 
-            // Don't allow automatic cancel, we will handle this locally
-            AllowCancel = false;
-
             // Load picker colours
             regionPickerBitmap = DaggerfallUI.GetImgBitmap(regionPickerImgName);
 
@@ -284,11 +281,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public override void Update()
         {
+            // important to happen before base.Update()
+            if (Input.GetKeyUp(exitKey) && RegionSelected)
+            {
+                CloseRegionPanel();
+                Input.ResetInputAxes();
+            }
+
             base.Update();
 
             // Toggle window closed with same hotkey used to open it
             if (Input.GetKeyUp(toggleClosedBinding))
-                CloseWindow();
+            {
+                if (RegionSelected)
+                    CloseRegionPanel();
+                else
+                    CloseWindow();             
+            }
 
             //input handling
 
@@ -301,14 +310,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     UpdateMouseOverLocation();
                 else
                     UpdateMouseOverRegion();
-            }
-
-            if (Input.GetKeyDown(exitKey))      //exit key will cancel any identifying actions if any
-            {                                   //if not ident. it will just close region panel or exit travel map
-                if (FindingLocation || identifying)
-                    StopIdentify(false);
-                else
-                    CloseTravelWindows();
             }
 
             UpdateRegionLabel();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -281,13 +281,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public override void Update()
         {
-            // important to happen before base.Update()
-            if (Input.GetKeyUp(exitKey) && RegionSelected)
-            {
-                CloseRegionPanel();
-                Input.ResetInputAxes();
-            }
-
             base.Update();
 
             // Toggle window closed with same hotkey used to open it


### PR DESCRIPTION
if wanted I will investigate if it is possible to only close regional window when in regional view - currently escape closes travel map window completely when in there
but this is more complex than thought at first glance