### PR TITLE
Potion maker & Item enchanter basic implementation

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -98,6 +98,7 @@ namespace DaggerfallWorkshop.Game
         DaggerfallQuestJournalWindow dfQuestJournalWindow;
         DaggerfallSpellBookWindow dfSpellBookWindow;
         DaggerfallSpellMakerWindow dfSpellMakerWindow;
+        DaggerfallItemMakerWindow dfItemMakerWindow;
         DaggerfallPotionMakerWindow dfPotionMakerWindow;
         DaggerfallCourtWindow dfCourtWindow;
 
@@ -228,6 +229,11 @@ namespace DaggerfallWorkshop.Game
             get { return dfSpellMakerWindow; }
         }
 
+        public DaggerfallItemMakerWindow DfItemMakerWindow
+        {
+            get { return dfItemMakerWindow; }
+        }
+
         public DaggerfallPotionMakerWindow DfPotionMakerWindow
         {
             get { return dfPotionMakerWindow; }
@@ -280,6 +286,7 @@ namespace DaggerfallWorkshop.Game
             dfTalkWindow = new DaggerfallTalkWindow(uiManager);
             dfSpellBookWindow = new DaggerfallSpellBookWindow(uiManager);
             dfSpellMakerWindow = new DaggerfallSpellMakerWindow(uiManager);
+            dfItemMakerWindow = new DaggerfallItemMakerWindow(uiManager);
             dfPotionMakerWindow = new DaggerfallPotionMakerWindow(uiManager);
             dfCourtWindow = new DaggerfallCourtWindow(uiManager);
             dfExteriorAutomapWindow = new DaggerfallExteriorAutomapWindow(uiManager);

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -98,6 +98,7 @@ namespace DaggerfallWorkshop.Game
         DaggerfallQuestJournalWindow dfQuestJournalWindow;
         DaggerfallSpellBookWindow dfSpellBookWindow;
         DaggerfallSpellMakerWindow dfSpellMakerWindow;
+        DaggerfallPotionMakerWindow dfPotionMakerWindow;
         DaggerfallCourtWindow dfCourtWindow;
 
         DaggerfallFontPlus fontPetrock32;
@@ -227,6 +228,11 @@ namespace DaggerfallWorkshop.Game
             get { return dfSpellMakerWindow; }
         }
 
+        public DaggerfallPotionMakerWindow DfPotionMakerWindow
+        {
+            get { return dfPotionMakerWindow; }
+        }
+
         public string FontsFolder
         {
             get { return Path.Combine(Application.streamingAssetsPath, fontsFolderName); }
@@ -274,6 +280,7 @@ namespace DaggerfallWorkshop.Game
             dfTalkWindow = new DaggerfallTalkWindow(uiManager);
             dfSpellBookWindow = new DaggerfallSpellBookWindow(uiManager);
             dfSpellMakerWindow = new DaggerfallSpellMakerWindow(uiManager);
+            dfPotionMakerWindow = new DaggerfallPotionMakerWindow(uiManager);
             dfCourtWindow = new DaggerfallCourtWindow(uiManager);
             dfExteriorAutomapWindow = new DaggerfallExteriorAutomapWindow(uiManager);
 

--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -97,7 +97,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         int listDisplayTotal;       // Total number of items displayed in scrolling areas
         int itemButtonMargin = 2;   // Margin of item buttons
         float textScale = 1f;       // Scale of text on item buttons
-        TextLabel miscLabelTemplate;// Template for misc text labels
 
         float foregroundAnimationDelay = 0.2f;    
         float backgroundAnimationDelay = 0.2f;
@@ -200,7 +199,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 textScale = 0.75f;
             }
             listDisplayTotal = listDisplayUnits * listWidth;
-            miscLabelTemplate = new TextLabel()
+            TextLabel miscLabelTemplate = new TextLabel()
             {
                 Position = Vector2.zero,
                 HorizontalAlignment = HorizontalAlignment.Left,
@@ -211,7 +210,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             LoadTextures(enhanced);
             SetupScrollBar();
             SetupScrollButtons();
-            SetupItemsList(enhanced);
+            SetupItemsList(enhanced, miscLabelTemplate);
         }
 
         /// <summary>
@@ -239,12 +238,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
             itemButtonMargin = itemMarginSize;
             this.textScale = textScale;
             this.toolTip = toolTip;
-            this.miscLabelTemplate = miscLabelTemplate;
 
             LoadTextures(false);
             SetupScrollBar();
             SetupScrollButtons();
-            SetupItemsList(false);
+            SetupItemsList(false, miscLabelTemplate);
         }
 
         public void ResetScroll()
@@ -291,7 +289,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             itemListDownButton.OnMouseClick += ItemsDownButton_OnMouseClick;
         }
 
