### PR TITLE
Fix Crushing bugs

### DIFF
--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -55,6 +55,7 @@ namespace DaggerfallWorkshop.Game
                 || failedClimbingCheck
                 || levitateMotor.IsLevitating
                 || playerMotor.IsRiding
+                || playerMotor.IsCrouching 
                 || Vector2.Distance(lastHorizontalPosition, new Vector2(controller.transform.position.x, controller.transform.position.z)) >= (0.003f)) // Approximation based on observing classic in-game
             {
                 isClimbing = false;

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -119,7 +119,7 @@ namespace DaggerfallWorkshop.Game
                 heightAction = HeightChangeAction.DoDismounting;
                 toggleRiding = false;
             }
-            else if (!playerMotor.IsRiding)
+            else if (!playerMotor.IsRiding && !playerMotor.IsCrouching)
             {
                 // Toggle crouching
                 if (!onWater && InputManager.Instance.ActionComplete(InputManager.Actions.Crouch))


### PR DESCRIPTION
players can wedge themselves into a slanted wall and climb up and kill themselves by triggering the overhead player crush check.  This fixes it by doing the folllowing:

Disable player crouching while climbing.
Disable Climbing while player crouching