### PR TITLE
Import and handle expiring items

### DIFF
--- a/Assets/Scripts/API/Save/SaveTree.cs
+++ b/Assets/Scripts/API/Save/SaveTree.cs
@@ -354,6 +354,7 @@ namespace DaggerfallConnect.Save
         public UInt32 RecordID;                 // Unique ID of this record. Called "mapID" and "map identifier" by Fixsave.
         public Byte QuestID;                    // Associated quest ID of this record (0 if no quest)
         public UInt32 ParentRecordID;           // ID of parent record
+        public UInt32 Time;                     // Time in game minutes. Known uses: Time for magically-created items to disappear, time for items under repair to be done being repaired.
         public UInt32 ItemObject;               // chunktcl's description: ItemObject. Active spell/spell book/permanent treasure container
         public UInt32 QuestObjectID;            // chunktcl's description: QuestObjectID
         public UInt32 NextObject;               // chunktcl's description: Link to next object in series

--- a/Assets/Scripts/API/Save/SaveTreeBaseRecord.cs
+++ b/Assets/Scripts/API/Save/SaveTreeBaseRecord.cs
@@ -248,8 +248,11 @@ namespace DaggerfallConnect.Save
             // ParentRecordID
             recordRoot.ParentRecordID = reader.ReadUInt32();
 
+            // Time
+            reader.BaseStream.Position = 43;
+            recordRoot.Time = reader.ReadUInt32();
+
             // ItemObject
-            reader.BaseStream.Position = 47;
             recordRoot.ItemObject = reader.ReadUInt32();
 
             // QuestObjectID

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -244,9 +244,10 @@ namespace DaggerfallWorkshop.Game.Entity
                 gameStarted = true;
             if (playerMotor != null)
             {
-                // Every game minute, apply fatigue loss to the player
+                // Apply per-minute events
                 if (lastGameMinutes != gameMinutes)
                 {
+                    // Apply fatigue loss to the player
                     int amount = DefaultFatigueLoss;
                     if (climbingMotor != null && climbingMotor.IsClimbing)
                         amount = ClimbingFatigueLoss;
@@ -260,6 +261,9 @@ namespace DaggerfallWorkshop.Game.Entity
                     }
 
                     DecreaseFatigue(amount);
+
+                    // Make magically-created items that have expired disappear
+                    items.RemoveExpiredItems();
                 }
 
                 // Handle events that are called by classic's update loop
@@ -620,6 +624,13 @@ namespace DaggerfallWorkshop.Game.Entity
                     else
                         newItem.TrappedSoulType = MobileTypes.None;
                 }
+
+                // Add existence time limit if item is flagged as having been made through the "Create Item" effect
+                if (((record as ItemRecord).ParsedData.flags & 0x1000) != 0)
+                {
+                    newItem.TimeForItemToDisappear = record.RecordRoot.Time;
+                }
+
                 // Add to local inventory or wagon
                 if (containerRecord.IsWagon)
                     wagonItems.AddItem(newItem);

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -58,6 +58,9 @@ namespace DaggerfallWorkshop.Game.Items
         // Soul trapped
         MobileTypes trappedSoulType = MobileTypes.None;
 
+        // Time for magically-created item to disappear
+        uint timeForItemToDisappear = 0;
+
         // Quest-related fields
         bool isQuestItem = false;
         ulong questUID = 0;
@@ -264,12 +267,21 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
-        /// Gets the soul trapped in a soul trap.
+        /// Gets/sets the soul trapped in a soul trap.
         /// </summary>
         public MobileTypes TrappedSoulType
         {
             get { return trappedSoulType; }
             set { trappedSoulType = value; }
+        }
+
+        /// <summary>
+        /// Gets/sets the time for this item to disappear.
+        /// </summary>
+        public uint TimeForItemToDisappear
+        {
+            get { return timeForItemToDisappear; }
+            set { timeForItemToDisappear = value; }
         }
 
         /// <summary>
@@ -1008,9 +1020,11 @@ namespace DaggerfallWorkshop.Game.Items
                 itemBroke = UserInterfaceWindows.HardStrings.itemHasBroken;
             itemBroke = itemBroke.Replace("%s", LongName);
             DaggerfallUI.Instance.PopupMessage(itemBroke);
-            EquipSlots slot = owner.ItemEquipTable.GetEquipSlot(this);
-            if (owner.ItemEquipTable.GetItem(slot) == this)
-                owner.ItemEquipTable.UnequipItem(slot);
+            foreach (EquipSlots slot in Enum.GetValues(typeof(EquipSlots)))
+            {
+                if (owner.ItemEquipTable.GetItem(slot) == this)
+                    owner.ItemEquipTable.UnequipItem(slot);
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -113,6 +113,35 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
+        /// Removes items that have expired. Used for magically-created items. Only for the player.
+        /// Note: Reverse-engineering suggests this was intended behavior in classic, but classic
+        /// does not correctly set the item flags so magically-created items never disappear.
+        /// </summary>
+        public void RemoveExpiredItems()
+        {
+            uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+            List<DaggerfallUnityItem> itemsToRemove = new List<DaggerfallUnityItem>();
+
+            foreach (DaggerfallUnityItem item in items.Values)
+            {
+                if (item.TimeForItemToDisappear != 0 && item.TimeForItemToDisappear < gameMinutes)
+                {
+                    Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+                    foreach (EquipSlots slotToCheck in Enum.GetValues(typeof(EquipSlots)))
+                    {
+                        if (player.ItemEquipTable.GetItem(slotToCheck) == item)
+                            player.ItemEquipTable.UnequipItem(slotToCheck);
+                    }
+                    itemsToRemove.Add(item);
+                }
+            }
+            foreach (DaggerfallUnityItem item in itemsToRemove)
+            {
+                RemoveItem(item);
+            }
+        }
+
+        /// <summary>
         /// Check if item exists in this collection.
         /// </summary>
         /// <param name="item">Item to check.</param>


### PR DESCRIPTION
This does a few things:

1. Identifies and imports time-limit data from items created with the "Create Item" spell in classic.
2. Items with a time limit will be removed when the time limit is reached. Note this doesn't happen in classic (items created with "Create Item" never disappear, despite the fact that you can set duration when creating a Create Item spell) due to a mismatch in the flag set and the flag checked. (Byte 43 of the itemRecord is ORed with 0x10, but what is checked for 0x10 is byte 21 of the base record. If you manually set that classic then will remove the item when the duration runs out.)
3. Fixed a bug with unequipping broken weapons. It relied on `GetEquipSlot()`, but for weapons that can be equipped in either slot (one-handed weapons), it would return the unequipped hand, as it was apparently written specifically for when looking for a free slot to equip to, not to check the slot for an already equipped weapon. I think I didn't realize this when I wrote the weapon breaking code. This is fixed now and the fixed way is also used for unequipping expiring items made with Create Item.