### PR TITLE
map zoom behavior changed, "Map" section in ini-file contains map related entries now

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -35,7 +35,6 @@ EnableToolTips=True
 ToolTipDelayInSeconds=0.0
 ToolTipBackgroundColor=404040D2
 ToolTipTextColor=E6E6C8FF
-AutomapNumberOfDungeons=5
 ShopQualityPresentation=0
 ShopQualityHUDDelay=4
 ShowQuestJournalClocksAsCountdown=False
@@ -67,6 +66,11 @@ ClickToAttack = False
 CameraRecoilStrength = 3
 SoundVolume = 1.0
 MusicVolume = 1.0
+
+[Map]
+AutomapNumberOfDungeons=5
+ExteriorMapDefaultZoomLevel=8
+ExteriorMapResetZoomLevelOnNewLocation=True
 
 [Startup]
 StartCellX=109

--- a/Assets/Scripts/Game/ExteriorAutomap.cs
+++ b/Assets/Scripts/Game/ExteriorAutomap.cs
@@ -84,7 +84,7 @@ namespace DaggerfallWorkshop.Game
         GameObject gameObjectCameraExteriorAutomap = null; // used to hold reference to GameObject to which camera class for automap camera is attached to
         Camera cameraExteriorAutomap = null; // camera for exterior automap camera        
         Quaternion cameraTransformRotationSaved; // camera rotation is saved so that after closing and reopening exterior automap the camera transform settings can be restored
-        float cameraOrthographicSizeSaved; // camera's orthographic size is saved so that after closing and reopening exterior automap the camera settings can be restored
+        //float cameraOrthographicSizeSaved; // camera's orthographic size is saved so that after closing and reopening exterior automap the camera settings can be restored
 
         GameObject gameObjectPlayerAdvanced = null; // used to hold reference to instance of GameObject "PlayerAdvanced"
 
@@ -261,7 +261,7 @@ namespace DaggerfallWorkshop.Game
 
             // restore camera rotation and zoom
             gameObjectCameraExteriorAutomap.transform.rotation = cameraTransformRotationSaved;
-            cameraExteriorAutomap.orthographicSize = cameraOrthographicSizeSaved;
+            //cameraExteriorAutomap.orthographicSize = cameraOrthographicSizeSaved;
 
             // recreate building nameplates (since a discovery could have happened since exterior automap has been opened last time)
             createBuildingNameplates(location);
@@ -279,7 +279,7 @@ namespace DaggerfallWorkshop.Game
         public void updateAutomapStateOnWindowPop()
         {
             cameraTransformRotationSaved = gameObjectCameraExteriorAutomap.transform.rotation;
-            cameraOrthographicSizeSaved = cameraExteriorAutomap.orthographicSize;
+            //cameraOrthographicSizeSaved = cameraExteriorAutomap.orthographicSize;
 
             // destroy the camera so it does not use system resources
             if (gameObjectCameraExteriorAutomap != null)
@@ -449,7 +449,7 @@ namespace DaggerfallWorkshop.Game
             Camera.main.cullingMask = Camera.main.cullingMask & ~((1 << layerAutomap)); // don't render automap layer with main camera
 
             cameraTransformRotationSaved = Quaternion.identity;
-            cameraOrthographicSizeSaved = 10.0f; // dummy value > 0.0f -> will be overwritten once camera zoom is applied
+            //cameraOrthographicSizeSaved = 10.0f; // dummy value > 0.0f -> will be overwritten once camera zoom is applied
 
             // important that transition events/delegates are created in Awake() instead of OnEnable (since exteriorAutomap gameobject is disabled when going indoors and enabled when going outdoors)
             PlayerGPS.OnMapPixelChanged += OnMapPixelChanged;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -51,7 +51,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         //const float locationSizeBasedStartZoomMultiplier = 10.0f; // the zoom multiplier based on location size used as starting zoom
         const float startZoomMultiplier = 8.0f;
 
-        const bool resetZoomLevelOnNewLocation = false;        
+        const bool resetZoomLevelOnNewLocation = true;        
 
         // this is a helper class to implement behaviour and easier use of hotkeys and key modifiers (left-shift, right-shift, ...) in conjunction
         // note: currently a combination of key modifiers like shift+alt is not supported. all specified modifiers are comined with an or-relation
@@ -162,7 +162,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         Camera cameraExteriorAutomap = null; // camera for exterior automap camera
 
-        float zoomLevel = 0.0f; // the camera zoom level
+        float zoomLevel = -1.0f; // the camera zoom level, -1.0 indicates uninitialized
 
         Panel dummyPanelAutomap = null; // used to determine correct render panel position
         Panel panelRenderAutomap = null; // level geometry is rendered into this panel
@@ -488,11 +488,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 compass.CompassCamera = cameraExteriorAutomap;
             }
 
