### PR TITLE
Make all sound effects respect volume setting

### DIFF
--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -95,6 +95,9 @@ namespace DaggerfallWorkshop.Game
                 StartWaiting();
             }
 
+            // Update sound volume
+            dfAudioSource.AudioSource.volume = DaggerfallUnity.Settings.SoundVolume;
+
             // Start rain loop if not running
             if ((Presets == AmbientSoundPresets.Rain || Presets == AmbientSoundPresets.Storm) && rainLoop == null)
             {

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -709,7 +709,7 @@ namespace DaggerfallWorkshop.Game
         public void PlayOneShot(AudioClip clip)
         {
             if (audioSource)
-                audioSource.PlayOneShot(clip);
+                audioSource.PlayOneShot(clip, DaggerfallUnity.Settings.SoundVolume);
         }
 
         public void PlayOneShot(SoundClips clip)

--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -107,7 +107,7 @@ namespace DaggerfallWorkshop.Game
 
                 // Play attack sound only about half the time
                 if (Random.value > 0.5f)
-                    dfAudioSource.AudioSource.PlayOneShot(attackClip);
+                    dfAudioSource.AudioSource.PlayOneShot(attackClip, volumeScale * DaggerfallUnity.Settings.SoundVolume);
             }
         }
 

--- a/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
@@ -118,7 +118,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                 var source = QuestMachine.Instance.GetComponent<AudioSource>();
                 if (source != null && !source.isPlaying)
                 {
-                    source.PlayOneShot(clip);
+                    source.PlayOneShot(clip, DaggerfallUnity.Settings.SoundVolume);
                     lastTimePlayed = gameSeconds;
                 }
             }

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -146,7 +146,10 @@ namespace DaggerfallWorkshop.Game
                     }
 
                     if (!ridingAudioSource.isPlaying)
+                    {
+                        ridingAudioSource.volume = DaggerfallUnity.Settings.SoundVolume;
                         ridingAudioSource.Play();
+                    }
                 }
                 // Time for a whinney?
                 if (neighTime < Time.time)

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharClassSelect.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharClassSelect.cs
@@ -87,7 +87,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 uiManager.PushWindow(messageBox);
 
                 AudioClip clip = DaggerfallUnity.Instance.SoundReader.GetAudioClip(SoundClips.SelectClassDrums);
-                DaggerfallUI.Instance.AudioSource.PlayOneShot(clip);
+                DaggerfallUI.Instance.AudioSource.PlayOneShot(clip, DaggerfallUnity.Settings.SoundVolume);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharRaceSelect.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharRaceSelect.cs
@@ -112,7 +112,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 uiManager.PushWindow(messageBox);
 
                 AudioClip clip = DaggerfallUnity.Instance.SoundReader.GetAudioClip((uint)selectedRace.ClipID);
-                DaggerfallUI.Instance.AudioSource.PlayOneShot(clip);
+                DaggerfallUI.Instance.AudioSource.PlayOneShot(clip, DaggerfallUnity.Settings.SoundVolume);
             }
         }
 

--- a/Assets/Scripts/Internal/DaggerfallAction.cs
+++ b/Assets/Scripts/Internal/DaggerfallAction.cs
@@ -248,7 +248,10 @@ namespace DaggerfallWorkshop
                 ActivateNext();
 
             if (PlaySound && Index > 0 && audioSource)
+            {
+                audioSource.volume = DaggerfallUnity.Settings.SoundVolume;
                 audioSource.Play();
+            }
 
             //stop if failed to get valid delegate from lookup - ideally this check should be done before playing
             //sound & activating next, but for testing purposes is done after

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -317,7 +317,10 @@ namespace DaggerfallWorkshop
             // Manually start sound if playOnAwake true.
             // This is necessary as sound is procedurally created after awake.
             if (audioSource.playOnAwake)
+            {
+                audioSource.volume = DaggerfallUnity.Settings.SoundVolume;
                 audioSource.Play();
+            }
         }
 
         private bool ReadyCheck()


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=1009.

I can't reproduce the issue there about music playing even when at 0 volume. For me it turns off completely. But the issues of sound effects ignoring the volume setting are fixed.

Was a bit tricky to figure out because sounds are played in several different ways:
1) Goes through a PlayOneShot function in DFAudioSource. In this case, DFAudioSource handles applying the volume setting and the call to PlayOneShot can ignore the volume setting. (No fixes needed here)
2) Goes through PlayOneShot in AudioSource. In this case, the volume setting needs to be applied in the call. (This needed to be done for enemies' PlayAttackSound() and for sounds in character creation)
3) Goes through Play() on an AudioSource. In this case, the Audiosource's "volume" needs to be set to match the volume setting. This had to be done in a few different places, and should fix weather sounds/crickets, DaggerfallAction sounds, quest sounds, and riding sounds.

I think the only sound that doesn't respect the sound volume setting now is .VID files. Not sure how their sound is handled.