### PR TITLE
Biography quiz for new characters

### DIFF
--- a/Assets/Scripts/API/BiogFile.cs
+++ b/Assets/Scripts/API/BiogFile.cs
@@ -328,6 +328,48 @@ namespace DaggerfallConnect.Arena2
             }
         }
 
+        public static int GetClassAffinityIndex(DFCareer custom, List<DFCareer> classes)
+        {
+            int highestAffinity = 0;
+            int selectedIndex = 0;
+            for (int i = 0; i < classes.Count; i++)
+            {
+                int affinity = 0;
+                List<DFCareer.Skills> classSkills = new List<DFCareer.Skills>();
+                classSkills.Add(classes[i].PrimarySkill1);
+                classSkills.Add(classes[i].PrimarySkill2);
+                classSkills.Add(classes[i].PrimarySkill3);
+                classSkills.Add(classes[i].MajorSkill1);
+                classSkills.Add(classes[i].MajorSkill2);
+                classSkills.Add(classes[i].MajorSkill3);
+                classSkills.Add(classes[i].MinorSkill1);
+                classSkills.Add(classes[i].MinorSkill2);
+                classSkills.Add(classes[i].MinorSkill3);
+                classSkills.Add(classes[i].MinorSkill4);
+                classSkills.Add(classes[i].MinorSkill5);
+                classSkills.Add(classes[i].MinorSkill6);
+                if (classSkills.Contains(custom.PrimarySkill1)) affinity++;
+                if (classSkills.Contains(custom.PrimarySkill2)) affinity++;
+                if (classSkills.Contains(custom.PrimarySkill3)) affinity++;
+                if (classSkills.Contains(custom.MajorSkill1)) affinity++;
+                if (classSkills.Contains(custom.MajorSkill2)) affinity++;
+                if (classSkills.Contains(custom.MajorSkill3)) affinity++;
+                if (classSkills.Contains(custom.MinorSkill1)) affinity++;
+                if (classSkills.Contains(custom.MinorSkill2)) affinity++;
+                if (classSkills.Contains(custom.MinorSkill3)) affinity++;
+                if (classSkills.Contains(custom.MinorSkill4)) affinity++;
+                if (classSkills.Contains(custom.MinorSkill5)) affinity++;
+                if (classSkills.Contains(custom.MinorSkill6)) affinity++;
+                if (affinity > highestAffinity)
+                {
+                    highestAffinity = affinity;
+                    selectedIndex = i;
+                }
+            }
+
+            return selectedIndex;
+        }
+
         #endregion
 
         #region Properties

--- a/Assets/Scripts/API/BiogFile.cs
+++ b/Assets/Scripts/API/BiogFile.cs
@@ -3,6 +3,9 @@ using DaggerfallConnect.Utility;
 using DaggerfallWorkshop;
 using System.IO;
 using System.Collections.Generic;
+using DaggerfallWorkshop.Game.Entity;
+using UnityEngine;
+using DaggerfallWorkshop.Game.Items;
 
 namespace DaggerfallConnect.Arena2
 {
@@ -67,6 +70,235 @@ namespace DaggerfallConnect.Arena2
             reader.Close();
         }
 
