### PR TITLE
Near death experience simplified

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -78,3 +78,4 @@ LypyL_GameConsole=True
 LypyL_ModSystem=True
 MeshAndTextureReplacement=False
 CompressModdedTextures=True
+NearDeathWarning=True

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -44,6 +44,7 @@ namespace DaggerfallWorkshop.Game
         Camera mainCamera = null;
         PlayerMouseLook playerMouseLook = null;
         PlayerHealth playerHealth = null;
+        HealthChangeDetector healthChangeDetector = null;
         StartGameBehaviour startGameBehaviour = null;
         PlayerEntity playerEntity = null;
         DaggerfallEntityBehaviour playerEntityBehaviour = null;
@@ -122,6 +123,12 @@ namespace DaggerfallWorkshop.Game
         {
             get { return (playerHealth) ? playerHealth : playerHealth = GetComponentFromObject<PlayerHealth>(PlayerObject, "Player"); }
             set { playerHealth = value; }
+        }
+
+        public HealthChangeDetector HealthChangeDetector
+        {
+            get { return (healthChangeDetector) ? healthChangeDetector : healthChangeDetector = GetComponentFromObject<HealthChangeDetector>(PlayerObject, "Player"); }
+            set { healthChangeDetector = value; }
         }
 
         public StartGameBehaviour StartGameBehaviour

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
@@ -51,6 +51,35 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 BurnOut();
             }
         }
+        protected void RandomlyReverseAlphaDirection()
+        {
+            const float minChance = -0.01f; // negative so it takes a little while before it can reverse at least.
+            const float chanceStep = 0.008f;
+
+            if (alphaDirection == AlphaDirection.None)
+                return;
+
+            // chance of reversal grows over time.
+            chanceReverseState += chanceStep * Time.deltaTime;
+
+            // randomly reverse alpha
+            if (Random.Range(0f, 1f) < chanceReverseState)
+            {
+                // chance gets reset each time it's randomly reversed.
+                chanceReverseState = minChance;
+                ReverseAlphaDirection();
+            }
+        }
+        private void ReverseAlphaDirection()
+        {
+            if (alphaDirection == AlphaDirection.Increasing)
+                alphaDirection = AlphaDirection.Decreasing;
+            else if (alphaDirection == AlphaDirection.Decreasing)
+                alphaDirection = AlphaDirection.Increasing;
+
+            if (reversalCount != -1)
+                reversalCount++;
+        }
         protected void SetAlphaValue()
         {
             // increment alpha depending on State
@@ -89,36 +118,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             AlphaValue = 0;
             IsBurnedOut = true;
-        }
-
-        protected void RandomlyReverseAlphaDirection()
-        {
-            const float minChance = -0.01f; // negative so it takes a little while before it can reverse at least.
-            const float chanceStep = 0.008f;
-
-            if (alphaDirection == AlphaDirection.None)
-                return;
-
-            // chance of reversal grows over time.
-            chanceReverseState += chanceStep * Time.deltaTime;
-
-            // randomly reverse alpha
-            if (Random.Range(0f, 1f) < chanceReverseState)
-            {
-                // chance gets reset each time it's randomly reversed.
-                chanceReverseState = minChance;
-                ReverseAlphaDirection();
-            }
-        }
-        private void ReverseAlphaDirection()
-        {
-            if (alphaDirection == AlphaDirection.Increasing)
-                alphaDirection = AlphaDirection.Decreasing;
-            else if (alphaDirection == AlphaDirection.Decreasing)
-                alphaDirection = AlphaDirection.Increasing;
-
-            if (reversalCount != -1)
-                reversalCount++;
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
@@ -48,7 +48,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             if (reversalCount >= reversalCountThreshold && reversalCountThreshold != -1)
             {
-                BurnOut();
+                IsBurnedOut = true;
             }
         }
         protected void RandomlyReverseAlphaDirection()
@@ -99,6 +99,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 CheckReverseAlphaDirection();
                 SetAlphaValue();
             }
