### PR TITLE
Add ability to get work inside castles

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -473,6 +473,7 @@ namespace DaggerfallWorkshop.Game
             public List<RumorMillEntry> listRumorMill;
             public Dictionary<ulong, TextFile.Token[]> dictQuestorPostQuestMessage;
             public Dictionary<int, NpcWorkEntry> npcsWithWork;
+            public Dictionary<int, bool> castleNPCsSpokenTo = new Dictionary<int, bool>();
         }
 
         // faction IDs for factions listed in "tell me about"
@@ -673,7 +674,7 @@ namespace DaggerfallWorkshop.Game
         public void TalkToStaticNPC(StaticNPC targetNPC, bool isSpyMaster = false)
         {
             if (IsNpcOfferingQuest(targetNPC.Data.nameSeed)) {
-                DaggerfallUI.UIManager.PushWindow(new DaggerfallQuestOfferWindow(DaggerfallUI.UIManager, npcsWithWork[targetNPC.Data.nameSeed].npc, npcsWithWork[targetNPC.Data.nameSeed].socialGroup));
+                DaggerfallUI.UIManager.PushWindow(new DaggerfallQuestOfferWindow(DaggerfallUI.UIManager, npcsWithWork[targetNPC.Data.nameSeed].npc, npcsWithWork[targetNPC.Data.nameSeed].socialGroup, true));
                 return;
             }
             else if (IsCastleNpcOfferingQuest(targetNPC.Data.nameSeed))
@@ -681,7 +682,7 @@ namespace DaggerfallWorkshop.Game
                 FactionFile.FactionData targetFactionData;
                 PersistentFactionData factionsData = GameManager.Instance.PlayerEntity.FactionData;
                 factionsData.GetFactionData(targetNPC.Data.factionID, out targetFactionData);
-                DaggerfallUI.UIManager.PushWindow(new DaggerfallQuestOfferWindow(DaggerfallUI.UIManager, targetNPC.Data, (FactionFile.SocialGroups)targetFactionData.sgroup));
+                DaggerfallUI.UIManager.PushWindow(new DaggerfallQuestOfferWindow(DaggerfallUI.UIManager, targetNPC.Data, (FactionFile.SocialGroups)targetFactionData.sgroup, false));
                 return;
             }
             currentNPCType = NPCType.Static;
@@ -1876,6 +1877,7 @@ namespace DaggerfallWorkshop.Game
             saveDataConversation.listRumorMill = listRumorMill;
             saveDataConversation.dictQuestorPostQuestMessage = dictQuestorPostQuestMessage;
             saveDataConversation.npcsWithWork = npcsWithWork;
+            saveDataConversation.castleNPCsSpokenTo = castleNPCsSpokenTo;
             return saveDataConversation;
         }
 
@@ -1956,6 +1958,9 @@ namespace DaggerfallWorkshop.Game
 
             if (data.npcsWithWork != null)
                 npcsWithWork = data.npcsWithWork;
+
+            if (data.castleNPCsSpokenTo != null)
+                castleNPCsSpokenTo = data.castleNPCsSpokenTo;
 
             // update topic list
             AssembleTopiclistTellMeAbout();

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1972,11 +1972,11 @@ namespace DaggerfallWorkshop.Game
             {
                 return false;
             }
-            // 1 in 6 chance that a castle NPC is offering a quest
+            // 25% chance that a castle NPC is offering a quest
             // TODO: Determine probability in classic.
-            int rand = UnityEngine.Random.Range(0, 6);
+            int rand = UnityEngine.Random.Range(0, 4);
             bool result = false;
-            if (rand == 5)
+            if (rand == 0)
             {
                 result = true;
             }
@@ -2707,7 +2707,7 @@ namespace DaggerfallWorkshop.Game
                                 IsPlayerInSameLocationWorldCell = true;
 
                             // test if dialog partner is same person as person resource
-                            if (GameManager.Instance.IsPlayerInside)
+                            if (GameManager.Instance.IsPlayerInside && !GameManager.Instance.IsPlayerInsideCastle)
                             {                              
                                 if (this.targetStaticNPC != null && this.currentNPCType == NPCType.Static && this.targetStaticNPC.Data.buildingKey == GameManager.Instance.PlayerEnterExit.Interior.EntryDoor.buildingKey && this.nameNPC == captionString)
                                     dialogPartnerIsSamePersonAsPersonResource = true;                            

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestOfferWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestOfferWindow.cs
@@ -27,7 +27,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             this.socialGroup = socialGroup;
 
             // Remove potential questor from pool after quest has been offered
-            TalkManager.Instance.RemoveNpcQuestor(npc.nameSeed);
+            if (!GameManager.Instance.IsPlayerInsideCastle)
+                TalkManager.Instance.RemoveNpcQuestor(npc.nameSeed);
 
             // Clear background
             ParentPanel.BackgroundColor = Color.clear;
@@ -39,7 +40,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void Setup()
         {
-            CloseWindow();
             GetQuest();
         }
 
@@ -76,7 +76,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     messageBox.Show();
                 }
             }
-            else
+            else if (!GameManager.Instance.IsPlayerInsideCastle) // Failed get quest messages do not appear inside castles in classic.
             {
                 ShowFailGetQuestMessage();
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestOfferWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestOfferWindow.cs
@@ -17,14 +17,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     {
         StaticNPC.NPCData questorNPC;
         FactionFile.SocialGroups socialGroup;
+        bool menu;
 
         #region Constructors
 
-        public DaggerfallQuestOfferWindow(IUserInterfaceManager uiManager, StaticNPC.NPCData npc, FactionFile.SocialGroups socialGroup)
+        public DaggerfallQuestOfferWindow(IUserInterfaceManager uiManager, StaticNPC.NPCData npc, FactionFile.SocialGroups socialGroup, bool menu)
             : base(uiManager)
         {
             questorNPC = npc;
             this.socialGroup = socialGroup;
+            this.menu = menu;
 
             // Remove potential questor from pool after quest has been offered
             if (!GameManager.Instance.IsPlayerInsideCastle)
@@ -40,6 +42,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void Setup()
         {
+            CloseWindow();
             GetQuest();
         }
 
@@ -84,7 +87,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void QuestPopupMessage_OnClose()
         {
-            CloseWindow();
+            // Close popup menu if talk was initiated from one
+            if (menu) {
+                CloseWindow();
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -92,7 +92,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 // Show refuse message
                 sender.CloseWindow();
-                ShowQuestPopupMessage(offeredQuest, (int)QuestMachine.QuestMessages.RefuseQuest, false);
+                ShowQuestPopupMessage(offeredQuest, (int)QuestMachine.QuestMessages.RefuseQuest);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -92,7 +92,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 // Show refuse message
                 sender.CloseWindow();
-                ShowQuestPopupMessage(offeredQuest, (int)QuestMachine.QuestMessages.RefuseQuest);
+                ShowQuestPopupMessage(offeredQuest, (int)QuestMachine.QuestMessages.RefuseQuest, false);
             }
         }
 


### PR DESCRIPTION
This is a continuation of my work on the "work" functionality in TalkManager.

I used a separate dictionary because 1. The block structure for castles/dungeons is different than towns and 2. the process of looking for work in a castle is simpler. There's no "work" dialogue in classic for castle questors so an NPC list doesn't need to be pre-populated.