### PR TITLE
Swimming bug fixes

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -308,8 +308,9 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 // Clear flags when not in a dungeon
-                // commenting this out allows player to swim outside - MeteoricDragon
-                //isPlayerSwimming = false;
+                // don't clear swimming if we're outside on a water tile - MeteoricDragon
+                if (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0)
+                    isPlayerSwimming = false;
                 isPlayerSubmerged = false;
                 levitateMotor.IsSwimming = false;
             }

--- a/Assets/Scripts/Game/UserInterface/HUDVitals.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDVitals.cs
@@ -82,7 +82,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public float Breath
         {
             get { return breathProgress.Amount; }
-            set { SetRemainingBreath(value); }
+            set { breathProgress.Amount = value;
+                  SetRemainingBreathColor(value); }
         }
 
         public HUDVitals()
@@ -153,7 +154,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
                 if (DaggerfallUnity.Settings.EnableVitalsIndicators)
                 {
-                    UpdateIndicators();
+                    // these progress bars never smooth-change.
+                    healthProgressGain.Amount = playerEntity.CurrentHealth / (float)playerEntity.MaxHealth;
+                    fatigueProgressGain.Amount = playerEntity.CurrentFatigue / (float)playerEntity.MaxFatigue;
+                    magickaProgressGain.Amount = playerEntity.CurrentMagicka / (float)playerEntity.MaxMagicka;
+                    UpdateSmoothBars();
+                    PositionIndicators();
                 }
                 else
                 {
@@ -162,17 +168,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     fatigueProgress.Amount = playerEntity.CurrentFatigue / (float)playerEntity.MaxFatigue;
                     magickaProgress.Amount = playerEntity.CurrentMagicka / (float)playerEntity.MaxMagicka;
                 }
-                SetRemainingBreath(playerEntity.CurrentBreath / (float)playerEntity.MaxBreath);
+                breathProgress.Amount = playerEntity.CurrentBreath / (float)playerEntity.MaxBreath;
+                SetRemainingBreathColor(breathProgress.Amount);
             }
         }
 
-        void UpdateIndicators()
+        void UpdateSmoothBars()
         {
-            // these progress bars never smooth-change.
-            healthProgressGain.Amount = playerEntity.CurrentHealth / (float)playerEntity.MaxHealth;
-            fatigueProgressGain.Amount = playerEntity.CurrentFatigue / (float)playerEntity.MaxFatigue;
-            magickaProgressGain.Amount = playerEntity.CurrentMagicka / (float)playerEntity.MaxMagicka;
-
             float target;
             // if there's any change in health... Smooth update the Loss bar, and
             // decide if should smooth update or instant update the progress bar
@@ -212,7 +214,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             healthProgress.Cycle();
             fatigueProgress.Cycle();
             magickaProgress.Cycle();
+        }
 
+        void PositionIndicators()
+        {
             healthProgressLoss.Position = healthProgress.Position;
             healthProgressLoss.Size = healthProgress.Size;
 
@@ -230,7 +235,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             magickaProgressGain.Position = magickaProgress.Position;
             magickaProgressGain.Size = magickaProgress.Size;
-
         }
         void LoadAssets()
         {
@@ -257,9 +261,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             magickaProgressGain.Color = magickaGainColor;
         }
 
-        void SetRemainingBreath(float amount)
+        void SetRemainingBreathColor(float amount)
         {
-            breathProgress.Amount = amount;
             int threshold = ((GameManager.Instance.PlayerEntity.Stats.LiveEndurance) >> 3) + 4;
             if (threshold > GameManager.Instance.PlayerEntity.CurrentBreath)
                 breathProgress.Color = new Color32(148, 12, 0, 255);

--- a/Assets/Scripts/Game/UserInterface/HUDVitals.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDVitals.cs
@@ -162,7 +162,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     fatigueProgress.Amount = playerEntity.CurrentFatigue / (float)playerEntity.MaxFatigue;
                     magickaProgress.Amount = playerEntity.CurrentMagicka / (float)playerEntity.MaxMagicka;
                 }
