### PR TITLE
NPCs don't stop if weapon drawn

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -153,6 +153,8 @@ namespace DaggerfallWorkshop.Game.Entity
         public Crimes CrimeCommitted { get { return crimeCommitted; } set { crimeCommitted = value; } }
         public bool HaveShownSurrenderToGuardsDialogue { get { return haveShownSurrenderToGuardsDialogue; } set { haveShownSurrenderToGuardsDialogue = value; } }
         public bool Arrested { get { return arrested; } set { arrested = value; } }
+        public bool IsInBeastForm { get; set; }
+        public bool IsInvisible { get; set; }
 
         #endregion
 

--- a/Assets/Scripts/Game/MobilePersonMotor.cs
+++ b/Assets/Scripts/Game/MobilePersonMotor.cs
@@ -212,13 +212,19 @@ namespace DaggerfallWorkshop.Game
             bool withinIdleDistance = (distanceToPlayer < idleDistance);
             bool playerStandingStill = GameManager.Instance.PlayerMotor.IsStandingStill;
             bool sheathed = GameManager.Instance.WeaponManager.Sheathed;
+            //bool enemiesNearby = GameManager.Instance.AreEnemiesNearby();
             // NPC shouldn't stop to talk if any of these conditions are true:
             // TODO: Add these conditions to wantsToStop:
             // player in beast form
-            // player just got caught in crime
             // player is invisible
 
-            bool wantsToStop = playerStandingStill && withinIdleDistance && sheathed; 
+            bool wantsToStop = playerStandingStill && withinIdleDistance && sheathed;
+
+            // greatly reduce # of calls to AreEnemiesNearby() by short-circuit evaluation
+            if (wantsToStop && !GameManager.Instance.AreEnemiesNearby())
+                wantsToStop = true;
+            else
+                wantsToStop = false;
 
             if (!wantsToStop && mobileBillboard.IsIdle)
             {

--- a/Assets/Scripts/Game/MobilePersonMotor.cs
+++ b/Assets/Scripts/Game/MobilePersonMotor.cs
@@ -209,14 +209,24 @@ namespace DaggerfallWorkshop.Game
 
             // Go idle if near player
             distanceToPlayer = GameManager.Instance.PlayerMotor.DistanceToPlayer(transform.position);
+            bool withinIdleDistance = (distanceToPlayer < idleDistance);
             bool playerStandingStill = GameManager.Instance.PlayerMotor.IsStandingStill;
-            if (!playerStandingStill && mobileBillboard.IsIdle)
+            bool sheathed = GameManager.Instance.WeaponManager.Sheathed;
+            // NPC shouldn't stop to talk if any of these conditions are true:
+            // TODO: Add these conditions to wantsToStop:
+            // player in beast form
+            // player just got caught in crime
+            // player is invisible
+
+            bool wantsToStop = playerStandingStill && withinIdleDistance && sheathed; 
+
+            if (!wantsToStop && mobileBillboard.IsIdle)
             {
                 // Switch animation state back to moving
                 mobileBillboard.IsIdle = false;
                 currentMobileState = MobileStates.MovingForward;
             }
-            else if (playerStandingStill && !mobileBillboard.IsIdle && distanceToPlayer < idleDistance)
+            else if (wantsToStop && !mobileBillboard.IsIdle)
             {
                 // Switch animation state to idle
                 mobileBillboard.IsIdle = true;

--- a/Assets/Scripts/Game/MobilePersonMotor.cs
+++ b/Assets/Scripts/Game/MobilePersonMotor.cs
@@ -212,13 +212,10 @@ namespace DaggerfallWorkshop.Game
             bool withinIdleDistance = (distanceToPlayer < idleDistance);
             bool playerStandingStill = GameManager.Instance.PlayerMotor.IsStandingStill;
             bool sheathed = GameManager.Instance.WeaponManager.Sheathed;
-            //bool enemiesNearby = GameManager.Instance.AreEnemiesNearby();
-            // NPC shouldn't stop to talk if any of these conditions are true:
-            // TODO: Add these conditions to wantsToStop:
-            // player in beast form
-            // player is invisible
+            bool invisible = GameManager.Instance.PlayerEntity.IsInvisible;
+            bool inBeastForm = GameManager.Instance.PlayerEntity.IsInBeastForm;
 
-            bool wantsToStop = playerStandingStill && withinIdleDistance && sheathed;
+            bool wantsToStop = playerStandingStill && withinIdleDistance && sheathed && !invisible && !inBeastForm;
 
             // greatly reduce # of calls to AreEnemiesNearby() by short-circuit evaluation
             if (wantsToStop && !GameManager.Instance.AreEnemiesNearby())


### PR DESCRIPTION
Mobile Town NPCs now won't stop if your weapon is drawn.  

Also makes TODO note for other NPC stop conditions:

**Conditions to do in future:**
Player is in beast form.
Player just got caught committing a crime
Player is invisible.