### PR TITLE
First pass at enemy casting

### DIFF
--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
@@ -3,9 +3,9 @@
 --- !u!1 &131734
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 488118}
   - component: {fileID: 3367684}
@@ -21,9 +21,9 @@ GameObject:
 --- !u!1 &140354
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 481572}
   - component: {fileID: 11410784}
@@ -51,7 +51,7 @@ GameObject:
 --- !u!4 &481572
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -65,7 +65,7 @@ Transform:
 --- !u!4 &488118
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 131734}
   m_LocalRotation: {x: 0, y: -0.32127059, z: 0, w: 0.94698745}
@@ -78,7 +78,7 @@ Transform:
 --- !u!23 &2302536
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 131734}
   m_Enabled: 1
@@ -113,14 +113,14 @@ MeshRenderer:
 --- !u!33 &3367684
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 131734}
   m_Mesh: {fileID: 0}
 --- !u!82 &8249844
 AudioSource:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -215,7 +215,7 @@ AudioSource:
 --- !u!114 &11410784
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -226,10 +226,11 @@ MonoBehaviour:
   EnemyType: 15
   EnemyReaction: 0
   EnemyGender: 0
+  ClassicSpawnDistanceType: 0
 --- !u!114 &11424130
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -242,7 +243,7 @@ MonoBehaviour:
 --- !u!114 &11435454
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -254,7 +255,7 @@ MonoBehaviour:
 --- !u!114 &11439840
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -271,10 +272,11 @@ MonoBehaviour:
   MoveSound: 0
   BarkSound: 0
   AttackSound: 0
+  RaceForSounds: 0
 --- !u!114 &11449422
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -285,7 +287,7 @@ MonoBehaviour:
 --- !u!114 &11452974
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -297,7 +299,7 @@ MonoBehaviour:
 --- !u!114 &11470552
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -308,7 +310,7 @@ MonoBehaviour:
 --- !u!114 &11478892
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 131734}
   m_Enabled: 1
@@ -372,14 +374,16 @@ MonoBehaviour:
       ChanceForAttack5: 0
       PrimaryAttackAnimFrames5: 
       RangedAttackAnimFrames: 
+      Team: 0
     EnemyState: 0
     StateAnims: []
     AnimStateRecord: 0
     StateAnimFrames: 
+    ClassicSpawnDistanceType: 0
 --- !u!114 &11492232
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -395,7 +399,7 @@ MonoBehaviour:
 --- !u!114 &11495432
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -406,7 +410,7 @@ MonoBehaviour:
 --- !u!114 &11499798
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -420,7 +424,7 @@ MonoBehaviour:
 --- !u!143 &14323946
 CharacterController:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Material: {fileID: 0}
@@ -466,13 +470,13 @@ Prefab:
       value: .0500000007
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
+  m_SourcePrefab: {fileID: 0}
   m_RootGameObject: {fileID: 140354}
-  m_IsPrefabParent: 1
+  m_IsPrefabAsset: 1
 --- !u!114 &114000013776501450
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -483,7 +487,7 @@ MonoBehaviour:
 --- !u!114 &114564829754804976
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -494,7 +498,7 @@ MonoBehaviour:
 --- !u!114 &114919659270182526
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 140354}
   m_Enabled: 1
@@ -502,8 +506,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d9ffab243d560eb4698f5f394d36eb67, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  FireMissilePrefab: {fileID: 0}
-  ColdMissilePrefab: {fileID: 0}
-  PoisonMissilePrefab: {fileID: 0}
-  ShockMissilePrefab: {fileID: 0}
-  MagicMissilePrefab: {fileID: 0}
+  FireMissilePrefab: {fileID: 114701158002484598, guid: 738ed1902aee8694d83f5b5fbf151bd8,
+    type: 2}
+  ColdMissilePrefab: {fileID: 114701158002484598, guid: 481b796491f5b9543b5711183faef15a,
+    type: 2}
+  PoisonMissilePrefab: {fileID: 114701158002484598, guid: d6d8b5ee1acb1424591a58ec6aa291d1,
+    type: 2}
+  ShockMissilePrefab: {fileID: 114701158002484598, guid: f1cb8f301b9f6d74fb1e42543c002b1a,
+    type: 2}
+  MagicMissilePrefab: {fileID: 114701158002484598, guid: 7033bba38a223be4fab81dfb8f3b8f90,
+    type: 2}

--- a/Assets/Scripts/DaggerfallUnityEnums.cs
+++ b/Assets/Scripts/DaggerfallUnityEnums.cs
@@ -220,7 +220,8 @@ namespace DaggerfallWorkshop
         PrimaryAttack,      // Records 5-9      (Usually a melee attack animation)
         Hurt,               // Records 10-14    (Mob has been struck)
         Idle,               // Records 15-19    (Frost and ice Daedra have animated idle states)
-        RangedAttack1,      // Records 20-24    (Spellcast or bow attack based on mobile type)
+        RangedAttack1,      // Records 20-24    (Bow attack)
+        Spell,              // Records 20-24 or, if absent, copy of PrimaryAttack
         RangedAttack2,      // Records 25-29    (Bow attack on 475, 489, 490 only, absent on other humanoids)
         // TODO: Seducer transform special
     }

