### PR TITLE
Implement AI target selection and infighting

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -31,6 +31,7 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(HelpCommand.name, HelpCommand.description, HelpCommand.usage, HelpCommand.Execute);
             ConsoleCommandsDatabase.RegisterCommand(LoadCommand.name, LoadCommand.description, LoadCommand.usage, LoadCommand.Execute);
             ConsoleCommandsDatabase.RegisterCommand(GodCommand.name, GodCommand.description, GodCommand.usage, GodCommand.Execute);
+            ConsoleCommandsDatabase.RegisterCommand(NoTargetCommand.name, NoTargetCommand.description, NoTargetCommand.usage, NoTargetCommand.Execute);
             ConsoleCommandsDatabase.RegisterCommand(Suicide.name, Suicide.description, Suicide.usage, Suicide.Execute);
             ConsoleCommandsDatabase.RegisterCommand(ShowDebugStrings.name, ShowDebugStrings.description, ShowDebugStrings.usage, ShowDebugStrings.Execute);
             ConsoleCommandsDatabase.RegisterCommand(SetWeather.name, SetWeather.description, SetWeather.usage, SetWeather.Execute);
@@ -228,6 +229,26 @@ namespace Wenzil.Console
                     PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
                     playerEntity.GodMode = !playerEntity.GodMode;
                     return string.Format("Godmode enabled: {0}", playerEntity.GodMode);
