### PR TITLE
Implement classic melee timer and reflexes

### DIFF
--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
@@ -83,9 +83,11 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 0}
   m_StaticBatchInfo:
@@ -98,12 +100,14 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &3367684
 MeshFilter:
@@ -141,54 +145,69 @@ AudioSource:
   rolloffCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
-    - serializedVersion: 2
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
       time: 1
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   panLevelCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
   spreadCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
@@ -218,7 +237,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MeleeAttackSpeed: 1.25
-  MeleeDistance: 2.5
+  MeleeDistance: 3.2
 --- !u!114 &11435454
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -338,11 +357,24 @@ MonoBehaviour:
       ParrySounds: 0
       MapChance: 0
       LootTableKey: 
-      HitFrame: 0
       Weight: 0
+      CastsMagic: 0
+      SeesThroughInvisibility: 0
+      SoulPts: 0
+      PrimaryAttackAnimFrames: 
+      ChanceForAttack2: 0
+      PrimaryAttackAnimFrames2: 
+      ChanceForAttack3: 0
+      PrimaryAttackAnimFrames3: 
+      ChanceForAttack4: 0
+      PrimaryAttackAnimFrames4: 
+      ChanceForAttack5: 0
+      PrimaryAttackAnimFrames5: 
+      RangedAttackAnimFrames: 
     EnemyState: 0
     StateAnims: []
     AnimStateRecord: 0
+    StateAnimFrames: 
 --- !u!114 &11492232
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
@@ -81,9 +81,11 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 0}
   m_StaticBatchInfo:
@@ -96,12 +98,14 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &3367684
 MeshFilter:
@@ -139,54 +143,69 @@ AudioSource:
   rolloffCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
-    - serializedVersion: 2
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
       time: 1
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   panLevelCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
   spreadCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
@@ -216,7 +235,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MeleeAttackSpeed: 1.25
-  MeleeDistance: 2.5
+  MeleeDistance: 3.2
 --- !u!114 &11435454
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -325,11 +344,24 @@ MonoBehaviour:
       ParrySounds: 0
       MapChance: 0
       LootTableKey: 
-      HitFrame: 0
       Weight: 0
+      CastsMagic: 0
+      SeesThroughInvisibility: 0
+      SoulPts: 0
+      PrimaryAttackAnimFrames: 
+      ChanceForAttack2: 0
+      PrimaryAttackAnimFrames2: 
+      ChanceForAttack3: 0
+      PrimaryAttackAnimFrames3: 
+      ChanceForAttack4: 0
+      PrimaryAttackAnimFrames4: 
+      ChanceForAttack5: 0
+      PrimaryAttackAnimFrames5: 
+      RangedAttackAnimFrames: 
     EnemyState: 0
     StateAnims: []
     AnimStateRecord: 0
+    StateAnimFrames: 
 --- !u!114 &11492232
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -24,8 +24,8 @@ namespace DaggerfallWorkshop.Game
     [RequireComponent(typeof(CharacterController))]
     public class EnemyMotor : MonoBehaviour
     {
-        public float OpenDoorDistance = 2f;         // Maximum distance to open door
-        public const float AttackSpeedDivisor = 3f;       // How much to slow down during attack animations
+        public float OpenDoorDistance = 2f;             // Maximum distance to open door
+        public const float AttackSpeedDivisor = 3f;     // How much to slow down during attack animations
 
         EnemySenses senses;
         Vector3 targetPos;


### PR DESCRIPTION
Things this does:

- Implements classic melee timer
- Fix what seems to be oversight in classic where higher speed enemies would instead attack less
- Implements reflexes as in classic. This is in classic, too, but like so many things does not seem to work correctly (I swear, it's like they purposely left the game with a random thing missing/reversed, etc. in every game mechanic so we'd have the fun of patching the holes), because the value it refers to in the enemy object data seems to always be 0 and is not ever set by anything, so no matter what reflexes setting you choose it seems enemies attack at "very high" reflexes in classic. Luckily, although having this correctly refer to the reflexes setting slows down attacks at, for example, the "average" setting of 2, I think the above fix more or less offsets this, as many enemies have high speed attributes. At any rate the resultant attack rates seemed OK in testing.

BTW reflex setting is also supposed to affect skill increases, but I don't think that's in yet. It may also have another effect on attacks that isn't in yet.

- Matched enemy melee range to classic (128 Daggerfall distance units). Doing this also automatically updated the enemy prefabs in other ways, although I'm not sure if those updates actually affect anything or not.