### PR TITLE
Impose restriction on enemies approaching player

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -369,6 +369,20 @@ namespace DaggerfallWorkshop.Game
 
             var motion = transform.forward * moveSpeed;
 
+            if (!senses.TargetIsWithinPitchAngle(45.0f))
+            {
+                if (flies || isLevitating || swims)
+                {
+                    if (!senses.TargetIsAbove())
+                        motion = -transform.up * moveSpeed;
+                    else
+                        motion = transform.up * moveSpeed;
+                }
+                else
+                    return; // maybe change mobile state to stationary too?
+            }
+
+
             // Prevent rat stacks (enemies don't stand on shorter enemies)
             AvoidEnemies(ref motion);
 

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -444,6 +444,31 @@ namespace DaggerfallWorkshop.Game
                 return false;
         }
 
+        public bool TargetIsWithinPitchAngle(float targetAngle)
+        {
+            Vector3 toTarget = lastKnownTargetPos - transform.position;
+            Vector3 directionToLastKnownTarget2D = toTarget.normalized;
+            Plane verticalTransformToLastKnownPos = new Plane(lastKnownTargetPos, transform.position, transform.position + Vector3.up);
+            // first project enemy direction to horizontal plane.
+            Vector3 enemyDirection2D = Vector3.ProjectOnPlane(transform.forward, Vector3.up);
+            // next project enemy direction to vertical plane intersecting with last known position
+            enemyDirection2D = Vector3.ProjectOnPlane(enemyDirection2D, verticalTransformToLastKnownPos.normal);
+
+            float angle = Vector3.Angle(directionToLastKnownTarget2D, enemyDirection2D);
+
+            if (angle < targetAngle)
+                return true;
+            else
+                return false;
+        }
+
+        public bool TargetIsAbove()
+        {
+            if (lastKnownTargetPos.y > transform.position.y)
+                return true;
+            return false;
+        }
+
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
If a ground enemy sees the player at a greater pitch than 45 degrees up or down, they will wait before pursuing,  If it is a flying enemy, they will move straight up or down to get within pitch range before approaching the player.  Since all enemies are 2-dimensional, this prevents them from disappearing underneath or above the player.

I'd like anyone who's available to test it and let me know what they think.  I tested ground enemies and they work,  I can't find a good situation with swimming or flying enemies to test it.  I can't cast levitate on guards to test it either.