### PR TITLE
Implement shoplifting

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -229,6 +229,18 @@ namespace DaggerfallWorkshop.Game.Formulas
             return Mathf.Clamp(chance, 5, 95);
         }
 
+        // Calculate chance of being caught shoplifting items
+        public static int CalculateShopliftingChance(PlayerEntity player, DaggerfallEntity na, int shopQuality, int weightAndNumItems)
+        {
+            Formula_2de_2i del;
+            if (formula_2de_2i.TryGetValue("CalculateShopliftingChance", out del))
+                return del(player, null, shopQuality, weightAndNumItems);
+
+            int chance = 100 - player.Skills.GetLiveSkillValue(DFCareer.Skills.Pickpocket);
+            chance += shopQuality + weightAndNumItems;
+            return Mathf.Clamp(chance, 5, 95);
+        }
+
         // Calculate how many uses a skill needs before its value will rise.
         public static int CalculateSkillUsesForAdvancement(int skillValue, int skillAdvancementMultiplier, float careerAdvancementMultiplier, int level)
         {

--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -31,7 +31,7 @@ namespace DaggerfallWorkshop.Game.Guilds
         protected const int PromotionFreeRoomsId = 5238;
         protected const int PromotionFreeShipsId = 5239;
         protected const int PromotionHouseId = 5240;
-        protected const int PromotionNoHouseId = 5241;  // TODO: Use if already own a house
+        protected const int PromotionNoHouseId = 5241;
         protected const int ArmorId = 463;
         protected const int HouseId = 462;
         protected const int NoArmorId = 461;
@@ -149,7 +149,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             if (rank == 6)
                 return PromotionFreeShipsId;
             if (rank == 9)
-                return PromotionHouseId;
+                return DaggerfallBankManager.OwnsHouse ? PromotionNoHouseId : PromotionHouseId;
 
             return PromotionMsgId;
         }
