### PR TITLE
Abstracts HealthChangeDetector

### DIFF
--- a/Assets/Prefabs/Player/PlayerAdvanced.prefab
+++ b/Assets/Prefabs/Player/PlayerAdvanced.prefab
@@ -40,6 +40,7 @@ GameObject:
   - component: {fileID: 114101796857139080}
   - component: {fileID: 114220683863726122}
   - component: {fileID: 114033680799267548}
+  - component: {fileID: 114397629012878356}
   m_Layer: 0
   m_Name: PlayerAdvanced
   m_TagString: Player
@@ -1151,6 +1152,17 @@ MonoBehaviour:
   SnowParticles: {fileID: 1620007807851924}
   WeatherType: 0
   ClimateWeathers: 
+--- !u!114 &114397629012878356
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de88bed3f7cb70d46a6d00009998cb81, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114492803959826104
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -120,6 +120,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public ItemEquipTable ItemEquipTable { get { return equipTable; } }
         public int MaxHealth { get { return maxHealth; } set { maxHealth = value; } }
         public int CurrentHealth { get { return GetCurrentHealth(); } set { SetHealth(value); } }
+        public float CurrentHealthPercent { get { return GetCurrentHealth() / (float)maxHealth; } }
         public int MaxFatigue { get { return (stats.LiveStrength + stats.LiveEndurance) * 64; } }
         public int CurrentFatigue { get { return GetCurrentFatigue(); } set { SetFatigue(value); } }
         public int MaxMagicka { get { return FormulaHelper.SpellPoints(stats.LiveIntelligence, career.SpellPointMultiplierValue); } }

--- a/Assets/Scripts/Game/Player/CameraRecoiler.cs
+++ b/Assets/Scripts/Game/Player/CameraRecoiler.cs
@@ -37,11 +37,9 @@ namespace DaggerfallWorkshop.Game
                 return cameraRecoilSetting;
             }
         }
-        
+
         protected Transform playerCamTransform;
-        protected int previousMaxHealth;
-        protected int previousHealth;
-        protected int healthLost;
+        protected HealthChangeDetector healthDetector;
         protected bool bSwaying; // true if player is reeling from damage
         protected Vector2 swayAxis;
         protected float timerStart;
