### PR TITLE
Match magic item merchant stock to classic

### DIFF
--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -208,6 +208,7 @@ namespace DaggerfallWorkshop
         public int Weight;                          // Weight of this enemy. Affects chance of being knocked back by a hit.
         public bool CastsMagic;                     // Whether this enemy casts magic. Only used for enemy classes.
         public bool SeesThroughInvisibility;        // Whether this enemy sees through the shade, chameleon and invisibility effects.
+        public int SoulPts;                         // Number of enchantment points in a trapped soul of this enemy
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -16,6 +16,7 @@ using UnityEngine;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallConnect.FallExe;
 using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop.Utility;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -61,7 +62,6 @@ namespace DaggerfallWorkshop.Game.Items
         static readonly int[][] enchantmentPtsForItemPowerArrays = { null, null, null, extraSpellPtsEnchantPts, potentVsEnchantPts, regensHealthEnchantPts,
                                                                     vampiricEffectEnchantPts, increasedWeightAllowanceEnchantPts, null, null, null, null, null,
                                                                     improvesTalentsEnchantPts, goodRepWithEnchantPts};
-        static readonly int[] enemySoulPts = { 0, 0x3E8, 0x3E8, 0, 0, 0, 0, 0x3E8, 0x0BB8, 0x3E8, 0x2710, 0, 0x3E8, 0x0BB8, 0x3E8, 0, 0x0BB8, 0, 0x7530, 0x2710, 0, 0x0BB8, 0x0BB8, 0x7530, 0x3E8, 0x0C350 };
         static readonly ushort[] enchantmentPointCostsForNonParamTypes = { 0, 0x0F448, 0x0F63C, 0x0FF9C, 0x0FD44, 0, 0, 0, 0x384, 0x5DC, 0x384, 0x64, 0x2BC };
 
         private enum BodyMorphology
@@ -550,7 +550,8 @@ namespace DaggerfallWorkshop.Game.Items
                                         break;
                                     // Bound soul
                                     case EnchantmentTypes.SoulBound:
-                                        value += enemySoulPts[magicItem.enchantments[i].param]; // TODO: Not sure about this. Should be negative? Needs to be tested.
+                                        MobileEnemy mobileEnemy = GameObjectHelper.EnemyDict[magicItem.enchantments[i].param];
+                                        value += mobileEnemy.SoulPts; // TODO: Not sure about this. Should be negative? Needs to be tested.
                                         break;
                                     default:
                                     // Enchantments that provide a non-spell effect with a parameter (when effect applies, what enemies are affected, etc.)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -106,23 +106,47 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Setup Methods
 
-        // TODO: replace with proper merchant item generation...
-        // classic seems to have a deterministic method for generating magic items being sold
         ItemCollection GetMerchantMagicItems()
         {
             if (merchantItems == null)
             {
                 PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
                 ItemCollection items = new ItemCollection();
-                DaggerfallUnityItem magicArm = ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
-                magicArm.legacyMagic = new DaggerfallEnchantment[1];
-                magicArm.legacyMagic[0].type = EnchantmentTypes.CastWhenHeld;
-                magicArm.legacyMagic[0].param = 87;
-                items.AddItem(magicArm);
-                DaggerfallUnityItem magicWeap = ItemBuilder.CreateRandomWeapon(playerEntity.Level);
-                magicWeap.legacyMagic = new DaggerfallEnchantment[1];
-                magicWeap.legacyMagic[0].type = EnchantmentTypes.CastWhenHeld;
-                magicWeap.legacyMagic[0].param = 87;
+                int numOfItems = (buildingDiscoveryData.quality / 2) + 1;
+
+                for ( int i = 0; i <= numOfItems; i++)
+                {
+                    DaggerfallUnityItem magicItem = ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
+
+                    // Item is already identified
+                    magicItem.flags |= 0x20;
+
+                    items.AddItem(magicItem);
+                }
+
+                items.AddItem(ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Spellbook));
+
+                if (guild.Rank >= 4)
+                {
+                    for (int i = 0; i <= numOfItems; i++)
+                    {
+                        DaggerfallUnityItem magicItem = ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Soul_trap);
+                        magicItem.value = 5000;
+
+                        if (UnityEngine.Random.Range(1, 101) >= 25)
+                            magicItem.TrappedSoulType = MobileTypes.None;
+                        else
+                        {
+                            int id = UnityEngine.Random.Range(0, 43);
+                            magicItem.TrappedSoulType = (MobileTypes)id;
+                            MobileEnemy mobileEnemy = GameObjectHelper.EnemyDict[id];
+                            magicItem.value += mobileEnemy.SoulPts;
+                        }
+
+                        items.AddItem(magicItem);
+                    }
+                }
+
                 merchantItems = items;
             }
             return merchantItems;

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -180,6 +180,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 40,
                 SeesThroughInvisibility = true,
                 LootTableKey = "D",