--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -218,6 +218,8 @@ namespace DaggerfallWorkshop
         public int ChanceForAttack5;                // Chance to use PrimaryAttackAnimFrames3 for an attack
         public int[] PrimaryAttackAnimFrames5;      // Alternate animation sequence to play when doing primary attack
         public int[] RangedAttackAnimFrames;        // Animation sequence to play when doing bow & arrow attack
+        public bool HasSpellAnimation;              // Whether or not this character has specific animations for casting spells
+        public int[] SpellAnimFrames;               // Animation sequence to play when doing a spell cast
         public MobileTeams Team;                    // Team that this enemy uses if enemy in-fighting is on
     }
 

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -61,9 +61,6 @@ namespace DaggerfallWorkshop.Game
 
         void Update()
         {
-            // TODO: Determine when enemy will cast a spell and select from their spell list
-            // Once spell is selected, set this as ReadySpell on their peered EntityEffectManager and change local anim state to casting
-
             // If a melee attack has reached the damage frame we can run a melee attempt
             if (mobile.DoMeleeDamage)
             {

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -27,13 +27,13 @@ namespace DaggerfallWorkshop.Game
     {
         public float MeleeAttackSpeed = 1.25f;      // Number of seconds between melee attacks
         public float MeleeDistance = 3.2f;          // Maximum distance for melee attack
+        public float MeleeTimer = 0;                // Must be 0 for a melee attack or touch spell to be done
 
         //EnemyMotor motor;
         EnemySenses senses;
         EnemySounds sounds;
         DaggerfallMobileUnit mobile;
         DaggerfallEntityBehaviour entityBehaviour;
-        float meleeTimer = 0;
         int damage = 0;
         float classicUpdateTimer = 0f;
         bool classicUpdate = false;
@@ -79,22 +79,22 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Countdown to next melee attack
-            meleeTimer -= Time.deltaTime;
+            MeleeTimer -= Time.deltaTime;
 
-            if (meleeTimer < 0)
-                meleeTimer = 0;
+            if (MeleeTimer < 0)
+                MeleeTimer = 0;
 
             EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
             int speed = entity.Stats.LiveSpeed;
 
             // Note: Speed comparison here is reversed from classic. Classic's way makes fewer attack
             // attempts at higher speeds, so it seems backwards.
-            if (classicUpdate && (DFRandom.rand() % speed >= (speed >> 3) + 6 && meleeTimer == 0))
+            if (classicUpdate && (DFRandom.rand() % speed >= (speed >> 3) + 6 && MeleeTimer == 0))
             {
                 MeleeAnimation();
 
-                meleeTimer = Random.Range(1500, 3001);
-                meleeTimer -= 50 * (GameManager.Instance.PlayerEntity.Level - 10);
+                MeleeTimer = Random.Range(1500, 3001);
+                MeleeTimer -= 50 * (GameManager.Instance.PlayerEntity.Level - 10);
 
                 // Note: In classic, what happens here is
                 // meleeTimer += 450 * (enemydata[130] - 2);
@@ -103,12 +103,12 @@ namespace DaggerfallWorkshop.Game
                 // Instead enemydata[130] seems to instead always be 0, the equivalent of
                 // "very high" reflexes, regardless of what the game reflexes are.
                 // Here, we use the reflexes data as was intended.
-                meleeTimer += 450 * ((int)GameManager.Instance.PlayerEntity.Reflexes - 2);
+                MeleeTimer += 450 * ((int)GameManager.Instance.PlayerEntity.Reflexes - 2);
 
-                if (meleeTimer > 100000 || meleeTimer < 0)
-                    meleeTimer = 1500;
+                if (MeleeTimer > 100000 || MeleeTimer < 0)
+                    MeleeTimer = 1500;
 
-                meleeTimer /= 980; // Approximates classic frame update
+                MeleeTimer /= 980; // Approximates classic frame update
             }
         }
 

--- a/Assets/Scripts/Game/EnemyBlood.cs
+++ b/Assets/Scripts/Game/EnemyBlood.cs
@@ -21,6 +21,7 @@ namespace DaggerfallWorkshop.Game
     public class EnemyBlood : MonoBehaviour
     {
         const int bloodArchive = 380;
+        const int sparklesIndex = 3;
 
         public void ShowBloodSplash(int bloodIndex, Vector3 bloodPosition)
         {
@@ -32,6 +33,21 @@ namespace DaggerfallWorkshop.Game
                 go.name = "BloodSplash";
                 DaggerfallBillboard c = go.GetComponent<DaggerfallBillboard>();
                 go.transform.position = bloodPosition + transform.forward * 0.02f;
+                c.OneShot = true;
+                c.FramesPerSecond = 10;
+            }
+        }
+
+        public void ShowMagicSparkles(Vector3 sparklesPosition)
+        {
+            // Create oneshot animated billboard for sparkles effect
+            DaggerfallUnity dfUnity = DaggerfallUnity.Instance;
+            if (dfUnity)
+            {
+                GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(bloodArchive, sparklesIndex, null);
+                go.name = "MagicSparkles";
+                DaggerfallBillboard c = go.GetComponent<DaggerfallBillboard>();
+                go.transform.position = sparklesPosition + transform.forward * 0.02f;
                 c.OneShot = true;
                 c.FramesPerSecond = 10;
             }

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -332,7 +332,7 @@ namespace DaggerfallWorkshop.Game
                     }
                     else if (entity.CurrentMagicka > 0 && CanCastRangedSpell(entity) && DFRandom.rand() % 40 == 0)
                     {
-                        entityEffectManager.ReadySpell = selectedSpell;
+                        entityEffectManager.SetReadySpell(selectedSpell);
                     }
                     else
                         // If no ranged attack, move towards target
@@ -353,7 +353,7 @@ namespace DaggerfallWorkshop.Game
                 TurnToTarget(direction.normalized);
             else if (senses.TargetInSight && entity.CurrentMagicka > 0 && attack.MeleeTimer == 0 && CanCastTouchSpell(entity))
             {
-                entityEffectManager.ReadySpell = selectedSpell;
+                entityEffectManager.SetReadySpell(selectedSpell);
 
                 attack.MeleeTimer = Random.Range(1500, 3001);
                 attack.MeleeTimer -= 50 * (GameManager.Instance.PlayerEntity.Level - 10);

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -330,9 +330,10 @@ namespace DaggerfallWorkshop.Game
                         else if (!mobile.IsPlayingOneShot())
                             mobile.ChangeEnemyState(MobileStates.Idle);
                     }
-                    else if (entity.CurrentMagicka > 0 && CanCastRangedSpell(entity) && DFRandom.rand() % 40 == 0)
+                    else if (entity.CurrentMagicka > 0 && CanCastRangedSpell(entity) && DFRandom.rand() % 40 == 0
+                        && entityEffectManager.SetReadySpell(selectedSpell) && mobile.Summary.EnemyState != MobileStates.Spell)
                     {
-                        entityEffectManager.SetReadySpell(selectedSpell);
+                        mobile.ChangeEnemyState(MobileStates.Spell);
                     }
                     else
                         // If no ranged attack, move towards target
@@ -351,9 +352,11 @@ namespace DaggerfallWorkshop.Game
                 PursueTarget(direction, moveSpeed);
             else if (!senses.TargetIsWithinYawAngle(22.5f))
                 TurnToTarget(direction.normalized);
-            else if (senses.TargetInSight && entity.CurrentMagicka > 0 && attack.MeleeTimer == 0 && CanCastTouchSpell(entity))
+            else if (senses.TargetInSight && entity.CurrentMagicka > 0 && attack.MeleeTimer == 0 && CanCastTouchSpell(entity)
+                && entityEffectManager.SetReadySpell(selectedSpell))
             {
-                entityEffectManager.SetReadySpell(selectedSpell);
+                if (mobile.Summary.EnemyState != MobileStates.Spell)
+                        mobile.ChangeEnemyState(MobileStates.Spell);
 
                 attack.MeleeTimer = Random.Range(1500, 3001);
                 attack.MeleeTimer -= 50 * (GameManager.Instance.PlayerEntity.Level - 10);

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -351,7 +351,7 @@ namespace DaggerfallWorkshop.Game
                 PursueTarget(direction, moveSpeed);
             else if (!senses.TargetIsWithinYawAngle(22.5f))
                 TurnToTarget(direction.normalized);
-            else if (senses.TargetInSight && entity.CurrentMagicka > 0 && attack.MeleeTimer == 0 && CanCastSelfOrTouchSpell(entity))
+            else if (senses.TargetInSight && entity.CurrentMagicka > 0 && attack.MeleeTimer == 0 && CanCastTouchSpell(entity))
             {
                 entityEffectManager.ReadySpell = selectedSpell;
 
@@ -394,15 +394,15 @@ namespace DaggerfallWorkshop.Game
             return true;
         }
 
-        bool CanCastSelfOrTouchSpell(DaggerfallEntity entity)
+        bool CanCastTouchSpell(DaggerfallEntity entity)
         {
             EffectBundleSettings[] spells = entity.GetSpells();
             List<EffectBundleSettings> rangeSpells = new List<EffectBundleSettings>();
             int count = 0;
             foreach (EffectBundleSettings spell in spells)
             {
-                if (spell.TargetType == TargetTypes.CasterOnly
-                    || spell.TargetType == TargetTypes.ByTouch)
+                if (spell.TargetType == TargetTypes.ByTouch
+                    || spell.TargetType == TargetTypes.AreaAroundCaster)
                 {
                     rangeSpells.Add(spell);
                     count++;

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -387,9 +387,9 @@ namespace DaggerfallWorkshop.Game
                 return false;
 
             EffectBundleSettings selectedSpellSettings = rangeSpells[Random.Range(0, count)];
-            // TODO: If target has the selected spell already in effect on them, return false
-
             selectedSpell = new EntityEffectBundle(selectedSpellSettings, entityBehaviour);
+            if (EffectsAlreadyOnTarget(selectedSpell))
+                return false;
 
             return true;
         }
@@ -413,9 +413,39 @@ namespace DaggerfallWorkshop.Game
                 return false;
 
             EffectBundleSettings selectedSpellSettings = rangeSpells[Random.Range(0, count)];
-            // TODO: If target has the selected spell already in effect on them, return false
-
             selectedSpell = new EntityEffectBundle(selectedSpellSettings, entityBehaviour);
+            if (EffectsAlreadyOnTarget(selectedSpell))
+                return false;
+
+            return true;
+        }
+
+        bool EffectsAlreadyOnTarget(EntityEffectBundle spell)
+        {
+            if (entityBehaviour.Target)
+            {
+                EntityEffectManager targetEffectManager = entityBehaviour.Target.GetComponent<EntityEffectManager>();
+                LiveEffectBundle[] bundles = targetEffectManager.EffectBundles;
+
+                for (int i = 0; i < spell.Settings.Effects.Length; i++)
+                {
+                    bool foundEffect = false;
+                    // Get effect template
+                    IEntityEffect effectTemplate = GameManager.Instance.EntityEffectBroker.GetEffectTemplate(spell.Settings.Effects[i].Key);
+                    for (int j = 0; j < bundles.Length && !foundEffect; j++)
+                    {
+                        for (int k = 0; k < bundles[j].liveEffects.Count && !foundEffect; k++)
+                        {
+
+                            if (bundles[j].liveEffects[k].GetType() == effectTemplate.GetType())
+                                foundEffect = true;
+                        }
+                    }
+
+                    if (!foundEffect)
+                        return false;
+                }
+            }
 
             return true;
         }

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -351,7 +351,7 @@ namespace DaggerfallWorkshop.Game
                 PursueTarget(direction, moveSpeed);
             else if (!senses.TargetIsWithinYawAngle(22.5f))
                 TurnToTarget(direction.normalized);
-            else if (senses.TargetInSight && entity.CurrentMagicka > 0 && attack.MeleeTimer == 0 && CanCastTouchSpell(entity))
+            else if (senses.TargetInSight && entity.CurrentMagicka > 0 && attack.MeleeTimer == 0 && CanCastSelfOrTouchSpell(entity))
             {
                 entityEffectManager.ReadySpell = selectedSpell;
 
@@ -394,15 +394,15 @@ namespace DaggerfallWorkshop.Game
             return true;
         }
 
-        bool CanCastTouchSpell(DaggerfallEntity entity)
+        bool CanCastSelfOrTouchSpell(DaggerfallEntity entity)
         {
             EffectBundleSettings[] spells = entity.GetSpells();
             List<EffectBundleSettings> rangeSpells = new List<EffectBundleSettings>();
             int count = 0;
             foreach (EffectBundleSettings spell in spells)
             {
-                if (spell.TargetType == TargetTypes.ByTouch
-                    || spell.TargetType == TargetTypes.AreaAroundCaster)
+                if (spell.TargetType == TargetTypes.CasterOnly
+                    || spell.TargetType == TargetTypes.ByTouch)
                 {
                     rangeSpells.Add(spell);
                     count++;

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -54,6 +54,7 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int currentHealth;
         protected int currentFatigue;
         protected int currentMagicka;
+        protected int maxMagicka;
         protected int currentBreath;
         protected WeaponMaterialTypes minMetalToHit;
         protected sbyte[] armorValues = new sbyte[NumberBodyParts];
@@ -246,7 +247,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public float CurrentHealthPercent { get { return GetCurrentHealth() / (float)maxHealth; } }
         public int MaxFatigue { get { return (stats.LiveStrength + stats.LiveEndurance) * 64; } }
         public int CurrentFatigue { get { return GetCurrentFatigue(); } set { SetFatigue(value); } }
-        public int MaxMagicka { get { return FormulaHelper.SpellPoints(stats.LiveIntelligence, career.SpellPointMultiplierValue); } }
+        public int MaxMagicka { get { return (this == GameManager.Instance.PlayerEntity ? FormulaHelper.SpellPoints(stats.LiveIntelligence, career.SpellPointMultiplierValue) : maxMagicka); } set { maxMagicka = value; } }
         public int CurrentMagicka { get { return GetCurrentMagicka(); } set { SetMagicka(value); } }
         public int MaxBreath { get { return stats.LiveEndurance / 2; } }
         public int CurrentBreath { get { return currentBreath; } set { SetBreath(value); } }

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -17,6 +17,8 @@ using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.Player;
+using DaggerfallConnect.Save;
+using DaggerfallWorkshop.Game.MagicAndEffects;
 
 namespace DaggerfallWorkshop.Game.Entity
 {
@@ -377,7 +379,8 @@ namespace DaggerfallWorkshop.Game.Entity
 
         public void SetEnemySpells(byte[] spellList)
         {
-            //MaxMagicka = 10 * level + 100; TODO: Enemies should be able to set maximum spell points independent of the rules used by the player.
+            // Enemies don't follow same rule as player for maximum spell points
+            MaxMagicka = 10 * level + 100;
             currentMagicka = MaxMagicka;
             skills.SetPermanentSkillValue(DFCareer.Skills.Destruction, 80);
             skills.SetPermanentSkillValue(DFCareer.Skills.Restoration, 80);
@@ -386,9 +389,25 @@ namespace DaggerfallWorkshop.Game.Entity
             skills.SetPermanentSkillValue(DFCareer.Skills.Thaumaturgy, 80);
             skills.SetPermanentSkillValue(DFCareer.Skills.Mysticism, 80);
 
-            // Iterate over spellList and assign data from SPELLS.STD
+            // Add spells to enemy from standard list
+            foreach (byte spellID in spellList)
+            {
+                SpellRecord.SpellRecordData spellData;
+                GameManager.Instance.EntityEffectBroker.GetClassicSpellRecord(spellID, out spellData);
+                if (spellData.index == -1)
+                {
+                    Debug.LogError("Failed to locate enemy spell in standard spells list.");
+                    continue;
+                }
 
-            return;
+                EffectBundleSettings bundle;
+                if (!GameManager.Instance.EntityEffectBroker.ClassicSpellRecordDataToEffectBundleSettings(spellData, BundleTypes.Spell, out bundle))
+                {
+                    Debug.LogError("Failed to create effect bundle for enemy spell.");
+                    continue;
+                }
+                AddSpell(bundle);
+            }
         }
 
         public DFCareer.EnemyGroups GetEnemyGroup()

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -403,7 +403,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 EffectBundleSettings bundle;
                 if (!GameManager.Instance.EntityEffectBroker.ClassicSpellRecordDataToEffectBundleSettings(spellData, BundleTypes.Spell, out bundle))
                 {
-                    Debug.LogError("Failed to create effect bundle for enemy spell.");
+                    Debug.LogError("Failed to create effect bundle for enemy spell: " + spellData.spellName);
                     continue;
                 }
                 AddSpell(bundle);

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -697,7 +697,32 @@ namespace DaggerfallWorkshop.Game.Formulas
                         InflictDisease(target, diseaseListB);
                     break;
                 case (int)MonsterCareers.Spider:
-                    // if target does not have paralyze (spell id 66), cast it
+                case (int)MonsterCareers.GiantScorpion:
+                    EntityEffectManager targetEffectManager = target.EntityBehaviour.GetComponent<EntityEffectManager>();
+                    LiveEffectBundle[] bundles = targetEffectManager.EffectBundles;
+                    bool paralyzeAlreadyActive = false;
+
+                    foreach (LiveEffectBundle bundle in bundles)
+                    {
+                        foreach (IEntityEffect effect in bundle.liveEffects)
+                        {
+                            if (effect is Paralyze)
+                            {
+                                paralyzeAlreadyActive = true;
+                            }
+                        }
+                    }
+
+                    if (!paralyzeAlreadyActive)
+                    {
+                        SpellRecord.SpellRecordData spellData;
+                        GameManager.Instance.EntityEffectBroker.GetClassicSpellRecord(66, out spellData);
+                        EffectBundleSettings bundle;
+                        GameManager.Instance.EntityEffectBroker.ClassicSpellRecordDataToEffectBundleSettings(spellData, BundleTypes.Spell, out bundle);
+                        EntityEffectBundle spell = new EntityEffectBundle(bundle, attacker.EntityBehaviour);
+                        EntityEffectManager attackerEffectManager = attacker.EntityBehaviour.GetComponent<EntityEffectManager>();
+                        attackerEffectManager.SetReadySpell(spell, true);
+                    }
                     break;
                 case (int)MonsterCareers.Werewolf:
                     //uint random = DFRandom.rand();
@@ -721,9 +746,6 @@ namespace DaggerfallWorkshop.Game.Formulas
                 case (int)MonsterCareers.Mummy:
                     if (UnityEngine.Random.Range(1, 100 + 1) <= 5)
                         InflictDisease(target, diseaseListC);
-                    break;
-                case (int)MonsterCareers.GiantScorpion:
-                    // if target does not have paralyze (spell id 66), cast it
                     break;
                 case (int)MonsterCareers.Vampire:
                 case (int)MonsterCareers.VampireAncient:

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -104,11 +104,6 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             get { return (entityType == EntityTypes.Player); }
         }
 
-        public bool IsEnemyEntity
-        {
-            get { return (entityType == EntityTypes.EnemyClass || entityType == EntityTypes.EnemyMonster); }
-        }
-
         public LiveEffectBundle[] EffectBundles
         {
             get { return instancedBundles.ToArray(); }
@@ -237,9 +232,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                     return;
                 }
             }
-            
             // Enemies always cast ready spell instantly once queued
-            if (IsEnemyEntity)
+            else
             {
                 CastReadySpell();
             }
@@ -319,13 +313,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             // TODO: Do not need to show spellcasting animations for certain spell effects
             if (IsPlayerEntity)
                 GameManager.Instance.PlayerSpellCasting.PlayOneShot(readySpell.Settings.ElementType);
-
-            // Play enemy casting animation and fire spell
-            if (IsEnemyEntity)
+            else
                 EnemyCastReadySpell();
 
             // Block further casting attempts until previous cast is complete
-            castInProgress = true;
+            // castInProgress = true;
         }
 
         public void AssignBundle(EntityEffectBundle sourceBundle, bool showNonPlayerFailures = false)

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -56,7 +56,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         EntityEffectBundle lastSpell = null;
         bool instantCast = false;
         bool castInProgress = false;
-        bool readySpellIsMagicItem = false;
+        bool readySpellDoesNotCostSpellPoints = false;
         int readySpellCastingCost;
 
         DaggerfallEntityBehaviour entityBehaviour = null;
@@ -247,10 +247,10 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// Assigns a new spell to be cast.
         /// For player entity, this will display "press button to fire spell" message.
         /// </summary>
-        public void SetReadySpell(EntityEffectBundle spell, bool isMagicItem = false)
+        public void SetReadySpell(EntityEffectBundle spell, bool noSpellPointCost = false)
         {
             // Do nothing if silenced
-            if (SilenceCheck())
+            if (SilenceCheck() && !noSpellPointCost)
                 return;
 
             // Spell must appear valid
@@ -265,7 +265,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             bool godModeCast = (IsPlayerEntity && GameManager.Instance.PlayerEntity.GodMode);
 
             // Enforce spell point costs - Daggerfall does this when setting ready spell
-            if (entityBehaviour.Entity.CurrentMagicka < readySpellCastingCost && !godModeCast)
+            if (entityBehaviour.Entity.CurrentMagicka < readySpellCastingCost && !godModeCast && !noSpellPointCost)
             {
                 // Output message only for player
                 if (IsPlayerEntity)
@@ -278,7 +278,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
             // Assign spell - caster only spells are cast instantly
             readySpell = spell;
-            readySpellIsMagicItem = isMagicItem;
+            readySpellDoesNotCostSpellPoints = noSpellPointCost;
             if (readySpell.Settings.TargetType == TargetTypes.CasterOnly)
                 instantCast = true;
 
@@ -291,7 +291,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public void AbortReadySpell()
         {
             readySpell = null;
-            readySpellIsMagicItem = false;
+            readySpellDoesNotCostSpellPoints = false;
         }
 
         public void CastReadySpell()
@@ -304,8 +304,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             if (readySpell == null || castInProgress)
                 return;
 
-            // Deduct spellpoint cost from entity if not using a magic item
-            if (!readySpellIsMagicItem)
+            // Deduct spellpoint cost from entity if not free (magic item, innate ability)
+            if (!readySpellDoesNotCostSpellPoints)
                 entityBehaviour.Entity.DecreaseMagicka(readySpellCastingCost);
 
             // Play casting animation based on element type
@@ -1089,7 +1089,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         {
             lastSpell = null;
             readySpell = null;
-            readySpellIsMagicItem = false;
+            readySpellDoesNotCostSpellPoints = false;
         }
         
         int GetCastSoundID(ElementTypes elementType)
@@ -1297,7 +1297,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             readySpellCastingCost = 0;
             instantCast = false;
             castInProgress = false;
-            readySpellIsMagicItem = false;
+            readySpellDoesNotCostSpellPoints = false;
         }
 
         #endregion  
@@ -1334,12 +1334,12 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             }
 
             // Clear ready spell and reset casting - do not store last spell if casting from item
-            lastSpell = (readySpellIsMagicItem) ? null : readySpell;
+            lastSpell = (readySpellDoesNotCostSpellPoints) ? null : readySpell;
             readySpell = null;
             readySpellCastingCost = 0;
             instantCast = false;
             castInProgress = false;
-            readySpellIsMagicItem = false;
+            readySpellDoesNotCostSpellPoints = false;
         }
 
         private void EntityEffectBroker_OnNewMagicRound()

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -314,12 +314,15 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             // Spell is released by event handler PlayerSpellCasting_OnReleaseFrame
             // TODO: Do not need to show spellcasting animations for certain spell effects
             if (IsPlayerEntity)
+            {
+                // Play casting animation and block further casting attempts until previous cast is complete
                 GameManager.Instance.PlayerSpellCasting.PlayOneShot(readySpell.Settings.ElementType);
+                castInProgress = true;
+            }
             else
+            {
                 EnemyCastReadySpell();
-
-            // Block further casting attempts until previous cast is complete
-            // castInProgress = true;
+            }
         }
 
         public void AssignBundle(EntityEffectBundle sourceBundle, bool showNonPlayerFailures = false)

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -247,15 +247,15 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// Assigns a new spell to be cast.
         /// For player entity, this will display "press button to fire spell" message.
         /// </summary>
-        public void SetReadySpell(EntityEffectBundle spell, bool noSpellPointCost = false)
+        public bool SetReadySpell(EntityEffectBundle spell, bool noSpellPointCost = false)
         {
             // Do nothing if silenced
             if (SilenceCheck() && !noSpellPointCost)
-                return;
+                return false;
 
             // Spell must appear valid
             if (spell == null || spell.Settings.Version < minAcceptedSpellVersion)
-                return;
+                return false;
 
             // Get spellpoint costs of this spell
             int totalGoldCostUnused;
@@ -273,7 +273,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
                 readySpell = null;
                 readySpellCastingCost = 0;
-                return;
+                return false;
             }
 
             // Assign spell - caster only spells are cast instantly
@@ -286,6 +286,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             {
                 DaggerfallUI.AddHUDText(HardStrings.pressButtonToFireSpell, 0.4f);
             }
+
+            return true;
         }
 
         public void AbortReadySpell()

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1278,6 +1278,22 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                 PlayCastSound(readySpell.CasterEntityBehaviour, GetCastSoundID(readySpell.Settings.ElementType));
             }
 
+            // Create magic sparkles effect
+            if (readySpell.Settings.TargetType != TargetTypes.SingleTargetAtRange &&
+                readySpell.Settings.TargetType != TargetTypes.AreaAtRange)
+            {
+                EnemyBlood sparkles = readySpell.CasterEntityBehaviour.GetComponent<EnemyBlood>();
+
+                Vector3 sparklesPos = entityBehaviour.transform.position;
+                CharacterController targetController = entityBehaviour.transform.GetComponent<CharacterController>();
+                sparklesPos.y += targetController.height / 8;
+
+                if (sparkles)
+                {
+                    sparkles.ShowMagicSparkles(sparklesPos);
+                }
+            }
+
             // Assign bundle directly to self if target is caster
             // Otherwise instatiate missile prefab based on element type
             if (readySpell.Settings.TargetType == TargetTypes.CasterOnly)

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -204,7 +204,8 @@ namespace DaggerfallWorkshop
             if (summary.EnemyState == MobileStates.Hurt ||
                 summary.EnemyState == MobileStates.PrimaryAttack ||
                 summary.EnemyState == MobileStates.RangedAttack1 ||
-                summary.EnemyState == MobileStates.RangedAttack2)
+                summary.EnemyState == MobileStates.RangedAttack2 ||
+                summary.EnemyState == MobileStates.Spell)
             {
                 return true;
             }
