### PR TITLE
Implemented a Notebook tab and Finished Quests tab of Journal window

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -1428,7 +1428,7 @@ namespace Wenzil.Console
         {
             public static readonly string name = "add";
             public static readonly string description = "Adds n inventory items to the character, based on the given keyword. n = 1 by default";
-            public static readonly string usage = "add (book|weapon|armor|cloth|ingr|relig|gold|magic|drug) [n]";
+            public static readonly string usage = "add (book|weapon|armor|cloth|ingr|relig|gold|magic|drug|map) [n]";
 
             public static string Execute(params string[] args)
             {
@@ -1482,6 +1482,9 @@ namespace Wenzil.Console
                             break;
                         case "drug":
                             newItem = ItemBuilder.CreateRandomDrug();
+                            break;
+                        case "map":
+                            newItem = ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Map);
                             break;
                         default:
                             return "unrecognized keyword. see usage";

--- a/Assets/Scripts/API/TextFile.cs
+++ b/Assets/Scripts/API/TextFile.cs
@@ -100,6 +100,8 @@ namespace DaggerfallConnect.Arena2
             Text = -1,
 
             TextHighlight = -2,
+            TextQuestion = -3,
+            TextAnswer = -4,
 
             NewLineOffset = 0x00,
             SameLineOffset = 0x01,

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -41,6 +41,8 @@ namespace DaggerfallWorkshop.Game
         public static Color DaggerfallDefaultInputTextColor = new Color32(227, 223, 0, 255);
         public static Color DaggerfallHighlightTextColor = new Color32(219, 130, 40, 255);
         public static Color DaggerfallAlternateHighlightTextColor = new Color32(255, 130, 40, 255);
+        public static Color DaggerfallQuestionTextColor = new Color(0.698f, 0.812f, 1.0f);
+        public static Color DaggerfallAnswerTextColor = Color.white;
         public static Color DaggerfallDefaultShadowColor = new Color32(93, 77, 12, 255);
         public static Color DaggerfallAlternateShadowColor1 = new Color32(44, 60, 60, 255);
         public static Color DaggerfallDefaultSelectedTextColor = new Color32(162, 36, 12, 255);

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -468,7 +468,11 @@ namespace DaggerfallWorkshop.Game
                     uiManager.PushWindow(dfSpellMakerWindow);
                     break;
                 case DaggerfallUIMessages.dfuiOpenTravelMapWindow:
-                    if (!GameManager.Instance.IsPlayerInside)
+                    if (GameManager.Instance.IsPlayerInside)
+                    {
+                        AddHUDText(HardStrings.cannotTravelIndoors);
+                    }
+                    else
                     {
                         if (GameManager.Instance.AreEnemiesNearby())
                         {
@@ -482,7 +486,7 @@ namespace DaggerfallWorkshop.Game
                     }
                     break;
                 case DaggerfallUIMessages.dfuiOpenAutomap:
-                    if (GameManager.Instance.PlayerEnterExit.IsPlayerInside) // open automap only if player is in interior or dungeon - TODO: location automap for exterior locations
+                    if (GameManager.Instance.IsPlayerInside) // open automap only if player is in interior or dungeon - TODO: location automap for exterior locations
                     {
                         GameManager.Instance.PauseGame(true);
                         uiManager.PushWindow(dfAutomapWindow);
@@ -518,7 +522,7 @@ namespace DaggerfallWorkshop.Game
                     }
                     break;
                 case DaggerfallUIMessages.dfuiOpenTransportWindow:
-                    if (GameManager.Instance.PlayerEnterExit.IsPlayerInside)
+                    if (GameManager.Instance.IsPlayerInside)
                     {
                         AddHUDText(HardStrings.cannotChangeTransportationIndoors);
                     }

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -530,6 +530,11 @@ namespace DaggerfallWorkshop.Game
                     uiManager.PushWindow(dfBookReaderWindow);
                     break;
                 case DaggerfallUIMessages.dfuiOpenQuestJournalWindow:
+                    dfQuestJournalWindow.DisplayMode = DaggerfallQuestJournalWindow.JournalDisplay.ActiveQuests;
+                    uiManager.PushWindow(dfQuestJournalWindow);
+                    break;
+                case DaggerfallUIMessages.dfuiOpenNotebookWindow:
+                    dfQuestJournalWindow.DisplayMode = DaggerfallQuestJournalWindow.JournalDisplay.Notebook;
                     uiManager.PushWindow(dfQuestJournalWindow);
                     break;
                 case DaggerfallUIMessages.dfuiOpenPlayerHistoryWindow:

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -42,7 +42,7 @@ namespace DaggerfallWorkshop.Game
         public static Color DaggerfallHighlightTextColor = new Color32(219, 130, 40, 255);
         public static Color DaggerfallAlternateHighlightTextColor = new Color32(255, 130, 40, 255);
         public static Color DaggerfallQuestionTextColor = new Color(0.698f, 0.812f, 1.0f);
-        public static Color DaggerfallAnswerTextColor = Color.white;
+        public static Color DaggerfallAnswerTextColor = DaggerfallDefaultInputTextColor;
         public static Color DaggerfallDefaultShadowColor = new Color32(93, 77, 12, 255);
         public static Color DaggerfallAlternateShadowColor1 = new Color32(44, 60, 60, 255);
         public static Color DaggerfallDefaultSelectedTextColor = new Color32(162, 36, 12, 255);

--- a/Assets/Scripts/Game/DaggerfallUIMessages.cs
+++ b/Assets/Scripts/Game/DaggerfallUIMessages.cs
@@ -52,6 +52,7 @@ namespace DaggerfallWorkshop.Game
         public const string dfuiOpenTransportWindow = "dfuiOpenTransportWindow";
         public const string dfuiOpenAutomap = "dfuiOpenAutomap";
         public const string dfuiOpenQuestJournalWindow = "dfuiOpenQuestJournalWindow";
+        public const string dfuiOpenNotebookWindow = "dfuiOpenNotebookWindow";
         public const string dfuiOpenPlayerHistoryWindow = "dfuiOpenPlayerHistoryWindow";
         public const string dfuiOpenSpellBookWindow = "dfuiOpenSpellBookWindow";
         public const string dfuiOpenSpellMakerWindow = "dfuiOpenSpellMakerWindow";

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -51,6 +51,7 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int goldPieces = 0;
         protected PersistentFactionData factionData = new PersistentFactionData();
         protected PersistentGlobalVars globalVars = new PersistentGlobalVars();
+        protected PlayerNotebook notebook = new PlayerNotebook();
 
         protected short[] skillUses;
         protected uint skillsRaisedThisLevel1 = 0;
@@ -128,6 +129,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public int GoldPieces { get { return goldPieces; } set { goldPieces = value; } }
         public PersistentFactionData FactionData { get { return factionData; } }
         public PersistentGlobalVars GlobalVars { get { return globalVars; } }
+        public PlayerNotebook Notebook { get { return notebook; } }
         public short[] SkillUses { get { return skillUses; } set { skillUses = value; } }
         public uint TimeOfLastSkillIncreaseCheck { get { return timeOfLastSkillIncreaseCheck; } set { timeOfLastSkillIncreaseCheck = value; } }
         public uint TimeOfLastSkillTraining { get { return timeOfLastSkillTraining; } set { timeOfLastSkillTraining = value; } }
@@ -510,6 +512,7 @@ namespace DaggerfallWorkshop.Game.Entity
             otherItems.Clear();
             factionData.Reset();
             globalVars.Reset();
+            notebook.Clear();
             SetEntityDefaults();
             startingLevelUpSkillSum = 0;
             currentLevelUpSkillSum = 0;

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -471,6 +471,10 @@ namespace DaggerfallWorkshop.Game
             {
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenQuestJournalWindow);
             }
+            else if (InputManager.Instance.ActionComplete(InputManager.Actions.NoteBook))
+            {
+                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenNotebookWindow);
+            }
             else if (InputManager.Instance.ActionComplete(InputManager.Actions.CastSpell))
             {
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenSpellBookWindow);

--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -119,6 +119,8 @@ namespace DaggerfallWorkshop.Game.Guilds
         private int GetPromotionMsgId(int newRank)
         {
             revealedDungeon = GameManager.Instance.PlayerGPS.DiscoverRandomLocation();
+            GameManager.Instance.PlayerEntity.Notebook.AddNote(
+                TextManager.Instance.GetText("DaggerfallUI", "readMapDB").Replace("%map", revealedDungeon.Name));
             switch (newRank)
             {
                 case 1:

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -115,9 +115,13 @@ namespace DaggerfallWorkshop.Game.Guilds
                     return PromotionSpymasterId;
                 case 6:
                     revealedDungeon = GameManager.Instance.PlayerGPS.DiscoverRandomLocation();
+                    GameManager.Instance.PlayerEntity.Notebook.AddNote(
+                        TextManager.Instance.GetText("DaggerfallUI", "readMapTG").Replace("%map", revealedDungeon.Name));
                     return PromotionMap1Id;
                 case 8:
                     revealedDungeon = GameManager.Instance.PlayerGPS.DiscoverRandomLocation();
+                    GameManager.Instance.PlayerEntity.Notebook.AddNote(
+                        TextManager.Instance.GetText("DaggerfallUI", "readMapTG").Replace("%map", revealedDungeon.Name));
                     return PromotionMap2Id;
                 default:
                     return PromotionMsgId;

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -19,6 +19,7 @@ using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Utility.AssetInjection;
+using DaggerfallWorkshop.Game.Questing;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -192,6 +193,35 @@ namespace DaggerfallWorkshop.Game.Items
             // Resolve potion names
             if (item.ItemGroup == ItemGroups.UselessItems1 && item.TemplateIndex == (int)UselessItems1.Glass_Bottle)
                 return MacroHelper.GetValue("%po", item);
+
+            // Resolve quest letters, get last 2 lines which should be the signoff
+            if (item.ItemGroup == ItemGroups.UselessItems2 && item.TemplateIndex == (int)UselessItems2.Parchment && item.IsQuestItem)
+            {
+                // Get the Item resource from quest
+                Quest quest = QuestMachine.Instance.GetQuest(item.QuestUID);
+                if (quest != null)
+                {
+                    Item questItem = quest.GetItem(item.QuestItemSymbol);
+                    if (questItem.UsedMessageID != 0)
+                    {
+                        Message msg = quest.GetMessage(questItem.UsedMessageID);
+                        TextFile.Token[] tokens = msg.GetTextTokens();
+                        string signoff = "";
+                        int lines = 0;
+                        for (int i = tokens.Length-1; i >= 0; i--)
+                        {
+                            TextFile.Token token = tokens[i];
+                            if (!string.IsNullOrEmpty(token.text))
+                            {
+                                signoff = token.text.Trim() + " " + signoff;
+                                lines++;
+                            }
+                            if (lines >= 2)
+                                return "Letter from " + signoff;
+                        }
+                    }
+                }
+            }
 
             return result;
         }

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -217,7 +217,7 @@ namespace DaggerfallWorkshop.Game.Items
                                 lines++;
                             }
                             if (lines >= 2)
