### PR TITLE
Height changer adjustments and partial swim implementation

### DIFF
--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -45,8 +45,9 @@ namespace DaggerfallWorkshop.Game
         /// <param name="moveDirection"></param>
         public void HandleJumpInput(ref Vector3 moveDirection)
         {
-            // Cancel jump if player is paralyzed
-            if (GameManager.Instance.PlayerEntity.IsParalyzed)
+            // Cancel jump if player is paralyzed or on a water tile
+            if (GameManager.Instance.PlayerEntity.IsParalyzed ||
+                GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 0)
                 return;
 
             if (InputManager.Instance.HasAction(InputManager.Actions.Jump))

--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -117,6 +117,9 @@ namespace DaggerfallWorkshop.Game
             if (falling)
             {
                 falling = false;
+                // don't take damage if landing in outdoor water
+                if (GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 0)
+                    return;
                 float fallDistance = fallStartLevel - myTransform.position.y;
                 if (fallDistance > fallingDamageThreshold)
                     FallingDamageAlert(fallDistance);

--- a/Assets/Scripts/Game/Player/HeadBobber.cs
+++ b/Assets/Scripts/Game/Player/HeadBobber.cs
@@ -13,11 +13,13 @@ namespace DaggerfallWorkshop.Game
         Crouching,
         Walking,
         Running,
-        Horse
+        Horse,
+        Swimming
     }
 
     [RequireComponent(typeof(CharacterController))]
     [RequireComponent(typeof(PlayerFootsteps))]
+    [RequireComponent(typeof(PlayerEnterExit))]
     public class HeadBobber : MonoBehaviour
     {
         private BobbingStyle bobStyle = BobbingStyle.Walking;
@@ -27,6 +29,7 @@ namespace DaggerfallWorkshop.Game
         }
         private PlayerMotor playerMotor;
         private Camera mainCamera;
+        private PlayerEnterExit playerEnterExit;
 
         private Vector3 restPos; //local position where your camera would rest when it's not bobbing.
         public Vector3 RestPos
@@ -53,6 +56,7 @@ namespace DaggerfallWorkshop.Game
         void Start()
         {
             playerMotor = GetComponent<PlayerMotor>();
+            playerEnterExit = GetComponent<PlayerEnterExit>();
             
             mainCamera = GameManager.Instance.MainCamera;
             restPos = mainCamera.transform.localPosition;
@@ -80,7 +84,9 @@ namespace DaggerfallWorkshop.Game
 
         protected void GetBobbingStyle()
         {
-            if (playerMotor.IsRunning)
+            if (playerEnterExit.IsPlayerSwimming)
+                bobStyle = BobbingStyle.Swimming;
+            else if (playerMotor.IsRunning)
                 bobStyle = BobbingStyle.Running;
             else if (playerMotor.IsCrouching)
                 bobStyle = BobbingStyle.Crouching;
@@ -123,6 +129,13 @@ namespace DaggerfallWorkshop.Game
                     bobYAmount = 0.115f * bobScalar;
                     nodXAmount = 0.2f;
                     nodYAmount = 0.1f;
+                    break;
+                case BobbingStyle.Swimming:
+                    // lots of swaying side to side
+                    bobXAmount = 0.02f * bobScalar;
+                    bobYAmount = 0.12f * bobScalar;
+                    nodXAmount = -0.3f;
+                    nodYAmount = -0.2f;
                     break;
                 default:
                     // error

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -25,6 +25,7 @@ namespace DaggerfallWorkshop.Game
     [RequireComponent(typeof(PlayerMotor))]
     [RequireComponent(typeof(CharacterController))]
     [RequireComponent(typeof(HeadBobber))]
+    [RequireComponent(typeof(LevitateMotor))]
     public class PlayerHeightChanger : MonoBehaviour
     {
         private HeightChangeAction heightAction;
@@ -44,6 +45,7 @@ namespace DaggerfallWorkshop.Game
         private PlayerMotor playerMotor;
         private CharacterController controller;
         private HeadBobber headBobber;
+        private LevitateMotor levitateMotor;
         private Camera mainCamera;
         private float controllerStandHeight = 1.78f;
         private float controllerCrouchHeight = 0.45f;
@@ -74,6 +76,7 @@ namespace DaggerfallWorkshop.Game
             controller = GetComponent<CharacterController>();
             headBobber = GetComponent<HeadBobber>();
             mainCamera = GameManager.Instance.MainCamera;
+            levitateMotor = GetComponent<LevitateMotor>();
             camSwimLevel = controllerSwimHeight / 2f;
             camCrouchLevel = controllerCrouchHeight / 2f;
             camStandLevel = controllerStandHeight / 2f;
@@ -272,6 +275,7 @@ namespace DaggerfallWorkshop.Game
                 controllerSink = false;
                 IsInWaterTile = false;
                 playerMotor.IsCrouching = false;
+                GameManager.Instance.PlayerEnterExit.IsPlayerSwimming = false;
             }
 
             timerTick();
@@ -316,6 +320,7 @@ namespace DaggerfallWorkshop.Game
                 controllerSink = true;
                 IsInWaterTile = true;
                 playerMotor.IsCrouching = false;
+                GameManager.Instance.PlayerEnterExit.IsPlayerSwimming = true;
             }
 
             timerTick();

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -19,7 +19,6 @@ namespace DaggerfallWorkshop.Game
         DoDismounting
     }
 
-    //Added the RequireComponent attribute to make sure that following components are indeed on this GameObject, since they are require to make this code work
     [RequireComponent(typeof(PlayerMotor))]
     [RequireComponent(typeof(CharacterController))]
     [RequireComponent(typeof(HeadBobber))]
@@ -45,10 +44,11 @@ namespace DaggerfallWorkshop.Game
         private float camStandLevel;
         private float camRideLevel;
         private float camTimer;
-        private bool toggleRiding;
-        private bool controllerMounted;
         private const float timerMax = 0.1f;
         private float camLerp_T;  // for lerping to new camera position
+        private bool toggleRiding;
+        private bool controllerMounted;
+
 
         private void Start()
         {
@@ -186,22 +186,37 @@ namespace DaggerfallWorkshop.Game
         #endregion
 
         #region Helpers
+        /// <summary>
+        /// Increment timer and camera LERP T value
+        /// </summary>
         private void timerTick()
         {
             camTimer += Time.deltaTime;
             camLerp_T = Mathf.Clamp((camTimer / timerMax), 0, 1);
         }
+        /// <summary>
+        /// Reset the camera timer and action
+        /// </summary>
         private void timerResetAction()
         {
             camTimer = 0f;
             heightAction = HeightChangeAction.DoNothing;
         }
+        /// <summary>
+        /// Set new camera position
+        /// </summary>
+        /// <param name="yPosMod">Y amount to change camera position</param>
         private void UpdateCameraPosition(float yPosMod)
         {
             Vector3 camPos = mainCamera.transform.localPosition;
             headBobber.RestPos = new Vector3(headBobber.RestPos.x, yPosMod);
             mainCamera.transform.localPosition = new Vector3(camPos.x, yPosMod, camPos.z);
         }
+        /// <summary>
+        /// Change controller height and position
+        /// </summary>
+        /// <param name="heightChange">Amount to modify controller height</param>
+        /// <param name="camChangeAmt">Amount to change controller position</param>
         private void ControllerHeightChange(float heightChange, float camChangeAmt)
         {
             controller.height += heightChange;
@@ -221,6 +236,7 @@ namespace DaggerfallWorkshop.Game
         }
         #endregion
 
+        #region Load Game Handling
         /// <summary>
         /// Immediately crouch/stand to match crouch state.
         /// </summary>
@@ -248,5 +264,6 @@ namespace DaggerfallWorkshop.Game
             controllerMounted = playerMotor.IsRiding;
             SnapToggleCrouching();
         }
+        #endregion
     }
 }

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System;
+using UnityEngine.Assertions;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -37,12 +38,14 @@ namespace DaggerfallWorkshop.Game
         private float controllerStandHeight = 1.78f;
         private float controllerCrouchHeight = 0.45f;
         private float controllerRideHeight = 2.6f;   // Height of a horse plus seated rider. (1.6m + 1m)
