### PR TITLE
Fix and clean flicker

### DIFF
--- a/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
@@ -21,22 +21,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public float AlphaValue { get; protected set; }
         protected int reversalCount = 0;
         protected int reversalCountThreshold;
-        public bool IsBurnedOut { get; set; }
+        public bool IsTimedOut { get; set; }
 
         public HUDFlickerBase()
         {
             Init();
         }
         public abstract void Init();
-        public virtual void InitAlphaDirection(AlphaDirection direct)
-        {
-            if (direct == AlphaDirection.Decreasing)
-                AlphaValue = alphaUpper;
-            else if (direct == AlphaDirection.Increasing)
-                AlphaValue = alphaLower;
-
-            alphaDirection = direct;
-        }
         public virtual void CheckReverseAlphaDirection()
         {
             // Alpha Direction Reversal Check
@@ -45,11 +36,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 ReverseAlphaDirection();
             else if (AlphaValue >= alphaLower && AlphaValue <= alphaUpper)
                 RandomlyReverseAlphaDirection();
-
-            if (reversalCount >= reversalCountThreshold && reversalCountThreshold != -1)
-            {
-                IsBurnedOut = true;
-            }
         }
         protected void RandomlyReverseAlphaDirection()
         {
@@ -82,38 +68,31 @@ namespace DaggerfallWorkshop.Game.UserInterface
         }
         protected void SetAlphaValue()
         {
-            // increment alpha depending on State
-            if (alphaDirection == AlphaDirection.Decreasing)
+            // set alpha depending on State
+            if ((reversalCount >= reversalCountThreshold && reversalCountThreshold != -1)
+                    || alphaDirection == AlphaDirection.None)
+                AlphaValue = 0;
+            else if (alphaDirection == AlphaDirection.Decreasing)
                 AlphaValue -= alphaSpeed * Time.deltaTime;
             else if (alphaDirection == AlphaDirection.Increasing)
                 AlphaValue += alphaSpeed * Time.deltaTime;
-            else if (alphaDirection == AlphaDirection.None)
-                AlphaValue = 0;
 
-            AlphaValue = Mathf.Clamp(AlphaValue, 0, 1);
+            AlphaValue = Mathf.Clamp(AlphaValue, 0, alphaUpper); 
         }
         public virtual void Cycle()
         {
-            if (!IsBurnedOut)
+            if (!IsTimedOut)
             {
+                if (reversalCount >= reversalCountThreshold && reversalCountThreshold != -1)
+                {
+                    IsTimedOut = true;
+                }
+
                 CheckReverseAlphaDirection();
                 SetAlphaValue();
             }
             else
                 AlphaValue = 0;
-        }
-
-        public virtual void Reset()
-        {
-            IsBurnedOut = false;
-            reversalCount = 0;
-            AlphaValue = alphaLower;
-        }
-
-        public virtual void ResetIfBurnedOut()
-        {
-            if (IsBurnedOut)
-                Reset();
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerBase.cs
@@ -66,8 +66,14 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (reversalCount != -1)
                 reversalCount++;
         }
-        protected void SetAlphaValue()
+        protected void SetAlphaValue(float overrideValue = -1)
         {
+            if (overrideValue != -1)
+            {
+                AlphaValue = overrideValue;
+                return;
+            }
+
             // set alpha depending on State
             if ((reversalCount >= reversalCountThreshold && reversalCountThreshold != -1)
                     || alphaDirection == AlphaDirection.None)
@@ -92,7 +98,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 SetAlphaValue();
             }
             else
-                AlphaValue = 0;
+                SetAlphaValue(0);
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerController.cs
@@ -49,11 +49,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             PlayerCondition condition = GetPlayerCondition();
 
-            if (vitalsDetector.HealthLost > 0)
-                flickerFast.ResetIfBurnedOut();
+            if (vitalsDetector.HealthLost > 0 && flickerFast.IsTimedOut)
+                flickerFast.Init();
 
             if (vitalsDetector.HealthGain > 0 && condition != PlayerCondition.Wounded)
-                flickerSlow.IsBurnedOut = true;
+                flickerSlow.IsTimedOut = true;
 
             Color backColor;
 
@@ -65,10 +65,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     break;
                 case PlayerCondition.Wounded:
                     flickerFast.Cycle();
-                    // Flicker slow runs if flickerFast is burned out, and cannot if it isn't burned out
-                    flickerSlow.IsBurnedOut = !flickerFast.IsBurnedOut;
+                    // Flicker slow runs if flickerFast is timed out, and cannot if it isn't timed out
+                    flickerSlow.IsTimedOut = !flickerFast.IsTimedOut;
                     flickerSlow.Cycle();
-                    if (flickerFast.IsBurnedOut)
+                    if (flickerFast.IsTimedOut)
                         backColor = new Color(flickerSlow.RedValue, 0, 0, flickerSlow.AlphaValue);
                     else
                         backColor = new Color(flickerFast.RedValue, 0, 0, flickerFast.AlphaValue);

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerFast.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerFast.cs
@@ -9,13 +9,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
     {
         public override void Init()
         {
-            Reset();
+            IsTimedOut = false;
             alphaSpeed = 7.0f;
             alphaLower = 0.0f;
             alphaUpper = 0.4f;
             RedValue = 0.3984f;
+            AlphaValue = alphaLower;
+            reversalCount = 0;
             reversalCountThreshold = 7;
-            InitAlphaDirection(AlphaDirection.Increasing);
+            alphaDirection = AlphaDirection.Increasing;
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterface/HUDFlickerSlow.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDFlickerSlow.cs
@@ -9,13 +9,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
     {
         public override void Init()
         {
-            Reset();
+            IsTimedOut = false;
             alphaSpeed = 0.2f;
             alphaLower = 0.1f;
             alphaUpper = 0.4f;
+            AlphaValue = alphaLower;
             RedValue = 0.0f;
+            reversalCount = 0;
             reversalCountThreshold = -1;
-            InitAlphaDirection(AlphaDirection.Increasing);
+            alphaDirection = AlphaDirection.Increasing;
         }
     }
 }


### PR DESCRIPTION
When setting breakpoints during the flashing and flickering, the amount of alpha can go past the intended amount because of more time passing due to taking more time to process the breakpoint.  If someone had a slowdown in their computer, this could also happen.  Their player's screen can end up permanently red.  This update fixes that.  Also, fixed some redundancy in code logic and simplified it.