-                                return "Letter from " + signoff;
+                                return HardStrings.letterPrefix + signoff;
                         }
                     }
                 }

--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs
@@ -1,0 +1,151 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Hazelnut
+// Contributors:    
+// 
+// Notes:
+//
+
+using System.Collections.Generic;
+using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop.Utility;
+using FullSerializer;
+
+namespace DaggerfallWorkshop.Game.Player
+{
+    /// <summary>
+    /// Stores player notes and finished quests.
+    /// </summary>
+    public class PlayerNotebook
+    {
+        List<TextFile.Token[]> notes = new List<TextFile.Token[]>();
+
+        List<TextFile.Token[]> finishedQuests = new List<TextFile.Token[]>();
+
+        readonly static TextFile.Token NothingToken = new TextFile.Token() {
+            formatting = TextFile.Formatting.Nothing,
+        };
+
+
+        public List<TextFile.Token[]> GetNotes()
+        {
+            return notes;
+        }
+
+        public void AddNote(string str)
+        {
+            if (!string.IsNullOrEmpty(str))
+            {
+                List<string> lines = new List<string>();
+                while (str.Length > 56)
+                {
+                    int pos = str.LastIndexOf(' ', 56);
+                    lines.Add(' ' + str.Substring(0, pos));
+                    str = str.Substring(pos+1);
+                }
+                lines.Add(' ' + str);
+
+                TextFile.Token[] note = new TextFile.Token[(lines.Count*2)+2];
+                note[0] = new TextFile.Token() {
+                    text = DaggerfallUnity.Instance.WorldTime.Now.DateString() + ':',
+                    formatting = TextFile.Formatting.Text,
+                };
+                note[1] = NothingToken;
+                int i = 2;
+                foreach (string line in lines)
+                {
+                    note[i++] = new TextFile.Token() {
+                        text = line,
+                        formatting = TextFile.Formatting.Text,
+                    };
+                    note[i++] = NothingToken;
+                }
+                notes.Add(note);
+            }
+        }
+
+        public List<TextFile.Token[]> GetFinishedQuests()
+        {
+            return finishedQuests;
+        }
+
+        public void AddFinishedQuestMessage(TextFile.Token[] message)
+        {
+            if (message != null && message.Length > 0)
+                finishedQuests.Add(message);
+        }
+
+        public void Clear()
+        {
+            finishedQuests.Clear();
+        }
+
+
+        public NotebookData_v1 GetNotebookSaveData()
+        {
+            NotebookData_v1 data = new NotebookData_v1();
+
+            List<List<string>> entries = ConvertList(notes);
+            data.notebookEntries = entries;
+
+            entries = ConvertList(finishedQuests);
+            data.finishedQuestEntries = entries;
+
+            return data;
+        }
+
+        private List<List<string>> ConvertList(List<TextFile.Token[]> list)
+        {
+            List<List<string>> entries = new List<List<string>>();
+            foreach (TextFile.Token[] entry in list)
+            {
+                List<string> lines = new List<string>();
+                foreach (TextFile.Token token in entry)
+                {
+                    if (token.formatting == TextFile.Formatting.Text)
+                        lines.Add(token.text);
+                }
+                entries.Add(lines);
+            }
+            return entries;
+        }
+
+        public void RestoreNotebookData(NotebookData_v1 notebookData)
+        {
+            notes = new List<TextFile.Token[]>();
+            ConvertData(notebookData.notebookEntries, notes);
+
+            finishedQuests = new List<TextFile.Token[]>();
+            ConvertData(notebookData.finishedQuestEntries, finishedQuests);
+        }
+
+        private void ConvertData(List<List<string>> listData, List<TextFile.Token[]> list)
+        {
+            foreach (List<string> entry in listData)
+            {
+                int i = 0;
+                TextFile.Token[] lines = new TextFile.Token[entry.Count * 2];
+                foreach (string line in entry)
+                {
+                    lines[i++] = new TextFile.Token() {
+                        text = line,
+                        formatting = TextFile.Formatting.Text
+                    };
+                    lines[i++] = NothingToken;
+                }
+                list.Add(lines);
+            }
+        }
+
+        [fsObject("v1")]
+        public class NotebookData_v1
+        {
+            public List<List<string>> notebookEntries;
+            public List<List<string>> finishedQuestEntries;
+        }
+
+    }
+}

--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using DaggerfallConnect.Arena2;
 using FullSerializer;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
 
 namespace DaggerfallWorkshop.Game.Player
 {
@@ -27,6 +28,9 @@ namespace DaggerfallWorkshop.Game.Player
         readonly static TextFile.Token NothingToken = new TextFile.Token() {
             formatting = TextFile.Formatting.Nothing,
         };
+        readonly static TextFile.Token NewLineToken = new TextFile.Token() {
+            formatting = TextFile.Formatting.NewLine,
+        };
 
         List<TextFile.Token[]> notes = new List<TextFile.Token[]>();
 
@@ -35,7 +39,20 @@ namespace DaggerfallWorkshop.Game.Player
 
         public List<TextFile.Token[]> GetNotes()
         {
-            return notes;
+            return new List<TextFile.Token[]>(notes);
+        }
+
+        public TextFile.Token[] GetNote(int index)
+        {
+            if (index < notes.Count)
+                return notes[index];
+            else
+                return null;
+        }
+
+        public void RemoveNote(int index)
+        {
+            notes.RemoveAt(index);
         }
 
         public void AddNote(string str)
@@ -48,17 +65,23 @@ namespace DaggerfallWorkshop.Game.Player
             }
         }
 
-        public void AddNote(List<TextFile.Token> entries)
+        public void AddNote(List<TextFile.Token> texts)
         {
-            if (entries != null && entries.Count > 0)
+            if (texts != null && texts.Count > 0)
             {
                 List<TextFile.Token> note = CreateNote();
-                foreach (TextFile.Token token in entries)
+                foreach (TextFile.Token token in texts)
                 {
                     if (string.IsNullOrEmpty(token.text))
-                        note.Add(NothingToken);
+                        note.Add(NewLineToken);
                     else
                         WrapLinesIntoNote(note, token.text, token.formatting);
+                    
+                    if ((note.Count - 2) >= (DaggerfallQuestJournalWindow.maxLinesSmall * 2))
+                    {
+                        notes.Add(note.ToArray());
+                        note = CreateNote();
+                    }
                 }
                 notes.Add(note.ToArray());
             }
@@ -96,7 +119,7 @@ namespace DaggerfallWorkshop.Game.Player
 
         public List<TextFile.Token[]> GetFinishedQuests()
         {
-            return finishedQuests;
+            return new List<TextFile.Token[]>(finishedQuests);
         }
 
         public void AddFinishedQuestMessage(TextFile.Token[] message)
@@ -191,7 +214,7 @@ namespace DaggerfallWorkshop.Game.Player
                             formatting = TextFile.Formatting.Text
                         });
                     }
-                    lines.Add(NothingToken);
+                    lines.Add(!string.IsNullOrEmpty(line) ? NothingToken : NewLineToken);
                 }
                 list.Add(lines.ToArray());
             }

--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using DaggerfallConnect.Arena2;
 using FullSerializer;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