@@ -274,6 +275,15 @@ namespace DaggerfallWorkshop
             if (summary.EnemyState == MobileStates.RangedAttack1 || summary.EnemyState == MobileStates.RangedAttack2)
             {
                 summary.StateAnimFrames = summary.Enemy.RangedAttackAnimFrames;
+
+                // Set to the first frame of this animation, and prepare frameIterator to start from the second frame when AnimateEnemy() next runs
+                currentFrame = summary.StateAnimFrames[0];
+                frameIterator = 1;
+            }
+
+            if (summary.EnemyState == MobileStates.Spell)
+            {
+                summary.StateAnimFrames = summary.Enemy.SpellAnimFrames;
 
                 // Set to the first frame of this animation, and prepare frameIterator to start from the second frame when AnimateEnemy() next runs
                 currentFrame = summary.StateAnimFrames[0];
@@ -694,6 +704,9 @@ namespace DaggerfallWorkshop
                     break;
                 case MobileStates.RangedAttack2:
                     anims = (summary.Enemy.HasRangedAttack2) ? (MobileAnimation[])EnemyBasics.RangedAttack2Anims.Clone() : null;
+                    break;
+                case MobileStates.Spell:
+                    anims = (summary.Enemy.HasSpellAnimation) ? (MobileAnimation[])EnemyBasics.RangedAttack1Anims.Clone() : (MobileAnimation[])EnemyBasics.PrimaryAttackAnims.Clone();
                     break;
                 default:
                     return null;

--- a/Assets/Scripts/Utility/EnemyBasics.cs
+++ b/Assets/Scripts/Utility/EnemyBasics.cs
@@ -234,6 +234,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "D",
                 SoulPts = 1000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3, 1 },
