### PR TITLE
Stack splitting

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -523,12 +523,12 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Determines if item is stackable.
         /// Only ingredients, gold pieces and arrows are stackable,
-        /// but enchanted ingredients and quest items are never stackable.
+        /// but equipped items, enchanted ingredients and quest items are never stackable.
         /// </summary>
         /// <returns>True if item stackable.</returns>
         public virtual bool IsStackable()
         {
-            if (IsQuestItem || IsEnchanted)
+            if (IsEquipped || IsQuestItem || IsEnchanted)
                 return false;
             if (IsIngredient ||
                 IsOfTemplate(ItemGroups.Currency, (int)Currency.Gold_pieces) ||

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -539,6 +539,14 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
+        /// Determines if item is a stack.
+        /// </summary>
+        /// <returns><c>true</c> if item is a stack, <c>false</c> otherwise.</returns>
+        public bool IsAStack() 
+        {
+            return stackCount > 1;
+        }
+        /// <summary>
         /// Allow use of item to be implemented by item object and overridden
         /// </summary>
         /// <returns><c>true</c>, if item use was handled, <c>false</c> otherwise.</returns>

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -292,7 +292,10 @@ namespace DaggerfallWorkshop.Game.Items
         /// <param name="position">Position to reorder to.</param>
         public void ReorderItem(DaggerfallUnityItem item, AddPosition position)
         {
-            if (!items.Contains(item.UID) || position == AddPosition.DontCare)
+            if (!items.Contains(item.UID))
+                return;
+            bool couldBeStacked = FindExistingStack(item) != null;
+            if (position == AddPosition.DontCare && !couldBeStacked)
                 return;
 
             RemoveItem(item);
@@ -590,7 +593,9 @@ namespace DaggerfallWorkshop.Game.Items
             int groupIndex = item.GroupIndex;
             foreach (DaggerfallUnityItem checkItem in items.Values)
             {
-                if (checkItem.ItemGroup == itemGroup && checkItem.GroupIndex == groupIndex && checkItem.IsStackable())
+                if (checkItem != item && 
+                    checkItem.ItemGroup == itemGroup && checkItem.GroupIndex == groupIndex && 
+                    checkItem.IsStackable())
                     return checkItem;
             }
 

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -253,6 +253,24 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
+        /// Remove some number of items from a stack, return the removed items or null if not possible.
+        /// Remark: returned items do not belong to any container.
+        /// </summary>
+        /// <returns>The items picked from stack.</returns>
+        /// <param name="stack">Source stack of items</param>
+        /// <param name="numberToPick">Number of items to pick</param>
+        public DaggerfallUnityItem SplitStack(DaggerfallUnityItem stack, int numberToPick) 
+        {
+            // Only handle stack splitting
+            if (!stack.IsAStack() || numberToPick < 1 || numberToPick >= stack.stackCount)
+                return null;
+            DaggerfallUnityItem pickedItems = new DaggerfallUnityItem(stack);
+            pickedItems.stackCount = numberToPick;
+            stack.stackCount -= numberToPick;
+            return pickedItems;
+        }
+
+        /// <summary>
         /// Removes an item from this collection.
         /// </summary>
         /// <param name="item">Item to remove. Must exist inside this collection.</param>

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -254,7 +254,6 @@ namespace DaggerfallWorkshop.Game.Items
 
         /// <summary>
         /// Remove some number of items from a stack, return the removed items or null if not possible.
-        /// Remark: returned items do not belong to any container.
         /// </summary>
         /// <returns>The items picked from stack.</returns>
         /// <param name="stack">Source stack of items</param>
@@ -266,6 +265,7 @@ namespace DaggerfallWorkshop.Game.Items
                 return null;
             DaggerfallUnityItem pickedItems = new DaggerfallUnityItem(stack);
             pickedItems.stackCount = numberToPick;
+            AddItem(pickedItems, noStack: true);
             stack.stackCount -= numberToPick;
             return pickedItems;
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1217,7 +1217,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // Shouldn't happen
                 if (oneItem == null)
                     return;
-                playerEntity.Items.AddItem(oneItem, noStack: true);
+                playerEntity.Items.AddItem(oneItem, preferredOrder, true);
                 item = oneItem;
             }
             // Try to equip the item, and update armour values accordingly

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1331,12 +1331,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 controlPressed = false;
 
                 // Show message box
-                const int goldToDropTextId = 25;
                 DaggerfallInputMessageBox mb = new DaggerfallInputMessageBox(uiManager, this);
-                mb.SetTextTokens(goldToDropTextId);
+                mb.SetTextBoxLabel(String.Format(TextManager.Instance.GetText("InventoryUI", "HowManyItems"), item.stackCount));
                 mb.TextPanelDistanceY = 0;
                 mb.InputDistanceX = 15;
-                mb.InputDistanceY = -6;
                 mb.TextBox.Numeric = true;
                 mb.TextBox.MaxCharacters = 8;
                 mb.TextBox.Text = "0";

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1210,6 +1210,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
                 return;
             }
+            // If more than one item selected, equip only one
+            if (item.IsAStack())
+            {
+                DaggerfallUnityItem oneItem = playerEntity.Items.SplitStack(item, 1);
+                // Shouldn't happen
+                if (oneItem == null)
+                    return;
+                playerEntity.Items.AddItem(oneItem, noStack: true);
+                item = oneItem;
+            }
             // Try to equip the item, and update armour values accordingly
             List<DaggerfallUnityItem> unequippedList = playerEntity.ItemEquipTable.EquipItem(item);
             if (unequippedList != null)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1684,10 +1684,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     Refresh(false);
                 }
             }
-            else if (selectedActionMode == ActionModes.Remove)
+            else if (selectedActionMode == ActionModes.Remove && CanCarry(item))
             {
-                if (CanCarry(item))
-                    TransferItem(item, remoteItems, localItems, false, true);
+                TransferItem(item, remoteItems, localItems, false, true);
             }
             else if (selectedActionMode == ActionModes.Info)
             {

--- a/Assets/StreamingAssets/Text/InventoryUI.txt
+++ b/Assets/StreamingAssets/Text/InventoryUI.txt
@@ -1,0 +1,5 @@
+- Text database for inventory screen
+
+schema: *key,text
+
+HowManyItems,                   Pick how many items (less than {0})?

--- a/Assets/StreamingAssets/Text/InventoryUI.txt.meta
+++ b/Assets/StreamingAssets/Text/InventoryUI.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 675b79d40fa684ec796b983cb0e5e961
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
(patch on top of stacking-and-equipping)
Allow user to pick or drop part of a stack by maintaining control key pressed while clicking on the stack.

Message box can probably be improved.
