### PR TITLE
Fix reading classic magic item names

### DIFF
--- a/Assets/Scripts/API/Save/ItemRecord.cs
+++ b/Assets/Scripts/API/Save/ItemRecord.cs
@@ -125,7 +125,12 @@ namespace DaggerfallConnect.Save
 
             // Read native item data
             parsedData = new ItemRecordData();
-            parsedData.name = FileProxy.ReadCString(reader, 32);
+
+            // Item names should only be read until the null terminator.
+            long pos = reader.BaseStream.Position;
+            parsedData.name = FileProxy.ReadCString(reader, 0);
+            reader.BaseStream.Position = pos + 32;
+
             parsedData.group = reader.ReadUInt16();
             parsedData.index = reader.ReadUInt16();
             parsedData.value = reader.ReadUInt32();


### PR DESCRIPTION
Items in classic saves should only have their names read up until the null terminator. This is because when classic creates a magic item, it first creates the base, non-magic item, including its name, and then it overwrites the name with the magic item name. Since the magic item names use the %it macro in place of the original names, they can be shorter than the original names, leaving the tail of the original name after the null terminator.

In my case I have a save game with "Cursing Champion straps". The name in SAVETREE.DAT is "Cursing %it aps", because "Cursing %it" was written over the "Champion str" part of "Champion straps". It showed up in Daggerfall Unity as "Cursing Champion straps aps". With this PR it shows correctly.