+                }
+                else
+                    return error;
+            }
+        }
+
+        private static class NoTargetCommand
+        {
+            public static readonly string name = "nt";
+            public static readonly string error = "Failed to set NoTarget mode";
+            public static readonly string usage = "nt";
+            public static readonly string description = "Toggle NoTarget mode";
+
+            public static string Execute(params string[] args)
+            {
+                PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+                if (playerEntity != null)
+                {
+                    playerEntity.NoTargetMode = !playerEntity.NoTargetMode;
+                    return string.Format("NoTarget enabled: {0}", playerEntity.NoTargetMode);
                 }
                 else
                     return error;

--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -86,3 +86,4 @@ DungeonAmbientLightScale=1.0
 NightAmbientLightScale=1.0
 PlayerTorchLightScale=1.0
 CombatVoices=True
+EnemyInfighting=True

--- a/Assets/Scripts/DaggerfallUnityEnums.cs
+++ b/Assets/Scripts/DaggerfallUnityEnums.cs
@@ -255,6 +255,34 @@ namespace DaggerfallWorkshop
     }
 
     /// <summary>
+    /// Mobile teams.
+    /// </summary>
+    public enum MobileTeams
+    {
+        PlayerAlly,
+        Vermin,
+        Spriggans,
+        Bears,
+        Tigers,
+        Spiders,
+        Orcs,
+        Centaurs,
+        Werecreatures,
+        Nymphs,
+        Aquatic,
+        Harpies,
+        Undead,
+        Giants,
+        Scorpions,
+        Magic,
+        Daedra,
+        Dragonlings,
+        KnightsAndMages,
+        Criminals,
+        CityWatch,
+    }
+
+    /// <summary>
     /// Mobile gender.
     /// All monsters have an unspecified gender and no male/female variations.
     /// When specifying gender for humanoids, a value of unspecified will randomly choose between male/female.

--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -218,6 +218,7 @@ namespace DaggerfallWorkshop
         public int ChanceForAttack5;                // Chance to use PrimaryAttackAnimFrames3 for an attack
         public int[] PrimaryAttackAnimFrames5;      // Alternate animation sequence to play when doing primary attack
         public int[] RangedAttackAnimFrames;        // Animation sequence to play when doing bow & arrow attack
+        public MobileTeams Team;                    // Team that this enemy uses if enemy in-fighting is on
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -376,7 +376,7 @@ namespace DaggerfallWorkshop.Game
                 EnemySenses enemySenses = caster.GetComponent<EnemySenses>();
                 if (enemySenses)
                 {
-                    aimDirection = enemySenses.DirectionToPlayer;
+                    aimDirection = enemySenses.DirectionToTarget;
                 }
             }
 

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -61,6 +61,9 @@ namespace DaggerfallWorkshop.Game
 
         void Update()
         {
+            if (entityBehaviour.Target == null)
+                return;
+
             // If a melee attack has reached the damage frame we can run a melee attempt
             if (mobile.DoMeleeDamage)
             {
@@ -116,18 +119,14 @@ namespace DaggerfallWorkshop.Game
 
         private void MeleeAnimation()
         {
-            // Are we in range and facing player? Then start attack.
-            if (senses.PlayerInSight)
+            // Are we in range and facing target? Then start attack.
+            if (senses.TargetInSight)
             {
                 // Take the speed of movement during the attack animation into account when deciding if to attack
                 EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
                 float attackSpeed = ((entity.Stats.LiveSpeed + PlayerSpeedChanger.dfWalkBase) / PlayerSpeedChanger.classicToUnitySpeedUnitRatio) / EnemyMotor.AttackSpeedDivisor;
 
-                if (senses.DistanceToPlayer >= MeleeDistance + attackSpeed)
-                    return;
-
-                // Don't attack if not hostile
-                if (!motor.IsHostile)
+                if (senses.DistanceToTarget >= MeleeDistance + attackSpeed)
                     return;
 
                 // Set melee animation state
@@ -146,18 +145,29 @@ namespace DaggerfallWorkshop.Game
             if (entityBehaviour)
             {
                 EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
+                EnemyEntity targetEntity = null;
+
+                if (entityBehaviour.Target != GameManager.Instance.PlayerEntityBehaviour)
+                    targetEntity = entityBehaviour.Target.Entity as EnemyEntity;
+
+                // Switch to hand-to-hand if enemy is immune to weapon
+                Items.DaggerfallUnityItem weapon = entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
+                if (weapon != null)
+                {
+                    if (targetEntity != null && targetEntity.MobileEnemy.MinMetalToHit > (Items.WeaponMaterialTypes)weapon.NativeMaterialValue)
+                        weapon = null;
+                }
 
                 damage = 0;
 
-                // Are we still in range and facing player? Then apply melee damage.
-                if (senses.DistanceToPlayer < MeleeDistance && senses.PlayerInSight)
+                // Are we still in range and facing target? Then apply melee damage.
+                if (senses.DistanceToTarget < MeleeDistance && senses.TargetInSight)
                 {
-                    damage = ApplyDamageToPlayer();
+                    if (entityBehaviour.Target == GameManager.Instance.PlayerEntityBehaviour)
+                        damage = ApplyDamageToPlayer(weapon);
+                    else
+                        damage = ApplyDamageToNonPlayer(weapon);
                 }
-
-                Items.DaggerfallUnityItem weapon = entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
-                if (weapon == null)
-                    weapon = entity.ItemEquipTable.GetItem(Items.EquipSlots.LeftHand);
 
                 if (damage <= 0)
                     sounds.PlayMissSound(weapon);
@@ -179,21 +189,30 @@ namespace DaggerfallWorkshop.Game
         {
             if (entityBehaviour)
             {
-                // Can we see player? Then apply damage.
-                if (senses.PlayerInSight)
+                // Can we see target? Then apply damage.
+                if (senses.TargetInSight)
                 {
-                    damage = ApplyDamageToPlayer();
+                    EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
+                    if (entityBehaviour.Target == GameManager.Instance.PlayerEntityBehaviour)
+                        damage = ApplyDamageToPlayer(entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand));
+                    else
+                        damage = ApplyDamageToNonPlayer(entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand));
 
-                    // Play arrow sound and add arrow to player inventory
-                    GameManager.Instance.PlayerObject.SendMessage("PlayArrowSound");
-
+                    // Play arrow sound and add arrow to target inventory
+                    if (entityBehaviour.Target == GameManager.Instance.PlayerEntityBehaviour)
+                        GameManager.Instance.PlayerObject.SendMessage("PlayArrowSound");
+                    else
+                    {
+                        EnemySounds targetSounds = entityBehaviour.Target.GetComponent<EnemySounds>();
+                        targetSounds.PlayArrowSound();
+                    }
                     Items.DaggerfallUnityItem arrow = Items.ItemBuilder.CreateItem(Items.ItemGroups.Weapons, (int)Items.Weapons.Arrow);
-                    GameManager.Instance.PlayerEntity.Items.AddItem(arrow);
+                    entityBehaviour.Target.Entity.Items.AddItem(arrow);
                 }
             }
         }
 
-        private int ApplyDamageToPlayer()
+        private int ApplyDamageToPlayer(Items.DaggerfallUnityItem weapon)
         {
             const int doYouSurrenderToGuardsTextID = 15;
 
@@ -201,7 +220,7 @@ namespace DaggerfallWorkshop.Game
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
 
             // Calculate damage
-            damage = FormulaHelper.CalculateAttackDamage(entity, playerEntity, (int)(Items.EquipSlots.RightHand), -1);
+            damage = FormulaHelper.CalculateAttackDamage(entity, playerEntity, weapon, -1);
 
             // Break any "normal power" concealment effects on enemy
             if (entity.IsMagicallyConcealedNormalPower && damage > 0)
@@ -236,6 +255,89 @@ namespace DaggerfallWorkshop.Game
                 }
                 else
                     SendDamageToPlayer();
+            }
+
+            return damage;
+        }
+
+        private int ApplyDamageToNonPlayer(Items.DaggerfallUnityItem weapon)
+        {
+            // TODO: Merge with hit code in WeaponManager to eliminate duplicate code
+            EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
+            EnemyEntity targetEntity = entityBehaviour.Target.Entity as EnemyEntity;
+            EnemySounds targetSounds = entityBehaviour.Target.GetComponent<EnemySounds>();
+            EnemyMotor targetMotor = entityBehaviour.Target.transform.GetComponent<EnemyMotor>();
+
+            // Calculate damage
+            damage = FormulaHelper.CalculateAttackDamage(entity, targetEntity, weapon, -1);
+
+            // Break any "normal power" concealment effects on enemy
+            if (entity.IsMagicallyConcealedNormalPower && damage > 0)
+                EntityEffectManager.BreakNormalPowerConcealmentEffects(entityBehaviour);
+
+            // Play hit sound and trigger blood splash at hit point
+            if (damage > 0)
+            {
+                targetSounds.PlayHitSound(weapon);
+
+                EnemyBlood blood = entityBehaviour.Target.transform.GetComponent<EnemyBlood>();
+
+                Vector3 bloodPos = entityBehaviour.Target.transform.position;
+                CharacterController targetController = entityBehaviour.Target.transform.GetComponent<CharacterController>();
+                bloodPos.y += targetController.height / 8;
+
+                if (blood)
+                {
+                    blood.ShowBloodSplash(targetEntity.MobileEnemy.BloodIndex, bloodPos);
+                }
+
+                // Knock back enemy based on damage and enemy weight
+                if (targetMotor)
+                {
+                    if (targetMotor.KnockBackSpeed <= (5 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)) &&
+                        entityBehaviour.EntityType == EntityTypes.EnemyClass ||
+                        targetEntity.MobileEnemy.Weight > 0)
+                    {
+                        float enemyWeight = targetEntity.GetWeightInClassicUnits();
+                        float tenTimesDamage = damage * 10;
+                        float twoTimesDamage = damage * 2;
+
+                        float knockBackAmount = ((tenTimesDamage - enemyWeight) * 256) / (enemyWeight + tenTimesDamage) * twoTimesDamage;
+                        float knockBackSpeed = (tenTimesDamage / enemyWeight) * (twoTimesDamage - (knockBackAmount / 256));
+                        knockBackSpeed /= (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10);
+
+                        if (knockBackSpeed < (15 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)))
+                            knockBackSpeed = (15 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10));
+                        targetMotor.KnockBackSpeed = knockBackSpeed;
+                        targetMotor.KnockBackDirection = transform.forward;
+                    }
+                }
+            }
+            else
+            {
+                WeaponTypes weaponType = WeaponTypes.Melee;
+                if (weapon != null)
+                    weaponType = DaggerfallUnity.Instance.ItemHelper.ConvertItemToAPIWeaponType(weapon);
+
+                if ((weaponType != WeaponTypes.Bow && !targetEntity.MobileEnemy.ParrySounds) || weaponType == WeaponTypes.Melee)
+                    sounds.PlayMissSound(weapon);
+                else if (targetEntity.MobileEnemy.ParrySounds)
+                    targetSounds.PlayParrySound();
+            }
+
+            targetEntity.DecreaseHealth(damage);
+
+            // Assign "cast when strikes" to target entity
+            if (weapon != null && weapon.IsEnchanted)
+            {
+                EntityEffectManager enemyEffectManager = targetEntity.EntityBehaviour.GetComponent<EntityEffectManager>();
+                if (enemyEffectManager)
+                    enemyEffectManager.StrikeWithItem(weapon, entityBehaviour);
+            }
+
+            if (targetMotor)
+            {
+                targetMotor.MakeEnemyHostileToAttacker(entityBehaviour);
             }
 
             return damage;

--- a/Assets/Scripts/Game/EnemyHealth.cs
+++ b/Assets/Scripts/Game/EnemyHealth.cs
@@ -45,7 +45,7 @@ namespace DaggerfallWorkshop.Game
 
             // Aggro this enemy
             // To enhance, use a script that "shouts" to other enemies in range and make them hostile to player also
