### PR TITLE
Prevent classic spawn check result getting stuck

### DIFF
--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -144,6 +144,10 @@ namespace DaggerfallWorkshop.Game
             else
                 classicUpdate = false;
 
+            // Reset whether enemy would be spawned or not in classic.
+            if (classicUpdate)
+                wouldBeSpawnedInClassic = false;
+
             // Update whether enemy would be spawned or not in classic.
             // Only check if within the maximum possible distance (Just under 1094 classic units)
             if (classicUpdate && distanceToPlayer < 1094 * MeshReader.GlobalScale)


### PR DESCRIPTION
Always reset to false first in case the player teleports from being nearby
enemies to not being nearby enemies.