### PR TITLE
Merging ui-rendering-test to master

### DIFF
--- a/Assets/Prefabs/Player/PlayerAdvanced.prefab
+++ b/Assets/Prefabs/Player/PlayerAdvanced.prefab
@@ -561,7 +561,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   limitDiagonalSpeed: 1
-  toggleRun: 0
   systemTimerUpdatesPerSecond: 0.055
   smoothFollower: {fileID: 4832112164805246}
   smoothFollowerLerpSpeed: 25
@@ -587,7 +586,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 100000}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2c69e8292036a13498bf8d5749391b75, type: 3}
   m_Name: 
@@ -1041,7 +1040,6 @@ MonoBehaviour:
   crouchingJumpDelta: 0.8
   fallingDamageThreshold: 10
   airControl: 0
-  antiBunnyHopFactor: 1
 --- !u!114 &114121517922970790
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1101,6 +1099,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 923e44bd2b461494586a0930c79739f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  toggleRun: 0
   walkSpeedOverride: 6
   useWalkSpeedOverride: 0
   runSpeedOverride: 11
@@ -1292,14 +1291,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5a5e1a08077a1254c9fa89e62375a542, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  restPos: {x: 0, y: 0, z: 0}
-  transitionSpeed: 10
-  bobSpeed: 0
-  bobXAmount: 0
-  bobYAmount: 0
-  nodXAmount: 0
-  nodYAmount: 0
-  bobScalar: 0
 --- !u!198 &198237622866876544
 ParticleSystem:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/DaggerfallUnityGame.unity
+++ b/Assets/Scenes/DaggerfallUnityGame.unity
@@ -267,6 +267,7 @@ GameObject:
   - component: {fileID: 97801940}
   - component: {fileID: 97801938}
   - component: {fileID: 97801942}
+  - component: {fileID: 97801943}
   m_Layer: 0
   m_Name: DaggerfallUI
   m_TagString: Untagged
@@ -413,6 +414,104 @@ MonoBehaviour:
   Gain: 3
   SongFolder: Songs/
   Song: -1
+--- !u!114 &97801943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 97801937}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d92490a3aace0254aaf1329ecdd82f24, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &100870827
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 100870828}
+  - component: {fileID: 100870830}
+  - component: {fileID: 100870829}
+  - component: {fileID: 100870832}
+  m_Layer: 5
+  m_Name: NonDiageticUIOutput
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &100870828
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 100870827}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1463923239}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &100870829
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 100870827}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -98529514, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &100870830
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 100870827}
+--- !u!223 &100870832
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 100870827}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 1
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1 &102824930
 GameObject:
   m_ObjectHideFlags: 0
@@ -1733,6 +1832,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1168575604}
+  - {fileID: 100870828}
   m_Father: {fileID: 0}
   m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2141,7 +2241,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22400016, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 11400006, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_Value
@@ -2153,7 +2253,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22400010, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.000000059604645
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}

--- a/Assets/Scenes/DaggerfallUnityGame.unity
+++ b/Assets/Scenes/DaggerfallUnityGame.unity
@@ -437,7 +437,7 @@ GameObject:
   - component: {fileID: 100870829}
   - component: {fileID: 100870832}
   m_Layer: 5
-  m_Name: NonDiageticUIOutput
+  m_Name: NonDiegeticUIOutput
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2241,7 +2241,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22400016, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 11400006, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_Value
@@ -2253,7 +2253,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22400010, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}
       propertyPath: m_AnchorMin.y
-      value: 0.000000059604645
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 312abd0527754e047a6bfbc424f09ace, type: 2}

--- a/Assets/Scenes/DaggerfallUnityStartup.unity
+++ b/Assets/Scenes/DaggerfallUnityStartup.unity
@@ -376,6 +376,115 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &749425353
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 749425358}
+  - component: {fileID: 749425357}
+  - component: {fileID: 749425356}
+  - component: {fileID: 749425355}
+  - component: {fileID: 749425354}
+  m_Layer: 0
+  m_Name: NonDiegeticUIOutput
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &749425354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 749425353}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -98529514, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &749425355
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 749425353}
+--- !u!114 &749425356
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 749425353}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &749425357
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 749425353}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &749425358
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 749425353}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1001 &1639715523
 Prefab:
   m_ObjectHideFlags: 0
@@ -506,6 +615,7 @@ GameObject:
   - component: {fileID: 2027584957}
   - component: {fileID: 2027584956}
   - component: {fileID: 2027584960}
+  - component: {fileID: 2027584961}
   m_Layer: 0
   m_Name: DaggerfallUI
   m_TagString: Untagged
@@ -650,6 +760,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ShowDebugString: 0
   Gain: 5
-  SoundBank: TimGM6mb.sf2
   SongFolder: Songs/
   Song: -1
+--- !u!114 &2027584961
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2027584955}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d92490a3aace0254aaf1329ecdd82f24, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -63,6 +63,8 @@ namespace DaggerfallWorkshop.Game
         DaggerfallAudioSource dfAudioSource;
         DaggerfallSongPlayer dfSongPlayer;
         UserInterfaceManager uiManager = new UserInterfaceManager();
+        UserInterfaceRenderTarget renderTarget = null;
+        Texture2D clearTexture;
 
         SpellIconCollection spellIconCollection;
 
@@ -123,6 +125,11 @@ namespace DaggerfallWorkshop.Game
         public static DaggerfallFont DefaultFont { get { return Instance.GetFont(4); } }
         
         public static IUserInterfaceManager UIManager { get { return Instance.uiManager; } }
+
+        public UserInterfaceRenderTarget RenderTarget
+        {
+            get { return (renderTarget) ? renderTarget : renderTarget = GetComponent<UserInterfaceRenderTarget>(); }
+        }
 
         public bool FadeInProgress
         {
@@ -247,6 +254,8 @@ namespace DaggerfallWorkshop.Game
 
         void Awake()
         {
+            clearTexture = CreateSolidTexture(Color.clear, 8);
+
             dfUnity = DaggerfallUnity.Instance;
             audioSource = GetComponent<AudioSource>();
             audioSource.spatialBlend = 0;
@@ -347,6 +356,11 @@ namespace DaggerfallWorkshop.Game
 
             // Set depth of GUI to appear on top of other elements
             GUI.depth = 0;
+
+            // Clear render target before drawing rest of UI stack
+            //RenderTarget.DrawTexture(RenderTarget.TargetRect, clearTexture, ScaleMode.StretchToFill);
+            //RenderTarget.DrawTextureWithTexCoords(RenderTarget.TargetRect, clearTexture, new Rect(0, 0, 1, 1), true);
+            //Graphics.Blit(clearTexture, RenderTarget.TargetTexture);
 
             // Draw top window
             if (uiManager.TopWindow != null)
@@ -711,6 +725,11 @@ namespace DaggerfallWorkshop.Game
             fadeTimer = 0;
             fadeTotalTime = 0;
             fadeInProgress = false;
+        }
+        
+        public void ClearRenderTarget()
+        {
+            Graphics.Blit(clearTexture, RenderTarget.TargetTexture);
         }
 
         #endregion
@@ -1093,6 +1112,23 @@ namespace DaggerfallWorkshop.Game
             messageBox.ClickAnywhereToClose = true;
             messageBox.Show();
             return messageBox;
+        }
+
+        public static Texture2D CreateSolidTexture(Color color, int dim)
+        {
+            Texture2D texture = null;
+
+            texture = new Texture2D(dim, dim);
+            Color32[] colors = new Color32[dim * dim];
+            for (int i = 0; i < colors.Length; i++)
+            {
+                colors[i] = color;
+            }
+            texture.SetPixels32(colors);
+            texture.Apply(false, true);
+            texture.filterMode = FilterMode.Point;
+
+            return texture;
         }
 
         #endregion

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -86,7 +86,7 @@ namespace DaggerfallWorkshop.Game
         const float versionTextScale = 1.0f;
         Vector2 versionTextScaleVector2 = new Vector2(versionTextScale, versionTextScale);
         float versionTextWidth;
