### PR TITLE
Crusher

### DIFF
--- a/Assets/Prefabs/Player/PlayerAdvanced.prefab
+++ b/Assets/Prefabs/Player/PlayerAdvanced.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114101796857139080}
   - component: {fileID: 114220683863726122}
   - component: {fileID: 114033680799267548}
-  - component: {fileID: 135216212425773840}
   m_Layer: 0
   m_Name: PlayerAdvanced
   m_TagString: Player
@@ -1301,18 +1300,6 @@ MonoBehaviour:
   nodXAmount: 0
   nodYAmount: 0
   bobScalar: 0
---- !u!135 &135216212425773840
-SphereCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 100000}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.23
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!198 &198237622866876544
 ParticleSystem:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Player/PlayerAdvanced.prefab
+++ b/Assets/Prefabs/Player/PlayerAdvanced.prefab
@@ -39,6 +39,8 @@ GameObject:
   - component: {fileID: 114549470222698842}
   - component: {fileID: 114101796857139080}
   - component: {fileID: 114220683863726122}
+  - component: {fileID: 114033680799267548}
+  - component: {fileID: 135216212425773840}
   m_Layer: 0
   m_Name: PlayerAdvanced
   m_TagString: Player
@@ -559,10 +561,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c9bfb03a8545a343883f7d2606b5814, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  standingHeight: 1.78
-  eyeHeight: 0.09
-  crouchingHeight: 0.45
-  ridingHeight: 2.6
   limitDiagonalSpeed: 1
   toggleRun: 0
   systemTimerUpdatesPerSecond: 0.055
@@ -1006,6 +1004,17 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 2
+--- !u!114 &114033680799267548
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e13b282693fb9b46bf1262c8c84685e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114097946917833764
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1058,6 +1067,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dcffcd439a0b0a94e846036ea849c8ef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  standHeight: 1.78
+  crouchHeight: 0.45
 --- !u!114 &114189154217185308
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1290,6 +1301,18 @@ MonoBehaviour:
   nodXAmount: 0
   nodYAmount: 0
   bobScalar: 0
+--- !u!135 &135216212425773840
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.23
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!198 &198237622866876544
 ParticleSystem:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -3,6 +3,7 @@ using DaggerfallWorkshop.Game.Serialization;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -55,7 +56,7 @@ namespace DaggerfallWorkshop.Game
             camStandLevel = standHeight / 2f;
             camRideLevel = rideHeight / 2f - eyeHeight;
 
-            // Use events to capture a couple of edge cases
+            // Use event to set whether player is crouched on load
             SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
         }
 
@@ -190,14 +191,14 @@ namespace DaggerfallWorkshop.Game
 
         private void SnapToggleCrouching()
         {
-            if (playerMotor.IsCrouching)
+            if (playerMotor.IsCrouching && controller.height != crouchHeight)
             {
                 controller.height = crouchHeight;
                 Vector3 pos = controller.transform.position;
                 pos.y -= (standHeight - crouchHeight) / 2.0f;
                 controller.transform.position = pos;
             }
-            else if (!playerMotor.IsCrouching)
+            else if (!playerMotor.IsCrouching && controller.height != standHeight)
             {
                 controller.height = standHeight;
                 Vector3 pos = controller.transform.position;

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -30,8 +30,8 @@ namespace DaggerfallWorkshop.Game
         private CharacterController controller;
         private HeadBobber headBobber;
         private Camera mainCamera;
-        private float standHeight = 1.78f;
-        private float crouchHeight = 0.45f;
+        public float standHeight = 1.78f;
+        public float crouchHeight = 0.45f;
         private float rideHeight = 2.6f;   // Height of a horse plus seated rider. (1.6m + 1m)
         private float eyeHeight = 0.09f;         // Eye height is 9cm below top of capsule.
         private float crouchChangeDistance;
@@ -71,7 +71,6 @@ namespace DaggerfallWorkshop.Game
                 DoMount();
             else
                 DoDismount();
-            
         }
 
         private void DoCrouch() // first lower camera, height last 
@@ -90,7 +89,6 @@ namespace DaggerfallWorkshop.Game
                 heightAction = HeightChangeAction.DoNothing;
             }
         }
-
         private void DoStand() // adjust height first, camera last
         {
             if (controller.height == crouchHeight)

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -188,31 +188,28 @@ namespace DaggerfallWorkshop.Game
             return !Physics.SphereCast(ray, controller.radius, distance);
         }
 
