### PR TITLE
Swimming improvements

### DIFF
--- a/Assets/Scripts/Game/LevitateMotor.cs
+++ b/Assets/Scripts/Game/LevitateMotor.cs
@@ -90,7 +90,8 @@ namespace DaggerfallWorkshop.Game
             {
                 // Do not allow player to swim up out of water, as he would immediately be pulled back in, making jerky movement and playing the splash sound repeatedly
                 if ((direction.y > 0) && (playerMotor.controller.transform.position.y + (50 * MeshReader.GlobalScale) - 0.93f) >=
-                (GameManager.Instance.PlayerEnterExit.blockWaterLevel * -1 * MeshReader.GlobalScale))
+                (GameManager.Instance.PlayerEnterExit.blockWaterLevel * -1 * MeshReader.GlobalScale) &&
+                !playerLevitating)
                     direction.y = 0;
 
                 Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -14,6 +14,7 @@ namespace DaggerfallWorkshop.Game
         private PlayerMotor playerMotor;
         private LevitateMotor levitateMotor;
         private CharacterController controller;
+        private PlayerHeightChanger heightChanger;
         private bool failedClimbingCheck = false;
         private bool isClimbing = false;
         private float climbingStartTimer = 0;
@@ -31,6 +32,7 @@ namespace DaggerfallWorkshop.Game
             playerMotor = GetComponent<PlayerMotor>();
             levitateMotor = GetComponent<LevitateMotor>();
             controller = GetComponent<CharacterController>();
+            heightChanger = GetComponent<PlayerHeightChanger>();
         }
 
         /// <summary>
@@ -55,7 +57,7 @@ namespace DaggerfallWorkshop.Game
                 || failedClimbingCheck
                 || levitateMotor.IsLevitating
                 || playerMotor.IsRiding
-                || playerMotor.IsCrouching 
+                || (playerMotor.IsCrouching && !heightChanger.ForcedSwimCrouch)
                 || Vector2.Distance(lastHorizontalPosition, new Vector2(controller.transform.position.x, controller.transform.position.z)) >= (0.003f)) // Approximation based on observing classic in-game
             {
                 isClimbing = false;

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -45,6 +45,7 @@ namespace DaggerfallWorkshop.Game
         private PlayerMotor playerMotor;
         private CharacterController controller;
         private HeadBobber headBobber;
+        private LevitateMotor levitateMotor;
         //private LevitateMotor levitateMotor;
         private Camera mainCamera;
         private float controllerStandHeight = 1.78f;
@@ -76,6 +77,7 @@ namespace DaggerfallWorkshop.Game
         private void Start()
         {
             playerMotor = GetComponent<PlayerMotor>();
+            levitateMotor = GetComponent<LevitateMotor>();
             controller = GetComponent<CharacterController>();
             headBobber = GetComponent<HeadBobber>();
             mainCamera = GameManager.Instance.MainCamera;
@@ -119,7 +121,12 @@ namespace DaggerfallWorkshop.Game
                 heightAction = HeightChangeAction.DoDismounting;
                 toggleRiding = false;
             }
-            else if (!playerMotor.IsRiding)
+            // automatically exit crouch if swimming and crouching
+            else if (levitateMotor.IsSwimming && playerMotor.IsCrouching)
+            {
+                HeightAction = HeightChangeAction.DoStanding;
+            }
+            else if (!playerMotor.IsRiding && !levitateMotor.IsSwimming)
             {
                 // Toggle crouching
                 if (!onWater && InputManager.Instance.ActionComplete(InputManager.Actions.Crouch))

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -45,7 +45,6 @@ namespace DaggerfallWorkshop.Game
         private PlayerMotor playerMotor;
         private CharacterController controller;
         private HeadBobber headBobber;
-        private LevitateMotor levitateMotor;
         //private LevitateMotor levitateMotor;
         private Camera mainCamera;
         private float controllerStandHeight = 1.78f;
@@ -77,7 +76,6 @@ namespace DaggerfallWorkshop.Game
         private void Start()
         {
             playerMotor = GetComponent<PlayerMotor>();
-            levitateMotor = GetComponent<LevitateMotor>();
             controller = GetComponent<CharacterController>();
             headBobber = GetComponent<HeadBobber>();
             mainCamera = GameManager.Instance.MainCamera;
@@ -121,12 +119,7 @@ namespace DaggerfallWorkshop.Game
                 heightAction = HeightChangeAction.DoDismounting;
                 toggleRiding = false;
             }
-            // automatically exit crouch if swimming and crouching
-            else if (levitateMotor.IsSwimming && playerMotor.IsCrouching)
-            {
-                HeightAction = HeightChangeAction.DoStanding;
-            }
-            else if (!playerMotor.IsRiding && !levitateMotor.IsSwimming)
+            else if (!playerMotor.IsRiding)
             {
                 // Toggle crouching
                 if (!onWater && InputManager.Instance.ActionComplete(InputManager.Actions.Crouch))

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -11,6 +11,7 @@ namespace DaggerfallWorkshop.Game
     public class PlayerSpeedChanger : MonoBehaviour
     {
         private PlayerMotor playerMotor;
+        private LevitateMotor levitateMotor;
 
         // If checked, the run key toggles between running and walking. Otherwise player runs if the key is held down and walks otherwise
         // There must be a button set up in the Input Manager called "Run"
@@ -32,6 +33,7 @@ namespace DaggerfallWorkshop.Game
         private void Start()
         {
             playerMotor = GameManager.Instance.PlayerMotor;
+            levitateMotor = GetComponent<LevitateMotor>();
         }
 
         private void Update()
@@ -81,7 +83,8 @@ namespace DaggerfallWorkshop.Game
             float playerSpeed = player.Stats.LiveSpeed;
             if (playerMotor == null) // fixes null reference bug.
                 playerMotor = GameManager.Instance.PlayerMotor;
-            if (playerMotor.IsCrouching)
+            // crouching speed penalty doesn't apply if swimming.
+            if (playerMotor.IsCrouching && !levitateMotor.IsSwimming)
                 baseSpeed = (playerSpeed + dfCrouchBase) / classicToUnitySpeedUnitRatio;
             else if (playerMotor.IsRiding)
                 baseSpeed = (playerSpeed + dfRideBase) / classicToUnitySpeedUnitRatio;

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -275,7 +275,7 @@ namespace DaggerfallWorkshop.Game
                     underwaterFog.UpdateFog(blockWaterLevel);
                 }
             }
-            else if(underwaterFog != null)
+            else if(underwaterFog != null && underwaterFog.originalFog != RenderSettings.fogMode)
             {
                 underwaterFog.ResetFog();
             }

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -29,7 +29,7 @@ namespace DaggerfallWorkshop.Game
     public class PlayerEnterExit : MonoBehaviour
     {
         const HideFlags defaultHideFlags = HideFlags.None;
-
+        UnderwaterFog underwaterFog;
         DaggerfallUnity dfUnity;
         CharacterController controller;
         bool isPlayerInside = false;
@@ -243,6 +243,7 @@ namespace DaggerfallWorkshop.Game
             // Wire event for when player enters a new location
             PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
             levitateMotor = GetComponent<LevitateMotor>();
+            underwaterFog = new UnderwaterFog();
         }
 
         void Update()
@@ -269,7 +270,16 @@ namespace DaggerfallWorkshop.Game
                     }
                     //Debug.Log(string.Format("Player is now inside block {0}", playerDungeonBlockData.BlockName));
                 }