-        Color versionTextColor = new Color(1, 1, 1, 0.5f);
+        Color versionTextColor = new Color(0.6f, 0.6f, 0.6f, 1);
 
         bool hudSetup = false;
         DaggerfallHUD dfHUD;

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -364,7 +364,7 @@ namespace DaggerfallWorkshop.Game
             // Set depth of GUI to appear on top of other elements
             GUI.depth = 0;
 
-            RenderTarget.ClearTargetTexture();
+            RenderTarget.Clear();
 
             // Draw top window
             if (uiManager.TopWindow != null)

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -71,6 +71,7 @@ namespace DaggerfallWorkshop.Game
         DaggerfallFont[] daggerfallFonts = new DaggerfallFont[5];
         char lastCharacterTyped;
         KeyCode lastKeyCode;
+        GameObject nonDiegeticUI = null;
 
         bool fadeInProgress;
         Panel fadeTargetPanel;
@@ -229,6 +230,12 @@ namespace DaggerfallWorkshop.Game
         public string FontsFolder
         {
             get { return Path.Combine(Application.streamingAssetsPath, fontsFolderName); }
+        }
+
+        public GameObject NonDiegeticUIOutput
+        {
+            get { return (nonDiegeticUI) ? nonDiegeticUI : nonDiegeticUI = GameManager.GetGameObjectWithName("NonDiegeticUIOutput"); }
+            set { nonDiegeticUI = value; }
         }
 
         public enum PopupStyle

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -64,7 +64,6 @@ namespace DaggerfallWorkshop.Game
         DaggerfallSongPlayer dfSongPlayer;
         UserInterfaceManager uiManager = new UserInterfaceManager();
         UserInterfaceRenderTarget renderTarget = null;
-        Texture2D clearTexture;
 
         SpellIconCollection spellIconCollection;
 
@@ -254,8 +253,6 @@ namespace DaggerfallWorkshop.Game
 
         void Awake()
         {
-            clearTexture = CreateSolidTexture(Color.clear, 8);
-
             dfUnity = DaggerfallUnity.Instance;
             audioSource = GetComponent<AudioSource>();
             audioSource.spatialBlend = 0;
@@ -342,6 +339,9 @@ namespace DaggerfallWorkshop.Game
 
         void OnGUI()
         {
+            RenderTexture oldRenderTexture = RenderTexture.active;
+            RenderTexture.active = RenderTarget.BackBufferTexture;
+
             // Store key downs for alternate input (e.g. text box input)
             // Possible to get multiple keydown events per frame, one with character, one with keycode
             // Only accept character or keycode if valid
@@ -354,13 +354,11 @@ namespace DaggerfallWorkshop.Game
                     lastKeyCode = Event.current.keyCode;
             }
 
+            if (Event.current.type != EventType.Repaint)
+                return;
+
             // Set depth of GUI to appear on top of other elements
             GUI.depth = 0;
-
-            // Clear render target before drawing rest of UI stack
-            //RenderTarget.DrawTexture(RenderTarget.TargetRect, clearTexture, ScaleMode.StretchToFill);
-            //RenderTarget.DrawTextureWithTexCoords(RenderTarget.TargetRect, clearTexture, new Rect(0, 0, 1, 1), true);
-            //Graphics.Blit(clearTexture, RenderTarget.TargetTexture);
 
             // Draw top window
             if (uiManager.TopWindow != null)
@@ -374,6 +372,9 @@ namespace DaggerfallWorkshop.Game
                 Vector2 versionTextPos = new Vector2(Screen.width - versionTextWidth, 0);
                 versionFont.DrawText(versionText, versionTextPos, versionTextScaleVector2, versionTextColor);
             }
+
+            RenderTexture.active = oldRenderTexture;
+            RenderTarget.Present();
         }
 
         void ProcessMessages()
@@ -725,11 +726,6 @@ namespace DaggerfallWorkshop.Game
             fadeTimer = 0;
             fadeTotalTime = 0;
             fadeInProgress = false;
-        }
-        
-        public void ClearRenderTarget()
-        {
-            Graphics.Blit(clearTexture, RenderTarget.TargetTexture);
         }
 
         #endregion

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -339,9 +339,6 @@ namespace DaggerfallWorkshop.Game
 
         void OnGUI()
         {
-            RenderTexture oldRenderTexture = RenderTexture.active;
-            RenderTexture.active = RenderTarget.BackBufferTexture;
-
             // Store key downs for alternate input (e.g. text box input)
             // Possible to get multiple keydown events per frame, one with character, one with keycode
             // Only accept character or keycode if valid
@@ -373,7 +370,6 @@ namespace DaggerfallWorkshop.Game
                 versionFont.DrawText(versionText, versionTextPos, versionTextScaleVector2, versionTextColor);
             }
 
-            RenderTexture.active = oldRenderTexture;
             RenderTarget.Present();
         }
 

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -357,6 +357,8 @@ namespace DaggerfallWorkshop.Game
             // Set depth of GUI to appear on top of other elements
             GUI.depth = 0;
 
+            RenderTarget.ClearTargetTexture();
+
             // Draw top window
             if (uiManager.TopWindow != null)
             {
@@ -369,8 +371,6 @@ namespace DaggerfallWorkshop.Game
                 Vector2 versionTextPos = new Vector2(Screen.width - versionTextWidth, 0);
                 versionFont.DrawText(versionText, versionTextPos, versionTextScaleVector2, versionTextColor);
             }
-
-            RenderTarget.Present();
         }
 
         void ProcessMessages()

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -346,6 +346,9 @@ namespace DaggerfallWorkshop.Game
 
         void OnGUI()
         {
+            // Set depth of GUI to appear on top of other elements
+            GUI.depth = 0;
+
             // Store key downs for alternate input (e.g. text box input)
             // Possible to get multiple keydown events per frame, one with character, one with keycode
             // Only accept character or keycode if valid
@@ -361,10 +364,7 @@ namespace DaggerfallWorkshop.Game
             if (Event.current.type != EventType.Repaint)
                 return;
 
-            // Set depth of GUI to appear on top of other elements
-            GUI.depth = 0;
-
-            RenderTarget.Clear();
+            //RenderTarget.Clear();
 
             // Draw top window
             if (uiManager.TopWindow != null)

--- a/Assets/Scripts/Game/DaggerfallUI.cs.meta
+++ b/Assets/Scripts/Game/DaggerfallUI.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: 336d8af6fdfa8234d9dfca56c0fd323d
-timeCreated: 1437888875
+timeCreated: 1527640700
 licenseType: Pro
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 2
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Game/FPSCrosshair.cs
+++ b/Assets/Scripts/Game/FPSCrosshair.cs
@@ -26,11 +26,11 @@ namespace DaggerfallWorkshop.Game
             if (CrosshairTexture != null)
             {
                 GUI.color = new Color(1, 1, 1, 0.75f);
-                GUI.DrawTexture(
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(
                     new Rect((Screen.width * 0.5f) - (CrosshairTexture.width * 0.5f),
                         (Screen.height * 0.5f) - (CrosshairTexture.height * 0.5f),
                         CrosshairTexture.width,
-                        CrosshairTexture.height), CrosshairTexture);
+                        CrosshairTexture.height), (Texture2D)CrosshairTexture);
                 GUI.color = Color.white;
             }
         }

--- a/Assets/Scripts/Game/FPSSpellCasting.cs
+++ b/Assets/Scripts/Game/FPSSpellCasting.cs
@@ -114,8 +114,8 @@ namespace DaggerfallWorkshop.Game
 
                 // Draw spell cast texture behind other HUD elements
                 GUI.depth = 1;
