### PR TITLE
Temporary fix for saves with missing caster loadID

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1521,6 +1521,12 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                         continue;
                     }
 
+                    if (instancedBundle.caster == null)
+                    {
+                        Debug.LogWarning("RestoreInstancedBundleSaveData() could not restore effect as caster was not found.");
+                        continue;
+                    }
+
                     // Resume effect
                     effect.ParentBundle = instancedBundle;
                     effect.Resume(effectData, this, instancedBundle.caster);
@@ -1556,7 +1562,10 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             {
                 SerializableEnemy serializableEnemy = SaveLoadManager.StateManager.GetEnemy(loadID);
                 if (!serializableEnemy)
-                    throw new Exception(string.Format("EntityEffect.RestoreEffectSaveData() could not find SerializableEnemy for LoadID {0} in StateManager.", loadID));
+                {
+                    Debug.LogError(string.Format("EntityEffect.RestoreEffectSaveData() could not find SerializableEnemy for LoadID {0} in StateManager.", loadID));
+                    return null;
+                }
 
                 caster = serializableEnemy.GetComponent<DaggerfallEntityBehaviour>();
                 if (!caster)


### PR DESCRIPTION
A temporary workaround for https://forums.dfworkshop.net/viewtopic.php?f=24&t=1374.

In my experience this happens _every_ time you save with a spell having been cast by an enemy, whether on the player or on another enemy. I'm kind of surprised this hasn't been brought up more on the forum.

I don't know what the underlying cause is, but this treats the symptom and at least allows for loading an affected saved game and continuing play.

By the way, a somewhat pedantic note, but the failure in `GetCasterReference` was throwing an exception. I changed it to `LogError` to indicate the same level of "error", but where this is used for resuming effects, a failure was just a `LogWarningFormat` so there I used a same level `LogWarning`, but unless I'm missing something it seems like these should either both be "errors" or both be "warnings".

Interkarma if you have a fix in the works, you can ignore this PR if you want.
 