### PR TITLE
Bug fixes

### DIFF
--- a/Assets/Scripts/Game/LevitateMotor.cs
+++ b/Assets/Scripts/Game/LevitateMotor.cs
@@ -28,6 +28,7 @@ namespace DaggerfallWorkshop.Game
         PlayerMotor playerMotor;
         PlayerSpeedChanger speedChanger;
         PlayerGroundMotor groundMotor;
+        ClimbingMotor climbingMotor;
         Camera playerCamera;
         float moveSpeed = levitateMoveSpeed;
         Vector3 moveDirection = Vector3.zero;
@@ -49,6 +50,7 @@ namespace DaggerfallWorkshop.Game
             playerMotor = GetComponent<PlayerMotor>();
             groundMotor = GetComponent<PlayerGroundMotor>();
             speedChanger = GetComponent<PlayerSpeedChanger>();
+            climbingMotor = GetComponent<ClimbingMotor>();
             playerCamera = GameManager.Instance.MainCamera;
         }
 
@@ -78,7 +80,7 @@ namespace DaggerfallWorkshop.Game
             if (InputManager.Instance.HasAction(InputManager.Actions.Jump) || InputManager.Instance.HasAction(InputManager.Actions.FloatUp))
                 upDownVector = upDownVector + Vector3.up;
             if (InputManager.Instance.HasAction(InputManager.Actions.Crouch) || InputManager.Instance.HasAction(InputManager.Actions.FloatDown) ||
-                GameManager.Instance.PlayerEnterExit.IsPlayerSwimming && (GameManager.Instance.PlayerEntity.CarriedWeight * 4) > 250)
+                !climbingMotor.IsClimbing && GameManager.Instance.PlayerEnterExit.IsPlayerSwimming && (GameManager.Instance.PlayerEntity.CarriedWeight * 4) > 250)
                 upDownVector = upDownVector + Vector3.down;
             AddMovement(upDownVector, true);
 

--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -152,7 +152,7 @@ namespace DaggerfallWorkshop.Game
             }
             else if (!climbingMotor.IsRappelling)
             {
-                const float antiBumpFactor = .75f;
+                const float antiBumpFactor = 20.75f;
                 float minRange = (controller.height / 2f);
                 float maxRange = minRange + 0.90f;
 


### PR DESCRIPTION
Fix can't climb while sinking with overweight-ness.
Fix Anti-bump factor being too low.
Fix Rappel bug.

Discovered new bug.  When climbing onto a house with a gabled roof, the player will continue moving forward until they reach the top of the gable.  Harmless but quirky.  

I'm really unsure how to fix it...  The controller detects side collision with it, or a capsule cast detects it.  And the code is set to keep the player moving until they've stepped onto the ledge if they get past a certain height when climbing.  It does that to prevent teleporting into the sky.