### PR TITLE
fix: only stack stackable items

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -522,17 +522,22 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// Determines if item is stackable.
-        /// Only ingredients, gold pieces and arrows are stackable.
+        /// Only ingredients, gold pieces and arrows are stackable,
+        /// quest items are not stackable.
         /// </summary>
         /// <returns>True if item stackable.</returns>
         public virtual bool IsStackable()
         {
-            if (IsIngredient || 
-                IsOfTemplate(ItemGroups.Currency, (int) Currency.Gold_pieces) || 
+            // I think some quests are paid in "quest" money,
+            // make them stackable nonetheless
+            if (IsOfTemplate(ItemGroups.Currency, (int) Currency.Gold_pieces))
+                return true;
+            if (IsQuestItem)
+                return false;
+            if (IsIngredient ||
                 IsOfTemplate(ItemGroups.Weapons, (int) Weapons.Arrow))
                 return true;
-            else
-                return false;
+            return false;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -523,21 +523,19 @@ namespace DaggerfallWorkshop.Game.Items
 
         /// Determines if item is stackable.
         /// Only ingredients, gold pieces and arrows are stackable,
-        /// quest items are not stackable.
+        /// and quest items are never stackable.
         /// </summary>
         /// <returns>True if item stackable.</returns>
         public virtual bool IsStackable()
         {
-            // I think some quests are paid in "quest" money,
-            // make them stackable nonetheless
-            if (IsOfTemplate(ItemGroups.Currency, (int) Currency.Gold_pieces))
-                return true;
             if (IsQuestItem)
                 return false;
-            if (IsIngredient ||
+            if (IsIngredient || 
+                IsOfTemplate(ItemGroups.Currency, (int) Currency.Gold_pieces) || 
                 IsOfTemplate(ItemGroups.Weapons, (int) Weapons.Arrow))
                 return true;
-            return false;
+            else
+                return false;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -227,7 +227,7 @@ namespace DaggerfallWorkshop.Game.Items
             // Add the item based on stack behaviour
             // TODO: Look at implementing proper stacking with max limits, split, merge, etc.
             DaggerfallUnityItem stack = FindExistingStack(item);
-            if (stack != null && !stack.IsQuestItem && !item.IsQuestItem && !noStack)
+            if (stack != null && !noStack)
             {
                 // Add to stack count
                 stack.stackCount += item.stackCount;
@@ -572,7 +572,7 @@ namespace DaggerfallWorkshop.Game.Items
             int groupIndex = item.GroupIndex;
             foreach (DaggerfallUnityItem checkItem in items.Values)
             {
-                if (checkItem.ItemGroup == itemGroup && checkItem.GroupIndex == groupIndex)
+                if (checkItem.ItemGroup == itemGroup && checkItem.GroupIndex == groupIndex && checkItem.IsStackable())
                     return checkItem;
             }
 


### PR DESCRIPTION
Make IsStackable() even slightly more conservative about what can be
stacked, by not allowing quest items stacking;
That done, stacking no longer need quest items special handling (after a
FindExistingStack() fix, though).

I did allow stacking for "quest" money and standard money, because I
think some quests are paid that way in classic Daggerfall; But that may
be totally irrelevant in DFU.

It would be great to allow stacking potions, because non caster that
depend on potions can have quite a few in their inventory.