+                SpellAnimFrames = new int[] { 0, 1, 2, 3, 1 },
                 Team = MobileTeams.Magic,
             },
 
@@ -812,6 +813,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "I",
                 SoulPts = 30000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3 },
+                SpellAnimFrames = new int[] { 0, 0, 0, 0, 0, 0 },
                 Team = MobileTeams.Undead,
             },
 
@@ -918,6 +920,8 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames4 = new int[] { 0, 1, -1, 3, 2, -1, 3, 2, 1, 0 }, // Not used in classic. Fight stance used instead.
                 ChanceForAttack5 = 20,
                 PrimaryAttackAnimFrames5 = new int[] { 0, -1, 4, 5, -1, 4, 5, 0 }, // Not used in classic. Spell animation played instead.
+                HasSpellAnimation = true,
+                SpellAnimFrames = new int[] { 0, 0, 1, 2, 3, 3, 3 },
                 Team = MobileTeams.Orcs,
             },
 
@@ -985,6 +989,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "I",
                 SoulPts = 30000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, -1, 3 },
+                SpellAnimFrames = new int[] { 0, 0, 0, 0, 0 },
                 Team = MobileTeams.Undead,
             },
 
@@ -1058,6 +1063,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3, -1, 4, 5, 0 },
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { -1, 4, 5, 0 },
+                SpellAnimFrames = new int[] { 1, 1, 3, 3 },
                 Team = MobileTeams.Daedra,
             },
 
