### PR TITLE
Motor fixes

### DIFF
--- a/Assets/Prefabs/Player/PlayerAdvanced.prefab
+++ b/Assets/Prefabs/Player/PlayerAdvanced.prefab
@@ -41,6 +41,7 @@ GameObject:
   - component: {fileID: 114220683863726122}
   - component: {fileID: 114033680799267548}
   - component: {fileID: 114397629012878356}
+  - component: {fileID: 114025923971531530}
   m_Layer: 0
   m_Name: PlayerAdvanced
   m_TagString: Player
@@ -611,7 +612,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   limitDiagonalSpeed: 1
-  systemTimerUpdatesPerSecond: 0.055
+  systemTimerUpdatesDivisor: 0.0549254
   smoothFollower: {fileID: 4832112164805246}
   smoothFollowerLerpSpeed: 25
 --- !u!114 &11400008
@@ -1052,6 +1053,17 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 2
+--- !u!114 &114025923971531530
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6eb00cb2bd49d084ea7ffeed0adfd7fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114033680799267548
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1245,7 +1257,6 @@ MonoBehaviour:
   slideWhenOverSlopeLimit: 0
   slideOnTaggedObjects: 0
   slideSpeed: 12
-  antiBumpFactor: 2.35
 --- !u!114 &114583161180529142
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -126,10 +126,10 @@ namespace DaggerfallWorkshop.Game
         }
 
 
-    /// <summary>
-    /// If we stepped over a cliff or something, set the height at which we started falling
-    /// </summary>
-    public void CheckInitFall()
+        /// <summary>
+        /// If we stepped over a cliff or something, set the height at which we started falling
+        /// </summary>
+        public void CheckInitFall()
         {
             if (!falling)
             {
@@ -150,7 +150,27 @@ namespace DaggerfallWorkshop.Game
             }
             else if (!climbingMotor.IsRappelling)
             {
-                moveDirection.y -= gravity * Time.deltaTime;
+                const float antiBumpFactor = .75f;
+                float minRange = (controller.height / 2f);
+                float maxRange = minRange + 0.90f;
+                Vector3 checkRayOriginDisplacement = Vector3.ProjectOnPlane(moveDirection, Vector3.up).normalized * 0.10f;
+                Ray checkSlopeRay = new Ray(myTransform.position + checkRayOriginDisplacement, Vector3.down * maxRange);
+
+                RaycastHit hit;
+                float distance = Vector3.Distance(checkSlopeRay.origin, checkSlopeRay.direction);
+
+                if (!jumping && Physics.SphereCast(checkSlopeRay, 0.10f, out hit, distance))
+                {
+                    if (hit.distance > minRange && hit.distance < maxRange)
+                    {
+                        Debug.DrawRay(checkSlopeRay.origin, checkSlopeRay.direction, Color.cyan);
+                        moveDirection.y -= antiBumpFactor;
+                    }
+                }
+                //else
+                //{
+                    moveDirection.y -= gravity * Time.deltaTime;
+                //}
             }
         } 
                        

--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -19,6 +19,7 @@ namespace DaggerfallWorkshop.Game
         FrictionMotor frictionMotor;
         ClimbingMotor climbingMotor;
         Transform myTransform;
+        PlayerStepDetector stepDetector;
 
         private float fallStartLevel;
         private bool falling;
@@ -42,6 +43,7 @@ namespace DaggerfallWorkshop.Game
             controller = GetComponent<CharacterController>();
             frictionMotor = GetComponent<FrictionMotor>();
             climbingMotor = GetComponent<ClimbingMotor>();
+            stepDetector = GetComponent<PlayerStepDetector>();
             myTransform = playerMotor.transform;
         }
 
@@ -153,24 +155,13 @@ namespace DaggerfallWorkshop.Game
                 const float antiBumpFactor = .75f;
                 float minRange = (controller.height / 2f);
                 float maxRange = minRange + 0.90f;
-                Vector3 checkRayOriginDisplacement = Vector3.ProjectOnPlane(moveDirection, Vector3.up).normalized * 0.10f;
-                Ray checkSlopeRay = new Ray(myTransform.position + checkRayOriginDisplacement, Vector3.down * maxRange);
 
-                RaycastHit hit;
-                float distance = Vector3.Distance(checkSlopeRay.origin, checkSlopeRay.direction);
+                // should we apply anti-bump gravity?
+                if (stepDetector.HitDistance > minRange && stepDetector.HitDistance < maxRange)
+                    moveDirection.y -= antiBumpFactor;
 