+using UnityEngine;
 
 namespace DaggerfallWorkshop.Game.Player
 {
@@ -22,9 +23,9 @@ namespace DaggerfallWorkshop.Game.Player
     public class PlayerNotebook
     {
         public const int MaxLineLenth = 70;
-        private const int NULLINT = -1;
         private const string PrefixQuestion = "Q:";
         private const string PrefixAnswer = "A:";
+
         readonly static TextFile.Token NothingToken = new TextFile.Token() {
             formatting = TextFile.Formatting.Nothing,
         };
@@ -56,21 +57,34 @@ namespace DaggerfallWorkshop.Game.Player
             notes.RemoveAt(index);
         }
 
-        public void AddNote(string str, int index = NULLINT)
+        public void MoveNote(int srcIdx, int destIdx)
+        {
+            Debug.LogFormat("Moving note {0} to {1} ", srcIdx, destIdx);
+            var item = notes[srcIdx];
+            notes.RemoveAt(srcIdx);
+            if (destIdx > srcIdx)
+                destIdx--;
+            notes.Insert(destIdx, item);
+        }
+
+        public void AddNote(string str, int index = -1)
         {
             if (!string.IsNullOrEmpty(str))
             {
-                List<TextFile.Token> note = CreateNote(index == NULLINT);
+                List<TextFile.Token> note = CreateNote();
                 WrapLinesIntoNote(note, str, TextFile.Formatting.Text);
-                AddNote(index, note);
+                if (index == -1)
+                    notes.Add(note.ToArray());
+                else
+                    notes.Insert(index, note.ToArray());
             }
         }
 
-        public void AddNote(TextFile.Token[] texts, int index = NULLINT)
+        public void AddNote(List<TextFile.Token> texts)
         {
-            if (texts != null && texts.Length > 0)
+            if (texts != null && texts.Count > 0)
             {
-                List<TextFile.Token> note = CreateNote(index == NULLINT);
+                List<TextFile.Token> note = CreateNote();
                 foreach (TextFile.Token token in texts)
                 {
                     if (string.IsNullOrEmpty(token.text))
@@ -80,33 +94,22 @@ namespace DaggerfallWorkshop.Game.Player
                     
                     if ((note.Count - 2) >= (DaggerfallQuestJournalWindow.maxLinesSmall * 2))
                     {
-                        AddNote(index, note);
+                        notes.Add(note.ToArray());
                         note = CreateNote();
                     }
                 }
-                AddNote(index, note);
+                notes.Add(note.ToArray());
             }
         }
 
-        private void AddNote(int index, List<TextFile.Token> note)
-        {
-            if (index == NULLINT)
-                notes.Add(note.ToArray());
-            else
-                notes.Insert(index, note.ToArray());
-        }
-
-        private static List<TextFile.Token> CreateNote(bool date = true)
+        private static List<TextFile.Token> CreateNote()
         {
             List<TextFile.Token> note = new List<TextFile.Token>();
-            if (date)
-            {
-                note.Add(new TextFile.Token() {
-                    text = DaggerfallUnity.Instance.WorldTime.Now.LongDateTimeString() + ':',
-                    formatting = TextFile.Formatting.Text,
-                });
-                note.Add(NothingToken);
-            }
+            note.Add(new TextFile.Token() {
+                text = DaggerfallUnity.Instance.WorldTime.Now.LongDateTimeString() + ':',
+                formatting = TextFile.Formatting.Text,
+            });
+            note.Add(NothingToken);
             return note;
         }
 
@@ -149,6 +152,16 @@ namespace DaggerfallWorkshop.Game.Player
         public void RemoveFinishedQuest(int index)
         {
             finishedQuests.RemoveAt(index);
+        }
+
+        public void MoveFinishedQuest(int srcIdx, int destIdx)
+        {
+            Debug.LogFormat("Moving FinishedQuest {0} to {1} ", srcIdx, destIdx);
+            var item = finishedQuests[srcIdx];
+            finishedQuests.RemoveAt(srcIdx);
+            if (destIdx > srcIdx)
+                destIdx--;
+            finishedQuests.Insert(destIdx, item);
         }
 
         public void AddFinishedQuest(TextFile.Token[] message)

--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs
@@ -21,10 +21,10 @@ namespace DaggerfallWorkshop.Game.Player
     /// </summary>
     public class PlayerNotebook
     {
-        private const int MaxLineLenth = 70;
+        public const int MaxLineLenth = 70;
+        private const int NULLINT = -1;
         private const string PrefixQuestion = "Q:";
         private const string PrefixAnswer = "A:";
-
         readonly static TextFile.Token NothingToken = new TextFile.Token() {
             formatting = TextFile.Formatting.Nothing,
         };
@@ -36,6 +36,7 @@ namespace DaggerfallWorkshop.Game.Player
 
         List<TextFile.Token[]> finishedQuests = new List<TextFile.Token[]>();
 
+        #region Notes
 
         public List<TextFile.Token[]> GetNotes()
         {
@@ -55,21 +56,21 @@ namespace DaggerfallWorkshop.Game.Player
             notes.RemoveAt(index);
         }
 
-        public void AddNote(string str)
+        public void AddNote(string str, int index = NULLINT)
         {
             if (!string.IsNullOrEmpty(str))
             {
-                List<TextFile.Token> note = CreateNote();
+                List<TextFile.Token> note = CreateNote(index == NULLINT);
                 WrapLinesIntoNote(note, str, TextFile.Formatting.Text);
-                notes.Add(note.ToArray());
+                AddNote(index, note);
             }
         }
 
-        public void AddNote(List<TextFile.Token> texts)
+        public void AddNote(TextFile.Token[] texts, int index = NULLINT)
         {
-            if (texts != null && texts.Count > 0)
+            if (texts != null && texts.Length > 0)
             {
-                List<TextFile.Token> note = CreateNote();
+                List<TextFile.Token> note = CreateNote(index == NULLINT);
                 foreach (TextFile.Token token in texts)
                 {
                     if (string.IsNullOrEmpty(token.text))
@@ -79,22 +80,33 @@ namespace DaggerfallWorkshop.Game.Player
                     
                     if ((note.Count - 2) >= (DaggerfallQuestJournalWindow.maxLinesSmall * 2))
                     {
-                        notes.Add(note.ToArray());
+                        AddNote(index, note);
                         note = CreateNote();
                     }
                 }
-                notes.Add(note.ToArray());
+                AddNote(index, note);
             }
         }
 
-        private static List<TextFile.Token> CreateNote()
+        private void AddNote(int index, List<TextFile.Token> note)
+        {
+            if (index == NULLINT)
+                notes.Add(note.ToArray());
+            else
+                notes.Insert(index, note.ToArray());
+        }
+
+        private static List<TextFile.Token> CreateNote(bool date = true)
         {
             List<TextFile.Token> note = new List<TextFile.Token>();
-            note.Add(new TextFile.Token() {
-                text = DaggerfallUnity.Instance.WorldTime.Now.LongDateTimeString() + ':',
-                formatting = TextFile.Formatting.Text,
-            });
-            note.Add(NothingToken);
+            if (date)
+            {
+                note.Add(new TextFile.Token() {
+                    text = DaggerfallUnity.Instance.WorldTime.Now.LongDateTimeString() + ':',
+                    formatting = TextFile.Formatting.Text,
+                });
+                note.Add(NothingToken);
+            }
             return note;
         }
 
@@ -117,23 +129,43 @@ namespace DaggerfallWorkshop.Game.Player
             note.Add(NothingToken);
         }
 
+        #endregion
+
+        #region Finished Quests
+
         public List<TextFile.Token[]> GetFinishedQuests()
         {
             return new List<TextFile.Token[]>(finishedQuests);
         }
 
-        public void AddFinishedQuestMessage(TextFile.Token[] message)
+        public TextFile.Token[] GetFinishedQuest(int index)
+        {
+            if (index < finishedQuests.Count)
+                return finishedQuests[index];
+            else
+                return null;
+        }
+
+        public void RemoveFinishedQuest(int index)
+        {
+            finishedQuests.RemoveAt(index);
+        }
+
+        public void AddFinishedQuest(TextFile.Token[] message)
         {
             if (message != null && message.Length > 0)
                 finishedQuests.Add(message);
         }
+
+        #endregion
+
+        #region Save, Load & Clear
 
         public void Clear()
         {
             notes.Clear();
             finishedQuests.Clear();
         }
-
 
         public NotebookData_v1 GetNotebookSaveData()
         {
@@ -227,5 +259,6 @@ namespace DaggerfallWorkshop.Game.Player
             public List<List<string>> finishedQuestEntries;
         }
 
+        #endregion
     }
 }

--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs
@@ -68,12 +68,12 @@ namespace DaggerfallWorkshop.Game.Player
             notes.Insert(destIdx, item);
         }
 
-        public void AddNote(string str, TextFile.Formatting format = TextFile.Formatting.Text, int index = -1)
+        public void AddNote(string str, int index = -1)
         {
             if (!string.IsNullOrEmpty(str))
             {
                 List<TextFile.Token> note = CreateNote();
-                WrapLinesIntoNote(note, str, format);
+                WrapLinesIntoNote(note, str, TextFile.Formatting.Text);
                 if (index == -1)
                     notes.Add(note.ToArray());
                 else
@@ -108,7 +108,7 @@ namespace DaggerfallWorkshop.Game.Player
             List<TextFile.Token> note = new List<TextFile.Token>();
             note.Add(new TextFile.Token() {
                 text = DaggerfallUnity.Instance.WorldTime.Now.LongDateTimeString() + ':',
-                formatting = TextFile.Formatting.Text,
+                formatting = TextFile.Formatting.TextHighlight,
             });
             note.Add(NothingToken);
             return note;
@@ -204,9 +204,9 @@ namespace DaggerfallWorkshop.Game.Player
                 foreach (TextFile.Token token in entry)
                 {
                     if (token.formatting == TextFile.Formatting.Text)
-                        lines.Add(PrefixDateHeader + token.text);
-                    else if (token.formatting == TextFile.Formatting.TextHighlight)
                         lines.Add(token.text);
+                    else if (token.formatting == TextFile.Formatting.TextHighlight)
+                        lines.Add(PrefixDateHeader + token.text);
                     else if (token.formatting == TextFile.Formatting.TextQuestion)
                         lines.Add(PrefixQuestion + token.text);
                     else if (token.formatting == TextFile.Formatting.TextAnswer)
@@ -245,7 +245,7 @@ namespace DaggerfallWorkshop.Game.Player
                     {
                         lines.Add(new TextFile.Token() {
                             text = line.Substring(PrefixDateHeader.Length),
-                            formatting = TextFile.Formatting.Text
+                            formatting = TextFile.Formatting.TextHighlight
                         });
                     }
                     else if (line.StartsWith(PrefixQuestion))
@@ -266,7 +266,7 @@ namespace DaggerfallWorkshop.Game.Player
                     {
                         lines.Add(new TextFile.Token() {
                             text = line,
-                            formatting = notes ? TextFile.Formatting.TextHighlight : TextFile.Formatting.Text
+                            formatting = TextFile.Formatting.Text
                         });
                     }
                     lines.Add(!string.IsNullOrEmpty(line) ? NothingToken : NewLineToken);

--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs
@@ -31,9 +31,6 @@ namespace DaggerfallWorkshop.Game.Player
         readonly static TextFile.Token NothingToken = new TextFile.Token() {
             formatting = TextFile.Formatting.Nothing,
         };
-        readonly static TextFile.Token NewLineToken = new TextFile.Token() {
-            formatting = TextFile.Formatting.NewLine,
-        };
 
         List<TextFile.Token[]> notes = new List<TextFile.Token[]>();
 
@@ -90,7 +87,7 @@ namespace DaggerfallWorkshop.Game.Player
                 foreach (TextFile.Token token in texts)
                 {
                     if (string.IsNullOrEmpty(token.text))
-                        note.Add(NewLineToken);
+                        note.Add(TextFile.NewLineToken);
                     else
                         WrapLinesIntoNote(note, token.text, token.formatting);
                     
@@ -270,7 +267,7 @@ namespace DaggerfallWorkshop.Game.Player
                             formatting = TextFile.Formatting.Text
                         });
                     }
-                    lines.Add(!string.IsNullOrEmpty(line) ? NothingToken : NewLineToken);
+                    lines.Add(!string.IsNullOrEmpty(line) ? NothingToken : TextFile.NewLineToken);
                 }
                 list.Add(lines.ToArray());
             }

--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs
@@ -14,6 +14,7 @@ using DaggerfallConnect.Arena2;
 using FullSerializer;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using UnityEngine;
