### PR TITLE
Misc. fixes

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -114,7 +114,9 @@ namespace DaggerfallWorkshop.Game
         {
             if (attacker && senses)
             {
-                entityBehaviour.Target = attacker;
+                // Only assign target if don't already have target
+                if (entityBehaviour.Target == null)
+                    entityBehaviour.Target = attacker;
                 senses.LastKnownTargetPos = attacker.transform.position;
                 giveUpTimer = 200;
             }

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -252,13 +252,6 @@ namespace DaggerfallWorkshop.Game
             if (senses.DetectedTarget)
                 giveUpTimer = 200;
 
-            // Remain idle if no target or after giving up finding the target
-            if (giveUpTimer == 0)
-            {
-                mobile.ChangeEnemyState(MobileStates.Idle);
-                return;
-            }
-
             // GiveUpTimer value is from classic, so decrease at the speed of classic's update loop
             if (!senses.DetectedTarget
                 && giveUpTimer > 0 && classicUpdate)
@@ -266,6 +259,15 @@ namespace DaggerfallWorkshop.Game
 
             // Enemy will keep moving towards last known target position
             targetPos = senses.LastKnownTargetPos;
+
+            // Remain idle after finishing any attacks if no target or after giving up finding the target
+            if (entityBehaviour.Target == null || giveUpTimer == 0 || targetPos == EnemySenses.ResetPlayerPos)
+            {
+                if (!mobile.IsPlayingOneShot())
+                    mobile.ChangeEnemyState(MobileStates.Idle);
+
+                return;
+            }
 
             // Flying enemies and slaughterfish aim for target face
             if (flies || isLevitating || (swims && mobile.Summary.Enemy.ID == (int)MonsterCareers.Slaughterfish))

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -693,7 +693,7 @@ namespace DaggerfallWorkshop.Game
                             if (DaggerfallUnity.Settings.CombatVoices && entityBehaviour.EntityType == EntityTypes.EnemyClass && UnityEngine.Random.Range(1, 101) <= 40)
                             {
                                 Genders gender;
-                                if (enemyEntity.MobileEnemy.Gender == MobileGender.Male || enemyEntity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
+                                if (entityMobileUnit.Summary.Enemy.Gender == MobileGender.Male || enemyEntity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
                                     gender = Genders.Male;
                                 else
                                     gender = Genders.Female;

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1351,7 +1351,7 @@ namespace DaggerfallWorkshop.Utility
                 byte classicSpawnDistanceType = obj.Resources.FlatResource.SoundIndex;
 
                 // Add enemy
-                AddEnemy(obj, type, parent, loadID, classicSpawnDistanceType);
+                AddEnemy(obj, type, parent, loadID, classicSpawnDistanceType, false);
             }
             else
             {
@@ -1411,7 +1411,7 @@ namespace DaggerfallWorkshop.Utility
                 byte classicSpawnDistanceType = obj.Resources.FlatResource.SoundIndex;
 
                 // Add enemy
-                AddEnemy(obj, type, parent, loadID, classicSpawnDistanceType);
+                AddEnemy(obj, type, parent, loadID, classicSpawnDistanceType, false);
             }
             else
             {
@@ -1479,20 +1479,22 @@ namespace DaggerfallWorkshop.Utility
             MobileTypes type,
             Transform parent = null,
             ulong loadID = 0,
-            byte classicSpawnDistanceType = 0)
+            byte classicSpawnDistanceType = 0,
+            bool useGenderFlag = true)
         {
             // Get default reaction
             MobileReactions reaction = MobileReactions.Hostile;
             if (obj.Resources.FlatResource.Action == (int)DFBlock.EnemyReactionTypes.Passive)
                 reaction = MobileReactions.Passive;
 
-            // TODO: Review gender assignment from this flag data is always consistent
-            // Check against other usage of this flag byte for NPCs in interiors
             MobileGender gender = MobileGender.Unspecified;
-            if (obj.Resources.FlatResource.Flags == (int)DFBlock.EnemyGenders.Female)
-                gender = MobileGender.Female;
-            if (obj.Resources.FlatResource.Flags == (int)DFBlock.EnemyGenders.Male)
-                gender = MobileGender.Male;
+            if ((int)type > 43 && useGenderFlag)
+            {
+                if (obj.Resources.FlatResource.Flags == (int)DFBlock.EnemyGenders.Female)
+                    gender = MobileGender.Female;
+                if (obj.Resources.FlatResource.Flags == (int)DFBlock.EnemyGenders.Male)
+                    gender = MobileGender.Male;
+            }
 
             // Just setup demo enemies at this time
             string name = string.Format("DaggerfallEnemy [{0}]", type.ToString());


### PR DESCRIPTION
1) Quest AI will no longer target or be targeted by other AI. This solves the issue for now but I think we should ideally allow for spawning quest AI that can also fight each other.
2) Expanded AI to target if it can see player, as it could before, instead of limiting it to the classic spawn range. This is because the spawn is pretty small vertically, and sometimes there could be enemies in plain view that wouldn't react. I don't really like tying the AI "activating" it's target-seeking according to having the player in sight, but it works well enough. I also tried just using a wider radius around the player but then enemies were fighting a little too much and killing each other out of view of the player so I settled on player LOS for now, which is what the old behavior before the "infighting" PR was anyway.
3) Fixed issue with AI playing combat sounds, miss sounds at wrong timing.
4) Fixed referring to wrong gender value for doing AI voices, which caused mismatches between appearance and voice.
5) Fixed not playing AI hurt sounds when AI hit each other.
6) Classic only uses gender flag for fixed spawns. Doing same now for DF Unity.