### PR TITLE
Implement illusion effect behavior and adjust stealth detection

### DIFF
--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -206,7 +206,8 @@ namespace DaggerfallWorkshop
         public string LootTableKey;                 // Key to use when generating loot
         public int HitFrame;                        // Frame of attack animation at which hit on target is attempted
         public int Weight;                          // Weight of this enemy. Affects chance of being knocked back by a hit.
-        public bool CastsMagic;                      // Whether this enemy casts magic. Only used for enemy classes.
+        public bool CastsMagic;                     // Whether this enemy casts magic. Only used for enemy classes.
+        public bool SeesThroughInvisibility;        // Whether this enemy sees through the shade, chameleon and invisibility effects.
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -90,6 +90,10 @@ namespace DaggerfallWorkshop.Game.Entity
 
         private List<RoomRental_v1> rentedRooms = new List<RoomRental_v1>();
 
+        protected bool isInvisible = false;
+        protected bool isBlending = false;
+        protected bool isAShade = false;
+
         // Fatigue loss per in-game minute
         public const int DefaultFatigueLoss = 11;
         public const int ClimbingFatigueLoss = 22;
@@ -154,7 +158,9 @@ namespace DaggerfallWorkshop.Game.Entity
         public bool HaveShownSurrenderToGuardsDialogue { get { return haveShownSurrenderToGuardsDialogue; } set { haveShownSurrenderToGuardsDialogue = value; } }
         public bool Arrested { get { return arrested; } set { arrested = value; } }
         public bool IsInBeastForm { get; set; }
-        public bool IsInvisible { get; set; }
+        public bool IsInvisible { get { return isInvisible; } set { isInvisible = value; } }
+        public bool IsBlending { get { return isBlending; } set { isBlending = value; } }
+        public bool IsAShade { get { return isAShade; } set { isAShade = value; } }
 
         #endregion
 

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -384,13 +384,13 @@ namespace DaggerfallWorkshop.Game.Formulas
 
             if (attacker == player)
             {
-                // Apply swing modifiers. Not applied to hand-to-hand in classic.
+                // Apply swing modifiers.
                 FPSWeapon onscreenWeapon = GameManager.Instance.WeaponManager.ScreenWeapon;
 
                 if (onscreenWeapon != null)
                 {
                     // The Daggerfall manual groups diagonal slashes to the left and right as if they are the same, but they are different.
-                    // Classic does not apply swing modifiers to hand-to-hand.
+                    // Classic does not apply swing modifiers to unarmed attacks.
                     if (onscreenWeapon.WeaponState == WeaponStates.StrikeUp)
                     {
                         damageModifiers += -4;
@@ -534,6 +534,14 @@ namespace DaggerfallWorkshop.Game.Formulas
             damage = Mathf.Max(0, damage);
 
             DamageEquipment(attacker, target, damage, weapon, struckBodyPart);
+
+            if (attacker == player && damage > 0)
+            {
+                // TODO: Also dispel these for AI entities
+                player.IsAShade = false;
+                player.IsBlending = false;
+                player.IsInvisible = false;
+            }
 
             return damage;
         }

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -178,6 +178,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 1,
                 HitFrame = 3,
                 Weight = 40,
+                SeesThroughInvisibility = true,
                 LootTableKey = "D",
             },
 
@@ -621,6 +622,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 1,
                 HitFrame = 4,
                 Weight = 80,
+                SeesThroughInvisibility = true,
                 LootTableKey = "H",
             },
 
@@ -715,6 +717,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 1,
                 HitFrame = 3,
                 Weight = 0,
+                SeesThroughInvisibility = true,
                 LootTableKey = "I",
             },
 
@@ -747,6 +750,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 1,
                 HitFrame = 4,
                 Weight = 300,
+                SeesThroughInvisibility = true,
                 LootTableKey = "E",
             },
 
@@ -869,6 +873,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 1,
                 HitFrame = 3,
                 Weight = 0,
+                SeesThroughInvisibility = true,
                 LootTableKey = "I",
             },
 
@@ -931,6 +936,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 HitFrame = 3,
                 Weight = 800,
+                SeesThroughInvisibility = true,
                 LootTableKey = "J",
             },
 
@@ -962,6 +968,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 HitFrame = 2,
                 Weight = 800,
+                SeesThroughInvisibility = true,
                 LootTableKey = "J",
             },
 
@@ -993,6 +1000,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 HitFrame = 3,
                 Weight = 400,
+                SeesThroughInvisibility = true,
                 LootTableKey = "E",
             },
 
@@ -1024,6 +1032,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 3,
                 HitFrame = 4,
                 Weight = 400,
+                SeesThroughInvisibility = true,
                 LootTableKey = "Q",
             },
 
@@ -1055,6 +1064,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 1,
                 HitFrame = 2,
                 Weight = 200,
+                SeesThroughInvisibility = true,
                 LootTableKey = "Q",
             },
 
@@ -1086,6 +1096,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 3,
                 HitFrame = 3,
                 Weight = 400,
+                SeesThroughInvisibility = true,
                 LootTableKey = "Q",
             },
 
@@ -1117,6 +1128,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 HitFrame = 3,
                 Weight = 1000,
+                SeesThroughInvisibility = true,
                 LootTableKey = "S",
             },
 
@@ -1149,6 +1161,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 4,
                 HitFrame = 3,
                 Weight = 300,
+                SeesThroughInvisibility = true,
                 LootTableKey = "S",
             },
 


### PR DESCRIPTION
This implements enemy AI behavior for when the player has the Invisibility, Shade or Chameleon effects active, in a manner similar to classic.

Spells for these, etc. are not added by this. But you can test the behavior by setting the flags `IsInvisible` `IsAShade` or `IsBlending` in `PlayerEntity`. The effects are dispelled if you do damage to an enemy, the same as in classic.

Invisibility should work identically to classic (except for the "giveUpTimer" as I explain below). For shade and chameleon, though, the behavior differs. This is because, if I understand correctly, these effects are pretty much useless in classic. This is because as soon as an enemy has detected the player during one of its constant updates, they then see the player for the remainder of their "giveUpTimer" (as it's being called in `EnemyMotor.cs`). When the timer runs out, because of how frequently AI updates happen they are almost sure to immediately detect the player again and set the timer again, allowing them to see the player for another run of the timer. Maybe classic's behavior was created with a slower AI update rate in mind? I tried a shade effect in classic and indeed it didn't seem to do anything to stop an enemy from seeing me.

So for this PR, instead Shade and Chameleon effects are rolled against every classic AI update, so they can see you for a moment, then they can't, then they can, etc. I'm pretty happy with the behavior, it gives a feeling that they are searching for you but can't see you well.

Some enemy types ignore these effects and can always see the player. This is recreated from classic.

Also the enemy detection was refactored some. and enemies can now get the player's location from the player failing a stealth roll. I think this also happens in classic, and it recreates enemies coming through doors for you, etc. as they do in that game, and generally makes them feel a little more alive since you won't always find them in their starting spots. I had previously not added this because I didn't want to get rid of DF Unity's superior pursuit behavior where AI will go to the last spot they saw the player rather than try to walk through walls, but I added a timer to account for this. If the enemy recently had LOS with the player they will not update the location from the stealth check (i.e. they will go to the last spot they saw the player and not try to walk through a wall).