+using DaggerfallWorkshop.Utility;
 
 namespace DaggerfallWorkshop.Game.Player
 {
@@ -107,7 +108,7 @@ namespace DaggerfallWorkshop.Game.Player
         {
             List<TextFile.Token> note = new List<TextFile.Token>();
             note.Add(new TextFile.Token() {
-                text = DaggerfallUnity.Instance.WorldTime.Now.LongDateTimeString() + ':',
+                text = string.Format("{0} in {1}:", DaggerfallUnity.Instance.WorldTime.Now.DateTimeString(), MacroHelper.CityName(null)),
                 formatting = TextFile.Formatting.TextHighlight,
             });
             note.Add(NothingToken);

--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs.meta
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63e166f254310e346a91de669d779f62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Questing/Actions/RevealLocation.cs
+++ b/Assets/Scripts/Game/Questing/Actions/RevealLocation.cs
@@ -20,10 +20,13 @@ namespace DaggerfallWorkshop.Game.Questing
     public class RevealLocation : ActionTemplate
     {
         Symbol placeSymbol;
+        bool readMap;
+
+        // TODO some quests have a saying part to this action
 
         public override string Pattern
         {
-            get { return @"reveal (?<aPlace>\w+)"; }
+            get { return @"reveal (?<aPlace>\w+)|reveal (?<aPlace>\w+) (?<readMap>readmap)"; }
         }
 
         public RevealLocation(Quest parentQuest)
@@ -42,6 +45,7 @@ namespace DaggerfallWorkshop.Game.Questing
             RevealLocation action = new RevealLocation(parentQuest);
 
             action.placeSymbol = new Symbol(match.Groups["aPlace"].Value);
+            action.readMap = !string.IsNullOrEmpty(match.Groups["readMap"].Value);
 
             return action;
         }
@@ -55,6 +59,10 @@ namespace DaggerfallWorkshop.Game.Questing
 
             // Discover location
             GameManager.Instance.PlayerGPS.DiscoverLocation(place.SiteDetails.regionName, place.SiteDetails.locationName);
+
+            if (readMap)
+                GameManager.Instance.PlayerEntity.Notebook.AddNote(
+                    TextManager.Instance.GetText("DaggerfallUI", "readMap").Replace("%map", place.SiteDetails.locationName));
 
             SetComplete();
         }

--- a/Assets/Scripts/Game/Questing/Actions/RevealLocation.cs
+++ b/Assets/Scripts/Game/Questing/Actions/RevealLocation.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -22,11 +22,9 @@ namespace DaggerfallWorkshop.Game.Questing
         Symbol placeSymbol;
         bool readMap;
 
-        // TODO some quests have a saying part to this action
-
         public override string Pattern
         {
-            get { return @"reveal (?<aPlace>\w+)|reveal (?<aPlace>\w+) (?<readMap>readmap)"; }
+            get { return @"reveal (?<aPlace>\w+) (?<readMap>readmap)|reveal (?<aPlace>\w+)"; }
         }
 
         public RevealLocation(Quest parentQuest)
@@ -73,13 +71,14 @@ namespace DaggerfallWorkshop.Game.Questing
         public struct SaveData_v1
         {
             public Symbol placeSymbol;
+            public bool readMap;
         }
 
         public override object GetSaveData()
         {
             SaveData_v1 data = new SaveData_v1();
             data.placeSymbol = placeSymbol;
-
+            data.readMap = readMap;
             return data;
         }
 
@@ -90,6 +89,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
             SaveData_v1 data = (SaveData_v1)dataIn;
             placeSymbol = data.placeSymbol;
+            readMap = data.readMap;
         }
 
         #endregion

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -335,7 +335,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 {
                     var message = GetMessage(logEntry.messageID);
                     if (message != null)
-                        GameManager.Instance.PlayerEntity.Notebook.AddFinishedQuestMessage(message.GetTextTokens());
+                        GameManager.Instance.PlayerEntity.Notebook.AddFinishedQuest(message.GetTextTokens());
                 }
             }
         }

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -327,6 +327,17 @@ namespace DaggerfallWorkshop.Game.Questing
                 int repChange = QuestSuccess ? QuestSuccessRep : QuestFailureRep;
                 GameManager.Instance.PlayerEntity.FactionData.ChangeReputation(factionId, repChange, true);
             }
+            // Add the active quest messages to player notebook.
+            LogEntry[] logEntries = GetLogMessages();
+            if (logEntries != null && logEntries.Length > 0)
+            {
+                foreach (var logEntry in logEntries)
+                {
+                    var message = GetMessage(logEntry.messageID);
+                    if (message != null)
+                        GameManager.Instance.PlayerEntity.Notebook.AddFinishedQuestMessage(message.GetTextTokens());
+                }
+            }
         }
 
         public void StartTask(Symbol symbol)

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -17,9 +17,9 @@ using System.Collections.Generic;
 using FullSerializer;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Questing;
-using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Banking;
 using DaggerfallWorkshop.Game.Utility.ModSupport;
+using DaggerfallWorkshop.Game.Player;
 
 namespace DaggerfallWorkshop.Game.Serialization
 {
@@ -45,6 +45,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         const string questDataFilename = "QuestData.txt";
         const string discoveryDataFilename = "DiscoveryData.txt";
         const string conversationDataFilename = "ConversationData.txt";
+        const string notebookDataFilename = "NotebookData.txt";
         const string automapDataFilename = "AutomapData.txt";
         const string screenshotFilename = "Screenshot.jpg";
         const string bioFileName = "bio.txt";
@@ -931,6 +932,9 @@ namespace DaggerfallWorkshop.Game.Serialization
             // Get conversation data
             TalkManager.SaveDataConversation conversationData = GameManager.Instance.TalkManager.GetConversationSaveData();
 
+            // Get notebook data
+            PlayerNotebook.NotebookData_v1 notebookData = GameManager.Instance.PlayerEntity.Notebook.GetNotebookSaveData();
+
             // Serialize save data to JSON strings
             string saveDataJson = Serialize(saveData.GetType(), saveData);
             string saveInfoJson = Serialize(saveInfo.GetType(), saveInfo);
@@ -938,6 +942,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             string questDataJson = Serialize(questData.GetType(), questData);
             string discoveryDataJson = Serialize(discoveryData.GetType(), discoveryData);
             string conversationDataJson = Serialize(conversationData.GetType(), conversationData);
+            string notebookDataJson = Serialize(notebookData.GetType(), notebookData);
 
             //// Attempt to hide UI for screenshot
             //bool rawImageEnabled = false;
@@ -969,6 +974,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             WriteSaveFile(Path.Combine(path, questDataFilename), questDataJson);
             WriteSaveFile(Path.Combine(path, discoveryDataFilename), discoveryDataJson);
             WriteSaveFile(Path.Combine(path, conversationDataFilename), conversationDataJson);
+            WriteSaveFile(Path.Combine(path, notebookDataFilename), notebookDataJson);
 
             // Save backstory text
             if (!File.Exists(Path.Combine(path, bioFileName)))
@@ -1041,6 +1047,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             string questDataJson = ReadSaveFile(Path.Combine(path, questDataFilename));
             string discoveryDataJson = ReadSaveFile(Path.Combine(path, discoveryDataFilename));
             string conversationDataJson = ReadSaveFile(Path.Combine(path, conversationDataFilename));
+            string notebookDataJson = ReadSaveFile(Path.Combine(path, notebookDataFilename));
 
             // Load backstory text
             GameManager.Instance.PlayerEntity.BackStory = new List<string>();
@@ -1071,7 +1078,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             // Restore discovery data
             if (!string.IsNullOrEmpty(discoveryDataJson))
             {
-                Dictionary<int, PlayerGPS.DiscoveredLocation> discoveryData = Deserialize(typeof(Dictionary<int, PlayerGPS.DiscoveredLocation>), discoveryDataJson) as Dictionary<int, PlayerGPS.DiscoveredLocation>;
+                Dictionary<int, PlayerGPS.DiscoveredLocation> discoveryData =
+                    Deserialize(typeof(Dictionary<int, PlayerGPS.DiscoveredLocation>), discoveryDataJson) as Dictionary<int, PlayerGPS.DiscoveredLocation>;
                 GameManager.Instance.PlayerGPS.RestoreDiscoveryData(discoveryData);
             }
             else
@@ -1124,6 +1132,13 @@ namespace DaggerfallWorkshop.Game.Serialization
             else
             {
                 GameManager.Instance.TalkManager.RestoreConversationData(null);
+            }
+
+            // Restore notebook data
+            if (!string.IsNullOrEmpty(notebookDataJson))
+            {
+                PlayerNotebook.NotebookData_v1 notebookData = Deserialize(typeof(PlayerNotebook.NotebookData_v1), notebookDataJson) as PlayerNotebook.NotebookData_v1;
+                GameManager.Instance.PlayerEntity.Notebook.RestoreNotebookData(notebookData);
             }
 
             // Restore player position to world

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -1135,6 +1135,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             }
 
             // Restore notebook data
+            GameManager.Instance.PlayerEntity.Notebook.Clear();
             if (!string.IsNullOrEmpty(notebookDataJson))
             {
                 PlayerNotebook.NotebookData_v1 notebookData = Deserialize(typeof(PlayerNotebook.NotebookData_v1), notebookDataJson) as PlayerNotebook.NotebookData_v1;

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -165,7 +165,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             string line;
             while ((line = reader.ReadLine()) != null)
             {
-                AddTextLabel(line);
+                AddTextLabel(line, GetFont(), DaggerfallUI.DaggerfallDefaultTextColor);
                 NewLine();
             }
         }
@@ -177,13 +177,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
         /// </summary>
         /// <param name="text">Text for this label.</param>
         /// <param name="font">Font for this label.</param>
-        /// <param name="highlight">True to use DF highlight text color for this label.</param>
+        /// <param name="color">Text color for this label.</param>
         /// <returns>TextLabel.</returns>
-        public TextLabel AddTextLabel(string text, DaggerfallFont font = null, bool highlight = false)
+        public TextLabel AddTextLabel(string text, DaggerfallFont font, Color color)
         {
-            if (font == null)
-                font = GetFont();
-
             TextLabel textLabel = new TextLabel();
             textLabel.AutoSize = AutoSizeModes.None;
             textLabel.MinTextureDim = minTextureDimTextLabel;
@@ -198,7 +195,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 textLabel.MaxWidth = maxTextWidth;
             textLabel.Text = text;
             textLabel.Parent = this;
-            textLabel.TextColor = highlight ? DaggerfallUI.DaggerfallHighlightTextColor : TextColor;
+            textLabel.TextColor = color;
             textLabel.ShadowColor = ShadowColor;
             textLabel.ShadowPosition = ShadowPosition;
 
@@ -298,10 +295,16 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         }
                         break;
                     case TextFile.Formatting.Text:
-                        AddTextLabel(token.text, font);
+                        AddTextLabel(token.text, font, TextColor);
                         break;
                     case TextFile.Formatting.TextHighlight:
-                        AddTextLabel(token.text, font, true);
+                        AddTextLabel(token.text, font, DaggerfallUI.DaggerfallHighlightTextColor);
+                        break;
+                    case TextFile.Formatting.TextQuestion:
+                        AddTextLabel(token.text, font, DaggerfallUI.DaggerfallQuestionTextColor);
+                        break;
+                    case TextFile.Formatting.TextAnswer:
+                        AddTextLabel(token.text, font, DaggerfallUI.DaggerfallAnswerTextColor);
                         break;
                     case TextFile.Formatting.InputCursorPositioner:
                         break;

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -232,6 +232,14 @@ namespace DaggerfallWorkshop.Game.UserInterface
             cursorY = 0;
         }
 
+        public int LineHeight
+        {
+            get {
+                int lineHeight = lastLabel.TextHeight / lastLabel.NumTextLines + rowLeading;
+                return lineHeight;
+            }
+        }
+
         #region Protected Methods
 
         protected virtual void SetRowLeading(int amount)
@@ -242,14 +250,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         #endregion
 
         #region Private Methods
-
-        int LineHeight
-        {
-            get {
-                int lineHeight = lastLabel.TextHeight / lastLabel.NumTextLines + rowLeading;
-                return lineHeight;
-            }
-        }
 
         void LayoutTextElements(TextFile.Token[] tokens)
         {

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -32,6 +32,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         int rowLeading = 0;
         Vector2 shadowPosition = DaggerfallUI.DaggerfallDefaultShadowPos;
         Color textColor = DaggerfallUI.DaggerfallDefaultTextColor;
+        Color highlightColor = DaggerfallUI.DaggerfallHighlightTextColor;
         Color shadowColor = DaggerfallUI.DaggerfallDefaultShadowColor;
         HorizontalAlignment textAlignment = HorizontalAlignment.None;
         List<TextLabel> labels = new List<TextLabel>();
@@ -110,6 +111,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             get { return textColor; }
             set { textColor = value; }
+        }
+
+        public Color HighlightColor
+        {
+            get { return highlightColor; }
+            set { highlightColor = value; }
         }
 
         public Color ShadowColor
