### PR TITLE
Geographic context backgrounds & HUD arrow count

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -47,6 +47,7 @@ HelmAndShieldMaterialDisplay=0
 InteractionModeIcon = minimal
 AccelerateUICopyTexture=False
 SDFFontRendering=True
+EnableGeographicBackgrounds=False
 
 [Spells]
 EnableSpellLighting=True

--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -45,6 +45,7 @@ EnableVitalsIndicators=True
 EnableModernConversationStyleInTalkWindow=False
 HelmAndShieldMaterialDisplay=0
 InteractionModeIcon = minimal
+EnableArrowCounter=True
 AccelerateUICopyTexture=False
 SDFFontRendering=True
 EnableGeographicBackgrounds=False

--- a/Assets/Scripts/Game/UserInterface/PaperDoll.cs
+++ b/Assets/Scripts/Game/UserInterface/PaperDoll.cs
@@ -231,7 +231,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             }
         }
 
-        char[] regionBackgroundChars =
+        readonly char[] regionBackgroundIdxChars =
             {'3','1','2','2', '2','0','5','1', '5','2','1','1', '2','2','2','0', '2','0','2','2', '3','0','5','6', '2','2','2','2', '0','0','0','0',
              '0','6','6','6', '0','6','6','0', '6','0','0','3', '3','3','3','3', '3','5','5','5', '5','1','3','3', '3','2','0','0', '2','3' };
 
@@ -245,18 +245,18 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 PlayerEnterExit playerEnterExit = GameManager.Instance.PlayerEnterExit;
                 DFPosition position = playerGPS.CurrentMapPixel;
                 int region = DaggerfallUnity.Instance.ContentReader.MapFileReader.GetPoliticIndex(position.X, position.Y) - 128;
-                if (region < 0 || region >= DaggerfallUnity.Instance.ContentReader.MapFileReader.RegionCount || region >= regionBackgroundChars.Length)
+                if (region < 0 || region >= DaggerfallUnity.Instance.ContentReader.MapFileReader.RegionCount || region >= regionBackgroundIdxChars.Length)
                     return entity.RaceTemplate.PaperDollBackground;
 
                 // Set background based on location.
                 if (playerGPS.IsPlayerInTown(true))
-                    return "SCBG04I0.IMG";                                      // Town
+                    return "SCBG04I0.IMG";                                          // Town
                 else if (playerEnterExit.IsPlayerInsideDungeon)
-                    return "SCBG07I0.IMG";                                      // Dungeon
+                    return "SCBG07I0.IMG";                                          // Dungeon
                 else if (playerGPS.CurrentLocation.MapTableData.LocationType == DFRegion.LocationTypes.Graveyard && playerGPS.IsPlayerInLocationRect)
-                    return "SCBG08I0.IMG";                                      // Graveyard
+                    return "SCBG08I0.IMG";                                          // Graveyard
                 else                            
-                    return "SCBG0" + regionBackgroundChars[region] + "I0.IMG";  // Region
+                    return "SCBG0" + regionBackgroundIdxChars[region] + "I0.IMG";   // Region
             }
             else
             {

--- a/Assets/Scripts/Game/UserInterface/PaperDoll.cs
+++ b/Assets/Scripts/Game/UserInterface/PaperDoll.cs
@@ -237,6 +237,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         string GetPaperDollBackground(PlayerEntity entity)
         {
+            // TODO: If player is were-creature and has transformed, use entity.RaceTemplate.TransformedPaperDollBackground regardless of geo backgrounds
+
             if (DaggerfallUnity.Settings.EnableGeographicBackgrounds)
             {
                 PlayerGPS playerGPS = GameManager.Instance.PlayerGPS;
@@ -248,16 +250,18 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
                 // Set background based on location.
                 if (playerGPS.IsPlayerInTown(true))
-                    return "SCBG04I0.IMG";
+                    return "SCBG04I0.IMG";                                      // Town
                 else if (playerEnterExit.IsPlayerInsideDungeon)
-                    return "SCBG07I0.IMG";
+                    return "SCBG07I0.IMG";                                      // Dungeon
                 else if (playerGPS.CurrentLocation.MapTableData.LocationType == DFRegion.LocationTypes.Graveyard && playerGPS.IsPlayerInLocationRect)
-                    return "SCBG08I0.IMG";
-                else
-                    return "SCBG0" + regionBackgroundChars[region] + "I0.IMG";
+                    return "SCBG08I0.IMG";                                      // Graveyard
+                else                            
+                    return "SCBG0" + regionBackgroundChars[region] + "I0.IMG";  // Region
             }
             else
+            {
                 return entity.RaceTemplate.PaperDollBackground;
+            }
         }
 
         void BlitCloakInterior(PlayerEntity entity)

--- a/Assets/Scripts/Game/UserInterface/PaperDoll.cs
+++ b/Assets/Scripts/Game/UserInterface/PaperDoll.cs
@@ -232,7 +232,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         }
 
         char[] regionBackgroundChars =
