### PR TITLE
Climb down from top2

### DIFF
--- a/Assets/Scripts/Game/LevitateMotor.cs
+++ b/Assets/Scripts/Game/LevitateMotor.cs
@@ -87,15 +87,15 @@ namespace DaggerfallWorkshop.Game
             {  
                 // Hack to make sure that the player can get pushed by moving objects if he's not moving
                 const float pos = 0.0001f;
-                groundMotor.MoveOnGround(Vector3.up * pos);
-                groundMotor.MoveOnGround(Vector3.down * pos);
-                groundMotor.MoveOnGround(Vector3.left * pos);
-                groundMotor.MoveOnGround(Vector3.right * pos);
-                groundMotor.MoveOnGround(Vector3.forward * pos);
-                groundMotor.MoveOnGround(Vector3.back * pos);
+                groundMotor.MoveWithMovingPlatform(Vector3.up * pos);
+                groundMotor.MoveWithMovingPlatform(Vector3.down * pos);
+                groundMotor.MoveWithMovingPlatform(Vector3.left * pos);
+                groundMotor.MoveWithMovingPlatform(Vector3.right * pos);
+                groundMotor.MoveWithMovingPlatform(Vector3.forward * pos);
+                groundMotor.MoveWithMovingPlatform(Vector3.back * pos);
             }
 
-            groundMotor.MoveOnGround(moveDirection);
+            groundMotor.MoveWithMovingPlatform(moveDirection);
             moveDirection = Vector3.zero;
         }
 

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -170,7 +170,7 @@ namespace DaggerfallWorkshop.Game
             if (DaggerfallUnity.Settings.AdvancedClimbing && airborneGraspWall)
             {
                 if (IsRappelling)
-                {   // very lenient because we're trying to attach
+                {   // very lenient because we're trying to attach to wall with guarunteed success
                     startClimbHorizontalTolerance = 2f;
                     startClimbSkillCheckFrequency = 0.0f;
                 }
@@ -348,18 +348,22 @@ namespace DaggerfallWorkshop.Game
 
                 Debug.DrawRay(adjacentWallRay.origin, adjacentWallRay.direction, Color.cyan);
 
-                if (FindWallLoopCount == 0)
-                {
+                // Commented out for now because it doesn't seem neccessary to do recursion to find the adjacent wall
+                //if (FindWallLoopCount == 0)
+                //{
                     // The adjacent wall is an inside corner
                     atInsideCorner = isAtInsideCorner(hit);
-                }
+                //}
 
                 FindWallLoopCount = 0;
                 return true;
             }
             else
             {
-                FindWallLoopCount++;
+                /* Commented out for now because apparently it's not neccessary to perform 
+                 * recursive checks for the adjacent wall.  
+                 * 
+                 * FindWallLoopCount++;
                 if (FindWallLoopCount < 3)
                 {
                     // find next vector info now
@@ -374,7 +378,7 @@ namespace DaggerfallWorkshop.Game
 
                     return GetAdjacentWallInfo(origin, nextDirection, searchClockwise);
                 }
-                FindWallLoopCount = 0;
+                FindWallLoopCount = 0;*/
                 return false;
             }
         }
@@ -408,7 +412,7 @@ namespace DaggerfallWorkshop.Game
 
             // if strafing to either side, this will be set so we can check for wrap-around corners.
             Vector3 checkDirection = Vector3.zero;
-            //bool adjacentWallFound = false;
+            bool adjacentWallFound = false;
 
             if (!isSlipping)
             {
@@ -435,7 +439,7 @@ namespace DaggerfallWorkshop.Game
                     #region Horizontal Climbing
                     if (movedRight || movedLeft)
                     {
-                        //float checkScalar = controller.radius + 0.5f;
+                        float checkScalar = controller.radius + 0.5f;
                         if (movedRight)
                             checkDirection = Vector3.Cross(Vector3.up, myLedgeDirection).normalized;
                         else if (movedLeft)
@@ -446,7 +450,7 @@ namespace DaggerfallWorkshop.Game
                         Debug.DrawRay(myStrafeRay.origin, myStrafeRay.direction, Color.red);
 
                         // perform check for adjacent wall
-                        //adjacentWallFound = GetAdjacentWallInfo(controller.transform.position, checkDirection * checkScalar, movedLeft);
+                        adjacentWallFound = GetAdjacentWallInfo(controller.transform.position, checkDirection * checkScalar, movedLeft);
 
                         Vector3 intersection;
                         Vector3 intersectionOrthogonal;

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -158,10 +158,11 @@ namespace DaggerfallWorkshop.Game
             float startClimbHorizontalTolerance;
             float startClimbSkillCheckFrequency;
             bool airborneGraspWall = (!isClimbing && !isSlipping && acrobatMotor.Falling);
+            bool movingBack = InputManager.Instance.HasAction(InputManager.Actions.MoveBackwards);
 
-            // short circuit evaluate the raycast if not needed. also, prevents some bugs
-            bool groundCancelsClimbOrRappel = ((isClimbing || airborneGraspWall) && InputManager.Instance.HasAction(InputManager.Actions.MoveBackwards)   
-                && Physics.Raycast(controller.transform.position, Vector3.down, controller.height / 2 + 0.10f));
+            // short circuit evaluate the raycast in case not needed. also, prevents some bugs
+            bool groundCancelsClimbOrRappel = (((isClimbing && (movingBack || isSlipping)) || airborneGraspWall)  
+                && Physics.Raycast(controller.transform.position, Vector3.down, controller.height / 2 + 0.12f));
 
             if (DaggerfallUnity.Settings.AdvancedClimbing && !groundCancelsClimbOrRappel)
                 RappelChecks(airborneGraspWall);

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -144,7 +144,7 @@ namespace DaggerfallWorkshop.Game
                         else
                             rappelDirection = controller.transform.forward;
                         rappelDirection *= speed * 1.25f;
-                        groundMotor.MoveOnGround(rappelDirection);
+                        groundMotor.MoveWithMovingPlatform(rappelDirection);
                     }
                 }
             }

