### PR TITLE
QOL addition to auto-collect arrows

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -618,6 +618,12 @@ namespace DaggerfallWorkshop.Game
                             DaggerfallUI.AddHUDText(HardStrings.theBodyHasNoTreasure);
                             return;
                         }
+                        else if (loot.Items.Count == 1 && loot.Items.Contains(ItemGroups.Weapons, (int) Weapons.Arrow))
+                        {   // If only one item and it's arrows, then auto-pickup.
+                            GameManager.Instance.PlayerEntity.Items.TransferAll(loot.Items);
+                            DaggerfallUI.AddHUDText(HardStrings.youCollectArrows);
+                            return;
+                        }
                         break;
                     }
                 // No special handling for all other loot container types: (Nothing, RandomTreasure, DroppedLoot)

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -56,6 +56,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string youSeeA = "You see a %s.";
         public const string youSeeADeadPerson = "You see a dead person.";
         public const string youSeeADead = "You see a dead %s.";
+        public const string youCollectArrows = "You pluck your arrows out of the corpse.";
 
         public const string loiterHowManyHours = "Loiter how many hours : ";
         public const string restHowManyHours = "Rest how many hours : ";


### PR DESCRIPTION
Archers have to collect arrows from every corpse which is, quite frankly, a serious RSI risk! This auto-collects arrows from corpses if thats the only item the corpse loot container contains.

Not sure if you want to put this in 0.6 or are happy to add to 0.5... targeted the 0.6 branch but I give you the choice. It's a very simple change because this is a pain in the ass for archers. (i.e. my test char)