@@ -1094,6 +1100,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2, 3, -1, 4 },
                 ChanceForAttack2 = 50,
                 PrimaryAttackAnimFrames2 = new int[] { 3, -1, 4 },
+                SpellAnimFrames = new int[] { 1, 1, 3, 3 },
                 Team = MobileTeams.Daedra,
             },
 
@@ -1132,6 +1139,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 4, -1, 5, 0 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 1, -1, 2, 3, 4, -1, 5, 0, 4, -1, 5, 0 },
+                SpellAnimFrames = new int[] { 1, 1, 3, 3 },
                 Team = MobileTeams.Daedra,
             },
 
@@ -1166,6 +1174,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "Q",
                 SoulPts = 70000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, 3, -1, 4, 5 },
+                SpellAnimFrames = new int[] { 1, 1, 5, 5 },
                 Team = MobileTeams.Undead,
             },
 
@@ -1200,6 +1209,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "Q",
                 SoulPts = 150000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, -1, 2 },
+                SpellAnimFrames = new int[] { 0, 1, 2 },
                 Team = MobileTeams.Daedra,
             },
 
@@ -1234,6 +1244,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "Q",
                 SoulPts = 100000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 2, 3, -1, 4, 5 },
+                SpellAnimFrames = new int[] { 1, 1, 5, 5 },
                 Team = MobileTeams.Undead,
             },
 