-            if (zoomLevel == 0.0f)
-            {
-                zoomLevel = ComputeZoom();                
-            }
-
             if (exteriorAutomap.ResetAutomapSettingsSignalForExternalScript == true) // signaled to reset automap settings
             {
                 // reset values to default whenever player enters building or dungeon
@@ -501,7 +496,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 exteriorAutomap.ResetAutomapSettingsSignalForExternalScript = false; // indicate the settings were reset
             }
 
-            // now set camera zoom level (important: after (optional) zoomLevel init and resetCameraPosition() call - since it might have changed zoomLevel)
+            // compute the zoom level if required
+            if (zoomLevel == -1.0f || resetZoomLevelOnNewLocation)
+            {
+                zoomLevel = ComputeZoom();
+            }
+
+            // now set camera zoom level (either set the newly computed value or the old value (stored from last map close))
             cameraExteriorAutomap.orthographicSize = zoomLevel;
 
             // focus player position on exterior automap
@@ -982,11 +983,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// resets the camera transform of the 2D view mode
         /// </summary>
         private void resetCameraTransform()
-        {
-            if (resetZoomLevelOnNewLocation)
-            {
-                zoomLevel = ComputeZoom();
-            }
+        {            
             cameraExteriorAutomap.transform.position = exteriorAutomap.GameobjectPlayerMarkerArrow.transform.position + new Vector3(0.0f, 10.0f, 0.0f); //Vector3.zero + Vector3.up * cameraHeight;
             cameraExteriorAutomap.transform.rotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
             //cameraExteriorAutomap.transform.LookAt(Vector3.zero);            
@@ -1269,6 +1266,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // reset values to default
             resetCameraPosition();
+            zoomLevel = ComputeZoom();
+            cameraExteriorAutomap.orthographicSize = zoomLevel;
             exteriorAutomap.resetRotationBuildingNameplates();            
             updateAutomapView();
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -48,11 +48,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const float maxZoom = 25.0f; // the minimum external automap camera height
         const float minZoom = 250.0f; // the maximum external automap camera height
 
-        //const float locationSizeBasedStartZoomMultiplier = 10.0f; // the zoom multiplier based on location size used as starting zoom
-        const float startZoomMultiplier = 8.0f;
-
-        const bool resetZoomLevelOnNewLocation = true;        
-
         // this is a helper class to implement behaviour and easier use of hotkeys and key modifiers (left-shift, right-shift, ...) in conjunction
         // note: currently a combination of key modifiers like shift+alt is not supported. all specified modifiers are comined with an or-relation
         class HotkeySequence
@@ -161,6 +156,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         GameObject gameobjectExteriorAutomap = null; // used to hold reference to instance of GameObject "ExteriorAutomap" (which has script Game/ExteriorAutomap.cs attached)
 
         Camera cameraExteriorAutomap = null; // camera for exterior automap camera
+
+        //float locationSizeBasedStartZoomMultiplier = 10.0f; // the zoom multiplier based on location size used as starting zoom
+        float startZoomMultiplier; // the default zoom level multiplier
+        bool resetZoomLevelOnNewLocation; // flag to indicate if zoom level should be reset on changing location/when a new location is loaded
 
         float zoomLevel = -1.0f; // the camera zoom level, -1.0 indicates uninitialized
 
@@ -461,6 +460,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Store toggle closed binding for this window
             toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.AutoMap);
 
+            startZoomMultiplier = DaggerfallUnity.Settings.ExteriorMapDefaultZoomLevel;
+            resetZoomLevelOnNewLocation = DaggerfallUnity.Settings.ExteriorMapResetZoomLevelOnNewLocation;
+
             isSetup = true;
         }
 
@@ -490,14 +492,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (exteriorAutomap.ResetAutomapSettingsSignalForExternalScript == true) // signaled to reset automap settings
             {
-                // reset values to default whenever player enters building or dungeon
+                // reset values to default whenever player enters new location
                 resetCameraPosition();
+
+                if (resetZoomLevelOnNewLocation)
+                {
+                    zoomLevel = ComputeZoom();
+                }
 
                 exteriorAutomap.ResetAutomapSettingsSignalForExternalScript = false; // indicate the settings were reset
             }
 
             // compute the zoom level if required