@@ -51,6 +49,7 @@ namespace DaggerfallWorkshop.Game
         void Start()
         {
             playerCamTransform = GameManager.Instance.MainCamera.transform;
+            healthDetector = GetComponent<HealthChangeDetector>();
 
             // Get starting health and max health
             if (GameManager.Instance != null && GameManager.Instance.PlayerEntity != null)
@@ -72,33 +71,22 @@ namespace DaggerfallWorkshop.Game
             else
                 cameraRecoilSetting = GetRecoilSetting(DaggerfallUnity.Settings.CameraRecoilStrength);
 
-            // Check max health hasn't changed - this can indicate user has loaded a different character
-            // or current character has levelled up or changed in some way and the cached health values need to be refreshed.
-            // Just reset values and exit for this frame as the current relative health lost calculation is not valid when MaxHealth changes.
-            int maxHealth = GameManager.Instance.PlayerEntity.MaxHealth;
-            int currentHealth = GameManager.Instance.PlayerEntity.CurrentHealth;
-            if (maxHealth != previousMaxHealth)
-            {
-                ResetRecoil();
-                return;
-            }
-
+            int healthLost = healthDetector.HealthLost;
+            float healthLostPercent = healthDetector.HealthLostPercent;
             // Detect Health loss
-            int healthLost = previousHealth - currentHealth;
             if (healthLost > 0)
             {
                 const float minPercentThreshold = 0.02f;
-                float percentLost = (float)healthLost / maxHealth;
 
                 // useless to do it for less than a certain percentage
-                if (percentLost >= minPercentThreshold)
+                if (healthLostPercent > minPercentThreshold)
                 {
                     // Start swaying and timer countdown
                     bSwaying = true;
                     //Debug.Log("Percent loss: "  percentLost);
 
                     // longer timer for more health percent lost
-                    timerStart = CalculateTimerStart(percentLost);
+                    timerStart = CalculateTimerStart(healthLostPercent);
                     timer = timerStart;
 
                     // get a random unit vector axis for the sway direction
@@ -107,14 +95,11 @@ namespace DaggerfallWorkshop.Game
                 }
             }
 
-            // reset previous health to detect next health loss
-            previousHealth = currentHealth;  
-
             // do swaying
             if (bSwaying)
             {
                 const float timerSpeed = 2f * Mathf.PI; //how quickly the player's view recoils and how quickly it is finished recoiling.
-                timer -= Time.deltaTime* timerSpeed;
+                timer -= Time.deltaTime * timerSpeed;
 
                 // get new view rotation
                 float rotationScalar = CalculateRotationScalar(healthLost);
@@ -149,24 +134,24 @@ namespace DaggerfallWorkshop.Game
             // in stages of each 20% lost
             int piScalar = 5 + Mathf.FloorToInt(percentHealthLost * 5);
             //Debug.Log("timerStart is PI * " + piScalar);
-            return piScalar* Mathf.PI;
+            return piScalar * Mathf.PI;
         }
 
         protected virtual float AdjustForUserSetting(float maxRotationScalar)
         {
             switch (cameraRecoilSetting)
             {
-                case CameraRecoilSetting.Off:       return maxRotationScalar* 0f;
-                case CameraRecoilSetting.Low:       return maxRotationScalar* 0.25f;
-                case CameraRecoilSetting.Medium:    return maxRotationScalar* 0.50f;
-                case CameraRecoilSetting.High:      return maxRotationScalar* 0.75f;
-                case CameraRecoilSetting.VeryHigh:  return maxRotationScalar* 1f;
+                case CameraRecoilSetting.Off: return maxRotationScalar * 0f;
+                case CameraRecoilSetting.Low: return maxRotationScalar * 0.25f;
+                case CameraRecoilSetting.Medium: return maxRotationScalar * 0.50f;
+                case CameraRecoilSetting.High: return maxRotationScalar * 0.75f;
+                case CameraRecoilSetting.VeryHigh: return maxRotationScalar * 1f;
                 default: throw new Exception("Camera Recoil Setting not found!");
             }
         }
 
         protected virtual float CalculateRotationScalar(int healthLost)
-        { 
+        {
             float maxRotationScalar = AdjustForUserSetting(baseMaxRecoilSeverity);
 
             // each point of health lost makes the sway %1.5 of max effectiveness, up to a max of 100% effectiveness.
@@ -184,7 +169,7 @@ namespace DaggerfallWorkshop.Game
             //swayaxis provides direction for the sway
             float xAngle = Mathf.Sin(timer) * rotationScalar * swayAxis.x;
             float yAngle = Mathf.Sin(timer) * rotationScalar * swayAxis.y;
-            
+
             Vector3 newViewPositon = new Vector3(xAngle, yAngle);
 
             // return vector for euler angles
@@ -193,8 +178,6 @@ namespace DaggerfallWorkshop.Game
 
         public void ResetRecoil()
         {
-            previousMaxHealth = GameManager.Instance.PlayerEntity.MaxHealth;
-            previousHealth = GameManager.Instance.PlayerEntity.CurrentHealth;
             bSwaying = false;
         }
 

--- a/Assets/Scripts/Game/Player/HealthChangeDetector.cs
+++ b/Assets/Scripts/Game/Player/HealthChangeDetector.cs
@@ -1,0 +1,97 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Meteoric Dragon
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
+
+namespace DaggerfallWorkshop.Game
+{
+    public class HealthChangeDetector : MonoBehaviour
+    {
+        protected int previousMaxHealth;
+        protected int previousHealth;
+        public float HealthLostPercent { get; private set; }
+        public float HealthGainPercent { get { return -1 * HealthLostPercent; } }
+        public int HealthLost { get; private set; }
+        public int HealthGain { get { return -1 * HealthLost; } }
+
+        void Start()
+        {
+            // Get starting health and max health
+            if (GameManager.Instance != null && GameManager.Instance.PlayerEntity != null)
+                ResetHealth();
+
+            // Use events to capture a couple of edge cases
+            StreamingWorld.OnInitWorld += StreamingWorld_OnInitWorld;
+            SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
+            DaggerfallCourtWindow.OnCourtScreen += DaggerfallCourtWindow_OnCourtScreen;
+        }
+
+        void Update()
+        {
+            if (GameManager.IsGamePaused)
+                return;
+
+            // Check max health hasn't changed - this can indicate user has loaded a different character
+            // or current character has levelled up or changed in some way and the cached health values need to be refreshed.
+            // Just reset values and exit for this frame as the current relative health lost calculation is not valid when MaxHealth changes.
+            int maxHealth = GameManager.Instance.PlayerEntity.MaxHealth;
+            int currentHealth = GameManager.Instance.PlayerEntity.CurrentHealth;
+            if (maxHealth != previousMaxHealth)
+            {
+                ResetHealth();
+                return;
+            }
+
+            // Detect Health loss
+            HealthLost = previousHealth - currentHealth;
+            if (HealthLost > 0)
+            {
+                HealthLostPercent = (float)HealthLost / maxHealth;
+                //Debug.Log("Health Lost: " + HealthLost);
+            }
+
+            // reset previous health to detect next health loss
+            previousHealth = currentHealth;
+        }
+
+        public void ResetHealth()
+        {
+            previousMaxHealth = GameManager.Instance.PlayerEntity.MaxHealth;
+            previousHealth = GameManager.Instance.PlayerEntity.CurrentHealth;
+        }
+
+        private void StreamingWorld_OnInitWorld()
+        {
+            // Player can be moved by one system or another with swaying active
+            // This clears sway when player relocated
+            ResetHealth();
+        }
+
+        private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
+        {
+            // Loading a character with same MaxHealth but lower current health
+            // would also trigger a sway on load
+            // This resets on any load so sway is cleared for incoming character
+            ResetHealth();
+        }
+
+        private void DaggerfallCourtWindow_OnCourtScreen()
+        {
+            // Clear when player goes to court screen
+            ResetHealth();
+        }
+    }
+}

--- a/Assets/Scripts/Game/Player/HealthChangeDetector.cs.meta
+++ b/Assets/Scripts/Game/Player/HealthChangeDetector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: de88bed3f7cb70d46a6d00009998cb81
+timeCreated: 1528929861
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This commit takes health change detection code from CameraRecoiler and abstracts it to a new class "HealthChangeDetector" and makes it a component of playerAdvanced.  No Functionality changes.

This will allow easier modding for mods related to changes in Player Health, and other future functions.

Also, one additional Entity property is added to DaggerfallEntity, which allows shorthand way to get the current percentage of max health left of that entity.

This will also be used by the Near Death Experience code.  I figured it's better to make the code available for re-use rather than retype the same code in any new code that requires it.  