### PR TITLE
Add race/gender attack and hit sounds

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -85,3 +85,4 @@ AlternateRandomEnemySelection=False
 DungeonAmbientLightScale=1.0
 NightAmbientLightScale=1.0
 PlayerTorchLightScale=1.0
+CombatVoices=True

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -161,6 +161,17 @@ namespace DaggerfallWorkshop.Game
 
                 if (damage <= 0)
                     sounds.PlayMissSound(weapon);
+
+                if (DaggerfallUnity.Settings.CombatVoices && entity.EntityType == EntityTypes.EnemyClass && Random.Range(1, 101) <= 20)
+                {
+                    Genders gender;
+                    if (entity.MobileEnemy.Gender == MobileGender.Male || entity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
+                        gender = Genders.Male;
+                    else
+                        gender = Genders.Female;
+
+                    sounds.PlayAttackVoice(gender);
+                }
             }
         }
 

--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -30,6 +30,7 @@ namespace DaggerfallWorkshop.Game
         public SoundClips MoveSound;
         public SoundClips BarkSound;
         public SoundClips AttackSound;
+        public Entity.Races RaceForSounds;
 
         AudioClip moveClip;
         AudioClip barkClip;
@@ -65,6 +66,8 @@ namespace DaggerfallWorkshop.Game
                 BarkSound = (SoundClips)mobile.Summary.Enemy.BarkSound;
                 AttackSound = (SoundClips)mobile.Summary.Enemy.AttackSound;
             }
+
+            RaceForSounds = (Entity.Races)Random.Range(1, 6);
 
             // Start attrack timer
             StartWaiting();
@@ -155,6 +158,30 @@ namespace DaggerfallWorkshop.Game
                 {
                     dfAudioSource.PlayOneShot(SoundClips.SwingHighPitch);
                 }
+            }
+        }
+
+        public void PlayAttackVoice(Entity.Genders gender)
+        {
+            if (IsReady())
+            {
+                SoundClips sound = Entity.DaggerfallEntity.GetRaceGenderAttackSound(RaceForSounds, gender);
+                float pitch = dfAudioSource.AudioSource.pitch;
+                dfAudioSource.AudioSource.pitch = pitch + Random.Range(0, 0.3f);
+                dfAudioSource.PlayOneShot(sound);
+                dfAudioSource.AudioSource.pitch = pitch;
+            }
+        }
+
+        public void PlayPainVoice(Entity.Genders gender, int damage)
+        {
+            if (IsReady())
+            {
+                SoundClips sound = Entity.DaggerfallEntity.GetRaceGenderPainSound(RaceForSounds, gender, damage);
+                float pitch = dfAudioSource.AudioSource.pitch;
+                dfAudioSource.AudioSource.pitch = pitch + Random.Range(0, 0.3f);
+                dfAudioSource.PlayOneShot(sound);
+                dfAudioSource.AudioSource.pitch = pitch;
             }
         }
 

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -634,6 +634,131 @@ namespace DaggerfallWorkshop.Game.Entity
             return monsterFile.GetMonsterClass((int)career);
         }
 