@@ -234,7 +234,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             else
             {   // Give a house if one availiable
                 if (DaggerfallBankManager.OwnsHouse)
-                    DaggerfallUI.MessageBox((int)TransactionResult.ALREADY_OWN_HOUSE);
+                    DaggerfallUI.MessageBox((int) TransactionResult.ALREADY_OWN_HOUSE);
                 else
                 {
                     BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -106,61 +106,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Setup Methods
 
-        ItemCollection GetMerchantMagicItems()
-        {
-            if (merchantItems == null)
-            {
-                PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
-                ItemCollection items = new ItemCollection();
-                int numOfItems = (buildingDiscoveryData.quality / 2) + 1;
-
-                for ( int i = 0; i <= numOfItems; i++)
-                {
-                    DaggerfallUnityItem magicItem = ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
-
-                    // Item is already identified
-                    magicItem.flags |= 0x20;
-
-                    items.AddItem(magicItem);
-                }
-
-                items.AddItem(ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Spellbook));
-
-                if (guild.Rank >= 4)
-                {
-                    for (int i = 0; i <= numOfItems; i++)
-                    {
-                        DaggerfallUnityItem magicItem = ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Soul_trap);
-                        magicItem.value = 5000;
-
-                        if (UnityEngine.Random.Range(1, 101) >= 25)
-                            magicItem.TrappedSoulType = MobileTypes.None;
-                        else
-                        {
-                            int id = UnityEngine.Random.Range(0, 43);
-                            magicItem.TrappedSoulType = (MobileTypes)id;
-                            MobileEnemy mobileEnemy = GameObjectHelper.EnemyDict[id];
-                            magicItem.value += mobileEnemy.SoulPts;
-                        }
-
-                        items.AddItem(magicItem);
-                    }
-                }
-
-                merchantItems = items;
-            }
-            return merchantItems;
-        }
-
-        // TODO: classic seems to generate each time player select buy potions.. should we make more persistent for DFU?
-        ItemCollection GetMerchantPotions()
-        {
-            ItemCollection potions = new ItemCollection();
-            for (int n = UnityEngine.Random.Range(12, 20); n > 0; n--)
-                potions.AddItem(ItemBuilder.CreateRandomPotion());
-            return potions;
-        }
-
         protected override void Setup()
         {
             // Ascertain guild membership status, exempt Thieves Guild and Dark Brotherhood since should never find em until a member
@@ -242,6 +187,55 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         #endregion
 
         #region Private Methods
+
+        // TODO: Classic seems deterministic so when re-visiting each mages guildhall, player sees same stuff.
+        // Does it change with level? Is it always generated but uses a consistent seed? How should DFU do this?
+        ItemCollection GetMerchantMagicItems()
+        {
+            PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+            ItemCollection items = new ItemCollection();
+            int numOfItems = (buildingDiscoveryData.quality / 2) + 1;
+
+            for (int i = 0; i <= numOfItems; i++)
+            {
+                // Create magic item which is already identified
+                DaggerfallUnityItem magicItem = ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
+                magicItem.IdentifyItem();
+                items.AddItem(magicItem);
+            }
+
+            items.AddItem(ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Spellbook));
+
+            if (guild.CanAccessService(GuildServices.BuySoulgems))
+            {
+                for (int i = 0; i <= numOfItems; i++)
+                {
+                    DaggerfallUnityItem magicItem = ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Soul_trap);
+                    magicItem.value = 5000;
+
+                    if (UnityEngine.Random.Range(1, 101) >= 25)
+                        magicItem.TrappedSoulType = MobileTypes.None;
+                    else
+                    {
+                        int id = UnityEngine.Random.Range(0, 43);
+                        magicItem.TrappedSoulType = (MobileTypes)id;
+                        MobileEnemy mobileEnemy = GameObjectHelper.EnemyDict[id];
+                        magicItem.value += mobileEnemy.SoulPts;
+                    }
+                    items.AddItem(magicItem);
+                }
+            }
+            return items;
+        }
+
+        // TODO: classic seems to generate each time player select buy potions.. should we make more persistent for DFU?
+        ItemCollection GetMerchantPotions()
+        {
+            ItemCollection potions = new ItemCollection();
+            for (int n = UnityEngine.Random.Range(12, 20); n > 0; n--)
+                potions.AddItem(ItemBuilder.CreateRandomPotion());
+            return potions;
+        }
 
         void LoadTextures(bool member)
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -627,7 +627,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             if (windowMode == WindowModes.Buy)
             {
-                // TODO
+                // Calculate the weight of all items picked from shelves, then get chance of shoplifting success.
+                int weightAndNumItems = (int) basketItems.GetWeight() + basketItems.Count;
+                int chance = FormulaHelper.CalculateShopliftingChance(PlayerEntity, null, buildingDiscoveryData.quality, weightAndNumItems);
+
+                if (UnityEngine.Random.Range(0, 101) > chance)
+                {
+                    DaggerfallUI.Instance.PopupMessage(HardStrings.youAreSuccessful);
+                    PlayerEntity.Items.TransferAll(basketItems);
+                    PlayerEntity.TallyCrimeGuildRequirements(true, 1);
+                }
+                else
+                {   // Register crime and start spawning guards.
+                    DaggerfallUI.Instance.PopupMessage(HardStrings.youAreNotSuccessful);
+                    PlayerEntity.CrimeCommitted = PlayerEntity.Crimes.Theft;
+                    PlayerEntity.SpawnCityGuards(true);
+                }
+                CloseWindow();
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -123,6 +123,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string youPinchedGoldPiece = "You pinched 1 gold piece."; // Not in classic.
         public const string youPinchedGoldPieces = "You pinched %d gold pieces.";
         public const string youAreNotSuccessful = "You are not successful...";
+        public const string youAreSuccessful = "You are successful.";
 
         public const string daysUntilFreedom = "%d days until freedom.";
 


### PR DESCRIPTION
Guards currently spawn outside the shop due to min spawn distance I think. I like this in one respect that you can't simply flee to the exit and escape like you can in classic, but it does feel like you are getting away with stealing until you leave and see the dozens of guards waiting for you...

Allofich, can you check the formula I added please? I took it from chronicles.  PlayerEntity.SpawnCityGuards() needs more work, as you probably already know.