### PR TITLE
Support for mod localization

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModLoaderInterfaceWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModLoaderInterfaceWindow.cs
@@ -503,7 +503,8 @@ public class ModLoaderInterfaceWindow : DaggerfallPopupWindow
         ModDescriptionMessageBox.ClickAnywhereToClose = true;
         ModDescriptionMessageBox.ParentPanel.BackgroundTexture = null;
 
-        string[] modDescription = modSettings[currentSelection].modInfo.ModDescription.Split('\n');
+        Mod mod = ModManager.Instance.GetMod(modSettings[currentSelection].modInfo.ModTitle);
+        string[] modDescription = (mod.TryLocalize("Mod", "Description") ?? mod.ModInfo.ModDescription).Split('\n');
         ModDescriptionMessageBox.SetText(modDescription);
         uiManager.PushWindow(ModDescriptionMessageBox);
     }

--- a/Assets/Game/Addons/ModSupport/ModSettings/Editor/ModSettingsEditorWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/Editor/ModSettingsEditorWindow.cs
@@ -12,9 +12,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using UnityEngine;
 using UnityEditor;
 using UnityEditorInternal;
+using DaggerfallWorkshop.Utility;
 
 namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
 {
@@ -39,6 +41,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         string targetPath;
         string modName = "None";
         string localPath;
+        string textPath;
         ModSettingsData data;
 
         // Presets
@@ -95,6 +98,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             saveOnExit = EditorPrefs.GetBool(Prefs.SaveOnExit, true);
             rootPath = Path.Combine(Path.Combine(Application.dataPath, "Game"), "Addons");
             targetPath = EditorPrefs.GetString(Prefs.CurrentTarget, rootPath);
+            textPath = Path.Combine(Path.Combine(Application.dataPath, "StreamingAssets"), "Text");
 
             if (targetPath != rootPath)
                 Load();
@@ -176,6 +180,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
                         string path;
                         if (!string.IsNullOrEmpty(path = EditorUtility.OpenFilePanel("Select preset file", rootPath, "json")))
                             data.LoadPresets(path, true);
+                    }
+                    else if (GUILayout.Button("Export localization table"))
+                    {
+                        string path;
+                        if (!string.IsNullOrEmpty(path = EditorUtility.OpenFolderPanel("Select a folder", textPath, "")))
+                            MakeTextDatabase(Path.Combine(path, string.Format("mod_{0}.txt", modName)));
                     }
 
                     EditorGUILayout.Space();
@@ -502,6 +512,50 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         {
             return new Rect(right ? rect.x + rect.width / 2 : rect.x,
                 rect.y + line * lineHeight, rect.width / 2, EditorGUIUtility.singleLineHeight);
+        }
+
+        private void MakeTextDatabase(string path)
+        {
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.AppendFormat("- Text database for mod {0}.\n", modName);
+            stringBuilder.AppendLine("- how to use: translate and place this file named mod_filename.txt inside StreamingAssets/Text. Note that an english table is NOT mandatory.");
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("schema: *key, text");
+
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("- Mod details");
+            stringBuilder.AppendLine("- Mod.Description, description");
+
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("- Settings");
+
+            foreach (Section section in data.Sections)
+            {
+                stringBuilder.AppendFormat("Settings.{0}.Name, {1}\n", section.Name, section.Name);
+                stringBuilder.AppendFormat("Settings.{0}.Description, {1}\n", section.Name, Table.SanitizeEntryValue(section.Description));
+
+                foreach (Key key in section.Keys)
+                {
+                    stringBuilder.AppendFormat("Settings.{0}.{1}.Name, {2}\n", section.Name, key.Name, key.Name);
+                    stringBuilder.AppendFormat("Settings.{0}.{1}.Description, {2}\n", section.Name, key.Name, Table.SanitizeEntryValue(key.Description));
+                }
+            }
+
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("- Presets");
+
+            foreach (Preset preset in data.Presets)
+            {
+                stringBuilder.AppendFormat("Presets.{0}.Title, {1}\n", preset.Title, preset.Title);
+                stringBuilder.AppendFormat("Presets.{0}.Description, {1}\n", preset.Title, Table.SanitizeEntryValue(preset.Description));
+            }
+
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("- Additional strings which can be accessed from Mod.Localize().");
+            stringBuilder.AppendLine("- Default values can be provided with a table named textdatabase.txt inside the mod bundle.");
+
+            File.WriteAllText(path, stringBuilder.ToString());
         }
 
         #endregion

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
@@ -188,13 +188,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
 
                 // Description
                 if (!string.IsNullOrEmpty(section.Description))
