### PR TITLE
Fix music not updating when loading interior saves

### DIFF
--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -149,14 +149,6 @@ namespace DaggerfallWorkshop.Game
             if (!songPlayer)
                 return;
 
-            // If streaming world is set, we can ignore track changes before init complete
-            // This helps prevent music starting during first load or on wrong playlist
-            if (StreamingWorld)
-            {
-                if (StreamingWorld.IsInit)
-                    return;
-            }
-
             // Update context
             UpdatePlayerMusicEnvironment();
             UpdatePlayerMusicWeather();


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=1039&hilit=music and https://forums.dfworkshop.net/viewtopic.php?f=24&t=860 (except for the holiday text part).

You can reproduce the problem by doing the following:
1) Start Daggerfall Unity and load a saved game in an exterior
2) Load another saved game in an interior (building or dungeon, doesn't matter)
3) Observe that outdoors music is playing

The problem occurs at the code deleted by this PR, in `Update()` in `SongManager`.

```
            if (StreamingWorld)	
            {	
                if (StreamingWorld.IsInit)	
                    return;	
            }
```

It seems to be that the order of how `StreamingWorld.suppressworld` and `StreamingWorld.init` (both booleans) have been set is involved with the problem. If you load straight into a dungeon save, `StreamingWorld.suppressworld` is true from the start, and `StreamingWorld.init` ends up as false, allowing the SongManager to update the song. But if you load an exterior save first, `StreamingWorld.suppressworld` becomes false, and in the process of loading the interior save `StreamingWorld.init` becomes stuck at true, staying true while you're in the interior, until you leave it.

It doesn't seem like `StreamingWorld.init` should be stuck at true like this, as according to the comments it's supposed to indicate that the streaming world is being initialized and would only be true momentarily. I experimented with trying to fix this, such as by setting `StreamingWorld.suppressworld` to true in the load process earlier, before teleporting the player (this also fixes the holiday text issue and outdoor music temporarily playing while in the loading process) but ran into problems with the player ending up way in the air after leaving an interior if before loading that save they had gone outside in a different part of the game world.

I tested but I couldn't find that the code removed by this PR ever triggered except when causing the problem, so it seems like it wasn't serving it's intended purpose anyway, at least on my system and when running from the editor.