+                if (playerBlockIndex != -1)
+                {
+                    underwaterFog.UpdateFog(blockWaterLevel);
+                }
             }
+            else if(underwaterFog != null)
+            {
+                underwaterFog.ResetFog();
+            }
+
 
             // Count down holiday text display
             if (holidayTextTimer > 0)

--- a/Assets/Scripts/Game/UnderwaterFog.cs
+++ b/Assets/Scripts/Game/UnderwaterFog.cs
@@ -13,7 +13,7 @@ namespace DaggerfallWorkshop.Game
         Color waterFogColor;
         private float fogDensityMin;
         private float fogDensityMax;
-        private FogMode originalFog = FogMode.Linear;
+        public readonly FogMode originalFog = RenderSettings.fogMode;
 
         public UnderwaterFog()
         {
@@ -48,8 +48,6 @@ namespace DaggerfallWorkshop.Game
         { 
             sky.SetSkyFogColor(sky.skyColors);
             RenderSettings.fogMode = originalFog;
-            RenderSettings.fogStartDistance = 0;
-            RenderSettings.fogEndDistance = 2400;
         }
     }
 }

--- a/Assets/Scripts/Game/UnderwaterFog.cs
+++ b/Assets/Scripts/Game/UnderwaterFog.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using UnityStandardAssets.ImageEffects;
+
+namespace DaggerfallWorkshop.Game
+{
+    public class UnderwaterFog 
+    {
+        GlobalFog globalFog;
+        DaggerfallSky sky;
+        Camera mainCamera;
+        Color waterFogColor;
+        private float fogDensityMin;
+        private float fogDensityMax;
+        private FogMode originalFog = FogMode.Linear;
+
+        public UnderwaterFog()
+        {
+            mainCamera = GameManager.Instance.MainCamera;
+            globalFog = mainCamera.GetComponent<GlobalFog>();
+            globalFog.enabled = true;
+            sky = GameManager.Instance.SkyRig;
+            waterFogColor = new Color(0.25f, 0.55f, 0.79f, 1);
+            fogDensityMin = 0f;
+            fogDensityMax = 0.23f;
+        }
+
+        public void UpdateFog(float waterLevel)
+        {
+            float fogT;
+            float yPos = mainCamera.transform.position.y;
+
+            float adjustedCamYPos = yPos + (50 * MeshReader.GlobalScale) - 0.95f;
+            float waterEntryThreshold = (waterLevel * -1 * MeshReader.GlobalScale) + 0.38f;
+            float waterExitThreshold = (waterEntryThreshold) - 0.02f;
+
+            float clampedCamYPos = Mathf.Clamp(adjustedCamYPos, waterExitThreshold, waterEntryThreshold);
+
+            fogT = 1 - ((clampedCamYPos - waterExitThreshold) / (waterEntryThreshold - waterExitThreshold));
+
+            RenderSettings.fogColor = waterFogColor;
+            RenderSettings.fogMode = FogMode.Exponential;
+            RenderSettings.fogDensity = Mathf.Lerp(fogDensityMin, fogDensityMax, fogT);
+        }
+
+        public void ResetFog()
+        { 
+            sky.SetSkyFogColor(sky.skyColors);
+            RenderSettings.fogMode = originalFog;
+            RenderSettings.fogStartDistance = 0;
+            RenderSettings.fogEndDistance = 2400;
+        }
+    }
+}

