### PR TITLE
Add missing paralysis resist logic

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
@@ -609,7 +609,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             int roll = UnityEngine.Random.Range(1, 100);
             bool outcome = (roll <= ChanceValue());
 
-            //Debug.LogFormat("Effect '{0}' has a {1}% chance of succeeding and rolled {2} for a {3}", Key, chance, roll, (outcome) ? "success" : "fail");
+            //Debug.LogFormat("Effect '{0}' has a {1}% chance of succeeding and rolled {2} for a {3}", Key, ChanceValue(), roll, (outcome) ? "success" : "fail");
 
             return outcome;
         }

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -413,6 +413,25 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                     continue;
                 }
 
+                // Special handling for paralysis
+                if (effect is Paralyze)
+                {
+                    // Immune if saving throw made
+                    if (FormulaHelper.SavingThrow(effect, entityBehaviour.Entity) == 0)
+                    {
+                        if (IsPlayerEntity || showNonPlayerFailures)
+                        {
+                            // Output "Save versus spell made." for external contact spells
+                            DaggerfallUI.AddHUDText(TextManager.Instance.GetText(textDatabase, "saveVersusSpellMade"));
+                        }
+                        continue;
+                    }
+
+                    // Immune in god mode
+                    if (IsPlayerEntity && GameManager.Instance.PlayerEntity.GodMode)
+                        continue;
+                }
+
                 // Add effect
                 instancedBundle.liveEffects.Add(effect);
 


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=1443. Only way I saw to do it was to add special handling for paralysis in the effect manager. If the logic was within `Paralyze.cs`, I think the effect would have started and we'd have to undo the magic rounds that had been added, etc. If you have a better solution in mind, feel free to do it instead.

Also fixes saving throws. I was wondering why a custom class character with immunity to paralysis was not resisting paralysis from some Giant Scorpions I was testing with. Turned out the paralysis spell they use (Spider Touch) has both the paralysis and magic flags. I messed up with the saving throw logic before and made it only check for one and only one flag type, so it didn't work with 2 flag types. Now, like classic, it works with multiple flags.

Also made the player immune to paralysis in god mode, because it gets in the way of testing.