### PR TITLE
Fix anti-bump being applied while climbing and slipping

### DIFF
--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -157,7 +157,7 @@ namespace DaggerfallWorkshop.Game
                 float maxRange = minRange + 1.10f;
 
                 // should we apply anti-bump gravity?
-                if (stepDetector.HitDistance > minRange && stepDetector.HitDistance < maxRange)
+                if (!climbingMotor.IsClimbing && stepDetector.HitDistance > minRange && stepDetector.HitDistance < maxRange)
                     moveDirection.y -= antiBumpFactor;
 
                 // apply normal gravity


### PR DESCRIPTION
Anti- bump was being applied while climbing dungeon walls, and made the player zip to the ground when slipping and climbing.