### PR TITLE
Move env log to persistent data path

### DIFF
--- a/Assets/Scripts/GenerateDiagLog.cs
+++ b/Assets/Scripts/GenerateDiagLog.cs
@@ -304,7 +304,7 @@ namespace DaggerfallWorkshop
             StreamWriter sw = null;
             try
             {
-                string filePath = Path.Combine(Application.dataPath, fileName);
+                string filePath = Path.Combine(Application.persistentDataPath, fileName);
                 fs = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite);
                 sw = new StreamWriter(fs);
                 if (File.Exists(filePath))


### PR DESCRIPTION
This will enable logs to be written even when the game dir is installed
in a system dir.