### PR TITLE
Framework for implementing poisons

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -1404,7 +1404,7 @@ namespace Wenzil.Console
         {
             public static readonly string name = "add";
             public static readonly string description = "Adds n inventory items to the character, based on the given keyword. n = 1 by default";
-            public static readonly string usage = "add (book|weapon|armor|cloth|ingr|relig|gold|magic) [n]";
+            public static readonly string usage = "add (book|weapon|armor|cloth|ingr|relig|gold|magic|drug) [n]";
 
             public static string Execute(params string[] args)
             {
@@ -1455,6 +1455,9 @@ namespace Wenzil.Console
                             break;
                         case "magic":
                             newItem = ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
+                            break;
+                        case "drug":
+                            newItem = ItemBuilder.CreateRandomDrug();
                             break;
                         default:
                             return "unrecognized keyword. see usage";

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -354,6 +354,25 @@ namespace DaggerfallWorkshop.Game.Entity
                     }
                 }
             }
+
+            // Chance for poisoned weapon
+            if (player.Level > 1)
+            {
+                Items.DaggerfallUnityItem weapon = ItemEquipTable.GetItem(Game.Items.EquipSlots.RightHand);
+                if (weapon != null && (entityType == EntityTypes.EnemyClass || mobileEnemy.ID == (int)MobileTypes.Orc
+                        || mobileEnemy.ID == (int)MobileTypes.Centaur || mobileEnemy.ID == (int)MobileTypes.OrcSergeant))
+                {
+                    int chanceToPoison = 5;
+                    if (mobileEnemy.ID == (int)MobileTypes.Assassin)
+                        chanceToPoison = 60;
+
+                    if (UnityEngine.Random.Range(1, 101) < chanceToPoison)
+                    {
+                        // Apply poison
+                        weapon.poisonType = UnityEngine.Random.Range(0, 8);
+                    }
+                }
+            }
         }
 
         public void SetEnemySpells(byte[] spellList)

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -44,6 +44,7 @@ namespace DaggerfallWorkshop.Game.Items
         public int message;
         public DaggerfallEnchantment[] legacyMagic = null;
         public int stackCount = 1;
+        public int poisonType = -1;
 
         // Private item fields
         int playerTextureArchive;

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -305,6 +305,19 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
+        /// Creates a new random drug.
+        /// </summary>
+        /// <returns>DaggerfallUnityItem.</returns>
+        public static DaggerfallUnityItem CreateRandomDrug()
+        {
+            Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(ItemGroups.Drugs);
+            int groupIndex = UnityEngine.Random.Range(0, enumArray.Length);
+            DaggerfallUnityItem newItem = new DaggerfallUnityItem(ItemGroups.Drugs, groupIndex);
+
+            return newItem;
+        }
+
+        /// <summary>
         /// Generates a weapon.
         /// </summary>
         /// <param name="weapon"></param>

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1399,7 +1399,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         // Moving local and remote Use item clicks to new method
         // This ensures the items are handled the same except when needed
         // This will need more work as more usable items are available
-        void UseItem(DaggerfallUnityItem item)
+        void UseItem(DaggerfallUnityItem item, ItemCollection collection)
         {
             const int noSpellsTextId = 12;
 
@@ -1453,6 +1453,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 noSpells.SetTextTokens(textTokens);
                 noSpells.ClickAnywhereToClose = true;
                 noSpells.Show();
+            }
+            else if (item.ItemGroup == ItemGroups.Drugs)
+            {
+                // Drug poison IDs are 8 through 11. Template indexes are 78 through 81, so subtract from that.
+                Formulas.FormulaHelper.InflictPoison(playerEntity, item.TemplateIndex - 70, true);
+                collection.RemoveItem(item);
             }
             else
             {
@@ -1588,7 +1594,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (item.UseItem(localItems))
                     Refresh(false);
                 else
-                    UseItem(item);
+                {
+                    UseItem(item, localItems);
+                    Refresh(false);
+                }
             }
             else if (selectedActionMode == ActionModes.Remove)
             {
@@ -1635,7 +1644,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (item.UseItem(localItems))
                     Refresh(false);
                 else
-                    UseItem(item);
+                {
+                    UseItem(item, remoteItems);
+                    Refresh(false);
+                }
             }
             else if (selectedActionMode == ActionModes.Remove && CanCarry(item))
             {


### PR DESCRIPTION
This PR sets things up for you to implement poisons.

First, what this PR does:
1) Enemies have a chance to get poisoned weapons (matched to classic)
2) Poison inflicted on weapon hit, resistances and saving throws to sop it (matched to classic with bugs fixed)
3) Poison infliction by drugs (matched to classic)
4) Console command to add drugs
5) Includes code for setting up poison properties (minutes until start, damage)

No actual poison effect is in, just a debug message.

There are 12 poisons in the game. 0-7 are weapon poisons, 8 through 11 are the drugs. I just referred to them with an `int`, but you might want to use an enum. In addition to the drugs, I found names in `FALL.EXE` that appear to match for the poisons, so we have a name for all the poisons. See the pseudocode below.

The effect of a poison is very similar to a disease, so you should be able to pretty much re-use that code. The difference is a "round" of the poison effect is 1 game minute, rather than 1 game day. Also rather than starting at 0:00 of the next day, they start after a randomly chosen number of minutes.
If inflicted with a poison, textID 117 should show in the status window and when clicking `HEALTH` in the character sheet.