+        #region Static Methods
+
+        private static void ApplyPlayerEffect(PlayerEntity playerEntity, string effect)
+        {
+            string[] tokens = effect.Split(' ');
+            int parseResult;
+
+            // Skill modifier effect
+            if (int.TryParse(tokens[0], out parseResult))
+            {
+                short modValue;
+                DFCareer.Skills skill = (DFCareer.Skills)parseResult;
+                if (short.TryParse(tokens[1], out modValue))
+                {
+                    short startValue = playerEntity.Skills.GetPermanentSkillValue(skill);
+                    playerEntity.Skills.SetPermanentSkillValue(skill, (short)(startValue + modValue));
+                }
+                else
+                {
+                    Debug.LogError("CreateCharBiography: Invalid skill adjustment value.");
+                }
+            }
+            // Modify gold amount
+            else if (effect.StartsWith("GP"))
+            {
+                // Correct GP commands with spaces between the sign and the amount
+                if (tokens.Length > 2)
+                {
+                    tokens[1] = tokens[1] + tokens[2];
+                }
+                if (!int.TryParse(tokens[1], out parseResult))
+                {
+                    Debug.LogError("CreateCharBiography: GP - invalid argument.");
+                    return;
+                }
+                if (tokens[1][0] == '+')
+                {
+                    playerEntity.GoldPieces += parseResult;
+                }
+                else if (tokens[1][0] == '-')
+                {
+                    playerEntity.GoldPieces -= parseResult;
+                    // The player can't carry negative gold pieces
+                    playerEntity.GoldPieces = playerEntity.GoldPieces < 0 ? 0 : playerEntity.GoldPieces;
+                }
+            }
+            // Add item
+            else if (effect.StartsWith("IT"))
+            {
+                int itemGroup;
+                int templateIndex;
+                int material;
+                if (!int.TryParse(tokens[1], out itemGroup)
+                    || !int.TryParse(tokens[2], out templateIndex)
+                    || !int.TryParse(tokens[3], out material))
+                {
+                    Debug.LogError("CreateCharBiography: IT - invalid argument(s).");
+                    return;
+                }
+                    
+                DaggerfallUnityItem newItem;
+                if ((ItemGroups)itemGroup == ItemGroups.Weapons)
+                {
+                    newItem = ItemBuilder.CreateWeapon((Weapons)Enum.GetValues(typeof(Weapons)).GetValue(templateIndex), (WeaponMaterialTypes)material);
+                }
+                else if ((ItemGroups)itemGroup == ItemGroups.Armor)
+                {
+                    // Biography commands treat weapon and armor material types the same
+                    newItem = ItemBuilder.CreateArmor(playerEntity.Gender, playerEntity.Race, (Armor)Enum.GetValues(typeof(Armor)).GetValue(templateIndex), WeaponToArmorMaterialType((WeaponMaterialTypes)material));
+                }
+                else
+                {
+                    newItem = ItemBuilder.CreateItem((ItemGroups)itemGroup, templateIndex);
+                }
+                playerEntity.Items.AddItem(newItem);
+            }
+            // Adjust reputation
+            else if (effect.StartsWith("r"))
+            {
+                int id;
+                int amount;
+                // Adjust for a faction, social group otherwise
+                if (effect[1] == 'f')
+                {
+                    if (!int.TryParse(tokens[0].Split('f')[1], out id) || !int.TryParse(tokens[1], out amount))
+                    {
+                        Debug.LogError("CreateCharBiography: rf - invalid argument.");
+                        return;
+                    }
+                    // TODO: Not 100% sure if this should propagate or not
+                    playerEntity.FactionData.ChangeReputation(id, amount);
+                }
+                else
+                {
+                    if (!int.TryParse(tokens[0].Split('r')[1], out id) || !int.TryParse(tokens[1], out amount))
+                    {
+                        Debug.LogError("CreateCharBiography: r - invalid argument.");
+                        return;
+                    }
+                    playerEntity.SGroupReputations[id] += (short)amount;
+                }
+            }
+            // Adjust poison resistance
+            else if (effect.StartsWith("RP"))
+            {
+                if (!int.TryParse(tokens[1], out parseResult))
+                {
+                    playerEntity.BiographyResistPoisonMod = parseResult;
+                }
+                else
+                {
+                    Debug.LogError("CreateCharBiography: RP - invalid argument.");
+                }
+            }
+            // Adjust fatigue
+            else if (effect.StartsWith("FT"))
+            {
+                if (!int.TryParse(tokens[1], out parseResult))
+                {
+                    playerEntity.BiographyFatigueMod = parseResult;
+                }
+                else
+                {
+                    Debug.LogError("CreateCharBiography: FT - invalid argument.");
+                }
+            }
+            // Adjust reaction roll
+            else if (effect.StartsWith("RR"))
+            {
+                if (!int.TryParse(tokens[1], out parseResult))
+                {
+                    playerEntity.BiographyReactionMod = parseResult;
+                }
+                else
+                {
+                    Debug.LogError("CreateCharBiography: RR - invalid argument.");
+                }
+            }
+            // Adjust disease resistance
+            else if (effect.StartsWith("RD"))
+            {
+                if (!int.TryParse(tokens[1], out parseResult))
+                {
+                    playerEntity.BiographyResistDiseaseMod = parseResult;
+                }
+                else
+                {
+                    Debug.LogError("CreateCharBiography: RD - invalid argument.");
+                }
+            }
+            // Adjust magic resistance
+            else if (effect.StartsWith("MR"))
+            {
+                if (!int.TryParse(tokens[1], out parseResult))
+                {
+                    playerEntity.BiographyResistMagicMod = parseResult;
+                }
+                else
+                {
+                    Debug.LogError("CreateCharBiography: MR - invalid argument.");
+                }
+            }
+            // Adjust to-hit
+            else if (effect.StartsWith("TH"))
+            {
+                // TODO: Apply to-hit modifier when implemented
+                Debug.Log("CreateCharBiography: Biography to-hit modifier not yet implemented.");
+            }
+            else if (effect[0] == '#' || effect[0] == '!')
+            {
+                // TODO: Implement biography history text commands
+                Debug.Log("CreateCharBiography: Biography history text commands not yet implemented.");
+            }
+            // Unknown commands
+            else if (effect.StartsWith("AE"))
+            {
+                Debug.Log("CreateCharBiography: AE - command function unknown.");
+            }
+            else if (effect.StartsWith("AF"))
+            {
+                Debug.Log("CreateCharBiography: AF - command function unknown.");
+            }
+            else
+            {
+                Debug.LogError("CreateCharBiography: Invalid command - " + effect);
+            }
+        }
+
+        public static void ApplyEffects(List<string> effects, PlayerEntity playerEntity)
+        {
+            foreach (string effect in effects)
+            {
+                ApplyPlayerEffect(playerEntity, effect);
+            }
+        }
+
+        private static ArmorMaterialTypes WeaponToArmorMaterialType(WeaponMaterialTypes materialType)
+        {
+            switch (materialType)
+            {
+                case WeaponMaterialTypes.Iron:
+                    return ArmorMaterialTypes.Iron;
+                case WeaponMaterialTypes.Steel:
+                    return ArmorMaterialTypes.Steel;
+                case WeaponMaterialTypes.Silver:
+                    return ArmorMaterialTypes.Silver;
+                case WeaponMaterialTypes.Elven:
+                    return ArmorMaterialTypes.Elven;
+                case WeaponMaterialTypes.Dwarven:
+                    return ArmorMaterialTypes.Dwarven;
+                case WeaponMaterialTypes.Mithril:
+                    return ArmorMaterialTypes.Mithril;
+                case WeaponMaterialTypes.Adamantium:
+                    return ArmorMaterialTypes.Adamantium;
+                case WeaponMaterialTypes.Ebony:
+                    return ArmorMaterialTypes.Ebony;
+                case WeaponMaterialTypes.Orcish:
+                    return ArmorMaterialTypes.Orcish;
+                case WeaponMaterialTypes.Daedric:
+                    return ArmorMaterialTypes.Daedric;
+                default:
+                    return ArmorMaterialTypes.None;
+            }
+        }
+
+        #endregion
+
+        #region Properties
+
         public Question[] Questions
         {
             get { return questions; }
@@ -92,6 +324,7 @@ namespace DaggerfallConnect.Arena2
             {
                 get { return text; }
             }
+
             public List<Answer> Answers
             {
                 get { return answers; }
@@ -114,6 +347,8 @@ namespace DaggerfallConnect.Arena2
                 get { return effects; }
             }
         }
