### PR TITLE
Refine enemy attack range

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -119,11 +119,8 @@ namespace DaggerfallWorkshop.Game
             // Are we in range and facing target? Then start attack.
             if (senses.TargetInSight)
             {
-                // Take the speed of movement during the attack animation into account when deciding if to attack
-                EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
-                float attackSpeed = ((entity.Stats.LiveSpeed + PlayerSpeedChanger.dfWalkBase) / PlayerSpeedChanger.classicToUnitySpeedUnitRatio) / EnemyMotor.AttackSpeedDivisor;
-
-                if (senses.DistanceToTarget >= MeleeDistance + attackSpeed)
+                // Take the rate of target approach into account when deciding if to attack
+                if (senses.DistanceToTarget >= MeleeDistance + senses.TargetRateOfApproach)
                     return;
 
                 // Set melee animation state

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -41,6 +41,8 @@ namespace DaggerfallWorkshop.Game
         Vector3 directionToTarget;
         float distanceToPlayer;
         float distanceToTarget;
+        float lastDistanceToTarget;
+        float targetRateOfApproach;
         Vector3 lastKnownTargetPos;
         DaggerfallActionDoor actionDoor;
         float distanceToActionDoor;
@@ -131,6 +133,12 @@ namespace DaggerfallWorkshop.Game
         {
             get { return questBehaviour; }
             set { questBehaviour = value; }
+        }
+
+        public float TargetRateOfApproach
+        {
+            get { return targetRateOfApproach; }
+            set { targetRateOfApproach = value; }
         }
 
         void Start()
@@ -251,6 +259,14 @@ namespace DaggerfallWorkshop.Game
                         entityBehaviour.Target.Target = entityBehaviour;
                     }
                 }
+
+                // Compare change in target position to give AI some ability to read opponent's movements
+                if (lastDistanceToTarget != 0)
+                {
+                    targetRateOfApproach = (lastDistanceToTarget - distanceToTarget);
+                }
+
+                lastDistanceToTarget = distanceToTarget;
             }
 
             if (Player != null)


### PR DESCRIPTION
A while ago I set enemies to attack from somewhat beyond their actual range. I think I overdid it, though, and while watching a Youtube video I got the impression the player was learning to wait until the enemy swung, then run in and hit in the cooldown afterwards. That's not necessarily a bad thing, but I don't want enemies to be too easy to predict. This PR reduces the extra distance and also actually takes change of target position into consideration, so there shouldn't be enemies attacking from well out of range when the player is stationary, for example, something that I could see happen with the previous implementation (the one currently in master).