+        public static SoundClips GetRaceGenderAttackSound(Races race, Genders gender)
+        {
+            if (gender == Genders.Male)
+            {
+                switch (race)
+                {
+                    case Races.Breton:
+                        return SoundClips.BretonMalePain1;
+                    case Races.Redguard:
+                        return SoundClips.RedguardMalePain1;
+                    case Races.Nord:
+                        return SoundClips.NordMalePain1;
+                    case Races.DarkElf:
+                        return SoundClips.DarkElfMalePain1;
+                    case Races.HighElf:
+                        return SoundClips.HighElfMalePain1;
+                    case Races.WoodElf:
+                        return SoundClips.WoodElfMalePain1;
+                    case Races.Khajiit:
+                        return SoundClips.KhajiitMalePain1;
+                    case Races.Argonian:
+                        return SoundClips.ArgonianMalePain1;
+                    default:
+                        return SoundClips.None;
+                }
+            }
+            else
+            {
+                switch (race)
+                {
+                    case Races.Breton:
+                    case Races.Redguard:
+                    case Races.Nord:
+                        int random = UnityEngine.Random.Range(0, 3);
+                        if (random == 0)
+                            return SoundClips.BretonFemalePain1;
+                        else if (random == 1)
+                            return SoundClips.BretonFemalePain2;
+                        else
+                            return SoundClips.DarkElfFemalePain2;
+                    case Races.HighElf:
+                    case Races.WoodElf:
+                        random = UnityEngine.Random.Range(0, 2);
+                        if (random == 0)
+                            return SoundClips.HighElfFemalePain1;
+                        else
+                            return SoundClips.HighElfFemalePain2;
+                    case Races.Khajiit:
+                        random = UnityEngine.Random.Range(0, 2);
+                        if (random == 0)
+                            return SoundClips.KhajiitFemalePain1;
+                        else
+                            return SoundClips.KhajiitFemalePain2;
+                    case Races.Argonian:
+                        random = UnityEngine.Random.Range(0, 2);
+                        if (random == 0)
+                            return SoundClips.ArgonianFemalePain1;
+                        else
+                            return SoundClips.ArgonianFemalePain2;
+                    default:
+                        return SoundClips.None;
+                }
+            }
+        }
+
+        public static SoundClips GetRaceGenderPainSound(Races race, Genders gender, int damage)
+        {
+            if (gender == Genders.Male)
+            {
+                switch (race)
+                {
+                    case Races.Breton:
+                        return SoundClips.BretonMalePain2;
+                    case Races.Redguard:
+                        return SoundClips.RedguardMalePain2;
+                    case Races.Nord:
+                        return SoundClips.NordMalePain2;
+                    case Races.DarkElf:
+                        return SoundClips.DarkElfMalePain2;
+                    case Races.HighElf:
+                        return SoundClips.HighElfMalePain2;
+                    case Races.WoodElf:
+                        return SoundClips.WoodElfMalePain2;
+                    case Races.Khajiit:
+                        return SoundClips.KhajiitMalePain2;
+                    case Races.Argonian:
+                        return SoundClips.ArgonianMalePain2;
+                    default:
+                        return SoundClips.None;
+                }
+            }
+            else
+            {
+                switch (race)
+                {
+                    case Races.Breton:
+                    case Races.Redguard:
+                    case Races.Nord:
+                    case Races.DarkElf:
+                    case Races.Argonian:
+                    case Races.HighElf:
+                        if (damage >= 15)
+                            return SoundClips.NordFemalePain2;
+                        else
+                        {
+                            int random = UnityEngine.Random.Range(0, 2);
+                            if (random == 0)
+                                return SoundClips.RedguardFemalePain1;
+                            else
+                                return SoundClips.DarkElfFemalePain1;
+                        }
+                    case Races.WoodElf:
+                    case Races.Khajiit:
+                        if (damage >= 15)
+                            return SoundClips.WoodElfFemalePain2;
+                        else
+                        {
+                            return SoundClips.WoodElfFemalePain1;
+                        }
+                    default:
+                        return SoundClips.None;
+                }
+            }
+        }
+
         #endregion
 
         #region Event Handlers

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -19,6 +19,7 @@ using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Utility.AssetInjection;
+using DaggerfallWorkshop.Game.Entity;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -186,6 +187,19 @@ namespace DaggerfallWorkshop.Game
             {
                 dfAudioSource.AudioSource.pitch = 1f * AttackSpeedScale;
                 dfAudioSource.PlayOneShot(SwingWeaponSound, 0, 1.1f);
+            }
+        }
+
+        public void PlayAttackVoice()
+        {
+            if (dfAudioSource)
+            {
+                PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+                SoundClips sound = DaggerfallEntity.GetRaceGenderAttackSound(playerEntity.Race, playerEntity.Gender);
+                float pitch = dfAudioSource.AudioSource.pitch;
+                dfAudioSource.AudioSource.pitch = pitch + UnityEngine.Random.Range(0, 0.3f);
+                dfAudioSource.PlayOneShot(sound, 0, 1f);
+                dfAudioSource.AudioSource.pitch = pitch;
             }
         }
 

