### PR TITLE
 TerrainSampler implementation extended

### DIFF
--- a/Assets/Scripts/Terrain/DefaultTerrainSampler.cs
+++ b/Assets/Scripts/Terrain/DefaultTerrainSampler.cs
@@ -42,6 +42,7 @@ namespace DaggerfallWorkshop
         {
             HeightmapDimension = defaultHeightmapDimension;
             MaxTerrainHeight = maxTerrainHeight;
+            MeanTerrainHeightScale = baseHeightScale + noiseMapScale;
             OceanElevation = scaledOceanElevation;
             BeachElevation = scaledBeachElevation;
         }

--- a/Assets/Scripts/Terrain/NoiseTerrainSampler.cs
+++ b/Assets/Scripts/Terrain/NoiseTerrainSampler.cs
@@ -35,6 +35,7 @@ namespace DaggerfallWorkshop
         {
             HeightmapDimension = defaultHeightmapDimension;
             MaxTerrainHeight = 200;
+            MeanTerrainHeightScale = Scale;
             OceanElevation = -1;
             BeachElevation = -1;
         }

--- a/Assets/Scripts/Terrain/SimpleTerrainSampler.cs
+++ b/Assets/Scripts/Terrain/SimpleTerrainSampler.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop
         {
             HeightmapDimension = defaultHeightmapDimension;
             MaxTerrainHeight = 1;
+            MeanTerrainHeightScale = 1;
             OceanElevation = -1;
             BeachElevation = -1;
         }

--- a/Assets/Scripts/Terrain/TerrainSampler.cs
+++ b/Assets/Scripts/Terrain/TerrainSampler.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Michael Rauter (Nystul)
 // 
 // Notes:
 //
@@ -43,6 +43,13 @@ namespace DaggerfallWorkshop
         float MaxTerrainHeight { get; set; }
 
         /// <summary>
+        /// Mean scale factor of terrain height. This should return the mean value of the scale factor for terrain heights
+        /// (e.g. multiplication factor of low resolution height map values + multiplication factor of detailed height map values).
+        /// This value can/will be used by terrain-related mods.
+        /// </summary>
+        float MeanTerrainHeightScale { get; set; }        
+
+        /// <summary>
         /// Sea level. Use for clamping min height and texturing with ocean.
         /// </summary>
         float OceanElevation { get; set; }
@@ -51,6 +58,14 @@ namespace DaggerfallWorkshop
         /// Beach line elevation. How far above sea level the beach line extends.
         /// </summary>
         float BeachElevation { get; set; }
+
+        /// <summary>
+        /// get terrain height scale for given x and y position on the world map
+        /// </summary>
+        /// <param name="x">world map x position</param>
+        /// <param name="y">world map y position</param>
+        /// <returns></returns>
+        float TerrainHeightScale(int x, int y);
 
         /// <summary>
         /// Populates a MapPixelData struct using custom height sample generator.
@@ -68,10 +83,14 @@ namespace DaggerfallWorkshop
         protected int defaultHeightmapDimension = 129;
 
         public abstract int Version { get; }
-        public virtual int HeightmapDimension { get; set; }
+        public virtual int HeightmapDimension { get; set; }        
         public virtual float MaxTerrainHeight { get; set; }
+        public virtual float MeanTerrainHeightScale { get; set; }
         public virtual float OceanElevation { get; set; }
         public virtual float BeachElevation { get; set; }
+        
+        //this function may be overriden if terrain sampler implementation creates different height scales for different map pixels
+        public virtual float TerrainHeightScale(int x, int y) { return MeanTerrainHeightScale; } // default implementation returns MeanTerrainHeightScale for every world map position
 
         public abstract void GenerateSamples(ref MapPixelData mapPixel);
     }


### PR DESCRIPTION
TerrainSampler implementation extended - reason: mods may need terran height scale (e.g. Distant Terrain mod)

new property MeanTerrainHeightScale and new method TerrainHeightScale added

default use is fixed terrain height scale factor - set MeanTerrainHeightScale in constructor (SimpleTerrainSampler, NoiseTerrainSampler, DefaultTerrainSampler)

more sophisticated use: terrain height scale factor depends on map pixel position - override for method TerrainHeightScale(x,y) happens in this case (used by Distant Terrain Mod's Improved Terrain Sampler)