+            else
+                AlphaValue = 0;
         }
 
         public virtual void Reset()
@@ -112,12 +114,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             if (IsBurnedOut)
                 Reset();
-        }
-
-        public virtual void BurnOut()
-        {
-            AlphaValue = 0;
-            IsBurnedOut = true;
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
@@ -1,0 +1,124 @@
+﻿using UnityEngine;
+using System.Collections;
+using DaggerfallWorkshop.Game;
+
+namespace DaggerfallWorkshop.Game.UserInterface
+{
+    public abstract class HUDFlickerBase
+    {
+        public enum AlphaDirection
+        {
+            None,
+            Decreasing,
+            Increasing
+        }
+        protected AlphaDirection alphaDirection;
+        protected float chanceReverseState = 0;
+        protected float alphaSpeed;
+        protected float alphaUpper;
+        protected float alphaLower;
+        public float RedValue { get; protected set; }
+        public float AlphaValue { get; protected set; }
+        protected int reversalCount = 0;
+        protected int reversalCountThreshold;
+        public bool IsBurnedOut { get; set; }
+
+        public HUDFlickerBase()
+        {
+            Init();
+        }
+        public abstract void Init();
+        public virtual void InitAlphaDirection(AlphaDirection direct)
+        {
+            if (direct == AlphaDirection.Decreasing)
+                AlphaValue = alphaUpper;
+            else if (direct == AlphaDirection.Increasing)
+                AlphaValue = alphaLower;
+
+            alphaDirection = direct;
+        }
+        public virtual void CheckReverseAlphaDirection()
+        {
+            // Alpha Direction Reversal Check
+            if ((alphaDirection == AlphaDirection.Increasing && AlphaValue >= alphaUpper) ||
+                (alphaDirection == AlphaDirection.Decreasing && AlphaValue <= alphaLower))
+                ReverseAlphaDirection();
+            else if (AlphaValue >= alphaLower && AlphaValue <= alphaUpper)
+                RandomlyReverseAlphaDirection();
+
+            if (reversalCount >= reversalCountThreshold && reversalCountThreshold != -1)
+            {
+                BurnOut();
+            }
+        }
+        protected void SetAlphaValue()
+        {
+            // increment alpha depending on State
+            if (alphaDirection == AlphaDirection.Decreasing)
+                AlphaValue -= alphaSpeed * Time.deltaTime;
+            else if (alphaDirection == AlphaDirection.Increasing)
+                AlphaValue += alphaSpeed * Time.deltaTime;
+            else if (alphaDirection == AlphaDirection.None)
+                AlphaValue = 0;
+
+            AlphaValue = Mathf.Clamp(AlphaValue, 0, 1);
+        }
+        public virtual void Cycle()
+        {
+            if (!IsBurnedOut)
+            {
+                CheckReverseAlphaDirection();
+                SetAlphaValue();
+            }
+        }
+
+        public virtual void Reset()
+        {
+            IsBurnedOut = false;
+            reversalCount = 0;
+            AlphaValue = alphaLower;
+        }
+
+        public virtual void ResetIfBurnedOut()
+        {
+            if (IsBurnedOut)
+                Reset();
+        }
+
+        public virtual void BurnOut()
+        {
+            AlphaValue = 0;
+            IsBurnedOut = true;
+        }
+
+        protected void RandomlyReverseAlphaDirection()
+        {
+            const float minChance = -0.01f; // negative so it takes a little while before it can reverse at least.
+            const float chanceStep = 0.008f;
+
+            if (alphaDirection == AlphaDirection.None)
+                return;
+
+            // chance of reversal grows over time.
+            chanceReverseState += chanceStep * Time.deltaTime;
+
+            // randomly reverse alpha
+            if (Random.Range(0f, 1f) < chanceReverseState)
+            {
+                // chance gets reset each time it's randomly reversed.
+                chanceReverseState = minChance;
+                ReverseAlphaDirection();
+            }
+        }
+        private void ReverseAlphaDirection()
+        {
+            if (alphaDirection == AlphaDirection.Increasing)
+                alphaDirection = AlphaDirection.Decreasing;
+            else if (alphaDirection == AlphaDirection.Decreasing)
+                alphaDirection = AlphaDirection.Increasing;
+
+            if (reversalCount != -1)
+                reversalCount++;
+        }
+    }
+}

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs.meta
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a71d6741e6ecfdc49a17ade06cb20ad4
+timeCreated: 1529111766
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
@@ -1,0 +1,88 @@
+﻿using UnityEngine;
+using System.Collections;
+using DaggerfallWorkshop.Game;
+
+namespace DaggerfallWorkshop.Game.UserInterface
+{
+    public class HUDFlickerController : BaseScreenComponent
+    {
+        private enum PlayerCondition
+        {
+            Normal,
+            Injured,
+            Wounded,
+            Dead
+        }
+        private PlayerCondition condition;
+        private HealthChangeDetector healthDetector;
+        private HUDFlickerFast flickerFast;
+        private HUDFlickerSlow flickerSlow;
+
+        private const float injuredThreshold = 0.4f; // Health percentage that flicker is triggered at.
+        private const float woundedThreshold = 0.2f; // Health percentage that throb will continue at.
+        public HUDFlickerController()
+        {
+            healthDetector = GameManager.Instance.HealthChangeDetector;
+            flickerFast = new HUDFlickerFast();
+            flickerSlow = new HUDFlickerSlow();
+        }
+        private PlayerCondition GetPlayerCondition()
+        {
+            if (GameManager.Instance.PlayerEntity.CurrentHealth <= 0)
+                return PlayerCondition.Dead;
+            else if (IsBelowThreshold(woundedThreshold))
+                return PlayerCondition.Wounded;
+            else if (IsBelowThreshold(injuredThreshold))
+                return PlayerCondition.Injured;
+            else
+                return PlayerCondition.Normal;
+        }
+        private bool IsBelowThreshold(float threshold)
+        {
+            return ((GameManager.Instance.PlayerEntity.CurrentHealthPercent) < threshold);
+        }
+        public void NextCycle()
+        {
+            condition = GetPlayerCondition();
+
+            CheckResetFlickers();
+            CalculateBackgroundColor();
+        }
+        private void CheckResetFlickers()
+        {
+            if (healthDetector.HealthLost > 0)
+                flickerFast.ResetIfBurnedOut();
+
+            if (healthDetector.HealthGain > 0)
+                flickerSlow.BurnOut();
+        }
+        private void CalculateBackgroundColor()
+        {
+            Color backColor;
+            // Decide what alpha and red to use in background color
+            switch (condition)
+            {
+                case PlayerCondition.Injured:
+                    flickerFast.Cycle();
+                    backColor = new Color(flickerFast.RedValue, 0, 0, flickerFast.AlphaValue);
+                    break;
+                case PlayerCondition.Wounded:
+                    flickerFast.Cycle();
+                    // Flicker slow runs if flickerFast is burned out, and cannot if it isn't burned out
+                    flickerSlow.IsBurnedOut = !flickerFast.IsBurnedOut;
+                    flickerSlow.Cycle();
+                    if (flickerFast.IsBurnedOut)
+                        backColor = new Color(flickerSlow.RedValue, 0, 0, flickerSlow.AlphaValue);
+                    else
+                        backColor = new Color(flickerFast.RedValue, 0, 0, flickerFast.AlphaValue);
+                    break;
+                default:
+                    backColor = new Color();
+                    break;
+            }
+
+            if (condition != PlayerCondition.Dead && backColor != Parent.BackgroundColor)
+                Parent.BackgroundColor = backColor;
+        }
+    }
+}

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
@@ -13,7 +13,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Wounded,
             Dead
         }