+        private float controllerSwimHeight = 0.30f;
         private float eyeHeight = 0.09f;         // Eye height is 9cm below top of capsule.
         private float camCrouchToStandDist;
         private float camRideToStandDist;
         private float camCrouchLevel;
         private float camStandLevel;
         private float camRideLevel;
+        private float camSwimLevel;
         private float camTimer;
         private const float timerMax = 0.1f;
         private float camLerp_T;  // for lerping to new camera position
@@ -61,6 +64,7 @@ namespace DaggerfallWorkshop.Game
             camCrouchLevel = controllerCrouchHeight / 2f;
             camStandLevel = controllerStandHeight / 2f;
             camRideLevel = controllerRideHeight / 2f - eyeHeight;
+            camSwimLevel = controllerSwimHeight / 2f;
 
             // Use event to set whether player is crouched on load
             SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
@@ -187,6 +191,28 @@ namespace DaggerfallWorkshop.Game
 
         #region Helpers
         /// <summary>
+        /// Anti-floating point roundoff
+        /// </summary>
+        /// <param name="value">The value to evaluate</param>
+        /// <returns></returns>
+        private float GetNearbyValue(float value)
+        {
+            if (CloseEnough(value, controllerStandHeight))
+                return controllerStandHeight;
+            else if (CloseEnough(value, controllerCrouchHeight))
+                return controllerCrouchHeight;
+            else if (CloseEnough(value, controllerRideHeight))
+                return controllerRideHeight;
+            else if (CloseEnough(value, controllerSwimHeight))
+                return controllerSwimHeight;
+
+            return 0;
+    }
+        private bool CloseEnough(float value1, float value2, float acceptableDifference = 0.01f)
+        {
+            return Math.Abs(value1 - value2) <= acceptableDifference;
+        }
+        /// <summary>
         /// Increment timer and camera LERP T value
         /// </summary>
         private void timerTick()
