### PR TITLE
Differentiate duplicate plants in long name (tooltips)

### DIFF
--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -29,6 +29,7 @@ namespace DaggerfallWorkshop.Game.Items
     public class ItemHelper
     {
         public const int wagonKgLimit = 750;
+        const string textDatabase = "DaggerfallUI";
 
         #region Fields
 
@@ -173,6 +174,12 @@ namespace DaggerfallWorkshop.Game.Items
             // Return result without material prefix if item is unidentified or an Artifact.
             if (!item.IsIdentified || item.IsArtifact)
                 return result;
+
+            // Differentiate plant ingredients with 2 variants
+            if (item.ItemGroup == ItemGroups.PlantIngredients1 && item.TemplateIndex < 18)
+                return string.Format("{0} {1}", result, TextManager.Instance.GetText(textDatabase, "northern"));
+            if (item.ItemGroup == ItemGroups.PlantIngredients2 && item.TemplateIndex < 18)
+                return string.Format("{0} {1}", result, TextManager.Instance.GetText(textDatabase, "southern"));
 
             // Resolve weapon material
             if (item.ItemGroup == ItemGroups.Weapons && item.TemplateIndex != (int)Weapons.Arrow)

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -26,3 +26,5 @@ failedQuest,        failed
 finishQuestHeader,  {0} {1} at {2}:
 quest,              Quest
 noteHeader,         {0} in {1}:
+northern,           (northern)
+southern,           (southern)


### PR DESCRIPTION
Used the suffixes "(northern)" and "(southern)" based on Allofich's suggestion.