### PR TITLE
Re-work classic DF rep propagation algorithm

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -882,7 +882,7 @@ namespace DaggerfallConnect.Arena2
         {
             // Unmodded faction.txt contains multiples of same id
             // This resolver counter is used to give a faction a unique id if needed
-            int resolverId = 1000;
+            int resolverId = 980;
 
             // Clear existing dictionary
             factionDict.Clear();

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -258,6 +258,8 @@ namespace DaggerfallWorkshop.Game.Guilds
                     return IsMember();
                 case GuildServices.Identify:
                     return true;
+                case GuildServices.BuySpells:
+                    return true;
                 case GuildServices.Donate:
                     return true;
                 case GuildServices.CureDisease:

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -338,6 +338,10 @@ namespace DaggerfallWorkshop.Game.Player
         /// <summary>
         /// Change reputation value by amount. Propagation is matched to classic.
         /// </summary>
+        /// <param name="factionID">Faction ID of faction initiate reputation change.</param>
+        /// <param name="amount">Amount to change reputation, positive or negative.</param>
+        /// <param name="propagate">True if reputation change should propagate to affiliated factions and allies/enemies.</param>
+        /// <returns></returns>
         public bool ChangeReputation(int factionID, int amount, bool propagate = false)
         {
             if (factionDict.ContainsKey(factionID))
@@ -351,7 +355,7 @@ namespace DaggerfallWorkshop.Game.Player
                 }
                 else
                 {
-                    // If a knightly order faction, propagate rep for the generic order only.
+                    // If a knightly order faction, propagate rep for the generic order only
                     // (this is what classic does - assume due to all affiliated nobles being aloof from such matters..)
                     if (factionData.ggroup == (int)FactionFile.GuildGroups.KnightlyOrder)
                     {
@@ -378,7 +382,7 @@ namespace DaggerfallWorkshop.Game.Player
                             ChangeReputation(enemies[i], -amount / 2);
                         }
 
-                        // If a temple deity faction, also propagate rep for generic temple faction hierarchy.
+                        // If a temple deity faction, also propagate rep for generic temple faction hierarchy
                         if (factionData.type == (int)FactionFile.FactionTypes.God)
                             ChangeReputation((int)FactionFile.FactionIDs.Generic_Temple, amount, true);
                     }
@@ -393,13 +397,13 @@ namespace DaggerfallWorkshop.Game.Player
         /// </summary>
         /// <param name="factionData">Faction data of parent faction node to change rep for it and children.</param>
         /// <param name="factionID">Faction ID of faction where rep change was initiated.</param>
-        /// <param name="amount">Amount to change reputation. (half applied to all but init & questor factions)</param>
+        /// <param name="amount">Amount to change reputation. (half applied to all but init and questor factions)</param>
         private void PropagateReputationChange(FactionFile.FactionData factionData, int factionID, int amount)
         {
-            // Do full reputation change for specific faction & questor npcs, and half reputation change for all other factions in hierarchy.
+            // Do full reputation change for specific faction & questor npcs, and half reputation change for all other factions in hierarchy
             ChangeReputation(factionData.id, (factionData.id == factionID || questorIds.Contains((GuildNpcServices)factionData.id)) ? amount : amount / 2);
 
-            // Recursively propagate reputation changes to all child factions.
+            // Recursively propagate reputation changes to all child factions
             if (factionData.children != null)
                 foreach (int id in factionData.children)
                     if (factionDict.ContainsKey(id))

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -398,7 +398,7 @@ namespace DaggerfallWorkshop.Game.Player
         /// <param name="factionData">Faction data of parent faction node to change rep for it and children.</param>
         /// <param name="factionID">Faction ID of faction where rep change was initiated.</param>
         /// <param name="amount">Amount to change reputation. (half applied to all but init and questor factions)</param>
-        private void PropagateReputationChange(FactionFile.FactionData factionData, int factionID, int amount)
+        public void PropagateReputationChange(FactionFile.FactionData factionData, int factionID, int amount)
         {
             // Do full reputation change for specific faction & questor npcs, and half reputation change for all other factions in hierarchy
             ChangeReputation(factionData.id, (factionData.id == factionID || questorIds.Contains((GuildNpcServices)factionData.id)) ? amount : amount / 2);

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -400,8 +400,8 @@ namespace DaggerfallWorkshop.Game.Player
         /// <param name="amount">Amount to change reputation. (half applied to all but init and questor factions)</param>
         public void PropagateReputationChange(FactionFile.FactionData factionData, int factionID, int amount)
         {
-            // Do full reputation change for specific faction & questor npcs, and half reputation change for all other factions in hierarchy
-            ChangeReputation(factionData.id, (factionData.id == factionID || questorIds.Contains((GuildNpcServices)factionData.id)) ? amount : amount / 2);
+            // Do full reputation change for specific faction, a root parent, and questor npcs. Then half reputation change for all other factions in hierarchy
+            ChangeReputation(factionData.id, (factionData.id == factionID || factionData.parent == 0 || questorIds.Contains((GuildNpcServices)factionData.id)) ? amount : amount / 2);
 
             // Recursively propagate reputation changes to all child factions
             if (factionData.children != null)

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -365,15 +365,7 @@ namespace DaggerfallWorkshop.Game.Player
                     }
                     else
                     {
-                        // Navigate up to the root faction
-                        while (factionDict.ContainsKey(factionData.parent))
-                            factionData = factionDict[factionData.parent];
-
-                        // Propagate reputation changes for all children of the root
-                        if (factionData.children != null)
-                            PropagateReputationChange(factionData, factionID, amount);
-
-                        // Change ally and enemy faction reputations
+                        // Change ally and enemy faction reputations first (for guild faction or social questgiver npc)
                         int[] allies = { factionData.ally1, factionData.ally2, factionData.ally3 };
                         int[] enemies = { factionData.enemy1, factionData.enemy2, factionData.enemy3 };
                         for (int i = 0; i < 3; ++i)
@@ -381,6 +373,14 @@ namespace DaggerfallWorkshop.Game.Player
                             ChangeReputation(allies[i], amount / 2);
                             ChangeReputation(enemies[i], -amount / 2);
                         }
+
+                        // Navigate up to the root faction (treat Dark Brotherhood faction as a root faction)
+                        while (factionDict.ContainsKey(factionData.parent) && factionData.id != (int)FactionFile.FactionIDs.The_Dark_Brotherhood)
+                            factionData = factionDict[factionData.parent];
+
+                        // Propagate reputation changes for all children of the root
+                        if (factionData.children != null)
+                            PropagateReputationChange(factionData, factionID, amount);
 
                         // If a temple deity faction, also propagate rep for generic temple faction hierarchy
                         if (factionData.type == (int)FactionFile.FactionTypes.God)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -553,7 +553,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     // Change reputation
                     int rep = Math.Abs(playerEntity.FactionData.GetReputation(factionId));
                     if (UnityEngine.Random.Range(1, 101) <= (2 * amount / rep + 1))
-                        playerEntity.FactionData.ChangeReputation(factionId, 1, true); // Does not propagate in classic
+                        playerEntity.FactionData.ChangeReputation(factionId, 1); // Does not propagate in classic
 
                     // Show thanks message
                     DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, uiManager.TopWindow);

--- a/Assets/Scripts/Game/Utility/TravelTimeCalculator.cs
+++ b/Assets/Scripts/Game/Utility/TravelTimeCalculator.cs
@@ -152,7 +152,7 @@ namespace DaggerfallWorkshop.Game.Utility
         {
             int travelTimeInHours = (travelTimeInMinutes + 59) / 60;
             int cost = 0;
-            if (sleepModeInn)
+            if (sleepModeInn && !GameManager.Instance.GuildManager.GetGuild(FactionFile.GuildGroups.KnightlyOrder).FreeTavernRooms())
                 cost = 5 * ((travelTimeInHours - pixelsTraveledOnOcean) / 24) + 5;
             if ((pixelsTraveledOnOcean > 0) && !hasShip && travelShip)
                 cost += 25 * (pixelsTraveledOnOcean / 24 + 1);

--- a/Assets/StreamingAssets/Tables/QuestList-Classic.txt
+++ b/Assets/StreamingAssets/Tables/QuestList-Classic.txt
@@ -202,7 +202,7 @@ K0C30Y03, Merchants, N, 30,
 -P0B00L04, Vampires, M, 0,
 -P0B00L06, Vampires, M, 0,
 -P0B01L02, Vampires, M, 1,
--P0B10L07, Vampires, M, 10,\
+-P0B10L07, Vampires, M, 10,
 -P0B10L08, Vampires, M, 10, In vanilla DF P0B10L08.QBN file is missing but P0B1XL08.QBN is used instead.
 -P0B10L10, Vampires, M, 10,
 -P0B1XL08, Vampires, M, 1X, BROKEN. QBN file is a counterpart of P0B10L08.QRC
@@ -237,7 +237,7 @@ R0C20Y07, Nobility, N, 20,
 R0C20Y22, Nobility, N, 20,
 R0C30Y25, Nobility, N, 30,
 -R0C40Y23, Nobility, N, 40, BROKEN. QRC file is missing in DF+DFQFIX
--R0C4XY23, Nobility, N, 4X, Needs support for until _thing_ perform:
+-R0C4XY23, Nobility, N, 4X, Needs support for until _thing_ performed:
 R0C60Y24, Nobility, N, 60,
 
 -- Daedra Princes

--- a/Assets/StreamingAssets/Tables/QuestList-Classic.txt
+++ b/Assets/StreamingAssets/Tables/QuestList-Classic.txt
@@ -202,7 +202,7 @@ K0C30Y03, Merchants, N, 30,
 -P0B00L04, Vampires, M, 0,
 -P0B00L06, Vampires, M, 0,
 -P0B01L02, Vampires, M, 1,
--P0B10L07, Vampires, M, 10,
+-P0B10L07, Vampires, M, 10,\
 -P0B10L08, Vampires, M, 10, In vanilla DF P0B10L08.QBN file is missing but P0B1XL08.QBN is used instead.
 -P0B10L10, Vampires, M, 10,
 -P0B1XL08, Vampires, M, 1X, BROKEN. QBN file is a counterpart of P0B10L08.QRC
@@ -237,7 +237,7 @@ R0C20Y07, Nobility, N, 20,
 R0C20Y22, Nobility, N, 20,
 R0C30Y25, Nobility, N, 30,
 -R0C40Y23, Nobility, N, 40, BROKEN. QRC file is missing in DF+DFQFIX
-R0C4XY23, Nobility, N, 4X,
+-R0C4XY23, Nobility, N, 4X, Needs support for until _thing_ perform:
 R0C60Y24, Nobility, N, 60,
 
 -- Daedra Princes


### PR DESCRIPTION
- Simplify code, thanks to Allofich for implementing as classic and removing guesswork.
- Works from guild faction ids rather than questor npc id.
- Fixes classic bug with knightly orders where rep isn't propagated to children of generic order.
- Fixes classic bug with knightly orders where rep is doubled for generic order when performing non-member quests.
- Keeps classic behaviour of not propagating for a specific knightly order. I assume due to all affiliated nobles being aloof from such matters, but this is easily changed if we want.