### PR TITLE
Prevent normal items from stacking with quest items

### DIFF
--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -216,7 +216,7 @@ namespace DaggerfallWorkshop.Game.Items
             // Add the item based on stack behaviour
             // TODO: Look at implementing proper stacking with max limits, split, merge, etc.
             DaggerfallUnityItem stack = FindExistingStack(item);
-            if (stack != null && !item.IsQuestItem && !noStack)
+            if (stack != null && !stack.IsQuestItem && !item.IsQuestItem && !noStack)
             {
                 // Add to stack count
                 stack.stackCount += item.stackCount;


### PR DESCRIPTION
Problem mentionned in
https://forums.dfworkshop.net/viewtopic.php?f=24&t=1274

I noticed that FindExistingStack() also makes use of a IsStackable flag, maybe quest items should not be stackable instead?