-                GUI.DrawTextureWithTexCoords(leftHandPosition, currentAnims[frameIndex], leftHandAnimRect);
-                GUI.DrawTextureWithTexCoords(rightHandPosition, currentAnims[frameIndex], rightHandAnimRect);
+                DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(leftHandPosition, currentAnims[frameIndex], leftHandAnimRect);
+                DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(rightHandPosition, currentAnims[frameIndex], rightHandAnimRect);
             }
         }
 

--- a/Assets/Scripts/Game/FPSSpellCasting.cs
+++ b/Assets/Scripts/Game/FPSSpellCasting.cs
@@ -99,6 +99,8 @@ namespace DaggerfallWorkshop.Game
             //    currentFrame = 0;
             //}
 
+            GUI.depth = 1;
+
             // Must be ready
             if (!ReadyCheck() || GameManager.IsGamePaused)
                 return;
@@ -113,7 +115,6 @@ namespace DaggerfallWorkshop.Game
                 int frameIndex = frameIndices[currentFrame];
 
                 // Draw spell cast texture behind other HUD elements
-                GUI.depth = 1;
                 DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(leftHandPosition, currentAnims[frameIndex], leftHandAnimRect);
                 DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(rightHandPosition, currentAnims[frameIndex], rightHandAnimRect);
             }

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -99,9 +99,9 @@ namespace DaggerfallWorkshop.Game
                 GUI.depth = 1;
                 Texture2D tex;
                 if (CustomTextures.TryGetValue((int)weaponState + "-" + currentFrame, out tex))
-                    GUI.DrawTexture(weaponPosition, tex);
+                    DaggerfallUI.Instance.RenderTarget.DrawTexture(weaponPosition, tex);
                 else
-                    GUI.DrawTextureWithTexCoords(weaponPosition, weaponAtlas, curAnimRect);
+                    DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(weaponPosition, weaponAtlas, curAnimRect);
             }
         }
 

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -80,6 +80,8 @@ namespace DaggerfallWorkshop.Game
 
         void OnGUI()
         {
+            GUI.depth = 1;
+
             // Must be ready
             if (!ReadyCheck() || WeaponType == WeaponTypes.None || GameManager.IsGamePaused)
                 return;
@@ -96,7 +98,6 @@ namespace DaggerfallWorkshop.Game
             if (Event.current.type.Equals(EventType.Repaint) && ShowWeapon)
             {
                 // Draw weapon texture behind other HUD elements
-                GUI.depth = 1;
                 Texture2D tex;
                 if (CustomTextures.TryGetValue((int)weaponState + "-" + currentFrame, out tex))
                     DaggerfallUI.Instance.RenderTarget.DrawTexture(weaponPosition, tex);

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -82,6 +82,7 @@ namespace DaggerfallWorkshop.Game
         TalkManager talkManager = null;
         GuildManager guildManager = null;
         QuestListsManager questListsManager = null;
+        GameObject nonDiageticUI = null;
 
         #endregion
 
@@ -374,6 +375,12 @@ namespace DaggerfallWorkshop.Game
         public bool IsPlayerInsideCastle
         {
             get { return PlayerEnterExit.IsPlayerInsideDungeonCastle; }
+        }
+
+        public GameObject NonDiageticUIOutput
+        {
+            get { return (nonDiageticUI) ? nonDiageticUI : nonDiageticUI = GetGameObjectWithName("NonDiageticUIOutput"); }
+            set { nonDiageticUI = value; }
         }
 
         #endregion

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -82,7 +82,6 @@ namespace DaggerfallWorkshop.Game
         TalkManager talkManager = null;
         GuildManager guildManager = null;
         QuestListsManager questListsManager = null;
-        GameObject nonDiegeticUI = null;
 
         #endregion
 
@@ -375,12 +374,6 @@ namespace DaggerfallWorkshop.Game
         public bool IsPlayerInsideCastle
         {
             get { return PlayerEnterExit.IsPlayerInsideDungeonCastle; }
-        }
-
-        public GameObject NonDiegeticUIOutput
-        {
-            get { return (nonDiegeticUI) ? nonDiegeticUI : nonDiegeticUI = GetGameObjectWithName("NonDiegeticUIOutput"); }
-            set { nonDiegeticUI = value; }
         }
 
         #endregion

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -82,7 +82,7 @@ namespace DaggerfallWorkshop.Game
         TalkManager talkManager = null;
         GuildManager guildManager = null;
         QuestListsManager questListsManager = null;
-        GameObject nonDiageticUI = null;
+        GameObject nonDiegeticUI = null;
 
         #endregion
 
@@ -377,10 +377,10 @@ namespace DaggerfallWorkshop.Game
             get { return PlayerEnterExit.IsPlayerInsideDungeonCastle; }
         }
 
-        public GameObject NonDiageticUIOutput
+        public GameObject NonDiegeticUIOutput
         {
-            get { return (nonDiageticUI) ? nonDiageticUI : nonDiageticUI = GetGameObjectWithName("NonDiageticUIOutput"); }
-            set { nonDiageticUI = value; }
+            get { return (nonDiegeticUI) ? nonDiegeticUI : nonDiegeticUI = GetGameObjectWithName("NonDiegeticUIOutput"); }
+            set { nonDiegeticUI = value; }
         }
 
         #endregion

--- a/Assets/Scripts/Game/GameManager.cs.meta
+++ b/Assets/Scripts/Game/GameManager.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: 0de185bad246eaf478cff5b6517e12a1
-timeCreated: 1524015182
+timeCreated: 1527640669
 licenseType: Pro
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 3
+  executionOrder: 4
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Game/PlayerCompass.cs
+++ b/Assets/Scripts/Game/PlayerCompass.cs
@@ -136,8 +136,8 @@ namespace DaggerfallWorkshop.Game
             compassDstRect.width = compassBoxRect.width - (boxOutlineSize * 2) * scale;
             compassDstRect.height = compassTexture.height * scale;
 
-            GUI.DrawTextureWithTexCoords(compassDstRect, compassTexture, compassSrcRect, false);
-            GUI.DrawTexture(compassBoxRect, compassBoxTexture, ScaleMode.StretchToFill, true);
+            DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(compassDstRect, compassTexture, compassSrcRect, false);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(compassBoxRect, compassBoxTexture, ScaleMode.StretchToFill, true);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -415,7 +415,8 @@ namespace DaggerfallWorkshop.Game.Questing
             lastNPCClicked = null;
 
             // Clear debugger state
-            DaggerfallUI.Instance.DaggerfallHUD.PlaceMarker.ClearSiteTargets();
+            if (DaggerfallUI.Instance.DaggerfallHUD != null)
+                DaggerfallUI.Instance.DaggerfallHUD.PlaceMarker.ClearSiteTargets();
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs.meta
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: a3c4f94f182742e48947399a2012f0a4
-timeCreated: 1508197028
+timeCreated: 1527640700
 licenseType: Pro
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 2
+  executionOrder: 3
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -934,12 +934,28 @@ namespace DaggerfallWorkshop.Game.Serialization
             string discoveryDataJson = Serialize(discoveryData.GetType(), discoveryData);
             string conversationDataJson = Serialize(conversationData.GetType(), conversationData);
 
+            //// Attempt to hide UI for screenshot
+            //bool rawImageEnabled = false;
+            //UnityEngine.UI.RawImage rawImage = DaggerfallUI.Instance.RenderTarget.GetDiegeticCanvasRawImage();
+            //if (rawImage)
+            //{
+            //    rawImageEnabled = rawImage.enabled;
+            //    rawImage.enabled = false;
+            //}
+
             // Create screenshot for save
             // TODO: Hide UI for screenshot or use a different method
+            yield return new WaitForEndOfFrame();
             yield return new WaitForEndOfFrame();
             Texture2D screenshot = new Texture2D(Screen.width, Screen.height);
             screenshot.ReadPixels(new Rect(0, 0, Screen.width, Screen.height), 0, 0);
             screenshot.Apply();
+
+            //// Restore UI after screenshot
+            //if (rawImageEnabled)
+            //{
+            //    rawImage.enabled = true;
+            //}
 
             // Save data to files
             WriteSaveFile(Path.Combine(path, saveDataFilename), saveDataJson);

--- a/Assets/Scripts/Game/ShowPlayerDamage.cs
+++ b/Assets/Scripts/Game/ShowPlayerDamage.cs
@@ -44,7 +44,7 @@ namespace DaggerfallWorkshop.Game
                 if (alphaFadeValue > 0)
                 {
                     GUI.color = new Color(1, 0, 0, alphaFadeValue);
-                    GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), damageTexture);
+                    DaggerfallUI.Instance.RenderTarget.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), damageTexture);
                 }
                 else
                 {

--- a/Assets/Scripts/Game/ShowTitleScreen.cs
+++ b/Assets/Scripts/Game/ShowTitleScreen.cs
@@ -69,8 +69,8 @@ namespace DaggerfallWorkshop.Game
         {
             if (ShowTitle && TitleScreenTexture)
             {
-                GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), blackTexture, ScaleMode.StretchToFill);
-                GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), TitleScreenTexture, ScaleMode.ScaleToFit, false, 1.6f);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), blackTexture, ScaleMode.StretchToFill);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), TitleScreenTexture, ScaleMode.ScaleToFit, false, 1.6f);
             }
         }
 

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -171,7 +171,7 @@ namespace DaggerfallWorkshop.Game
                                     Screen.height - (ridingTexure.height * horseScaleY),
                                     ridingTexure.width * horseScaleY,
                                     ridingTexure.height * horseScaleY);
