### PR TITLE
Implemented ImportedComponentAttribute

### DIFF
--- a/Assets/Game/Addons/ModSupport/Editor/CreateModEditorWindow.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/CreateModEditorWindow.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -513,6 +513,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                         if(!tempAssetPaths.Contains(serializedPrefabPath))
                             tempAssetPaths.Add(serializedPrefabPath);
                     }
+
+                    string importedComponentsPath = CheckForImportedComponents(assetPath);
+                    if (importedComponentsPath != null)
+                    {
+                        if (!tempAssetPaths.Contains(importedComponentsPath))
+                            tempAssetPaths.Add(importedComponentsPath);
+                    }
                 }
             }
 
@@ -727,6 +734,19 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             return result.Succeeded;
         }
 
+        private string CheckForImportedComponents(string prefabPath)
+        {
+            var go = AssetDatabase.LoadAssetAtPath(prefabPath, typeof(GameObject)) as GameObject;
+            string importedComponentsPath = ImportedComponentAttribute.Save(go, GetTempModDirPath(modInfo.ModTitle));
+            if (importedComponentsPath != null)
+            {
+                importedComponentsPath = GetAssetPathFromFilePath(importedComponentsPath);
+                AddAssetToMod(importedComponentsPath);
+                AssetDatabase.Refresh();
+                return importedComponentsPath;
+            }
 
+            return null;
+        }
     }
 }

