### PR TITLE
Fix books from classic saves to open

### DIFF
--- a/Assets/Scripts/API/ItemsFile.cs
+++ b/Assets/Scripts/API/ItemsFile.cs
@@ -27,7 +27,7 @@ namespace DaggerfallConnect.FallExe
         public long position;                       // Position record was read from FALL.EXE
         public Byte[] name;                         // Display name
         public Int32 baseWeightUnits;               // Base weight in 0.25kg units
-        public Int16 hitPoints;                     // Hit points
+        public UInt16 hitPoints;                    // Hit points
         public Int32 capacityOrTarget;              // Capacity of container or target of effect
         public Int32 basePrice;                     // Base price before material, mercantile, etc. modify value
         public Int16 enchantmentPoints;             // Base enchantment points before material
@@ -435,7 +435,7 @@ namespace DaggerfallConnect.FallExe
             item.position = reader.BaseStream.Position;
             item.name = reader.ReadBytes(nameLength);
             item.baseWeightUnits = reader.ReadInt32();
-            item.hitPoints = reader.ReadInt16();
+            item.hitPoints = reader.ReadUInt16();
             item.capacityOrTarget = reader.ReadInt32();
             item.basePrice = reader.ReadInt32();
             item.enchantmentPoints = reader.ReadInt16();

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -248,7 +248,7 @@ namespace DaggerfallWorkshop.Game.Items
         public static DaggerfallUnityItem CreateRandomBook()
         {
             Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(ItemGroups.Books);
-            DaggerfallUnityItem book = new DaggerfallUnityItem(ItemGroups.Books, Array.IndexOf(enumArray, Books.Book));
+            DaggerfallUnityItem book = new DaggerfallUnityItem(ItemGroups.Books, Array.IndexOf(enumArray, Books.Book0));
 
             // TODO: FIXME: I don't know what the higher order bits are for the message field. I just know that message & 0xFF encodes
             // the ID of the book. Thus the books that are randomly generated are missing information that the actual game provides.

--- a/Assets/Scripts/Game/Items/ItemEnums.cs
+++ b/Assets/Scripts/Game/Items/ItemEnums.cs
@@ -289,15 +289,15 @@ namespace DaggerfallWorkshop.Game.Items
         Champion_straps = 181,
     }
 
-    public enum Books  // modified to conform with real Daggerfall save game - IC112016
+    public enum Books
     {
-        UNKNOWN_BOOK_TYPE = 276,
-        Potion_recipe = 277,
-        Parchment = 279,
-        Book = 279,
+        Book0 = 277,
+        Book1 = 277,
+        Book2 = 277,
+        Book3 = 277,
     }
 
-    public enum Furniture // Index numbers are from ItemTemplates.txt
+    public enum Furniture
     {
         Plain_single_bed = 217,
         Fancy_single_bed = 218,
@@ -337,7 +337,7 @@ namespace DaggerfallWorkshop.Game.Items
         Bandage = 249,
         Oil = 252,
         Candle = 253,
-        Parchment = 278,
+        Parchment = 279,
     }
 
     public enum ReligiousItems  //checked
@@ -575,9 +575,8 @@ namespace DaggerfallWorkshop.Game.Items
         Spellbook = 132,
         Soul_trap = 274,
         Letter_of_credit = 275,
-        //Ruby = 0,
-        UNKNOWN_MISC_ITEM, // modified order to ensure Potion_recipe is index 4 -IC112016
-        Potion_recipe = 277,
+        Ruby = 0,
+        Potion_recipe = 278,
         Dead_Body = 281,
         House_Deed = 285,
         Ship_Deed = 286,

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1419,16 +1419,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Handle local items
             if (item.ItemGroup == ItemGroups.Books)
             {
-                // Unreadable parchment (the one with a note graphic) is actually in UselessItems2
-                if (item.TemplateIndex == (int)Books.Book || item.TemplateIndex == (int)Books.Parchment)
-                {
-                    DaggerfallUI.Instance.BookReaderWindow.BookTarget = item;
-                    DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenBookReaderWindow);
-                }
-                else if (item.TemplateIndex == (int)Books.Parchment)
-                {
-                    // TODO: implement note viewer? Or is parchment just blank paper? -IC112016
-                }
+                DaggerfallUI.Instance.BookReaderWindow.BookTarget = item;
+                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenBookReaderWindow);
             }
             else if (item.ItemGroup == ItemGroups.MiscItems && item.TemplateIndex == (int)MiscItems.Potion_recipe)
             {


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=678.

The only check classic does for whether to open the book screen when doing `USE` in the inventory on an item is whether it is in group 7, the books group. Changing DF Unity to also just check this solves this issue.

Also made various fixes to the item template enums that were mixed up and causing some issues. (For example, a book in classic can have group index 1 through 4, which I think is supposed to be for different quality books, but only one of these is "book" in master, causing the books imported from classic to fail)

The changes to the enums are all from data in the .EXE (I found where they are listed) so they should all be correct.

Also included latest ItemTemplates.txt and MagicItemTemplates.txt since these are out-of-date.