-            motor.MakeEnemyHostileToPlayer(sendingPlayer);
+            motor.MakeEnemyHostileToAttacker(GameManager.Instance.PlayerEntityBehaviour);
 
             if (mobile != null)
             {

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -30,22 +30,28 @@ namespace DaggerfallWorkshop.Game
         public float FieldOfView = 180f;        // Enemy field of view
 
         DaggerfallMobileUnit mobile;
-        bool playerInSight;
-        bool playerInEarshot;
-        Vector3 directionToPlayer;
+        DaggerfallEntityBehaviour entityBehaviour;
+        EnemyMotor motor;
+        EnemyEntity enemyEntity;
+        bool targetInSight;
+        bool targetInEarshot;
+        Vector3 directionToTarget;
         float distanceToPlayer;
-        Vector3 lastKnownPlayerPos;
+        float distanceToTarget;
+        Vector3 lastKnownTargetPos;
         DaggerfallActionDoor actionDoor;
         float distanceToActionDoor;
         bool hasEncounteredPlayer = false;
         bool wouldBeSpawnedInClassic = false;
-        bool detectedPlayer = false;
+        bool detectedTarget = false;
         uint timeOfLastStealthCheck = 0;
         bool blockedByIllusionEffect = false;
         float lastHadLOSTimer = 0f;
 
         float classicUpdateTimer = 0f;
         bool classicUpdate = false;
+        float classicTargetUpdateTimer = 0f;
+        float systemTimerUpdatesDivisor = .0549254f;  // Divisor for updates per second by the system timer at memory location 0x46C.
 
         float classicSpawnDespawnExterior = 4096 * MeshReader.GlobalScale;
         float classicSpawnXZDist = 0f;
@@ -54,30 +60,30 @@ namespace DaggerfallWorkshop.Game
         float classicDespawnXZDist = 0f;
         float classicDespawnYDist = 0f;
 
-        GameObject Player
+        DaggerfallEntityBehaviour Player
         {
-            get { return GameManager.Instance.PlayerObject; }
+            get { return GameManager.Instance.PlayerEntityBehaviour; }
         }
 
-        public bool PlayerInSight
+        public bool TargetInSight
         {
-            get { return playerInSight; }
+            get { return targetInSight; }
         }
 
-        public bool DetectedPlayer
+        public bool DetectedTarget
         {
-            get { return detectedPlayer; }
-            set { detectedPlayer = value; }
+            get { return detectedTarget; }
+            set { detectedTarget = value; }
         }
 
-        public bool PlayerInEarshot
+        public bool TargetInEarshot
         {
-            get { return playerInEarshot; }
+            get { return targetInEarshot; }
         }
 
-        public Vector3 DirectionToPlayer
+        public Vector3 DirectionToTarget
         {
-            get { return directionToPlayer; }
+            get { return directionToTarget; }
         }
 
         public float DistanceToPlayer
@@ -85,10 +91,15 @@ namespace DaggerfallWorkshop.Game
             get { return distanceToPlayer; }
         }
 
-        public Vector3 LastKnownPlayerPos
+        public float DistanceToTarget
         {
-            get { return lastKnownPlayerPos; }
-            set { lastKnownPlayerPos = value; }
+            get { return distanceToTarget; }
+        }
+
+        public Vector3 LastKnownTargetPos
+        {
+            get { return lastKnownTargetPos; }
+            set { lastKnownTargetPos = value; }
         }
 
         public DaggerfallActionDoor LastKnownDoor
@@ -116,7 +127,10 @@ namespace DaggerfallWorkshop.Game
         void Start()
         {
             mobile = GetComponentInChildren<DaggerfallMobileUnit>();
-            lastKnownPlayerPos = ResetPlayerPos;
+            entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
+            enemyEntity = entityBehaviour.Entity as EnemyEntity;
+            motor = GetComponent<EnemyMotor>();
+            lastKnownTargetPos = ResetPlayerPos;
 
             short[] classicSpawnXZDistArray = { 1024, 384, 640, 768, 768, 768, 768 };
             short[] classicSpawnYDistUpperArray = { 128, 128, 128, 384, 768, 128, 256 };
@@ -187,27 +201,76 @@ namespace DaggerfallWorkshop.Game
 
                 if (playerInside)
                 {
-                    if (lowerY == 0 && YDiffToPlayerAbs > upperY)
-                        wouldBeSpawnedInClassic = false;
+                    if (lowerY == 0)
+                    {
+                        if (YDiffToPlayerAbs > upperY)
+                            wouldBeSpawnedInClassic = false;
+                    }
                     else if (YDiffToPlayer < lowerY || YDiffToPlayer > upperY)
                         wouldBeSpawnedInClassic = false;
                 }
             }
 
+            if (classicUpdate)
+            {
+                classicTargetUpdateTimer += Time.deltaTime / systemTimerUpdatesDivisor;
+
+                if (entityBehaviour.Target != null && entityBehaviour.Target.Entity.CurrentHealth <= 0)
+                    entityBehaviour.Target = null;
+
+                // NoTarget mode
+                if ((GameManager.Instance.PlayerEntity.NoTargetMode || !motor.IsHostile) && entityBehaviour.Target == Player)
+                    entityBehaviour.Target = null;
+
+                if ((motor.IsHostile && entityBehaviour.Target == null) || classicTargetUpdateTimer > 10) // Timing is 200 in classic, about 10 seconds.
+                {
+                    classicTargetUpdateTimer = 0f;
+
+                    // Is enemy in area around player?
+                    if (wouldBeSpawnedInClassic)
+                    {
+                        entityBehaviour.Target = GetTarget();
+                    }
+
+                    // Make targeted character also target this character if it doesn't have a target yet.
+                    if (entityBehaviour.Target != null && entityBehaviour.Target.Target == null)
+                    {
+                        entityBehaviour.Target.Target = entityBehaviour;
+                    }
+                }
+            }
+
             if (Player != null)
             {
+                // Get distance to player
                 Vector3 toPlayer = Player.transform.position - transform.position;
-                directionToPlayer = toPlayer.normalized;
                 distanceToPlayer = toPlayer.magnitude;
 
-                playerInSight = CanSeePlayer();
+                Vector3 toTarget = ResetPlayerPos;
+                if (entityBehaviour.Target != null)
+                    toTarget = entityBehaviour.Target.transform.position - transform.position;
+
+                if (toTarget != ResetPlayerPos)
+                {
+                    distanceToTarget = toTarget.magnitude;
+                    directionToTarget = toTarget.normalized;
+                }
+
+                if (entityBehaviour.Target == null)
+                {
+                    targetInSight = false;
+                    detectedTarget = false;
+                    return;
+                }
+
+                targetInSight = CanSeeTarget(entityBehaviour.Target);
 
                 // Classic stealth mechanics would be interfered with by hearing, so only enable
-                // hearing if the enemy has detected the player. If player has been seen we can omit hearing.
-                if (detectedPlayer && !playerInSight)
-                    playerInEarshot = CanHearPlayer();
+                // hearing if the enemy has detected the target. If target is visible we can omit hearing.
+                if (detectedTarget && !targetInSight)
+                    targetInEarshot = CanHearTarget(entityBehaviour.Target);
                 else
-                    playerInEarshot = false;
+                    targetInEarshot = false;
 
                 // Note: In classic an enemy can continue to track the player as long as their
                 // giveUpTimer is > 0. Since the timer is reset to 200 on every detection this
@@ -222,36 +285,34 @@ namespace DaggerfallWorkshop.Game
                         lastHadLOSTimer--;
                 }
 