@@ -298,7 +305,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         AddTextLabel(token.text, font, TextColor);
                         break;
                     case TextFile.Formatting.TextHighlight:
-                        AddTextLabel(token.text, font, DaggerfallUI.DaggerfallHighlightTextColor);
+                        AddTextLabel(token.text, font, HighlightColor);
                         break;
                     case TextFile.Formatting.TextQuestion:
                         AddTextLabel(token.text, font, DaggerfallUI.DaggerfallQuestionTextColor);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1446,6 +1446,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 cannotUse.ClickAnywhereToClose = true;
                 cannotUse.Show();
             }
+            else if (item.IsOfTemplate(ItemGroups.MiscItems, (int)MiscItems.Map) && collection != null)
+            {   // Handle map items
+                RecordLocationFromMap(item);
+                collection.RemoveItem(item);
+                Refresh(false);
+            }
             else if (item.TemplateIndex == (int)MiscItems.Spellbook)
             {
                 if (playerEntity.SpellbookCount() == 0)
@@ -1526,6 +1532,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     // Discover the location
                     gps.DiscoverLocation(gps.CurrentRegionName, location.Name);
                     gps.LocationRevealedByMapItem = location.Name;
+                    GameManager.Instance.PlayerEntity.Notebook.AddNote(
+                        TextManager.Instance.GetText("DaggerfallUI", "readMap").Replace("%map", location.Name));
                     break;
                 }
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -139,6 +139,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             questLogLabel                   = new MultiFormatTextLabel();
             questLogLabel.Position          = new Vector2(30, 38);
             questLogLabel.Size              = new Vector2(238, 138);
+            questLogLabel.HighlightColor    = Color.white;
             questLogLabel.OnMouseClick      += QuestLogLabel_OnMouseClick;
             questLogLabel.OnRightMouseClick += QuestLogLabel_OnRightMouseClick;
             mainPanel.Components.Add(questLogLabel);
@@ -303,7 +304,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             if (!string.IsNullOrEmpty(enteredNoteLine))
             {
-                GameManager.Instance.PlayerEntity.Notebook.AddNote(enteredNoteLine, selectedEntry);
+                GameManager.Instance.PlayerEntity.Notebook.AddNote(enteredNoteLine, TextFile.Formatting.TextHighlight, selectedEntry);
                 lastMessageIndex = NULLINT;
             }
             selectedEntry = NULLINT;
@@ -512,8 +513,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         break;
 
                     var token = tokens[j];
-                    if (token.formatting == TextFile.Formatting.Text || token.formatting == TextFile.Formatting.TextAnswer ||
-                        token.formatting == TextFile.Formatting.TextQuestion || token.formatting == TextFile.Formatting.NewLine)
+                    if (token.formatting == TextFile.Formatting.Text ||
+                        token.formatting == TextFile.Formatting.TextHighlight ||
+                        token.formatting == TextFile.Formatting.TextAnswer ||
+                        token.formatting == TextFile.Formatting.TextQuestion ||
+                        token.formatting == TextFile.Formatting.NewLine)
                     {
                         totalLineCount++;
                         entryLineMap.Add(i);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -102,6 +102,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 Debug.LogError("failed to load texture: " + nativeImgName);
                 CloseWindow();
             }
+            if (defaultToolTip != null)
+                defaultToolTip.ToolTipDelay = 1;
 
             mainPanel                       = DaggerfallUI.AddPanel(NativePanel, AutoSizeModes.None);
             mainPanel.BackgroundTexture     = texture;
@@ -116,6 +118,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             dialogButton.Size               = new Vector2(68, 10);
             dialogButton.OnMouseClick       += DialogButton_OnMouseClick;
             dialogButton.Name               = "dialog_button";
+            dialogButton.ToolTip            = defaultToolTip;
+            dialogButton.ToolTipText        = TextManager.Instance.GetText(textDatabase, "dialogButtonInfo");
             mainPanel.Components.Add(dialogButton);
 
             upArrowButton                   = new Button();
@@ -155,6 +159,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 HorizontalAlignment = HorizontalAlignment.Center,
                 Font = DaggerfallUI.LargeFont,
                 ShadowColor = new Color(0f, 0.2f, 0.5f),
+                ToolTip = defaultToolTip,
+                ToolTipText = TextManager.Instance.GetText(textDatabase, "activeQuestsInfo"),
             };
             titlePanel.Components.Add(titleLabel);
             mainPanel.Components.Add(titlePanel);
@@ -486,6 +492,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             messageCount = questMessages.Count;
             questLogLabel.TextScale = 1;
             titleLabel.Text = TextManager.Instance.GetText(textDatabase, "activeQuests");
+            titleLabel.ToolTipText = TextManager.Instance.GetText(textDatabase, "activeQuestsInfo");
 
             int totalLineCount = 0;
             entryLineMap = new List<int>(maxLinesQuests);;
@@ -529,6 +536,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             messageCount = finishedQuests.Count;
             questLogLabel.TextScale = 1;
             titleLabel.Text = TextManager.Instance.GetText(textDatabase, "finishedQuests");
+            titleLabel.ToolTipText = TextManager.Instance.GetText(textDatabase, "finishedQuestsInfo");
             SetTextWithListEntries(finishedQuests, maxLinesQuests);
         }
 
@@ -538,6 +546,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             messageCount = notes.Count;
             questLogLabel.TextScale = textScaleSmall;
             titleLabel.Text = TextManager.Instance.GetText(textDatabase, "notebook");
+            titleLabel.ToolTipText = TextManager.Instance.GetText(textDatabase, "notebookInfo");
             SetTextWithListEntries(notes, maxLinesSmall);
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -357,7 +357,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 Message questMessage = questMessages[selectedEntry];
                 Debug.Log(questMessage.ParentQuest.QuestName);
                 Place place = questMessage.ParentQuest.LastPlaceReferenced;
-                if (place != null && (place.SiteDetails.siteType == SiteTypes.Dungeon || place.SiteDetails.siteType == SiteTypes.Town))
+                if (place != null &&
+                    !string.IsNullOrEmpty(place.SiteDetails.locationName) &&
+                    place.SiteDetails.locationName != GameManager.Instance.PlayerGPS.CurrentLocation.Name)
                 {
                     findPlaceRegion = DaggerfallUnity.Instance.ContentReader.MapFileReader.GetRegionIndex(place.SiteDetails.regionName);
                     findPlaceName = place.SiteDetails.locationName;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -21,12 +21,6 @@ using DaggerfallWorkshop.Game.Player;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
-    /* ##TODO:
-     * dialogue text
-     * implement sorting / filtering
-     * option to show letters recieved
-     */ 
-
     public class DaggerfallQuestJournalWindow : DaggerfallPopupWindow
     {
         #region Fields

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -34,10 +34,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const string textDatabase = "DaggerfallUI";
         const string nativeImgName = "LGBK00I0.IMG";
 
-        readonly static TextFile.Token NewLineToken = new TextFile.Token() {
-            formatting = TextFile.Formatting.NewLine,
-        };
-
         const int NULLINT = -1;
         const int maxLinesQuests = 19;
         public const int maxLinesSmall = 26;
@@ -521,7 +517,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                     textTokens.Add(token);
                 }
-                textTokens.Add(NewLineToken);
+                textTokens.Add(TextFile.NewLineToken);
                 totalLineCount++;
                 entryLineMap.Add(i);
             }
@@ -582,7 +578,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                     textTokens.Add(token);
                 }
-                textTokens.Add(NewLineToken);
+                textTokens.Add(TextFile.NewLineToken);
                 totalLineCount++;
                 entryLineMap.Add(--boundary);
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Lypyl (lypyldf@gmail.com)
-// Contributors:    
+// Contributors:    Hazelnut
 // 
 // Notes:
 //
@@ -51,6 +51,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         List<Message> questMessages;
         int messageCount = 0;
+        int findPlaceRegion;
         string findPlaceName;
 
         KeyCode toggleClosedBinding1;
@@ -113,21 +114,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             dialogButton                    = new Button();
             dialogButton.Position           = new Vector2(32, 187);
             dialogButton.Size               = new Vector2(68, 10);
-            dialogButton.OnMouseClick       += dialogButton_OnMouseClick;
+            dialogButton.OnMouseClick       += DialogButton_OnMouseClick;
             dialogButton.Name               = "dialog_button";
             mainPanel.Components.Add(dialogButton);
 
             upArrowButton                   = new Button();
             upArrowButton.Position          = new Vector2(181, 188);
             upArrowButton.Size              = new Vector2(13, 7);
-            upArrowButton.OnMouseClick      += upArrowButton_OnMouseClick;
+            upArrowButton.OnMouseClick      += UpArrowButton_OnMouseClick;
             upArrowButton.Name              = "uparrow_button";
             mainPanel.Components.Add(upArrowButton);
 
             downArrowButton                 = new Button();
             downArrowButton.Position        = new Vector2(209, 188);
             downArrowButton.Size            = new Vector2(13, 7);
-            downArrowButton.OnMouseClick    += downArrowButton_OnMouseClick;
+            downArrowButton.OnMouseClick    += DownArrowButton_OnMouseClick;
             downArrowButton.Name            = "downarrow_button";
             mainPanel.Components.Add(downArrowButton);
 
@@ -161,7 +162,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             questMessages = QuestMachine.Instance.GetAllQuestLogMessages();
 
-            // Store toggle closed binding for this window
+            // Store toggle closed bindings for this window
             toggleClosedBinding1 = InputManager.Instance.GetBinding(InputManager.Actions.LogBook);
             toggleClosedBinding2 = InputManager.Instance.GetBinding(InputManager.Actions.NoteBook);
 
@@ -222,7 +223,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region events
 
-        public void dialogButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void DialogButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             switch (DisplayMode)
             {
@@ -241,13 +242,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             selectedEntry = NULLINT;
         }
 
-        public void upArrowButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void UpArrowButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (currentMessageIndex - 1 >= 0)
                 currentMessageIndex -= 1;
         }
 
-        public void downArrowButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void DownArrowButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (currentMessageIndex + 1 < messageCount)
                 currentMessageIndex += 1;
@@ -255,12 +256,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void MainPanel_OnMouseScrollUp(BaseScreenComponent sender)
         {
-            upArrowButton_OnMouseClick(sender, Vector2.zero);
+            UpArrowButton_OnMouseClick(sender, Vector2.zero);
         }
 
         void MainPanel_OnMouseScrollDown(BaseScreenComponent sender)
         {
-            downArrowButton_OnMouseClick(sender, Vector2.zero);
+            DownArrowButton_OnMouseClick(sender, Vector2.zero);
         }
 
         void TitlePanel_OnMouseClick(BaseScreenComponent sender, Vector2 position)
