### PR TITLE
Handle used weapon hand for save/load

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -140,6 +140,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public PlayerPositionData_v1 playerPosition;
         public PlayerEntityData_v1 playerEntity;
         public bool weaponDrawn;
+        public bool usingLeftHand;
         public TransportModes transportMode;
         public PlayerPositionData_v1 boardShipPosition;  // Holds the player position from before boarding a ship.
         public Dictionary<int, GuildMembership_v1> guildMemberships;

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -153,6 +153,7 @@ namespace DaggerfallWorkshop.Game.Serialization
 
             // Store weapon state
             data.weaponDrawn = !weaponManager.Sheathed;
+            data.usingLeftHand = !weaponManager.UsingRightHand;
             // Store transport mode
             data.transportMode = transportManager.TransportMode;
             // Store pre boarding ship position
@@ -340,6 +341,7 @@ namespace DaggerfallWorkshop.Game.Serialization
 
             // Restore sheath state
             weaponManager.Sheathed = !data.weaponDrawn;
+            weaponManager.UsingRightHand = !data.usingLeftHand;
             // Restore transport mode
             transportManager.TransportMode = data.transportMode;
             // Restore pre boarding ship position

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -506,7 +506,8 @@ namespace DaggerfallWorkshop.Game.Utility
             }
 
             // Set whether the player's weapon is drawn
-            GameManager.Instance.WeaponManager.Sheathed = (!saveVars.WeaponDrawn);
+            WeaponManager weaponManager = GameManager.Instance.WeaponManager;
+            weaponManager.Sheathed = (!saveVars.WeaponDrawn);
 
             // Set game time
             DaggerfallUnity.Instance.WorldTime.Now.FromClassicDaggerfallTime(saveVars.GameTime);
@@ -551,6 +552,9 @@ namespace DaggerfallWorkshop.Game.Utility
 
             // Assign gold pieces
             playerEntity.GoldPieces = (int)characterRecord.ParsedData.physicalGold;
+
+            // Assign weapon hand being used
+            weaponManager.UsingRightHand = !saveVars.UsingLeftHandWeapon;
 
             // GodMode setting
             playerEntity.GodMode = saveVars.GodMode;


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=936.

Also imports used hand from classic saves.

Existing DF Unity saves will be loaded as if the right hand was being used. Saves made after this PR is applied will load with the correct hand.