+
+        #endregion
     }
 }
 

--- a/Assets/Scripts/API/BiogFile.cs
+++ b/Assets/Scripts/API/BiogFile.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using DaggerfallConnect.Utility;
+using DaggerfallWorkshop;
+using System.IO;
+using System.Collections.Generic;
+
+namespace DaggerfallConnect.Arena2
+{
+    public class BiogFile
+    {
+        const int questionCount = 12;
+
+        string questionsStr = string.Empty;
+        Question[] questions = new Question[questionCount];
+
+        public BiogFile(int classIndex)
+        {
+            // Load text file
+            string fileName = "BIOG" + classIndex.ToString("D" + 2) + "T0.TXT";
+            FileProxy txtFile = new FileProxy(Path.Combine(DaggerfallUnity.Instance.Arena2Path, fileName), FileUsage.UseDisk, true);
+            questionsStr = System.Text.Encoding.UTF8.GetString(txtFile.GetBytes());
+
+            // Parse text into questions
+            StringReader reader = new StringReader(questionsStr);
+            for (int i = 0; i < questionCount; i++)
+            {
+                questions[i] = new Question();
+
+                string curLine = reader.ReadLine();
+                // Parse question text
+                for (int j = 0; j < Question.lines; j++)
+                {
+                    // Check if the next line is part of the question
+                    if (j == 0) // first question line should lead with a number followed by a '.'
+                    {
+                        questions[i].Text[j] = curLine.Split(new[] { '.' }, 2)[1].Trim();
+                    } 
+                    else if (j > 0 && curLine.IndexOf (".") != 1 && curLine.IndexOf (".") != 2)
+                    {
+                        questions[i].Text[j] = curLine.Trim();
+                    }
+                    else 
+                    {
+                        break;
+                    }
+                    curLine = reader.ReadLine();
+                }
+                // Parse answers to the current question
+                while (curLine.Length > 1) // Line without 2-char preamble = Empty line = end of answers
+                {
+                    Answer ans = new Answer();
+                    // Get Answer text
+                    if (curLine.IndexOf(".") == 1)
+                    {
+                        ans.Text = curLine.Split('.')[1].Trim();
+                        curLine = reader.ReadLine();
+                    }
+                    // Add answer effects
+                    while (curLine.IndexOf(".") != 1 && curLine.Length > 1)
+                    {
+                        ans.Effects.Add(curLine.Trim());
+                        curLine = reader.ReadLine();
+                    }
+                    questions[i].Answers.Add(ans);
+                }
+            }
+            reader.Close();
+        }
+
+        public Question[] Questions
+        {
+            get { return questions; }
+        }
+
+        public class Question
+        {
+            public const int lines = 2;
+            const int maxAnswers = 10;
+
+            string[] text = new string[lines];
+            List<Answer> answers = new List<Answer>();
+
+            public Question()
+            {
+                for (int i = 0; i < lines; i++)
+                {
+                    text[i] = string.Empty;
+                }
+            }
+
+            public string[] Text
+            {
+                get { return text; }
+            }
+            public List<Answer> Answers
+            {
+                get { return answers; }
+            }
+        }
+
+        public class Answer
+        {
+            string text = string.Empty;
+            List<string> effects = new List<string>();
+
+            public string Text
+            {
+                get { return text; }
+                set { text = value; }
+            }
+
+            public List<String> Effects
+            {
+                get { return effects; }
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/API/BiogFile.cs
+++ b/Assets/Scripts/API/BiogFile.cs
@@ -208,7 +208,7 @@ namespace DaggerfallConnect.Arena2
             // Adjust poison resistance
             else if (effect.StartsWith("RP"))
             {
-                if (!int.TryParse(tokens[1], out parseResult))
+                if (int.TryParse(tokens[1], out parseResult))
                 {
                     playerEntity.BiographyResistPoisonMod = parseResult;
                 }
@@ -220,7 +220,7 @@ namespace DaggerfallConnect.Arena2
             // Adjust fatigue
             else if (effect.StartsWith("FT"))
             {
-                if (!int.TryParse(tokens[1], out parseResult))
+                if (int.TryParse(tokens[1], out parseResult))
                 {
                     playerEntity.BiographyFatigueMod = parseResult;
                 }
@@ -232,7 +232,7 @@ namespace DaggerfallConnect.Arena2
             // Adjust reaction roll
             else if (effect.StartsWith("RR"))
             {
-                if (!int.TryParse(tokens[1], out parseResult))
+                if (int.TryParse(tokens[1], out parseResult))
                 {
                     playerEntity.BiographyReactionMod = parseResult;
                 }
@@ -244,7 +244,7 @@ namespace DaggerfallConnect.Arena2
             // Adjust disease resistance
             else if (effect.StartsWith("RD"))
             {
-                if (!int.TryParse(tokens[1], out parseResult))
+                if (int.TryParse(tokens[1], out parseResult))
                 {
                     playerEntity.BiographyResistDiseaseMod = parseResult;
                 }
@@ -256,7 +256,7 @@ namespace DaggerfallConnect.Arena2
             // Adjust magic resistance
             else if (effect.StartsWith("MR"))
             {
-                if (!int.TryParse(tokens[1], out parseResult))
+                if (int.TryParse(tokens[1], out parseResult))
                 {
                     playerEntity.BiographyResistMagicMod = parseResult;
                 }
@@ -268,7 +268,7 @@ namespace DaggerfallConnect.Arena2
             // Adjust to-hit
             else if (effect.StartsWith("TH"))
             {
-                if (!int.TryParse(tokens[1], out parseResult))
+                if (int.TryParse(tokens[1], out parseResult))
                 {
                     playerEntity.BiographyAvoidHitMod = parseResult;
                 }
@@ -282,14 +282,18 @@ namespace DaggerfallConnect.Arena2
                 // TODO: Implement biography history text commands
                 Debug.Log("CreateCharBiography: Biography history text commands not yet implemented.");
             }
-            // Unknown commands
+            // Unimplemented commands
             else if (effect.StartsWith("AE"))
             {
-                Debug.Log("CreateCharBiography: AE - command function unknown.");
+                Debug.Log("CreateCharBiography: AE - command unimplemented.");
             }
             else if (effect.StartsWith("AF"))
             {
-                Debug.Log("CreateCharBiography: AF - command function unknown.");
+                Debug.Log("CreateCharBiography: AF - command unimplemented.");
+            }
+            else if (effect.StartsWith("AO"))
+            {
+                Debug.Log("CreateCharBiography: AO - command unimplemented.");
             }
             else
             {

--- a/Assets/Scripts/API/BiogFile.cs
+++ b/Assets/Scripts/API/BiogFile.cs
@@ -268,8 +268,14 @@ namespace DaggerfallConnect.Arena2
             // Adjust to-hit
             else if (effect.StartsWith("TH"))
             {
-                // TODO: Apply to-hit modifier when implemented
-                Debug.Log("CreateCharBiography: Biography to-hit modifier not yet implemented.");
+                if (!int.TryParse(tokens[1], out parseResult))
+                {
+                    playerEntity.BiographyAvoidHitMod = parseResult;
+                }
+                else
+                {
+                    Debug.LogError("CreateCharBiography: TH - invalid argument.");
+                }
             }
             else if (effect[0] == '#' || effect[0] == '!')
             {

--- a/Assets/Scripts/API/BiogFile.cs.meta
+++ b/Assets/Scripts/API/BiogFile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d697b3b04aaa1c4ab2b536a4789ae1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/API/BiogFileMCP.cs
+++ b/Assets/Scripts/API/BiogFileMCP.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
+
+namespace DaggerfallConnect.Arena2
+{
+    public partial class BiogFile : IMacroContextProvider
+    {
+        public MacroDataSource GetMacroDataSource()
+        {
+            return new BiogFileMacroDataSource(this);
+        }
+
+        /// <summary>
+        /// MacroDataSource context sensitive methods for items in Daggerfall Unity.
+        /// </summary>
+        private class BiogFileMacroDataSource : MacroDataSource
+        {
+            private BiogFile parent;
+            
+            public BiogFileMacroDataSource(BiogFile biogFile)
+            {
+                parent = biogFile;
+            }
+
+            public override string CommonersRep()
+            {
+                // %r1
+                const int index = 0;
+                return GetChangeStr(parent.changedReputations[index]);
+            }
+
+            public override string MerchantsRep()
+            {
+                // %r2
+                const int index = 1;
+                return GetChangeStr(parent.changedReputations[index]);
+            }
+
+            public override string ScholarsRep()
+            {
+                // %r3
+                const int index = 2;
+                return GetChangeStr(parent.changedReputations[index]);
+            }
+
+            public override string NobilityRep()
+            {
+                // %r4
+                const int index = 3;
+                return GetChangeStr(parent.changedReputations[index]);
+            }
+
+            public override string UnderworldRep()
+            {
+                // %r5
+                const int index = 4;
+                return GetChangeStr(parent.changedReputations[index]);
+            }
+
+            private string GetChangeStr(short val)
+            {
+                if (val == 0)
+                {
+                    return HardStrings.unchanged;
+                }
+                else if (val < 0)
+                {
+                    return HardStrings.lower;
+                }
+                else
+                {
+                    return HardStrings.higher;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/API/BiogFileMCP.cs.meta
+++ b/Assets/Scripts/API/BiogFileMCP.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d15d8ebe15a8b3a4285cacd9217f378d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Items/ItemEnums.cs
+++ b/Assets/Scripts/Game/Items/ItemEnums.cs
@@ -525,8 +525,8 @@ namespace DaggerfallWorkshop.Game.Items
 
     public enum MiscellaneousIngredients2 //checked
     {
-        Ivory,
-        Pearl,
+        Ivory = 76,
+        Pearl = 77,
     }
 
     public enum Transportation  //Checked

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -974,18 +974,6 @@ namespace DaggerfallWorkshop.Game.Items
             equipTable.EquipItem(shortShirt, true, false);
             equipTable.EquipItem(casualPants, true, false);
 
-            // Always add ebony dagger until biography implemented
-            items.AddItem(ItemBuilder.CreateWeapon(Weapons.Dagger, WeaponMaterialTypes.Ebony));
-
-            // Add a cuirass
-            items.AddItem(ItemBuilder.CreateArmor(playerEntity.Gender, playerEntity.Race, Armor.Cuirass, ArmorMaterialTypes.Leather));
-
-            // Add alternate weapons
-            items.AddItem(ItemBuilder.CreateWeapon(Weapons.Longsword, WeaponMaterialTypes.Steel));
-            items.AddItem(ItemBuilder.CreateWeapon(Weapons.Katana, WeaponMaterialTypes.Iron));
-            items.AddItem(ItemBuilder.CreateWeapon(Weapons.Staff, WeaponMaterialTypes.Silver));
-            items.AddItem(ItemBuilder.CreateWeapon(Weapons.Long_Bow, WeaponMaterialTypes.Silver));
-
             // Add some starting gold
             playerEntity.GoldPieces += 100;
         }

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -975,9 +975,38 @@ namespace DaggerfallWorkshop.Game.Items
             equipTable.EquipItem(casualPants, true, false);
 
             // Add class-specific starting weapon
-            byte[] StartingWeaponTypesByClass      = { 3, 6, 6, 3, 11, 3, 3, 1, 6, 3, 3, 7, 2, 254, 14, 13, 5, 7, 7 };
-            byte[] StartingWeaponMaterialsByClass  = { 1, 0, 0, 1,  0, 0, 0, 1, 0, 0, 0, 0, 1, 254,  1,  0, 0, 0, 0 };
-            items.AddItem(ItemBuilder.CreateWeapon((Weapons)StartingWeaponTypesByClass[classIndex], (WeaponMaterialTypes)StartingWeaponMaterialsByClass[classIndex]));
+            Weapons[] StartingWeaponTypesByClass = { Weapons.Staff,      // Mage
+                                                     Weapons.Saber,      // Spellsword
+                                                     Weapons.Saber,      // Battlemage
+                                                     Weapons.Shortsword, // Sorcerer
+                                                     Weapons.Mace,       // Healer
+                                                     Weapons.Shortsword, // Nightblade
+                                                     Weapons.Shortsword, // Bard
+                                                     Weapons.Tanto,      // Burglar
+                                                     Weapons.Saber,      // Rogue
+                                                     Weapons.Shortsword, // Acrobat
+                                                     Weapons.Shortsword, // Thief
+                                                     Weapons.Longsword,  // Assassin
+                                                     Weapons.Staff,      // Monk
+                                                     Weapons.Long_Bow,   // Archer
+                                                     Weapons.Battle_Axe, // Ranger
+                                                     Weapons.Warhammer,  // Barbarian
+                                                     Weapons.Broadsword, // Warrior
+                                                     Weapons.Longsword   // Knight
+                                                     };
+            byte[] StartingWeaponMaterialsByClass  = { 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0 }; // 0 = iron, 1 = steel
+            items.AddItem(ItemBuilder.CreateWeapon(StartingWeaponTypesByClass[classIndex], (WeaponMaterialTypes)StartingWeaponMaterialsByClass[classIndex]));
+
+            // Archer also gets a steel battleaxe and some arrows
+            const int archerIndex = 13;
+            const int archerArrows = 24;
+            if (classIndex == archerIndex)
+            {
+                items.AddItem(ItemBuilder.CreateWeapon(Weapons.Battle_Axe, WeaponMaterialTypes.Steel));
+                DaggerfallUnityItem arrowPile = ItemBuilder.CreateWeapon(Weapons.Arrow, WeaponMaterialTypes.Iron);
+                arrowPile.stackCount = archerArrows;
+                items.AddItem(arrowPile);
+            }
 
             // Add some starting gold
             playerEntity.GoldPieces += 100;

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -941,7 +941,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Assigns basic starting gear to a new character.
         /// </summary>
-        public void AssignStartingGear(PlayerEntity playerEntity)
+        public void AssignStartingGear(PlayerEntity playerEntity, int classIndex)
         {
             // Get references
             ItemCollection items = playerEntity.Items;
@@ -973,6 +973,11 @@ namespace DaggerfallWorkshop.Game.Items
             items.AddItem(casualPants);
             equipTable.EquipItem(shortShirt, true, false);
             equipTable.EquipItem(casualPants, true, false);
+
+            // Add class-specific starting weapon
+            byte[] StartingWeaponTypesByClass      = { 3, 6, 6, 3, 11, 3, 3, 1, 6, 3, 3, 7, 2, 254, 14, 13, 5, 7, 7 };
+            byte[] StartingWeaponMaterialsByClass  = { 1, 0, 0, 1,  0, 0, 0, 1, 0, 0, 0, 0, 1, 254,  1,  0, 0, 0, 0 };
+            items.AddItem(ItemBuilder.CreateWeapon((Weapons)StartingWeaponTypesByClass[classIndex], (WeaponMaterialTypes)StartingWeaponMaterialsByClass[classIndex]));
 
             // Add some starting gold
             playerEntity.GoldPieces += 100;

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Numidium
 // 
 // Notes:
 //
@@ -14,6 +14,7 @@ using System.IO;
 using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Entity;
+using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game.Player
 {
@@ -55,6 +56,7 @@ namespace DaggerfallWorkshop.Game.Player
         public uint timeToBecomeVampireOrWerebeast;
         public uint lastTimePlayerAteOrDrankAtTavern;
         public sbyte biographyReactionMod;
+        public List<string> biographyEffects;
 
         public CharacterDocument()
         {

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -57,6 +57,7 @@ namespace DaggerfallWorkshop.Game.Player
         public uint lastTimePlayerAteOrDrankAtTavern;
         public sbyte biographyReactionMod;
         public List<string> biographyEffects;
+        public int classIndex;
 
         public CharacterDocument()
         {

--- a/Assets/Scripts/Game/UserInterface/SkillsRollout.cs
+++ b/Assets/Scripts/Game/UserInterface/SkillsRollout.cs
@@ -29,10 +29,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
     /// </summary>
     public class SkillsRollout : Panel
     {
-        // This value is normally 6
-        // Increased to 10 temporarily to compensate for biography bonuses
-        // This will be reverted to 6 once biographies implemented
-        const int bonusPoolPerSkillGroup = 10;
+        const int bonusPoolPerSkillGroup = 6;
 
         const int minPrimarySkill = 28;
         const int minMajorSkill = 18;

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
@@ -1,0 +1,54 @@
+﻿// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Numidium
+// Contributors:    
+// 
+// Notes:
+//
+
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+using DaggerfallConnect;
+using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop;
+using DaggerfallWorkshop.Game.UserInterface;
+using DaggerfallWorkshop.Utility.AssetInjection;
+
+namespace DaggerfallWorkshop.Game.UserInterfaceWindows
+{
+    /// <summary>
+    /// Implements biography questionnaire
+    /// </summary>
+    public class CreateCharBiography : DaggerfallPopupWindow
+    {
+        const string nativeImgName = "BIOG00I0.IMG";
+
+        Texture2D nativeTexture;
+
+        public CreateCharBiography(IUserInterfaceManager uiManager)
+            : base(uiManager)
+        {
+        }
+
+        protected override void Setup()
+        {
+            base.Setup();
+            
+            // Load native texture
+            nativeTexture = DaggerfallUI.GetTextureFromImg(nativeImgName);
+            if (!nativeTexture)
+                throw new Exception("CreateCharBiography: Could not load native texture.");
+
+            NativePanel.BackgroundTexture = nativeTexture;
+        }
+
+        public override void Update()
+        {
+            base.Update();
+        }
+    }
+}

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
@@ -39,6 +39,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int buttonsTop = 71;
         const int buttonWidth = 149;
         const int buttonHeight = 24;
+        const int reputationToken = 35;
 
         int classIndex = 0;
         int questionIndex = 0;
@@ -47,7 +48,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button[] answerButtons = new Button[buttonCount];
         TextLabel[] answerLabels = new TextLabel[buttonCount];
         BiogFile biogFile;
-        List<string> playerEffects = new List<string>();
 
         public CreateCharBiography(IUserInterfaceManager uiManager)
             : base(uiManager)
@@ -129,7 +129,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 foreach (string effect in curAnswers[answerIndex].Effects)
                 {
-                    playerEffects.Add(effect);
+                    biogFile.AnswerEffects.Add(effect);
                 }
                 questionIndex++;
                 PopulateControls(biogFile.Questions[questionIndex]);
@@ -137,6 +137,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             else
             {
                 CloseWindow();
+                // Show reputation changes
+                biogFile.DigestRepChanges();
+                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
+                messageBox.SetTextTokens(reputationToken, biogFile);
+                messageBox.ClickAnywhereToClose = true;
+                messageBox.Show();
             }
         }
 
@@ -152,7 +158,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public List<string> PlayerEffects
         {
-            get { return playerEffects; }
+            get { return biogFile.AnswerEffects; }
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
@@ -154,6 +154,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public int ClassIndex
         {
             set { classIndex = value; }
+            get { return classIndex; }
         }
 
         public List<string> PlayerEffects

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
@@ -18,6 +18,7 @@ using DaggerfallWorkshop;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Items;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -135,10 +136,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else
             {
-                foreach (string effect in playerEffects)
-                {
-                    ApplyPlayerEffect(GameManager.Instance.PlayerEntity, effect);
-                }
                 CloseWindow();
             }
         }
@@ -148,27 +145,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             base.Update();
         }
 
-        protected void ApplyPlayerEffect(PlayerEntity playerEntity, string effect)
-        {
-            string[] tokens = effect.Split(' ');
-            int parseResult;
-
-            // Skill modifier effect
-            if (int.TryParse(tokens[0], out parseResult))
-            {
-                short modValue;
-                DFCareer.Skills skill = (DFCareer.Skills)parseResult;
-                if (short.TryParse(tokens[1], out modValue))
-                {
-                    short startValue = GameManager.Instance.PlayerEntity.Skills.GetPermanentSkillValue(skill);
-                    GameManager.Instance.PlayerEntity.Skills.SetPermanentSkillValue(skill, (short)(startValue + modValue));
-                }
-            }
-        }
-
         public int ClassIndex
         {
             set { classIndex = value; }
+        }
+
+        public List<string> PlayerEffects
+        {
+            get { return playerEffects; }
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs.meta
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 380c4e2a90730b341b765e1288edf725
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharChooseBio.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharChooseBio.cs
@@ -1,0 +1,84 @@
+﻿// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Numidium
+// Contributors:    
+// 
+// Notes:
+//
+
+using UnityEngine;
+using System;
+using DaggerfallWorkshop.Game.UserInterface;
+using DaggerfallWorkshop.Utility.AssetInjection;
+
+namespace DaggerfallWorkshop.Game.UserInterfaceWindows
+{
+    /// <summary>
+    /// Implements bio choice (automatically or manually generate) window
+    /// </summary>
+    public class CreateCharChooseBio : DaggerfallPopupWindow
+    {
+        const string nativeImgName = "BUTN02I0.IMG";
+
+        Texture2D nativeTexture;
+        Panel bioChoosePanel = new Panel();
+        Button chooseGenerate;
+        Button chooseQuestions;
+        Rect chooseGenerateRect = new Rect(8, 41, 167, 54);
+        Rect chooseQuestionsRect = new Rect(8, 113, 167, 46);
+        bool choseQuestions = false;
+
+        public CreateCharChooseBio(IUserInterfaceManager uiManager, DaggerfallBaseWindow previous = null)
+            : base(uiManager, previous)
+        {
+        }
+
+        protected override void Setup()
+        {
+            base.Setup();
+
+            // Load native texture
+            nativeTexture = DaggerfallUI.GetTextureFromImg(nativeImgName);
+            if (!nativeTexture)
+                throw new Exception("CreateCharChooseBio: Could not load native texture.");
+
+            // Create panel for window
+            bioChoosePanel.Size = TextureReplacement.GetSize(nativeTexture, nativeImgName);
+            bioChoosePanel.HorizontalAlignment = HorizontalAlignment.Center;
+            bioChoosePanel.VerticalAlignment = VerticalAlignment.Middle;
+            bioChoosePanel.BackgroundTexture = nativeTexture;
+            bioChoosePanel.BackgroundTextureLayout = BackgroundLayout.StretchToFill;
+            NativePanel.Components.Add(bioChoosePanel);
+
+            // Create buttons
+            chooseGenerate = DaggerfallUI.AddButton(chooseGenerateRect, bioChoosePanel);
+            chooseGenerate.OnMouseClick += ChooseGenerate_OnMouseClick;
+            chooseQuestions = DaggerfallUI.AddButton(chooseQuestionsRect, bioChoosePanel);
+            chooseQuestions.OnMouseClick += ChooseQuestions_OnMouseClick;
+        }
+
+        void ChooseGenerate_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            CloseWindow();
+        }
+
+        void ChooseQuestions_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            choseQuestions = true;
+            CloseWindow();
+        }
+
+        public override void Update()
+        {
+            base.Update();
+        }
+
+        public bool ChoseQuestions
+        {
+            get { return choseQuestions; }
+        }
+    }
+}

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharChooseBio.cs.meta
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharChooseBio.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f49a6d77b9ae7d246ab93c0dca1fffa5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharClassSelect.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharClassSelect.cs
@@ -69,6 +69,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (index == classList.Count) // "Custom" option selected
             {
                 selectedClass = null;
+                selectedClassIndex = -1;
                 CloseWindow();
             } 
             else 
@@ -107,6 +108,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public int SelectedClassIndex
         {
             get { return selectedClassIndex; }
+        }
+
+        public List<DFCareer> ClassList
+        {
+            get { return classList; }
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharClassSelect.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharClassSelect.cs
@@ -31,6 +31,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         List<DFCareer> classList = new List<DFCareer>();
         DFCareer selectedClass;
+        int selectedClassIndex = 0;
 
         public DFCareer SelectedClass
         {
@@ -73,6 +74,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             else 
             {
                 selectedClass = classList[index];
+                selectedClassIndex = index;
 
                 TextFile.Token[] textTokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(startClassDescriptionID + index);
                 DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
@@ -100,6 +102,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 selectedClass = null;
                 sender.CancelWindow();
             }
+        }
+
+        public int SelectedClassIndex
+        {
+            get { return selectedClassIndex; }
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
@@ -176,7 +176,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 createCharBiographyWindow.OnClose += CreateCharBiographyWindow_OnClose;
             }
 
-            createCharBiographyWindow.ClassIndex = createCharClassSelectWindow.SelectedClassIndex;
+            if (createCharClassSelectWindow.SelectedClassIndex == -1) // custom class
+            {
+                // Determine the most similar class
+                createCharBiographyWindow.ClassIndex = BiogFile.GetClassAffinityIndex(characterDocument.career, createCharClassSelectWindow.ClassList);
+            } 
+            else
+            {
+                createCharBiographyWindow.ClassIndex = createCharClassSelectWindow.SelectedClassIndex;
+            }
             wizardStage = WizardStages.BiographyQuestions;
             uiManager.PushWindow(createCharBiographyWindow);
         }
@@ -349,7 +357,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             characterDocument.career.Speed = createCharCustomClassWindow.Stats.WorkingStats.LiveSpeed;
             characterDocument.career.Luck = createCharCustomClassWindow.Stats.WorkingStats.LiveLuck;
 
-            SetNameSelectWindow();
+            SetChooseBioWindow();
         }
 
         void CreateCharChooseBioWindow_OnClose()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
@@ -366,6 +366,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void CreateCharBiographyWindow_OnClose()
         {
+            characterDocument.biographyEffects = createCharBiographyWindow.PlayerEffects;
             SetNameSelectWindow();
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
@@ -40,6 +40,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         CreateCharGenderSelect createCharGenderSelectWindow;
         CreateCharClassSelect createCharClassSelectWindow;
         CreateCharCustomClass createCharCustomClassWindow;
+        CreateCharChooseBio createCharChooseBioWindow;
+        CreateCharBiography createCharBiographyWindow;
         CreateCharNameSelect createCharNameSelectWindow;
         CreateCharFaceSelect createCharFaceSelectWindow;
         CreateCharAddBonusStats createCharAddBonusStatsWindow;
@@ -58,8 +60,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SelectGender,
             SelectClassMethod,      // Class questions not implemented, goes straight to SelectClassFromList
             SelectClassFromList,
-            CustomClassBuilder,     // Custom class not implemented
-            SelectBiographyMethod,  // Biography not implemented
+            CustomClassBuilder,
+            SelectBiographyMethod,
+            BiographyQuestions,
             SelectName,
             SelectFace,
             AddBonusStats,
@@ -151,6 +154,30 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             wizardStage = WizardStages.CustomClassBuilder;
             uiManager.PushWindow(createCharCustomClassWindow);
+        }
+
+        void SetChooseBioWindow()
+        {
+            if (createCharChooseBioWindow == null)
+            {
+                createCharChooseBioWindow = new CreateCharChooseBio(uiManager, createCharRaceSelectWindow);
+                createCharChooseBioWindow.OnClose += CreateCharChooseBioWindow_OnClose;
+            }
+
+            wizardStage = WizardStages.SelectBiographyMethod;
+            uiManager.PushWindow(createCharChooseBioWindow);
+        }
+
+        void SetBiographyWindow()
+        {
+            if (createCharBiographyWindow == null)
+            {
+                createCharBiographyWindow = new CreateCharBiography(uiManager);
+                createCharBiographyWindow.OnClose += CreateCharBiographyWindow_OnClose;
+            }
+
+            wizardStage = WizardStages.BiographyQuestions;
+            uiManager.PushWindow(createCharBiographyWindow);
         }
 
         void SetNameSelectWindow()
@@ -290,7 +317,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 else
                 {
                     characterDocument.career = createCharClassSelectWindow.SelectedClass;
-                    SetNameSelectWindow();
+                    SetChooseBioWindow();
                 }
             }
             else
@@ -322,6 +349,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             characterDocument.career.Luck = createCharCustomClassWindow.Stats.WorkingStats.LiveLuck;
 
             SetNameSelectWindow();
+        }
+
+        void CreateCharChooseBioWindow_OnClose()
+        {
+            if (!createCharChooseBioWindow.ChoseQuestions)
+            {
+                SetNameSelectWindow();
+            } 
+            else
+            {
+                SetBiographyWindow();
+            }
+        }
+
+        void CreateCharBiographyWindow_OnClose()
+        {
+
         }
 
         void NameSelectWindow_OnClose()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
@@ -176,6 +176,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 createCharBiographyWindow.OnClose += CreateCharBiographyWindow_OnClose;
             }
 
+            createCharBiographyWindow.ClassIndex = createCharClassSelectWindow.SelectedClassIndex;
             wizardStage = WizardStages.BiographyQuestions;
             uiManager.PushWindow(createCharBiographyWindow);
         }
@@ -365,7 +366,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void CreateCharBiographyWindow_OnClose()
         {
-
+            SetNameSelectWindow();
         }
 
         void NameSelectWindow_OnClose()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
@@ -364,6 +364,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             if (!createCharChooseBioWindow.ChoseQuestions)
             {
+                // Choose answers at random
+                System.Random rand = new System.Random(System.DateTime.Now.Millisecond);
+                BiogFile autoBiog = new BiogFile(createCharClassSelectWindow.SelectedClassIndex);
+                for (int i = 0; i < autoBiog.Questions.Length; i++)
+                {
+                    List<BiogFile.Answer> answers;
+                    answers = autoBiog.Questions[i].Answers;
+                    int index = rand.Next(0, answers.Count);
+                    for (int j = 0; j < answers[index].Effects.Count; j++)
+                    {
+                        autoBiog.AnswerEffects.Add(answers[index].Effects[j]);
+                    }
+                }
+
                 SetNameSelectWindow();
             } 
             else
@@ -375,6 +389,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         void CreateCharBiographyWindow_OnClose()
         {
             characterDocument.biographyEffects = createCharBiographyWindow.PlayerEffects;
+            characterDocument.classIndex = createCharBiographyWindow.ClassIndex;
             SetNameSelectWindow();
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -420,5 +420,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string helpSkills = "Skills";
         public const string helpSpecialAdvantages = "Special Advantages";
         public const string helpSpecialDisadvantages = "Special Disadvantages";
+        public const string lower = "Lower";
+        public const string higher = "Higher";
+        public const string unchanged = "Unchanged";
     }
 }

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -388,7 +388,7 @@ namespace DaggerfallWorkshop.Game.Utility
             }
 
             // Assign starting gear to player entity
-            DaggerfallUnity.Instance.ItemHelper.AssignStartingGear(playerEntity);
+            DaggerfallUnity.Instance.ItemHelper.AssignStartingGear(playerEntity, characterDocument.classIndex);
 
             // Apply biography effects to player entity
             BiogFile.ApplyEffects(characterDocument.biographyEffects, playerEntity);

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -390,6 +390,9 @@ namespace DaggerfallWorkshop.Game.Utility
             // Assign starting gear to player entity
             DaggerfallUnity.Instance.ItemHelper.AssignStartingGear(playerEntity);
 
+            // Apply biography effects to player entity
+            BiogFile.ApplyEffects(characterDocument.biographyEffects, playerEntity);
+
             // Setup bank accounts and houses
             Banking.DaggerfallBankManager.SetupAccounts();
             Banking.DaggerfallBankManager.SetupHouses();

--- a/Assets/Scripts/Utility/MacroDataSource.cs
+++ b/Assets/Scripts/Utility/MacroDataSource.cs
@@ -346,5 +346,34 @@ namespace DaggerfallWorkshop.Utility
             throw new NotImplementedException();
         }
 
+        public virtual string CommonersRep()
+        {
+            // %r1
+            throw new NotImplementedException();
+        }
+
+        public virtual string MerchantsRep()
+        {
+            // %r2
+            throw new NotImplementedException();
+        }
+
+        public virtual string ScholarsRep()
+        {
+            // %r3
+            throw new NotImplementedException();
+        }
+
+        public virtual string NobilityRep()
+        {
+            // %r4
+            throw new NotImplementedException();
+        }
+
+        public virtual string UnderworldRep()
+        {
+            // %r5
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -173,11 +173,11 @@ namespace DaggerfallWorkshop.Utility
             { "%qdat", null },// Quest date of log entry [2]
             { "%qot", null }, // The log comment
             { "%qua", Condition }, // Condition
-            { "%r1", null },  // Commoners rep
-            { "%r2", null },  // Merchants rep
-            { "%r3", null },  // Scholers rep
-            { "%r4", null },  // Nobilitys rep
-            { "%r5", null },  // Underworld rep
+            { "%r1", CommonersRep },  // Commoners rep
+            { "%r2", MerchantsRep },  // Merchants rep
+            { "%r3", ScholarsRep },  // Scholers rep
+            { "%r4", NobilityRep },  // Nobilitys rep
+            { "%r5", UnderworldRep },  // Underworld rep
             { "%ra", PlayerRace },  // Player's race
 			{ "%reg", RegionInContext }, // Region in context
             { "%rn", null },  // Regent's Name
@@ -1233,6 +1233,36 @@ namespace DaggerfallWorkshop.Utility
         {
             // %clm
             return mcp.GetMacroDataSource().MagnitudePerLevel();
+        }
+
+        public static string CommonersRep(IMacroContextProvider mcp)
+        {
+            // %r1
+            return mcp.GetMacroDataSource().CommonersRep();
+        }
+
+        public static string MerchantsRep(IMacroContextProvider mcp)
+        {
+            // %r2
+            return mcp.GetMacroDataSource().MerchantsRep();
+        }
+
+        public static string ScholarsRep(IMacroContextProvider mcp)
+        {
+            // %r3
+            return mcp.GetMacroDataSource().ScholarsRep();
+        }
+
+        public static string NobilityRep(IMacroContextProvider mcp)
+        {
+            // %r4
+            return mcp.GetMacroDataSource().NobilityRep();
+        }
+
+        public static string UnderworldRep(IMacroContextProvider mcp)
+        {
+            // %r5
+            return mcp.GetMacroDataSource().UnderworldRep();
         }
 
         #endregion


### PR DESCRIPTION
In classic, the quiz also generates the player's backstory that you can view with the History button but that's another PR's worth of work.

From the testing I've done I see that the granted starter items more or less work for all the classes' quizzes. I haven't tested it with custom quizzes so I don't know if artifacts will work.

I found one minor issue: selecting "a pearl" adds an emerald instead. The item enums match up with the arguments I'm passing to CreateItem but somehow the item that it fetches from the item template list ends up being an emerald.