### PR TITLE
Fix overly fast video playback

### DIFF
--- a/Assets/Scripts/Game/UserInterface/DaggerfallVideo.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallVideo.cs
@@ -35,6 +35,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         AudioSource[] audioSources = new AudioSource[clipQueueLength];
         int flip = 0;
         double nextEventTime;
+        bool lastPlayedAudioFrame;
 
         public bool Playing { get; set; }
         public VidFile VidFile { get { return vidFile; } }
@@ -117,6 +118,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         audioSources[flip].PlayScheduled(nextEventTime);
                         nextEventTime += vidFile.FrameDelay;
                         flip = (clipQueueLength - 1) - flip;
+                        lastPlayedAudioFrame = true;
                     }
 
                     if (vidFile.LastBlockType == VidBlockTypes.Video_StartFrame ||
@@ -126,6 +128,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         // Update video
                         vidTexture.SetPixels32(vidFile.FrameBuffer);
                         vidTexture.Apply(false);
+
+                        // Several videos have parts that are only video frames.
+                        // If nextEventTime is not updated, the playback becomes too fast in these parts.
+                        if (!lastPlayedAudioFrame)
+                        {
+                            nextEventTime += vidFile.FrameDelay;
+                        }
+
+                        lastPlayedAudioFrame = false;
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=507.

The problem was that `DaggerfallVideo` seemed to assume that there would always be an audio frame to use to update `nextEventTime`, but there are parts in several of Daggerfall's videos where there are stretches of only video frames. Another issue was that the audioBuffer length when the last audio frame played could be very small, leading to short `frameDelay`. Enforcing a minimum `frameDelay` and accounting for parts where there are no audio frames fixes the speed ups at the end of `ANIM0000.VID` (the book intro) and `ANIM0005.VID` (meeting Lysandus's ghost). It may also slightly improve the timing of the Bethesda logo intro (you can see the sparkle disappear at the end now) and the end frames of some endings.

I tested all the video files in the game with this PR and they all play fine.