-                if (!blockedByIllusionEffect && (playerInSight || playerInEarshot))
+                if (!blockedByIllusionEffect && (targetInSight || targetInEarshot))
                 {
-                    detectedPlayer = true;
-                    lastKnownPlayerPos = Player.transform.position;
+                    detectedTarget = true;
+                    lastKnownTargetPos = entityBehaviour.Target.transform.position;
                     lastHadLOSTimer = 200f;
                 }
                 else if (!blockedByIllusionEffect && StealthCheck())
                 {
-                    detectedPlayer = true;
+                    detectedTarget = true;
 
-                    // Only get the player's location from the stealth check if we haven't had
+                    // Only get the target's location from the stealth check if we haven't had
                     // actual LOS for a while. This gives better pursuit behavior since enemies
                     // will go to the last spot they saw the player instead of walking into walls.
                     if (lastHadLOSTimer <= 0)
-                        lastKnownPlayerPos = Player.transform.position;
+                        lastKnownTargetPos = entityBehaviour.Target.transform.position;
                 }
                 else
-                    detectedPlayer = false;
+                    detectedTarget = false;
 
-                if (detectedPlayer && !hasEncounteredPlayer)
+                if (detectedTarget && !hasEncounteredPlayer && entityBehaviour.Target == Player)
                 {
                     hasEncounteredPlayer = true;
 
                     // Check appropriate language skill to see if player can pacify enemy
                     DaggerfallEntityBehaviour entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
-                    EnemyMotor motor = GetComponent<EnemyMotor>();
                     if (entityBehaviour && motor &&
                         (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass))
                     {
-                        EnemyEntity enemyEntity = entityBehaviour.Entity as EnemyEntity;
                         DFCareer.Skills languageSkill = enemyEntity.GetLanguageSkill();
                         if (languageSkill != DFCareer.Skills.None)
                         {
@@ -277,67 +338,77 @@ namespace DaggerfallWorkshop.Game
             if (!wouldBeSpawnedInClassic)
                 return false;
 
-            if (distanceToPlayer > 1024 * MeshReader.GlobalScale)
-                return false;
+            if (distanceToTarget > 1024 * MeshReader.GlobalScale)
+                    return false;
 
             uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
             if (gameMinutes == timeOfLastStealthCheck)
-                return detectedPlayer;
+                return detectedTarget;
 
-            PlayerMotor playerMotor = GameManager.Instance.PlayerMotor;
-            if (playerMotor.IsMovingLessThanHalfSpeed)
+            if (entityBehaviour.Target == Player)
             {
-                if ((gameMinutes & 1) == 1)
-                    return detectedPlayer;
-            }
-            else if (hasEncounteredPlayer)
-                return true;
+                PlayerMotor playerMotor = GameManager.Instance.PlayerMotor;
+                if (playerMotor.IsMovingLessThanHalfSpeed)
+                {
+                    if ((gameMinutes & 1) == 1)
+                        return detectedTarget;
+                }
+                else if (hasEncounteredPlayer)
+                    return true;
 
-            PlayerEntity player = GameManager.Instance.PlayerEntity;
-            if (player.TimeOfLastStealthCheck != gameMinutes)
-            {
-                player.TallySkill(DFCareer.Skills.Stealth, 1);
-                player.TimeOfLastStealthCheck = gameMinutes;
+                PlayerEntity player = GameManager.Instance.PlayerEntity;
+                if (player.TimeOfLastStealthCheck != gameMinutes)
+                {
+                    player.TallySkill(DFCareer.Skills.Stealth, 1);
+                    player.TimeOfLastStealthCheck = gameMinutes;
+                }
             }
+
             timeOfLastStealthCheck = gameMinutes;
 
-            int stealthRoll = 2 * ((int)(distanceToPlayer / MeshReader.GlobalScale) * player.Skills.GetLiveSkillValue(DaggerfallConnect.DFCareer.Skills.Stealth) >> 10);
+            int stealthRoll = 2 * ((int)(distanceToTarget / MeshReader.GlobalScale) * entityBehaviour.Target.Entity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth) >> 10);
 
             return Random.Range(1, 101) > stealthRoll;
         }
 
         public bool BlockedByIllusionEffect()
         {
-            // Note: These effects only block detection for the player.
             // In classic if the target is another AI character true is always returned.
 
             // Some enemy types can see through these effects.
             if (mobile.Summary.Enemy.SeesThroughInvisibility)
                 return false;
 
-            // If not one of the above enemy types, and player has invisibility,
-            // detection is always blocked.
-            PlayerEntity player = GameManager.Instance.PlayerEntity;
-            if (player.IsInvisible)
-                return true;
+            if (entityBehaviour.Target == Player)
+            {
+                // If not one of the above enemy types, and player has invisibility,
+                // detection is always blocked.
+                PlayerEntity player = GameManager.Instance.PlayerEntity;
+                if (player.IsInvisible)
+                    return true;
 
-            // If player doesn't have any illusion effect, detection is not blocked.
-            if (!player.IsBlending && !player.IsAShade)
+                // If player doesn't have any illusion effect, detection is not blocked.
+                if (!player.IsBlending && !player.IsAShade)
+                    return false;
+
+                // Player has either chameleon or shade. Try to see through it.
+                int chance;
+                if (player.IsBlending)
+                    chance = 8;
+                else // is a shade
+                    chance = 4;
+
+                return Random.Range(1, 101) > chance;
+            }
+            else // TODO: Apply these effects for concealed AI characers.
+            {
                 return false;
-
-            // Player has either chameleon or shade. Try to see through it.
-            int chance;
-            if (player.IsBlending)
-                chance = 8;
-            else // is a shade
-                chance = 4;
-
-            return Random.Range(1, 101) > chance;
+            }
         }
 
         public bool TargetIsWithinYawAngle(float targetAngle)
         {
-            Vector3 toTarget = lastKnownPlayerPos - transform.position;
+            Vector3 toTarget = lastKnownTargetPos - transform.position;
             Vector3 directionToLastKnownTarget2D = toTarget.normalized;
             directionToLastKnownTarget2D.y = 0;
 
@@ -355,27 +426,116 @@ namespace DaggerfallWorkshop.Game
 
         #region Private Methods
 
-        private bool CanSeePlayer()
+        DaggerfallEntityBehaviour GetTarget()
+        {
+            DaggerfallEntityBehaviour highestPriorityTarget = null;
+            float highestPriority = -1;
+            bool sawSelectedTarget = false;
+            Vector3 directionToTargetHolder = directionToTarget;
+            float distanceToTargetHolder = distanceToTarget;
+
+            DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
+            for (int i = 0; i < entityBehaviours.Length; i++)
+            {
+                DaggerfallEntityBehaviour targetBehaviour = entityBehaviours[i];
+                EnemyEntity targetEntity = null;
+                if (targetBehaviour != Player)
+                    targetEntity = targetBehaviour.Entity as EnemyEntity;
+
+                // Can't target self
+                if (targetBehaviour == entityBehaviour)
+                    continue;
+
+                // Evaluate potential targets
+                if (targetBehaviour.EntityType == EntityTypes.EnemyMonster || targetBehaviour.EntityType == EntityTypes.EnemyClass
+                    || targetBehaviour.EntityType == EntityTypes.Player)
+                {
+                    Vector3 toTarget = targetBehaviour.transform.position - transform.position;
+                    directionToTarget = toTarget.normalized;
+                    distanceToTarget = toTarget.magnitude;
+
+                    EnemySenses targetSenses = null;
+                    if (targetBehaviour.EntityType == EntityTypes.EnemyMonster || targetBehaviour.EntityType == EntityTypes.EnemyClass)
+                        targetSenses = targetBehaviour.GetComponent<EnemySenses>();
+
+                    bool see = CanSeeTarget(targetBehaviour);
+
+                    if (targetSenses)
+                    {
+                        // Is potential target neither visible nor in area around player? If so, reject as target.
+                        if (!targetSenses.WouldBeSpawnedInClassic && !see)
+                            continue;
+                    }
+
+                    // Can't target ally
+                    if (DaggerfallUnity.Settings.EnemyInfighting)
+                    {
+                        if (targetEntity != null && targetEntity.MobileEnemy.Team == enemyEntity.MobileEnemy.Team)
+                            continue;
+                    }
+                    else // TODO: Support player-summoned allies, even without infighting option
+                    {
+                        if (targetBehaviour != Player)
+                            continue;
+                    }
+
+                    // NoTarget mode
+                    if ((GameManager.Instance.PlayerEntity.NoTargetMode || !motor.IsHostile) && targetBehaviour == Player)
+                        continue;
+
+                    float priority = 0;
+
+                    // Add 5 priority if this potential target isn't already targeting someone
+                    if (targetBehaviour.Target == null)
+                        priority += 5;
+
+                    if (see)
+                        priority += 20;
+
+                    // Add distance priority
+                    float distancePriority = 30 - distanceToTarget;
+                    if (distancePriority < 0)
+                        distancePriority = 0;
+
+                    priority += distancePriority;
+                    if (priority > highestPriority)
+                    {
+                        highestPriority = priority;
+                        highestPriorityTarget = targetBehaviour;
+                        sawSelectedTarget = see;
+                    }
+                }
+            }
+
+            // Restore direction and distance values
+            directionToTarget = directionToTargetHolder;
+            distanceToTarget = distanceToTargetHolder;
+
+            targetInSight = sawSelectedTarget;
+            return highestPriorityTarget;
+        }
+
+
+        private bool CanSeeTarget(DaggerfallEntityBehaviour target)
         {
             bool seen = false;
             actionDoor = null;
 
-            if (distanceToPlayer < SightRadius + mobile.Summary.Enemy.SightModifier)
+            if (distanceToTarget < SightRadius + mobile.Summary.Enemy.SightModifier)
             {
-                // Check if player in field of view
-                float angle = Vector3.Angle(directionToPlayer, transform.forward);
+                // Check if target in field of view
+                float angle = Vector3.Angle(directionToTarget, transform.forward);
                 if (angle < FieldOfView * 0.5f)
                 {
-                    // Check if line of sight to player
+                    // Check if line of sight to target
                     RaycastHit hit;
-                    Ray ray = new Ray(transform.position, directionToPlayer);
+                    Ray ray = new Ray(transform.position, directionToTarget);
                     if (Physics.Raycast(ray, out hit, SightRadius))
                     {
-                        // Check if hit was player
-                        if (hit.transform.gameObject == Player)
-                        {
+                        // Check if hit was target
+                        DaggerfallEntityBehaviour entity = hit.transform.gameObject.GetComponent<DaggerfallEntityBehaviour>();
+                        if (entity == target)
                             seen = true;
-                        }
 
                         // Check if hit was an action door
                         DaggerfallActionDoor door = hit.transform.gameObject.GetComponent<DaggerfallActionDoor>();
@@ -394,24 +554,25 @@ namespace DaggerfallWorkshop.Game
             return seen;
         }
 
-        private bool CanHearPlayer()
+        private bool CanHearTarget(DaggerfallEntityBehaviour target)
         {
             bool heard = false;
             float hearingScale = 1f;
 
-            // If something is between enemy and player then return false (was reduce hearingScale by half), to minimize
+            // If something is between enemy and target then return false (was reduce hearingScale by half), to minimize
             // enemies walking against walls.
             // Hearing is not impeded by doors or other non-static objects
             RaycastHit hit;
-            Ray ray = new Ray(transform.position, directionToPlayer);
+            Ray ray = new Ray(transform.position, directionToTarget);
             if (Physics.Raycast(ray, out hit))
             {
-                if (hit.transform.gameObject != Player && hit.transform.gameObject.isStatic)
+                DaggerfallEntityBehaviour entity = hit.transform.gameObject.GetComponent<DaggerfallEntityBehaviour>();
+                if (entity != target && hit.transform.gameObject.isStatic)
                     return false;
             }
 
-            // TODO: Modify this by how much noise the player is making
-            if (distanceToPlayer < (HearingRadius * hearingScale) + mobile.Summary.Enemy.HearingModifier)
+            // TODO: Modify this by how much noise the target is making
+            if (distanceToTarget < (HearingRadius * hearingScale) + mobile.Summary.Enemy.HearingModifier)
             {
                 heard = true;
             }

--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -22,10 +22,10 @@ namespace DaggerfallWorkshop.Game.Entity
         #region Fields
 
         public EntityTypes EntityType = EntityTypes.None;
-
         EntityTypes lastEntityType = EntityTypes.None;
         DaggerfallEntity entity = null;
         DaggerfallLoot corpseLootContainer = null;
+        DaggerfallEntityBehaviour target = null;
 
         #endregion
 
@@ -38,6 +38,12 @@ namespace DaggerfallWorkshop.Game.Entity
         {
             get { return entity; }
             set { SetEntityValue(value); }
+        }
+
+        public DaggerfallEntityBehaviour Target
+        {
+            get { return target; }
+            set { target = value; }
         }
 
         /// <summary>
@@ -214,7 +220,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         {
                             GameManager.Instance.MakeEnemiesHostile();
                         }
-                        enemyMotor.MakeEnemyHostileToPlayer(GameManager.Instance.PlayerObject);
+                        enemyMotor.MakeEnemyHostileToAttacker(GameManager.Instance.PlayerEntityBehaviour);
                     }
                 }
             }
@@ -236,7 +242,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     break;
                 case EntityTypes.CivilianNPC:
                     Entity = new CivilianEntity(this);
-                    break; 
+                    break;
             }
 
             lastEntityType = type;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -35,6 +35,7 @@ namespace DaggerfallWorkshop.Game.Entity
         #region Fields
 
         bool godMode = false;
+        bool noTargetMode = false;
         bool preventEnemySpawns = false;
         bool preventNormalizingReputations = false;
         bool isResting = false;
@@ -113,6 +114,7 @@ namespace DaggerfallWorkshop.Game.Entity
         #region Properties
 
         public bool GodMode { get { return godMode; } set { godMode = value; } }
+        public bool NoTargetMode { get { return noTargetMode; } set { noTargetMode = value; } }
         public bool PreventEnemySpawns { get { return preventEnemySpawns; } set { preventEnemySpawns = value; } }
         public bool PreventNormalizingReputations { get { return preventNormalizingReputations; } set { preventNormalizingReputations = value; } }
         public bool IsResting { get { return isResting; } set { isResting = value; } }

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -554,8 +554,8 @@ namespace DaggerfallWorkshop.Game
                     EnemySenses enemySenses = entityBehaviour.GetComponent<EnemySenses>();
                     if (enemySenses)
                     {
-                        // Is enemy already aware of player or close enough they would be spawned in classic?
-                        if (enemySenses.PlayerInSight || enemySenses.PlayerInEarshot || enemySenses.WouldBeSpawnedInClassic)
+                        // Can enemy see player or is close enough they would be spawned in classic?
+                        if ((entityBehaviour.Target == Instance.PlayerEntityBehaviour && enemySenses.TargetInSight) || enemySenses.WouldBeSpawnedInClassic)
                         {
                             areEnemiesNearby = true;
                             break;

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -150,7 +150,7 @@ namespace DaggerfallWorkshop.Game
             else // schedule climbing events
             {
                 // schedule climbing start
-                if (climbingStartTimer <= (playerMotor.systemTimerUpdatesPerSecond * startClimbSkillCheckFrequency))
+                if (climbingStartTimer <= (playerMotor.systemTimerUpdatesDivisor * startClimbSkillCheckFrequency))
                     climbingStartTimer += Time.deltaTime;
                 else
                 {
@@ -165,7 +165,7 @@ namespace DaggerfallWorkshop.Game
                 }
 
                 // schedule climbing continues, Faster updates if slipping
-                if (climbingContinueTimer <= (playerMotor.systemTimerUpdatesPerSecond * (isSlipping ? regainHoldSkillCheckFrequency : continueClimbingSkillCheckFrequency)))
+                if (climbingContinueTimer <= (playerMotor.systemTimerUpdatesDivisor * (isSlipping ? regainHoldSkillCheckFrequency : continueClimbingSkillCheckFrequency)))
                     climbingContinueTimer += Time.deltaTime;
                 else
                 {

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -1131,7 +1131,7 @@ namespace DaggerfallWorkshop.Game
                     {
                         GameManager.Instance.MakeEnemiesHostile();
                     }
-                    enemyMotor.MakeEnemyHostileToPlayer(gameObject);
+                    enemyMotor.MakeEnemyHostileToAttacker(GameManager.Instance.PlayerEntityBehaviour);
                 }
             }
         }       

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -29,8 +29,8 @@ namespace DaggerfallWorkshop.Game
         // If true, diagonal speed (when strafing + moving forward or back) can't exceed normal move speed; otherwise it's about 1.4 times faster
         public bool limitDiagonalSpeed = true;
 
-        public float systemTimerUpdatesPerSecond = .055f; // Number of updates per second by the system timer at memory location 0x46C.
-                                                          // Used for timing various things in classic.
+        public float systemTimerUpdatesDivisor = .0549254f; // Divisor for updates by the system timer at memory location 0x46C.
+                                                            // Used for timing various things in classic.
 
         // FixedUpdate is too choppy to give smooth camera movement. This handles a smooth following child transform.
         public Transform smoothFollower;                // The Transform that follows; will lerp to this Transform's position.

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -118,6 +118,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox alternateRandomEnemySelection;
         Checkbox advancedClimbing;
         Checkbox combatVoices;
+        Checkbox enemyInfighting;
         HorizontalSlider dungeonAmbientLightScale;
         HorizontalSlider nightAmbientLightScale;
         HorizontalSlider playerTorchLightScale;
@@ -268,6 +269,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             alternateRandomEnemySelection = AddCheckbox(leftPanel, "alternateRandomEnemySelection", DaggerfallUnity.Settings.AlternateRandomEnemySelection);
             advancedClimbing = AddCheckbox(leftPanel, "advancedClimbing", DaggerfallUnity.Settings.AdvancedClimbing);
             combatVoices = AddCheckbox(leftPanel, "combatVoices", DaggerfallUnity.Settings.CombatVoices);
+            enemyInfighting = AddCheckbox(leftPanel, "enemyInfighting", DaggerfallUnity.Settings.EnemyInfighting);
 
             y = 0;
 
@@ -363,6 +365,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.CameraRecoilStrength = cameraRecoilStrength.ScrollIndex;
             DaggerfallUnity.Settings.AdvancedClimbing = advancedClimbing.IsChecked;
             DaggerfallUnity.Settings.CombatVoices = combatVoices.IsChecked;
+            DaggerfallUnity.Settings.EnemyInfighting = enemyInfighting.IsChecked;
 
             DaggerfallUnity.Settings.DungeonAmbientLightScale = dungeonAmbientLightScale.GetValue();
             DaggerfallUnity.Settings.NightAmbientLightScale = nightAmbientLightScale.GetValue();

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -630,13 +630,13 @@ namespace DaggerfallWorkshop.Game
                         int damage;
                         if (usingRightHand)
                         {
-                            damage = FormulaHelper.CalculateAttackDamage(playerEntity, enemyEntity, (int)(EquipSlots.RightHand), entityMobileUnit.Summary.AnimStateRecord);
                             strikingWeapon = currentRightHandWeapon;
+                            damage = FormulaHelper.CalculateAttackDamage(playerEntity, enemyEntity, strikingWeapon, entityMobileUnit.Summary.AnimStateRecord);
                         }
                         else
                         {
-                            damage = FormulaHelper.CalculateAttackDamage(playerEntity, enemyEntity, (int)(EquipSlots.LeftHand), entityMobileUnit.Summary.AnimStateRecord);
                             strikingWeapon = currentLeftHandWeapon;
+                            damage = FormulaHelper.CalculateAttackDamage(playerEntity, enemyEntity, strikingWeapon, entityMobileUnit.Summary.AnimStateRecord);
                         }
 
                         // Break any "normal power" concealment effects on player
@@ -732,7 +732,7 @@ namespace DaggerfallWorkshop.Game
                             {
                                 GameManager.Instance.MakeEnemiesHostile();
                             }
-                            enemyMotor.MakeEnemyHostileToPlayer(gameObject);
+                            enemyMotor.MakeEnemyHostileToAttacker(GameManager.Instance.PlayerEntityBehaviour);
                         }
                     }
                 }

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -147,6 +147,7 @@ namespace DaggerfallWorkshop
         public float NightAmbientLightScale { get; set; }
         public float PlayerTorchLightScale { get; set; }
         public bool CombatVoices { get; set; }