-                if (!jumping && Physics.SphereCast(checkSlopeRay, 0.10f, out hit, distance))
-                {
-                    if (hit.distance > minRange && hit.distance < maxRange)
-                    {
-                        Debug.DrawRay(checkSlopeRay.origin, checkSlopeRay.direction, Color.cyan);
-                        moveDirection.y -= antiBumpFactor;
-                    }
-                }
-                //else
-                //{
-                    moveDirection.y -= gravity * Time.deltaTime;
-                //}
+                // apply normal gravity
+                moveDirection.y -= gravity * Time.deltaTime;   
             }
         } 
                        

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -102,6 +102,7 @@ namespace DaggerfallWorkshop.Game
         {
             if (airborneGraspWall)
             {
+                // TODO: prevent rappelling if small falls
                 if (!IsRappelling)
                 {
                     // should rappelling start?

--- a/Assets/Scripts/Game/Player/FrictionMotor.cs
+++ b/Assets/Scripts/Game/Player/FrictionMotor.cs
@@ -18,9 +18,6 @@ namespace DaggerfallWorkshop.Game
 
         public float slideSpeed = 12.0f;
 
-        // Small amounts of this results in bumping when walking down slopes, but large amounts results in falling too fast
-        public float antiBumpFactor = .75f;
-
         private PlayerMotor playerMotor;
         private Transform myTransform;
         private RaycastHit hit;
@@ -79,7 +76,7 @@ namespace DaggerfallWorkshop.Game
                 }
 
                 float inputModifyFactor = (inputX != 0.0f && inputY != 0.0f && playerMotor.limitDiagonalSpeed) ? .7071f : 1.0f;
-                moveDirection = new Vector3(inputX * inputModifyFactor, -antiBumpFactor, inputY * inputModifyFactor);
+                moveDirection = new Vector3(inputX * inputModifyFactor, 0, inputY * inputModifyFactor);
                 moveDirection = myTransform.TransformDirection(moveDirection) * playerMotor.Speed;
                 playerControl = true;
             }

--- a/Assets/Scripts/Game/Player/PlayerStepDetector.cs
+++ b/Assets/Scripts/Game/Player/PlayerStepDetector.cs
@@ -1,0 +1,63 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Meteoric Dragon
+// Contributors:    
+// 
+// Notes: This class detects information about where the player is going to step
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
+using DaggerfallWorkshop.Game.Entity;
+
+namespace DaggerfallWorkshop.Game
+{
+    /// <summary>
+    /// Detects information about where the player is going to step
+    /// </summary>
+    public class PlayerStepDetector : MonoBehaviour
+    {
+        CharacterController controller;
+        AcrobatMotor acrobatMotor;
+
+        // could declare other useful properties if more info is needed about the surface hit
+        public float HitDistance { get; private set; }
+
+        void Start()
+        {
+            controller = GetComponent<CharacterController>();
+            acrobatMotor = GetComponent<AcrobatMotor>();
+        }
+
+        /// <summary>
+        /// Detects information about where the player is going to step via SphereCast downwards, Dispaced toward moveDirection
+        /// </summary>
+        /// <param name="moveDirection"></param>
+        public void FindStep(Vector3 moveDirection)
+        {
+            if (GameManager.IsGamePaused)
+                return;
+            Vector3 position = controller.transform.position;
+            float minRange = (controller.height / 2f);
+            float maxRange = minRange + 2.10f;
+            // get the normalized horizontal component of player's direction
+            Vector3 checkRayOriginDisplacement = Vector3.ProjectOnPlane(moveDirection, Vector3.up).normalized * 0.10f;
+            Ray checkStepRay = new Ray(position + checkRayOriginDisplacement, Vector3.down * maxRange);
+
+            RaycastHit hit;
+
+            if (!acrobatMotor.Jumping && Physics.SphereCast(checkStepRay, 0.1f, out hit, maxRange))
+                HitDistance = hit.distance;
+            else
+                HitDistance = 0f;
+
+        }
+    }
+}

--- a/Assets/Scripts/Game/Player/PlayerStepDetector.cs.meta
+++ b/Assets/Scripts/Game/Player/PlayerStepDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6eb00cb2bd49d084ea7ffeed0adfd7fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -52,6 +52,7 @@ namespace DaggerfallWorkshop.Game
         private AcrobatMotor acrobatMotor;
         private PlayerGroundMotor groundMotor;
         private PlayerEnterExit playerEnterExit;
+        private PlayerStepDetector stepDetector;
 
         private CollisionFlags collisionFlags = 0;
 
@@ -219,6 +220,7 @@ namespace DaggerfallWorkshop.Game
             levitateMotor = GetComponent<LevitateMotor>();
             frictionMotor = GetComponent<FrictionMotor>();
             acrobatMotor = GetComponent<AcrobatMotor>();
+            stepDetector = GetComponent<PlayerStepDetector>();
             playerEnterExit = GameManager.Instance.PlayerEnterExit;
 
             // Allow for resetting specific player state on new game or when game starts loading
@@ -280,6 +282,7 @@ namespace DaggerfallWorkshop.Game
                 acrobatMotor.CheckAirControl(ref moveDirection, speed);
             }
 
+            stepDetector.FindStep(moveDirection);
             acrobatMotor.ApplyGravity(ref moveDirection);
 
             acrobatMotor.HitHead(ref moveDirection);


### PR DESCRIPTION
Fixes 2 bugs

Rappelling no longer happens if you step back off short heighted walls or objects.
Anti-bump gravity now is used when going down slopes, but not when walking off cliffs

Does this by Creating a small component class for playerAdvanced called PlayerStepDetector whose value is accessed by AcrobaticMotor and ClimbingMotor.  The component class detects what the player is about to step onto by measuring the distance of RaycastHit by SphereCast downward.  The origin of this ray is offset by the player Movement vector so it detects the distance to the floor that the player is stepping onto instead of the floor directly beneath.  The component class is for efficiency and code reuse, Like VitalsChangeDetector.  Kills two birds with one stone.  Poor birdies.  Good stone.

PlayerAdvanced.prefab was auto generated with some code changes that I'm not certain are neccessary, @Interkarma please tell me if   This change is neccessary: 
```
systemTimerUpdatesPerSecond: 0.055
systemTimerUpdatesDivisor: 0.0549254
```