@@ -308,10 +309,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             sender.CloseWindow();
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
             {
-                Debug.Log("Find " + findPlaceName);
+                Debug.Log("Find " + findPlaceName + findPlaceRegion);
                 this.CloseWindow();
-                DaggerfallUI.Instance.DfTravelMapWindow.PrePopulateFind(findPlaceName);
+                DaggerfallUI.Instance.DfTravelMapWindow.GotoLocation(findPlaceName, findPlaceRegion);
                 //uiManager.PushWindow(DaggerfallUI.Instance.DfTravelMapWindow);
+                //DaggerfallUI.Instance.DfTravelMapWindow.OnPush;
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenTravelMapWindow);
             }
         }
@@ -357,8 +359,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 Place place = questMessage.ParentQuest.LastPlaceReferenced;
                 if (place != null && (place.SiteDetails.siteType == SiteTypes.Dungeon || place.SiteDetails.siteType == SiteTypes.Town))
                 {
+                    findPlaceRegion = DaggerfallUnity.Instance.ContentReader.MapFileReader.GetRegionIndex(place.SiteDetails.regionName);
                     findPlaceName = place.SiteDetails.locationName;
-                    DaggerfallMessageBox dialogBox = CreateDialogBox(GetDialogText(findPlaceName, "selectedPlace", "confirmFind"));
+                    string entryStr = string.Format("{0} in {1} province", findPlaceName, place.SiteDetails.regionName);
+                    DaggerfallMessageBox dialogBox = CreateDialogBox(GetDialogText(entryStr, "selectedPlace", "confirmFind"));
                     dialogBox.OnButtonClick += FindPlace_OnButtonClick;
                     DaggerfallUI.UIManager.PushWindow(dialogBox);
                 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -304,7 +304,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             if (!string.IsNullOrEmpty(enteredNoteLine))
             {
-                GameManager.Instance.PlayerEntity.Notebook.AddNote(enteredNoteLine, TextFile.Formatting.TextHighlight, selectedEntry);
+                GameManager.Instance.PlayerEntity.Notebook.AddNote(enteredNoteLine, selectedEntry);
                 lastMessageIndex = NULLINT;
             }
             selectedEntry = NULLINT;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -17,7 +17,6 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Questing;
 using DaggerfallWorkshop.Game.Player;
-using System.Runtime.CompilerServices;
 
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -48,7 +48,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        public static DaedraData[] daedraData = new DaedraData[] {
+        public static DaedraData[] daedraData = {
             new DaedraData((int) FactionFile.FactionIDs.Hircine, "X0C00Y00", 155, "HIRCINE.FLC", Weather.WeatherType.None),  // Restrict to only glenmoril witches?
             new DaedraData((int) FactionFile.FactionIDs.Clavicus_Vile, "V0C00Y00", 1, "CLAVICUS.FLC", Weather.WeatherType.None),
             new DaedraData((int) FactionFile.FactionIDs.Mehrunes_Dagon, "Y0C00Y00", 320, "MEHRUNES.FLC", Weather.WeatherType.None),

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -29,8 +29,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
 {
     public class DaggerfallTalkWindow : DaggerfallPopupWindow
     {
-        const string textDatabase = "DaggerfallUI";
-
         const string talkWindowImgName    = "TALK01I0.IMG";
         const string talkCategoriesImgName = "TALK02I0.IMG";
         const string highlightedOptionsImgName = "TALK03I0.IMG";
@@ -48,7 +46,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         Color textcolorPlayerSays = new Color(0.698f, 0.812f, 1.0f);
 
-        Color textcolorQuestion = new Color(0.698f, 0.812f, 1.0f);
         //Color textcolorQuestionHighlighted = new Color(0.8f, 0.9f, 1.0f);
         Color textcolorHighlighted = Color.white;
 
@@ -695,7 +692,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 Position = new Vector2(118, 158),
                 Size = new Vector2(67, 18),
                 ToolTip = defaultToolTip,
-                ToolTipText = TextManager.Instance.GetText(textDatabase, "copyLogbookInfo"),
+                ToolTipText = TextManager.Instance.GetText(TalkManager.TextDatabase, "copyLogbookInfo"),
             };
             if (defaultToolTip != null)
                 buttonLogbook.ToolTip.ToolTipDelay = 1;
@@ -1217,7 +1214,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             ListBox.ListItem textLabelQuestion;
             ListBox.ListItem textLabelAnswer;
             listboxConversation.AddItem(question, out textLabelQuestion);
-            textLabelQuestion.textColor = textcolorQuestion;
+            textLabelQuestion.textColor = DaggerfallUI.DaggerfallQuestionTextColor;
             textLabelQuestion.selectedTextColor = textcolorHighlighted; // textcolorQuestionHighlighted            
             textLabelQuestion.textLabel.HorizontalAlignment = HorizontalAlignment.Right;
             textLabelQuestion.textLabel.HorizontalTextAlignment = TextLabel.HorizontalTextAlignmentSetting.Left;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -29,6 +29,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
 {
     public class DaggerfallTalkWindow : DaggerfallPopupWindow
     {
+        const string textDatabase = "DaggerfallUI";
+
         const string talkWindowImgName    = "TALK01I0.IMG";
         const string talkCategoriesImgName = "TALK02I0.IMG";
         const string highlightedOptionsImgName = "TALK03I0.IMG";
@@ -290,13 +292,14 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             base.OnPop();
 
+            // Send any copied conversation text to notebook
             copyIndexes.Sort();
             List<TextFile.Token> copiedEntries = new List<TextFile.Token>(copyIndexes.Count);
             int prev = -1;
             foreach (int idx in copyIndexes)
             {
                 if (idx - prev != 1 && prev > -1)
-                    copiedEntries.Add(new TextFile.Token() { formatting = TextFile.Formatting.NewLine } ); // test if this fixes stuff
+                    copiedEntries.Add(new TextFile.Token());
                 TextFile.Token entry = new TextFile.Token();
                 ListBox.ListItem item = listboxConversation.GetItem(idx);
                 bool question = (item.textColor == DaggerfallUI.DaggerfallQuestionTextColor || item.textColor == textcolorQuestionBackgroundModernConversationStyle);
@@ -585,7 +588,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             listboxConversation.WrapTextItems = true;
             listboxConversation.WrapWords = true;
             listboxConversation.RectRestrictedRenderArea = new Rect(listboxConversation.Position, listboxConversation.Size);
-            listboxConversation.VerticalScrollMode = ListBox.VerticalScrollModes.PixelWise;        
+            listboxConversation.VerticalScrollMode = ListBox.VerticalScrollModes.PixelWise;
+            listboxConversation.SelectedShadowPosition = DaggerfallUI.DaggerfallDefaultShadowPos;
             mainPanel.Components.Add(listboxConversation);
 
             SetStartConversation();
@@ -690,8 +694,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
             buttonLogbook = new Button {
                 Position = new Vector2(118, 158),
                 Size = new Vector2(67, 18),
+                ToolTip = defaultToolTip,
+                ToolTipText = TextManager.Instance.GetText(textDatabase, "copyLogbookInfo"),
             };
+            if (defaultToolTip != null)
+                buttonLogbook.ToolTip.ToolTipDelay = 1;
             buttonLogbook.OnMouseClick += ButtonLogbook_OnMouseClick;
+            buttonLogbook.OnRightMouseClick += ButtonLogbook_OnRightMouseClick;
             mainPanel.Components.Add(buttonLogbook);
         }
 
@@ -1486,7 +1495,39 @@ namespace DaggerfallWorkshop.Game.UserInterface
         private void ButtonLogbook_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (!copyIndexes.Contains(listboxConversation.SelectedIndex))
+            {
                 copyIndexes.Add(listboxConversation.SelectedIndex);
+                MarkCopiedListItem(listboxConversation.GetItem(listboxConversation.SelectedIndex));
+            }
+            else
+            {
+                copyIndexes.Remove(listboxConversation.SelectedIndex);
+                MarkCopiedListItem(listboxConversation.GetItem(listboxConversation.SelectedIndex), true);
+            }
+        }
+
+        private void ButtonLogbook_OnRightMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            copyIndexes.Clear();
+            for (int idx = 0; idx < listboxConversation.Count; idx++)
+            {
+                copyIndexes.Add(idx);
+                MarkCopiedListItem(listboxConversation.GetItem(idx));
+            }
+        }
+
+        private void MarkCopiedListItem(ListBox.ListItem item, bool unmark = false)
+        {
+            if (unmark)
+            {
+                item.shadowColor = DaggerfallUI.DaggerfallDefaultShadowColor;
+                item.selectedShadowColor = DaggerfallUI.DaggerfallDefaultShadowColor;
+            }
+            else
+            {
+                item.shadowColor = Color.blue;
+                item.selectedShadowColor = Color.blue;
+            }
         }
 
         private void ButtonGoodbye_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -308,7 +308,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 copiedEntries.Add(entry);
                 prev = idx;
             }
-            GameManager.Instance.PlayerEntity.Notebook.AddNote(copiedEntries.ToArray());
+            GameManager.Instance.PlayerEntity.Notebook.AddNote(copiedEntries);
         }
 
         public override void Update()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -186,6 +186,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Button buttonConversationDown;
         Button buttonOkay;
         Button buttonGoodbye;
+        Button buttonLogbook;
 
         // checkbox buttons
         Button buttonCheckboxTonePolite;
@@ -664,6 +665,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
             buttonGoodbye.Name = "button_goodbye";
             buttonGoodbye.OnMouseClick += ButtonGoodbye_OnMouseClick;
             mainPanel.Components.Add(buttonGoodbye);
+
+            buttonLogbook = new Button {
+                Position = new Vector2(118, 158),
+                Size = new Vector2(67, 18),
+            };
+            buttonLogbook.OnMouseClick += ButtonLogbook_OnMouseClick;
+            mainPanel.Components.Add(buttonLogbook);
         }
 
         void SetupCheckboxes()
@@ -1452,6 +1460,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 SelectTopicFromTopicList(listboxTopic.SelectedIndex);
             }
+        }
+
+        private void ButtonLogbook_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            GameManager.Instance.PlayerEntity.Notebook.AddNote(listboxConversation.SelectedItem);
         }
 
         private void ButtonGoodbye_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -308,7 +308,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 copiedEntries.Add(entry);
                 prev = idx;
             }
-            GameManager.Instance.PlayerEntity.Notebook.AddNote(copiedEntries);
+            GameManager.Instance.PlayerEntity.Notebook.AddNote(copiedEntries.ToArray());
         }
 
         public override void Update()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -56,6 +56,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Dictionary<string, Vector2> offsetLookup    = new Dictionary<string, Vector2>();
         string[] selectedRegionMapNames;    //different maps for selected region
 
+        string prePopulateFind = null;
+
         DFBitmap regionPickerBitmap;
         ImgFile loadedImg;
         DFRegion currentDFRegion;
@@ -179,6 +181,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             teleportationTravel = true;
         }
 
