### PR TITLE
Highlight ListBox items with MouseOver events.

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -43,9 +43,10 @@ namespace DaggerfallWorkshop.Game
         public static Color DaggerfallDefaultShadowColor = new Color32(93, 77, 12, 255);
         public static Color DaggerfallAlternateShadowColor1 = new Color32(44, 60, 60, 255);
         public static Color DaggerfallDefaultSelectedTextColor = new Color32(162, 36, 12, 255);
+        public static Color DaggerfallBrighterSelectedTextColor = new Color32(254, 56, 18, 255);
         public static Color DaggerfallUnityStatDrainedTextColor = new Color32(190, 85, 24, 255);
         public static Color DaggerfallUnityStatIncreasedTextColor = new Color32(178, 207, 255, 255);
-        public static Color DaggerfallDefaultTextCursorColor = new Color32(154, 134, 0, 200);
+        public static Color DaggerfallDefaultTextCursorColor = new Color32(255, 110, 110, 200);
         public static Color DaggerfallUnityDefaultToolTipBackgroundColor = new Color32(64, 64, 64, 210);
         public static Color DaggerfallUnityDefaultToolTipTextColor = new Color32(230, 230, 200, 255);
         public static Color DaggerfallUnityDefaultCheckboxToggleColor = new Color32(146, 12, 4, 255);

--- a/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
+++ b/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
@@ -901,6 +901,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
         }
 
         /// <summary>
+        /// Mouse is moving.
+        /// </summary>
+        protected virtual void MouseMove(int x, int y)
+        {
+            if (OnMouseMove != null)
+                OnMouseMove(x, y);
+        }
+
+        /// <summary>
         /// Mouse wheel scrolled up.
         /// </summary>
         protected virtual void MouseScrollUp()

--- a/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
+++ b/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
@@ -532,7 +532,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 if (mouseOverComponent == true)
                 {
                     // Raise mouse leaving event
-                    MouseExit();
+                    MouseLeave(this);
                     mouseOverComponent = false;
                 }
             }
@@ -894,7 +894,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// <summary>
         /// Mouse exited control area.
         /// </summary>
-        protected virtual void MouseExit()
+        protected virtual void MouseLeave(BaseScreenComponent sender)
         {
             if (OnMouseLeave != null)
                 OnMouseLeave(this);

--- a/Assets/Scripts/Game/UserInterface/ListBox.cs
+++ b/Assets/Scripts/Game/UserInterface/ListBox.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         int maxCharacters = -1;
         DaggerfallFont font;
         int selectedIndex = 0;
+        int highlightedIndex = -1;
         int scrollIndex = 0;
         bool enabledHorizontalScroll = false;
         int horizontalScrollIndex = 0;
@@ -77,6 +78,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             public Color selectedTextColor = DaggerfallUI.DaggerfallDefaultSelectedTextColor;
             public Color shadowColor = DaggerfallUI.DaggerfallDefaultShadowColor;
             public Color selectedShadowColor = DaggerfallUI.DaggerfallDefaultShadowColor;
+            public Color highlightedTextColor = DaggerfallUI.DaggerfallHighlightTextColor;
 
             public ListItem(TextLabel textLabel)
             {
@@ -269,8 +271,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #endregion
 
-        #region Overrides
+        #region Constructors
+        public ListBox()
+        {
+            OnMouseMove += MouseMove;
+            OnMouseLeave += MouseLeave;
+        }
+        #endregion
 
+        #region Overrides
         public override void Update()
         {
             base.Update();
@@ -314,6 +323,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     if (i == selectedIndex)
                     {
                         label.TextColor = listItems[i].selectedTextColor;
+                        label.ShadowPosition = selectedShadowPosition;
+                        label.ShadowColor = listItems[i].selectedShadowColor;
+                    }
+                    else if (i == highlightedIndex)
+                    {
+                        label.TextColor = listItems[i].highlightedTextColor;
                         label.ShadowPosition = selectedShadowPosition;
                         label.ShadowColor = listItems[i].selectedShadowColor;
                     }
@@ -369,6 +384,43 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     y += label.TextHeight + rowSpacing;
                 }
             }           
+        }
+        protected override void MouseMove(int x, int y)
+        {
+            if (listItems.Count == 0)
+                return;
+            
+            if (verticalScrollMode == VerticalScrollModes.EntryWise)
+            {
+                int row = (y / (font.GlyphHeight + rowSpacing));
+                int index = scrollIndex + row;
+                if (index >= 0 && index < Count)
+                {
+                    highlightedIndex = index;
+                }
+            }
+            else if (verticalScrollMode == VerticalScrollModes.PixelWise)
+            {
+                int yCurrentItem = 0;
+                int yNextItem = 0;
+                for (int i = 0; i < listItems.Count; i++)
+                {
+                    yNextItem = yCurrentItem + listItems[i].textLabel.TextHeight + rowSpacing;
+                    int yVal = scrollIndex + y;
+                    if (yVal >= yCurrentItem - rowSpacing * 0.5 && yVal < yNextItem - rowSpacing * 0.5)
+                    {
+                        highlightedIndex = i;
+                        break;
+                    }
+                    yCurrentItem = yNextItem;
+                }
+
+            }
+        }
+
+        protected override void MouseLeave(BaseScreenComponent sender)
+        {
+            highlightedIndex = -1;
         }
 
         protected override void MouseClick(Vector2 clickPosition)

