### PR TITLE
Climb update

### DIFF
--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -84,22 +84,6 @@ namespace DaggerfallWorkshop.Game
                         showClimbingModeMessage = false;
                         isClimbing = true;
                     }
-
-                    // Initial check to start climbing
-                    if ((gameMinutes - timeOfLastClimbingCheck) > 18)
-                    {
-                        Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-                        player.TallySkill(DFCareer.Skills.Climbing, 1);
-                        timeOfLastClimbingCheck = gameMinutes;
-                        if (UnityEngine.Random.Range(1, 101) > 95)
-                        {
-                            if (UnityEngine.Random.Range(1, 101) > player.Skills.GetLiveSkillValue(DFCareer.Skills.Climbing))
-                            {
-                                isClimbing = false;
-                                failedClimbingCheck = true;
-                            }
-                        }
-                    }
                 }
             }
 

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -192,7 +192,7 @@ namespace DaggerfallWorkshop.Game
             skill = Mathf.Clamp(skill, 5, 95);
 
             // Skill Check
-            float percentRolled = Mathf.Lerp(basePercentSuccess, 101, skill * .01f);
+            float percentRolled = Mathf.Lerp(basePercentSuccess, 100, skill * .01f);
 
             if (percentRolled < UnityEngine.Random.Range(1, 101)) // Failed Check?
             {

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -16,8 +16,10 @@ namespace DaggerfallWorkshop.Game
         private LevitateMotor levitateMotor;
         private CharacterController controller;
         private PlayerEnterExit playerEnterExit;
+        private AcrobatMotor acrobatMotor;
         private bool failedClimbingCheck = false;
         private bool isClimbing = false;
+        private bool isSlipping = false;
         private float climbingStartTimer = 0;
         private float climbingContinueTimer = 0;
         private uint timeOfLastClimbingCheck = 0;
@@ -28,6 +30,10 @@ namespace DaggerfallWorkshop.Game
         {
             get { return isClimbing; }
         }
+        public bool IsSlipping
+        {
+            get { return isSlipping; }
+        }
         void Start()
         {
             player = GameManager.Instance.PlayerEntity;
@@ -35,7 +41,7 @@ namespace DaggerfallWorkshop.Game
             levitateMotor = GetComponent<LevitateMotor>();
             controller = GetComponent<CharacterController>();
             playerEnterExit = GetComponent<PlayerEnterExit>();
-            //heightChanger = GetComponent<PlayerHeightChanger>();
+            acrobatMotor = GetComponent<AcrobatMotor>();
         }
 
         /// <summary>
@@ -47,7 +53,10 @@ namespace DaggerfallWorkshop.Game
             float stopClimbingDistance = 0.12f;
 
             if (isClimbing)
+            {
                 collisionFlags = CollisionFlags.Sides;
+                acrobatMotor.Falling = false;
+            }
 
             // Should we stop climbing?
             uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -33,7 +33,7 @@ namespace DaggerfallWorkshop.Game
         // minimum percent chance to regain hold per skill check if slipping, gets closer to 100 with higher skill
         private const int regainHoldMinChance = 20;
         // minimum percent chance to continue climbing per skill check, gets closer to 100 with higher skill
-        private const int continueClimbMinChance = 80;
+        private const int continueClimbMinChance = 70;
         public bool IsClimbing
         {
             get { return isClimbing; }

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -61,7 +61,6 @@ namespace DaggerfallWorkshop.Game
             float stopClimbingDistance = 0.12f;
 
             // Should we stop climbing?
-            uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
             if (!InputManager.Instance.HasAction(InputManager.Actions.MoveForwards)
                 || (playerMotor.CollisionFlags & CollisionFlags.Sides) == 0
                 || levitateMotor.IsLevitating
@@ -75,7 +74,6 @@ namespace DaggerfallWorkshop.Game
                 isSlipping = false;
                 showClimbingModeMessage = true;
                 climbingStartTimer = 0;
-                timeOfLastClimbingCheck = gameMinutes;
 
                 // Reset position for horizontal distance check
                 lastHorizontalPosition = new Vector2(controller.transform.position.x, controller.transform.position.z);

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -163,7 +163,7 @@ namespace DaggerfallWorkshop.Game
             if (!isSlipping)
             {
                 moveDirection = ledgeDirection * playerMotor.Speed;
-                moveDirection.y = Vector3.up.y * climbingBoost;
+                moveDirection.y = Vector3.up.y * (playerMotor.Speed / 3) * climbingBoost;
             }
             else
             {

--- a/Assets/Scripts/Game/Player/HeadBobber.cs
+++ b/Assets/Scripts/Game/Player/HeadBobber.cs
@@ -222,7 +222,7 @@ namespace DaggerfallWorkshop.Game
                 bounceTimerDown = 0f;
 
             }
-            else if (readyToBounce)
+            else if (readyToBounce && (isGrounded || isSwimming))
             {
                 const float bounceMax = 0.17f;
                 const float timerMax = 0.10f;

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -241,11 +241,6 @@ namespace DaggerfallWorkshop.Game
             // Handle climbing
             climbingMotor.ClimbingCheck(ref collisionFlags);
 
-            if (climbingMotor.IsClimbing)
-            {
-                acrobatMotor.Falling = false;
-            }
-
             // Do nothing if player levitating/swimming or climbing - replacement motor will take over movement for levitating/swimming
             if (levitateMotor && (levitateMotor.IsLevitating || levitateMotor.IsSwimming) || climbingMotor.IsClimbing)
                 return;

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -239,7 +239,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Handle climbing
-            climbingMotor.ClimbingCheck(ref collisionFlags);
+            climbingMotor.ClimbingCheck();
 
             // Do nothing if player levitating/swimming or climbing - replacement motor will take over movement for levitating/swimming
             if (levitateMotor && (levitateMotor.IsLevitating || levitateMotor.IsSwimming) || climbingMotor.IsClimbing)


### PR DESCRIPTION
Fixes all known bugs with climbing, including falling when climbing a long wall out of the water.  Slips are no longer meaningless.  Implements a skill check system like the system described in UESP for classic DF.

Player now has a chance to climb successfully, a chance to slip, and a lower chance to regain hold and continue climbing.  All chances can be offset by having a high skill in climbing.

70% base chance of success for continuing to climb per skill check.  A player with 50 climbing skill would boost this to 85% and 75 would boost to 92.5%

20% base chance of regaining hold (at 37% of climbing skill check's wait time).  a player with 50 skill would boost this chance to 60%, 75 skill boosts it to 80%

As an added bonus, once the player is climbing, they can swivel around and look in any direction as long as they hold the forward key and keep in mind when they reach the top they'll move in the direction they are facing!  They can also slip and catch and won't move away from the wall while looking elsewhere.

