### PR TITLE
Fix free room for member of region knightly order

### DIFF
--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -164,9 +164,9 @@ namespace DaggerfallWorkshop.Game.Guilds
                 return true;
 
             FactionFile.FactionData factionData;
-            if (DaggerfallUnity.Instance.ContentReader.FactionFileReader.GetFactionData(GetFactionId(), out factionData))
-                if (GameManager.Instance.PlayerGPS.CurrentLocation.RegionIndex + 1 == factionData.region)
-                    return true;
+            if (DaggerfallUnity.Instance.ContentReader.FactionFileReader.GetFactionData(GetFactionId(), out factionData)
+                && GameManager.Instance.PlayerGPS.CurrentLocation.RegionIndex == factionData.region)
+                return true;
 
             return false;
         }


### PR DESCRIPTION
The knightly order code was still using +1 when checking the region ID, although the FactionData now subtracts 1 from the IDs from `FACTION.TXT` when importing (like classic does) and the +1 check is no longer necessary.