-            {'3','2','2','2', '2','0','5','1', '5','2','1','1', '2','2','2','0', '2','0','2','2', '3','0','5','6', '2','2','2','2', '0','0','0','0',
+            {'3','1','2','2', '2','0','5','1', '5','2','1','1', '2','2','2','0', '2','0','2','2', '3','0','5','6', '2','2','2','2', '0','0','0','0',
              '0','6','6','6', '0','6','6','0', '6','0','0','3', '3','3','3','3', '3','5','5','5', '5','1','3','3', '3','2','0','0', '2','3' };
 
         string GetPaperDollBackground(PlayerEntity entity)
@@ -247,11 +247,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     return entity.RaceTemplate.PaperDollBackground;
 
                 // Set background based on location.
-                if (playerGPS.IsPlayerInTown())
+                if (playerGPS.IsPlayerInTown(true))
                     return "SCBG04I0.IMG";
                 else if (playerEnterExit.IsPlayerInsideDungeon)
                     return "SCBG07I0.IMG";
-                else if (playerGPS.CurrentLocation.MapTableData.LocationType == DFRegion.LocationTypes.Graveyard)
+                else if (playerGPS.CurrentLocation.MapTableData.LocationType == DFRegion.LocationTypes.Graveyard && playerGPS.IsPlayerInLocationRect)
                     return "SCBG08I0.IMG";
                 else
                     return "SCBG0" + regionBackgroundChars[region] + "I0.IMG";

--- a/Assets/Scripts/Game/UserInterface/PaperDoll.cs
+++ b/Assets/Scripts/Game/UserInterface/PaperDoll.cs
@@ -221,13 +221,43 @@ namespace DaggerfallWorkshop.Game.UserInterface
         // Update player background panel
         void RefreshBackground(PlayerEntity entity)
         {
-            if (lastBackgroundName != entity.RaceTemplate.PaperDollBackground)
+            string backgroundName = GetPaperDollBackground(entity);
+            if (lastBackgroundName != backgroundName)
             {
-                Texture2D texture = ImageReader.GetTexture(entity.RaceTemplate.PaperDollBackground, 0, 0, false);
+                Texture2D texture = ImageReader.GetTexture(backgroundName, 0, 0, false);
                 backgroundPanel.BackgroundTexture = ImageReader.GetSubTexture(texture, backgroundSubRect, backgroundFullSize);
                 backgroundPanel.Size = new Vector2(paperDollWidth, paperDollHeight);
-                lastBackgroundName = entity.RaceTemplate.PaperDollBackground;
+                lastBackgroundName = backgroundName;
             }
+        }
+
+        char[] regionBackgroundChars =
+            {'3','2','2','2', '2','0','5','1', '5','2','1','1', '2','2','2','0', '2','0','2','2', '3','0','5','6', '2','2','2','2', '0','0','0','0',
+             '0','6','6','6', '0','6','6','0', '6','0','0','3', '3','3','3','3', '3','5','5','5', '5','1','3','3', '3','2','0','0', '2','3' };
+
+        string GetPaperDollBackground(PlayerEntity entity)
+        {
+            if (DaggerfallUnity.Settings.EnableGeographicBackgrounds)
+            {
+                PlayerGPS playerGPS = GameManager.Instance.PlayerGPS;
+                PlayerEnterExit playerEnterExit = GameManager.Instance.PlayerEnterExit;
+                DFPosition position = playerGPS.CurrentMapPixel;
+                int region = DaggerfallUnity.Instance.ContentReader.MapFileReader.GetPoliticIndex(position.X, position.Y) - 128;
+                if (region < 0 || region >= DaggerfallUnity.Instance.ContentReader.MapFileReader.RegionCount || region >= regionBackgroundChars.Length)
+                    return entity.RaceTemplate.PaperDollBackground;
+
+                // Set background based on location.
+                if (playerGPS.IsPlayerInTown())
+                    return "SCBG04I0.IMG";
+                else if (playerEnterExit.IsPlayerInsideDungeon)
+                    return "SCBG07I0.IMG";
+                else if (playerGPS.CurrentLocation.MapTableData.LocationType == DFRegion.LocationTypes.Graveyard)
+                    return "SCBG08I0.IMG";
+                else
+                    return "SCBG0" + regionBackgroundChars[region] + "I0.IMG";
+            }
+            else
+                return entity.RaceTemplate.PaperDollBackground;
         }
 
         void BlitCloakInterior(PlayerEntity entity)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -101,6 +101,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox crosshair;
         Checkbox vitalsIndicators;
         Checkbox freeScaling;
+        Checkbox arrowCounter;
         HorizontalSlider interactionModeIcon;
         Checkbox showQuestJournalClocksAsCountdown;
         Checkbox inventoryInfoPanel;
@@ -240,6 +241,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             interactionModeIcon = AddSlider(leftPanel, "interactionModeIcon",
                 Enum.IsDefined(typeof(InteractionModeIconModes), DaggerfallUnity.Settings.InteractionModeIcon) ? (int)Enum.Parse(typeof(InteractionModeIconModes), DaggerfallUnity.Settings.InteractionModeIcon) : 0,
                 Enum.GetNames(typeof(InteractionModeIconModes)));
+            arrowCounter = AddCheckbox(leftPanel, "arrowCounter", DaggerfallUnity.Settings.EnableArrowCounter);
 
             y = 0;
 
@@ -347,6 +349,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.Crosshair = crosshair.IsChecked;
             DaggerfallUnity.Settings.InteractionModeIcon = ((InteractionModeIconModes)interactionModeIcon.Value).ToString();
             DaggerfallUnity.Settings.EnableVitalsIndicators = vitalsIndicators.IsChecked;
+            DaggerfallUnity.Settings.EnableArrowCounter = arrowCounter.IsChecked;
 
             DaggerfallUnity.Settings.FreeScaling = freeScaling.IsChecked;
             DaggerfallUnity.Settings.ShowQuestJournalClocksAsCountdown = showQuestJournalClocksAsCountdown.IsChecked;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -107,7 +107,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox enhancedItemLists;  
         Checkbox enableModernConversationStyleInTalkWindow;
         HorizontalSlider helmAndShieldMaterialDisplay;
-        
+        Checkbox geographicBackgrounds;
 
         // Enhancements
         Checkbox modSystem;
@@ -252,6 +252,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             enableModernConversationStyleInTalkWindow = AddCheckbox(rightPanel, "enableModernConversationStyleInTalkWindow", DaggerfallUnity.Settings.EnableModernConversationStyleInTalkWindow);
             helmAndShieldMaterialDisplay = AddSlider(rightPanel, "helmAndShieldMaterialDisplay",
                 DaggerfallUnity.Settings.HelmAndShieldMaterialDisplay, "off", "noLeatChai", "noLeat", "on");
+            geographicBackgrounds = AddCheckbox(rightPanel, "geographicBackgrounds", DaggerfallUnity.Settings.EnableGeographicBackgrounds);
         }
 
         private void Enhancements(Panel leftPanel, Panel rightPanel)