+        public bool EnemyInfighting { get; set; }
 
         #endregion
 
@@ -239,6 +240,7 @@ namespace DaggerfallWorkshop
             NightAmbientLightScale = GetFloat(sectionEnhancements, "NightAmbientLightScale", 0.0f, 1.0f);
             PlayerTorchLightScale = GetFloat(sectionEnhancements, "PlayerTorchLightScale", 0.0f, 1.0f);
             CombatVoices = GetBool(sectionEnhancements, "CombatVoices");
+            EnemyInfighting = GetBool(sectionEnhancements, "EnemyInfighting");
         }
 
         /// <summary>
@@ -324,6 +326,7 @@ namespace DaggerfallWorkshop
             SetFloat(sectionEnhancements, "NightAmbientLightScale", NightAmbientLightScale);
             SetFloat(sectionEnhancements, "PlayerTorchLightScale", PlayerTorchLightScale);
             SetBool(sectionEnhancements, "CombatVoices", CombatVoices);
+            SetBool(sectionEnhancements, "EnemyInfighting", EnemyInfighting);
 
             // Write settings to persistent file
             WriteSettingsFile();

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -200,6 +200,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 Weight = 2,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 4, 5 },
+                Team = MobileTeams.Vermin,
             },
 
             // Imp
@@ -233,6 +234,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "D",
                 SoulPts = 1000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 1 },
