### PR TITLE
Re-enable sneaking while riding

### DIFF
--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -47,9 +47,9 @@ namespace DaggerfallWorkshop.Game
         /// <param name="speed"></param>
         public void HandleInputSpeedAdjustment(ref float speed)
         {
-            if (!playerMotor.IsRiding && playerMotor.IsGrounded)
+            if (playerMotor.IsGrounded)
             {
-                if (InputManager.Instance.HasAction(InputManager.Actions.Run))
+                if (InputManager.Instance.HasAction(InputManager.Actions.Run) && !playerMotor.IsRiding)
                 {
                     try
                     {


### PR DESCRIPTION
Fixes a regression in which sneaking was disabled while riding a horse or cart. Midknightprince has been asking on the forums about this.

https://forums.dfworkshop.net/viewtopic.php?f=19&t=1288&p=16230#p16230

I think the change came when @MeteoricDragon moved player speed changing out to its own class. Perhaps he thought it was a mistake that you can sneak on the horse/cart, but it's possible in classic and there is even a specific sound effect that plays while sneaking on the horse. Or it may have just been an oversight, and not intentionally changed.