The effects of the 12 poisons are hard-coded (SPELLS.STD is unrelated, as far as I can see).
The function (called for every game minute) that applies poison effects looks like this:

```
  if ( poison.minutesUntilStartingPoison == 0 )
  {
    if ( poison.state == 0 )
      poison.state = 1; // State is no longer 0, can show "You have been poisoned." in status
    if ( poison.type <= 11 ) // 11 valid types
    {
      switch ( poison.type )
      {
        case 0: // Nux Vomica
          int damage = DFRandom(2, 12); // "DFRandom" means a random value between (min, max)  inclusive of both min and max
          ApplyHealthDamage(target, damage);
          break;
        case 1: // Arsenic
          ApplyHealthDamage(target, 2);
          target.Endurance--;
          if ( target.Endurance < 1 )
          {
            target.Endurance = 1;
          }
          poison.state = 2; // Can be cured as disease after finishing all rounds
          break;
        case 2: // Moonseed
          int damage = DFRandom(1, 10);
          ApplyHealthDamage(target, damage);
          break;
        case 3: // Drothweed
          int damage = DFRandom(5, 10);
          target.Strength  -= damage;
          if ( target.Strength < 1 )
          {
            target.Strength = 1;
          }
          damage = DFRandom(1, 5);
          target.Agility -= damage;
          if ( target.Agility < 1 )
          {
            target.Agility = 1;
          }
          damage = DFRandom(1, 5);
          target.Speed -= damage;
          if ( target.Speed < 1 )
          {
            target.Speed = 1;
          }
          poison.status = 2; // Can be cured as disease after finishing all rounds
          break;
        case 4: // Somnalius
          int damage = DFRandom(10, 100);
          ApplyFatigueDamage(target, damage); // remember to multiply by 64 for fatigue modifications
          break;
        case 5: // Pyrrhic Acid
          int damage = DFRandom(1, 30);
          ApplyHealthDamage(target, damage);
          break;
        case 6: // Magebane
          int damage = DFRandom(1, 5);
          target.Willpower -= damage;
          if ( target.Willpower < 1 )
          {
            target.Willpower = 1;
          }
          target.CurrentSpellPoints -= DFRandom(5, 15);
          if ( target.CurrentSpellPoints < 0 )
            target.CurrentSpellPoints = 0;
          poison.status = 2; // Can be cured as disease after finishing all rounds
          break;
        case 7: // Thyrwort
          int damage = DFRandom(5, 20);
          target.Willpower -= damage;
          if ( target.Willpower < 1 )
          {
            target.Willpower = 1;
          }
          damage = DFRandom(10, 20);
          target.Personality -= damage;
          if ( target.Personality < 1 )
          {
            target.Personality = 1;
          }
          poison.state = 2; // Can be cured as disease after finishing all rounds
          break;
        case 8: // Indulcet
          int damage = DFRandom(10, 100);
          ApplyFatigueDamage(target, damage);
          int bonus = DFRandom(4, 10);
          target.Luck += bonus;
          poison.status = 2; // Can be cured as disease after finishing all rounds
          break;
        case 9: // Sursum
          int damage = DFRandom(10, 30);
          target.Intelligence -= damage;
          if ( target.Intelligence < 1 )
          {
            target.Intelligence = 1;
          }
          int bonus = DFRandom(5, 20);
          target.Strength += bonus;
          poison.status = 2; // Can be cured as disease after finishing all rounds
          break;
        case 10: // Quaesto Vil
          int damage =  DFRandom(1, 4);
          target.Willpower -= damage;
          if ( target.Willpower < 1 )
          {
            target.Willpower = 1;
          }
          int bonus = DFRandom(5, 10);
          ApplyFatigueDamage(target, -bonus);
          poison.state = 2; // Can be cured as disease after finishing all rounds
          break;
        case 11: // Aegrotat
          int damage = DFRandom(1, 5);
          target.Endurance -= damage;
          if ( target.Endurance < 1 )
          {
             target.Endurance = 1;
          }
          int bonus = DFRandom(5, 10);
          target.CurrentSpellPoints += bonus;
          if ( target.CurrentSpellPoints > target.MaxSpellPoints )
            target.CurrentSpellPoints = target.MaxSpellPoints;
          poison.state = 2; // Can be cured as disease after finishing all rounds
          break;
      }
    }
    DaggerfallUI.AddHUDText(UserInterfaceWindows.HardStrings.youFeelSomewhatBad);
    if ( poison.RemainingRounds > 0 )
    {
      --poison.RemainingRounds;
    }
    else // All rounds done
    {
      if ( poison.State != 2 ) // If not curable as a disease (i.e., no attributes affected), stop here
        return;
      poison.curableAsDisease = true; // What actually happens here is classic sets the poisonType to 0. Poisons in classic are actually types 128 and up (diseases are below that). By setting the poisonType low, it should be recognized by the cure disease function (either at a temple service or through a potion/spell, which ignores the 128 and up poison types), allowing restoring of the lost attributes.
    }
  }
  --poison.MinutesUntilStartingPoison;

```

Note that classic is missing a check that there are poison rounds remaining before applying the effects. This makes the poison rounds only have a meaning for the types that are "curable as diseases" after finishing. http://en.uesp.net/wiki/Daggerfall:Poison also talks about poisons going indefinitely. I think this is probably an oversight and we should check that poison rounds remain before applying effects. If no attribute damage was done (not "curable as a disease"), the poison could just be removed when it runs out of rounds (i.e. passed from the character's system), as curing it at that point would have no effect anyway.