+                Team = MobileTeams.Magic,
             },
 
             // Spriggan
@@ -269,6 +271,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "B",
                 SoulPts = 1000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3, 3, 3 },
+                Team = MobileTeams.Spriggans,
             },
 
             // Giant Bat
@@ -298,6 +301,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 Weight = 80,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3 },
+                Team = MobileTeams.Vermin,
             },
 
             // Grizzly Bear
@@ -331,6 +335,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 Weight = 1000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 0 },
+                Team = MobileTeams.Bears,
             },
 
             // Sabertooth Tiger
@@ -364,6 +369,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 Weight = 1000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 4, 5 },
+                Team = MobileTeams.Tigers,
             },
 
             // Spider
@@ -393,6 +399,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 Weight = 400,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3, 4, 5 },
+                Team = MobileTeams.Spiders,
             },
 
             // Orc
@@ -427,6 +434,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 4, -1, 5, 0 },
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 4, -1, 5, 0 },
+                Team = MobileTeams.Orcs,
             },
 
             // Centaur
@@ -461,6 +469,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 1, 1, 2, -1, 3, 3, 4 },
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 0, 1, 1, 1, 2, -1, 3, 3, 2, 1, 1, -1, 2, 3, 3, 4 },
+                Team = MobileTeams.Centaurs,
             },
 
             // Werewolf
