### PR TITLE
Shorten enemy stealth check range

### DIFF
--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -196,7 +196,7 @@ namespace DaggerfallWorkshop.Game
 
         public bool StealthCheck()
         {
-            if (distanceToPlayer > 1024 * MeshReader.GlobalScale)
+            if (distanceToPlayer > 768 * MeshReader.GlobalScale)
                 return false;
 
             uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();


### PR DESCRIPTION
Since I allowed enemies to detect the player through walls with the stealth check (check between the player and the enemy's stealth stats), they are detecting from a little too far away. Someone who did a video on YouTube was wondering if the game was bugged. Adjusting it down to the value in this PR seems to help for now. In classic the actual stealth check uses a distance of 1024 but I think it's also limited by the distance of enemies before they are unloaded, which I don't fully understand but I think is around 768 in interiors (1024 in exteriors).