### PR TITLE
Fix spurious "you cannot carry anymore stuff."

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -596,11 +596,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Handle click based on action
             if (selectedActionMode == ActionModes.Select)
             {
-                int canCarry = CanCarryAmount(item);
+                int canCarry;
                 if (usingWagon)
-                {
-                    canCarry = Math.Max(canCarry, WagonCanHoldAmount(item));
-                }
+                    canCarry = WagonCanHoldAmount(item);
+                else 
+                    canCarry = CanCarryAmount(item);
                 if (windowMode == WindowModes.Buy)
                 {
                     TransferItem(item, remoteItems, basketItems, canCarry, equip: true);


### PR DESCRIPTION
When, while you're selling items, you put items back into your open
wagon, you can sometimes get a "you can't carry that much weight" kind
of message and yet the items are correctly removed from the selling
selection.

The culpit is the seemingly harmless

    int canCarry = CanCarryAmount(item);
    if (usingWagon)
    {
        canCarry = Math.Max(canCarry, WagonCanHoldAmount(item));
    }

because CanCarryAmount() an WagonCanHoldAmount() not only return how
many instances of a given item still fit in character's inventory or
wagon, but they also display the above message if none fits; So they
cannot be freely composed, like above.

While I think I understand the intention behind that max() ("you can
pick the item if it fits in either your pack or your wagon"), I think it
currently has another bug, because the item is not put in your pack if
it doesn't fix in the wagon; So under the right conditions you can stack
pretty much everything in your wagon.

This patch remove that fallback logic entirely, which is the simplest
fix.