### PR TITLE
Fix Save Explorer not opening if game isn't running

### DIFF
--- a/Assets/Scripts/Editor/SaveExplorerWindow.cs
+++ b/Assets/Scripts/Editor/SaveExplorerWindow.cs
@@ -502,6 +502,35 @@ namespace DaggerfallWorkshop
                         }
                     }
                 }
+
+                // Prevent duplicate names so save games aren't automatically removed from the Save Select GUI
+                for (int i = 0; i < saveNames.Length; i++)
+                {
+                    int duplicateCount = 0;
+                    for (int j = i + 1; j < saveNames.Length; j++)
+                    {
+                        if (saveNames[j].text == saveNames[i].text)
+                        {
+                            bool unique = false;
+                            while (!unique)
+                            {
+                                unique = true;
+                                string replaceText = saveNames[j].text + "(" + ++duplicateCount + ")";
+                                for (int k = 0; k < saveNames.Length; k++)
+                                {
+                                    if (saveNames[k].text == replaceText)
+                                    {
+                                        unique = false;
+                                        break;
+                                    }
+                                }
+
+                                if (unique)
+                                    saveNames[j].text = replaceText;
+                            }
+                        }
+                    }
+                }
             }
 
             return true;

--- a/Assets/Scripts/Editor/SaveExplorerWindow.cs
+++ b/Assets/Scripts/Editor/SaveExplorerWindow.cs
@@ -486,7 +486,7 @@ namespace DaggerfallWorkshop
                     {
                         if (saveGames.HasSave(i))
                         {
-                            saveGames.OpenSave(i);
+                            saveGames.OpenSave(i, false);
                             saveTrees[i] = saveGames.SaveTree;
                             saveVars[i] = saveGames.SaveVars;
                             saveNames[i] = new GUIContent(saveGames.SaveName);

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -647,7 +647,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         public void DiscoverLocation(string regionName, string locationName)
         {
-            DFLocation location;        
+            DFLocation location;
             bool found = dfUnity.ContentReader.GetLocation(regionName, locationName, out location);
             if (!found)
                 throw new Exception(String.Format("Error finding location {0} : {1}", regionName, locationName));


### PR DESCRIPTION
My previous code to import MAPSAVE data from classic saves (https://github.com/Interkarma/daggerfall-unity/commit/fd988d9b12c4ae3cbae5e48ef30f85924f843d9f) is causing Save Explorer to fail with a null exception if you try to open it without the game running in the editor. This happens because `PlayerGPS.dfUnity` isn't instantiated.

We could instantiate it, but I noticed that the MAPSAVE import makes a noticeable delay in Save Explorer as all the up-to-six saves are processed. Since Save Explorer doesn't do anything with that data yet anyway, I just disabled the import for Save Explorer. Ideally the import should be optimized, but I don't know how complex of a fix that would be.