-                    GUI.DrawTexture(pos, ridingTexure.texture);
+                    DaggerfallUI.Instance.RenderTarget.DrawTexture(pos, ridingTexure.texture);
                 }
             }
         }

--- a/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
+++ b/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
@@ -688,14 +688,14 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 Color color = GUI.color;
                 GUI.color = mouseOverBackgroundColor;
-                GUI.DrawTexture(myRect, backgroundColorTexture, ScaleMode.StretchToFill);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(myRect, backgroundColorTexture, ScaleMode.StretchToFill);
                 GUI.color = color;
             }
             else if (backgroundColor != Color.clear && backgroundColorTexture)
             {
                 Color color = GUI.color;
                 GUI.color = backgroundColor;
-                GUI.DrawTexture(myRect, backgroundColorTexture, ScaleMode.StretchToFill);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(myRect, backgroundColorTexture, ScaleMode.StretchToFill);
                 GUI.color = color;
             }
 
@@ -706,15 +706,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 {
                     case BackgroundLayout.Tile:
                         backgroundTexture.wrapMode = TextureWrapMode.Repeat;
-                        GUI.DrawTextureWithTexCoords(myRect, backgroundTexture, new Rect(0, 0, myRect.width / backgroundTexture.width, myRect.height / backgroundTexture.height));
+                        DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(myRect, backgroundTexture, new Rect(0, 0, myRect.width / backgroundTexture.width, myRect.height / backgroundTexture.height));
                         break;
                     case BackgroundLayout.StretchToFill:
                         backgroundTexture.wrapMode = TextureWrapMode.Clamp;
-                        GUI.DrawTexture(myRect, backgroundTexture, ScaleMode.StretchToFill);
+                        DaggerfallUI.Instance.RenderTarget.DrawTexture(myRect, backgroundTexture, ScaleMode.StretchToFill);
                         break;
                     case BackgroundLayout.ScaleToFit:
                         backgroundTexture.wrapMode = TextureWrapMode.Clamp;
-                        GUI.DrawTexture(myRect, backgroundTexture, ScaleMode.ScaleToFit);
+                        DaggerfallUI.Instance.RenderTarget.DrawTexture(myRect, backgroundTexture, ScaleMode.ScaleToFit);
                         break;
                 }
             }
@@ -1220,17 +1220,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         private void CreateBackgroundColorTexture()
         {
             if (backgroundColorTexture == null)
-            {
-                backgroundColorTexture = new Texture2D(colorTextureDim, colorTextureDim);
-                Color32[] colors = new Color32[colorTextureDim * colorTextureDim];
-                for (int i = 0; i < colors.Length; i++)
-                {
-                    colors[i] = Color.white;
-                }
-                backgroundColorTexture.SetPixels32(colors);
-                backgroundColorTexture.Apply(false, true);
-                backgroundColorTexture.filterMode = FilterMode.Point;
-            }
+                backgroundColorTexture = DaggerfallUI.CreateSolidTexture(Color.white, colorTextureDim);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterface/Checkbox.cs
+++ b/Assets/Scripts/Game/UserInterface/Checkbox.cs
@@ -127,9 +127,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Color guiColor = GUI.color;
             GUI.color = checkboxColor;
             if (!isChecked)
-                GUI.DrawTexture(rect, uncheckedTexture);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(rect, uncheckedTexture);
             else
-                GUI.DrawTexture(rect, checkedTexture);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(rect, checkedTexture);
 
             // Restore previous color
             GUI.color = guiColor;

--- a/Assets/Scripts/Game/UserInterface/DaggerfallFont.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallFont.cs
@@ -111,7 +111,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     Color guiColor = GUI.color;
 
                     GUI.color = color;
-                    GUI.DrawTextureWithTexCoords(rect, atlasTexture, atlasRects[asciiBytes[i] - asciiStart]);
+                    DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(rect, atlasTexture, atlasRects[asciiBytes[i] - asciiStart]);
 
                     GUI.color = guiColor;
                 }

--- a/Assets/Scripts/Game/UserInterface/DaggerfallVideo.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallVideo.cs
@@ -151,7 +151,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 float temp = rect.yMin;
                 rect.yMin = rect.yMax;
                 rect.yMax = temp;
-                GUI.DrawTexture(rect, vidTexture, ScaleMode.StretchToFill);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(rect, vidTexture, ScaleMode.StretchToFill);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterface/HUDCompass.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCompass.cs
@@ -135,8 +135,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             compassDstRect.width = compassBoxRect.width - (boxOutlineSize * 2) * Scale.x;
             compassDstRect.height = compassTextureHeight * Scale.y;
 
-            GUI.DrawTextureWithTexCoords(compassDstRect, compassTexture, compassSrcRect, false);
-            GUI.DrawTexture(compassBoxRect, compassBoxTexture, ScaleMode.StretchToFill, true);
+            DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(compassDstRect, compassTexture, compassSrcRect, false);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(compassBoxRect, compassBoxTexture, ScaleMode.StretchToFill, true);
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterface/HorizontalSlider.cs
+++ b/Assets/Scripts/Game/UserInterface/HorizontalSlider.cs
@@ -326,9 +326,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Color color = GUI.color;
             if (TintColor.HasValue)
                 GUI.color = TintColor.Value;
-            GUI.DrawTexture(leftRect, hScrollThumbLeft, ScaleMode.StretchToFill);
-            GUI.DrawTexture(bodyRect, hScrollThumbBody, ScaleMode.StretchToFill);
-            GUI.DrawTexture(rightRect, hScrollThumbRight, ScaleMode.StretchToFill);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(leftRect, hScrollThumbLeft, ScaleMode.StretchToFill);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(bodyRect, hScrollThumbBody, ScaleMode.StretchToFill);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(rightRect, hScrollThumbRight, ScaleMode.StretchToFill);
             GUI.color = color;
         }
 

--- a/Assets/Scripts/Game/UserInterface/Outline.cs
+++ b/Assets/Scripts/Game/UserInterface/Outline.cs
@@ -79,7 +79,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 Rect topRect = rect;
                 topRect.height = outlineThickness * LocalScale.y;
-                GUI.DrawTexture(topRect, outlineTexture);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(topRect, outlineTexture);
             }
 
             // Left
@@ -87,7 +87,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 Rect leftRect = rect;
                 leftRect.width = outlineThickness * LocalScale.x;
