### PR TITLE
 implemented "Where am I?" question/answers,  special npc "where is" answer in same location

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1092,8 +1092,9 @@ namespace DaggerfallWorkshop.Game
                     {
                         dungeonName = GameManager.Instance.PlayerEnterExit.Dungeon.Summary.LocationName;
                     }
-                    if (dungeonName[dungeonName.Length - 1] == '.')
-                        dungeonName = dungeonName.Remove(dungeonName.Length - 1); // remove character '.' from castle text record entry
+
+                    dungeonName = dungeonName.TrimEnd('.'); // remove character '.' from castle text record entry
+
                     return String.Format(TextManager.Instance.GetText(textDatabase, "AnswerTextWhereAmI"), dungeonName, GameManager.Instance.PlayerEnterExit.Dungeon.Summary.RegionName);
                 }
             }
@@ -1406,8 +1407,8 @@ namespace DaggerfallWorkshop.Game
                         {
                             dungeonName = GameManager.Instance.PlayerEnterExit.Dungeon.Summary.LocationName;
                         }
-                        if (dungeonName[dungeonName.Length-1] == '.')
-                            dungeonName = dungeonName.Remove(dungeonName.Length - 1); // remove character '.' from castle text record entry
+
+                        dungeonName = dungeonName.TrimEnd('.'); // remove character '.' from castle text record entry
 
                         if (dungeonName == listItem.caption)
                         {

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1067,7 +1067,7 @@ namespace DaggerfallWorkshop.Game
                 if (GameManager.Instance.PlayerEnterExit.ExteriorDoors.Length > 0) // in building
                 {
                     PlayerGPS.DiscoveredBuilding discoveredBuilding;
-                    if (GameManager.Instance.PlayerGPS.GetDiscoveredBuilding(GameManager.Instance.PlayerEnterExit.ExteriorDoors[0].buildingKey, out discoveredBuilding))
+                    if (GameManager.Instance.PlayerGPS.GetAnyBuilding(GameManager.Instance.PlayerEnterExit.ExteriorDoors[0].buildingKey, out discoveredBuilding))
                     {
                         return String.Format(TextManager.Instance.GetText(textDatabase, "AnswerTextWhereAmI"), discoveredBuilding.displayName, GameManager.Instance.PlayerGPS.CurrentLocation.Name);
                     }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1080,15 +1080,20 @@ namespace DaggerfallWorkshop.Game
                 else // in dungeon
                 {
                     DaggerfallDungeon.DungeonSummary ds = GameManager.Instance.PlayerEnterExit.Dungeon.Summary;
-                    string castleName = "";
+                    string dungeonName = "";
                     if (ds.RegionName == "Daggerfall" && ds.LocationName == "Daggerfall")
-                        castleName = ExpandRandomTextRecord(475);
+                        dungeonName = ExpandRandomTextRecord(475);
                     else if (ds.RegionName == "Wayrest" && ds.LocationName == "Wayrest")
-                        castleName = ExpandRandomTextRecord(476);
+                        dungeonName = ExpandRandomTextRecord(476);
                     else if (ds.RegionName == "Sentinel" && ds.LocationName == "Sentinel")
-                        castleName = ExpandRandomTextRecord(477);
-                    castleName = castleName.Remove(castleName.Length-1); // remove character '.' from castle text record entry
-                    return String.Format(TextManager.Instance.GetText(textDatabase, "AnswerTextWhereAmI"), castleName, GameManager.Instance.PlayerEnterExit.Dungeon.Summary.RegionName);
+                        dungeonName = ExpandRandomTextRecord(477);
+                    else
+                    {
+                        dungeonName = GameManager.Instance.PlayerEnterExit.Dungeon.Summary.LocationName;
+                    }
+                    if (dungeonName[dungeonName.Length - 1] == '.')
+                        dungeonName = dungeonName.Remove(dungeonName.Length - 1); // remove character '.' from castle text record entry
+                    return String.Format(TextManager.Instance.GetText(textDatabase, "AnswerTextWhereAmI"), dungeonName, GameManager.Instance.PlayerEnterExit.Dungeon.Summary.RegionName);
                 }
             }
             else
@@ -1373,7 +1378,42 @@ namespace DaggerfallWorkshop.Game
                 else
                     listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.DoesNotKnowAboutItem;
             }
