### PR TITLE
Added warning for staying afloat overencumbered

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -41,6 +41,7 @@ namespace DaggerfallWorkshop.Game
         bool isPlayerSubmerged = false;
         bool isRespawning = false;
         bool lastInteriorStartFlag;
+        bool displayAfloatMessage = false;
         DaggerfallInterior interior;
         DaggerfallDungeon dungeon;
         StreamingWorld world;
@@ -305,6 +306,17 @@ namespace DaggerfallWorkshop.Game
                         SendMessage("PlayLargeSplash", SendMessageOptions.DontRequireReceiver);
                     isPlayerSwimming = true;
                     levitateMotor.IsSwimming = true;
+                }
+
+                bool overEncumbered = (GameManager.Instance.PlayerEntity.CarriedWeight * 4 > 250);
+                if ((overEncumbered && levitateMotor.IsSwimming) && !displayAfloatMessage)
+                {
+                    DaggerfallUI.AddHUDText(HardStrings.cannotFloat, 1.75f);
+                    displayAfloatMessage = true;
+                }
+                else if ((!overEncumbered || !levitateMotor.IsSwimming) && displayAfloatMessage)
+                {
+                    displayAfloatMessage = false;
                 }
 
                 // Check if player is submerged and needs to start holding breath

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -38,6 +38,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string cannotCarryAnymore = "You cannot carry anymore stuff.";
         public const string cannotHoldAnymore = "Your cart cannot hold anymore stuff.";
         public const string cannotCarryGold = "You cannot carry that much gold.";
+        public const string cannotFloat = "You are carrying too much to stay afloat.";
         public const string youHaveNoArrows = "You have no arrows.";
 
         public const string enterSaveName = "Enter save name";


### PR DESCRIPTION
I added a warning for staying afloat while overencumbered.  The duration of this message is 1.75 seconds.  I noticed that the default duration seemed a little too short. So I used 1.75 instead.