-        private PlayerCondition condition;
         private HealthChangeDetector healthDetector;
         private HUDFlickerFast flickerFast;
         private HUDFlickerSlow flickerSlow;
@@ -43,23 +42,16 @@ namespace DaggerfallWorkshop.Game.UserInterface
         }
         public void NextCycle()
         {
-            condition = GetPlayerCondition();
-
-            CheckResetFlickers();
-            CalculateBackgroundColor();
-        }
-        private void CheckResetFlickers()
-        {
             if (healthDetector.HealthLost > 0)
                 flickerFast.ResetIfBurnedOut();
 
             if (healthDetector.HealthGain > 0)
                 flickerSlow.BurnOut();
-        }
-        private void CalculateBackgroundColor()
-        {
+
             Color backColor;
-            // Decide what alpha and red to use in background color
+
+            PlayerCondition condition = GetPlayerCondition();
+
             switch (condition)
             {
                 case PlayerCondition.Injured:

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
@@ -42,6 +42,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         }
         public void NextCycle()
         {
+            if (!DaggerfallUnity.Settings.NearDeathWarning)
+                return;
+
             PlayerCondition condition = GetPlayerCondition();
 
             if (healthDetector.HealthLost > 0)

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
@@ -42,7 +42,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         }
         public void NextCycle()
         {
-            if (!DaggerfallUnity.Settings.NearDeathWarning)
+            if (  !DaggerfallUnity.Settings.NearDeathWarning 
+                || DaggerfallUI.Instance.FadeBehaviour.FadeInProgress
+                || Parent.BackgroundColor.a > 0.9f) // prevents conflict with fade in from black
                 return;
 
             PlayerCondition condition = GetPlayerCondition();

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
@@ -42,15 +42,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
         }
         public void NextCycle()
         {
+            PlayerCondition condition = GetPlayerCondition();
+
             if (healthDetector.HealthLost > 0)
                 flickerFast.ResetIfBurnedOut();
 
-            if (healthDetector.HealthGain > 0)
-                flickerSlow.BurnOut();
+            if (healthDetector.HealthGain > 0 && condition != PlayerCondition.Wounded)
+                flickerSlow.IsBurnedOut = true;
 
             Color backColor;
-
-            PlayerCondition condition = GetPlayerCondition();
 
             switch (condition)
             {

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs.meta
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f0f4049b5f1b7cd4ab99aa2df7adca18
+timeCreated: 1529111766
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerFast.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerFast.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+using System.Collections;
+using DaggerfallWorkshop.Game;
+
+namespace DaggerfallWorkshop.Game.UserInterface
+{
+
+    public class HUDFlickerFast : HUDFlickerBase
+    {
+        public override void Init()
+        {
+            Reset();
+            alphaSpeed = 7.0f;
+            alphaLower = 0.0f;
+            alphaUpper = 0.4f;
+            RedValue = 0.3984f;
+            reversalCountThreshold = 7;
+            InitAlphaDirection(AlphaDirection.Increasing);
+        }
+    }
+}

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerFast.cs.meta
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerFast.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6feae3ba405e94b4c8d4ecd1df04422a
+timeCreated: 1529111766
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerSlow.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerSlow.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+using System.Collections;
+using DaggerfallWorkshop.Game;
+
+namespace DaggerfallWorkshop.Game.UserInterface
+{
+
+    public class HUDFlickerSlow : HUDFlickerBase
+    {
+        public override void Init()
+        {
+            Reset();
+            alphaSpeed = 0.2f;
+            alphaLower = 0.1f;
+            alphaUpper = 0.4f;
+            RedValue = 0.0f;
+            reversalCountThreshold = -1;
+            InitAlphaDirection(AlphaDirection.Increasing);
+        }
+    }
+}

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerSlow.cs.meta
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerSlow.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 58c954e6bc5aa984cadb8d1fbc8c68ac
+timeCreated: 1529111766
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -94,6 +94,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox modSystem;
         Checkbox assetImport;
         Checkbox compressModdedTextures;
+        Checkbox nearDeathWarning;
         HorizontalSlider cameraRecoilStrength;
 
         // Video
@@ -206,6 +207,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             modSystem = AddCheckbox(rightPanel, "modSystem", DaggerfallUnity.Settings.LypyL_ModSystem);
             assetImport = AddCheckbox(rightPanel, "assetImport", DaggerfallUnity.Settings.MeshAndTextureReplacement);
             compressModdedTextures = AddCheckbox(rightPanel, "compressModdedTextures", DaggerfallUnity.Settings.CompressModdedTextures);
+            nearDeathWarning = AddCheckbox(rightPanel, "nearDeathWarning", DaggerfallUnity.Settings.NearDeathWarning);
         }
 
         private void Video(Panel leftPanel, Panel rightPanel)
@@ -285,6 +287,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.LypyL_ModSystem = modSystem.IsChecked;
             DaggerfallUnity.Settings.MeshAndTextureReplacement = assetImport.IsChecked;
             DaggerfallUnity.Settings.CompressModdedTextures = compressModdedTextures.IsChecked;
+            DaggerfallUnity.Settings.NearDeathWarning = nearDeathWarning.IsChecked;
             DaggerfallUnity.Settings.CameraRecoilStrength = cameraRecoilStrength.ScrollIndex;
 
             /* Video */

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         HUDCrosshair crosshair = new HUDCrosshair();
         HUDVitals vitals = new HUDVitals();
         HUDCompass compass = new HUDCompass();
+        HUDFlickerController flickerController = new HUDFlickerController();
         HUDInteractionModeIcon interactionModeIcon = new HUDInteractionModeIcon();
         HUDPlaceMarker placeMarker = new HUDPlaceMarker();
         EscortingNPCFacePanel escortingFaces = new EscortingNPCFacePanel();
@@ -112,6 +113,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             ParentPanel.Components.Add(vitals);
             ParentPanel.Components.Add(compass);
             ParentPanel.Components.Add(interactionModeIcon);
+            ParentPanel.Components.Add(flickerController);
         }
 
         protected override void Setup()
@@ -192,6 +194,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 questDebugger.NextState();
             }
