### PR TITLE
Stop fast travel countdown when canceling

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -369,6 +369,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
+        public override void CancelWindow()
+        {
+            doFastTravel = false;
+            base.CancelWindow();
+        }
+
         /// <summary>
         /// Button handler for travel-with-incubating-disease confirmation pop up.
         /// </summary>
@@ -402,6 +408,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public void ExitButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
         {
+            doFastTravel = false;
             DaggerfallUI.Instance.UserInterfaceManager.PopWindow();
         }
 


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=742.

It's not realistic that you can cancel and "turn back time" after days have already supposedly passed, but it's good enough for now and is convenient, anyway.

As an aside, in classic, the background world events are actually being run for each day as the counter goes down, so it isn't just decorative like it is for us. And so of course, you can't cancel. We could do that, too, and it might speed up loading of a new location, although as I recall the background event processing doesn't really take up significant time. If we do that, we'd need to remove the ability to cancel, or store all changes to be undone when canceling (would probably be a pain to do that). Also it would be kind of cool if canceling just stopped the countdown where it was, leaving the player somewhere mid-way on the trip.