### PR TITLE
4 Directional Climbing and jumping to and from walls.

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -80,4 +80,5 @@ LypyL_ModSystem=True
 MeshAndTextureReplacement=False
 CompressModdedTextures=True
 NearDeathWarning=True
+AdvancedClimbing=True
 AlternateRandomEnemySelection=False

--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -14,6 +14,7 @@ namespace DaggerfallWorkshop.Game
 
         PlayerMotor playerMotor;
         FrictionMotor frictionMotor;
+        ClimbingMotor climbingMotor;
         Transform myTransform;
 
         private float fallStartLevel;
@@ -36,6 +37,7 @@ namespace DaggerfallWorkshop.Game
         {
             playerMotor = GetComponent<PlayerMotor>();
             frictionMotor = GetComponent<FrictionMotor>();
+            climbingMotor = GetComponent<ClimbingMotor>();
             myTransform = playerMotor.transform;
         }
 
@@ -129,10 +131,14 @@ namespace DaggerfallWorkshop.Game
                 if (GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 0)
                     return;
                 float fallDistance = fallStartLevel - myTransform.position.y;
-                if (fallDistance > fallingDamageThreshold)
-                    FallingDamageAlert(fallDistance);
-                else if (fallDistance > fallingDamageThreshold / 2f)
-                    BadFallDetected(fallDistance);
+                // TODO: make sure this doesn't break falls
+                if (!climbingMotor.IsClimbing || climbingMotor.IsSlipping)
+                { 
+                    if (fallDistance > fallingDamageThreshold)
+                        FallingDamageAlert(fallDistance);
+                    else if (fallDistance > fallingDamageThreshold / 2f)
+                        BadFallDetected(fallDistance);
+                }
             }
         }
 

--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -131,7 +131,7 @@ namespace DaggerfallWorkshop.Game
                 if (GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 0)
                     return;
                 float fallDistance = fallStartLevel - myTransform.position.y;
