### PR TITLE
Sorceror Magicka restrictions and mages guild benefit.

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1783,7 +1783,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 DaggerfallUnity.Instance.WorldTime.Now.RaiseTime(1 * DaggerfallDateTime.SecondsPerHour);
                 int healthRecoveryRate = FormulaHelper.CalculateHealthRecoveryRate(this);
                 int fatigueRecoveryRate = FormulaHelper.CalculateFatigueRecoveryRate(MaxFatigue);
-                int spellPointRecoveryRate = FormulaHelper.CalculateSpellPointRecoveryRate(MaxMagicka);
+                int spellPointRecoveryRate = FormulaHelper.CalculateSpellPointRecoveryRate(this);
 
                 CurrentHealth += healthRecoveryRate;
                 CurrentFatigue += fatigueRecoveryRate;

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -177,13 +177,16 @@ namespace DaggerfallWorkshop.Game.Formulas
         }
 
         // Calculate how many spell points the player should recover per hour of rest
-        public static int CalculateSpellPointRecoveryRate(int maxSpellPoints)
+        public static int CalculateSpellPointRecoveryRate(PlayerEntity player)
         {
             Formula_1i del;
             if (formula_1i.TryGetValue("HealingRateModifier", out del))
-                return del(maxSpellPoints);
+                return del(player.MaxMagicka);
 
-            return Mathf.Max((int)Mathf.Floor(maxSpellPoints / 8), 1);
+            if (player.Career.NoRegenSpellPoints)
+                return 0;
+
+            return Mathf.Max((int)Mathf.Floor(player.MaxMagicka / 8), 1);
         }
 
         // Calculate chance of successfully lockpicking a door in an interior (an animating door). If this is higher than a random number between 0 and 100 (inclusive), the lockpicking succeeds.

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -193,6 +193,11 @@ namespace DaggerfallWorkshop.Game.Guilds
             return false;
         }
 
+        public virtual bool FreeMagickaRecharge()
+        {
+            return false;
+        }
+
         public virtual int ReducedRepairCost(int price)
         {
             return price;

--- a/Assets/Scripts/Game/Guilds/MagesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/MagesGuild.cs
@@ -116,7 +116,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public override bool FreeMagickaRecharge()
         {
-            if (GameManager.Instance.PlayerEntity.Career.NoRegenSpellPoints)
+            if (IsMember() && GameManager.Instance.PlayerEntity.Career.NoRegenSpellPoints)
                 return true;
             return false;
         }

--- a/Assets/Scripts/Game/Guilds/MagesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/MagesGuild.cs
@@ -114,6 +114,13 @@ namespace DaggerfallWorkshop.Game.Guilds
             return (rank >= 6);
         }
 
+        public override bool FreeMagickaRecharge()
+        {
+            if (GameManager.Instance.PlayerEntity.Career.NoRegenSpellPoints)
+                return true;
+            return false;
+        }
+
         #endregion
 
         #region Service Access:

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -59,6 +59,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int InsufficientRankId = 3100;
         const int TooGenerousId = 702;
         const int DonationThanksId = 703;
+        const int SorcerorMagickaRecharge = 465;
 
         Texture2D baseTexture;
         PlayerEntity playerEntity;