@@ -219,7 +245,7 @@ namespace DaggerfallWorkshop.Game
         /// <param name="camChangeAmt">Amount to change controller position</param>
         private void ControllerHeightChange(float heightChange, float camChangeAmt)
         {
-            controller.height += heightChange;
+            controller.height = GetNearbyValue(controller.height + heightChange);
             controller.transform.position += new Vector3(0, camChangeAmt);
         }
 

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -39,8 +39,6 @@ namespace DaggerfallWorkshop.Game
         private float controllerCrouchHeight = 0.45f;
         private float controllerRideHeight = 2.6f;   // Height of a horse plus seated rider. (1.6m + 1m)
         private float eyeHeight = 0.09f;         // Eye height is 9cm below top of capsule.
-        //private float controllerStandToCrouchDist;
-        //private float controllerStandtoRideDist;
         private float camCrouchToStandDist;
         private float camRideToStandDist;
         private float camCrouchLevel;
@@ -97,7 +95,9 @@ namespace DaggerfallWorkshop.Game
 
                 
         }
-
+        /// <summary>
+        /// Continue calling actions to increment camera towards destination.
+        /// </summary>
         private void Update()
         {
             if (heightAction == HeightChangeAction.DoNothing)
@@ -113,6 +113,7 @@ namespace DaggerfallWorkshop.Game
                 DoDismount();
         }
 
+        #region HeightChangerActions
         private void DoCrouch() // first lower camera, Controller height last 
         {
             timerTick();
@@ -124,7 +125,7 @@ namespace DaggerfallWorkshop.Game
                 ControllerHeightChange(controllerCrouchHeight - controllerStandHeight, -1 * camCrouchToStandDist);
                 UpdateCameraPosition(mainCamera.transform.localPosition.y + camCrouchToStandDist);
 
-                ResetTimerAction();
+                timerResetAction();
                 playerMotor.IsCrouching = true;
             }
         }
@@ -141,7 +142,7 @@ namespace DaggerfallWorkshop.Game
 
             if (camTimer >= timerMax)
             {
-                ResetTimerAction();
+                timerResetAction();
             }
         }
         private void DoMount() // adjust height first, camera last
@@ -161,7 +162,7 @@ namespace DaggerfallWorkshop.Game
 
             if (camTimer >= timerMax)
             {
-                ResetTimerAction();
+                timerResetAction();
             }
         }
         private void DoDismount() // adjust height first, camera last
@@ -179,15 +180,18 @@ namespace DaggerfallWorkshop.Game
 
             if (camTimer >= timerMax)
             {
-                ResetTimerAction();
+                timerResetAction();
             }
         }
+        #endregion
+
+        #region Helpers
         private void timerTick()
         {
             camTimer += Time.deltaTime;
             camLerp_T = Mathf.Clamp((camTimer / timerMax), 0, 1);
         }
-        private void ResetTimerAction()
+        private void timerResetAction()
         {
             camTimer = 0f;
             heightAction = HeightChangeAction.DoNothing;
@@ -215,7 +219,11 @@ namespace DaggerfallWorkshop.Game
             Ray ray = new Ray(controller.transform.position, Vector3.up); 
             return !Physics.SphereCast(ray, controller.radius, distance);
         }
+        #endregion
 
+        /// <summary>
+        /// Immediately crouch/stand to match crouch state.
+        /// </summary>
         private void SnapToggleCrouching()
         {
             if (playerMotor.IsCrouching && controller.height != controllerCrouchHeight)

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -63,7 +63,10 @@ namespace DaggerfallWorkshop.Game
         private float camCrouchToStandDist;
         private float camStandToRideDist;
         private float camTimer;
-        private const float timerMax = 0.1f;
+        private const float timerFast = 0.10f;
+        private const float timerMedium = 0.25f;
+        private const float timerSlow = 0.4f;
+        private float timerMax = 0.1f;
         private float camLerp_T;  // for lerping to new camera position
         private bool toggleRiding;
         private bool toggleSink;
@@ -95,6 +98,7 @@ namespace DaggerfallWorkshop.Game
         public void DecideHeightAction()
         {
             bool onWater = OnWater;
+            timerMax = timerSlow;
             if (onWater && !toggleSink)
             {
                 heightAction = HeightChangeAction.DoSinking;
@@ -127,6 +131,34 @@ namespace DaggerfallWorkshop.Game
                 }
             }  
         }
