### PR TITLE
TextureReplacement: read scale from xml (MobilePersonBillboard)

### DIFF
--- a/Assets/Scripts/Game/Utility/PopulationManager.cs
+++ b/Assets/Scripts/Game/Utility/PopulationManager.cs
@@ -181,6 +181,11 @@ namespace DaggerfallWorkshop.Game.Utility
                     poolItem.scheduleEnable = false;
                     poolItem.npc.RandomiseNPC(GetEntityRace());
                     poolItem.npc.Motor.InitMotor();
+
+                    // Adjust billboard position for actual size
+                    Vector2 size = poolItem.npc.Billboard.GetBillboardSize();
+                    if (Mathf.Abs(size.y - 2f) > 0.1f)
+                        poolItem.npc.Billboard.transform.Translate(0, (size.y - 2f) * 0.52f, 0);
                 }
 
                 // Get distance to player
@@ -200,6 +205,7 @@ namespace DaggerfallWorkshop.Game.Utility
                     poolItem.npc.Motor.gameObject.SetActive(false);
                     poolItem.active = false;
                     poolItem.scheduleEnable = false;
+                    poolItem.npc.Billboard.transform.localPosition = Vector3.zero;
                     poolItem.scheduleRecycle = false;
                 }
 

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -473,7 +473,7 @@ namespace DaggerfallWorkshop
                 finalSize.y = (size.Height + yChange);
 
                 // Set optional scale
-                TextureReplacement.SetEnemyScale(archive, i, ref finalSize);
+                TextureReplacement.SetBillboardScale(archive, i, ref finalSize);
  
                 // Store final size and frame count
                 summary.RecordSizes[i] = finalSize * MeshReader.GlobalScale;

--- a/Assets/Scripts/Internal/MobilePersonBillboard.cs
+++ b/Assets/Scripts/Internal/MobilePersonBillboard.cs
@@ -20,6 +20,7 @@ using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop
 {
@@ -261,6 +262,9 @@ namespace DaggerfallWorkshop
                 int yChange = (int)(size.Height * (scale.Height / BlocksFile.ScaleDivisor));
                 finalSize.x = (size.Width + xChange);
                 finalSize.y = (size.Height + yChange);
+
+                // Set optional scale
+                TextureReplacement.SetBillboardScale(textureArchive, i, ref finalSize);
 
                 // Store final size and frame count
                 recordSizes[i] = finalSize * MeshReader.GlobalScale;

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -439,7 +439,10 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             }
         }
 
-        public static void SetEnemyScale(int archive, int record, ref Vector2 size)
+        /// <summary>
+        /// Read scale from xml and apply to given vector.
+        /// </summary>
+        public static void SetBillboardScale(int archive, int record, ref Vector2 size)
         {
             if (!DaggerfallUnity.Settings.MeshAndTextureReplacement)
                 return;


### PR DESCRIPTION
Allow custom scale for wandering npcs as discussed on forums.  Instead of using raycast as previosly said, i left position of parent gameobject with Motor as is, and moved child gameobject with billboard meshrender via transform. This doesn't affect small variations so behaviour with original graphics is unaltered.