--- a/Assets/Scripts/Game/UserInterface/ListBox.cs
+++ b/Assets/Scripts/Game/UserInterface/ListBox.cs
@@ -79,6 +79,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             public Color shadowColor = DaggerfallUI.DaggerfallDefaultShadowColor;
             public Color selectedShadowColor = DaggerfallUI.DaggerfallDefaultShadowColor;
             public Color highlightedTextColor = DaggerfallUI.DaggerfallHighlightTextColor;
+            public Color highlightedSelectedTextColor = DaggerfallUI.DaggerfallBrighterSelectedTextColor;
 
             public ListItem(TextLabel textLabel)
             {
@@ -320,24 +321,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     currentLine += label.NumTextLines;                
                     label.StartCharacterIndex = horizontalScrollIndex;
                     label.RefreshLayout();
-                    if (i == selectedIndex)
-                    {
-                        label.TextColor = listItems[i].selectedTextColor;
-                        label.ShadowPosition = selectedShadowPosition;
-                        label.ShadowColor = listItems[i].selectedShadowColor;
-                    }
-                    else if (i == highlightedIndex)
-                    {
-                        label.TextColor = listItems[i].highlightedTextColor;
-                        label.ShadowPosition = selectedShadowPosition;
-                        label.ShadowColor = listItems[i].selectedShadowColor;
-                    }
-                    else
-                    {
-                        label.TextColor = listItems[i].textColor;
-                        label.ShadowPosition = shadowPosition;
-                        label.ShadowColor = listItems[i].shadowColor;
-                    }
+
+                    DecideTextColor(label, i);
 
                     label.Position = new Vector2(x, y);
                     label.Draw();
@@ -364,18 +349,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     else if (horizontalScrollMode == HorizontalScrollModes.PixelWise)
                         x = -horizontalScrollIndex;
                     label.RefreshLayout();
-                    if (i == selectedIndex)
-                    {
-                        label.TextColor = listItems[i].selectedTextColor;
-                        label.ShadowPosition = selectedShadowPosition;
-                        label.ShadowColor = listItems[i].selectedShadowColor;
-                    }
-                    else
-                    {
-                        label.TextColor = listItems[i].textColor;
-                        label.ShadowPosition = shadowPosition;
-                        label.ShadowColor = listItems[i].shadowColor;
-                    }
+
+                    DecideTextColor(label, i);
 
                     label.HorzPixelScrollOffset = x;
                     label.Position = new Vector2(x, y);
@@ -384,6 +359,34 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     y += label.TextHeight + rowSpacing;
                 }
             }           
+        }
+
+        private void DecideTextColor(TextLabel label, int i)
+        {
+            if (i == highlightedIndex && i == selectedIndex)
+            {
+                label.TextColor = listItems[i].highlightedSelectedTextColor;
+                label.ShadowPosition = selectedShadowPosition;
+                label.ShadowColor = listItems[i].selectedShadowColor;
+            }
+            else if (i == selectedIndex)
+            {
+                label.TextColor = listItems[i].selectedTextColor;
+                label.ShadowPosition = selectedShadowPosition;
+                label.ShadowColor = listItems[i].selectedShadowColor;
+            }
+            else if (i == highlightedIndex)
+            {
+                label.TextColor = listItems[i].highlightedTextColor;
+                label.ShadowPosition = selectedShadowPosition;
+                label.ShadowColor = listItems[i].selectedShadowColor;
+            }
+            else
+            {
+                label.TextColor = listItems[i].textColor;
+                label.ShadowPosition = shadowPosition;
+                label.ShadowColor = listItems[i].shadowColor;
+            }
         }
         protected override void MouseMove(int x, int y)
         {


### PR DESCRIPTION
A graphical tweak that makes mouseover actions on list boxes highlight the text to help people see what they are clicking better, and worry less about if they're actually clicking on an item above the one they meant to point click.  It affects saved games list, spell list, talk topics, etc.  I think It turned out quite well.

I tested: Saved games list, spellbook list, Buy spells list, talk topics list.