### PR TITLE
Fix ArgumentOutOfRangeException

### DIFF
--- a/Assets/Scripts/API/BaseImageFile.cs
+++ b/Assets/Scripts/API/BaseImageFile.cs
@@ -38,6 +38,11 @@ namespace DaggerfallConnect.Arena2
         /// </summary>
         internal FileProxy managedFile = new FileProxy();
 
+        /// <summary>
+        /// Indicates whether file has been loaded.
+        /// </summary>
+        private bool isLoaded = false;
+
         #endregion
 
         #region Class Structures
@@ -134,6 +139,14 @@ namespace DaggerfallConnect.Arena2
             get;
         }
 
+        /// <summary>
+        /// Gets value indicating whether image file has been loaded.
+        /// </summary>
+        public bool IsLoaded
+        {
+            get { return isLoaded; }
+        }
+
         #endregion
 
         #region Public Methods
@@ -145,7 +158,20 @@ namespace DaggerfallConnect.Arena2
         /// <param name="usage">Specify if file will be accessed from disk, or loaded into RAM.</param>
         /// <param name="readOnly">File will be read-only if true, read-write if false.</param>
         /// <returns>True if successful, otherwise false.</returns>
-        public abstract bool Load(string filePath, FileUsage usage, bool readOnly);
+        public bool Load(string filePath, FileUsage usage, bool readOnly)
+        {
+            isLoaded = LoadImpl(filePath, usage, readOnly);
+            return isLoaded;
+        }
+
+        /// <summary>
+        /// Loads an image file.
+        /// </summary>
+        /// <param name="filePath">Absolute path to file</param>
+        /// <param name="usage">Specify if file will be accessed from disk, or loaded into RAM.</param>
+        /// <param name="readOnly">File will be read-only if true, read-write if false.</param>
+        /// <returns>True if successful, otherwise false.</returns>
+        protected abstract bool LoadImpl(string filePath, FileUsage usage, bool readOnly);
 
         /// <summary>
         /// Gets number of frames in specified record.

--- a/Assets/Scripts/API/CfaFile.cs
+++ b/Assets/Scripts/API/CfaFile.cs
@@ -113,7 +113,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="filePath">Absolute path to *.CFA file.</param>
         /// <param name="usage">Specify if file will be accessed from disk, or loaded into RAM.</param>
         /// <param name="readOnly">File will be read-only if true, read-write if false.</param>
-        public override bool Load(string filePath, FileUsage usage, bool readOnly)
+        protected override bool LoadImpl(string filePath, FileUsage usage, bool readOnly)
         {
             // Exit if this file already loaded
             if (managedFile.FilePath == filePath)

--- a/Assets/Scripts/API/CifRciFile.cs
+++ b/Assets/Scripts/API/CifRciFile.cs
@@ -174,7 +174,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="usage">Specify if file will be accessed from disk, or loaded into RAM.</param>
         /// <param name="readOnly">File will be read-only if true, read-write if false.</param>
         /// <returns>True if successful, otherwise false.</returns>
-        public override bool Load(string filePath, FileUsage usage, bool readOnly)
+        protected override bool LoadImpl(string filePath, FileUsage usage, bool readOnly)
         {
             // Exit if this file already loaded
             if (managedFile.FilePath == filePath)

--- a/Assets/Scripts/API/ImgFile.cs
+++ b/Assets/Scripts/API/ImgFile.cs
@@ -217,7 +217,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="usage">Specify if file will be accessed from disk, or loaded into RAM.</param>
         /// <param name="readOnly">File will be read-only if true, read-write if false.</param>
         /// <returns>True if successful, otherwise false.</returns>
-        public override bool Load(string filePath, FileUsage usage, bool readOnly)
+        protected override bool LoadImpl(string filePath, FileUsage usage, bool readOnly)
         {
             // Exit if this file already loaded
             if (managedFile.FilePath == filePath)

--- a/Assets/Scripts/API/Save/SaveImage.cs
+++ b/Assets/Scripts/API/Save/SaveImage.cs
@@ -43,7 +43,7 @@ namespace DaggerfallConnect.Save
             get { return 1; }
         }
 
-        public override bool Load(string filePath, FileUsage usage, bool readOnly)
+        protected override bool LoadImpl(string filePath, FileUsage usage, bool readOnly)
         {
             // Validate filename
             string fn = Path.GetFileName(filePath);

--- a/Assets/Scripts/API/SkyFile.cs
+++ b/Assets/Scripts/API/SkyFile.cs
@@ -113,7 +113,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="usage">Specify if file will be accessed from disk, or loaded into RAM.</param>
         /// <param name="readOnly">File will be read-only if true, read-write if false.</param>
         /// <returns>True if successful, otherwise false.</returns>
-        public override bool Load(string filePath, FileUsage usage, bool readOnly)
+        protected override bool LoadImpl(string filePath, FileUsage usage, bool readOnly)
         {
             // Exit if this file already loaded
             if (managedFile.FilePath == filePath)

--- a/Assets/Scripts/API/TextureFile.cs
+++ b/Assets/Scripts/API/TextureFile.cs
@@ -273,7 +273,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="usage">Specify if file will be accessed from disk, or loaded into RAM.</param>
         /// <param name="readOnly">File will be read-only if true, read-write if false.</param>
         /// <returns>True if successful, otherwise false.</returns>
-        public override bool Load(string filePath, FileUsage usage, bool readOnly)
+        protected override bool LoadImpl(string filePath, FileUsage usage, bool readOnly)
         {
             // Exit if this file already loaded
             if (managedFile.FilePath == filePath)

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -953,7 +953,12 @@ namespace DaggerfallWorkshop.Game
             if (!dfUnity.IsReady)
                 return null;
 
-            ImgFile imgFile = new ImgFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, readOnly);            
+            ImgFile imgFile = new ImgFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, readOnly);
+            if (!imgFile.IsLoaded)
+            {
+                return null;
+            }
+
             Texture2D texture;
             if (!TextureReplacement.TryImportImage(name, out texture))
             {


### PR DESCRIPTION
 *Templatize BaseImageFile.Load*

- Templatize BaseImageFile.Load to encapsulate common behavior in base.
- Expose result of Load as property to clients. There are better ways to
  expose the result to clients, but it would require uncoupling a bunch
  of code not worth touching for the sake of fixing the exception in the
  next commit.

*Fix ArgumentOutOfRangeException when arena2 dir unset*

Note, it'd be better if arena2 resources were loaded after arena2 dir is
set by the player (including LoadSpellIcons specifically for this
exception), but I'll leave that as an excercise for someone more
familiar with how arena2 resources are loaded.