+        public void PrePopulateFind(string placeName)
+        {
+            prePopulateFind = placeName;
+        }
+
         #endregion
 
 
@@ -283,6 +290,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.OnPop();
             teleportationTravel = false;
+            prePopulateFind = null;
         }
 
         public override void Update()
@@ -822,6 +830,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 findPopUp.TextPanelDistanceY = 5;
                 findPopUp.TextBox.WidthOverride = 308;
                 findPopUp.TextBox.MaxCharacters = 32;
+                if (!string.IsNullOrEmpty(prePopulateFind))
+                    findPopUp.TextBox.Text = prePopulateFind;
                 findPopUp.OnGotUserInput += HandleLocationFindEvent;
                 findPopUp.Show();
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -64,6 +64,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string potionRecipeFor = "Recipe for Potion of %po";
         public const string potionOf = "Potion of %po";
         public const string cannotUseThis = "You cannot use this.";
+        public const string letterPrefix = "Letter: ";
         public const string multipleAssignments = "You have multiple assignments...";
 
         public const string youAreEntering = "You are entering %s";

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -257,6 +257,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public const string cannotChangeTransportationIndoors = "You cannot change transportation indoors.";
         public const string cannotTravelWithEnemiesNearby = "You cannot travel with enemies nearby.";
+        public const string cannotTravelIndoors = "You cannot travel while indoors.";
 
         public const string powersUnknown = "Powers unknown.";
 

--- a/Assets/Scripts/Utility/DaggerfallDateTime.cs
+++ b/Assets/Scripts/Utility/DaggerfallDateTime.cs
@@ -404,11 +404,12 @@ namespace DaggerfallWorkshop.Utility
         }
 
         /// <summary>
-        /// Gets a long date time string of HH:MM:SS on Dayname of MonthName, 3EYYY
+        /// Gets a long date time string of "HH:MM:SS on Dayname, xth of MonthName, 3EYYY"
         /// </summary>
         public string LongDateTimeString()
         {
-            return string.Format("{0:00}:{1:00}:{2:00} on {3}, {4:00} of {5:00}, 3E{6}", Hour, Minute, Second, DayName, Day + 1, MonthName, Year);
+            string suffix = GetSuffix(Day + 1);
+            return string.Format("{0:00}:{1:00}:{2:00} on {3}, {4}{5} of {6:00}, 3E{7}", Hour, Minute, Second, DayName, Day + 1, suffix, MonthName, Year);
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/DaggerfallDateTime.cs
+++ b/Assets/Scripts/Utility/DaggerfallDateTime.cs
@@ -413,6 +413,15 @@ namespace DaggerfallWorkshop.Utility
         }
 
         /// <summary>
+        /// Gets a date time string of "HH:MM:SS on xth of MonthName, 3EYYY"
+        /// </summary>
+        public string DateTimeString()
+        {
+            string suffix = GetSuffix(Day + 1);
+            return string.Format("{0:00}:{1:00}:{2:00} on {3}{4} of {5:00}, 3E{6}", Hour, Minute, Second, Day + 1, suffix, MonthName, Year);
+        }
+
+        /// <summary>
         /// Get date string in format of Day Name the xth of Month Name
         /// </summary>
         public string DateString()

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -471,7 +471,7 @@ namespace DaggerfallWorkshop.Utility
         //
         #region Global macro handlers
 