@@ -201,8 +202,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (guild.FreeMagickaRecharge() && playerEntity.CurrentMagicka < playerEntity.MaxMagicka)
             {
                 DaggerfallMessageBox msgBox = new DaggerfallMessageBox(uiManager, this);
-                msgBox.SetText("It is customary for the guild to recharge the magicka of sorcerors.");
-                //TODO: find ID for GetRandomTokens to replace SetTextMessage above.  
+                msgBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRandomTokens(SorcerorMagickaRecharge));
                 msgBox.ClickAnywhereToClose = true;
                 msgBox.Show();
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -220,10 +220,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ServiceButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            PlayerEntity player = GameManager.Instance.PlayerEntity;
             if (guild.GetFactionId() == (int)FactionFile.FactionIDs.The_Mages_Guild 
-                && GameManager.Instance.PlayerEntity.Career.NoRegenSpellPoints)
+                && player.Career.NoRegenSpellPoints)
             {
-                if (GameManager.Instance.PlayerEntity.CurrentMagicka < GameManager.Instance.PlayerEntity.MaxMagicka)
+                if (player.CurrentMagicka < player.MaxMagicka)
                 {
                     DaggerfallMessageBox msgBox = new DaggerfallMessageBox(uiManager, this);
                     msgBox.SetText("It is customary for the guild to recharge the magicka of sorcerors.");
@@ -235,7 +236,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     msgBox.Show();
 
                     // Refill magicka
-                    GameManager.Instance.PlayerEntity.CurrentMagicka = GameManager.Instance.PlayerEntity.MaxMagicka;
+                    player.CurrentMagicka = player.MaxMagicka;
                 }
             }
             // Check access to service

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -197,7 +197,25 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 playerEntity.SetHealth(playerEntity.MaxHealth);
                 DaggerfallUI.MessageBox(350);
             }
-            // TODO: Check for magicka restoration (sorcerers)
+            // Check for magicka restoration (sorcerers)
+            if (guild.GetFactionId() == (int)FactionFile.FactionIDs.The_Mages_Guild 
+                && playerEntity.Career.NoRegenSpellPoints)
+            {
+                if (playerEntity.CurrentMagicka < playerEntity.MaxMagicka)
+                {
+                    DaggerfallMessageBox msgBox = new DaggerfallMessageBox(uiManager, this);
+                    msgBox.SetText("It is customary for the guild to recharge the magicka of sorcerors.");
+                    //TODO: find ID for GetRandomTokens to replace SetTextMessage above.  
+                    // There's one other message that gets used: 
+                    // "I see your magicka is low. You sorcerors really need to be more careful. Here, let me recharge you."  
+                    //msgBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRandomTokens(RefillMagickaID));
+                    msgBox.ClickAnywhereToClose = true;
+                    msgBox.Show();
+
+                    // Refill magicka
+                    playerEntity.SetMagicka(playerEntity.MaxMagicka);
+                }
+            }
         }
 
         #endregion
@@ -220,25 +238,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ServiceButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            PlayerEntity player = GameManager.Instance.PlayerEntity;
-            if (guild.GetFactionId() == (int)FactionFile.FactionIDs.The_Mages_Guild 
-                && player.Career.NoRegenSpellPoints)
-            {
-                if (player.CurrentMagicka < player.MaxMagicka)
-                {
-                    DaggerfallMessageBox msgBox = new DaggerfallMessageBox(uiManager, this);
-                    msgBox.SetText("It is customary for the guild to recharge the magicka of sorcerors.");
-                    //TODO: find ID for GetRandomTokens to replace SetTextMessage above.  
-                    // There's one other message that gets used: 
-                    // "I see your magicka is low. You sorcerors really need to be more careful. Here, let me recharge you."  
-                    //msgBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRandomTokens(RefillMagickaID));
-                    msgBox.ClickAnywhereToClose = true;
-                    msgBox.Show();
-
-                    // Refill magicka
-                    player.CurrentMagicka = player.MaxMagicka;
-                }
-            }
             // Check access to service
             if (!guild.CanAccessService(service))
             {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -198,23 +198,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 DaggerfallUI.MessageBox(350);
             }
             // Check for magicka restoration (sorcerers)