+
+            flickerController.NextCycle();
 
             base.Update();
         }

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -139,6 +139,7 @@ namespace DaggerfallWorkshop
         public bool LypyL_ModSystem { get; set; }
         public bool MeshAndTextureReplacement { get; set; }
         public bool CompressModdedTextures { get; set; }
+        public bool NearDeathWarning { get; set; }
 
         #endregion
 
@@ -223,6 +224,7 @@ namespace DaggerfallWorkshop
             LypyL_ModSystem = GetBool(sectionEnhancements, "LypyL_ModSystem");
             MeshAndTextureReplacement = GetBool(sectionEnhancements, "MeshAndTextureReplacement");
             CompressModdedTextures = GetBool(sectionEnhancements, "CompressModdedTextures");
+            NearDeathWarning = GetBool(sectionEnhancements, "NearDeathWarning");
         }
 
         /// <summary>
@@ -300,6 +302,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionEnhancements, "LypyL_ModSystem", LypyL_ModSystem);
             SetBool(sectionEnhancements, "MeshAndTextureReplacement", MeshAndTextureReplacement);
             SetBool(sectionEnhancements, "CompressModdedTextures", CompressModdedTextures);
+            SetBool(sectionEnhancements, "NearDeathWarning", NearDeathWarning);
 
             // Write settings to persistent file
             WriteSettingsFile();

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -51,6 +51,8 @@ assetImport,                                        Allow Custom Assets
 assetImportInfo,                                    Import assets from enabled mods and loose files.
 compressModdedTextures,                             Compress Modded Textures
 compressModdedTexturesInfo,                         Import textures with a compressed format which uses less graphics memory.
+nearDeathWarning,									Near Death Warning
+nearDeathWarningInfo,								Show blinking/pulsating screen effects to warn when near death.
 
 resolution,                                         Resolution
 resolutionInfo,                                     Screen resolution


### PR DESCRIPTION
This version is greatly simplified and cleaner.  Also includes a setting in Advanced Settings window to toggle the effects off.

When the player is reduced to < 40% health.  they will experience a flashing red flicker effect.  If < 20% health, the player fades in and out of darkness until their health is raised above 20% threshold.