### PR TITLE
Implement classic reputation propagation

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1693,7 +1693,7 @@ namespace DaggerfallWorkshop.Game.Entity
             FactionFile.FactionData peopleFaction;
             FactionData.FindFactionByTypeAndRegion(15, regionIndex + 1, out peopleFaction);
 
-            FactionData.ChangeReputation(peopleFaction.id, -(reputationLossPerCrime[(int)crimeCommitted] / 2));
+            FactionData.ChangeReputation(peopleFaction.id, -(reputationLossPerCrime[(int)crimeCommitted] / 2), true);
         }
 
         public void RaiseReputationForDoingSentence()
@@ -1705,7 +1705,7 @@ namespace DaggerfallWorkshop.Game.Entity
             FactionData.FindFactionByTypeAndRegion(15, regionIndex + 1, out peopleFaction);
 
             // Classic changes reputation here by (1 - halfOfLegalRepPlayerLostFromCrime) / 2). Probably a bug.
-            FactionData.ChangeReputation(peopleFaction.id, (halfOfLegalRepPlayerLostFromCrime - 1) / 2);
+            FactionData.ChangeReputation(peopleFaction.id, (halfOfLegalRepPlayerLostFromCrime - 1) / 2, true);
         }
 
         public bool SurrenderToCityGuards(bool voluntarySurrender)

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -120,6 +120,14 @@ namespace DaggerfallWorkshop.Game.Guilds
             return memberships.ContainsKey(guildGroup);
         }
 
+        public bool GetJoinedGuildOfGuildGroup(FactionFile.GuildGroups guildGroup, out Guild value)
+        {
+            if (memberships.TryGetValue(guildGroup, out value))
+                return true;
+
+            return false;
+        }
+
         public Guild JoinGuild(FactionFile.GuildGroups guildGroup, int buildingFactionId = 0)
         {
             if (memberships.ContainsKey(guildGroup))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -553,7 +553,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     // Change reputation
                     int rep = Math.Abs(playerEntity.FactionData.GetReputation(factionId));
                     if (UnityEngine.Random.Range(1, 101) <= (2 * amount / rep + 1))
-                        playerEntity.FactionData.ChangeReputation(factionId, 1, true);
+                        playerEntity.FactionData.ChangeReputation(factionId, 1, true); // Does not propagate in classic
 
                     // Show thanks message
                     DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, uiManager.TopWindow);


### PR DESCRIPTION
Implements reputation propagation based on reversing classic code. This is a response to http://forums.dfworkshop.net/viewtopic.php?f=19&t=910 but.

This does not yet 100% replicate classic behavior for quest rewards, just the propagation part. I used http://en.uesp.net/wiki/Daggerfall:The_Infested_House as a test case. In classic the quest reputation reward seems to be given based on the faction ID of the NPC quester, in this case faction 846 ("Questers"), the ID for the NPC in a knightly order who gives quests. DF Unity appears to instead be using the faction ID of the knightly order. This causes a different propagation and different results.

Would it be an easy fix to assign the faction ID of the NPC clicked on rather than of the faction itself? I don't know if that is how it works for all quests in classic but I would assume so for now unless there is evidence otherwise. If that change is made I think we will have behavior equivalent to classic.

@ajrb Regarding the thread discussion above.
I think the difference on UESP might be because in one case whoever wrote it accidentally compared the before + after results after doing 2 quests or something. At any rate, the reputation reward will vary depending on the faction relationships with the region and knightly order (as well as any allies or enemies they may have randomly added for that game).