-                    AddSectionDescriptionBox(section.Description);
+                    AddSectionDescriptionBox(mod.TryLocalize("Settings", section.Name, "Description") ?? section.Description);
 
                 // Add keys to window with corrispective controls
                 foreach (Key key in section.Keys)
                 {
                     int height = 6;
-                    TextLabel keyLabel = GetKeyLabel(key, height);
+                    TextLabel keyLabel = GetKeyLabel(section, key, height);
                     BaseScreenComponent control = key.OnWindow(this, x, y, ref height);
                     uiControls.Add(key, control);
                     AddAtNextPosition(height, keyLabel, control);
@@ -302,7 +302,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             AddAtNextPosition((int)background.Size.y, background);
 
             TextLabel textLabel = new TextLabel(DaggerfallUI.Instance.Font5);
-            textLabel.Text = ModSettingsData.FormattedName(section.Name);
+            textLabel.Text = ModSettingsData.FormattedName(mod.TryLocalize("Settings", section.Name, "Name") ?? section.Name);
             textLabel.TextColor = sectionTitleColor;
             textLabel.ShadowColor = sectionTitleShadow;
             textLabel.TextScale = 0.9f;
@@ -335,16 +335,16 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             AddAtNextPosition(height, background);
         }
 
-        private TextLabel GetKeyLabel(Key key, int height)
+        private TextLabel GetKeyLabel(Section section, Key key, int height)
         {
             TextLabel textLabel = new TextLabel();
-            textLabel.Text = ModSettingsData.FormattedName(key.Name);
+            textLabel.Text = ModSettingsData.FormattedName(mod.TryLocalize("Settings", section.Name, key.Name, "Name") ?? key.Name);
             textLabel.ShadowColor = Color.clear;
             textLabel.TextScale = textScale;
             textLabel.HorizontalAlignment = HorizontalAlignment.None;
             textLabel.Position = new Vector2(x, y + (float)(height - textLabel.TextHeight) / 2);         
             textLabel.ToolTip = defaultToolTip;
-            textLabel.ToolTipText = key.Description;
+            textLabel.ToolTipText = mod.TryLocalize("Settings", section.Name, key.Name, "Description") ?? key.Description;
             return textLabel;
         }
 
@@ -443,7 +443,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             if (!settings.HasLoadedPresets)
                 settings.LoadPresets();
 
-            presetPicker = new PresetPicker(uiManager, this, settings);
+            presetPicker = new PresetPicker(uiManager, this, mod, settings);
             presetPicker.ApplyChangesCallback = RefreshControls;
             uiManager.PushWindow(presetPicker);
         }

--- a/Assets/Game/Addons/ModSupport/ModSettings/PresetPicker.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/PresetPicker.cs
@@ -29,6 +29,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         const int titleMaxChars = 20;
         const int descriptionMaxChars = 35;
 
+        readonly Mod mod;
         readonly ModSettingsData settings;
 
         Panel mainPanel                 = new Panel();
@@ -76,9 +77,10 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
 
         #region Constructors
 
