### PR TITLE
Item Icon variants - books and LoC

### DIFF
--- a/Assets/Resources/ItemTemplates.txt
+++ b/Assets/Resources/ItemTemplates.txt
@@ -5515,7 +5515,7 @@
         "isOneHanded": false,
         "isIngredient": false,
         "worldTextureArchive": 209,
-        "worldTextureRecord": 8,
+        "worldTextureRecord": 7,
         "playerTextureArchive": 0,
         "playerTextureRecord": 0
     },
@@ -5548,7 +5548,7 @@
         "basePrice": 2500,
         "enchantmentPoints": 0,
         "rarity": 9,
-        "variants": 3,
+        "variants": 2,
         "drawOrderOrEffect": 0,
         "isBluntWeapon": false,
         "isLiquid": false,
@@ -5556,8 +5556,8 @@
         "isIngredient": false,
         "worldTextureArchive": 209,
         "worldTextureRecord": 2,
-        "playerTextureArchive": 0,
-        "playerTextureRecord": 0
+        "playerTextureArchive": 209,
+        "playerTextureRecord": 2
     },
     {
         "index": 278,

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -264,6 +264,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // TODO: Change DaggerfallUnityItem.message from int to ushort
             book.message = DaggerfallUnity.Instance.ItemHelper.getRandomBookID();
+            book.CurrentVariant = UnityEngine.Random.Range(0, book.TotalVariants);
             return book;
         }
 


### PR DESCRIPTION
* Fixed book display where they show using holy tome icon in old saves. Populating player tex archive + record and then changed GetRandomBook to select one of the 3 variants that are allowed instead of just using the same icon for every book. One of these is the spellbook icon... since classic only uses one icon for books (assuming a bug given variant number) and I think this will be confusing I have reduced variants to 2.

* Also changed the icon for LoC to an unused icon. (was going to be for deeds I think)