--- a/Assets/Scripts/Game/UnderwaterFog.cs.meta
+++ b/Assets/Scripts/Game/UnderwaterFog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e243188026c862f47aeb447ef6735656
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Internal/DaggerfallSky.cs
+++ b/Assets/Scripts/Internal/DaggerfallSky.cs
@@ -72,7 +72,7 @@ namespace DaggerfallWorkshop
         System.Random random = new System.Random(0);
         bool showNightSky = true;
 
-        SkyColors skyColors = new SkyColors();
+        public SkyColors skyColors = new SkyColors();
         float starChance = 0.004f;
         byte[] starColorIndices = new byte[] { 16, 32, 74, 105, 112, 120 };     // Some random sky colour indices
 
@@ -318,6 +318,11 @@ namespace DaggerfallWorkshop
             westTexture.Apply(false, true);
             eastTexture.Apply(false, true);
 
+            SetSkyFogColor(colors);
+        }
+
+        public void SetSkyFogColor(SkyColors colors)
+        {
             // Set camera clear colour
             cameraClearColor = colors.clearColor;
             myCamera.backgroundColor = ((cameraClearColor * SkyTintColor) * 2f) * SkyColorScale;

--- a/Assets/Scripts/Utility/CameraClearManager.cs
+++ b/Assets/Scripts/Utility/CameraClearManager.cs
@@ -23,7 +23,7 @@ public class CameraClearManager : MonoBehaviour
     public CameraClearFlags cameraClearExterior = CameraClearFlags.Depth;
     public CameraClearFlags cameraClearInterior = CameraClearFlags.Color;
     public Color cameraClearColor = Color.black;
-    public bool toggleGlobalFog = true;
+    //public bool toggleGlobalFog = true;
 
     GlobalFog globalFog;
     bool lastInside = false;
@@ -53,12 +53,13 @@ public class CameraClearManager : MonoBehaviour
                 mainCamera.backgroundColor = cameraClearColor;
                 //Debug.Log("Camera clear set to inside");
 
+                // Comment this out, We're not Unity 5.5 anymore - MeteoricDragon
                 // Disable global fog inside
                 // This fixes an issue with solid camera clear not working in Unity 5.5
-                if (toggleGlobalFog && globalFog)
-                {
-                    globalFog.enabled = false;
-                }
+                //if (toggleGlobalFog && globalFog)
+                //{
+                //    globalFog.enabled = false;
+                //}
 
                 lastInside = isInside;
             }
@@ -69,10 +70,10 @@ public class CameraClearManager : MonoBehaviour
                 //Debug.Log("Camera clear set to outside");
 
                 // Enable global fog outside
-                if (toggleGlobalFog && globalFog)
-                {
-                    globalFog.enabled = true;
-                }
+                //if (toggleGlobalFog && globalFog)
+                //{
+                //    globalFog.enabled = true;
+                //}
 
                 lastInside = isInside;
             }   


### PR DESCRIPTION
- Implements a smooth underwater fog,  if the player is partially underwater, the fog fades partially in, until the camera is under.  This eliminates the blinking sensation that happens when exiting/entering water.

 - commented out a toggle for global fog because it was there to fix an issue with solid camera clear not working in Unity 5.5 because we're not unity 5.5 anymore, and it was preventing underwater fog from working.

- The player will no longer toggle crouch while using crouch key to swim down if player is in water.  Also, if player enters water and is crouching, will automatically stand.

- In some situations, the player could be stuck in the water while levitating.  This simple change allows the player to exit the water if they are levitating.