### PR TITLE
Fix all enemy classes using female texture 483

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -661,7 +661,7 @@ namespace DaggerfallWorkshop
                     if ((MobileTypes)summary.Enemy.ID == MobileTypes.Ghost ||
                         (MobileTypes)summary.Enemy.ID == MobileTypes.Wraith)
                         anims = (MobileAnimation[])EnemyBasics.GhostWraithMoveAnims.Clone();
-                    else if ((MobileTypes)summary.Enemy.ID == MobileTypes.Thief &&
+                    else if (summary.Enemy.FemaleTexture == 483 &&
                         summary.Enemy.Gender == MobileGender.Female)
                         anims = (MobileAnimation[])EnemyBasics.FemaleThiefIdleAnims.Clone();
                     else if ((MobileTypes)summary.Enemy.ID == MobileTypes.Rat)


### PR DESCRIPTION
Previous fix for the small diagonal sprite was only fixing for the female thief. Other classes use the same textures and needed to be fixed as well. The check is now for the texture used and covers all the cases.