### PR TITLE
Match non-LOS sense of player to classic

### DIFF
--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -107,6 +107,12 @@ namespace DaggerfallWorkshop.Game
             set { hasEncounteredPlayer = value; }
         }
 
+        public bool WouldBeSpawnedInClassic
+        {
+            get { return wouldBeSpawnedInClassic; }
+            set { wouldBeSpawnedInClassic = value; }
+        }
+
         void Start()
         {
             mobile = GetComponentInChildren<DaggerfallMobileUnit>();

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -538,11 +538,11 @@ namespace DaggerfallWorkshop.Game
 
         /// <summary>
         /// Determines if enemies are nearby. Uses include whether player is able to rest or not.
-        /// Based on minimum distance to nearest monster, and if monster can actually sense player.
+        /// Based on distance to nearest monster, and if monster can actually sense player.
         /// </summary>
-        /// <param name="minMonsterDistance">Monsters must be at least this close.</param>
+        /// <param name="minMonsterSpawnerDistance">Monster spawners must be at least this close.</param>
         /// <returns>True if enemies are nearby.</returns>
-        public bool AreEnemiesNearby(float minMonsterDistance = 12f)
+        public bool AreEnemiesNearby(float minMonsterSpawnerDistance = 12f)
         {
             bool areEnemiesNearby = false;
             DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
@@ -551,18 +551,11 @@ namespace DaggerfallWorkshop.Game
                 DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
                 if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
                 {
-                    // Is a monster inside min distance?
-                    if (Vector3.Distance(entityBehaviour.transform.position, PlayerController.transform.position) < minMonsterDistance)
-                    {
-                        areEnemiesNearby = true;
-                        break;
-                    }
-
-                    // Is monster already aware of player?
                     EnemySenses enemySenses = entityBehaviour.GetComponent<EnemySenses>();
                     if (enemySenses)
                     {
-                        if (enemySenses.PlayerInSight || enemySenses.PlayerInEarshot)
+                        // Is enemy already aware of player or close enough they would be spawned in classic?
+                        if (enemySenses.PlayerInSight || enemySenses.PlayerInEarshot || enemySenses.WouldBeSpawnedInClassic)
                         {
                             areEnemiesNearby = true;
                             break;
@@ -576,7 +569,7 @@ namespace DaggerfallWorkshop.Game
             for (int i = 0; i < spawners.Length; i++)
             {
                 // Is a spawner inside min distance?
-                if (Vector3.Distance(spawners[i].transform.position, PlayerController.transform.position) < minMonsterDistance)
+                if (Vector3.Distance(spawners[i].transform.position, PlayerController.transform.position) < minMonsterSpawnerDistance)
                 {
                     areEnemiesNearby = true;
                     break;

--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -17,6 +17,7 @@ namespace DaggerfallWorkshop.Game
         public MobileTypes EnemyType = MobileTypes.SkeletalWarrior;
         public MobileReactions EnemyReaction = MobileReactions.Hostile;
         public MobileGender EnemyGender = MobileGender.Unspecified;
+        public byte ClassicSpawnDistanceType = 0;
 
         DaggerfallEntityBehaviour entityBehaviour;
 
@@ -54,7 +55,7 @@ namespace DaggerfallWorkshop.Game
                 // Setup mobile billboard
                 Vector2 size = Vector2.one;
                 mobileEnemy.Gender = gender;
-                dfMobile.SetEnemy(dfUnity, mobileEnemy, EnemyReaction);
+                dfMobile.SetEnemy(dfUnity, mobileEnemy, EnemyReaction, ClassicSpawnDistanceType);
 
                 // Setup controller
                 CharacterController controller = GetComponent<CharacterController>();
@@ -119,10 +120,11 @@ namespace DaggerfallWorkshop.Game
         /// Change enemy settings and configure in a single call.
         /// </summary>
         /// <param name="enemyType">Enemy type.</param>
-        public void ApplyEnemySettings(MobileTypes enemyType, MobileReactions enemyReaction, MobileGender gender)
+        public void ApplyEnemySettings(MobileTypes enemyType, MobileReactions enemyReaction, MobileGender gender, byte classicSpawnDistanceType = 0)
         {
             EnemyType = enemyType;
             EnemyReaction = enemyReaction;
+            ClassicSpawnDistanceType = classicSpawnDistanceType;
             ApplyEnemySettings(gender);
         }
 

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -98,6 +98,7 @@ namespace DaggerfallWorkshop
             public EnemyImportedTextures ImportedTextures;      // Textures imported from mods
             public int AnimStateRecord;                         // Record number of animation state
             public int[] StateAnimFrames;                       // Sequence of frames to play for this animation. Used for attacks
+            public byte ClassicSpawnDistanceType;               // 0 through 6 value read from spawn marker that determines distance at which enemy spawns/despawns in classic.
         }
 
         void Start()
@@ -143,7 +144,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         /// <param name="dfUnity">DaggerfallUnity singleton. Required for content readers and settings.</param>
         /// <param name="enemyType">Enemy type.</param>
-        public void SetEnemy(DaggerfallUnity dfUnity, MobileEnemy enemy, MobileReactions reaction)
+        public void SetEnemy(DaggerfallUnity dfUnity, MobileEnemy enemy, MobileReactions reaction, byte classicSpawnDistanceType)
         {
             // Initial enemy settings
             summary.Enemy = enemy;
@@ -158,6 +159,9 @@ namespace DaggerfallWorkshop
             // Apply enemy state and update orientation
             lastOrientation = -1;
             ApplyEnemyState();
+
+            // Set initial contact range
+            summary.ClassicSpawnDistanceType = classicSpawnDistanceType;
 
             // Raise setup flag
             summary.IsSetup = true;

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1348,8 +1348,10 @@ namespace DaggerfallWorkshop.Utility
                 if (serialize)
                     loadID = (ulong)(blockData.Position + obj.Position);
 
+                byte classicSpawnDistanceType = obj.Resources.FlatResource.SoundIndex;
+
                 // Add enemy
-                AddEnemy(obj, type, parent, loadID);
+                AddEnemy(obj, type, parent, loadID, classicSpawnDistanceType);
             }
             else
             {
@@ -1406,8 +1408,10 @@ namespace DaggerfallWorkshop.Utility
                 else
                     type = DungeonNonWaterEnemiesToPlace[slot];
 
+                byte classicSpawnDistanceType = obj.Resources.FlatResource.SoundIndex;
+
                 // Add enemy
-                AddEnemy(obj, type, parent, loadID);
+                AddEnemy(obj, type, parent, loadID, classicSpawnDistanceType);
             }
             else
             {
@@ -1465,14 +1469,17 @@ namespace DaggerfallWorkshop.Utility
             // Cast to enum
             MobileTypes type = (MobileTypes)(obj.Resources.FlatResource.FactionOrMobileId & 0xff);
 
-            AddEnemy(obj, type, parent, loadID);
+            byte classicSpawnDistanceType = obj.Resources.FlatResource.SoundIndex;
+
+            AddEnemy(obj, type, parent, loadID, classicSpawnDistanceType);
         }
 
         private static void AddEnemy(
             DFBlock.RdbObject obj,
             MobileTypes type,
             Transform parent = null,
-            ulong loadID = 0)
+            ulong loadID = 0,
+            byte classicSpawnDistanceType = 0)
         {
             // Get default reaction
             MobileReactions reaction = MobileReactions.Hostile;
@@ -1495,7 +1502,7 @@ namespace DaggerfallWorkshop.Utility
             if (setupEnemy != null)
             {
                 // Configure enemy
-                setupEnemy.ApplyEnemySettings(type, reaction, gender);
+                setupEnemy.ApplyEnemySettings(type, reaction, gender, classicSpawnDistanceType);
 
                 // Align non-flying units with ground
                 DaggerfallMobileUnit mobileUnit = setupEnemy.GetMobileBillboardChild();


### PR DESCRIPTION
Should fix https://forums.dfworkshop.net/viewtopic.php?f=24&t=1227, in as much as it generally matches the range to classic.

This could maybe be tidied up a little but I wanted to get it in before the release which is probably upcoming.

Background of the issue:
In classic, enemies can detect the player without having LOS, through walls, etc., depending on a roll against the player's stealth skill. This is why they sometimes open doors and come out of rooms at you, etc. I implemented this a while ago but not the correct range at which the check should happen. Enemies were approaching the player from a lot further than in classic, and enemies weren't being found in their expected spots in Privateer's Hold, etc. This may also have been making it more difficult to find a spot away from enemies to rest. In classic the stealth check itself has a big range but it's limited by the spawn/despawn range, because AI characters won't be active to do the check unless they are near the player. It turns out a byte in the spawn markers, from 0 through 6, determines the X-range and Y-range from the player at which an enemy spawns/despawns (the distances for spawning and despawning are a little different). That is recreated by this PR now, using these distances to limit the range of their stealth detection, effectively recreating classic behavior, but without actually spawning and despawning them.