--- a/Assets/Scripts/Game/PlayerDeath.cs
+++ b/Assets/Scripts/Game/PlayerDeath.cs
@@ -162,9 +162,7 @@ namespace DaggerfallWorkshop.Game
 
             // There are 3 pain-like sounds for each race/gender. The third one, used here, sounds like
             // it may have been meant for when the player dies.
-
-            PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
-            SoundClips sound = GetRaceGenderPain3Sound((Races)playerEntity.RaceTemplate.ID, playerEntity.Gender);
+            SoundClips sound = GetRaceGenderPain3Sound(playerEntity.Race, playerEntity.Gender);
 
             if (DaggerfallUI.Instance.DaggerfallAudioSource)
                 DaggerfallUI.Instance.DaggerfallAudioSource.PlayOneShot(sound, 0);

--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -293,6 +293,20 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
+        // Capture this message so we can play pain voice
+        public void RemoveHealth(int amount)
+        {
+            if (dfAudioSource && DaggerfallUnity.Settings.CombatVoices && Random.Range(1, 101) <= 40)
+            {
+                Entity.PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+                SoundClips sound = Entity.DaggerfallEntity.GetRaceGenderPainSound(playerEntity.Race, playerEntity.Gender, amount);
+                float pitch = dfAudioSource.AudioSource.pitch;
+                dfAudioSource.AudioSource.pitch = pitch + Random.Range(0, 0.3f);
+                dfAudioSource.PlayOneShot((int)sound, 0, 1f);
+                dfAudioSource.AudioSource.pitch = pitch;
+            }
+        }
+
         // Capture this message so we can play enemies' arrow sounds on player
         public void PlayArrowSound()
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -117,6 +117,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox nearDeathWarning;
         Checkbox alternateRandomEnemySelection;
         Checkbox advancedClimbing;
+        Checkbox combatVoices;
         HorizontalSlider dungeonAmbientLightScale;
         HorizontalSlider nightAmbientLightScale;
         HorizontalSlider playerTorchLightScale;
@@ -266,6 +267,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             nearDeathWarning = AddCheckbox(leftPanel, "nearDeathWarning", DaggerfallUnity.Settings.NearDeathWarning);
             alternateRandomEnemySelection = AddCheckbox(leftPanel, "alternateRandomEnemySelection", DaggerfallUnity.Settings.AlternateRandomEnemySelection);
             advancedClimbing = AddCheckbox(leftPanel, "advancedClimbing", DaggerfallUnity.Settings.AdvancedClimbing);
+            combatVoices = AddCheckbox(leftPanel, "combatVoices", DaggerfallUnity.Settings.CombatVoices);
 
             y = 0;
 
@@ -360,6 +362,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.AlternateRandomEnemySelection = alternateRandomEnemySelection.IsChecked;
             DaggerfallUnity.Settings.CameraRecoilStrength = cameraRecoilStrength.ScrollIndex;
             DaggerfallUnity.Settings.AdvancedClimbing = advancedClimbing.IsChecked;
+            DaggerfallUnity.Settings.CombatVoices = combatVoices.IsChecked;
 
             DaggerfallUnity.Settings.DungeonAmbientLightScale = dungeonAmbientLightScale.GetValue();
             DaggerfallUnity.Settings.NightAmbientLightScale = nightAmbientLightScale.GetValue();

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -334,9 +334,9 @@ namespace DaggerfallWorkshop.Game
             }
             else if (!isDamageFinished && ScreenWeapon.GetCurrentFrame() == ScreenWeapon.GetHitFrame())
             {
-                // The attack has reached the hit frame.
-                // Attempt to transfer damage based on last attack hand.
-                // Get attack hand weapon
+                // Chance to play attack voice
+                if (DaggerfallUnity.Settings.CombatVoices && ScreenWeapon.WeaponType != WeaponTypes.Bow && UnityEngine.Random.Range(1, 101) <= 20)
+                    ScreenWeapon.PlayAttackVoice();
 
                 // Transfer damage.
                 bool hitEnemy = false;
@@ -688,6 +688,17 @@ namespace DaggerfallWorkshop.Game
                                     enemyMotor.KnockBackSpeed = knockBackSpeed;
                                     enemyMotor.KnockBackDirection = mainCamera.transform.forward;
                                 }