+
+        private void SetChangeSpeed(HeightChangeAction action)
+        {
+            switch (action)
+            {
+                case HeightChangeAction.DoNothing:
+                    timerMax = timerSlow;
+                    break;
+                case HeightChangeAction.DoCrouching:
+                    timerMax = timerFast;
+                    break;
+                case HeightChangeAction.DoStanding:
+                    timerMax = timerFast;
+                    break;
+                case HeightChangeAction.DoMounting:
+                    timerMax = timerMedium;
+                    break;
+                case HeightChangeAction.DoDismounting:
+                    timerMax = timerFast;
+                    break;
+                case HeightChangeAction.DoSinking:
+                    timerMax = timerSlow;
+                    break;
+                case HeightChangeAction.DoUnsinking:
+                    timerMax = timerSlow;
+                    break;
+            }
+        }
         /// <summary>
         /// Continue calling actions to increment camera towards destination.
         /// </summary>
@@ -134,6 +166,8 @@ namespace DaggerfallWorkshop.Game
         {
             if (heightAction == HeightChangeAction.DoNothing || GameManager.IsGamePaused)
                 return;
+
+            SetChangeSpeed(heightAction);
             if (heightAction == HeightChangeAction.DoSinking)
                 DoSinking();
             else if (heightAction == HeightChangeAction.DoUnsinking)

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -428,11 +428,11 @@ namespace DaggerfallWorkshop.Game
             PlayerPositionData_v1 savePos = saveData.playerData.playerPosition;
 
             // save is crouched
-            if (!savePos.isCrouching)
+            if (!savePos.isCrouching && playerMotor.IsCrouching)
             {
                 heightAction = HeightChangeAction.DoStanding;
             }
-            else if (savePos.isCrouching)
+            else if (savePos.isCrouching && !playerMotor.IsCrouching)
             {
                 heightAction = HeightChangeAction.DoCrouching;
             }              

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -382,7 +382,6 @@ namespace DaggerfallWorkshop.Game
                     eyeChange = eyeHeight;
             }
             controller.transform.position += new Vector3(0, heightChange / 2 + eyeChange);
-            //Debug.LogFormat("IsGrounded = {0}, \nHeight = {1}", playerMotor.IsGrounded, controller.height);
 
             return controller.height / 2 + eyeChange;
         }

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -35,18 +35,22 @@ namespace DaggerfallWorkshop.Game
         private CharacterController controller;
         private HeadBobber headBobber;
         private Camera mainCamera;
-        public float standHeight = 1.78f;
-        public float crouchHeight = 0.45f;
-        private float rideHeight = 2.6f;   // Height of a horse plus seated rider. (1.6m + 1m)
+        private float controllerStandHeight = 1.78f;
+        private float controllerCrouchHeight = 0.45f;
+        private float controllerRideHeight = 2.6f;   // Height of a horse plus seated rider. (1.6m + 1m)
         private float eyeHeight = 0.09f;         // Eye height is 9cm below top of capsule.
-        private float crouchChangeDistance;
-        //private float rideChangeDistance;
+        //private float controllerStandToCrouchDist;
+        //private float controllerStandtoRideDist;
+        private float camCrouchToStandDist;
+        private float camRideToStandDist;
         private float camCrouchLevel;
         private float camStandLevel;
         private float camRideLevel;
-        private float heightTimer;
+        private float camTimer;
         private bool toggleRiding;
+        private bool controllerMounted;
         private const float timerMax = 0.1f;
