### PR TITLE
Remove support for obsolete modsettings format

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsData.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsData.cs
@@ -394,8 +394,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             // TODO: remove support for old ini files.
             return (mod.AssetBundle.Contains("modsettings.json")
                 || mod.AssetBundle.Contains(mod.Title + ".ini.txt")
-                || mod.AssetBundle.Contains("modsettings.ini.txt")
-                || mod.AssetBundle.Contains(mod.FileName + ".ini.txt"));
+                || mod.AssetBundle.Contains("modsettings.ini.txt"));
         }
 
         /// <summary>
@@ -411,19 +410,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             }
             else if (mod.AssetBundle.Contains(mod.Title + ".ini.txt"))
             {
-                Debug.LogFormat("{0} is using a legacy modsettings format.", mod.Title);
+                Debug.LogWarningFormat("{0} is using an obsolete modsettings format!", mod.Title);
                 LoadLegacySettingsFromMod(mod, mod.Title + ".ini.txt", ref instance);
             }
             else if (mod.AssetBundle.Contains("modsettings.ini.txt"))
             {
-                Debug.LogFormat("{0} is using a legacy modsettings format.", mod.Title);
+                Debug.LogWarningFormat("{0} is using an obsolete modsettings format!", mod.Title);
                 LoadLegacySettingsFromMod(mod, "modsettings.ini.txt", ref instance);
-            }
-            else if (mod.AssetBundle.Contains(mod.FileName + ".ini.txt"))
-            {
-                // Note: this is unsafe because file name can be changed by user.
-                Debug.LogWarningFormat("{0} is using an obsolete modsettings filename!", mod.Title);
-                LoadLegacySettingsFromMod(mod, mod.FileName + ".ini.txt", ref instance);
             }
 
             if (instance != null)


### PR DESCRIPTION
Initially mod settings file was named _modfilename.ini.txt_, then was changed on Lypyl suggestion to _modsettings.ini.txt_ to avoid breaking if mod filename was changed. It's been a while since we moved from plain textboxes to a json-based window with typed controls, so i think it's time to remove support for the oldest one.

I'm confident no mod is using it but tell me if i'm wrong,  I want to be sure not to break any existing mod  :)

I'm not in a hurry to stop supporting _modsettings.ini.txt_, but i slightly changed the log message printed during the automatic local upgrade to reflect this change.