-        private static string CityName(IMacroContextProvider mcp)
+        public static string CityName(IMacroContextProvider mcp)
         {   // %cn
             PlayerGPS gps = GameManager.Instance.PlayerGPS;
             if (gps.HasCurrentLocation)

--- a/Assets/StreamingAssets/Quests/20C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/20C00Y00.txt
@@ -186,4 +186,4 @@ _S.10_ task:
 	place foe _monster_ at _hideout_ saying 1040 
 
 _readmap_ task:
-	reveal _hideout_ 
+	reveal _hideout_ readmap

--- a/Assets/StreamingAssets/Quests/B0B81Y02.txt
+++ b/Assets/StreamingAssets/Quests/B0B81Y02.txt
@@ -282,7 +282,7 @@ _artifact4_ task:
 
 _readmap_ task:
 	start timer _S.30_ 
-	reveal _dungeon2_ 
+	reveal _dungeon2_ readmap
 	place npc _wizard_ at _dungeon2_ 
 
 _S.13_ task:

--- a/Assets/StreamingAssets/Quests/B0C00Y05.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y05.txt
@@ -142,5 +142,6 @@ _clearclick_ task:
 variable _map_
 variable _nomap_
 _S.07_ task:
-	when _map_ and _pcgetsgold_ 
-	reveal _newdung_ saying 1080 
+	when _map_ and _pcgetsgold_
+    say 1080
+	reveal _newdung_ readmap

--- a/Assets/StreamingAssets/Quests/C0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y11.txt
@@ -176,5 +176,5 @@ variable _map_
 variable _nomap_
 _S.13_ task:
 	when _map_ and _questdone_ 
-                say 1080 
-	reveal _newdung_
+    say 1080 
+	reveal _newdung_ readmap

--- a/Assets/StreamingAssets/Quests/K0C00Y07.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y07.txt
@@ -289,7 +289,7 @@ _S.07_ task:
 	say 1018 
 
 _S.08_ task:
-	reveal _mondung_ 
+	reveal _mondung_ readmap
 
 _S.09_ task:
 	clicked npc _victim_ 

--- a/Assets/StreamingAssets/Quests/K0C01Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C01Y00.txt
@@ -227,7 +227,7 @@ _S.05_ task:
 	say 1015 
 
 _S.06_ task:
-	reveal _mondung_ 
+	reveal _mondung_ readmap
 	log 1017 step 2 
 
 variable _S.07_

--- a/Assets/StreamingAssets/Quests/K0C30Y03.txt
+++ b/Assets/StreamingAssets/Quests/K0C30Y03.txt
@@ -605,12 +605,12 @@ _S.25_ task:
 	start timer _S.26_ 
 
 _S.26_ task:
-	reveal _mondung_ 
+	reveal _mondung_ readmap
 	get item letter32 
 	say 1032 
 
 _S.27_ task:
-	reveal _mondung_ 
+	reveal _mondung_ readmap
 	get item letter15 
 	get item bothdorjii 
 	say 1032 
@@ -624,8 +624,8 @@ _S.29_ task:
 	repute with _gaffer_ exceeds 10 do _S.30_ 
 
 _S.30_ task:
-	reveal _mondung_ 
-	reveal _mondung2_ 
+	reveal _mondung_ readmap
+	reveal _mondung2_ readmap
 	log 1042 step 4 
 	get item letter33 
 	say 1034 
@@ -649,7 +649,7 @@ _S.34_ task:
 	say 1055 
 
 _S.35_ task:
-	reveal _mondung2_ 
+	reveal _mondung2_ readmap
 
 _2letter_ task:
 	get item letter28 

--- a/Assets/StreamingAssets/Quests/L0B00Y02.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y02.txt
@@ -180,7 +180,7 @@ _S.04_ task:
 	say 1014 
 
 _S.05_ task:
-	reveal _stronghold_ 
+	reveal _stronghold_ readmap
 	log 1012 step 1 
 
 _S.06_ task:

--- a/Assets/StreamingAssets/Quests/M0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y00.txt
@@ -152,4 +152,5 @@ variable _map_
 variable _nomap_
 _S.11_ task:
 	when _map_ and _pcgetsgold_ 
-	reveal _newdung_ saying 1080 
+	reveal _newdung_ readmap
+    say 1080 

--- a/Assets/StreamingAssets/Quests/M0B00Y06.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y06.txt
@@ -161,7 +161,8 @@ variable _map_
 variable _nomap_
 _S.06_ task:
 	when _map_ and _S.02_ 
-	reveal _newdung_ saying 1080 
+	reveal _newdung_ readmap
+    say 1080 
 
 _monster1_ task:
 	say 1021 

--- a/Assets/StreamingAssets/Quests/M0B00Y07.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y07.txt
@@ -135,7 +135,8 @@ variable _map_
 variable _nomap_
 _S.06_ task:
 	when _map_ and _S.02_ 
-	reveal _newdung_ saying 1080 
+	reveal _newdung_ readmap
+    say 1080 
 
 _monster1_ task:
 	place foe _bear_ at _house_ 

--- a/Assets/StreamingAssets/Quests/M0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y16.txt
@@ -188,7 +188,7 @@ _success_ task:
 variable _qtime_
 _duelist_ task:
 	when _success_ and _map_ 
-	reveal _newdung_ 
+	reveal _newdung_ readmap
 	say 1080 
 
 _victim_ task:

--- a/Assets/StreamingAssets/Quests/M0B1XY01.txt
+++ b/Assets/StreamingAssets/Quests/M0B1XY01.txt
@@ -141,4 +141,5 @@ variable _map_
 variable _nomap_
 _S.08_ task:
 	when _map_ and _pcgetsgold_ 
-	reveal _newdung_ saying 1080 
+	reveal _newdung_ readmap
+    say 1080 

--- a/Assets/StreamingAssets/Quests/M0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/M0B20Y02.txt
@@ -154,4 +154,5 @@ variable _map_
 variable _nomap_
 _S.09_ task:
 	when _map_ and _pcgetsgold_ 
-	reveal _newdung_ saying 1080 
+	reveal _newdung_ readmap
+    say 1080 

--- a/Assets/StreamingAssets/Quests/M0B30Y03.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y03.txt
@@ -139,7 +139,8 @@ variable _map_
 variable _nomap_
 _S.07_ task:
 	when _map_ and _pcgetsgold_ 
-	reveal _newdung_ saying 1080 
+	reveal _newdung_ readmap
+    say 1080 
 
 _S.08_ task:
 	when _nomap_ and _pcgetsgold_ 

--- a/Assets/StreamingAssets/Quests/M0B30Y04.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y04.txt
@@ -154,7 +154,8 @@ variable _map_
 variable _nomap_
 _S.07_ task:
 	when _map_ and _pcgetsgold_ 
-	reveal _newdung_ saying 1080 
+	reveal _newdung_ readmap
+    say 1080 
 	end quest
 
 _S.08_ task:

--- a/Assets/StreamingAssets/Quests/M0B30Y08.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y08.txt
@@ -127,8 +127,8 @@ _S.02_ task:
 _mapvict_ task:
 	when _qgclicked_ and _mondead_ and _map_
 	give pc _gold_ 
-	reveal _newdung_
-                say 1080
+	reveal _newdung_ readmap
+    say 1080
 	end quest 
 
 _clearclick_ task:

--- a/Assets/StreamingAssets/Quests/M0B40Y05.txt
+++ b/Assets/StreamingAssets/Quests/M0B40Y05.txt
@@ -227,8 +227,8 @@ variable _map_
 variable _nomap_
 _S.11_ task:
 	when _map_ and _victory_ 
-	reveal _newdung_
-                say 1080 
+	reveal _newdung_ readmap
+    say 1080 
 
 _end_ task:
                 end quest

--- a/Assets/StreamingAssets/Quests/M0B50Y09.txt
+++ b/Assets/StreamingAssets/Quests/M0B50Y09.txt
@@ -134,5 +134,5 @@ variable _map_
 variable _nomap_
 _S.06_ task:
 	when _map_ and _victory_ 
-	reveal _newdung_
-                say 1080
+	reveal _newdung_ readmap
+    say 1080

--- a/Assets/StreamingAssets/Quests/M0B60Y10.txt
+++ b/Assets/StreamingAssets/Quests/M0B60Y10.txt
@@ -153,7 +153,8 @@ variable _map_
 variable _nomap_
 _S.10_ task:
 	when _map_ and _S.02_ 
-	reveal _newdung_ saying 1080 
+	reveal _newdung_ readmap
+    say 1080 
 
 _S.11_ task:
 	when _nomap_ and _S.02_ 

--- a/Assets/StreamingAssets/Quests/N0B00Y17.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y17.txt
@@ -410,7 +410,7 @@ _S.14_ task:
 	prompt 1041 yes _S.10_ no _S.11_ 
 
 _S.15_ task:
-	reveal _itemdung_ 
+	reveal _itemdung_ readmap
 	log 1023 step 2 
 
 _S.16_ task:

--- a/Assets/StreamingAssets/Quests/N0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y11.txt
@@ -201,5 +201,5 @@ variable _map_
 variable _nomap_
 _S.05_ task:
 	when _map_ and _giveingredient_ 
-	reveal _newdung_
-                say 1080 
+	reveal _newdung_ readmap
+    say 1080 

--- a/Assets/StreamingAssets/Quests/O0A0AL00.txt
+++ b/Assets/StreamingAssets/Quests/O0A0AL00.txt
@@ -205,7 +205,7 @@ _traveltime_ task:
 _questdone_ task:
 	toting _clothing_ and _thiefmember_ clicked 
 	give pc _gold_ 
-	reveal _dungeon_ 
+	reveal _dungeon_ readmap
 	end quest 
 
 _S.02_ task:

--- a/Assets/StreamingAssets/Quests/P0A01L00.txt
+++ b/Assets/StreamingAssets/Quests/P0A01L00.txt
@@ -164,7 +164,7 @@ _clearclick_ task:
 	clear _qgclicked_ _clearclick_ 
 
 _readletter_ task:
-	reveal _mondung_ 
+	reveal _mondung_ readmap
 	log 1015 step 0 
 
 _S.06_ task:

--- a/Assets/StreamingAssets/Tables/QuestList-Classic.txt
+++ b/Assets/StreamingAssets/Tables/QuestList-Classic.txt
@@ -235,10 +235,10 @@ R0C11Y27, Nobility, N, 11,
 R0C11Y28, Nobility, N, 11,
 R0C20Y07, Nobility, N, 20,
 R0C20Y22, Nobility, N, 20,
-R0C30Y25, Nobility, N, 30,
+-R0C30Y25, Nobility, N, 30, Needs support for: reveal totambuCoven in province 46 at 423290
 -R0C40Y23, Nobility, N, 40, BROKEN. QRC file is missing in DF+DFQFIX
--R0C4XY23, Nobility, N, 4X, Needs support for until _thing_ performed:
-R0C60Y24, Nobility, N, 60,
+-R0C4XY23, Nobility, N, 4X, Needs support for: until _thing_ performed: & reveal _skeffingcoven_ in province 38 at 5531
+-R0C60Y24, Nobility, N, 60, Needs support for: reveal kykosCoven in province 11 at 484567
 
 -- Daedra Princes
 -10C00Y00

--- a/Assets/StreamingAssets/Text/ConversationText.txt
+++ b/Assets/StreamingAssets/Text/ConversationText.txt
@@ -2,6 +2,7 @@
 
 schema: *key,text
 
+copyLogbookInfo,                Left-click: toggle copy of selected text. Right-click: copy whole current conversation.
 east,                           east
 northeast,                      northeast
 north,                          north

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -15,6 +15,6 @@ confirmFind,        Do you want to open the world map and prepare to travel to t
 confirmFind2,       (Note: you can still cancel the travel from the map)
 enterNote,          Enter your note below:
 copyLogbookInfo,    Left-click to toggle copying of selected text entry or right-click to copy the current conversation.
-readMap,            Discovered the location of %map after studying a map I found.
+readMap,            Discovered the location of %map after studying a map.
 readMapTG,          The Thieves Guild have revealed the closely guarded where-abouts of a treasure trove called %map.
 readMapDB,          The Dark Brotherhood revealed the secret of some treasure-laden crypts located at somewhere called %map.

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -2,9 +2,13 @@
 
 schema: *key,text
 
+dialogButtonInfo,   Switch between: Active Quests :: Finished Quests :: Notebook
 activeQuests,       Active Quests
+activeQuestsInfo,   Click on an active quest that has a target location to initiate travel.
 finishedQuests,     Finished Quests
+finishedQuestsInfo, Click on an entry to move it. Right click to delete.
 notebook,           Notebook
+notebookInfo,       Click a note to move. Right click to delete. Click in-between to add a new note.
 selectedEntry,      Selected entry:
 confirmMove,        Do you want to change the position of this entry?
 confirmMove2,       (If you select 'Yes' then it will be moved to before the next entry clicked)
@@ -14,7 +18,6 @@ selectedPlace,      Selected location:
 confirmFind,        Do you want to open the world map and prepare to travel to this place?
 confirmFind2,       (Note: you can still cancel the travel from the map)
 enterNote,          Enter your note below:
-copyLogbookInfo,    Left-click to toggle copying of selected text entry or right-click to copy the current conversation.
 readMap,            Discovered the location of %map after studying a map.
 readMapTG,          The Thieves Guild have revealed the closely guarded where-abouts of a treasure trove called %map.
 readMapDB,          The Dark Brotherhood revealed the secret of some treasure-laden crypts located at somewhere called %map.

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -7,7 +7,7 @@ finishedQuests,     Finished Quests
 notebook,           Notebook
 selectedEntry,      Selected entry:
 confirmMove,        Are you sure you want to change the position of this entry? 
-confirmMove2,       (It will be moved to the next position clicked if you select 'Yes')
+confirmMove2,       (It will be moved to before the entry next clicked if you select 'Yes')
 confirmRemove,      Are you sure you want to remove this entry?
 confirmRemove2,     (It will be deleted permanently and cannot be restored)
 enterNote,          Enter your note below:

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -15,3 +15,6 @@ confirmFind,        Do you want to open the world map and prepare to travel to t
 confirmFind2,       (Note: you can still cancel the travel from the map)
 enterNote,          Enter your note below:
 copyLogbookInfo,    Left-click to toggle copying of selected text entry or right-click to copy the current conversation.
+readMap,            Discovered the location of %map after studying a map I found.
+readMapTG,          The Thieves Guild have revealed the closely guarded where-abouts of a treasure trove called %map.
+readMapDB,          The Dark Brotherhood revealed the secret of some treasure-laden crypts located at somewhere called %map.

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -11,7 +11,7 @@ confirmMove2,       (If you select 'Yes' then it will be moved to before the nex
 confirmRemove,      Are you sure you want to remove this entry?
 confirmRemove2,     (It will be deleted permanently and cannot be restored)
 selectedPlace,      Selected location:
-confirmFind,        Do you want to open the travel map and find this place?
-confirmFind2,       (This will only find the location if you're already in the correct region)
+confirmFind,        Do you want to open the world map and prepare to travel to this place?
+confirmFind2,       (Note: you can still cancel the travel from the map)
 enterNote,          Enter your note below:
 copyLogbookInfo,    Left-click to toggle copying of selected text entry or right-click to copy the current conversation.

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -5,5 +5,10 @@ schema: *key,text
 activeQuests,       Active Quests
 finishedQuests,     Finished Quests
 notebook,           Notebook
-confirmRemove,      Are you sure you want to delete the entry dated
+selectedEntry,      Selected entry:
+confirmMove,        Are you sure you want to change the position of this entry? 
+confirmMove2,       (It will be moved to the next position clicked if you select 'Yes')
+confirmRemove,      Are you sure you want to remove this entry?
+confirmRemove2,     (It will be deleted permanently and cannot be restored)
+enterNote,          Enter your note below:
 copyLogbookInfo,    Left-click to toggle copying of selected text entry or right-click to copy the current conversation.

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -6,9 +6,12 @@ activeQuests,       Active Quests
 finishedQuests,     Finished Quests
 notebook,           Notebook
 selectedEntry,      Selected entry:
-confirmMove,        Are you sure you want to change the position of this entry? 
-confirmMove2,       (It will be moved to before the entry next clicked if you select 'Yes')
+confirmMove,        Do you want to change the position of this entry?
+confirmMove2,       (If you select 'Yes' then it will be moved to before the next entry clicked)
 confirmRemove,      Are you sure you want to remove this entry?
 confirmRemove2,     (It will be deleted permanently and cannot be restored)
+selectedPlace,      Selected location:
+confirmFind,        Do you want to open the travel map and find this place?
+confirmFind2,       (This will only find the location if you're already in the correct region)
 enterNote,          Enter your note below:
 copyLogbookInfo,    Left-click to toggle copying of selected text entry or right-click to copy the current conversation.

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -2,6 +2,8 @@
 
 schema: *key,text
 
-activeQuests,   Active Quests
-finishedQuests, Finished Quests
-notebook,       Notebook
+activeQuests,       Active Quests
+finishedQuests,     Finished Quests
+notebook,           Notebook
+confirmRemove,      Are you sure you want to delete the entry dated
+copyLogbookInfo,    Left-click to toggle copying of selected text entry or right-click to copy the current conversation.

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -1,0 +1,7 @@
+- Text database for general daggerfall UI. These text items were previously hardcoded into FALL.EXE.
+
+schema: *key,text
+
+activeQuests,   Active Quests
+finishedQuests, Finished Quests
+notebook,       Notebook

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt.meta
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ebf622d84ef40b946b06a38d5720a2c5
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Assume will go in 0.6, but didn't target that branch, is up to you to decide.

* Created a DaggerfallUI.txt strings table. Intending this to have messages for UI windows that only have a few strings. Heavy string UI windows like SpellMaker or Automap will still have their own. Let me know if you'd rather have one per window even if there's only a handful of messages. Seems that journal window now has quite a few, more than originally anticipated.

* Even though PlayerNotebook is a member of PlayerEntity it serialises to it's own file and controls this separate from the player serialisation.

* I added a message that pops up if player tries to travel while indoors like the one for transport changes. This isn't in classic but is both more consistent and helps a player clicking on a quest in the journal understand why it doesn't bring up the map. (bug report avoidance!)

* Enabled shadows for text in conversation panel on talk window. This is so I can change the shadow colour to indicate which text chunks will be copied. Hope you don't mind Nystul, it was the most elegant solution I could find.

