### PR TITLE
Fix enemy animations

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -390,17 +390,8 @@ namespace DaggerfallWorkshop
             // Check if orientation flip needed
             bool flip = summary.StateAnims[orientation].FlipLeftRight;
 
-            // Some characters' idle animations need to be inverted. Add as needed.
-            if ((summary.Enemy.ID == (int)MobileTypes.GiantBat
-                || summary.Enemy.ID == (int)MobileTypes.Imp
-                || summary.Enemy.ID == (int)MobileTypes.Dreugh
-                || summary.Enemy.ID == (int)MobileTypes.Lamia)
-                && summary.EnemyState == MobileStates.Idle)
-                flip = !flip;
-
-            // Scorpion Idle and Move animations need to be inverted
-            if (summary.Enemy.ID == (int)MobileTypes.GiantScorpion &&
-                summary.EnemyState == MobileStates.Idle || summary.EnemyState == MobileStates.Move)
+            // Scorpion animations need to be inverted
+            if (summary.Enemy.ID == (int)MobileTypes.GiantScorpion)
                 flip = !flip;
 
             // Update Record/Frame texture
@@ -650,16 +641,35 @@ namespace DaggerfallWorkshop
             switch (state)
             {
                 case MobileStates.Move:
-                    anims = (MobileAnimation[])EnemyBasics.MoveAnims.Clone();
+                    if ((MobileTypes)summary.Enemy.ID == MobileTypes.Ghost ||
+                        (MobileTypes)summary.Enemy.ID == MobileTypes.Wraith)
+                        anims = (MobileAnimation[])EnemyBasics.GhostWraithMoveAnims.Clone();
+                    else
+                        anims = (MobileAnimation[])EnemyBasics.MoveAnims.Clone();
                     break;
                 case MobileStates.PrimaryAttack:
-                    anims = (MobileAnimation[])EnemyBasics.PrimaryAttackAnims.Clone();
+                    if ((MobileTypes)summary.Enemy.ID == MobileTypes.Ghost ||
+                        (MobileTypes)summary.Enemy.ID == MobileTypes.Wraith)
+                        anims = (MobileAnimation[])EnemyBasics.GhostWraithAttackAnims.Clone();
+                    else
+                        anims = (MobileAnimation[])EnemyBasics.PrimaryAttackAnims.Clone();
                     break;
                 case MobileStates.Hurt:
                     anims = (MobileAnimation[])EnemyBasics.HurtAnims.Clone();
                     break;
                 case MobileStates.Idle:
-                    anims = (summary.Enemy.HasIdle) ? (MobileAnimation[])EnemyBasics.IdleAnims.Clone() : (MobileAnimation[])EnemyBasics.MoveAnims.Clone();
+                    if ((MobileTypes)summary.Enemy.ID == MobileTypes.Ghost ||
+                        (MobileTypes)summary.Enemy.ID == MobileTypes.Wraith)
+                        anims = (MobileAnimation[])EnemyBasics.GhostWraithMoveAnims.Clone();
+                    else if ((MobileTypes)summary.Enemy.ID == MobileTypes.Thief &&
+                        summary.Enemy.Gender == MobileGender.Female)
+                        anims = (MobileAnimation[])EnemyBasics.FemaleThiefIdleAnims.Clone();
+                    else if ((MobileTypes)summary.Enemy.ID == MobileTypes.Rat)
+                        anims = (MobileAnimation[])EnemyBasics.RatIdleAnims.Clone();
+                    else if (!summary.Enemy.HasIdle)
+                        anims = (MobileAnimation[])EnemyBasics.MoveAnims.Clone();
+                    else
+                        anims = (MobileAnimation[])EnemyBasics.IdleAnims.Clone();
                     break;
                 case MobileStates.RangedAttack1:
                     anims = (summary.Enemy.HasRangedAttack1) ? (MobileAnimation[])EnemyBasics.RangedAttack1Anims.Clone() : null;

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -32,17 +32,17 @@ namespace DaggerfallWorkshop.Utility
         public static int RangedAttack1AnimSpeed = 10;
         public static int RangedAttack2AnimSpeed = 10;
 
-        // Move animations (double as idle animations for swimming and flying mobs)
+        // Move animations (double as idle animations for swimming and flying enemies, and enemies without idle animations)
         public static MobileAnimation[] MoveAnims = new MobileAnimation[]
         {
-            new MobileAnimation() {Record = 0, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing south (front facing player)
-            new MobileAnimation() {Record = 1, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing south-west
-            new MobileAnimation() {Record = 2, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing west
-            new MobileAnimation() {Record = 3, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing north-west
-            new MobileAnimation() {Record = 4, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing north (back facing player)
-            new MobileAnimation() {Record = 3, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},              // Facing north-east
-            new MobileAnimation() {Record = 2, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},              // Facing east
-            new MobileAnimation() {Record = 1, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},              // Facing south-east
+            new MobileAnimation() {Record = 0, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing south (front facing player)
+            new MobileAnimation() {Record = 1, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing south-west
+            new MobileAnimation() {Record = 2, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing west
+            new MobileAnimation() {Record = 3, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing north-west
+            new MobileAnimation() {Record = 4, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing north (back facing player)
+            new MobileAnimation() {Record = 3, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing north-east
+            new MobileAnimation() {Record = 2, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing east
+            new MobileAnimation() {Record = 1, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing south-east
         };
 
         // PrimaryAttack animations
@@ -108,6 +108,58 @@ namespace DaggerfallWorkshop.Utility
             new MobileAnimation() {Record = 28, FramePerSecond = RangedAttack2AnimSpeed, FlipLeftRight = true},    // Facing north-east
             new MobileAnimation() {Record = 27, FramePerSecond = RangedAttack2AnimSpeed, FlipLeftRight = true},    // Facing east
             new MobileAnimation() {Record = 26, FramePerSecond = RangedAttack2AnimSpeed, FlipLeftRight = true},    // Facing south-east
+        };
+
+        // Female thief idle animations
+        public static MobileAnimation[] FemaleThiefIdleAnims = new MobileAnimation[]
+        {
+            new MobileAnimation() {Record = 15, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing south (front facing player)
+            new MobileAnimation() {Record = 11, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing south-west
+            new MobileAnimation() {Record = 17, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing west
+            new MobileAnimation() {Record = 18, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing north-west
+            new MobileAnimation() {Record = 19, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing north (back facing player)
+            new MobileAnimation() {Record = 18, FramePerSecond = IdleAnimSpeed, FlipLeftRight = true},             // Facing north-east
+            new MobileAnimation() {Record = 17, FramePerSecond = IdleAnimSpeed, FlipLeftRight = true},             // Facing east
+            new MobileAnimation() {Record = 11, FramePerSecond = IdleAnimSpeed, FlipLeftRight = true},             // Facing south-east
+        };
+
+        // Rat idle animations
+        public static MobileAnimation[] RatIdleAnims = new MobileAnimation[]
+        {
+            new MobileAnimation() {Record = 15, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing south (front facing player)
+            new MobileAnimation() {Record = 16, FramePerSecond = IdleAnimSpeed, FlipLeftRight = true},             // Facing south-west
+            new MobileAnimation() {Record = 17, FramePerSecond = IdleAnimSpeed, FlipLeftRight = true},             // Facing west
+            new MobileAnimation() {Record = 18, FramePerSecond = IdleAnimSpeed, FlipLeftRight = true},             // Facing north-west
+            new MobileAnimation() {Record = 19, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing north (back facing player)
+            new MobileAnimation() {Record = 18, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing north-east
+            new MobileAnimation() {Record = 17, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing east
+            new MobileAnimation() {Record = 16, FramePerSecond = IdleAnimSpeed, FlipLeftRight = false},            // Facing south-east
+        };
+
+        // Wraith and ghost idle/move animations
+        public static MobileAnimation[] GhostWraithMoveAnims = new MobileAnimation[]
+        {
+            new MobileAnimation() {Record = 0, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing south (front facing player)
+            new MobileAnimation() {Record = 1, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing south-west
+            new MobileAnimation() {Record = 2, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing west
+            new MobileAnimation() {Record = 3, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing north-west
+            new MobileAnimation() {Record = 4, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing north (back facing player)
+            new MobileAnimation() {Record = 3, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing north-east
+            new MobileAnimation() {Record = 2, FramePerSecond = MoveAnimSpeed, FlipLeftRight = false},             // Facing east
+            new MobileAnimation() {Record = 1, FramePerSecond = MoveAnimSpeed, FlipLeftRight = true},              // Facing south-east
+        };
+
+        // Ghost and Wraith attack animations
+        public static MobileAnimation[] GhostWraithAttackAnims = new MobileAnimation[]
+        {
+            new MobileAnimation() {Record = 5, FramePerSecond = PrimaryAttackAnimSpeed, FlipLeftRight = false},    // Facing south (front facing player)
+            new MobileAnimation() {Record = 6, FramePerSecond = PrimaryAttackAnimSpeed, FlipLeftRight = false},    // Facing south-west
+            new MobileAnimation() {Record = 7, FramePerSecond = PrimaryAttackAnimSpeed, FlipLeftRight = true},     // Facing west
+            new MobileAnimation() {Record = 8, FramePerSecond = PrimaryAttackAnimSpeed, FlipLeftRight = false},    // Facing north-west
+            new MobileAnimation() {Record = 9, FramePerSecond = PrimaryAttackAnimSpeed, FlipLeftRight = false},    // Facing north (back facing player)
+            new MobileAnimation() {Record = 8, FramePerSecond = PrimaryAttackAnimSpeed, FlipLeftRight = true},     // Facing north-east
+            new MobileAnimation() {Record = 7, FramePerSecond = PrimaryAttackAnimSpeed, FlipLeftRight = false},    // Facing east
+            new MobileAnimation() {Record = 6, FramePerSecond = PrimaryAttackAnimSpeed, FlipLeftRight = true},     // Facing south-east
         };
 
         // TODO: Seducer special animations


### PR DESCRIPTION
I noticed that there were still several issues with enemy animations, but I think (and hope) this should resolve all the problems.

1) Enemy female thief has a small animation frame in the idle animations when looking diagonally. There used to be a fix for this but I removed it in https://github.com/Interkarma/daggerfall-unity/pull/483 because I noticed the female thief being stretched too large when attacking diagonally. The old fix was for all diagonal animations but it's only the idle animations where the problem is. Also, better than stretching the sprite as the old fix did, there is a correct-size diagonal idle, misplaced among the hurt animations for some reason. Now that is used and it looks correct in-game.

2) In that PR I also removed a fix for the rat, because I noticed it being flipped when it shouldn't. On closer inspection it needed a more customized fix, because it's just the 3 mid-way frames between "towards player" and "away from player" that needed flipping.

 3) I also confirmed wrong-way animations for the werewolf, slaughterfish and scorpion. It also would have been wrongly flipped for other enemy types using "move" animations for their idle that we weren't specifically doing a correction flip on, meaning the wereboar and dragonling.

4) Fixed the ghost and wraith. Both needed the sideways animation for their move/idle and their attack to be flipped.

5) There was a logic error here:

            ```
            // Scorpion Idle and Move animations need to be inverted
            if (summary.Enemy.ID == (int)MobileTypes.GiantScorpion &&
                summary.EnemyState == MobileStates.Idle || summary.EnemyState == MobileStates.Move)
                flip = !flip;
            ```
     
      which was always being true for any moving enemy, which led to the moving animations being defined as needing to be flipped when they didn't really need to be. This is also why !HasIdle enemies using move animations for their idle were seemingly needing to be flipped (I had set giant bat, imp, dreughs and lamias to be flipped this way, because I had noticed them all being reversed, but it was actually all !HasIdle enemy types)