@@ -1272,6 +1283,7 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 3, -1, 4, 0, -1, 4, 3, -1, 4, 0, -1, 4, 3 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 1, -1, 2, 1, 0, 1, -1, 2, 1, 0 },
+                SpellAnimFrames = new int[] { 1, 1, 3, 3 },
                 Team = MobileTeams.Daedra,
             },
 
@@ -1307,6 +1319,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "S",
                 SoulPts = 100000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 1, 2, -1, 3, 4, 4 },
+                SpellAnimFrames = new int[] { 0, 1, 2, 3, 4 },
                 Team = MobileTeams.Undead,
             },
 
@@ -1341,6 +1354,7 @@ namespace DaggerfallWorkshop.Utility
                 LootTableKey = "S",
                 SoulPts = 250000,
                 PrimaryAttackAnimFrames = new int[] { 0, 1, 1, 2, -1, 3, 4, 4 },
+                SpellAnimFrames = new int[] { 0, 1, 2, 3, 4 },
                 Team = MobileTeams.Undead,
             },
 
@@ -1647,6 +1661,8 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 0, 1, -1, 3, 2, 1, 0 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, -1, 5, 4, 0 },
+                HasSpellAnimation = true,
+                SpellAnimFrames = new int[] { 0, 1, 2, 3, 3 },
                 Team = MobileTeams.KnightsAndMages,
             },
 
