### PR TITLE
Import books from modding locations

### DIFF
--- a/Assets/Scripts/API/BookFile.cs
+++ b/Assets/Scripts/API/BookFile.cs
@@ -102,6 +102,17 @@ namespace DaggerfallConnect.Arena2
         }
 
         /// <summary>
+        /// Open a book file from binary data.
+        /// </summary>
+        /// <param name="data">Byte array to parse as a book file.</param>
+        /// <param name="name">Name to describe book.</param>
+        public void OpenBook(byte[] data, string name)
+        {
+            bookFile.Load(data, name);
+            ReadHeader();
+        }
+
+        /// <summary>
         /// Reads the TextResource tokens for this page record.
         /// </summary>
         /// <param name="page">Page index.</param>

--- a/Assets/Scripts/API/FileProxy.cs
+++ b/Assets/Scripts/API/FileProxy.cs
@@ -103,9 +103,7 @@ namespace DaggerfallConnect.Utility
         /// <param name="name">Name, filename, or path  to describe memory buffer.</param>
         public FileProxy(byte[] data, string name)
         {
-            fileBuffer = data;
-            managedFilePath = name;
-            fileUsage = FileUsage.UseMemory;
+            Load(data, name);
         }
 
         #endregion
@@ -233,6 +231,18 @@ namespace DaggerfallConnect.Utility
                 default:
                     return LoadDisk(filePath, fileAccess, fileShare);
             }
+        }
+
+        /// <summary>
+        /// Load a binary array.
+        /// </summary>
+        /// <param name="data">Byte array to assign (usage will be set to FileUsage.useMemory).</param>
+        /// <param name="name">Name, filename, or path  to describe memory buffer.</param>
+        public void Load(byte[] data, string name)
+        {
+            fileBuffer = data;
+            managedFilePath = name;
+            fileUsage = FileUsage.UseMemory;
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/AssetInjection/BookReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/BookReplacement.cs
@@ -1,0 +1,75 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: TheLacus
+// Contributors:
+// 
+// Notes:
+//
+
+using System.IO;
+using UnityEngine;
+using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop.Game.Utility.ModSupport;
+
+namespace DaggerfallWorkshop.Utility.AssetInjection
+{
+    /// <summary>
+    /// Handles import and injection of custom books with the purpose of providing modding support.
+    /// Book files are imported from mod bundles with load order or loaded directly from disk.
+    /// </summary>
+    public static class BookReplacement
+    {
+        #region Fields & Properties
+
+        static readonly string booksPath = Path.Combine(Application.streamingAssetsPath, "Books");
+
+        /// <summary>
+        /// Path to custom books on disk.
+        /// </summary>
+        public static string BooksPath
+        {
+            get { return booksPath; }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Seeks book data from mods.
+        /// If a book file with the given name is found, data is loaded on the given book instance.
+        /// If no data is found, the instance is left unaltered.
+        /// </summary>
+        /// <param name="name">Name of book including .TXT extension</param>
+        /// <param name="book">Book instance on which imported data is loaded.</param>
+        /// <returns>True if book is found.</returns>
+        public static bool TryImportBook(string name, BookFile book)
+        {
+            if (DaggerfallUnity.Settings.MeshAndTextureReplacement)
+            {
+                // Seek from loose files
+                string path = Path.Combine(booksPath, name);
+                if (File.Exists(path))
+                {
+                    book.OpenBook(File.ReadAllBytes(path), name);
+                    return true;
+                }
+
+                // Seek from mods
+                TextAsset textAsset;
+                if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(name, false, out textAsset))
+                {
+                    book.OpenBook(textAsset.bytes, name);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Utility/AssetInjection/BookReplacement.cs.meta
+++ b/Assets/Scripts/Utility/AssetInjection/BookReplacement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4626ff54c0a7c534484dca27f8af6894
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/TextProvider.cs
+++ b/Assets/Scripts/Utility/TextProvider.cs
@@ -20,6 +20,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Items;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop.Utility
 {
@@ -184,7 +185,8 @@ namespace DaggerfallWorkshop.Utility
 
         public virtual bool OpenBook(string name)
         {
-            if (!bookFile.OpenBook(DaggerfallUnity.Instance.Arena2Path, name))
+            if (!BookReplacement.TryImportBook(name, bookFile) &&
+                !bookFile.OpenBook(DaggerfallUnity.Instance.Arena2Path, name))
                 return false;
 
             isBookOpen = true;

--- a/Assets/StreamingAssets/Books.meta
+++ b/Assets/StreamingAssets/Books.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05c8cb313b541b84aa298cf89e0f36c2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Books/.gitignore
+++ b/Assets/StreamingAssets/Books/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything in this directory
+*
+# Except these files
+!.gitignore
+!readme.txt
+!readme.txt.meta


### PR DESCRIPTION
BOK*.TXT files are seeked from StreamingAssets/Books and inside mod bundles.
This allows to provide overrides via the asset-injection framework without replacing core files on disk.