@@ -352,7 +353,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.EnableInventoryInfoPanel = inventoryInfoPanel.IsChecked;
             DaggerfallUnity.Settings.EnableEnhancedItemLists = enhancedItemLists.IsChecked;
             DaggerfallUnity.Settings.EnableModernConversationStyleInTalkWindow = enableModernConversationStyleInTalkWindow.IsChecked;
-            DaggerfallUnity.Settings.HelmAndShieldMaterialDisplay = helmAndShieldMaterialDisplay.ScrollIndex;        
+            DaggerfallUnity.Settings.HelmAndShieldMaterialDisplay = helmAndShieldMaterialDisplay.ScrollIndex;
+            DaggerfallUnity.Settings.EnableGeographicBackgrounds = geographicBackgrounds.IsChecked;
 
             /* Enhancements */
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -150,9 +150,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             questDebugger.AutoSize = AutoSizeModes.ScaleToFit;
             ParentPanel.Components.Add(questDebugger);
 
-            arrowCountTextLabel.HorizontalAlignment = HorizontalAlignment.Left;
-            arrowCountTextLabel.Position = new Vector2(0, 192);
-            arrowCountTextLabel.TextColor = new Color(0.4f, 0.4f, 0.4f);
+            arrowCountTextLabel.HorizontalAlignment = HorizontalAlignment.Center;
+            arrowCountTextLabel.Position = new Vector2(0, 194);
+            arrowCountTextLabel.TextColor = new Color(0.6f, 0.6f, 0.6f);
             arrowCountTextLabel.ShadowPosition = Vector2.zero;
             arrowCountTextLabel.TextScale = 0.75f;
             NativePanel.Components.Add(arrowCountTextLabel);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -17,6 +17,7 @@ using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Items;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -30,6 +31,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         PopupText popupText = new PopupText();
         TextLabel midScreenTextLabel = new TextLabel();