-                GUI.DrawTexture(leftRect, outlineTexture);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(leftRect, outlineTexture);
             }
 
             // Right
@@ -96,7 +96,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 Rect rightRect = rect;
                 rightRect.x = rect.xMax;
                 rightRect.width = outlineThickness * LocalScale.x;
-                GUI.DrawTexture(rightRect, outlineTexture);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(rightRect, outlineTexture);
             }
 
             // Bottom
@@ -106,7 +106,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 bottomRect.y = rect.yMax;
                 bottomRect.width += outlineThickness * LocalScale.y;
                 bottomRect.height = outlineThickness * LocalScale.y;
-                GUI.DrawTexture(bottomRect, outlineTexture);
+                DaggerfallUI.Instance.RenderTarget.DrawTexture(bottomRect, outlineTexture);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterface/Panel.cs
+++ b/Assets/Scripts/Game/UserInterface/Panel.cs
@@ -206,19 +206,19 @@ namespace DaggerfallWorkshop.Game.UserInterface
             }
 
             // Draw fill
-            GUI.DrawTextureWithTexCoords(fillBordersRect, fillBordersTexture, new Rect(0, 0, fillBordersRect.width / fillBordersTexture.width, fillBordersRect.height / fillBordersTexture.height));
+            DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(fillBordersRect, fillBordersTexture, new Rect(0, 0, fillBordersRect.width / fillBordersTexture.width, fillBordersRect.height / fillBordersTexture.height));
 
             // Draw corners
-            GUI.DrawTexture(topLeftBorderRect, topLeftBorderTexture);
-            GUI.DrawTexture(topRightBorderRect, topRightBorderTexture);
-            GUI.DrawTexture(bottomLeftBorderRect, bottomLeftBorderTexture);
-            GUI.DrawTexture(bottomRightBorderRect, bottomRightBorderTexture);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(topLeftBorderRect, topLeftBorderTexture);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(topRightBorderRect, topRightBorderTexture);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(bottomLeftBorderRect, bottomLeftBorderTexture);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(bottomRightBorderRect, bottomRightBorderTexture);
 
             // Draw edges
-            GUI.DrawTextureWithTexCoords(topBorderRect, topBorderTexture, new Rect(0, 0, (topBorderRect.width / LocalScale.x) / topBorderTexture.width, 1));
-            GUI.DrawTextureWithTexCoords(leftBorderRect, leftBorderTexture, new Rect(0, 0, 1, (leftBorderRect.height / LocalScale.y) / leftBorderTexture.height));
-            GUI.DrawTextureWithTexCoords(rightBorderRect, rightBorderTexture, new Rect(0, 0, 1, (rightBorderRect.height / LocalScale.y) / rightBorderTexture.height));
-            GUI.DrawTextureWithTexCoords(bottomBorderRect, bottomBorderTexture, new Rect(0, 0, (bottomBorderRect.width / LocalScale.y) / bottomBorderTexture.width, 1));
+            DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(topBorderRect, topBorderTexture, new Rect(0, 0, (topBorderRect.width / LocalScale.x) / topBorderTexture.width, 1));
+            DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(leftBorderRect, leftBorderTexture, new Rect(0, 0, 1, (leftBorderRect.height / LocalScale.y) / leftBorderTexture.height));
+            DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(rightBorderRect, rightBorderTexture, new Rect(0, 0, 1, (rightBorderRect.height / LocalScale.y) / rightBorderTexture.height));
+            DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(bottomBorderRect, bottomBorderTexture, new Rect(0, 0, (bottomBorderRect.width / LocalScale.y) / bottomBorderTexture.width, 1));
         }
 
         void UpdateBorderDrawRects(Rect drawRect)

--- a/Assets/Scripts/Game/UserInterface/ReflexPicker.cs
+++ b/Assets/Scripts/Game/UserInterface/ReflexPicker.cs
@@ -60,7 +60,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             base.Draw();
 
-            GUI.DrawTextureWithTexCoords(buttonRect, highlightTexture, highlightRect);
+            DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(buttonRect, highlightTexture, highlightRect);
         }
 
         #region Private Methods

--- a/Assets/Scripts/Game/UserInterface/TextCursor.cs
+++ b/Assets/Scripts/Game/UserInterface/TextCursor.cs
@@ -103,7 +103,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             Rect rect = Rectangle;
             rect.width = cursorThickness * LocalScale.x;
-            GUI.DrawTexture(rect, cursorTexture);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(rect, cursorTexture);
         }
 
         void SetThickness(int value)

--- a/Assets/Scripts/Game/UserInterface/TextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/TextLabel.cs
@@ -274,12 +274,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 shadowRect.x += shadowPosition.x * LocalScale.x;
                 shadowRect.y += shadowPosition.y * LocalScale.y;
                 GUI.color = shadowColor;
-                GUI.DrawTextureWithTexCoords(shadowRect, textureToDraw, innerRect);
+                DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(shadowRect, textureToDraw, innerRect);
             }
 
             // Draw text
             GUI.color = textColor;