@@ -496,6 +505,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 480,
                 SoulPts = 1000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, -1, 2 },
+                Team = MobileTeams.Werecreatures,
             },
 
             // Nymph
@@ -528,6 +538,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "C",
                 SoulPts = 10000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, 3, 4, -1, 5 },
+                Team = MobileTeams.Nymphs,
             },
 
             // Slaughterfish
@@ -561,6 +572,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 0, 3, -1, 5, 4, 3, 3, -1, 5, 4, 3, -1, 5, 0 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 3, -1, 5, 0 },
+                Team = MobileTeams.Aquatic,
             },
 
             // Orc Sergeant
@@ -595,6 +607,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames = new int[] { 0, -1, 1, 2, 3, 4, -1, 5, 0 },
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 5, 4, 3, -1, 2, 1, 0 },
+                Team = MobileTeams.Orcs,
             },
 
             // Harpy
@@ -627,6 +640,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "D",
                 SoulPts = 3000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3 },
+                Team = MobileTeams.Harpies,
             },
 
             // Wereboar
@@ -662,6 +676,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 560,
                 SoulPts = 1000,
                 PrimaryAttackAnimFrames = new int[] { 0, -1, 1, 2, 2 },
+                Team = MobileTeams.Werecreatures,
             },
 
             // Skeletal Warrior
@@ -695,6 +710,7 @@ namespace DaggerfallWorkshop.Utility
                 SeesThroughInvisibility = true,
                 LootTableKey = "H",
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, 3, -1, 4, 5 },
+                Team = MobileTeams.Undead,
             },
 
             // Giant
@@ -727,6 +743,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 3000,
                 SoulPts = 3000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3, 4, -1, 5 },
+                Team = MobileTeams.Giants,
             },
 
             // Zombie
@@ -760,6 +777,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 4 },
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 0, 2, -1, 3, 4 },
+                Team = MobileTeams.Undead,
             },
 
             // Ghost
@@ -794,6 +812,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "I",
                 SoulPts = 30000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3 },
+                Team = MobileTeams.Undead,
             },
 
             // Mummy
@@ -828,6 +847,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "E",
                 SoulPts = 10000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 4 },
+                Team = MobileTeams.Undead,
             },
 
             // Giant Scorpion
@@ -857,6 +877,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 Weight = 600,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 3, 2, 1, 0 },
+                Team = MobileTeams.Scorpions,
             },
 
             // Orc Shaman
@@ -897,6 +918,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames4 = new int[] { 0, 1, -1, 3, 2, -1, 3, 2, 1, 0 }, // Not used in classic. Fight stance used instead.
                 ChanceForAttack5 = 20,
                 PrimaryAttackAnimFrames5 = new int[] { 0, -1, 4, 5, -1, 4, 5, 0 }, // Not used in classic. Spell animation played instead.
+                Team = MobileTeams.Orcs,
             },
 
             // Gargoyle
@@ -916,7 +938,7 @@ namespace DaggerfallWorkshop.Utility
                 MoveSound = (int)SoundClips.EnemyGargoyleMove,
                 BarkSound = (int)SoundClips.EnemyGargoyleBark,
                 AttackSound = (int)SoundClips.EnemyGargoyleAttack,
-                MinMetalToHit = Game.Items.WeaponMaterialTypes.Mithril,
+                MinMetalToHit = WeaponMaterialTypes.Mithril,
                 MinDamage = 10,
                 MaxDamage = 15,
                 MinHealth = 19,
@@ -928,6 +950,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 300,
                 SoulPts = 3000,
                 PrimaryAttackAnimFrames = new int[] { 0, 2, 1, 2, 3, -1, 4, 0 },
+                Team = MobileTeams.Magic,
             },
 
             // Wraith
@@ -962,6 +985,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "I",
                 SoulPts = 30000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3 },
+                Team = MobileTeams.Undead,
             },
 
             // Orc Warlord
@@ -998,6 +1022,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 4, -1, 5, 0 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 1, -1, 2, 3, 4 -1, 5, 0, 4, -1, 5, 0 },
+                Team = MobileTeams.Orcs,
             },
 
             // Frost Daedra
@@ -1033,6 +1058,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3, -1, 4, 5, 0 },
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { -1, 4, 5, 0 },
+                Team = MobileTeams.Daedra,
             },
 
             // Fire Daedra
@@ -1068,6 +1094,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3, -1, 4 },
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 3, -1, 4 },
+                Team = MobileTeams.Daedra,
             },
 
             // Daedroth