+        TextLabel arrowCountTextLabel = new TextLabel();
         HUDCrosshair crosshair = new HUDCrosshair();
         HUDVitals vitals = new HUDVitals();
         HUDCompass compass = new HUDCompass();
@@ -54,6 +56,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public bool ShowLocalQuestPlaces { get; set; }
         public bool ShowEscortingFaces { get; set; }
         public bool ShowActiveSpells { get; set; }
+        public bool ShowArrowCount { get; set; }
 
         public PopupText PopupText
         {
@@ -109,6 +112,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             ShowEscortingFaces = true;
             ShowLocalQuestPlaces = true;
             ShowActiveSpells = true;
+            ShowArrowCount = DaggerfallUnity.Settings.EnableArrowCounter;
 
             // Get references
             //player = GameObject.FindGameObjectWithTag("Player");
@@ -145,6 +149,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             questDebugger.Size = new Vector2(640, 400);
             questDebugger.AutoSize = AutoSizeModes.ScaleToFit;
             ParentPanel.Components.Add(questDebugger);
+
+            arrowCountTextLabel.HorizontalAlignment = HorizontalAlignment.Left;
+            arrowCountTextLabel.Position = new Vector2(0, 192);
+            arrowCountTextLabel.TextColor = new Color(0.4f, 0.4f, 0.4f);
+            arrowCountTextLabel.ShadowPosition = Vector2.zero;
+            arrowCountTextLabel.TextScale = 0.75f;
+            NativePanel.Components.Add(arrowCountTextLabel);
         }
 
         public override void Update()
@@ -181,6 +192,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     midScreenTextTimer = -1;
                     midScreenTextLabel.Text = string.Empty;
+                }
+            }
+
+            // Update arrow count if player holding an unsheathed bow
+            arrowCountTextLabel.Enabled = false;
+            if (ShowArrowCount && !GameManager.Instance.WeaponManager.Sheathed)
+            {
+                DaggerfallUnityItem held = GameManager.Instance.PlayerEntity.ItemEquipTable.GetItem(EquipSlots.RightHand);
+                if (held != null && held.ItemGroup == ItemGroups.Weapons &&
+                    (held.TemplateIndex == (int)Weapons.Long_Bow || held.TemplateIndex == (int)Weapons.Short_Bow))
+                {
+                    DaggerfallUnityItem arrows = GameManager.Instance.PlayerEntity.Items.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow);
+                    arrowCountTextLabel.Text = (arrows != null) ? arrows.stackCount.ToString() : "0";
+                    arrowCountTextLabel.Enabled = true;
                 }
             }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -150,12 +150,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             questDebugger.AutoSize = AutoSizeModes.ScaleToFit;
             ParentPanel.Components.Add(questDebugger);
 
-            arrowCountTextLabel.HorizontalAlignment = HorizontalAlignment.Center;
-            arrowCountTextLabel.Position = new Vector2(0, 194);
             arrowCountTextLabel.TextColor = new Color(0.6f, 0.6f, 0.6f);
             arrowCountTextLabel.ShadowPosition = Vector2.zero;
-            arrowCountTextLabel.TextScale = 0.75f;
-            NativePanel.Components.Add(arrowCountTextLabel);
+            ParentPanel.Components.Add(arrowCountTextLabel);
         }
 
         public override void Update()
@@ -203,8 +200,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (held != null && held.ItemGroup == ItemGroups.Weapons &&
                     (held.TemplateIndex == (int)Weapons.Long_Bow || held.TemplateIndex == (int)Weapons.Short_Bow))
                 {
+                    // Arrow count label position is offset to left of compass and centred relative to compass height
+                    // This is done every frame to handle adaptive resolutions
+                    Vector2 arrowLabelPos = compass.Position;
+                    arrowLabelPos.x -= arrowCountTextLabel.TextWidth;
+                    arrowLabelPos.y += compass.Size.y / 2 - arrowCountTextLabel.TextHeight / 2;
+
                     DaggerfallUnityItem arrows = GameManager.Instance.PlayerEntity.Items.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow);
                     arrowCountTextLabel.Text = (arrows != null) ? arrows.stackCount.ToString() : "0";
+                    arrowCountTextLabel.TextScale = NativePanel.LocalScale.x;
+                    arrowCountTextLabel.Position = arrowLabelPos;
                     arrowCountTextLabel.Enabled = true;
                 }
             }

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -109,6 +109,7 @@ namespace DaggerfallWorkshop
         public bool EnableVitalsIndicators { get; set; }
         public bool SDFFontRendering { get; set; }
         public bool EnableGeographicBackgrounds { get; set; }