+        private float camLerp_T;  // for lerping to new camera position
 
         private void Start()
         {
@@ -54,11 +58,11 @@ namespace DaggerfallWorkshop.Game
             controller = GetComponent<CharacterController>();
             headBobber = GetComponent<HeadBobber>();
             mainCamera = GameManager.Instance.MainCamera;
-            crouchChangeDistance = (standHeight - crouchHeight) / 2f;
-            //rideChangeDistance = (rideHeight - standHeight) / 2f - eyeHeight;
-            camCrouchLevel = crouchHeight / 2f;
-            camStandLevel = standHeight / 2f;
-            camRideLevel = rideHeight / 2f - eyeHeight;
+            camCrouchToStandDist = (controllerStandHeight - controllerCrouchHeight) / 2f;
+            camRideToStandDist = (controllerRideHeight - controllerStandHeight) / 2f - eyeHeight;
+            camCrouchLevel = controllerCrouchHeight / 2f;
+            camStandLevel = controllerStandHeight / 2f;
+            camRideLevel = controllerRideHeight / 2f - eyeHeight;
 
             // Use event to set whether player is crouched on load
             SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
@@ -111,110 +115,93 @@ namespace DaggerfallWorkshop.Game
 
         private void DoCrouch() // first lower camera, Controller height last 
         {
-            heightTimer += Time.deltaTime;
-            float t = Mathf.Clamp((heightTimer / timerMax), 0, 1);
+            timerTick();
 
-            UpdateCameraPosition(Mathf.Lerp(camStandLevel, camCrouchLevel, t));
+            UpdateCameraPosition(Mathf.Lerp(camStandLevel, camCrouchLevel, camLerp_T));
 
-            if (heightTimer >= timerMax)
+            if (camTimer >= timerMax)
             {
-                ControllerHeightChange();
-                UpdateCameraPosition(mainCamera.transform.localPosition.y + crouchChangeDistance);
+                ControllerHeightChange(controllerCrouchHeight - controllerStandHeight, -1 * camCrouchToStandDist);
+                UpdateCameraPosition(mainCamera.transform.localPosition.y + camCrouchToStandDist);
 
-                heightTimer = 0f;
-                heightAction = HeightChangeAction.DoNothing;
+                ResetTimerAction();
+                playerMotor.IsCrouching = true;
             }
         }
         private void DoStand() // adjust height first, camera last
         {
-            if (controller.height == crouchHeight)
-                ControllerHeightChange();
-
-            heightTimer += Time.deltaTime;
-            float t = Mathf.Clamp((heightTimer / timerMax), 0, 1);
-           
-            UpdateCameraPosition(Mathf.Lerp(camCrouchLevel, camStandLevel, t));
-
-            if (heightTimer >= timerMax)
+            if (playerMotor.IsCrouching)
             {
-                heightTimer = 0f;
-                heightAction = HeightChangeAction.DoNothing;
+                ControllerHeightChange(controllerStandHeight - controllerCrouchHeight, camCrouchToStandDist);
+                playerMotor.IsCrouching = false;
+            }
+            timerTick();
+
+            UpdateCameraPosition(Mathf.Lerp(camCrouchLevel, camStandLevel, camLerp_T));
+
+            if (camTimer >= timerMax)
+            {
+                ResetTimerAction();
             }
         }
         private void DoMount() // adjust height first, camera last
         {
-            if (controller.height != rideHeight)
-                ControllerHeightChange();
+            float prevControllerHeight = playerMotor.IsCrouching ? controllerCrouchHeight : controllerStandHeight;
+            if (!controllerMounted)
+            { 
+                ControllerHeightChange(controllerRideHeight - prevControllerHeight, camRideToStandDist);
+                controllerMounted = true;
+                playerMotor.IsCrouching = false;
+            }
 
-            heightTimer += Time.deltaTime;
-            float t = Mathf.Clamp((heightTimer / timerMax), 0, 1);
+            timerTick();
 
             float prevCamLevel = playerMotor.IsCrouching ? camCrouchLevel : camStandLevel;
-            UpdateCameraPosition(Mathf.Lerp(prevCamLevel, camRideLevel, t));
+            UpdateCameraPosition(Mathf.Lerp(prevCamLevel, camRideLevel, camLerp_T));
 
-            if (heightTimer >= timerMax)
+            if (camTimer >= timerMax)
             {
-                heightTimer = 0f;
-                heightAction = HeightChangeAction.DoNothing;
-                playerMotor.IsRiding = true;
+                ResetTimerAction();
             }
         }
         private void DoDismount() // adjust height first, camera last
         {
-            if (controller.height == rideHeight)
-                ControllerHeightChange();
-
-            heightTimer += Time.deltaTime;
-            float t = Mathf.Clamp((heightTimer / timerMax), 0, 1);
-
-            UpdateCameraPosition(Mathf.Lerp(camRideLevel, camStandLevel, t));
-
-            if (heightTimer >= timerMax)
+            if (controllerMounted)
             {
-                heightTimer = 0f;
-                heightAction = HeightChangeAction.DoNothing;
-                playerMotor.IsRiding = false;
+                ControllerHeightChange(controllerStandHeight - controllerRideHeight, -1 * camRideToStandDist);
+                controllerMounted = false;
+                playerMotor.IsCrouching = false;
+            }
+
+            timerTick();
+
+            UpdateCameraPosition(Mathf.Lerp(camRideLevel, camStandLevel, camLerp_T));
+
+            if (camTimer >= timerMax)
+            {
+                ResetTimerAction();
             }
         }
-
+        private void timerTick()
+        {
+            camTimer += Time.deltaTime;
+            camLerp_T = Mathf.Clamp((camTimer / timerMax), 0, 1);
+        }
+        private void ResetTimerAction()
+        {
+            camTimer = 0f;
+            heightAction = HeightChangeAction.DoNothing;
+        }
         private void UpdateCameraPosition(float yPosMod)
         {
             Vector3 camPos = mainCamera.transform.localPosition;
             headBobber.RestPos = new Vector3(headBobber.RestPos.x, yPosMod);
             mainCamera.transform.localPosition = new Vector3(camPos.x, yPosMod, camPos.z);
         }
-
-        private void ControllerHeightChange()
+        private void ControllerHeightChange(float heightChange, float camChangeAmt)
         {
-            if (heightAction == HeightChangeAction.DoCrouching)
-            {
-                controller.height = crouchHeight;
-                controller.transform.position -= new Vector3(0, crouchChangeDistance);
-                playerMotor.IsCrouching = true;
-            }
-            else if (heightAction == HeightChangeAction.DoStanding)
-            {
-                controller.height = standHeight;
-                controller.transform.position += new Vector3(0, crouchChangeDistance);
-                playerMotor.IsCrouching = false;
-            }
-            else if (heightAction == HeightChangeAction.DoMounting)
-            {
-                controller.height = rideHeight;
-                Vector3 pos = controller.transform.position;
-                float prevHeight = playerMotor.IsCrouching ? crouchHeight : standHeight;
-                pos.y += (rideHeight - prevHeight) / 2.0f;
-                controller.transform.position = pos;
-                playerMotor.IsCrouching = false;
-            }
-            else if (heightAction == HeightChangeAction.DoDismounting)
-            {
-                controller.height = standHeight;
-                Vector3 pos = controller.transform.position;
-                pos.y -= (rideHeight - standHeight) / 2.0f;
-                controller.transform.position = pos;
-                playerMotor.IsCrouching = false;
-            }
+            controller.height += heightChange;
+            controller.transform.position += new Vector3(0, camChangeAmt);
         }
 
         /// <summary>
@@ -223,7 +210,7 @@ namespace DaggerfallWorkshop.Game
         /// <returns>returns true if enough room</returns>
         private bool CanStand()
         { 
-            float distance = crouchChangeDistance;
+            float distance = camCrouchToStandDist;
 
             Ray ray = new Ray(controller.transform.position, Vector3.up); 
             return !Physics.SphereCast(ray, controller.radius, distance);
@@ -231,18 +218,18 @@ namespace DaggerfallWorkshop.Game
 
         private void SnapToggleCrouching()
         {
-            if (playerMotor.IsCrouching && controller.height != crouchHeight)
+            if (playerMotor.IsCrouching && controller.height != controllerCrouchHeight)
             {
-                controller.height = crouchHeight;
+                controller.height = controllerCrouchHeight;
                 Vector3 pos = controller.transform.position;
-                pos.y -= (standHeight - crouchHeight) / 2.0f;
+                pos.y -= (controllerStandHeight - controllerCrouchHeight) / 2.0f;
                 controller.transform.position = pos;
             }
-            else if (!playerMotor.IsCrouching && controller.height != standHeight)
+            else if (!playerMotor.IsCrouching && controller.height != controllerStandHeight)
             {
-                controller.height = standHeight;
+                controller.height = controllerStandHeight;
                 Vector3 pos = controller.transform.position;
-                pos.y += (standHeight - crouchHeight) / 2.0f;
+                pos.y += (controllerStandHeight - controllerCrouchHeight) / 2.0f;
                 controller.transform.position = pos;
             }
         }
@@ -250,6 +237,7 @@ namespace DaggerfallWorkshop.Game
         private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
         {
             playerMotor.IsCrouching = saveData.playerData.playerPosition.isCrouching;
+            controllerMounted = playerMotor.IsRiding;
             SnapToggleCrouching();
         }
     }

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -42,12 +42,13 @@ namespace DaggerfallWorkshop.Game
         private float controllerRideHeight = 2.6f;   // Height of a horse plus seated rider. (1.6m + 1m)
         private float controllerSwimHeight = 0.30f;
         private float eyeHeight = 0.09f;         // Eye height is 9cm below top of capsule.
-        private float camCrouchToStandDist;
-        private float camRideToStandDist;
         private float camCrouchLevel;
         private float camStandLevel;
         private float camRideLevel;
         private float camSwimLevel;
+        private float camSwimToCrouchDist;
+        private float camCrouchToStandDist;
+        private float camStandToRideDist;
         private float camTimer;
         private const float timerMax = 0.1f;
         private float camLerp_T;  // for lerping to new camera position
@@ -61,12 +62,13 @@ namespace DaggerfallWorkshop.Game
             controller = GetComponent<CharacterController>();
             headBobber = GetComponent<HeadBobber>();
             mainCamera = GameManager.Instance.MainCamera;
-            camCrouchToStandDist = (controllerStandHeight - controllerCrouchHeight) / 2f;
-            camRideToStandDist = (controllerRideHeight - controllerStandHeight) / 2f;
+            camSwimLevel = controllerSwimHeight / 2f;
             camCrouchLevel = controllerCrouchHeight / 2f;
             camStandLevel = controllerStandHeight / 2f;
             camRideLevel = controllerRideHeight / 2f - eyeHeight;
-            camSwimLevel = controllerSwimHeight / 2f;
+            camSwimToCrouchDist = (controllerCrouchHeight - controllerSwimHeight) / 2f;
+            camCrouchToStandDist = (controllerStandHeight - controllerCrouchHeight) / 2f;
+            camStandToRideDist = (controllerRideHeight - controllerStandHeight) / 2f;
 
             // Use event to set whether player is crouched on load
             SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
@@ -156,7 +158,7 @@ namespace DaggerfallWorkshop.Game
             if (!controllerMounted)
             {
                 float height = controllerRideHeight - (playerMotor.IsCrouching ? controllerCrouchHeight : controllerStandHeight);
-                float camDist = playerMotor.IsCrouching ? camRideToStandDist + camCrouchToStandDist : camRideToStandDist;
+                float camDist = playerMotor.IsCrouching ? camStandToRideDist + camCrouchToStandDist : camStandToRideDist;
                 ControllerHeightChange(height, camDist);
                 controllerMounted = true;
                 playerMotor.IsCrouching = false;
@@ -176,7 +178,7 @@ namespace DaggerfallWorkshop.Game
         {
             if (controllerMounted)
             {
-                ControllerHeightChange(controllerStandHeight - controllerRideHeight, -1 * camRideToStandDist);
+                ControllerHeightChange(controllerStandHeight - controllerRideHeight, -1 * camStandToRideDist);
                 controllerMounted = false;
                 playerMotor.IsCrouching = false;
             }

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -142,6 +142,7 @@ namespace DaggerfallWorkshop.Game
         public bool IsPlayerSwimming
         {
             get { return isPlayerSwimming; }
+            set { isPlayerSwimming = value; }
         }
 
         /// <summary>
@@ -307,7 +308,8 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 // Clear flags when not in a dungeon
-                isPlayerSwimming = false;
+                // commenting this out allows player to swim outside - MeteoricDragon
+                //isPlayerSwimming = false;
                 isPlayerSubmerged = false;
                 levitateMotor.IsSwimming = false;
             }

--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -59,6 +59,7 @@ namespace DaggerfallWorkshop.Game
         SoundClips currentFootstepSound2 = SoundClips.None;
         DaggerfallDateTime.Seasons currentSeason = DaggerfallDateTime.Seasons.Summer;
         bool isInside = false;
+        bool isInOutsideWater = false;
 
         void Start()
         {
@@ -91,12 +92,14 @@ namespace DaggerfallWorkshop.Game
             // Can only do this when PlayerEnterExit is available, otherwise default to true
             bool playerInside = (playerEnterExit == null) ? true : playerEnterExit.IsPlayerInside;
             bool playerInBuilding = (playerEnterExit == null) ? false : playerEnterExit.IsPlayerInsideBuilding;
+            bool playerSwimmingOutside = (GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 0 && playerMotor.IsGrounded);
 
             // Change footstep sounds between winter/summer variants or when player enters/exits an interior space
-            if (dfUnity.WorldTime.Now.SeasonValue != currentSeason || isInside != playerInside)
+            if (dfUnity.WorldTime.Now.SeasonValue != currentSeason || isInside != playerInside || playerSwimmingOutside != isInOutsideWater)
             {
                 currentSeason = dfUnity.WorldTime.Now.SeasonValue;
                 isInside = playerInside;
+                isInOutsideWater = playerSwimmingOutside;
                 if (!isInside)
                     if (currentSeason == DaggerfallDateTime.Seasons.Winter)
                     {
@@ -123,6 +126,15 @@ namespace DaggerfallWorkshop.Game
                 clip2 = null;
             }
 
+            // walking on water tile
+            if (playerSwimmingOutside)
+            {
+                currentFootstepSound1 = FootstepSoundSubmerged;
+                currentFootstepSound2 = FootstepSoundSubmerged;
+                clip1 = null;
+                clip2 = null;
+            }
+
             // Use water sounds if in water
             if (playerEnterExit.blockWaterLevel != 10000)
             {
@@ -145,7 +157,8 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Not in water, reset footsteps to normal
-            if ((currentFootstepSound1 == FootstepSoundSubmerged || currentFootstepSound1 == FootstepSoundShallow)
+            if ((!playerSwimmingOutside) 
+                && (currentFootstepSound1 == FootstepSoundSubmerged || currentFootstepSound1 == FootstepSoundShallow)
                 && (playerEnterExit.blockWaterLevel == 10000 || (playerMotor.transform.position.y - 0.95f) >= (playerEnterExit.blockWaterLevel * -1 * MeshReader.GlobalScale)))
             {
                 currentFootstepSound1 = FootstepSoundDungeon1;

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -247,7 +247,7 @@ namespace DaggerfallWorkshop.Game
             speed = speedChanger.GetBaseSpeed();
             speedChanger.HandleInputSpeedAdjustment(ref speed);
 
-            heightChanger.HandlePlayerInput();
+            heightChanger.DecideHeightAction();
 
             UpdateSmoothFollower();
         }

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -52,6 +52,7 @@ namespace DaggerfallWorkshop.Game
         private FrictionMotor frictionMotor;
         private AcrobatMotor acrobatMotor;
         private PlayerGroundMotor groundMotor;
+        private PlayerEnterExit playerEnterExit;
 
         private CollisionFlags collisionFlags = 0;
 
@@ -158,6 +159,7 @@ namespace DaggerfallWorkshop.Game
             levitateMotor = GetComponent<LevitateMotor>();
             frictionMotor = GetComponent<FrictionMotor>();
             acrobatMotor = GetComponent<AcrobatMotor>();
+            playerEnterExit = GameManager.Instance.PlayerEnterExit;
 
             // Allow for resetting specific player state on new game or when game starts loading
             SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
@@ -246,6 +248,8 @@ namespace DaggerfallWorkshop.Game
 
             speed = speedChanger.GetBaseSpeed();
             speedChanger.HandleInputSpeedAdjustment(ref speed);
+            if (playerEnterExit.IsPlayerSwimming)
+                speed = speedChanger.GetSwimSpeed(speed);
 
             heightChanger.DecideHeightAction();
 

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -204,7 +204,6 @@ namespace DaggerfallWorkshop.Game.Serialization
         public float yaw;
         public float pitch;
         public bool isCrouching;
-        public bool isInWaterTile;
         public int worldPosX;
         public int worldPosZ;
         public bool insideDungeon;

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -204,6 +204,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public float yaw;
         public float pitch;
         public bool isCrouching;
+        public bool isInWaterTile;
         public int worldPosX;
         public int worldPosZ;
         public bool insideDungeon;

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -176,6 +176,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public PlayerPositionData_v1 GetPlayerPositionData()
         {
             PlayerPositionData_v1 playerPosition = new PlayerPositionData_v1();
+            PlayerHeightChanger heightChanger = GetComponent<PlayerHeightChanger>();
             playerPosition.position = transform.position;
             playerPosition.worldCompensation = GameManager.Instance.StreamingWorld.WorldCompensation;
             playerPosition.worldContext = playerEnterExit.WorldContext;
@@ -183,6 +184,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             playerPosition.yaw = playerMouseLook.Yaw;
             playerPosition.pitch = playerMouseLook.Pitch;
             playerPosition.isCrouching = playerMotor.IsCrouching;
+            playerPosition.isInWaterTile = heightChanger.IsInWaterTile;
             playerPosition.worldPosX = StreamingWorld.LocalPlayerGPS.WorldX;
             playerPosition.worldPosZ = StreamingWorld.LocalPlayerGPS.WorldZ;
             playerPosition.insideDungeon = playerEnterExit.IsPlayerInsideDungeon;
@@ -376,6 +378,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             playerMouseLook.Yaw = positionData.yaw;
             playerMouseLook.Pitch = positionData.pitch;
             playerMotor.IsCrouching = positionData.isCrouching;
+            PlayerHeightChanger heightChanger = GetComponent<PlayerHeightChanger>();
+            heightChanger.IsInWaterTile = positionData.isInWaterTile;
         }
 
         #endregion

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -184,7 +184,6 @@ namespace DaggerfallWorkshop.Game.Serialization
             playerPosition.yaw = playerMouseLook.Yaw;
             playerPosition.pitch = playerMouseLook.Pitch;
             playerPosition.isCrouching = playerMotor.IsCrouching;
-            playerPosition.isInWaterTile = heightChanger.IsInWaterTile;
             playerPosition.worldPosX = StreamingWorld.LocalPlayerGPS.WorldX;
             playerPosition.worldPosZ = StreamingWorld.LocalPlayerGPS.WorldZ;
             playerPosition.insideDungeon = playerEnterExit.IsPlayerInsideDungeon;
@@ -378,8 +377,6 @@ namespace DaggerfallWorkshop.Game.Serialization
             playerMouseLook.Yaw = positionData.yaw;
             playerMouseLook.Pitch = positionData.pitch;
             playerMotor.IsCrouching = positionData.isCrouching;
-            PlayerHeightChanger heightChanger = GetComponent<PlayerHeightChanger>();
-            heightChanger.IsInWaterTile = positionData.isInWaterTile;
         }
 
         #endregion


### PR DESCRIPTION
Go ahead and give a try.

Includes integration with swimming speed, skill usage, skill tally.

The horse can be mounted/unmounted while swimming. Slight boost to height when mounted.

Known bugs:

When loading a save game, the height is sometimes wrong but can be fixed by crouching once or twice.

Not done yet:

- No footstep change for swimming yet. 
- Will adjust headbobber to bob differently for swimming.  
- Need to adjust EnemyMotor to keep non-flying enemies from going on water tiles.