-                breathProgress.Amount = playerEntity.CurrentBreath / (float)playerEntity.MaxBreath;
+                SetRemainingBreath(playerEntity.CurrentBreath / (float)playerEntity.MaxBreath);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterface/HUDVitals.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDVitals.cs
@@ -111,12 +111,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 magickaProgressGain.VerticalAlignment = VerticalAlignment.Bottom;
 
                 // to make bar appear behind other bars, add it first.
-                Components.Add(healthProgressGain);
-                Components.Add(fatigueProgressGain);
-                Components.Add(magickaProgressGain);
                 Components.Add(healthProgressLoss);
                 Components.Add(fatigueProgressLoss);
                 Components.Add(magickaProgressLoss);
+                Components.Add(healthProgressGain);
+                Components.Add(fatigueProgressGain);
+                Components.Add(magickaProgressGain);
             }
 
             Components.Add(healthProgress);
@@ -215,11 +215,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             fatigueProgress.Cycle();
             magickaProgress.Cycle();
 
-            // disallow non-indicator bars to go above indicators
+            // disallow non-indicator bars from going above indicators
             healthProgress.Amount = Mathf.Min(healthProgress.Amount, healthProgressLoss.Amount, healthProgressGain.Amount);
             fatigueProgress.Amount = Mathf.Min(fatigueProgress.Amount, fatigueProgressLoss.Amount, fatigueProgressGain.Amount);
             magickaProgress.Amount = Mathf.Min(magickaProgress.Amount, magickaProgressLoss.Amount, magickaProgressGain.Amount);
-
         }
 
         void PositionIndicators()

--- a/Assets/Scripts/Game/UserInterface/HUDVitals.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDVitals.cs
@@ -214,6 +214,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             healthProgress.Cycle();
             fatigueProgress.Cycle();
             magickaProgress.Cycle();
+
+            // disallow non-indicator bars to go above indicators
+            healthProgress.Amount = Mathf.Min(healthProgress.Amount, healthProgressLoss.Amount, healthProgressGain.Amount);
+            fatigueProgress.Amount = Mathf.Min(fatigueProgress.Amount, fatigueProgressLoss.Amount, fatigueProgressGain.Amount);
+            magickaProgress.Amount = Mathf.Min(magickaProgress.Amount, magickaProgressLoss.Amount, magickaProgressGain.Amount);
+
         }
 
         void PositionIndicators()

--- a/Assets/Scripts/Game/UserInterface/VerticalProgressSmoother.cs
+++ b/Assets/Scripts/Game/UserInterface/VerticalProgressSmoother.cs
@@ -12,13 +12,20 @@ namespace DaggerfallWorkshop.Game.UserInterface
         private float targetPercent;
         private float timer;
         private const float timerMax = 0.4f;
-        private bool cycleTimer;
+        public bool cycleTimer;
 
+        /// <summary>
+        /// Start a smooth change with delay and target
+        /// </summary>
+        /// <param name="target">Target percent to change bar to</param>
         public void BeginSmoothChange(float target)
         {
-            cycleTimer = true;
-            timer = -0.5f;
-            prevPercent = Amount;
+            if (cycleTimer == false)
+            {
+                cycleTimer = true;
+                prevPercent = Amount;
+                timer = -0.5f;
+            }
             targetPercent = target;
         }
 


### PR DESCRIPTION
This one is a really important fix: Fixes bug introduced by the indicator bars.  Because the property call in DaggerfallHUD for updating the breath bar was discarded in favor of updating the breath bar in the vitals class (to be consistent with the other vitals updating in the class), the SetRemainingBreath method was overlooked, which does more than set the amount, it sets the color of the bar according to the percent left. **Which causes the breath bar not to appear.**  Now the code properly sets the color and the breath bar appears.

Also Fixes bug identified by @Allofich , namely, if you load a game from swimming in a dungeon, you continue at swim speed.  Now the code checks to make sure the player is not on a water tile before clearing the swimming flag.

Also refactors code in the HUDVitals class to make a little more sense.

update: fixes to the vitals bars prevent the bars from displaying more than is actually tallied by the playerEntity.  could be caused when the player gets struck immediately after healing.

Placed the loss indicators behind the gain indicators.  Looks better if healing immediately after taking damage.  and can see both indicators working simultaneously.

Multiple consecutive healing or damage actions will no longer reset the timer or add delay for the smoothing.  It will just update the target amount to smooth the bar to.

