### PR TITLE
Extend start quest to load from quest packs

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/StartQuest.cs
+++ b/Assets/Scripts/Game/Questing/Actions/StartQuest.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -62,7 +62,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 questName = string.Format("S{0:0000000}", questIndex1);
 
             // Attempt to parse quest
-            Quest quest = QuestMachine.Instance.ParseQuest(questName);
+            Quest quest = GameManager.Instance.QuestListsManager.GetQuest(questName);
             if (quest != null)
             {
                 QuestMachine.Instance.ScheduleQuest(quest);

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Hazelnut
 // 
 // Notes:
 //
@@ -12,8 +12,6 @@
 using UnityEngine;
 using System;
 using System.IO;
-using System.Text;
-using System.Collections;
 using System.Collections.Generic;
 using FullSerializer;
 using DaggerfallConnect.Arena2;
@@ -541,11 +539,12 @@ namespace DaggerfallWorkshop.Game.Questing
 
         /// <summary>
         /// Parses a new quest from name.
+        /// AJRB: Internal use only, use QuestListsManager.GetQuest() instead.
         /// Quest will attempt to load from QuestSourceFolder property path.
         /// </summary>
         /// <param name="questName">Name of quest filename. Extensions .txt is optional.</param>
         /// <returns>Quest object if successfully parsed, otherwise null.</returns>
-        public Quest ParseQuest(string questName)
+        private Quest ParseQuest(string questName)
         {
             string[] source = GetQuestSourceText(questName);
             if (source == null || source.Length == 0)


### PR DESCRIPTION
I've changed the start quest action to pick up quests in the following order

1) Any classic quests in /Quests folder.
2) Any init quests registered by quest list.
3) Any quests in same folder as an init quest.
4) Any guild quests registered by quest list.
5) Any social quests registered by quest list.
