### PR TITLE
Save and load poisons on weapons

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -547,10 +547,10 @@ namespace DaggerfallWorkshop.Game.Formulas
                 }
 
                 // Handle poisoned weapons
-                if (damage > 0 && weapon.poisonType != -1)
+                if (damage > 0 && weapon.poisonType != Items.Poisons.None)
                 {
                     InflictPoison(target, weapon.poisonType, false);
-                    weapon.poisonType = -1;
+                    weapon.poisonType = Items.Poisons.None;
                 }
             }
 
@@ -884,7 +884,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return damage;
         }
 
-        public static void InflictPoison(DaggerfallEntity target, int poisonType, bool bypassResistance)
+        public static void InflictPoison(DaggerfallEntity target, Items.Poisons poisonType, bool bypassResistance)
         {
                                             // Poison types. 0-7 are weapon poisons. 8-11 are drugs
                                             // 0     1    2     3     4     5    6    7     8    9   10   11
@@ -902,9 +902,10 @@ namespace DaggerfallWorkshop.Game.Formulas
             {
                 if (target.Level != 1)
                 {
-                    int roundsOfPoison = UnityEngine.Random.Range(MinRoundsOfPoison[poisonType], MaxRoundsOfPoison[poisonType] + 1);
-                    int minutesUntilStartingPoison = UnityEngine.Random.Range(MinMinutesToPoison[poisonType], MaxMinutesToPoison[poisonType] + 1);
-                    Debug.Log(target.Name + " afflicted with poison " + poisonType + ", starting in " + minutesUntilStartingPoison
+                    int index = (int)poisonType - 128;
+                    int roundsOfPoison = UnityEngine.Random.Range(MinRoundsOfPoison[index], MaxRoundsOfPoison[index] + 1);
+                    int minutesUntilStartingPoison = UnityEngine.Random.Range(MinMinutesToPoison[index], MaxMinutesToPoison[index] + 1);
+                    Debug.Log(target.Name + " afflicted with " + poisonType + ", starting in " + minutesUntilStartingPoison
                         + " minutes, lasting for " + roundsOfPoison + " minutes.");
                 }
             }

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -44,7 +44,7 @@ namespace DaggerfallWorkshop.Game.Items
         public int message;
         public DaggerfallEnchantment[] legacyMagic = null;
         public int stackCount = 1;
-        public int poisonType = -1;
+        public Poisons poisonType = Poisons.None;
 
         // Private item fields
         int playerTextureArchive;
@@ -636,6 +636,7 @@ namespace DaggerfallWorkshop.Game.Items
             data.questUID = questUID;
             data.questItemSymbol = questItemSymbol;
             data.trappedSoulType = trappedSoulType;
+            data.poisonType = poisonType;
 
             return data;
         }
@@ -1276,6 +1277,7 @@ namespace DaggerfallWorkshop.Game.Items
             questUID = data.questUID;
             questItemSymbol = data.questItemSymbol;
             trappedSoulType = data.trappedSoulType;
+            poisonType = data.poisonType;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemEnums.cs
+++ b/Assets/Scripts/Game/Items/ItemEnums.cs
@@ -151,6 +151,26 @@ namespace DaggerfallWorkshop.Game.Items
         Feet = 6,
     }
 
+    /// <summary>
+    /// Poison IDs. The first 8 are found on enemy weapons. The last 4 are created by ingesting drugs.
+    /// </summary>
+    public enum Poisons
+    {
+        None = -1,
+        Nux_Vomica = 128,
+        Arsenic = 129,
+        Moonseed = 130,
+        Drothweed = 131,
+        Somnalius = 132,
+        Pyrrhic_Acid = 133,
+        Magebane = 134,
+        Thyrwort = 135,
+        Indulcet = 136,
+        Sursum = 137,
+        Quaesto_Vil = 138,
+        Aegrotat = 139,
+    }
+
     public enum Drugs //checked
     {
         Indulcet = 78,

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -266,6 +266,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public Symbol questItemSymbol;
         public MobileTypes trappedSoulType;
         public string className;
+        public Items.Poisons poisonType;
     }
 
     #endregion


### PR DESCRIPTION
Uses an enum matched to the IDs that would be found from poisons on weapons in classic.