-        void SetupItemsList(bool enhanced)
+        void SetupItemsList(bool enhanced, TextLabel miscLabelTemplate)
         {
             // List panel for scrolling behaviour
             Panel itemsListPanel = DaggerfallUI.AddPanel(itemListPanelRect, this);

--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -213,10 +213,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// <param name="itemListRect">Item list coordinate rect, excluding scrollbar.</param>
         /// <param name="itemsRects">Individual items display coordinate rects. (1 per width*height)</param>
         /// <param name="miscLabelPos">Misc label relative position. (Vector2.zero for default)</param>
+        /// <param name="toolTip">Tool tip class to use if items should display tooltips.</param>
         /// <param name="itemMarginSize">Individual item display margin size.</param>
         /// <param name="textScale">Text scale factor.</param>
-        /// <param name="toolTip">Tool tip class to use if items should display tooltips.</param>
-        public ItemListScroller(int listRows, int listCols, Rect itemListRect, Rect[] itemsRects, Vector2 miscLabelPos, int itemMarginSize = 1, float textScale = 1f, ToolTip toolTip = null)
+        public ItemListScroller(int listRows, int listCols, Rect itemListRect, Rect[] itemsRects, Vector2 miscLabelPos, ToolTip toolTip = null, int itemMarginSize = 1, float textScale = 1f)
             : base()
         {
             listDisplayTotal = listRows * listCols;
@@ -252,7 +252,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             itemListScrollBar = new VerticalScrollBar
             {
                 Position = new Vector2(1, 18),
-                Size = new Vector2(6, 117),
+                Size = new Vector2(6, itemListPanelRect.height - 35),
                 DisplayUnits = listDisplayUnits
             };
             Components.Add(itemListScrollBar);
@@ -273,7 +273,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             itemListDownButton = new Button
             {
-                Position = new Vector2(0, 136),
+                Position = new Vector2(0, itemListPanelRect.height - 16),
                 Size = new Vector2(9, 16),
                 BackgroundTexture = redDownArrow
             };

--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -18,16 +18,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
     /// </summary>
     public class ItemListScroller : Panel
     {
-        #region UI Rects, Controls, Textures for normal 4 item mode
+        #region UI Rects, Controls, Textures
 
         Rect itemListPanelRect = new Rect(9, 0, 50, 152);
-        Rect[] itemButtonRects4 = new Rect[]
-        {
-            new Rect(0, 0, 50, 38),
-            new Rect(0, 38, 50, 38),
-            new Rect(0, 76, 50, 38),
-            new Rect(0, 114, 50, 38)
-        };
+        Rect[] itemButtonRects = itemButtonRects4;
         Rect upArrowRect = new Rect(0, 0, 9, 16);
         Rect downArrowRect = new Rect(0, 136, 9, 16);
         DFSize arrowsFullSize = new DFSize(9, 152);
@@ -49,9 +43,21 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #endregion
 
+        #region UI Rects for normal 4 item mode
+
+        static Rect[] itemButtonRects4 = new Rect[]
+        {
+            new Rect(0, 0, 50, 38),
+            new Rect(0, 38, 50, 38),
+            new Rect(0, 76, 50, 38),
+            new Rect(0, 114, 50, 38)
+        };
+
+        #endregion
+
         #region UI Rects, Textures for enhanced 16 item mode
 
-        Rect[] itemButtonRects16 = new Rect[]
+        static Rect[] itemButtonRects16 = new Rect[]
         {
             new Rect(0, 0, 25, 19),     new Rect(25, 0, 25, 19),
             new Rect(0, 19, 25, 19),    new Rect(25, 19, 25, 19),
@@ -62,7 +68,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             new Rect(0, 114, 25, 19),   new Rect(25, 114, 25, 19),
             new Rect(0, 133, 25, 19),   new Rect(25, 133, 25, 19)
         };
-        Rect[] itemCutoutRects16 = new Rect[]
+        static Rect[] itemCutoutRects16 = new Rect[]
         {
             new Rect(23, 72, 23, 22),   new Rect(23, 10, 23, 22),
             new Rect(0, 41, 23, 22),    new Rect(23, 41, 23, 22),
@@ -178,6 +184,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 // Configure enhanced mode to display 16 items
                 listDisplayUnits = 16;
+                itemButtonRects = itemButtonRects16;
                 itemButtonMarginSize = 1;
                 textScale = 0.75f;
                 scrollNum = 2;
@@ -245,7 +252,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             itemAnimPanels = new Panel[listDisplayUnits];
             itemStackLabels = new TextLabel[listDisplayUnits];
             itemMiscLabels = new TextLabel[listDisplayUnits];
-            Rect[] itemButtonRects = (enhanced) ? itemButtonRects16 : itemButtonRects4;
 
             for (int i = 0; i < listDisplayUnits; i++)
             {

--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -224,7 +224,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 throw new ArgumentException();
 
             listDisplayUnits = listRows;
-            this.listWidth = listCols;
+            listWidth = listCols;
             itemListPanelRect = itemListRect;
             itemButtonRects = itemsRects;
             itemButtonMargin = itemMarginSize;

--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -97,6 +97,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         int listDisplayTotal;       // Total number of items displayed in scrolling areas
         int itemButtonMargin = 2;   // Margin of item buttons
         float textScale = 1f;       // Scale of text on item buttons
+        TextLabel miscLabelTemplate;// Template for misc text labels
 
         float foregroundAnimationDelay = 0.2f;    
         float backgroundAnimationDelay = 0.2f;
@@ -157,7 +158,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             get { return foregroundAnimationDelay; }
             set { foregroundAnimationDelay = value; }
         }
-        /// <summary>Handler for label text (top left)</summary>
+        /// <summary>Handler for misc label text (defaults to top left)</summary>
         public ItemLabelTextHandler LabelTextHandler
         {
             get { return labelTextHandler; }
@@ -178,7 +179,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         #region Constructors, Public methods
 
         /// <summary>
-        /// Initializes a new instance of the ItemListScroller using default values setup for DF inventory screens.
+        /// Initializes a new instance of the ItemListScroller using default coordinates preset for use on DF inventory screens.
         /// Switches to advanced display of 16 items instead of 4 if user enables enhanced item lists.
         /// </summary>
         /// <param name="toolTip">Tool tip class to use if items should display tooltips.</param>
@@ -199,26 +200,34 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 textScale = 0.75f;
             }
             listDisplayTotal = listDisplayUnits * listWidth;
+            miscLabelTemplate = new TextLabel()
+            {
+                Position = Vector2.zero,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Top,
+                TextScale = textScale
+            };
+
             LoadTextures(enhanced);
             SetupScrollBar();
             SetupScrollButtons();
-            SetupItemsList(enhanced, Vector2.zero);
+            SetupItemsList(enhanced);
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DaggerfallWorkshop.Game.UserInterface.ItemListScroller"/> class.
+        /// Initializes a fully customised new instance of ItemListScroller.
         /// </summary>
         /// <param name="listRows">Number of rows of items this list will display at one time.</param>
         /// <param name="listCols">Number of items displayed per row.</param>
         /// <param name="itemListRect">Item list coordinate rect, excluding scrollbar.</param>
         /// <param name="itemsRects">Individual items display coordinate rects. (1 per width*height)</param>
-        /// <param name="miscLabelPos">Misc label relative position. (Vector2.zero for default)</param>
+        /// <param name="miscLabelTemplate">Template for misc label: relative position, font, horiz & vert alignment, text scale. (defaults: Vector2.zero, Font4, Left, Top, 1)</param>
         /// <param name="toolTip">Tool tip class to use if items should display tooltips.</param>
         /// <param name="itemMarginSize">Individual item display margin size.</param>
-        /// <param name="textScale">Text scale factor.</param>
-        public ItemListScroller(int listRows, int listCols, Rect itemListRect, Rect[] itemsRects, Vector2 miscLabelPos, ToolTip toolTip = null, int itemMarginSize = 1, float textScale = 1f)
+        /// <param name="textScale">Text scale factor for stack labels.</param>
+        public ItemListScroller(int listRows, int listCols, Rect itemListRect, Rect[] itemsRects, TextLabel miscLabelTemplate, ToolTip toolTip = null, int itemMarginSize = 1, float textScale = 1f)
             : base()
-        {
+        {//, int miscLabelFont = 4
             listDisplayTotal = listRows * listCols;
             if (itemsRects.Length != listDisplayTotal)
                 throw new ArgumentException();
@@ -230,11 +239,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             itemButtonMargin = itemMarginSize;
             this.textScale = textScale;
             this.toolTip = toolTip;
+            this.miscLabelTemplate = miscLabelTemplate;
 
             LoadTextures(false);
             SetupScrollBar();
             SetupScrollButtons();
-            SetupItemsList(false, miscLabelPos);
+            SetupItemsList(false);
         }
 
         public void ResetScroll()
@@ -281,7 +291,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             itemListDownButton.OnMouseClick += ItemsDownButton_OnMouseClick;
         }
 
-        void SetupItemsList(bool enhanced, Vector2 miscLabelPos)
+        void SetupItemsList(bool enhanced)
         {
             // List panel for scrolling behaviour
             Panel itemsListPanel = DaggerfallUI.AddPanel(itemListPanelRect, this);
@@ -331,10 +341,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 itemStackLabels[i].TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
 
                 // Misc labels
-                itemMiscLabels[i] = DaggerfallUI.AddTextLabel(DaggerfallUI.Instance.Font4, miscLabelPos, string.Empty, itemButtons[i]);
-                itemMiscLabels[i].HorizontalAlignment = HorizontalAlignment.Left;
-                itemMiscLabels[i].VerticalAlignment = VerticalAlignment.Top;
-                itemMiscLabels[i].TextScale = textScale;
+                itemMiscLabels[i] = DaggerfallUI.AddTextLabel(miscLabelTemplate.Font, miscLabelTemplate.Position, string.Empty, itemButtons[i]);
+                itemMiscLabels[i].HorizontalAlignment = miscLabelTemplate.HorizontalAlignment;
+                itemMiscLabels[i].VerticalAlignment = miscLabelTemplate.VerticalAlignment;
+                itemMiscLabels[i].TextScale = miscLabelTemplate.TextScale;
             }
         }
 

--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Items;
+using System;
 
 namespace DaggerfallWorkshop.Game.UserInterface
 {
@@ -22,6 +23,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         Rect itemListPanelRect = new Rect(9, 0, 50, 152);
         Rect[] itemButtonRects = itemButtonRects4;
+
         Rect upArrowRect = new Rect(0, 0, 9, 16);
         Rect downArrowRect = new Rect(0, 136, 9, 16);
         DFSize arrowsFullSize = new DFSize(9, 152);
@@ -174,6 +176,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #region Constructors, Public methods
 
+        /// <summary>
+        /// Initializes a new instance of the ItemListScroller using default values setup for DF inventory screens.
+        /// Switches to advanced display of 16 items instead of 4 if user enables enhanced item lists.
+        /// </summary>
+        /// <param name="toolTip">Tool tip class to use if items should display tooltips.</param>
+        /// <param name="disableEnhanced">If set to <c>true</c> disable enhanced regardless of user settings.</param>
         public ItemListScroller(ToolTip toolTip, bool disableEnhanced = false)
             : base()
         {
@@ -192,7 +200,38 @@ namespace DaggerfallWorkshop.Game.UserInterface
             LoadTextures(enhanced);
             SetupScrollBar();
             SetupScrollButtons();
-            SetupItemsList(enhanced);
+            SetupItemsList(enhanced, Vector2.zero);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DaggerfallWorkshop.Game.UserInterface.ItemListScroller"/> class.
+        /// </summary>
+        /// <param name="listDisplayUnits">Number of items this list will display at a time.</param>
+        /// <param name="listWidth">Number of items displayed per row. (should be a factor of listDisplayUnits)</param>
+        /// <param name="itemListRect">Item list coordinate rect.</param>
+        /// <param name="itemRects">Individual item display coordinate rects. (1 per list display)</param>
+        /// <param name="miscLabelPos">Misc label relative position. (Vector2.zero for default)</param>
+        /// <param name="itemMarginSize">Individual item display margin size.</param>
+        /// <param name="textScale">Text scale factor.</param>
+        /// <param name="toolTip">Tool tip class to use if items should display tooltips.</param>
+        public ItemListScroller(int listDisplay, int listWidth, Rect itemListRect, Rect[] itemRects, Vector2 miscLabelPos, int itemMarginSize = 1, float textScale = 1f, ToolTip toolTip = null)
+            : base()
+        {
+            if (itemRects.Length != listDisplayUnits || listDisplay % listWidth > 0)
+                throw new ArgumentException();
+            
+            listDisplayUnits = listDisplay;
+            scrollNum = listWidth;
+            itemListPanelRect = itemListRect;
+            itemButtonRects = itemRects;
+            itemButtonMarginSize = itemMarginSize;
+            this.textScale = textScale;
+            this.toolTip = toolTip;
+
+            LoadTextures(false);
+            SetupScrollBar();
+            SetupScrollButtons();
+            SetupItemsList(false, miscLabelPos);
         }
 
         public void ResetScroll()
@@ -239,7 +278,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             itemListDownButton.OnMouseClick += ItemsDownButton_OnMouseClick;
         }
 
-        void SetupItemsList(bool enhanced)
+        void SetupItemsList(bool enhanced, Vector2 miscLabelPos)
         {
             // List panel for scrolling behaviour
             Panel itemsListPanel = DaggerfallUI.AddPanel(itemListPanelRect, this);
@@ -289,7 +328,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 itemStackLabels[i].TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
 
                 // Misc labels
-                itemMiscLabels[i] = DaggerfallUI.AddTextLabel(DaggerfallUI.Instance.Font4, Vector2.zero, string.Empty, itemButtons[i]);
+                itemMiscLabels[i] = DaggerfallUI.AddTextLabel(DaggerfallUI.Instance.Font4, miscLabelPos, string.Empty, itemButtons[i]);
                 itemMiscLabels[i].HorizontalAlignment = HorizontalAlignment.Left;
                 itemMiscLabels[i].VerticalAlignment = VerticalAlignment.Top;
                 itemMiscLabels[i].TextScale = textScale;

--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -536,22 +536,26 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         void ItemsUpButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            itemListScrollBar.ScrollIndex--;
+            if (scroller)
+                itemListScrollBar.ScrollIndex--;
         }
 
         void ItemsDownButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            itemListScrollBar.ScrollIndex++;
+            if (scroller)
+                itemListScrollBar.ScrollIndex++;
         }
 
         void ItemsListPanel_OnMouseScrollUp(BaseScreenComponent sender)
         {
-            itemListScrollBar.ScrollIndex--;
+            if (scroller)
+                itemListScrollBar.ScrollIndex--;
         }
 
         void ItemsListPanel_OnMouseScrollDown(BaseScreenComponent sender)
         {
-            itemListScrollBar.ScrollIndex++;
+            if (scroller)
+                itemListScrollBar.ScrollIndex++;
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -272,6 +272,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     });
                     break;
 
+                case GuildServices.MakePotions:
+                    CloseWindow();
+                    uiManager.PushWindow(DaggerfallUI.Instance.DfPotionMakerWindow);
+                    break;
+
                 case GuildServices.BuyMagicItems:   // TODO: switch items depending on npcService?
                     CloseWindow();
                     uiManager.PushWindow(new DaggerfallTradeWindow(uiManager, DaggerfallTradeWindow.WindowModes.Buy, this, guild) {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -277,6 +277,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     uiManager.PushWindow(DaggerfallUI.Instance.DfPotionMakerWindow);
                     break;
 
+/*                case GuildServices.BuySpells:
+                    uiManager.PushWindow(new DaggerfallBankingWindow(uiManager, this));
+                    break;
+*/
+                case GuildServices.MakeSpells:
+                    CloseWindow();
+                    uiManager.PushWindow(DaggerfallUI.Instance.DfSpellMakerWindow);
+                    break;
+
                 case GuildServices.BuyMagicItems:   // TODO: switch items depending on npcService?
                     CloseWindow();
                     uiManager.PushWindow(new DaggerfallTradeWindow(uiManager, DaggerfallTradeWindow.WindowModes.Buy, this, guild) {
@@ -284,19 +293,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     });
                     break;
 
+                case GuildServices.MakeMagicItems:
+                    CloseWindow();
+                    uiManager.PushWindow(DaggerfallUI.Instance.DfItemMakerWindow);
+                    break;
+
+/*                case GuildServices.SellMagicItems:
+                    CloseWindow();
+                    uiManager.PushWindow(DaggerfallUI.Instance.DfPotionMakerWindow);
+                    break;
+*/
                 case GuildServices.Teleport:
                     CloseWindow();
                     DaggerfallUI.Instance.DfTravelMapWindow.ActivateTeleportationTravel();
                     uiManager.PushWindow(DaggerfallUI.Instance.DfTravelMapWindow);
-                    break;
-
-                //case GuildServices.BuySpells:
-                //uiManager.PushWindow(new DaggerfallBankingWindow(uiManager, this));
-                //break;
-
-                case GuildServices.MakeSpells:
-                    CloseWindow();
-                    uiManager.PushWindow(DaggerfallUI.Instance.DfSpellMakerWindow);
                     break;
 
                 case GuildServices.ReceiveArmor:

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -175,7 +175,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Enums
 
-        protected enum TabPages
+        public enum TabPages
         {
             WeaponsAndArmor,
             MagicItems,
@@ -710,28 +710,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Select new tab page
             selectedTabPage = tabPage;
 
-            // Clear all button selections
-            weaponsAndArmorButton.BackgroundTexture = weaponsAndArmorNotSelected;
-            magicItemsButton.BackgroundTexture = magicItemsNotSelected;
-            clothingAndMiscButton.BackgroundTexture = clothingAndMiscNotSelected;
-            ingredientsButton.BackgroundTexture = ingredientsNotSelected;
+            // Set all buttons to appropriate state
+            weaponsAndArmorButton.BackgroundTexture = (tabPage == TabPages.WeaponsAndArmor) ? weaponsAndArmorSelected : weaponsAndArmorNotSelected;
+            magicItemsButton.BackgroundTexture = (tabPage == TabPages.MagicItems) ? magicItemsSelected : magicItemsNotSelected;
+            clothingAndMiscButton.BackgroundTexture = (tabPage == TabPages.ClothingAndMisc) ? clothingAndMiscSelected : clothingAndMiscNotSelected;
+            ingredientsButton.BackgroundTexture = (tabPage == TabPages.Ingredients) ? ingredientsSelected : ingredientsNotSelected;
 
-            // Set new button selection texture background
-            switch (tabPage)
-            {
-                case TabPages.WeaponsAndArmor:
-                    weaponsAndArmorButton.BackgroundTexture = weaponsAndArmorSelected;
-                    break;
-                case TabPages.MagicItems:
-                    magicItemsButton.BackgroundTexture = magicItemsSelected;
-                    break;
-                case TabPages.ClothingAndMisc:
-                    clothingAndMiscButton.BackgroundTexture = clothingAndMiscSelected;
-                    break;
-                case TabPages.Ingredients:
-                    ingredientsButton.BackgroundTexture = ingredientsSelected;
-                    break;
-            }
             // Clear info panel
             if (itemInfoPanelLabel != null)
                 itemInfoPanelLabel.SetText(new TextFile.Token[0]);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs
@@ -1,0 +1,182 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Hazelnut
+
+using UnityEngine;
+using DaggerfallWorkshop.Game.UserInterface;
+using DaggerfallWorkshop.Utility;
+using DaggerfallConnect.Utility;
+
+namespace DaggerfallWorkshop.Game.UserInterfaceWindows
+{
+    public class DaggerfallItemMakerWindow : DaggerfallPopupWindow
+    {
+        #region UI Rects
+
+        Rect weaponsAndArmorRect = new Rect(175, 6, 81, 9);
+        Rect magicItemsRect = new Rect(175, 15, 81, 9);
+        Rect clothingAndMiscRect = new Rect(175, 24, 81, 9);
+        Rect ingredientsRect = new Rect(175, 33, 81, 9);
+
+        Rect exitButtonRect = new Rect(202, 176, 39, 22);
+
+        #endregion
+
+        #region UI Controls
+
+        Button weaponsAndArmorButton;
+        Button magicItemsButton;
+        Button clothingAndMiscButton;
+        Button ingredientsButton;
+        Button exitButton;
+
+        #endregion
+
+        #region UI Textures
+
+        Texture2D baseTexture;
+        Texture2D goldTexture;
+
+        Texture2D weaponsAndArmorNotSelected;
+        Texture2D magicItemsNotSelected;
+        Texture2D clothingAndMiscNotSelected;
+        Texture2D ingredientsNotSelected;
+        Texture2D weaponsAndArmorSelected;
+        Texture2D magicItemsSelected;
+        Texture2D clothingAndMiscSelected;
+        Texture2D ingredientsSelected;
+
+        #endregion
+
+        #region Fields
+
+        const string baseTextureName = "ITEM00I0.IMG";
+        const string goldTextureName = "ITEM01I0.IMG";
+        const int alternateAlphaIndex = 12;
+
+        DaggerfallInventoryWindow.TabPages selectedTabPage = DaggerfallInventoryWindow.TabPages.WeaponsAndArmor;
+
+        #endregion
+
+        #region Constructors
+
+        public DaggerfallItemMakerWindow(IUserInterfaceManager uiManager, DaggerfallBaseWindow previous = null)
+            : base(uiManager, previous)
+        {
+        }
+
+        #endregion
+
+        #region Setup Methods
+
+        protected override void Setup()
+        {
+            // Load textures
+            LoadTextures();
+
+            // Always dim background
+            ParentPanel.BackgroundColor = ScreenDimColor;
+
+            // Setup native panel background
+            NativePanel.BackgroundColor = new Color(0, 0, 0, 0.60f);
+            NativePanel.BackgroundTexture = baseTexture;
+
+            // Setup buttons
+            SetupButtons();
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        void LoadTextures()
+        {
+            baseTexture = ImageReader.GetTexture(baseTextureName, 0, 0, true, alternateAlphaIndex);
+            goldTexture = ImageReader.GetTexture(goldTextureName);
+            DFSize baseSize = new DFSize(320, 200);
+            DFSize goldSize = new DFSize(81, 36);
+
+            // Cut out tab page not selected button textures
+            weaponsAndArmorNotSelected = ImageReader.GetSubTexture(baseTexture, weaponsAndArmorRect, baseSize);
+            magicItemsNotSelected = ImageReader.GetSubTexture(baseTexture, magicItemsRect, baseSize);
+            clothingAndMiscNotSelected = ImageReader.GetSubTexture(baseTexture, clothingAndMiscRect, baseSize);
+            ingredientsNotSelected = ImageReader.GetSubTexture(baseTexture, ingredientsRect, baseSize);
+
+            // Cut out tab page selected button textures
+            weaponsAndArmorSelected = ImageReader.GetSubTexture(goldTexture, new Rect(0, 0, 81, 9), goldSize);
+            magicItemsSelected = ImageReader.GetSubTexture(goldTexture, new Rect(0, 9, 81, 9), goldSize);
+            clothingAndMiscSelected = ImageReader.GetSubTexture(goldTexture, new Rect(0, 18, 81, 9), goldSize);
+            ingredientsSelected = ImageReader.GetSubTexture(goldTexture, new Rect(0, 27, 81, 9), goldSize);
+        }
+
+        void SetupButtons()
+        {
+            // Tab page buttons
+            weaponsAndArmorButton = DaggerfallUI.AddButton(weaponsAndArmorRect, NativePanel);
+            weaponsAndArmorButton.OnMouseClick += WeaponsAndArmor_OnMouseClick;
+
+            magicItemsButton = DaggerfallUI.AddButton(magicItemsRect, NativePanel);
+            magicItemsButton.OnMouseClick += MagicItems_OnMouseClick;
+
+            clothingAndMiscButton = DaggerfallUI.AddButton(clothingAndMiscRect, NativePanel);
+            clothingAndMiscButton.OnMouseClick += ClothingAndMisc_OnMouseClick;
+
+            ingredientsButton = DaggerfallUI.AddButton(ingredientsRect, NativePanel);
+            ingredientsButton.OnMouseClick += Ingredients_OnMouseClick;
+
+            SelectTabPage(selectedTabPage);
+
+            // Exit button
+            exitButton = DaggerfallUI.AddButton(exitButtonRect, NativePanel);
+            exitButton.OnMouseClick += ExitButton_OnMouseClick;
+        }
+
+        protected void SelectTabPage(DaggerfallInventoryWindow.TabPages tabPage)
+        {
+            // Select new tab page
+            selectedTabPage = tabPage;
+
+            // Set all buttons to appropriate state
+            weaponsAndArmorButton.BackgroundTexture = (tabPage == DaggerfallInventoryWindow.TabPages.WeaponsAndArmor) ? weaponsAndArmorSelected : weaponsAndArmorNotSelected;
+            magicItemsButton.BackgroundTexture = (tabPage == DaggerfallInventoryWindow.TabPages.MagicItems) ? magicItemsSelected : magicItemsNotSelected;
+            clothingAndMiscButton.BackgroundTexture = (tabPage == DaggerfallInventoryWindow.TabPages.ClothingAndMisc) ? clothingAndMiscSelected : clothingAndMiscNotSelected;
+            ingredientsButton.BackgroundTexture = (tabPage == DaggerfallInventoryWindow.TabPages.Ingredients) ? ingredientsSelected : ingredientsNotSelected;
+
+            // TODO - update items
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        private void WeaponsAndArmor_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            SelectTabPage(DaggerfallInventoryWindow.TabPages.WeaponsAndArmor);
+        }
+
+        private void MagicItems_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            SelectTabPage(DaggerfallInventoryWindow.TabPages.MagicItems);
+        }
+
+        private void ClothingAndMisc_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            SelectTabPage(DaggerfallInventoryWindow.TabPages.ClothingAndMisc);
+        }
+
+        private void Ingredients_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            SelectTabPage(DaggerfallInventoryWindow.TabPages.Ingredients);
+        }
+
+        private void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            CloseWindow();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs
@@ -3,12 +3,19 @@
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
-// Original Author: Hazelnut
+// Original Author: Gavin Clayton (interkarma@dfworkshop.net)
+// Contributors:    Hazelnut
+//
+// Notes:
+//
 
 using UnityEngine;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Utility;
 using DaggerfallConnect.Utility;
+using DaggerfallWorkshop.Game.Items;
+using System.Collections.Generic;
+using DaggerfallWorkshop.Game.Entity;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -21,17 +28,47 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Rect clothingAndMiscRect = new Rect(175, 24, 81, 9);
         Rect ingredientsRect = new Rect(175, 33, 81, 9);
 
+        Rect powersButtonRect = new Rect(8, 183, 77, 10);
+        Rect sideeffectsButtonRect = new Rect(106, 183, 77, 10);
         Rect exitButtonRect = new Rect(202, 176, 39, 22);
+
+        Rect enchantButtonRect = new Rect(200, 115, 43, 15);
+        Rect selectedItemRect = new Rect(196, 68, 50, 37);
+
+        Rect itemListScrollerRect = new Rect(253, 49, 60, 148);
+        Rect itemListPanelRect = new Rect(10, 0, 50, 148);
+
+        Rect[] itemButtonRects = new Rect[]
+        {
+            new Rect(0, 0, 50, 37),
+            new Rect(0, 37, 50, 37),
+            new Rect(0, 74, 50, 37),
+            new Rect(0, 111, 50, 37)
+        };
 
         #endregion
 
         #region UI Controls
 
+        TextLabel nameLabel = new TextLabel();
+        TextLabel goldLabel = new TextLabel();
+        TextLabel costLabel = new TextLabel();
+        TextLabel enchantLabel = new TextLabel();
+
         Button weaponsAndArmorButton;
         Button magicItemsButton;
         Button clothingAndMiscButton;
         Button ingredientsButton;
+
+        Button powersButton;
+        Button sideeffectsButton;
         Button exitButton;
+
+        Button enchantButton;
+        Button selectedItemButton;
+        Panel selectedItemPanel;
+
+        ItemListScroller itemsListScroller;
 
         #endregion
 
@@ -58,6 +95,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int alternateAlphaIndex = 12;
 
         DaggerfallInventoryWindow.TabPages selectedTabPage = DaggerfallInventoryWindow.TabPages.WeaponsAndArmor;
+        List<DaggerfallUnityItem> itemsFiltered = new List<DaggerfallUnityItem>();
+        DaggerfallUnityItem selectedItem;
+
+        private PlayerEntity playerEntity;
+        PlayerEntity PlayerEntity {
+            get { return (playerEntity != null) ? playerEntity : playerEntity = GameManager.Instance.PlayerEntity; }
+        }
 
         #endregion
 
@@ -84,8 +128,49 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             NativePanel.BackgroundColor = new Color(0, 0, 0, 0.60f);
             NativePanel.BackgroundTexture = baseTexture;
 
-            // Setup buttons
+            // Setup UI
+            SetupLabels();
             SetupButtons();
+            SetupItemListScrollers();
+
+            SelectTabPage(selectedTabPage);
+        }
+
+        public override void OnPush()
+        {
+            if (!IsSetup)
+                return;
+
+            Refresh();
+        }
+
+        public override void OnPop()
+        {
+        }
+
+        void Refresh()
+        {
+            // Update labels
+            nameLabel.Text = (selectedItem != null) ? selectedItem.shortName : "";
+            goldLabel.Text = PlayerEntity.GetGoldAmount().ToString();
+            costLabel.Text = (selectedItem != null) ? "8132" : "";
+            enchantLabel.Text = (selectedItem != null) ? "0 / 60" : "";
+
+            // Add appropriate items to filtered list
+            itemsFiltered.Clear();
+            ItemCollection playerItems = PlayerEntity.Items;
+            for (int i = 0; i < playerItems.Count; i++)
+                AddFilteredItem(playerItems.GetItem(i));
+
+            itemsListScroller.Items = itemsFiltered;
+
+            if (selectedItem != null) {
+                ImageData image = DaggerfallUnity.Instance.ItemHelper.GetInventoryImage(selectedItem);
+                selectedItemPanel.BackgroundTexture = image.texture;
+                selectedItemPanel.Size = new Vector2(image.texture.width, image.texture.height);
+            } else {
+                selectedItemPanel.BackgroundTexture = null;
+            }
         }
 
         #endregion
@@ -112,29 +197,62 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             ingredientsSelected = ImageReader.GetSubTexture(goldTexture, new Rect(0, 27, 81, 9), goldSize);
         }
 
+        void SetupLabels()
+        {
+            nameLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(52, 3), NativePanel);
+            goldLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(71, 15), NativePanel);
+            costLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(64, 27), NativePanel);
+            enchantLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(98, 39), NativePanel);
+        }
+
         void SetupButtons()
         {
             // Tab page buttons
             weaponsAndArmorButton = DaggerfallUI.AddButton(weaponsAndArmorRect, NativePanel);
             weaponsAndArmorButton.OnMouseClick += WeaponsAndArmor_OnMouseClick;
-
             magicItemsButton = DaggerfallUI.AddButton(magicItemsRect, NativePanel);
             magicItemsButton.OnMouseClick += MagicItems_OnMouseClick;
-
             clothingAndMiscButton = DaggerfallUI.AddButton(clothingAndMiscRect, NativePanel);
             clothingAndMiscButton.OnMouseClick += ClothingAndMisc_OnMouseClick;
-
             ingredientsButton = DaggerfallUI.AddButton(ingredientsRect, NativePanel);
             ingredientsButton.OnMouseClick += Ingredients_OnMouseClick;
 
-            SelectTabPage(selectedTabPage);
+            // Add powers & side-effects buttons
+            Button powersButton = DaggerfallUI.AddButton(powersButtonRect, NativePanel);
+            powersButton.OnMouseClick += PowersButton_OnMouseClick;
+            Button sideeffectsButton = DaggerfallUI.AddButton(sideeffectsButtonRect, NativePanel);
+            sideeffectsButton.OnMouseClick += SideeffectsButton_OnMouseClick;
 
             // Exit button
             exitButton = DaggerfallUI.AddButton(exitButtonRect, NativePanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
+
+            Button enchantButton = DaggerfallUI.AddButton(enchantButtonRect, NativePanel);
+            enchantButton.OnMouseClick += EnchantButton_OnMouseClick;
+
+            // Selected item button
+            selectedItemButton = DaggerfallUI.AddButton(selectedItemRect, NativePanel);
+            selectedItemButton.SetMargins(Margins.All, 2);
+            selectedItemButton.OnMouseClick += SelectedItemButton_OnMouseClick;
+            // Selected item icon image panel
+            selectedItemPanel = DaggerfallUI.AddPanel(selectedItemButton, AutoSizeModes.ScaleToFit);
+            selectedItemPanel.HorizontalAlignment = HorizontalAlignment.Center;
+            selectedItemPanel.VerticalAlignment = VerticalAlignment.Middle;
+            selectedItemPanel.MaxAutoScale = 1f;
         }
 
-        protected void SelectTabPage(DaggerfallInventoryWindow.TabPages tabPage)
+        void SetupItemListScrollers()
+        {
+            itemsListScroller = new ItemListScroller(4, 1, itemListPanelRect, itemButtonRects, new TextLabel(), defaultToolTip)
+            {
+                Position = new Vector2(itemListScrollerRect.x, itemListScrollerRect.y),
+                Size = new Vector2(itemListScrollerRect.width, itemListScrollerRect.height),
+            };
+            NativePanel.Components.Add(itemsListScroller);
+            itemsListScroller.OnItemClick += ItemListScroller_OnItemClick;
+        }
+
+        void SelectTabPage(DaggerfallInventoryWindow.TabPages tabPage)
         {
             // Select new tab page
             selectedTabPage = tabPage;
@@ -145,12 +263,72 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             clothingAndMiscButton.BackgroundTexture = (tabPage == DaggerfallInventoryWindow.TabPages.ClothingAndMisc) ? clothingAndMiscSelected : clothingAndMiscNotSelected;
             ingredientsButton.BackgroundTexture = (tabPage == DaggerfallInventoryWindow.TabPages.Ingredients) ? ingredientsSelected : ingredientsNotSelected;
 
-            // TODO - update items
+            // Update items
+            Refresh();
+        }
+
+        // Add item to filtered items based on selected tab
+        void AddFilteredItem(DaggerfallUnityItem item)
+        {
+            if (item == selectedItem)
+                return;
+
+            bool isWeaponOrArmor = (item.ItemGroup == ItemGroups.Weapons || item.ItemGroup == ItemGroups.Armor);
+
+            if (selectedTabPage == DaggerfallInventoryWindow.TabPages.WeaponsAndArmor)
+            {   // Weapons and armor
+                if (isWeaponOrArmor && !item.IsEnchanted)
+                    itemsFiltered.Add(item);
+            }
+            else if (selectedTabPage == DaggerfallInventoryWindow.TabPages.MagicItems)
+            {   // Enchanted items
+                // TODO: seems completely pointless, is there any use case for this?
+                if (item.IsEnchanted)
+                    itemsFiltered.Add(item);
+            }
+            else if (selectedTabPage == DaggerfallInventoryWindow.TabPages.Ingredients)
+            {   // Ingredients
+                if (item.IsIngredient && !item.IsEnchanted)
+                    itemsFiltered.Add(item);
+            }
+            else if (selectedTabPage == DaggerfallInventoryWindow.TabPages.ClothingAndMisc)
+            {   // Everything else
+                // TODO, filter only enchantable items...
+                if (!isWeaponOrArmor && !item.IsEnchanted && !item.IsIngredient && !item.IsOfTemplate((int) MiscItems.Spellbook))
+                    itemsFiltered.Add(item);
+            }
         }
 
         #endregion
 
         #region Event Handlers
+
+        private void ItemListScroller_OnItemClick(DaggerfallUnityItem item)
+        {
+            selectedItem = item;
+            Refresh();
+        }
+
+        private void SelectedItemButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            selectedItem = null;
+            Refresh();
+        }
+
+        private void PowersButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            Debug.Log("Add powers");
+        }
+
+        private void SideeffectsButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            Debug.Log("Add side-effects");
+        }
+
+        private void EnchantButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            Debug.Log("Enchant item!");
+        }
 
         private void WeaponsAndArmor_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs.meta
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d7956722926a2814687034746a1922f2
+timeCreated: 1528927718
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -125,15 +125,26 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void SetupItemListScrollers()
         {
-
+            TextLabel miscLabelTemplate = new TextLabel(DaggerfallUI.Instance.Font3)
+            {
+                Position = new Vector2(0, ingredientButtonRects[0].height),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.None
+            };
             // Setup item list scroller for ingredients
-            ingredientsListScroller = new ItemListScroller(4, 3, ingredientsListRect, ingredientButtonRects, Vector2.down, defaultToolTip)
+            ingredientsListScroller = new ItemListScroller(4, 3, ingredientsListRect, ingredientButtonRects, miscLabelTemplate, defaultToolTip, 2, 0.8f)
             {
                 Position = new Vector2(ingredientsListScrollerRect.x, ingredientsListScrollerRect.y),
                 Size = new Vector2(ingredientsListScrollerRect.width, ingredientsListScrollerRect.height),
+                LabelTextHandler = ItemLabelTextHandler
             };
             NativePanel.Components.Add(ingredientsListScroller);
             ingredientsListScroller.OnItemClick += IngredientsListScroller_OnItemClick;
+        }
+
+        string ItemLabelTextHandler(DaggerfallUnityItem item)
+        {
+            return item.ItemName.ToUpper();
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -4,6 +4,10 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Hazelnut
+// Contributors:    Gavin Clayton (interkarma@dfworkshop.net)
+//
+// Notes:
+//
 
 using UnityEngine;
 using DaggerfallWorkshop.Game.UserInterface;
@@ -92,9 +96,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             NativePanel.BackgroundColor = new Color(0, 0, 0, 0.60f);
             NativePanel.BackgroundTexture = baseTexture;
 
-            // Setup buttons
+            // Setup UI
             SetupButtons();
             SetupItemListScrollers();
+
             Refresh();
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -23,7 +23,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region UI Controls
 
-        Panel mainPanel = new Panel();
         Button recipesButton;
         Button mixButton;
         Button exitButton;
@@ -49,7 +48,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Setup Methods
 
-        // guildrank DarkBrotherHood 3
         protected override void Setup()
         {
             // Load textures
@@ -59,7 +57,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             ParentPanel.BackgroundColor = ScreenDimColor;
 
             // Setup native panel background
-            NativePanel.BackgroundColor = new Color(0, 0, 0, 0.75f);
+            NativePanel.BackgroundColor = new Color(0, 0, 0, 0.60f);
             NativePanel.BackgroundTexture = baseTexture;
 
             // Setup buttons

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -8,6 +8,9 @@
 using UnityEngine;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Items;
+using DaggerfallWorkshop.Game.Entity;
+using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -19,6 +22,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Rect mixButtonRect = new Rect(169, 42, 36, 16);
         Rect exitButtonRect = new Rect(290, 178, 24, 16);
 
+        Rect ingredientsListScrollerRect = new Rect(5, 30, 151, 142);
+        Rect ingredientsListRect = new Rect(11, 0, 140, 142);
+
+        static Rect[] ingredientButtonRects = new Rect[]
+        {
+            new Rect(0, 0, 28, 28),     new Rect(56, 0, 28, 28),    new Rect(112, 0, 28, 28),
+            new Rect(0, 38, 28, 28),    new Rect(56, 38, 28, 28),   new Rect(112, 38, 28, 28),
+            new Rect(0, 76, 28, 28),    new Rect(56, 76, 28, 28),   new Rect(112, 76, 28, 28),
+            new Rect(0, 114, 28, 28),   new Rect(56, 114, 28, 28),  new Rect(112, 114, 28, 28)
+        };
+
+
         #endregion
 
         #region UI Controls
@@ -26,6 +41,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button recipesButton;
         Button mixButton;
         Button exitButton;
+
+        ItemListScroller ingredientsListScroller;
 
         #endregion
 
@@ -36,6 +53,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int alternateAlphaIndex = 12;
 
         #endregion
+
+        List<DaggerfallUnityItem> ingredients = new List<DaggerfallUnityItem>();
 
         #region Constructors
 
@@ -62,6 +81,30 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Setup buttons
             SetupButtons();
+            SetupItemListScrollers();
+            Refresh();
+        }
+
+        public override void OnPush()
+        {
+            if (!IsSetup)
+                return;
+
+            Refresh();
+        }
+
+        void Refresh()
+        {
+            // Add ingredient items to list
+            ingredients.Clear();
+            ItemCollection playerItems = GameManager.Instance.PlayerEntity.Items;
+            for (int i = 0; i < playerItems.Count; i++)
+            {
+                DaggerfallUnityItem item = playerItems.GetItem(i);
+                if (item.IsIngredient)
+                    ingredients.Add(item);
+            }
+            ingredientsListScroller.Items = ingredients;
         }
 
         #endregion
@@ -80,9 +123,27 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
         }
 