@@ -1105,6 +1132,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 4, -1, 5, 0 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 1, -1, 2, 3, 4, -1, 5, 0, 4, -1, 5, 0 },
+                Team = MobileTeams.Daedra,
             },
 
             // Vampire
@@ -1138,6 +1166,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "Q",
                 SoulPts = 70000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, 3, -1, 4, 5 },
+                Team = MobileTeams.Undead,
             },
 
             // Daedra Seducer
@@ -1171,6 +1200,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "Q",
                 SoulPts = 150000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2 },
+                Team = MobileTeams.Daedra,
             },
 
             // Vampire Ancient
@@ -1204,6 +1234,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "Q",
                 SoulPts = 100000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, 3, -1, 4, 5 },
+                Team = MobileTeams.Undead,
             },
 
             // Daedra Lord
@@ -1241,6 +1272,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 3, -1, 4, 0, -1, 4, 3, -1, 4, 0, -1, 4, 3 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 1, -1, 2, 1, 0, 1, -1, 2, 1, 0 },
+                Team = MobileTeams.Daedra,
             },
 
             // Lich
@@ -1275,6 +1307,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "S",
                 SoulPts = 100000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 1, 2, -1, 3, 4, 4 },
+                Team = MobileTeams.Undead,
             },
 
             // Ancient Lich
@@ -1308,6 +1341,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "S",
                 SoulPts = 250000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 1, 2, -1, 3, 4, 4 },
+                Team = MobileTeams.Undead,
             },
 
             // Dragonling
@@ -1337,6 +1371,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 Weight = 10000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3 },
+                Team = MobileTeams.Dragonlings,
             },
 
             // Fire Atronach
@@ -1368,6 +1403,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 1000,
                 SoulPts = 30000,
                 PrimaryAttackAnimFrames = new int[] { 0, -1, 1, 2, 3, 4 },
+                Team = MobileTeams.Magic,
             },
 
             // Iron Atronach
@@ -1399,6 +1435,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 1000,
                 SoulPts = 30000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 4 },
+                Team = MobileTeams.Magic,
             },
 
             // Flesh Atronach
@@ -1430,6 +1467,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 1000,
                 SoulPts = 30000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 4 },
+                Team = MobileTeams.Magic,
             },
 
             // Ice Atronach
@@ -1463,6 +1501,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 4 },
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 0, -1, 3, 4 },
+                Team = MobileTeams.Magic,
             },
 
             // Weights in classic (From offset 0x1BD8D9 in FALL.EXE) only have entries
@@ -1505,6 +1544,7 @@ namespace DaggerfallWorkshop.Utility
                 Weight = 10000, // Using same value as other dragonling
                 SoulPts = 500000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3 },
+                Team = MobileTeams.Dragonlings,
             },
 
             // Dreugh
@@ -1541,6 +1581,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 0, 1, 2, 3, -1, 4 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 5, -1, 6, 7 },
+                Team = MobileTeams.Aquatic,
             },
 
             // Lamia
@@ -1577,6 +1618,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 0, 3, -1, 5, 4, 3, 3, -1, 5, 4, 3, -1, 5, 0 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 3, -1, 5, 0 },
+                Team = MobileTeams.Aquatic,
             },
 
             // Mage
@@ -1605,6 +1647,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 0, 1, -1, 3, 2, 1, 0 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, -1, 5, 4, 0 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Spellsword
@@ -1634,6 +1677,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 1, -1, 2, 2, 1, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Battlemage
@@ -1663,6 +1707,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Sorcerer
@@ -1690,6 +1735,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 4, 5, -1, 3, 2, 1, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Healer
@@ -1718,6 +1764,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 0, 1, -1, 3, 2, 1, 0 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, -1, 5, 4, 0 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Nightblade
@@ -1747,6 +1794,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.Criminals,
             },
 
             // Bard
@@ -1776,6 +1824,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Burglar
@@ -1805,6 +1854,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.Criminals,
             },
 
             // Rogue
@@ -1834,6 +1884,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.Criminals,
             },
 
             // Acrobat
@@ -1863,6 +1914,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Thief
@@ -1892,6 +1944,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.Criminals,
             },
 
             // Assassin
@@ -1921,6 +1974,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.Criminals,
             },
 
             // Monk
@@ -1950,6 +2004,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 5, 5, 3, -1, 2, 1, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Archer
@@ -1978,6 +2033,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Ranger
@@ -2005,6 +2061,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Barbarian
@@ -2034,6 +2091,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 5, 5, 3, -1, 2, 1, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.Criminals,
             },
 
             // Warrior
@@ -2063,6 +2121,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 5, 5, 3, -1, 2, 1, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // Knight
@@ -2092,6 +2151,7 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 5, 5, 3, -1, 2, 1, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                Team = MobileTeams.KnightsAndMages,
             },
 
             // City Watch - The Haltmeister
@@ -2115,6 +2175,7 @@ namespace DaggerfallWorkshop.Utility
                 MapChance = 0,
                 CastsMagic = false,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3, 4 },
+                Team = MobileTeams.CityWatch,
             },
         };
 

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -96,6 +96,8 @@ playerTorchLightScale,								Player torch light
 playerTorchLightScaleInfo,							Scale of player personal light
 combatVoices,										Combat vocalizations
 combatVoicesInfo,									Player and NPCs will vocalize when attacking or being hit
+enemyInfighting,									Enemy infighting
+enemyInfightingInfo,								AI characters will fight others that they aren't allied with
 
 resolution,                                         Resolution
 resolutionInfo,                                     Screen resolution


### PR DESCRIPTION
This is one I was looking forward to doing, and although it could still do with improvement, mainly in enemy pathfinding, it works pretty well. Please give it some testing, though, as it touches a lot of things and could break something. I think I've fixed all the problems I encountered. There's a lot of raycasting going on but I've tried to avoid too much FPS drop.

I worked on this to prepare for the Sanguine Rose artifact, which allows the player to summon a Daedroth, but I ended up implementing an "enemy infighting" mode that I think is fun to play with.

What's in the PR:
1) Enemies now evaluate targets and choose one, instead of always targeting the player. (Unless "enemy infighting" is turned on, they reject all targets but the player. Later I intend to figure player allies into this, to allow the Sanguine Rose to work). Target selection is based on classic, then tweaked to get better results.
2) Optional "enemy infighting" mode (default on), where enemies of differing "teams" (don't really like that name, would like to call them "factions" but that has already has a different meaning) will attack each other if they see each other. They are grouped so similar enemies (if there are any) are on the same team.
3) Enemies can hit each other now, not just the player.
4) Pacified/guard types will ignore the player but, if "enemy infighting" is on, still fight any enemy teams.
5) Weapon-wielding AI will use hand-to-hand if enemy is immune to their weapon.
6) New console command "nt" activates "NoTarget" mode, where enemies will ignore player.
7) Fixed a mistake in the "wouldBeSpawnedInClassic" code that sometimes caused enemies to wrongly get a "false".