--- a/Assets/Scripts/Game/Player/FrictionMotor.cs
+++ b/Assets/Scripts/Game/Player/FrictionMotor.cs
@@ -51,38 +51,10 @@ namespace DaggerfallWorkshop.Game
             rayDistance = controller.height * .5f + controller.radius;
         }
 
-        private void Update()
+        public void GroundedMovement(ref Vector3 moveDirection)
         {
+            SetSliding();
 
-        }
-
-        public void MoveIfSliding(ref Vector3 moveDirection)
-        {
-            CheckFooting();
-            SlideMovement(ref moveDirection);
-        }
-
-        private void CheckFooting()
-        {
-            sliding = false;
-            // See if surface immediately below should be slid down. We use this normally rather than a ControllerColliderHit point,
-            // because that interferes with step climbing amongst other annoyances
-            if (Physics.Raycast(myTransform.position, -Vector3.up, out hit, rayDistance))
-            {
-                if (Vector3.Angle(hit.normal, Vector3.up) > slideLimit)
-                    sliding = true;
-            }
-            // However, just raycasting straight down from the center can fail when on steep slopes
-            // So if the above raycast didn't catch anything, raycast down from the stored ControllerColliderHit point instead
-            else
-            {
-                Physics.Raycast(contactPoint + Vector3.up, -Vector3.up, out hit);
-                if (Vector3.Angle(hit.normal, Vector3.up) > slideLimit)
-                    sliding = true;
-            }
-        }
-        private void SlideMovement(ref Vector3 moveDirection)
-        {
             // If sliding (and it's allowed), or if we're on an object tagged "Slide", get a vector pointing down the slope we're on
             if ((sliding && slideWhenOverSlopeLimit) || (slideOnTaggedObjects && hit.collider.tag == "Slide"))
             {
@@ -111,7 +83,26 @@ namespace DaggerfallWorkshop.Game
                 moveDirection = myTransform.TransformDirection(moveDirection) * playerMotor.Speed;
                 playerControl = true;
             }
+        }
 
+        private void SetSliding()
+        {
+            sliding = false;
+            // See if surface immediately below should be slid down. We use this normally rather than a ControllerColliderHit point,
+            // because that interferes with step climbing amongst other annoyances
+            if (Physics.Raycast(myTransform.position, -Vector3.up, out hit, rayDistance))
+            {
+                if (Vector3.Angle(hit.normal, Vector3.up) > slideLimit)
+                    sliding = true;
+            }
+            // However, just raycasting straight down from the center can fail when on steep slopes
+            // So if the above raycast didn't catch anything, raycast down from the stored ControllerColliderHit point instead
+            else
+            {
+                Physics.Raycast(contactPoint + Vector3.up, -Vector3.up, out hit);
+                if (Vector3.Angle(hit.normal, Vector3.up) > slideLimit)
+                    sliding = true;
+            }
         }
     }
 }

--- a/Assets/Scripts/Game/Player/PlayerGroundMotor.cs
+++ b/Assets/Scripts/Game/Player/PlayerGroundMotor.cs
@@ -45,7 +45,7 @@ namespace DaggerfallWorkshop.Game
         /// Moves the player on solid ground & floating platforms.
         /// </summary>
         /// <param name="moveDirection">the vector the player should move to</param>
-        public void MoveOnGround(Vector3 moveDirection)
+        public void MoveWithMovingPlatform(Vector3 moveDirection)
         {
             // Moving platform support
             if (activePlatform != null)

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -269,7 +269,7 @@ namespace DaggerfallWorkshop.Game
                 acrobatMotor.CheckFallingDamage();
 
                 // checks if sliding and applies movement to moveDirection if true
-                frictionMotor.MoveIfSliding(ref moveDirection);
+                frictionMotor.GroundedMovement(ref moveDirection);
 
                 acrobatMotor.HandleJumpInput(ref moveDirection);
             }
@@ -284,7 +284,7 @@ namespace DaggerfallWorkshop.Game
 
             acrobatMotor.HitHead(ref moveDirection);
 
-            groundMotor.MoveOnGround(moveDirection);
+            groundMotor.MoveWithMovingPlatform(moveDirection);
             grounded = (collisionFlags & CollisionFlags.Below) != 0;
         }
 


### PR DESCRIPTION
Fixes climbing teleportation upon hitting the ground.  Also makes you dismount wall when close enough to the ground.

Fixed bugs where rappel and grasp wall in air would still work even if disabled in settings