+        public bool EnableArrowCounter { get; set; }
 
         // [Spells]
         public bool EnableSpellLighting { get; set; }
@@ -208,6 +209,7 @@ namespace DaggerfallWorkshop
             EnableVitalsIndicators = GetBool(sectionGUI, "EnableVitalsIndicators");
             SDFFontRendering = GetBool(sectionGUI, "SDFFontRendering");
             EnableGeographicBackgrounds = GetBool(sectionGUI, "EnableGeographicBackgrounds");
+            EnableArrowCounter = GetBool(sectionGUI, "EnableArrowCounter");
 
             EnableSpellLighting = GetBool(sectionSpells, "EnableSpellLighting");
             EnableSpellShadows = GetBool(sectionSpells, "EnableSpellShadows");
@@ -295,6 +297,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionGUI, "EnableVitalsIndicators", EnableVitalsIndicators);
             SetBool(sectionGUI, "SDFFontRendering", SDFFontRendering);
             SetBool(sectionGUI, "EnableGeographicBackgrounds", EnableGeographicBackgrounds);
+            SetBool(sectionGUI, "EnableArrowCounter", EnableArrowCounter);
 
             SetBool(sectionSpells, "EnableSpellLighting", EnableSpellLighting);
             SetBool(sectionSpells, "EnableSpellShadows", EnableSpellShadows);

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -108,6 +108,7 @@ namespace DaggerfallWorkshop
         public bool AccelerateUICopyTexture { get; set; }
         public bool EnableVitalsIndicators { get; set; }
         public bool SDFFontRendering { get; set; }
+        public bool EnableGeographicBackgrounds { get; set; }
 
         // [Spells]
         public bool EnableSpellLighting { get; set; }
@@ -206,6 +207,7 @@ namespace DaggerfallWorkshop
             AccelerateUICopyTexture = GetBool(sectionGUI, "AccelerateUICopyTexture");
             EnableVitalsIndicators = GetBool(sectionGUI, "EnableVitalsIndicators");
             SDFFontRendering = GetBool(sectionGUI, "SDFFontRendering");
+            EnableGeographicBackgrounds = GetBool(sectionGUI, "EnableGeographicBackgrounds");
 
             EnableSpellLighting = GetBool(sectionSpells, "EnableSpellLighting");
             EnableSpellShadows = GetBool(sectionSpells, "EnableSpellShadows");
@@ -292,6 +294,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionGUI, "AccelerateUICopyTexture", AccelerateUICopyTexture);
             SetBool(sectionGUI, "EnableVitalsIndicators", EnableVitalsIndicators);
             SetBool(sectionGUI, "SDFFontRendering", SDFFontRendering);
+            SetBool(sectionGUI, "EnableGeographicBackgrounds", EnableGeographicBackgrounds);
 
             SetBool(sectionSpells, "EnableSpellLighting", EnableSpellLighting);
             SetBool(sectionSpells, "EnableSpellShadows", EnableSpellShadows);

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -61,6 +61,8 @@ vitalsIndicators,									Vitals Indicators
 vitalsIndicatorsInfo,								Show indicators on vitals bars that display changes in vitals
 interactionModeIcon,                                Interaction Mode Icon
 interactionModeIconInfo,                            Style of contex icon for interaction mode
+arrowCounter,                                       Arrow counter
+arrowCounterInfo,                                   Enable an arrow counter on the HUD when using bows
 freeScaling,										Free scaling
 freeScalingInfo,									UI is stretched as required to fill entire viewport with no regard to aspect ratio
 showQuestJournalClocksAsCountdown,                  Countdown quest journal clocks

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -73,6 +73,8 @@ enableModernConversationStyleInTalkWindow,          TalkWindow Modern Style
 enableModernConversationStyleInTalkWindowInfo,      Modern Conversation Style In TalkWindow
 helmAndShieldMaterialDisplay,                       Helm and Shield Material Display
 helmAndShieldMaterialDisplayInfo,                   Show material for helms and shields in info popups and tooltips
+geographicBackgrounds,                              Geographic backgrounds
+geographicBackgroundsInfo,                          Contextual character backgrounds based on geographic location
 
 modSystem,                                          Mod System
 modSystemInfo,                                      Enable support for mods.


### PR DESCRIPTION
Both are toggled by a new setting.
Arrow count position is centered because I could not figure out how to ensure it was just left of the compass where it looks brilliant. I found that it disappeared under the compass at different resolutions. It would be nice to move it if someone can help.