### PR TITLE
 Implement selling magic items at fence in TG 

### DIFF
--- a/Assets/Scripts/Game/Guilds/Services.cs
+++ b/Assets/Scripts/Game/Guilds/Services.cs
@@ -249,7 +249,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                     return GuildServices.MakeMagicItems;
 
                 case GuildNpcServices.TG_SellMagicItems:
-                    return GuildServices.BuyMagicItems;
+                    return GuildServices.SellMagicItems;
 
                 case GuildNpcServices.MG_Teleportation:
                     return GuildServices.Teleport;
@@ -320,7 +320,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                 case GuildServices.MakeMagicItems:
                     return HardStrings.serviceMakeMagicItems;
                 case GuildServices.SellMagicItems:
-                    return HardStrings.serviceBuyMagicItems;
+                    return HardStrings.serviceSellMagicItems;
                 case GuildServices.Teleport:
                     return HardStrings.serviceTeleport;
                 case GuildServices.DaedraSummoning:

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -152,7 +152,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                     return IsMember();
                 case GuildServices.Quests:
                     return true;
-                case GuildServices.BuyMagicItems:
+                case GuildServices.SellMagicItems:
                     return (rank >= 2);
                 case GuildServices.Spymaster:
                     return (rank >= 4);

--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -50,10 +50,11 @@ namespace DaggerfallWorkshop.Game
         public void HandleJumpInput(ref Vector3 moveDirection)
         {
             // Cancel jump if player is paralyzed or swimming on a water tile
-            // Jump is also ignored when player is slowfalling
+            // Jump is also ignored when player is slowfalling or riding cart
             if (GameManager.Instance.PlayerEntity.IsParalyzed ||
                 GameManager.Instance.PlayerMotor.OnExteriorWater == PlayerMotor.OnExteriorWaterMethod.Swimming ||
-                GameManager.Instance.PlayerEntity.IsSlowFalling)
+                GameManager.Instance.PlayerEntity.IsSlowFalling ||
+                GameManager.Instance.TransportManager.TransportMode == TransportModes.Cart)
                 return;
 
             if (InputManager.Instance.HasAction(InputManager.Actions.Jump))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -332,11 +332,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     uiManager.PushWindow(DaggerfallUI.Instance.DfItemMakerWindow);
                     break;
 
-/*                case GuildServices.SellMagicItems:
+                case GuildServices.SellMagicItems:
                     CloseWindow();
-                    uiManager.PushWindow(DaggerfallUI.Instance.DfPotionMakerWindow);
+                    uiManager.PushWindow(new DaggerfallTradeWindow(uiManager, DaggerfallTradeWindow.WindowModes.SellMagic, this, guild));
                     break;
-*/
+
                 case GuildServices.Teleport:
                     CloseWindow();
                     DaggerfallUI.Instance.DfTravelMapWindow.ActivateTeleportationTravel();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -128,6 +128,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Buy,
             Repair,
             Identify,
+            SellMagic
         }
 
         #endregion
@@ -363,6 +364,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         case WindowModes.Sell:
                             cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality) * item.stackCount;
                             break;
+                        case WindowModes.SellMagic: // TODO: Fencing base price higher and guild rep affects it. Implement new formula or can this be used?
+                            cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality);
+                            break;
                         case WindowModes.Repair:
                             cost += FormulaHelper.CalculateItemRepairCost(item.value, buildingDiscoveryData.quality, item.currentCondition, item.maxCondition, guild) * item.stackCount;
                             break;
@@ -379,7 +383,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private int GetTradePrice()
         {
-            if (windowMode == WindowModes.Sell)
+            if (windowMode == WindowModes.Sell || windowMode == WindowModes.SellMagic)
                 return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, true);
             else if (windowMode == WindowModes.Identify)
                 return cost;
@@ -451,6 +455,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 default:
                 case WindowModes.Sell:
+                case WindowModes.SellMagic:
                     containerImage = DaggerfallUnity.ItemHelper.GetContainerImage(InventoryContainerImages.Merchant);
                     break;
                 case WindowModes.Buy:
@@ -488,7 +493,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     // Add if not equipped & accepted for selling
                     DaggerfallUnityItem item = localItems.GetItem(i);
-                    if (!item.IsEquipped && (windowMode != WindowModes.Sell || itemTypesAccepted.Contains(item.ItemGroup)))
+                    if (!item.IsEquipped &&
+                        ((windowMode == WindowModes.Sell && itemTypesAccepted.Contains(item.ItemGroup)) ||
+                         (windowMode == WindowModes.SellMagic && item.IsEnchanted)))
                         AddLocalItem(item);
                 }
             }
@@ -516,7 +523,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             base.LoadTextures();
 
             // Load special button texture.
-            if (windowMode == WindowModes.Sell) {
+            if (windowMode == WindowModes.Sell || windowMode == WindowModes.SellMagic) {
                 actionButtonsTexture = ImageReader.GetTexture(sellButtonsTextureName);
             } else if (windowMode == WindowModes.Buy) {
                 actionButtonsTexture = ImageReader.GetTexture(buyButtonsTextureName);
@@ -545,6 +552,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 switch (windowMode)
                 {
                     case WindowModes.Sell:
+                    case WindowModes.SellMagic:
                         if (remoteItems != null)
                             TransferItem(item, localItems, remoteItems);
                         break;
@@ -667,6 +675,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 switch (windowMode)
                 {
                     case WindowModes.Sell:
+                    case WindowModes.SellMagic:
                         int goldAmount = GetTradePrice();
                         float goldWeight = (float)goldAmount / DaggerfallBankManager.gold1kg;
                         if (PlayerEntity.CarriedWeight + goldWeight <= PlayerEntity.MaxEncumbrance)
@@ -721,7 +730,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             int msgOffset = 0;
             int tradePrice = GetTradePrice();
 
-            if (windowMode != WindowModes.Sell && PlayerEntity.GetGoldAmount() < tradePrice)
+            if (windowMode != WindowModes.Sell && windowMode != WindowModes.SellMagic && PlayerEntity.GetGoldAmount() < tradePrice)
             {
                 DaggerfallUI.MessageBox(notEnoughGoldId);
             }
@@ -734,7 +743,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     else
                         msgOffset = 1;
                 }
-                if (windowMode == WindowModes.Sell)
+                if (windowMode == WindowModes.Sell || windowMode == WindowModes.SellMagic)
                     msgOffset += 3;
 
                 DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -141,7 +141,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string serviceTeleport = "Teleportation";
         public const string serviceMakeSpells = "Make Spells";
         public const string serviceBuyMagicItems = "Buy Magic Items";
-        public const string serviceSellMagicItems = "Buy Magic Items";
+        public const string serviceSellMagicItems = "Sell Magic Items";
         public const string serviceDaedraSummon = "Daedra Summoning";
         public const string serviceMakeMagicItems = "Make Magic Items";
         public const string serviceRepairs = "Repairs";


### PR DESCRIPTION
Also disabled jumping with cart which I always intended to do.

@Allofich It currently re-uses the same calculation for cost. However UESP states "Appraisers will buy magical items from any member who is at least a Filcher in the Guild. They offer higher base prices than other merchants. The final price for your items is affected by your reputation with the faction." This implies that the function will need guild rank to be passed instead of building quality. If you give me the equation for the formula I'm happy to implement it... you do seem to have a few plates spinning right now. :-)