-        private void SetIsCrouching()
+        private void SnapToggleCrouching()
         {
-            
-            // Old code for reference
-            /* if (isCrouching && !wasCrouching)
+            if (playerMotor.IsCrouching)
             {
-                controller.height = crouchingHeight;
+                controller.height = crouchHeight;
                 Vector3 pos = controller.transform.position;
-                pos.y -= (standingHeight - crouchingHeight) / 2.0f;
+                pos.y -= (standHeight - crouchHeight) / 2.0f;
                 controller.transform.position = pos;
-                wasCrouching = isCrouching;
             }
-            else if (!isCrouching && wasCrouching)
+            else if (!playerMotor.IsCrouching)
             {
-                controller.height = standingHeight;
+                controller.height = standHeight;
                 Vector3 pos = controller.transform.position;
-                pos.y += (standingHeight - crouchingHeight) / 2.0f;
+                pos.y += (standHeight - crouchHeight) / 2.0f;
                 controller.transform.position = pos;
-                wasCrouching = isCrouching;
-    -       }*/
+            }
         }
 
         private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
         {
-            SetIsCrouching();
+            playerMotor.IsCrouching = saveData.playerData.playerPosition.isCrouching;
+            SnapToggleCrouching();
         }
     }
 }

--- a/Assets/Scripts/Game/PlayerCrush.cs
+++ b/Assets/Scripts/Game/PlayerCrush.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DaggerfallWorkshop.Game
+{
+    public class PlayerCrush : MonoBehaviour
+    {
+        private PlayerHeightChanger heightChanger;
+        private PlayerMotor playerMotor;
+        private SphereCollider crushCollider;
+        private CharacterController controller;
+    
+	    void Start ()
+        {
+            heightChanger = GetComponent<PlayerHeightChanger>();
+            playerMotor = GetComponent<PlayerMotor>();
+            
+            crushCollider = GetComponent<SphereCollider>();
+            crushCollider.center += new Vector3(0, 0.45f);
+            controller = GetComponent<CharacterController>();
+	    }
+	
+	    void Update ()
+        {
+
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            // if we didn't collide with a crushing object, return
+            if (other.gameObject.GetComponent<MeshCollider>() == null)
+                return;
+
+            // If player is standing, crushing object forces them into a crouch, 
+            if (!playerMotor.IsCrouching && heightChanger.HeightAction != HeightChangeAction.DoCrouching)
+            {
+                Debug.Log("Force Crouch");
+                heightChanger.HeightAction = HeightChangeAction.DoCrouching;
+            }
+            // if player already crouching, then kill.
+            else if (playerMotor.IsCrouching)
+            {
+                GameManager.Instance.PlayerEntity.SetHealth(0);
+                Debug.Log("Crush!");
+            }
+
+
+        }
+    }
+}

--- a/Assets/Scripts/Game/PlayerCrush.cs
+++ b/Assets/Scripts/Game/PlayerCrush.cs
@@ -35,17 +35,13 @@ namespace DaggerfallWorkshop.Game
             // If player is standing, crushing object forces them into a crouch, 
             if (!playerMotor.IsCrouching && heightChanger.HeightAction != HeightChangeAction.DoCrouching)
             {
-                Debug.Log("Force Crouch");
                 heightChanger.HeightAction = HeightChangeAction.DoCrouching;
             }
             // if player already crouching, then kill.
             else if (playerMotor.IsCrouching)
             {
                 GameManager.Instance.PlayerEntity.SetHealth(0);
-                Debug.Log("Crush!");
             }
-
-
         }
     }
 }

--- a/Assets/Scripts/Game/PlayerCrush.cs.meta
+++ b/Assets/Scripts/Game/PlayerCrush.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3e13b282693fb9b46bf1262c8c84685e
+timeCreated: 1526777255
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Implements a functional crushing system.  Also fixes a bug that was introduced with the smooth crouching update.  When loading a game with a different crouching state than your previous, your game would be stuck in either crouching while walking full speed, or walking while crouching speed.

**There is a problem that prevents this from being Merge-ready.**  There is a SphereCollider I attached to the PlayerAdvanced components and set it as a trigger, and I call OnTriggerEnter and perform the crush logic in the PlayerCrush class.  Because of the position of the SphereCollider, many rays and projectiles are blocked if they are below a certain angle (because the trigger collider blocks them)  I am seeking advice how to work around this.  I can imagine some but was wondering the best solution.