+        protected void SetupItemListScrollers()
+        {
+
+            // Setup item list scroller for ingredients
+            ingredientsListScroller = new ItemListScroller(4, 3, ingredientsListRect, ingredientButtonRects, Vector2.down, defaultToolTip)
+            {
+                Position = new Vector2(ingredientsListScrollerRect.x, ingredientsListScrollerRect.y),
+                Size = new Vector2(ingredientsListScrollerRect.width, ingredientsListScrollerRect.height),
+            };
+            NativePanel.Components.Add(ingredientsListScroller);
+            ingredientsListScroller.OnItemClick += IngredientsListScroller_OnItemClick;
+        }
+
         #endregion
 
         #region Event Handlers
+
+        protected virtual void IngredientsListScroller_OnItemClick(DaggerfallUnityItem item)
+        {
+            Debug.Log("click");
+        }
 
         private void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -1,0 +1,106 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Hazelnut
+
+using UnityEngine;
+using DaggerfallWorkshop.Game.UserInterface;
+using DaggerfallWorkshop.Utility;
+
+namespace DaggerfallWorkshop.Game.UserInterfaceWindows
+{
+    public class DaggerfallPotionMakerWindow : DaggerfallPopupWindow
+    {
+        #region UI Rects
+
+        Rect recipesButtonRect = new Rect(169, 26, 36, 16);
+        Rect mixButtonRect = new Rect(169, 42, 36, 16);
+        Rect exitButtonRect = new Rect(290, 178, 24, 16);
+
+        #endregion
+
+        #region UI Controls
+
+        Panel mainPanel = new Panel();
+        Button recipesButton;
+        Button mixButton;
+        Button exitButton;
+
+        #endregion
+
+        #region UI Textures
+
+        Texture2D baseTexture;
+        const string baseTextureName = "MASK00I0.IMG";
+        const int alternateAlphaIndex = 12;
+
+        #endregion
+
+        #region Constructors
+
+        public DaggerfallPotionMakerWindow(IUserInterfaceManager uiManager, DaggerfallBaseWindow previous = null)
+            : base(uiManager, previous)
+        {
+        }
+
+        #endregion
+
+        #region Setup Methods
+
+        // guildrank DarkBrotherHood 3
+        protected override void Setup()
+        {
+            // Load textures
+            LoadTextures();
+
+            // Always dim background
+            ParentPanel.BackgroundColor = ScreenDimColor;
+
+            // Setup native panel background
+            NativePanel.BackgroundColor = new Color(0, 0, 0, 0.75f);
+            NativePanel.BackgroundTexture = baseTexture;
+
+            // Setup buttons
+            SetupButtons();
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        void LoadTextures()
+        {
+            baseTexture = ImageReader.GetTexture(baseTextureName, 0, 0, true, alternateAlphaIndex);
+        }
+
+        void SetupButtons()
+        {
+            // Exit button
+            exitButton = DaggerfallUI.AddButton(exitButtonRect, NativePanel);
+            exitButton.OnMouseClick += ExitButton_OnMouseClick;
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        private void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            CloseWindow();
+        }
+
+        private void RecipesButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            CloseWindow();
+        }
+
+        private void MixButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            CloseWindow();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs.meta
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3707f90ad37634f42a3cb6121532cc5a
+timeCreated: 1528833129
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -143,9 +143,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #endregion
 
-            #region Private Methods
+        #region Private Methods
 
-            void LoadTextures()
+        void LoadTextures()
         {
             ImageData baseData = ImageReader.GetImageData(baseTextureName);
             baseTexture = baseData.texture;


### PR DESCRIPTION
- Upgraded ItemListScroller component to be flexible for use beyond inventory UI window.
- Fixes column swap issue when scrolling to end of lists with odd numbers of items.
- Implemented the basic buttons, item scrolling and movement for both potion and item maker UI screens. (You can't actually create potions or enchanted items yet)
- These are now prepared for when the effect system is ready to enable their functionality.

I'm really happy how the ItemListScroller handles item display, once I upgraded it the potion screen was really easy to do.