-            if (guild.GetFactionId() == (int)FactionFile.FactionIDs.The_Mages_Guild 
-                && playerEntity.Career.NoRegenSpellPoints)
+            if (guild.FreeMagickaRecharge() && playerEntity.CurrentMagicka < playerEntity.MaxMagicka)
             {
-                if (playerEntity.CurrentMagicka < playerEntity.MaxMagicka)
-                {
-                    DaggerfallMessageBox msgBox = new DaggerfallMessageBox(uiManager, this);
-                    msgBox.SetText("It is customary for the guild to recharge the magicka of sorcerors.");
-                    //TODO: find ID for GetRandomTokens to replace SetTextMessage above.  
-                    // There's one other message that gets used: 
-                    // "I see your magicka is low. You sorcerors really need to be more careful. Here, let me recharge you."  
-                    //msgBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRandomTokens(RefillMagickaID));
-                    msgBox.ClickAnywhereToClose = true;
-                    msgBox.Show();
+                DaggerfallMessageBox msgBox = new DaggerfallMessageBox(uiManager, this);
+                msgBox.SetText("It is customary for the guild to recharge the magicka of sorcerors.");
+                //TODO: find ID for GetRandomTokens to replace SetTextMessage above.  
+                msgBox.ClickAnywhereToClose = true;
+                msgBox.Show();
 
-                    // Refill magicka
-                    playerEntity.SetMagicka(playerEntity.MaxMagicka);
-                }
+                // Refill magicka
+                playerEntity.SetMagicka(playerEntity.MaxMagicka);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -220,6 +220,24 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ServiceButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            if (guild.GetFactionId() == (int)FactionFile.FactionIDs.The_Mages_Guild 
+                && GameManager.Instance.PlayerEntity.Career.NoRegenSpellPoints)
+            {
+                if (GameManager.Instance.PlayerEntity.CurrentMagicka < GameManager.Instance.PlayerEntity.MaxMagicka)
+                {
+                    DaggerfallMessageBox msgBox = new DaggerfallMessageBox(uiManager, this);
+                    msgBox.SetText("It is customary for the guild to recharge the magicka of sorcerors.");
+                    //TODO: find ID for GetRandomTokens to replace SetTextMessage above.  
+                    // There's one other message that gets used: 
+                    // "I see your magicka is low. You sorcerors really need to be more careful. Here, let me recharge you."  
+                    //msgBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRandomTokens(RefillMagickaID));
+                    msgBox.ClickAnywhereToClose = true;
+                    msgBox.Show();
+
+                    // Refill magicka
+                    GameManager.Instance.PlayerEntity.CurrentMagicka = GameManager.Instance.PlayerEntity.MaxMagicka;
+                }
+            }
             // Check access to service
             if (!guild.CanAccessService(service))
             {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -414,7 +414,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             int healthRecoveryRate = FormulaHelper.CalculateHealthRecoveryRate(playerEntity);
             int fatigueRecoveryRate = FormulaHelper.CalculateFatigueRecoveryRate(playerEntity.MaxFatigue);
-            int spellPointRecoveryRate = FormulaHelper.CalculateSpellPointRecoveryRate(playerEntity.MaxMagicka);
+            int spellPointRecoveryRate = FormulaHelper.CalculateSpellPointRecoveryRate(playerEntity);
 
             playerEntity.CurrentHealth += healthRecoveryRate;
             playerEntity.CurrentFatigue += fatigueRecoveryRate;
@@ -432,7 +432,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // For example, sorcerers cannot recover magicka from resting
             if (playerEntity.CurrentHealth == playerEntity.MaxHealth &&
                 playerEntity.CurrentFatigue == playerEntity.MaxFatigue &&
-                playerEntity.CurrentMagicka == playerEntity.MaxMagicka)
+                (playerEntity.CurrentMagicka == playerEntity.MaxMagicka || playerEntity.Career.NoRegenSpellPoints))
             {
                 return true;
             }


### PR DESCRIPTION
If the player has the NoRegenSpellPoints career property set to true:

->Spell points no longer recover when resting.
->Rest until fully healed doesn't require full magicka.
->The player can recharge spell points at mages guild by clicking any service like in classic.

@Nystul-the-Magician The TextProvider ID is needed for following messages so they can be used in TextProvider.GetRandomTokens.  Do you know the ID?

-> I see your magicka is low. You sorcerors really need to be more careful. Here, let me recharge you.
-> It is customary for the guild to recharge the magicka of sorcerors.

msgbox.SetText is used as a makeshift solution until the GetRandomTokens approach is used.