--- a/Assets/Game/Addons/ModSupport/ImportedComponentAttribute.cs
+++ b/Assets/Game/Addons/ModSupport/ImportedComponentAttribute.cs
@@ -1,0 +1,196 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: TheLacus
+// Contributors:
+// 
+// Notes:
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using FullSerializer;
+
+namespace DaggerfallWorkshop.Game.Utility.ModSupport
+{
+    /// <summary>
+    /// Defines a <see cref="Component"/> provided by a mod assembly which can be automatically serialized and deserialized.
+    /// </summary>
+    /// <remarks>
+    /// Monobehaviours defined in a mod assembly are not known to Unity when a prefab is loaded and deserialized from an assetbundle.
+    /// If a prefab is marked with this attribute, the bundled clone is stripped of any instance of the Monobehaviour and its data
+    /// is stored in a json file bundled with the mod. When the GameObject is loaded at runtime, the json file is used to
+    /// automatically add back the components (provided by the mod assembly) and deserialize them.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ImportedComponentAttribute : Attribute
+    {
+        private struct ImportedComponentsData
+        {
+            public List<Component> Components;
+            public Dictionary<string, ImportedComponentsData> Children;
+        }
+
+        readonly static Dictionary<string, Type> types = new Dictionary<string, Type>();
+
+        #region Public Methods
+
+        /// <summary>
+        /// Makes the filename for the imported components data.
+        /// </summary>
+        public static string MakeFileName(string prefabName)
+        {
+            return string.Format("{0}.imported.json", prefabName);
+        }
+
+#if UNITY_EDITOR
+
+        /// <summary>
+        /// Saves data for the imported components, if found.
+        /// </summary>
+        /// <param name="gameObject">A gameobject instance.</param>
+        /// <param name="directory">Where the json file will be created.</param>
+        /// <returns>Full path of json file or null.</returns>
+        public static string Save(GameObject gameObject, string directory)
+        {
+            // Get all imported components
+            var importedComponentsData = new ImportedComponentsData();
+            if (!SaveImportedComponents(gameObject, ref importedComponentsData))
+                return null;
+
+            // Serialize imported components data
+            fsData fsData;
+            ModManager._serializer.TrySerialize(importedComponentsData, out fsData);
+            string path = Path.Combine(directory, MakeFileName(gameObject.name));
+            File.WriteAllText(path, fsJsonPrinter.PrettyJson(fsData));
+            return path;
+        }
+
+#endif
+
+        /// <summary>
+        /// Restore imported components on this gameobject and its children.
+        /// </summary>
+        /// <param name="mod">The mod that contains components type and serialized data.</param>
+        /// <param name="gameObject">A gameobject instance.</param>
+        public static void Restore(Mod mod, GameObject gameObject)
+        {
+            RestoreImportedComponents(mod, gameObject, fsJsonParser.Parse(LoadSerializedFile(mod, gameObject.name)));
+        }
+
+        #endregion
+
+        #region Private Methods
+
+#if UNITY_EDITOR
+
+        /// <summary>
+        /// Seeks all imported components on a gameobject and its children.
+        /// Imported components are REMOVED from the prefab.
+        /// </summary>
+        /// <param name="gameObject">A gameobject instance.</param>
+        /// <param name="importedComponentsData">Instance to fill with components data.</param>
+        private static bool SaveImportedComponents(GameObject gameObject, ref ImportedComponentsData importedComponentsData)
+        {
+            bool saveNeeded = false;
+
+            // Get and destroy only imported components
+            importedComponentsData.Components = new List<Component>();
+            foreach (var component in gameObject.GetComponents(typeof(Component)))
+            {
+                if (GetCustomAttribute(component.GetType(), typeof(ImportedComponentAttribute)) != null)
+                {
+                    importedComponentsData.Components.Add(component);
+                    UnityEngine.Object.DestroyImmediate(component, true);
+                    if (!saveNeeded)
+                        saveNeeded = true;
+                }
+            }
+
+            // Iterate children
+            if (gameObject.transform.childCount > 0)
+            {
+                importedComponentsData.Children = new Dictionary<string, ImportedComponentsData>();
+                for (int i = 0; i < gameObject.transform.childCount; i++)
+                {
+                    Transform transform = gameObject.transform.GetChild(i);
+                    var childImportedComponentsData = new ImportedComponentsData();
+                    if (SaveImportedComponents(transform.gameObject, ref childImportedComponentsData) && !saveNeeded)
+                        saveNeeded = true;
+                    importedComponentsData.Children.Add(transform.gameObject.name, childImportedComponentsData);
+                }
+            }
+
+            return saveNeeded;
+        }
+
+#endif
+
+        /// <summary>
+        /// Restores and deserializes imported components on a gameobject and its children.
+        /// </summary>
+        /// <param name="gameObject">A gameobject instance.</param>
+        /// <param name="fsData">Serialized ImportedComponentsData for the gameobject.</param>
+        private static void RestoreImportedComponents(Mod mod, GameObject gameObject, fsData fsData)
+        {
+            Dictionary<string, fsData> dict = fsData.AsDictionary;
+            foreach (fsData componentData in dict["Components"].AsList)
+            {
+                // Add component and deserialize
+                Type type = FindType(mod, componentData.AsDictionary["$type"].AsString);
+                if (type != null)
+                {
+                    object instance = gameObject.AddComponent(type);
+                    ModManager._serializer.TryDeserialize(componentData, type, ref instance);
+                }
+            }
+
+            // Restore children
+            fsData children = dict["Children"];
+            if (children != null && !children.IsNull)
+            {
+                foreach (KeyValuePair<string, fsData> childData in children.AsDictionary)
+                {
+                    Transform child = gameObject.transform.Find(childData.Key);
+                    if (child != null)
+                        RestoreImportedComponents(mod, child.gameObject, childData.Value);
+                }
+            }
+        }
+
+        private static Type FindType(Mod mod, string typeName)
+        {
+            if (!string.IsNullOrEmpty(typeName))
+            {
+                Type type;
+                if (types.TryGetValue(typeName, out type))
+                    return type;
+
+                type = mod.GetCompiledType(typeName);
+                if (type != null)
+                {
+                    types.Add(typeName, type);
+                    return type;
+                }
+            }
+
+            Debug.LogErrorFormat("Failed to find type {0}.", typeName);
+            return null;
+        }
+
+        private static string LoadSerializedFile(Mod mod, string name)
+        {
+            var textAsset = mod.GetAsset<TextAsset>(MakeFileName(name));
+            if (textAsset != null)
+                return textAsset.text;
+
+            throw new Exception("Serialized data not found!");
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Game/Addons/ModSupport/ImportedComponentAttribute.cs.meta
+++ b/Assets/Game/Addons/ModSupport/ImportedComponentAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec64e01ded5059841bdfe7fc5ac1d395
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -627,6 +627,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                 return false;
             else
             {
+                if (la.T == typeof(GameObject) && assetBundle.Contains(ImportedComponentAttribute.MakeFileName(assetName)))
+                    ImportedComponentAttribute.Restore(this, la.Obj as GameObject);
+
                 loadedAssets.Add(assetName, la);
 
                 if (this.modInfo != null && string.IsNullOrEmpty(this.Title) == false)


### PR DESCRIPTION
One of the big limitations of the Mod Sytem is that MonoBehaviours provided my a mod can't be serialized to a prefab, because their type is not known by Unity when they are loaded from the assetbundle. The solution is to add components at runtime with `AddComponent()` but this is quite bothersome, and also impossible when a gameobject is instatiated by Asset-Injection without mod intervention.

As a workaround Lypyl introduced an interface to serialize custom scripts and provide a simple way to deserialize them, but it still requires the mod intervention so it doesn't fully satisfy all needs. For this reason i decided to give it a try with my own take on this issue.

## Component

Imported Monobehaviours needs to be assigned the `ImportedComponentAttribute`. Thats's all.

```
[ImportedComponent]
public class ExampleComponent : MonoBehaviour
{
    public string Title;
    public int Number;
}
```

## Serialization

The mod builder checks prefabs for components with the attribute and remove them on the bundled clone (the original is left unaltered), not before saving the required data to a json file named **prefabName.imported.json**. This is similar to what Lypyl was doing.
The final result looks like this:

![examplecomponent](https://user-images.githubusercontent.com/24359151/48316429-ca597f80-e5e3-11e8-8a83-86630346cde6.png)

```
{
    "Components": [
        {
            "Title": "Elephant",
            "Number": 24,
            "$type": "ExampleComponent"
        }
    ],
    "Children": {
        "Sphere": {
            "Components": [
                {
                    "Title": "Dog",
                    "Number": 234,
                    "$type": "ExampleComponent"
                }
            ],
            "Children": null
        }
    }
}
```

There are two things to notice:
+ Components without the attribute are not saved here because they are already managed by Unity with the **.prefab**.
+ FullSerializer adds `$type` properties with the full type name.

## Deserialization

When a prefab is loaded with `Mod.GetAsset()`, the mod manager automatically look for the **imported.json** file. This is the tricky (and somewhat hacky) part:
Instead of giving the gameobject instance to FullSerializer (which wouldn't work), we traverse the `fsData` dictionary to read the `$type` properties and retrieve the actual type at runtime from the compiled mod assembly. At this point we can make a new instance with `AddComponent()` and let FullSerializer do its work on it.

## Conclusion

Manually using `AddComponent()` is always the fastest option but if this is not possible or is otherwise not desiderable, the `ImportedComponentAttribute` can automatize this process.