### PR TITLE
Fix ResetWarDataForRegion using regionId - 1

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1623,14 +1623,14 @@ namespace DaggerfallWorkshop.Game.Entity
             {
                 int regionID = faction.region;
 
-                if (regionID > 0 && faction.type == (int)FactionFile.FactionTypes.Province)
+                if (regionID != -1 && faction.type == (int)FactionFile.FactionTypes.Province)
                 {
-                    regionData[regionID - 1].Flags[(int)RegionDataFlags.WarBeginning] = false;
-                    regionData[regionID - 1].Flags[(int)RegionDataFlags.WarOngoing] = false;
-                    regionData[regionID - 1].Flags[(int)RegionDataFlags.WarWon] = false;
-                    regionData[regionID - 1].Flags[(int)RegionDataFlags.WarLost] = false;
-                    regionData[regionID - 1].Flags2[flagsToFlags2Map[(int)RegionDataFlags.WarBeginning]] = false;
-                    regionData[regionID - 1].Values[(int)RegionDataFlags.WarOngoing] = 0;
+                    regionData[regionID].Flags[(int)RegionDataFlags.WarBeginning] = false;
+                    regionData[regionID].Flags[(int)RegionDataFlags.WarOngoing] = false;
+                    regionData[regionID].Flags[(int)RegionDataFlags.WarWon] = false;
+                    regionData[regionID].Flags[(int)RegionDataFlags.WarLost] = false;
+                    regionData[regionID].Flags2[flagsToFlags2Map[(int)RegionDataFlags.WarBeginning]] = false;
+                    regionData[regionID].Values[(int)RegionDataFlags.WarOngoing] = 0;
                 }
             }
         }


### PR DESCRIPTION
The comparison against -1 keeps the function from running on "Random Ruler", which has region of -1. (Regions of -1 in FACTION.TXT are the one exception that doesn't get corrected down 1 to become 0-based. This is already accounted for in the import.)

The problem was the

`regionData[regionID - 1]`

statements, written back when the faction IDs were 1-based. I think I only looked for `regionID + 1` when fixing these and didn't think to check for `regionID - 1`.