-        public PresetPicker(IUserInterfaceManager uiManager, DaggerfallBaseWindow previousWindow, ModSettingsData settings)
+        public PresetPicker(IUserInterfaceManager uiManager, DaggerfallBaseWindow previousWindow, Mod mod, ModSettingsData settings)
             : base(uiManager, previousWindow)
         {
+            this.mod = mod;
             this.settings = settings;
         }
 
@@ -272,10 +274,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         /// </summary>
         private void RegisterPreset(Preset preset, int position = -1)
         {
-            if (string.IsNullOrEmpty(preset.Title))
-                preset.Title = ModManager.GetText("missingTitle");
-            if (string.IsNullOrEmpty(preset.Description))
-                preset.Description = ModManager.GetText("missingDescription");
+            string title = preset.Title;
+            preset.Title = !string.IsNullOrEmpty(preset.Title) ?
+                 mod.TryLocalize("Presets", title, "Title") ?? preset.Title : ModManager.GetText("missingTitle");
+            preset.Description = !string.IsNullOrEmpty(preset.Description) ?
+                mod.TryLocalize("Presets", title, "Description") ?? preset.Description : ModManager.GetText("missingDescription");
 
             ListBox.ListItem itemOut;
             listBox.AddItem(preset.Title, out itemOut, position);

--- a/Assets/Scripts/Utility/Table.cs
+++ b/Assets/Scripts/Utility/Table.cs
@@ -13,6 +13,7 @@ using UnityEngine;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 
 namespace DaggerfallWorkshop.Utility
 {
@@ -87,6 +88,15 @@ namespace DaggerfallWorkshop.Utility
         public Table(string[] lines)
         {
             LoadTable(lines);
+        }
+
+        /// <summary>
+        /// Load constructor.
+        /// </summary>
+        /// <param name="text">Text of data file.</param>
+        public Table(string text)
+        {
+            LoadTable(text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None));
         }
 
         #endregion
@@ -372,6 +382,20 @@ namespace DaggerfallWorkshop.Utility
             }
 
             return result;
+        }
+
+        #endregion
+
+        #region Public Helpers
+
+        /// <summary>
+        /// Ensures that a string can be used as a value for a table entry.
+        /// </summary>
+        /// <param name="text">A candidate for an entry value.</param>
+        /// <returns>A safe string.</returns>
+        public static string SanitizeEntryValue(string text)
+        {
+            return text != null ? text.Replace(",", string.Empty) : string.Empty;
         }
 
         #endregion


### PR DESCRIPTION
This PR aims to provide a standard localization interface for mods.

### Concept
A mod called **modname** is automatically linked to a file named **mod_modname.txt** in _StreamingAssets/Text_ and/or a file name **textdatabase.txt** inside the mod bundle. The table in _StreamingAssets_ takes precedence.

### Settings
The file **settings.json** bundled with a mod provides informations used by the mod manager to draw controls in the mod settings window and store values to a local file. This includes setting names and descriptions/tooltips. These text string are seked automatically in the language table using the following patterns:

```
Mod.Description
Settings.SectionName.Name
Settings.SectionName.Description
Settings.SectionName.KeyName.Name
Settings.SectionName.KeyName.Description
Presets.PresetTitle.Title
Presets.PresetTitle.Description
```
If a key is missing, the default value from **settings.json** is used. This means there is no need to provide an english table. No support is required from individual mods, this is all managed by the mod manager.

### Mod Strings
The Mod instance includes a method called `Localize()` which can be used to seek additional localized strings from the text table. The key can be a string or a succession of strings wich are concatenated.
```
string Localize(string key) // key, text
string Localize(params string[] keyParts) // a.b.c, text 
```

`Fountain.Drink, Press key to drink at the fountain.`
`string text = mod.Localize("Fountain", "Drink").`

If a key is not found in the table from the Text folder, is seeked in the fallback table inside the mod.  This means that no additional files other than the dfmod are required for a standard english version. Mod developers only need to export strings to a text file and build it as an asset.
