### PR TITLE
Make death of player show red

### DIFF
--- a/Assets/Scripts/Game/FadeBehaviour.cs
+++ b/Assets/Scripts/Game/FadeBehaviour.cs
@@ -64,10 +64,11 @@ namespace DaggerfallWorkshop.Game
             if (fadeTargetPanel == null || !allowFade)
                 return;
 
-            fadeStartColor = Color.clear;
+            fadeStartColor = new Color(0.39f, 0, 0, 0.4f);
+            //fadeStartColor = Color.clear;
             fadeEndColor = Color.black;
             this.fadeDuration = fadeDuration;
-            fadeTargetPanel.BackgroundColor = Color.clear;
+            //fadeTargetPanel.BackgroundColor = Color.clear;
             fadeInProgress = true;
         }
 

--- a/Assets/Scripts/Game/FadeBehaviour.cs
+++ b/Assets/Scripts/Game/FadeBehaviour.cs
@@ -64,11 +64,21 @@ namespace DaggerfallWorkshop.Game
             if (fadeTargetPanel == null || !allowFade)
                 return;
 
-            fadeStartColor = new Color(0.39f, 0, 0, 0.4f);
-            //fadeStartColor = Color.clear;
+            fadeStartColor = Color.clear;
             fadeEndColor = Color.black;
             this.fadeDuration = fadeDuration;
-            //fadeTargetPanel.BackgroundColor = Color.clear;
+            fadeTargetPanel.BackgroundColor = Color.clear;
+            fadeInProgress = true;
+        }
+
+        public void FadeHUDBloodToBlack(float fadeDuration = 0.5f)
+        {
+            if (fadeTargetPanel == null || !allowFade)
+                return;
+
+            fadeStartColor = new Color(0.39f, 0, 0, 0.4f);
+            fadeEndColor = Color.black;
+            this.fadeDuration = fadeDuration;
             fadeInProgress = true;
         }
 

--- a/Assets/Scripts/Game/HUDFlickerMask.cs
+++ b/Assets/Scripts/Game/HUDFlickerMask.cs
@@ -63,14 +63,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     flickerFast.ResetIfBurnedOut();
                 }
 
-                // should the slow flicker be reset?
-                /*if ((  condition == PlayerCondition.Dead)
-                    && healthDetector.HealthLost != 0
-                    && flickerSlow.IsBurnedOut)
-                {
-                    flickerSlow.Reset();
-                }*/
-
                 // should the flash flicker be reset?
                 if ( condition == PlayerCondition.Normal )
                 {
@@ -102,19 +94,18 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     else
                         backColor = new Color(flickerFast.RedValue, 0, 0, flickerFast.AlphaValue);
                     break;
-                //case PlayerCondition.Dead:
-                // Doesn't seem to display the color when dying
-                //flickerFast.Cycle();
-                //backColor.a = flickerFast.AlphaValue;
-                //backColor.r = flickerFast.RedValue;
-                //break;
+                case PlayerCondition.Dead:
+                    // Doesn't seem to display the color when dying
+                    flickerFast.Cycle();
+                    backColor = new Color(flickerFast.RedValue, 0, 0, flickerFast.AlphaValue);
+                    break;
                 default:
                     backColor = new Color();
                     break;
             }
 
-            if (condition != PlayerCondition.Dead && backColor.a != 0)
-                Parent.BackgroundColor = new Color(backColor.r, 0, 0, backColor.a);
+            if (/*condition != PlayerCondition.Dead && */ backColor.a != 0)
+                Parent.BackgroundColor = backColor;
         }
     }
 }

--- a/Assets/Scripts/Game/PlayerDeath.cs
+++ b/Assets/Scripts/Game/PlayerDeath.cs
@@ -158,7 +158,7 @@ namespace DaggerfallWorkshop.Game
             startCameraHeight = mainCamera.transform.localPosition.y;
             targetCameraHeight = playerController.height - (playerController.height * 1.25f);
             currentCameraHeight = startCameraHeight;
-            DaggerfallUI.Instance.FadeBehaviour.FadeHUDToBlack(FadeDuration);
+            DaggerfallUI.Instance.FadeBehaviour.FadeHUDBloodToBlack(FadeDuration);
 
             // There are 3 pain-like sounds for each race/gender. The third one, used here, sounds like
             // it may have been meant for when the player dies.


### PR DESCRIPTION
Edits FadeBehavior.FadeHUDToBlack() to have fadeStartColor = a blood red color and fade that to black instead of clear to black.  I tested it in the game and it looks better than the inconsistent behavior that occurs that when you get hit and no flash of any sort occurs and it just fades to black.  Try it out. 