+                SoulPts = 1000,
             },
 
             // Spriggan
@@ -215,6 +216,7 @@ namespace DaggerfallWorkshop.Utility
                 HitFrame = 3,
                 Weight = 240,
                 LootTableKey = "B",
+                SoulPts = 1000,
             },
 
             // Giant Bat
@@ -370,6 +372,7 @@ namespace DaggerfallWorkshop.Utility
                 HitFrame = 3,
                 Weight = 600,
                 LootTableKey = "A",
+                SoulPts = 1000,
             },
 
             // Centaur
@@ -401,6 +404,7 @@ namespace DaggerfallWorkshop.Utility
                 HitFrame = 3,
                 Weight = 1200,
                 LootTableKey = "C",
+                SoulPts = 3000,
             },
 
             // Werewolf
@@ -435,6 +439,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 HitFrame = 2,
                 Weight = 480,
+                SoulPts = 1000,
             },
 
             // Nymph
@@ -466,6 +471,7 @@ namespace DaggerfallWorkshop.Utility
                 HitFrame = 5,
                 Weight = 200,
                 LootTableKey = "C",
+                SoulPts = 10000,
             },
 
             // Slaughterfish
@@ -526,6 +532,7 @@ namespace DaggerfallWorkshop.Utility
                 HitFrame = 2,
                 Weight = 600,
                 LootTableKey = "A",
+                SoulPts = 1000,
             },
 
             // Harpy
@@ -557,6 +564,7 @@ namespace DaggerfallWorkshop.Utility
                 HitFrame = 3,
                 Weight = 200,
                 LootTableKey = "D",
+                SoulPts = 3000,
             },
 
             // Wereboar
@@ -591,6 +599,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 HitFrame = 3,
                 Weight = 560,
+                SoulPts = 1000,
             },
 
             // Skeletal Warrior
@@ -655,6 +664,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "F",
                 HitFrame = 3,
                 Weight = 3000,
+                SoulPts = 3000,
             },
 
             // Zombie
@@ -719,6 +729,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 0,
                 SeesThroughInvisibility = true,
                 LootTableKey = "I",
+                SoulPts = 30000,
             },
 
             // Mummy
@@ -752,6 +763,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 300,
                 SeesThroughInvisibility = true,
                 LootTableKey = "E",
+                SoulPts = 10000,
             },
 
             // Giant Scorpion
@@ -812,6 +824,7 @@ namespace DaggerfallWorkshop.Utility
                 HitFrame = 3,
                 Weight = 400,
                 LootTableKey = "U",
+                SoulPts = 3000,
             },
 
             // Gargoyle
@@ -842,6 +855,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 HitFrame = 3,
                 Weight = 300,
+                SoulPts = 3000,
             },
 
             // Wraith
@@ -875,6 +889,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 0,
                 SeesThroughInvisibility = true,
                 LootTableKey = "I",
+                SoulPts = 30000,
             },
 
             // Orc Warlord
@@ -906,6 +921,7 @@ namespace DaggerfallWorkshop.Utility
                 HitFrame = 3,
                 Weight = 700,
                 LootTableKey = "T",
