### PR TITLE
Stacking and equipping

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -523,12 +523,12 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Determines if item is stackable.
         /// Only ingredients, gold pieces and arrows are stackable,
-        /// but enchanted ingredients and quest items are never stackable.
+        /// but equipped items, enchanted ingredients and quest items are never stackable.
         /// </summary>
         /// <returns>True if item stackable.</returns>
         public virtual bool IsStackable()
         {
-            if (IsQuestItem || IsEnchanted)
+            if (IsEquipped || IsQuestItem || IsEnchanted)
                 return false;
             if (IsIngredient ||
                 IsOfTemplate(ItemGroups.Currency, (int)Currency.Gold_pieces) ||

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -539,6 +539,14 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
+        /// Determines if item is a stack.
+        /// </summary>
+        /// <returns><c>true</c> if item is a stack, <c>false</c> otherwise.</returns>
+        public bool IsAStack() 
+        {
+            return stackCount > 1;
+        }
+        /// <summary>
         /// Allow use of item to be implemented by item object and overridden
         /// </summary>
         /// <returns><c>true</c>, if item use was handled, <c>false</c> otherwise.</returns>

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -292,7 +292,10 @@ namespace DaggerfallWorkshop.Game.Items
         /// <param name="position">Position to reorder to.</param>
         public void ReorderItem(DaggerfallUnityItem item, AddPosition position)
         {
-            if (!items.Contains(item.UID) || position == AddPosition.DontCare)
+            if (!items.Contains(item.UID))
+                return;
+            bool couldBeStacked = FindExistingStack(item) != null;
+            if (position == AddPosition.DontCare && !couldBeStacked)
                 return;
 
             RemoveItem(item);
@@ -590,7 +593,9 @@ namespace DaggerfallWorkshop.Game.Items
             int groupIndex = item.GroupIndex;
             foreach (DaggerfallUnityItem checkItem in items.Values)
             {
-                if (checkItem.ItemGroup == itemGroup && checkItem.GroupIndex == groupIndex && checkItem.IsStackable())
+                if (checkItem != item && 
+                    checkItem.ItemGroup == itemGroup && checkItem.GroupIndex == groupIndex && 
+                    checkItem.IsStackable())
                     return checkItem;
             }
 

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -253,6 +253,24 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
+        /// Remove some number of items from a stack, return the removed items or null if not possible.
+        /// Remark: returned items do not belong to any container.
+        /// </summary>
+        /// <returns>The items picked from stack.</returns>
+        /// <param name="stack">Source stack of items</param>
+        /// <param name="numberToPick">Number of items to pick</param>
+        public DaggerfallUnityItem SplitStack(DaggerfallUnityItem stack, int numberToPick) 
+        {
+            // Only handle stack splitting
+            if (!stack.IsAStack() || numberToPick < 1 || numberToPick >= stack.stackCount)
+                return null;
+            DaggerfallUnityItem pickedItems = new DaggerfallUnityItem(stack);
+            pickedItems.stackCount = numberToPick;
+            stack.stackCount -= numberToPick;
+            return pickedItems;
+        }
+
+        /// <summary>
         /// Removes an item from this collection.
         /// </summary>
         /// <param name="item">Item to remove. Must exist inside this collection.</param>

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -254,7 +254,6 @@ namespace DaggerfallWorkshop.Game.Items
 
         /// <summary>
         /// Remove some number of items from a stack, return the removed items or null if not possible.
-        /// Remark: returned items do not belong to any container.
         /// </summary>
         /// <returns>The items picked from stack.</returns>
         /// <param name="stack">Source stack of items</param>
@@ -266,6 +265,7 @@ namespace DaggerfallWorkshop.Game.Items
                 return null;
             DaggerfallUnityItem pickedItems = new DaggerfallUnityItem(stack);
             pickedItems.stackCount = numberToPick;
+            AddItem(pickedItems, noStack: true);
             stack.stackCount -= numberToPick;
             return pickedItems;
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1217,7 +1217,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // Shouldn't happen
                 if (oneItem == null)
                     return;
-                playerEntity.Items.AddItem(oneItem, noStack: true);
+                playerEntity.Items.AddItem(oneItem, preferredOrder, true);
                 item = oneItem;
             }
             // Try to equip the item, and update armour values accordingly

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1210,6 +1210,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
                 return;
             }
+            // If more than one item selected, equip only one
+            if (item.IsAStack())
+            {
+                DaggerfallUnityItem oneItem = playerEntity.Items.SplitStack(item, 1);
+                // Shouldn't happen
+                if (oneItem == null)
+                    return;
+                playerEntity.Items.AddItem(oneItem, noStack: true);
+                item = oneItem;
+            }
             // Try to equip the item, and update armour values accordingly
             List<DaggerfallUnityItem> unequippedList = playerEntity.ItemEquipTable.EquipItem(item);
             if (unequippedList != null)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1212,14 +1212,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             // If more than one item selected, equip only one
             if (item.IsAStack())
-            {
-                DaggerfallUnityItem oneItem = playerEntity.Items.SplitStack(item, 1);
-                // Shouldn't happen
-                if (oneItem == null)
-                    return;
-                playerEntity.Items.AddItem(oneItem, preferredOrder, true);
-                item = oneItem;
-            }
+                item = playerEntity.Items.SplitStack(item, 1);
             // Try to equip the item, and update armour values accordingly
             List<DaggerfallUnityItem> unequippedList = playerEntity.ItemEquipTable.EquipItem(item);
             if (unequippedList != null)


### PR DESCRIPTION
Don't stack equipped items with other items; and when asked to equip a stack, only equip one of the items.

Limitations:
- when unequipping an item, no attempt is done to stack it with other similar items;
- characters may have equipped stacked items already; Is it worth fixing while loading a gamesave?
