### PR TITLE
Implement creation of magic items in loot

### DIFF
--- a/Assets/Scripts/Game/Items/LootTables.cs
+++ b/Assets/Scripts/Game/Items/LootTables.cs
@@ -192,15 +192,11 @@ namespace DaggerfallWorkshop.Game.Items
             RandomIngredient(matrix.M1, ItemGroups.MiscellaneousIngredients1, items);
             RandomIngredient(matrix.M2, ItemGroups.MiscellaneousIngredients2, items);
 
-            // TEMP: Magic item chance is just another shot at armor or weapon for now
+            // Random magic item
             chance = matrix.MI;
             while (Random.Range(0, 100) < chance)
             {
-                if (Random.value < 0.5f)
-                    items.Add(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
-                else
-                    items.Add(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
-
+                items.Add(ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
             }
 

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -276,7 +276,7 @@ namespace DaggerfallWorkshop
                     {
                         if (itemGroup == ItemGroups.MagicItems)
                         {
-                            //TODO: Make magic item
+                            item = ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
                         }
                         else if (itemGroup == ItemGroups.Books)
                         {


### PR DESCRIPTION
Creation of magic items in loot (treasure piles, enemy equipment, house containers). Everything should be the same as classic except for the gold value of the items, which I still need to figure out (they'll just have the value of the non-magic versions for now). The magic item stats use the data read from `MAGIC.DEF`.

Also still need to do stocking of magic items by magic item merchants. (would be a separate PR)