### PR TITLE
Recreate classic way of choosing random enemies

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -80,3 +80,4 @@ LypyL_ModSystem=True
 MeshAndTextureReplacement=False
 CompressModdedTextures=True
 NearDeathWarning=True
+AlternateRandomEnemySelection=False

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -96,6 +96,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox assetImport;
         Checkbox compressModdedTextures;
         Checkbox nearDeathWarning;
+        Checkbox alternateRandomEnemySelection;
         HorizontalSlider cameraRecoilStrength;
 
         // Video
@@ -209,6 +210,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             assetImport = AddCheckbox(rightPanel, "assetImport", DaggerfallUnity.Settings.MeshAndTextureReplacement);
             compressModdedTextures = AddCheckbox(rightPanel, "compressModdedTextures", DaggerfallUnity.Settings.CompressModdedTextures);
             nearDeathWarning = AddCheckbox(rightPanel, "nearDeathWarning", DaggerfallUnity.Settings.NearDeathWarning);
+            alternateRandomEnemySelection = AddCheckbox(rightPanel, "alternateRandomEnemySelection", DaggerfallUnity.Settings.AlternateRandomEnemySelection);
         }
 
         private void Video(Panel leftPanel, Panel rightPanel)
@@ -289,6 +291,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.MeshAndTextureReplacement = assetImport.IsChecked;
             DaggerfallUnity.Settings.CompressModdedTextures = compressModdedTextures.IsChecked;
             DaggerfallUnity.Settings.NearDeathWarning = nearDeathWarning.IsChecked;
+            DaggerfallUnity.Settings.AlternateRandomEnemySelection = alternateRandomEnemySelection.IsChecked;
             DaggerfallUnity.Settings.CameraRecoilStrength = cameraRecoilStrength.ScrollIndex;
 
             /* Video */

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -141,6 +141,7 @@ namespace DaggerfallWorkshop
         public bool MeshAndTextureReplacement { get; set; }
         public bool CompressModdedTextures { get; set; }
         public bool NearDeathWarning { get; set; }
+        public bool AlternateRandomEnemySelection { get; set; }
 
         #endregion
 
@@ -227,6 +228,7 @@ namespace DaggerfallWorkshop
             MeshAndTextureReplacement = GetBool(sectionEnhancements, "MeshAndTextureReplacement");
             CompressModdedTextures = GetBool(sectionEnhancements, "CompressModdedTextures");
             NearDeathWarning = GetBool(sectionEnhancements, "NearDeathWarning");
+            AlternateRandomEnemySelection = GetBool(sectionEnhancements, "AlternateRandomEnemySelection");
         }
 
         /// <summary>
@@ -306,6 +308,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionEnhancements, "MeshAndTextureReplacement", MeshAndTextureReplacement);
             SetBool(sectionEnhancements, "CompressModdedTextures", CompressModdedTextures);
             SetBool(sectionEnhancements, "NearDeathWarning", NearDeathWarning);
+            SetBool(sectionEnhancements, "AlternateRandomEnemySelection", AlternateRandomEnemySelection);
 
             // Write settings to persistent file
             WriteSettingsFile();

--- a/Assets/Scripts/Utility/RandomEncounters.cs
+++ b/Assets/Scripts/Utility/RandomEncounters.cs
@@ -548,7 +548,6 @@ namespace DaggerfallWorkshop.Utility
                 },
             },
 
-            /*
             // Cemetery - Index18
             new RandomEncounterTable()
             {
@@ -579,8 +578,8 @@ namespace DaggerfallWorkshop.Utility
                     MobileTypes.Rogue,
                 },
             },
-            */
 
+            /*
             // Cemetery - DF Unity version
             new RandomEncounterTable()
             {
@@ -599,7 +598,7 @@ namespace DaggerfallWorkshop.Utility
                     MobileTypes.VampireAncient,
                     MobileTypes.Lich,
                 },
-            },
+            },*/
 
             // Underwater - Index19
             new RandomEncounterTable()

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -55,6 +55,8 @@ compressModdedTextures,                             Compress Modded Textures
 compressModdedTexturesInfo,                         Import textures with a compressed format which uses less graphics memory.
 nearDeathWarning,									Near Death Warning
 nearDeathWarningInfo,								Show blinking/pulsating screen effects to warn when near death.
+alternateRandomEnemySelection,						Alternate Random Enemy Selection
+alternateRandomEnemySelectionInfo,					Create random enemies in dungeons with more variability.
 
 resolution,                                         Resolution
 resolutionInfo,                                     Screen resolution


### PR DESCRIPTION
This implements the issue raised in https://forums.dfworkshop.net/viewtopic.php?f=24&t=560, which was closed as "intended". It should also address the issue raised here: https://www.reddit.com/r/daggerfallunity/comments/96pmzc/the_enemies_in_daggerfall_unity_are_way_off_and/

Classic selection is enabled by default. Previous random selection can be turned on by enabling "Alternate Random Enemy Selection" at the startup screen. (except the alternate, undead-heavy cemetery list for DF Unity is commented out and classic's list is being used now)

Basically how it works: As you know, there are `RANDOM MON` markers that make random enemies and `MONSTER` markers that make fixed enemies. Random enemies, though, are not completely random in classic. Most seem to have a value set in their "flags" part of the rdb resource data, and this is used to choose from a list of enemy types that is created for that dungeon (which is determined using dungeon ID as a seed for the random generator, with the player's level as an input that determines the result). There are some that don't have any value for the "flags" data, in which case it's a random choice from 1 to 6, without a set seed to use, so these vary every time you leave/enter the dungeon.

This doesn't affect "random encounters" that spawn intermittently in exteriors or that interrupt player rest. I might look at those later.