### PR TITLE
Faster flame animations

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -52,7 +52,7 @@ namespace DaggerfallWorkshop
         // Just using a simple animation speed for simple billboard anims
         // You can adjust this or extend as needed
         const int animalFps = 5;
-        const int lightFps = 12;
+        const int lightFps = 20;
 
         public BillboardSummary Summary
         {


### PR DESCRIPTION
The right speed is a bit subjective, but from memory, and watching flames on video,
it feels that torches and other flames are not fast enough.

(Unless gravity is lower in Tamriel, but from the look of physics in the
game it doesn't seem so).

I know we entered feature freeze for 0.5 (beside spells), but this is a one liner, and flames look painfully slow without this patch...