+                            }
+
+                            if (DaggerfallUnity.Settings.CombatVoices && entityBehaviour.EntityType == EntityTypes.EnemyClass && UnityEngine.Random.Range(1, 101) <= 40)
+                            {
+                                Genders gender;
+                                if (enemyEntity.MobileEnemy.Gender == MobileGender.Male || enemyEntity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
+                                    gender = Genders.Male;
+                                else
+                                    gender = Genders.Female;
+
+                                enemySounds.PlayPainVoice(gender, damage);
                             }
                         }
                         else

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -146,6 +146,7 @@ namespace DaggerfallWorkshop
         public float DungeonAmbientLightScale { get; set; }
         public float NightAmbientLightScale { get; set; }
         public float PlayerTorchLightScale { get; set; }
+        public bool CombatVoices { get; set; }
 
         #endregion
 
@@ -237,6 +238,7 @@ namespace DaggerfallWorkshop
             DungeonAmbientLightScale = GetFloat(sectionEnhancements, "DungeonAmbientLightScale", 0.0f, 1.0f);
             NightAmbientLightScale = GetFloat(sectionEnhancements, "NightAmbientLightScale", 0.0f, 1.0f);
             PlayerTorchLightScale = GetFloat(sectionEnhancements, "PlayerTorchLightScale", 0.0f, 1.0f);
+            CombatVoices = GetBool(sectionEnhancements, "CombatVoices");
         }
 
         /// <summary>
@@ -262,7 +264,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionVideo, "EnableTextureArrays", EnableTextureArrays);
             SetInt(sectionVideo, "RandomDungeonTextures", RandomDungeonTextures);
 
-            SetString (sectionAudio, "SoundFont", SoundFont);
+            SetString(sectionAudio, "SoundFont", SoundFont);
 
             SetBool(sectionChildGuard, "PlayerNudity", PlayerNudity);
 
@@ -321,6 +323,7 @@ namespace DaggerfallWorkshop
             SetFloat(sectionEnhancements, "DungeonAmbientLightScale", DungeonAmbientLightScale);
             SetFloat(sectionEnhancements, "NightAmbientLightScale", NightAmbientLightScale);
             SetFloat(sectionEnhancements, "PlayerTorchLightScale", PlayerTorchLightScale);
+            SetBool(sectionEnhancements, "CombatVoices", CombatVoices);
 
             // Write settings to persistent file
             WriteSettingsFile();

--- a/Assets/Scripts/SoundClips.cs
+++ b/Assets/Scripts/SoundClips.cs
@@ -499,7 +499,7 @@ namespace DaggerfallWorkshop
         HighElfMalePain1 = 402,
         HighElfMalePain2 = 403,
         HighElfMalePain3 = 404,
-        PlayerDeath = 405, // or WoodElfMalePain1
+        WoodElfMalePain1 = 405,
         WoodElfMalePain2 = 406,
         WoodElfMalePain3 = 407,
         KhajiitMalePain1 = 408,

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -94,6 +94,8 @@ nightAmbientLightScale,								Night ambient light
 nightAmbientLightScaleInfo,							Scale of the ambient light at night in interiors and exteriors
 playerTorchLightScale,								Player torch light 
 playerTorchLightScaleInfo,							Scale of player personal light
+combatVoices,										Combat vocalizations
+combatVoicesInfo,									Player and NPCs will vocalize when attacking or being hit
 
 resolution,                                         Resolution
 resolutionInfo,                                     Screen resolution


### PR DESCRIPTION
On by default, but can be turned off. Happens a percentage of the time when melee attacking or being hit, both for the player and for enemy classes.

Male sounds are pretty straight-forward, with unique sounds for each race.
Female sounds were a mixture. Some sounds are duplicates, and some races only seemed to have attack sounds or only pain sounds. I spent a fair bit of time listening to the sounds and working out a solution that ends up working pretty well. It basically works out to humans, elves, khajiit and argonians as 4 groups, with various bits of crossover.

Just for the purposes of sounds, each enemy class is randomly assigned a race (Breton through High Elf), to add some variety. This isn't saved or loaded at the moment, and is just intended to be for that character's voice, not to actually serve as the race.