+                SoulPts = 1000,
             },
 
             // Frost Daedra
@@ -938,6 +954,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 800,
                 SeesThroughInvisibility = true,
                 LootTableKey = "J",
+                SoulPts = 50000,
             },
 
             // Fire Daedra
@@ -970,6 +987,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 800,
                 SeesThroughInvisibility = true,
                 LootTableKey = "J",
+                SoulPts = 50000,
             },
 
             // Daedroth
@@ -1002,6 +1020,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 400,
                 SeesThroughInvisibility = true,
                 LootTableKey = "E",
+                SoulPts = 10000,
             },
 
             // Vampire
@@ -1034,6 +1053,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 400,
                 SeesThroughInvisibility = true,
                 LootTableKey = "Q",
+                SoulPts = 70000,
             },
 
             // Daedra Seducer
@@ -1066,6 +1086,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 200,
                 SeesThroughInvisibility = true,
                 LootTableKey = "Q",
+                SoulPts = 150000,
             },
 
             // Vampire Ancient
@@ -1098,6 +1119,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 400,
                 SeesThroughInvisibility = true,
                 LootTableKey = "Q",
+                SoulPts = 100000,
             },
 
             // Daedra Lord
@@ -1130,6 +1152,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 1000,
                 SeesThroughInvisibility = true,
                 LootTableKey = "S",
+                SoulPts = 800000,
             },
 
             // Lich
@@ -1163,6 +1186,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 300,
                 SeesThroughInvisibility = true,
                 LootTableKey = "S",
+                SoulPts = 100000,
             },
 
             // Ancient Lich
@@ -1195,6 +1219,7 @@ namespace DaggerfallWorkshop.Utility
                 HitFrame = 3,
                 Weight = 300,
                 LootTableKey = "S",
+                SoulPts = 250000,
             },
 
             // TODO: Figure out weights for monsters from here onward.
@@ -1256,6 +1281,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 HitFrame = 3,
                 Weight = 1000,
+                SoulPts = 30000,
             },
 
             // Iron Atronach
@@ -1286,6 +1312,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 HitFrame = 3,
                 Weight = 1000,
+                SoulPts = 30000,
             },
 
             // Flesh Atronach
@@ -1316,6 +1343,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 HitFrame = 3,
                 Weight = 1000,
+                SoulPts = 30000,
             },
 
             // Ice Atronach
@@ -1346,6 +1374,14 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 HitFrame = 3,
                 Weight = 1000,
+                SoulPts = 30000,
+            },
+
+            // Horse (unused, but can appear in merchant-sold soul traps)
+            new MobileEnemy()
+            {
+                ID = 39,
+                Name = "Horse",
             },
 
             // Dragonling
@@ -1374,6 +1410,7 @@ namespace DaggerfallWorkshop.Utility
                 ParrySounds = false,
                 MapChance = 0,
                 HitFrame = 2,
+                SoulPts = 500000,
             },
 
             // Dreugh
@@ -1404,6 +1441,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 HitFrame = 3,
                 LootTableKey = "R",
+                SoulPts = 10000,
             },
 
             // Lamia
@@ -1434,6 +1472,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 LootTableKey = "R",
                 HitFrame = 4,
+                SoulPts = 10000,
             },
 
             // Mage


### PR DESCRIPTION
Also fixed up list of enemy soul points and added that to enemy definitions.

When magic merchants stock soul traps with souls in them, it's a random selection from 0 through 42.
As far as I can see, there is nothing stopping it from choosing the unused "Horse" or the dragonling with 0 enchantment points. Since other 0-value animals can also be chosen I added a "Horse" stub to the enemy list to allow for the soul to appear. Not sure if we should allow those or not.

However, when an item with a soul bound to it breaks, the stored enemy is supposed to spawn. I assume classic probably crashes or something if an item with a horse soul breaks, so if we allow horse souls we'll have to account for that. We should account for that anyway in event somebody imports a classic save with an item with a horse soul.