-            
+
+            // test if npc is asked about building and is in the same building -> then he/she should know about building
+            if (listItem.questionType == QuestionType.LocalBuilding || listItem.questionType == QuestionType.QuestLocation)
+            {
+                if (GameManager.Instance.IsPlayerInside)
+                {
+                    if (GameManager.Instance.PlayerEnterExit.ExteriorDoors.Length > 0 && listItem.buildingKey == GameManager.Instance.PlayerEnterExit.ExteriorDoors[0].buildingKey)
+                    {
+                        listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.KnowsAboutItem;
+                    }
+                    else // in dungeon
+                    {
+                        DaggerfallDungeon.DungeonSummary ds = GameManager.Instance.PlayerEnterExit.Dungeon.Summary;
+                        string dungeonName = "";
+                        if (ds.RegionName == "Daggerfall" && ds.LocationName == "Daggerfall")
+                            dungeonName = ExpandRandomTextRecord(475);
+                        else if (ds.RegionName == "Wayrest" && ds.LocationName == "Wayrest")
+                            dungeonName = ExpandRandomTextRecord(476);
+                        else if (ds.RegionName == "Sentinel" && ds.LocationName == "Sentinel")
+                            dungeonName = ExpandRandomTextRecord(477);
+                        else
+                        {
+                            dungeonName = GameManager.Instance.PlayerEnterExit.Dungeon.Summary.LocationName;
+                        }
+                        if (dungeonName[dungeonName.Length-1] == '.')
+                            dungeonName = dungeonName.Remove(dungeonName.Length - 1); // remove character '.' from castle text record entry
+
+                        if (dungeonName == listItem.caption)
+                        {
+                            listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.KnowsAboutItem;
+                        }
+                    }
+                }
+            }
+
+
             if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)
             {
                 // messages if npc does not know

--- a/Assets/Scripts/Utility/BuildingNames.cs
+++ b/Assets/Scripts/Utility/BuildingNames.cs
@@ -145,6 +145,8 @@ namespace DaggerfallWorkshop.Utility
                                 break;
                             }
                         }
+                        if (a[a.Length - 1] == '.')
+                            a = a.Remove(a.Length - 1); // remove character '.' from castle text record entry if it is last character
                     }
                     else
                     {

--- a/Assets/Scripts/Utility/BuildingNames.cs
+++ b/Assets/Scripts/Utility/BuildingNames.cs
@@ -145,8 +145,7 @@ namespace DaggerfallWorkshop.Utility
                                 break;
                             }
                         }
-                        if (a[a.Length - 1] == '.')
-                            a = a.Remove(a.Length - 1); // remove character '.' from castle text record entry if it is last character
+                        a = a.TrimEnd('.'); // remove character '.' from castle text record entry if it is last character
                     }
                     else
                     {

--- a/Assets/StreamingAssets/Text/ConversationText.txt
+++ b/Assets/StreamingAssets/Text/ConversationText.txt
@@ -11,6 +11,8 @@ southwest,                      southwest
 south,                          south
 southeast,                      southeast
 AnyNews,                        Any news?
+WhereAmI,                       Where am I?
+AnswerTextWhereAmI,             You are in {0} in {1}.
 PreviousList,                   Previous List
 General,                        General
 Regional,                       Regional

--- a/Assets/StreamingAssets/Text/ConversationText.txt
+++ b/Assets/StreamingAssets/Text/ConversationText.txt
@@ -13,6 +13,8 @@ southeast,                      southeast
 AnyNews,                        Any news?
 WhereAmI,                       Where am I?
 AnswerTextWhereAmI,             You are in {0} in {1}.
+YouAreInSameBuilding,           You have found {0}. You are in it.
+NpcInSameBuilding,              {0} is around here in {1}.
 PreviousList,                   Previous List
 General,                        General
 Regional,                       Regional


### PR DESCRIPTION
- implemented "Where am I?" question/answers 
- trimming castle names read from text.rsc when last character is '.' (change to Assets/Scripts/Utility/BuildingNames.cs - should be ok, but pls take a look - I did this because I think it is an improvement since palace name would often break sentences with this '.', discovery system discovers castles without problems after this change - nameplates no longer contain the '.' character as well)
- special npc "where is" answer about location/person topic if in location:
 -- for building asked about that is the same building where the npc talk partner is in: npc always knows he is in the very same building and gives special answer now
 -- for quest person "where is" answer if npcs knows about person there is also a specific answer if npc is in same building as person