-            if (zoomLevel == -1.0f || resetZoomLevelOnNewLocation)
+            if (zoomLevel == -1.0f)
             {
                 zoomLevel = ComputeZoom();
             }

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -39,6 +39,7 @@ namespace DaggerfallWorkshop
         const string sectionGUI = "GUI";
         const string sectionSpells = "Spells";
         const string sectionControls = "Controls";
+        const string sectionMap = "Map";
         const string sectionStartup = "Startup";
         const string sectionExperimental = "Experimental";
         const string sectionEnhancements = "Enhancements";
@@ -97,7 +98,6 @@ namespace DaggerfallWorkshop
         public float ToolTipDelayInSeconds { get; set; }
         public Color32 ToolTipBackgroundColor { get; set; }
         public Color32 ToolTipTextColor { get; set; }
-        public int AutomapNumberOfDungeons { get; set; }
         public int ShopQualityPresentation { get; set; }
         public int ShopQualityHUDDelay { get; set; }
         public bool ShowQuestJournalClocksAsCountdown { get; set; }
@@ -128,6 +128,11 @@ namespace DaggerfallWorkshop
         public int CameraRecoilStrength { get; set; }
         public float MusicVolume { get; set; }
         public float SoundVolume { get; set; }
+
+        // [Map]
+        public int AutomapNumberOfDungeons { get; set; }
+        public float ExteriorMapDefaultZoomLevel { get; set; }
+        public bool ExteriorMapResetZoomLevelOnNewLocation { get; set; }
 
         // [Startup]
         public int StartCellX { get; set; }
@@ -201,8 +206,7 @@ namespace DaggerfallWorkshop
             EnableInventoryInfoPanel = GetBool(sectionGUI, "EnableInventoryInfoPanel");
             EnableEnhancedItemLists = GetBool(sectionGUI, "EnableEnhancedItemLists");
             EnableModernConversationStyleInTalkWindow = GetBool(sectionGUI, "EnableModernConversationStyleInTalkWindow");
-            HelmAndShieldMaterialDisplay = GetInt(sectionGUI, "HelmAndShieldMaterialDisplay", 0, 3);
-            AutomapNumberOfDungeons = GetInt(sectionGUI, "AutomapNumberOfDungeons", 0, 100);
+            HelmAndShieldMaterialDisplay = GetInt(sectionGUI, "HelmAndShieldMaterialDisplay", 0, 3);            
             ShopQualityPresentation = GetInt(sectionGUI, "ShopQualityPresentation", 0, 2);
             ShopQualityHUDDelay = GetInt(sectionGUI, "ShopQualityHUDDelay", 1, 10);
             ShowQuestJournalClocksAsCountdown = GetBool(sectionGUI, "ShowQuestJournalClocksAsCountdown");
@@ -227,6 +231,10 @@ namespace DaggerfallWorkshop
             CameraRecoilStrength = GetInt(sectionControls, "CameraRecoilStrength", 0, 4);
             SoundVolume = GetFloat(sectionControls, "SoundVolume", 0f, 1.0f);
             MusicVolume = GetFloat(sectionControls, "MusicVolume", 0f, 1.0f);
+
+            AutomapNumberOfDungeons = GetInt(sectionMap, "AutomapNumberOfDungeons", 0, 100);
+            ExteriorMapDefaultZoomLevel = GetFloat(sectionMap, "ExteriorMapDefaultZoomLevel", 4, 31);
+            ExteriorMapResetZoomLevelOnNewLocation = GetBool(sectionMap, "ExteriorMapResetZoomLevelOnNewLocation");
 
             StartCellX = GetInt(sectionStartup, "StartCellX", 2, 997);
             StartCellY = GetInt(sectionStartup, "StartCellY", 2, 497);


### PR DESCRIPTION
Hi Interkarma, please especially take a look on the 3rd point (the changes to the ini file) - since this is territory I usually don't touch - especially moving the setting "AutomapNumberOfDungeons" to the new "Map" section - if this is done correctly

- zoom settings changed - zoom is now independent of location size

- there is now a flag to change zoom reset behavior on location change

- ini file now has a "Map" section with map related settings: moved "AutomapNumberOfDungeons" to this section, added 2 new settings to this section: "ExteriorMapDefaultZoomLevel" and "ExteriorMapResetZoomLevelOnNewLocation"