-                // TODO: make sure this doesn't break falls
+
                 if (!climbingMotor.IsClimbing || climbingMotor.IsSlipping)
                 { 
                     if (fallDistance > fallingDamageThreshold)

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -17,7 +17,6 @@ namespace DaggerfallWorkshop.Game
         private CharacterController controller;
         private PlayerEnterExit playerEnterExit;
         private AcrobatMotor acrobatMotor;
-        private bool advancedClimbing = true;
         private bool isClimbing = false;
         private bool isSlipping = false;
         private float climbingStartTimer = 0;
@@ -83,7 +82,7 @@ namespace DaggerfallWorkshop.Game
 
             bool inputAbortCondition;
 
-            if (advancedClimbing)
+            if (DaggerfallUnity.Settings.AdvancedClimbing)
             {
                 // TODO: prevent crouch from toggling crouch when aborting climb
                 inputAbortCondition = (InputManager.Instance.HasAction(InputManager.Actions.Crouch)
@@ -105,7 +104,7 @@ namespace DaggerfallWorkshop.Game
                 // don't do horizontal position check if already climbing
                 || (!isClimbing && Vector2.Distance(lastHorizontalPosition, new Vector2(controller.transform.position.x, controller.transform.position.z)) > startClimbHorizontalTolerance)))
             {
-                if (isClimbing && inputAbortCondition && advancedClimbing)
+                if (isClimbing && inputAbortCondition && DaggerfallUnity.Settings.AdvancedClimbing)
                     WallEject = true;
                 isClimbing = false;
                 isSlipping = false;
@@ -219,7 +218,7 @@ namespace DaggerfallWorkshop.Game
                 float climbScalar = (playerMotor.Speed / 3) * climbingBoost;
                 moveDirection = ledgeDirection * playerMotor.Speed;
 
-                if (advancedClimbing)
+                if (DaggerfallUnity.Settings.AdvancedClimbing)
                 {
                     if (InputManager.Instance.HasAction(InputManager.Actions.MoveForwards))
                         moveDirection.y = Vector3.up.y * climbScalar;

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -95,7 +95,6 @@ namespace DaggerfallWorkshop.Game
             // reset for next use
             WallEject = false;
 
-            // TODO: Fix bug where landing from slipping causes no damage
             // Should we abort climbing?
             if (inputAbortCondition
                 || (playerMotor.CollisionFlags & CollisionFlags.Sides) == 0
@@ -122,7 +121,7 @@ namespace DaggerfallWorkshop.Game
                 if (climbingStartTimer <= (playerMotor.systemTimerUpdatesPerSecond * startClimbSkillCheckFrequency))
                     climbingStartTimer += Time.deltaTime;
                 else
-                {   // TODO: Why can I only jump and catch the wall once?
+                {
                     // automatic success if not falling
                     if (!airborneGraspWall)
                         StartClimbing();

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -140,9 +140,14 @@ namespace DaggerfallWorkshop.Game
                 {
                     climbingContinueTimer = 0;
                     // it's harder to regain hold while slipping than it is to continue climbing with a good hold on wall
-                    if (isSlipping)
+                    if (!InputManager.Instance.HasAction(InputManager.Actions.MoveForwards)
+                            && !InputManager.Instance.HasAction(InputManager.Actions.MoveBackwards)
+                            && !InputManager.Instance.HasAction(InputManager.Actions.MoveLeft)
+                            && !InputManager.Instance.HasAction(InputManager.Actions.MoveRight))
+                        isSlipping = false;
+                    else if (isSlipping)
                         isSlipping = !SkillCheck(regainHoldMinChance);
-                    else // TODO: skill check High success rate if stationary?
+                    else
                         isSlipping = !SkillCheck(continueClimbMinChance);
                 }
             }

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -55,7 +55,6 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Perform climbing check, and if successful, start climbing movement.
         /// </summary>
-        /// <param name="collisionFlags"></param>
         public void ClimbingCheck()
         {
             float stopClimbingDistance = 0.12f;

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -405,7 +405,6 @@ namespace DaggerfallWorkshop.Game
         /// Change controller height and position and return target height for camera to change to
         /// </summary>
         /// <param name="heightChange">Amount to modify controller height</param>
-        /// <param name="camChangeAmt">Amount to change controller position</param>
         /// <returns>the target height the camera should change to</returns>
         private float ControllerHeightChange(float heightChange)
         {

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -248,6 +248,12 @@ namespace DaggerfallWorkshop.Game
             // Player assumed to be in movement for now
             standingStill = false;
 
+
+            if (climbingMotor.WallEject)
+            {   // True in terms of the player having their feet on solid surface.
+                grounded = true;
+            }
+
             if (grounded)
             {
                 // Set standing still while grounded flag

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -97,6 +97,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox compressModdedTextures;
         Checkbox nearDeathWarning;
         Checkbox alternateRandomEnemySelection;
+        Checkbox advancedClimbing;
         HorizontalSlider cameraRecoilStrength;
 
         // Video
@@ -211,6 +212,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             compressModdedTextures = AddCheckbox(rightPanel, "compressModdedTextures", DaggerfallUnity.Settings.CompressModdedTextures);
             nearDeathWarning = AddCheckbox(rightPanel, "nearDeathWarning", DaggerfallUnity.Settings.NearDeathWarning);
             alternateRandomEnemySelection = AddCheckbox(rightPanel, "alternateRandomEnemySelection", DaggerfallUnity.Settings.AlternateRandomEnemySelection);
+            advancedClimbing = AddCheckbox(rightPanel, "advancedClimbing", DaggerfallUnity.Settings.AdvancedClimbing);
         }
 
         private void Video(Panel leftPanel, Panel rightPanel)
@@ -293,6 +295,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.NearDeathWarning = nearDeathWarning.IsChecked;
             DaggerfallUnity.Settings.AlternateRandomEnemySelection = alternateRandomEnemySelection.IsChecked;
             DaggerfallUnity.Settings.CameraRecoilStrength = cameraRecoilStrength.ScrollIndex;
+            DaggerfallUnity.Settings.AdvancedClimbing = advancedClimbing.IsChecked;
 
             /* Video */
 

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -142,6 +142,7 @@ namespace DaggerfallWorkshop
         public bool CompressModdedTextures { get; set; }
         public bool NearDeathWarning { get; set; }
         public bool AlternateRandomEnemySelection { get; set; }
+        public bool AdvancedClimbing { get; set; }
 
         #endregion
 
@@ -229,6 +230,7 @@ namespace DaggerfallWorkshop
             CompressModdedTextures = GetBool(sectionEnhancements, "CompressModdedTextures");
             NearDeathWarning = GetBool(sectionEnhancements, "NearDeathWarning");
             AlternateRandomEnemySelection = GetBool(sectionEnhancements, "AlternateRandomEnemySelection");
+            AdvancedClimbing = GetBool(sectionEnhancements, "AdvancedClimbing");
         }
 
         /// <summary>
@@ -309,6 +311,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionEnhancements, "CompressModdedTextures", CompressModdedTextures);
             SetBool(sectionEnhancements, "NearDeathWarning", NearDeathWarning);
             SetBool(sectionEnhancements, "AlternateRandomEnemySelection", AlternateRandomEnemySelection);
+            SetBool(sectionEnhancements, "AdvancedClimbing", AdvancedClimbing);
 
             // Write settings to persistent file
             WriteSettingsFile();

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -57,6 +57,8 @@ nearDeathWarning,									Near Death Warning
 nearDeathWarningInfo,								Show blinking/pulsating screen effects to warn when near death.
 alternateRandomEnemySelection,						Alternate Random Enemy Selection
 alternateRandomEnemySelectionInfo,					Create random enemies in dungeons with more variability.
+advancedClimbing,									Advanced Climbing System
+advancedClimbingInfo,								Climb walls in all directions & jump off them and grab them.
 
 resolution,                                         Resolution
 resolutionInfo,                                     Screen resolution


### PR DESCRIPTION
Implements a toggleable, true by default advanced climbing system.

4 directional climbing, the ability to pause climbing, Look around in any direction.
The ability to jump off a wall when climbing, onto another wall (skill check required).  Can also initialize a climb by jumping from the ground onto a wall with a skill check.

Known issue:  The checkbox setting on the gameplay section of the advanced settings page is out of margin, but still clickable.