@@ -1677,6 +1693,8 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, 1, -1, 2, 2, 1, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                HasSpellAnimation = true,
+                SpellAnimFrames = new int[] { 0, 1, 2, 3, 3 },
                 Team = MobileTeams.KnightsAndMages,
             },
 
@@ -1707,6 +1725,8 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                HasSpellAnimation = true,
+                SpellAnimFrames = new int[] { 0, 1, 2, 3, 3 },
                 Team = MobileTeams.KnightsAndMages,
             },
 
@@ -1764,6 +1784,8 @@ namespace DaggerfallWorkshop.Utility
                 PrimaryAttackAnimFrames2 = new int[] { 0, 1, -1, 3, 2, 1, 0 },
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 0, -1, 5, 4, 0 },
+                HasSpellAnimation = true,
+                SpellAnimFrames = new int[] { 0, 1, 2, 3, 3 },
                 Team = MobileTeams.KnightsAndMages,
             },
 
@@ -1794,6 +1816,8 @@ namespace DaggerfallWorkshop.Utility
                 ChanceForAttack3 = 33,
                 PrimaryAttackAnimFrames3 = new int[] { 4, -1, 5, 0, 0, 1, -1, 2, 3, 4, -1, 5, 0 },
                 RangedAttackAnimFrames = new int[] { 3, 2, 0, 0, 0, -1, 1, 1, 2, 3 },
+                HasSpellAnimation = true,
+                SpellAnimFrames = new int[] { 0, 1, 2, 3, 3 },
                 Team = MobileTeams.Criminals,
             },
 


### PR DESCRIPTION
Here is the start of enemy casting.

Implemented:
- Enemies assigned spells and spell points like in classic
- Enemies shoot a ranged spell like in classic

Not implemented:
- Spell casting animations
- Touch spells
- Some additional AI logic present in classic (don't cast a spell while it is still active on the target, intelligent enemies may stop casting when target has reflected a spell)

I'm sending a PR now because there is an issue maybe you can help with. For some reason enemies only cast a single spell, then stop. The logic in EnemyMotor.cs is correctly continuing to select spells for casting but something is stopping any more than 1 from shooting.

I had to make a few adjustments related to `EntityEffectManager.cs`:

- The `IsEnemyEntity` was always failing, because everything but the player is just type `None`.
- The  `EntityEffectManager` peered with enemies needed the missile prefabs assigned for instantiation.