-            GUI.DrawTextureWithTexCoords(totalRect, textureToDraw, innerRect);
+            DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(totalRect, textureToDraw, innerRect);
 
             // Restore starting colour
             GUI.color = guiColor;

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceManager.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceManager.cs
@@ -177,8 +177,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// </summary>
         private void AddWindow(UserInterfaceWindow window)
         {
-            DaggerfallUI.Instance.ClearRenderTarget();
-
             windows.Push(window);
             window.OnPush();
             if(window.PauseWhileOpen && GameManager.HasInstance)
@@ -190,8 +188,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// </summary>
         private void RemoveWindow()
         {
-            DaggerfallUI.Instance.ClearRenderTarget();
-
             UserInterfaceWindow oldWindow = TopWindow;
             if (oldWindow != null)
             {

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceManager.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceManager.cs
@@ -177,6 +177,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// </summary>
         private void AddWindow(UserInterfaceWindow window)
         {
+            DaggerfallUI.Instance.ClearRenderTarget();
+
             windows.Push(window);
             window.OnPush();
             if(window.PauseWhileOpen && GameManager.HasInstance)
@@ -188,6 +190,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// </summary>
         private void RemoveWindow()
         {
+            DaggerfallUI.Instance.ClearRenderTarget();
+
             UserInterfaceWindow oldWindow = TopWindow;
             if (oldWindow != null)
             {

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -23,7 +23,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         int createCount = 0;
         RenderTexture targetTexture = null;
-        Texture2D clearTexture = null;
         Rect targetRect = new Rect();
 
         #endregion
@@ -53,7 +52,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         private void Awake()
         {
             targetTexture = CheckTargetTexture(targetTexture);
-            clearTexture = DaggerfallUI.CreateSolidTexture(Color.clear, 8);
             UpdateNonDiegeticOutput();
         }
 
@@ -64,19 +62,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #endregion
 
-        #region Public Methods
-
-        /// <summary>
-        /// Sets the target texture to clear.
-        /// </summary>
-        public void ClearTargetTexture()
-        {
-            Graphics.Blit(clearTexture, targetTexture);
-        }
-
-        #endregion
-
         #region Drawing Methods
+
+        public void Clear()
+        {
+            GL.Clear(true, true, Color.clear);
+        }
 
         public void DrawTexture(Rect position, Texture2D image)
         {

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -154,7 +154,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         void UpdateNonDiegeticOutput()
         {
             // Must be able to find output canvas object
-            GameObject nonDiegeticUIOutput = GameManager.Instance.NonDiegeticUIOutput;
+            GameObject nonDiegeticUIOutput = DaggerfallUI.Instance.NonDiegeticUIOutput;
             if (!nonDiegeticUIOutput)
                 return;
 

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -66,7 +66,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         public void Clear()
         {
+            RenderTexture oldRt = RenderTexture.active;
+            RenderTexture.active = targetTexture;
+
             GL.Clear(true, true, Color.clear);
+
+            RenderTexture.active = oldRt;
         }
 
         public void DrawTexture(Rect position, Texture2D image)

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -131,7 +131,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (!IsReady(GetBackBufferTexture()))
                 return;
 
+            RenderTexture oldRt = RenderTexture.active;
+            RenderTexture.active = BackBufferTexture;
+
             GUI.DrawTexture(position, image);
+
+            RenderTexture.active = oldRt;
         }
 
         public void DrawTexture(Rect position, Texture2D image, ScaleMode scaleMode, bool alphaBlend = true, float imageAspect = 0)
@@ -139,7 +144,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (!IsReady(GetBackBufferTexture()))
                 return;
 
+            RenderTexture oldRt = RenderTexture.active;
+            RenderTexture.active = BackBufferTexture;
+
             GUI.DrawTexture(position, image, scaleMode, alphaBlend);
+
+            RenderTexture.active = oldRt;
         }
 
         public void DrawTextureWithTexCoords(Rect position, Texture image, Rect texCoords, bool alphaBlend = true)
@@ -147,7 +157,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (!IsReady(GetBackBufferTexture()))
                 return;
 
+            RenderTexture oldRt = RenderTexture.active;
+            RenderTexture.active = BackBufferTexture;
+
             GUI.DrawTextureWithTexCoords(position, image, texCoords, alphaBlend);
+
+            RenderTexture.active = oldRt;
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -51,13 +51,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         private void Awake()
         {
-            targetTexture = CheckTargetTexture(targetTexture);
+            CheckTargetTexture();
             UpdateNonDiegeticOutput();
         }
 
         private void Update()
         {
-            targetTexture = CheckTargetTexture(targetTexture);
+            CheckTargetTexture();
         }
 
         #endregion
@@ -76,7 +76,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         public void DrawTexture(Rect position, Texture2D image)
         {
-            if (!IsReady(targetTexture))
+            if (!IsReady())
                 return;
 
             RenderTexture oldRt = RenderTexture.active;
@@ -89,7 +89,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         public void DrawTexture(Rect position, Texture2D image, ScaleMode scaleMode, bool alphaBlend = true, float imageAspect = 0)
         {
-            if (!IsReady(targetTexture))
+            if (!IsReady())
                 return;
 
             RenderTexture oldRt = RenderTexture.active;
@@ -102,7 +102,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         public void DrawTextureWithTexCoords(Rect position, Texture image, Rect texCoords, bool alphaBlend = true)
         {
-            if (!IsReady(targetTexture))
+            if (!IsReady())
                 return;
 
             RenderTexture oldRt = RenderTexture.active;
@@ -118,24 +118,24 @@ namespace DaggerfallWorkshop.Game.UserInterface
         #region Render Texture Management
 
         // Check render texture is non-null and created
-        bool IsReady(RenderTexture targetTexture)
+        bool IsReady()
         {
             return (targetTexture != null && targetTexture.IsCreated());
         }
 
         // Check render texture and recreate if not valid
-        RenderTexture CheckTargetTexture(RenderTexture targetTexture)
+        void CheckTargetTexture()
         {
             // Just using screen dimensions for now while solving problems of redirecting rendering from UI components
             // Aiming for a baseline of 1:1 functionality with current setup before changing anything further
             int width = Screen.width;
             int height = Screen.height;
-            targetRect = new Rect(0, 0, width, height);
 
             // Just return same texture if still valid
-            if (!IsReady(targetTexture) || targetTexture.width != width || targetTexture.height != height)
+            if (!IsReady() || targetTexture.width != width || targetTexture.height != height)
             {
                 // Create target texture matching screen dimensions
+                targetRect = new Rect(0, 0, width, height);
                 targetTexture = new RenderTexture(width, height, 0, RenderTextureFormat.ARGB32);
                 targetTexture.name = string.Format("DaggerfallUI RenderTexture {0}", createCount++);
                 targetTexture.Create();
@@ -143,8 +143,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 RaiseOnCreateTargetTexture();
                 Debug.LogFormat("Created UI RenderTexture with dimensions {0}, {1}", width, height);
             }
-
-            return targetTexture;
         }
 
         void UpdateNonDiegeticOutput()

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -74,6 +74,33 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #endregion
 
+        #region Public Methods
+
+        /// <summary>
+        /// Gets diegetic canvas output raw image (if enabled)
+        /// </summary>
+        /// <returns>RawImage or null.</returns>
+        public RawImage GetDiegeticCanvasRawImage()
+        {
+            // Must be able to find output canvas object
+            GameObject nonDiegeticUIOutput = DaggerfallUI.Instance.NonDiegeticUIOutput;
+            if (!nonDiegeticUIOutput)
+                return null;
+
+            // Output canvas object must be active
+            if (!nonDiegeticUIOutput.activeInHierarchy)
+                return null;
+
+            // Get raw image component
+            RawImage rawImage = nonDiegeticUIOutput.GetComponent<RawImage>();
+            if (!rawImage)
+                return null;
+
+            return rawImage;
+        }
+
+        #endregion
+
         #region Drawing Methods
 
         public void Clear()
@@ -159,17 +186,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         void UpdateNonDiegeticOutput()
         {
-            // Must be able to find output canvas object
-            GameObject nonDiegeticUIOutput = DaggerfallUI.Instance.NonDiegeticUIOutput;
-            if (!nonDiegeticUIOutput)
-                return;
-
-            // Output canvas object must be active
-            if (!nonDiegeticUIOutput.activeInHierarchy)
-                return;
-
             // Get raw image component
-            RawImage rawImage = nonDiegeticUIOutput.GetComponent<RawImage>();
+            RawImage rawImage = GetDiegeticCanvasRawImage();
             if (!rawImage)
                 return;
 

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -16,26 +16,38 @@ namespace DaggerfallWorkshop.Game.UserInterface
 {
     /// <summary>
     /// Manages the render target texture for UI systems and provides helpers for drawing UI components.
+    /// Used a double-buffered rendering setup with a backbuffer texture and a presentation texture.
+    /// The front and back textures are swapped at the end of every UI draw operation.
     /// </summary>
     public class UserInterfaceRenderTarget : MonoBehaviour
     {
         #region Fields
 
         int createCount = 0;
-        RenderTexture targetTexture;
+        RenderTexture targetTextureA = null;
+        RenderTexture targetTextureB = null;
+        Texture2D clearTexture = null;
         Rect targetRect = new Rect();
+        bool flip = false;
 
         #endregion
 
         #region Properties
 
         /// <summary>
-        /// Gets current target texture.
-        /// Capture OnCreateTargetTexture to get latest render texture if this changes for any reason.
+        /// Gets current presentation texture.
         /// </summary>
-        public RenderTexture TargetTexture
+        public RenderTexture PresentationTexture
         {
-            get { return targetTexture; }
+            get { return GetPresentationTexture(); }
+        }
+
+        /// <summary>
+        /// Gets current backbuffer texture.
+        /// </summary>
+        public RenderTexture BackBufferTexture
+        {
+            get { return GetBackBufferTexture(); }
         }
 
         /// <summary>
@@ -52,97 +64,123 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         private void Awake()
         {
-            CreateTargetTexture();
+            targetTextureA = CheckTargetTexture(targetTextureA);
+            targetTextureB = CheckTargetTexture(targetTextureB);
+            clearTexture = DaggerfallUI.CreateSolidTexture(Color.clear, 8);
+            UpdateNonDiegeticOutput();
         }
 
         private void Update()
         {
-            if (!CheckTargetTextureSize() || !targetTexture.IsCreated())
-            {
-                CreateTargetTexture();
-                return;
-            }
+            targetTextureA = CheckTargetTexture(targetTextureA);
+            targetTextureB = CheckTargetTexture(targetTextureB);
         }
 
         #endregion
 
         #region Public Methods
+
+        /// <summary>
+        /// Flip presentation and backbuffer texture so latest render becomes presentation texture.
+        /// Updates non-diegetic canvas if currently enabled. If not using default non-diegetic canvas
+        /// then some other system (e.g. a diegetic quad) must present UI to end user.
+        /// </summary>
+        public void Present()
+        {
+            flip = !flip;
+            UpdateNonDiegeticOutput();
+            ClearBackBufferTexture();
+        }
+
+        /// <summary>
+        /// Sets the backbuffer to clear.
+        /// </summary>
+        public void ClearBackBufferTexture()
+        {
+            Graphics.Blit(clearTexture, GetBackBufferTexture());
+        }
+
+        /// <summary>
+        /// Sets the presentation texture to clear.
+        /// </summary>
+        public void ClearPresentationTexture()
+        {
+            Graphics.Blit(clearTexture, GetPresentationTexture());
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        RenderTexture GetPresentationTexture()
+        {
+            return (flip) ? targetTextureA : targetTextureB;
+        }
+
+        RenderTexture GetBackBufferTexture()
+        {
+            return (flip) ? targetTextureB : targetTextureA;
+        }
+
         #endregion
 
         #region Drawing Methods
 
         public void DrawTexture(Rect position, Texture2D image)
         {
-            if (!IsReady())
+            if (!IsReady(GetBackBufferTexture()))
                 return;
 
-            RenderTexture.active = targetTexture;
-
             GUI.DrawTexture(position, image);
-
-            RenderTexture.active = null;
         }
 
         public void DrawTexture(Rect position, Texture2D image, ScaleMode scaleMode, bool alphaBlend = true, float imageAspect = 0)
         {
-            if (!IsReady())
+            if (!IsReady(GetBackBufferTexture()))
                 return;
 
-            RenderTexture.active = targetTexture;
-
             GUI.DrawTexture(position, image, scaleMode, alphaBlend);
-
-            RenderTexture.active = null;
         }
 
         public void DrawTextureWithTexCoords(Rect position, Texture image, Rect texCoords, bool alphaBlend = true)
         {
-            if (!IsReady())
+            if (!IsReady(GetBackBufferTexture()))
                 return;
 
-            RenderTexture.active = targetTexture;
-
             GUI.DrawTextureWithTexCoords(position, image, texCoords, alphaBlend);
-
-            RenderTexture.active = null;
         }
 
         #endregion
 
         #region Render Texture Management
 
-        bool IsReady()
+        // Check render texture is non-null and created
+        bool IsReady(RenderTexture targetTexture)
         {
-            return (targetTexture && targetTexture.IsCreated());
+            return (targetTexture != null && targetTexture.IsCreated());
         }
 
-        bool CheckTargetTextureSize()
+        // Check render texture and recreate if not valid
+        RenderTexture CheckTargetTexture(RenderTexture targetTexture)
         {
-            if (!targetTexture)
-                return false;
-
-            if (targetTexture.width != Screen.width || targetTexture.height != Screen.height)
-                return false;
-
-            return true;
-        }
-
-        void CreateTargetTexture()
-        {
-            // Create target texture matching screen dimensions
-            // Notes:
-            //  - Just using screen dimensions for now while solving problems of redirecting rendering from UI components
-            //  - Aiming for a baseline of 1:1 functionality with current setup before changing anything further
+            // Just using screen dimensions for now while solving problems of redirecting rendering from UI components
+            // Aiming for a baseline of 1:1 functionality with current setup before changing anything further
             int width = Screen.width;
             int height = Screen.height;
-            targetTexture = new RenderTexture(width, height, 0, RenderTextureFormat.ARGB32);
-            targetTexture.name = string.Format("DaggerfallUI RenderTexture {0}", createCount++);
-            targetTexture.Create();
             targetRect = new Rect(0, 0, width, height);
-            UpdateNonDiegeticOutput();
-            RaiseOnCreateTargetTexture();
 
-            Debug.LogFormat("Created UI RenderTexture with dimensions {0}, {1}", width, height);
+            // Just return same texture if still valid
+            if (!IsReady(targetTexture) || targetTexture.width != width || targetTexture.height != height)
+            {
+                // Create target texture matching screen dimensions
+                targetTexture = new RenderTexture(width, height, 0, RenderTextureFormat.ARGB32);
+                targetTexture.name = string.Format("DaggerfallUI RenderTexture {0}", createCount++);
+                targetTexture.Create();
+                RaiseOnCreateTargetTexture();
+                Debug.LogFormat("Created UI RenderTexture with dimensions {0}, {1}", width, height);
+            }
+
+            return targetTexture;
         }
 
         void UpdateNonDiegeticOutput()
@@ -161,8 +199,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (!rawImage)
                 return;
 
-            // Set render texture to raw image
-            rawImage.texture = targetTexture;
+            // Set presentation render texture to raw image output
+            rawImage.texture = GetPresentationTexture();
             rawImage.SetNativeSize();
         }
 

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -60,6 +60,18 @@ namespace DaggerfallWorkshop.Game.UserInterface
             CheckTargetTexture();
         }
 
+        private void OnGUI()
+        {
+            // Clear behind everything else
+            GUI.depth = 10;
+
+            if (Event.current.type != EventType.Repaint)
+                return;
+
+            if (IsReady())
+                Clear();
+        }
+
         #endregion
 
         #region Drawing Methods

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -1,0 +1,184 @@
+﻿// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Gavin Clayton (interkarma@dfworkshop.net)
+// Contributors:    
+// 
+// Notes:
+//
+
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace DaggerfallWorkshop.Game.UserInterface
+{
+    /// <summary>
+    /// Manages the render target texture for UI systems and provides helpers for drawing UI components.
+    /// </summary>
+    public class UserInterfaceRenderTarget : MonoBehaviour
+    {
+        #region Fields
+
+        int createCount = 0;
+        RenderTexture targetTexture;
+        Rect targetRect = new Rect();
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets current target texture.
+        /// Capture OnCreateTargetTexture to get latest render texture if this changes for any reason.
+        /// </summary>
+        public RenderTexture TargetTexture
+        {
+            get { return targetTexture; }
+        }
+
+        /// <summary>
+        /// Gets rectangle of target texture.
+        /// </summary>
+        public Rect TargetRect
+        {
+            get { return targetRect; }
+        }
+
+        #endregion
+
+        #region Unity
+
+        private void Awake()
+        {
+            CreateTargetTexture();
+        }
+
+        private void Update()
+        {
+            if (!CheckTargetTextureSize() || !targetTexture.IsCreated())
+            {
+                CreateTargetTexture();
+                return;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+        #endregion
+
+        #region Drawing Methods
+
+        public void DrawTexture(Rect position, Texture2D image)
+        {
+            if (!IsReady())
+                return;
+
+            RenderTexture.active = targetTexture;
+
+            GUI.DrawTexture(position, image);
+
+            RenderTexture.active = null;
+        }
+
+        public void DrawTexture(Rect position, Texture2D image, ScaleMode scaleMode, bool alphaBlend = true, float imageAspect = 0)
+        {
+            if (!IsReady())
+                return;
+
+            RenderTexture.active = targetTexture;
+
+            GUI.DrawTexture(position, image, scaleMode, alphaBlend);
+
+            RenderTexture.active = null;
+        }
+
+        public void DrawTextureWithTexCoords(Rect position, Texture image, Rect texCoords, bool alphaBlend = true)
+        {
+            if (!IsReady())
+                return;
+
+            RenderTexture.active = targetTexture;
+
+            GUI.DrawTextureWithTexCoords(position, image, texCoords, alphaBlend);
+
+            RenderTexture.active = null;
+        }
+
+        #endregion
+
+        #region Render Texture Management
+
+        bool IsReady()
+        {
+            return (targetTexture && targetTexture.IsCreated());
+        }
+
+        bool CheckTargetTextureSize()
+        {
+            if (!targetTexture)
+                return false;
+
+            if (targetTexture.width != Screen.width || targetTexture.height != Screen.height)
+                return false;
+
+            return true;
+        }
+
+        void CreateTargetTexture()
+        {
+            // Create target texture matching screen dimensions
+            // Notes:
+            //  - Just using screen dimensions for now while solving problems of redirecting rendering from UI components
+            //  - Aiming for a baseline of 1:1 functionality with current setup before changing anything further
+            int width = Screen.width;
+            int height = Screen.height;
+            targetTexture = new RenderTexture(width, height, 0, RenderTextureFormat.ARGB32);
+            targetTexture.name = string.Format("DaggerfallUI RenderTexture {0}", createCount++);
+            targetTexture.Create();
+            targetRect = new Rect(0, 0, width, height);
+            UpdateNonDiageticOutput();
+            RaiseOnCreateTargetTexture();
+
+            Debug.LogFormat("Created UI RenderTexture with dimensions {0}, {1}", width, height);
+        }
+
+        void UpdateNonDiageticOutput()
+        {
+            // Must be able to find output canvas object
+            GameObject nonDiageticUIOutput = GameManager.Instance.NonDiageticUIOutput;
+            if (!nonDiageticUIOutput)
+                return;
+
+            // Output canvas object must be active
+            if (!nonDiageticUIOutput.activeInHierarchy)
+                return;
+
+            // Get raw image component
+            RawImage rawImage = nonDiageticUIOutput.GetComponent<RawImage>();
+            if (!rawImage)
+                return;
+
+            // Set render texture to raw image
+            rawImage.texture = targetTexture;
+            rawImage.SetNativeSize();
+        }
+
+        #endregion
+
+        #region Events
+
+        // OnCreateTargetTexture
+        public delegate void OnCreateTargetTextureEventHandler();
+        public event OnCreateTargetTextureEventHandler OnCreateTargetTexture;
+        protected virtual void RaiseOnCreateTargetTexture()
+        {
+            if (OnCreateTargetTexture != null)
+                OnCreateTargetTexture();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -139,25 +139,25 @@ namespace DaggerfallWorkshop.Game.UserInterface
             targetTexture.name = string.Format("DaggerfallUI RenderTexture {0}", createCount++);
             targetTexture.Create();
             targetRect = new Rect(0, 0, width, height);
-            UpdateNonDiageticOutput();
+            UpdateNonDiegeticOutput();
             RaiseOnCreateTargetTexture();
 
             Debug.LogFormat("Created UI RenderTexture with dimensions {0}, {1}", width, height);
         }
 
-        void UpdateNonDiageticOutput()
+        void UpdateNonDiegeticOutput()
         {
             // Must be able to find output canvas object
-            GameObject nonDiageticUIOutput = GameManager.Instance.NonDiageticUIOutput;
-            if (!nonDiageticUIOutput)
+            GameObject nonDiegeticUIOutput = GameManager.Instance.NonDiegeticUIOutput;
+            if (!nonDiegeticUIOutput)
                 return;
 
             // Output canvas object must be active
-            if (!nonDiageticUIOutput.activeInHierarchy)
+            if (!nonDiegeticUIOutput.activeInHierarchy)
                 return;
 
             // Get raw image component
-            RawImage rawImage = nonDiageticUIOutput.GetComponent<RawImage>();
+            RawImage rawImage = nonDiegeticUIOutput.GetComponent<RawImage>();
             if (!rawImage)
                 return;
 

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs.meta
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d92490a3aace0254aaf1329ecdd82f24
+timeCreated: 1527556131
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterface/VerticalProgress.cs
+++ b/Assets/Scripts/Game/UserInterface/VerticalProgress.cs
@@ -75,10 +75,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             dstRect.height *= amount;
 
             if (ProgressTexture)
-                GUI.DrawTextureWithTexCoords(dstRect, ProgressTexture, srcRect, false);
+                DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(dstRect, ProgressTexture, srcRect, false);
             else if (ColorTexture)
             {
-                GUI.DrawTextureWithTexCoords(dstRect, ColorTexture, srcRect, false);
+                DaggerfallUI.Instance.RenderTarget.DrawTextureWithTexCoords(dstRect, ColorTexture, srcRect, false);
             }
         }
     }

--- a/Assets/Scripts/Game/UserInterface/VerticalScrollBar.cs
+++ b/Assets/Scripts/Game/UserInterface/VerticalScrollBar.cs
@@ -216,9 +216,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Rect topRect = new Rect(totalRect.x, totalRect.y + thumbY, totalRect.width, topTextureHeight);
             Rect bodyRect = new Rect(totalRect.x, topRect.yMax, totalRect.width, thumbHeight - topTextureHeight - bottomTextureHeight);
             Rect bottomRect = new Rect(totalRect.x, bodyRect.yMax, totalRect.width, bottomTextureHeight);
-            GUI.DrawTexture(topRect, vScrollThumbTop, ScaleMode.StretchToFill);
-            GUI.DrawTexture(bodyRect, vScrollThumbBody, ScaleMode.StretchToFill);
-            GUI.DrawTexture(bottomRect, vScrollThumbBottom, ScaleMode.StretchToFill);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(topRect, vScrollThumbTop, ScaleMode.StretchToFill);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(bodyRect, vScrollThumbBody, ScaleMode.StretchToFill);
+            DaggerfallUI.Instance.RenderTarget.DrawTexture(bottomRect, vScrollThumbBottom, ScaleMode.StretchToFill);
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -26,7 +26,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     /// </summary>
     public class DaggerfallHUD : DaggerfallBaseWindow
     {
-        float crosshairScale = 0.5f;
+        float crosshairScale = 0.75f;
 
         PopupText popupText = new PopupText();
         TextLabel midScreenTextLabel = new TextLabel();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
@@ -23,14 +23,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     {
         IUserInterfaceWindow previousWindow;
 
-        Color screenDimColor = new Color32(0, 0, 0, 128);
+        //Color screenDimColor = new Color32(0, 0, 0, 128);
+        Color screenDimColor = Color.clear;
         bool allowCancel = true;
         bool cancelled = false;
 
         public Color ScreenDimColor
         {
             get { return GetScreenDimColor(); }
-            set { screenDimColor = value; }
+            set { screenDimColor = Color.clear;/*value*/; }
         }
 
         public bool AllowCancel
@@ -54,7 +55,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             : base(uiManager, screenWidth, screenHeight)
         {
             this.previousWindow = previousWindow;
-            this.screenDimColor.a = DaggerfallUnity.Settings.DimAlphaStrength;
+            this.screenDimColor.a = 0; //DaggerfallUnity.Settings.DimAlphaStrength;
         }
 
         protected override void Setup()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
@@ -172,6 +172,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             ParentPanel.BackgroundColor = ScreenDimColor;
 
             // Setup native panel background
+            NativePanel.BackgroundColor = new Color(0, 0, 0, 0.75f);
             NativePanel.BackgroundTexture = baseTexture;
 
             // Setup controls

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -201,7 +201,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void Setup()
         {
-            ParentPanel.BackgroundColor = ScreenDimColor;
+            ParentPanel.BackgroundColor = Color.black;
 
             // Set location pixel colors and identify flash color from palette file
             DFPalette colors = new DFPalette();


### PR DESCRIPTION
This change redirects the entire Daggerfall Unity UI into an offscreen RenderTexture target. There are also optimisations to how often UI was being redrawn. The offset render texture is presented to user through a RawImage on a Canvas during normal play.

The purpose of rendering the UI to an offscreen RenderTexture is to make the UI layer more flexible. For example, the same RenderTexture can be used as a non-diegetic overlay or as a diegetic panel inside the world for VR.

A few compromises had to be made for differences in how the RenderTexture handles alpha compared to the direct GUI.DrawTexture methods. The main change is the "background dim" is now gone for popup windows. This is closer to how classic works anyway. I've also removed the red flash when player injured for now. Otherwise everything is almost exactly the same.

I will continue tuning this, but I'm happy enough with changes to go into master for now.