### PR TITLE
Catch exception in GetGuild method and just log it as it can happen due to bad faction data.

### DIFF
--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -208,11 +208,17 @@ namespace DaggerfallWorkshop.Game.Guilds
         /// </summary>
         public Guild GetGuild(int factionId)
         {
-            FactionFile.GuildGroups guildGroup = GetGuildGroup(factionId);
-            if (guildGroup == FactionFile.GuildGroups.None)
+            try {
+                FactionFile.GuildGroups guildGroup = GetGuildGroup(factionId);
+                if (guildGroup == FactionFile.GuildGroups.None)
+                    return guildNotMember;
+                else
+                    return GetGuild(guildGroup, factionId);
+            // Catch erroneous faction data entries. (e.g. #91)
+            } catch (ArgumentOutOfRangeException e) {
+                DaggerfallUnity.LogMessage(e.Message, true);
                 return guildNotMember;
-            else
-                return GetGuild(guildGroup, factionId);
+            }
         }
 
         private FactionFile.GuildGroups GetGuildGroup(int factionId)


### PR DESCRIPTION
Unfortunately faction data has some erroneous entries that are marked as guilds (Knightly Orders) and don't match a valid Deity. This was happening when trying to talk to anyone if the PlayerEnterExit.factionID got set to one of these factions.