### PR TITLE
Fix incorrect starting skill values

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -566,13 +566,6 @@ namespace DaggerfallWorkshop.Game.Entity
 
             BackStory = character.backStory;
 
-            SetCurrentLevelUpSkillSum();
-
-            if (startingLevelUpSkillSum <= 0) // new character
-            {
-                startingLevelUpSkillSum = currentLevelUpSkillSum;
-            }
-
             if (maxHealth <= 0)
                 this.maxHealth = FormulaHelper.RollMaxHealth(level, career.HitPointsPerLevel);
             else

--- a/Assets/Scripts/Game/UserInterface/SkillsRollout.cs
+++ b/Assets/Scripts/Game/UserInterface/SkillsRollout.cs
@@ -33,11 +33,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         const int minPrimarySkill = 28;
         const int minMajorSkill = 18;
-        const int minMinorSkill = 12;
+        const int minMinorSkill = 13;
         const int minPrimaryBonusRoll = 0;
         const int maxPrimaryBonusRoll = 3;
         const int minMajorBonusRoll = 0;
-        const int maxMajorBonusRoll = 4;
+        const int maxMajorBonusRoll = 3;
         const int minMinorBonusRoll = 0;
         const int maxMinorBonusRoll = 3;
 

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -397,6 +397,10 @@ namespace DaggerfallWorkshop.Game.Utility
             // Apply biography effects to player entity
             BiogFile.ApplyEffects(characterDocument.biographyEffects, playerEntity);
 
+            // Assign starting level up skill sum
+            playerEntity.SetCurrentLevelUpSkillSum();
+            playerEntity.StartingLevelUpSkillSum = playerEntity.CurrentLevelUpSkillSum;
+
             // Setup bank accounts and houses
             Banking.DaggerfallBankManager.SetupAccounts();
             Banking.DaggerfallBankManager.SetupHouses();
@@ -531,6 +535,7 @@ namespace DaggerfallWorkshop.Game.Utility
             // Assign data to player entity
             PlayerEntity playerEntity = FindPlayerEntity();
             playerEntity.AssignCharacter(characterDocument, characterRecord.ParsedData.level, characterRecord.ParsedData.maxHealth, false);
+            playerEntity.SetCurrentLevelUpSkillSum();
 
             // Assign biography modifiers
             playerEntity.BiographyResistDiseaseMod = saveVars.BiographyResistDiseaseMod;


### PR DESCRIPTION
Fix for https://forums.dfworkshop.net/viewtopic.php?f=24&t=1366.

The issue: `startingSkillSum`, used to compute when the character gains a level, was being set in DF Unity in `AssignCharacter()`, which was being computed before skills from biography bonuses were added. In classic, it isn't computer until after character creation finishes. This meant not only that the skill bonuses from the character background (if they were a primary, major or minor skill) were being considered as skills raised during active gameplay, getting you to levels 2 and 3 sooner, but it also meant the player would have a lower `startingSkillSum` than they should have, so they would always level up a bit sooner than they should have been.