### PR TITLE
Handle asynchronous loading of audioClips

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
@@ -27,14 +27,12 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
         /// or play sound (soundname) x y
         /// the second number is not currently used for anything - purpose is unkown.
 
-        const float audioClipMaxDelay = 0.150f; //give up if sound takes longer to load
-
         public string   soundName;              //used to lookup sound index in sound table
         public int      soundIndex;
         public uint     interval;               //how often to play; measured in game minutes
         public int      unknown;                //according to Tipton's documentation, doesn't do anything
         public ulong    lastTimePlayed = 0;     //last time sound was played
-        public AudioClip clip;
+        public AudioClip clip;                  //preloading
 
 
         /// <summary>
@@ -86,7 +84,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                 playSoundAction.lastTimePlayed  = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToSeconds();
                 var soundID                     = (uint)QuestMachine.Instance.SoundsTable.GetInt("id", match.Groups["sound"].Value);
                 playSoundAction.soundIndex      = (int)DaggerfallUnity.Instance.SoundReader.GetSoundIndex(soundID);
-                playSoundAction.clip            = DaggerfallUnity.Instance.SoundReader.GetAudioClip(playSoundAction.soundIndex);
+                playSoundAction.clip = DaggerfallUnity.Instance.SoundReader.GetAudioClip(playSoundAction.soundIndex);
             }
             catch (System.Exception ex)
             {
@@ -116,28 +114,14 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
 
             if (lastTimePlayed + interval <= gameSeconds)
             {
-                var source = QuestMachine.Instance.GetComponent<AudioSource>();
-                if (source != null && !source.isPlaying)
+                DaggerfallAudioSource source = QuestMachine.Instance.GetComponent<DaggerfallAudioSource>();
+                if (source != null && !source.IsPlaying())
                 {
-                    DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(source, clip));
+                    source.PlayOneShot(soundIndex, DaggerfallUnity.Settings.SoundVolume);
                     lastTimePlayed = gameSeconds;
                 }
             }
             // Unlike message posts, the play sound command performs until task is cleared
-        }
-
-        private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip audioClip)
-        {
-            float loadWaitTimer = 0f;
-            while (audioClip.loadState == AudioDataLoadState.Unloaded ||
-                   audioClip.loadState == AudioDataLoadState.Loading)
-            {
-                loadWaitTimer += Time.deltaTime;
-                if (loadWaitTimer > audioClipMaxDelay)
-                    yield break;
-                yield return null;
-            }
-            source.PlayOneShot(audioClip, DaggerfallUnity.Settings.SoundVolume);
         }
 
         #region Serialization

--- a/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
@@ -127,7 +127,8 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
 
         private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip clip)
         {
-            while (clip.loadState == AudioDataLoadState.Loading)
+            while (clip.loadState == AudioDataLoadState.Unloaded ||
+                   clip.loadState == AudioDataLoadState.Loading)
             {
                 yield return null;
             }

--- a/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
@@ -13,6 +13,7 @@ using System.Collections;
 using UnityEngine;
 using System.Text.RegularExpressions;
 using FullSerializer;
+using System;
 
 namespace DaggerfallWorkshop.Game.Questing.Actions
 {
@@ -118,11 +119,20 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                 var source = QuestMachine.Instance.GetComponent<AudioSource>();
                 if (source != null && !source.isPlaying)
                 {
-                    source.PlayOneShot(clip, DaggerfallUnity.Settings.SoundVolume);
+                    DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(source, clip));
                     lastTimePlayed = gameSeconds;
                 }
             }
             // Unlike message posts, the play sound command performs until task is cleared
+        }
+
+        private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip clip)
+        {
+            while (clip.loadState == AudioDataLoadState.Loading)
+            {
+                yield return null;
+            }
+            source.PlayOneShot(clip);
         }
 
         #region Serialization

--- a/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
@@ -27,6 +27,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
         /// or play sound (soundname) x y
         /// the second number is not currently used for anything - purpose is unkown.
 
+        const float audioClipMaxDelay = 0.150f; //give up if sound takes longer to load
 
         public string   soundName;              //used to lookup sound index in sound table
         public int      soundIndex;
@@ -125,14 +126,18 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             // Unlike message posts, the play sound command performs until task is cleared
         }
 
-        private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip clip)
+        private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip audioClip)
         {
-            while (clip.loadState == AudioDataLoadState.Unloaded ||
-                   clip.loadState == AudioDataLoadState.Loading)
+            float loadWaitTimer = 0f;
+            while (audioClip.loadState == AudioDataLoadState.Unloaded ||
+                   audioClip.loadState == AudioDataLoadState.Loading)
             {
+                loadWaitTimer += Time.deltaTime;
+                if (loadWaitTimer > audioClipMaxDelay)
+                    yield break;
                 yield return null;
             }
-            source.PlayOneShot(clip, DaggerfallUnity.Settings.SoundVolume);
+            source.PlayOneShot(audioClip, DaggerfallUnity.Settings.SoundVolume);
         }
 
         #region Serialization

--- a/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
@@ -13,7 +13,6 @@ using System.Collections;
 using UnityEngine;
 using System.Text.RegularExpressions;
 using FullSerializer;
-using System;
 
 namespace DaggerfallWorkshop.Game.Questing.Actions
 {

--- a/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlaySound.cs
@@ -132,7 +132,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             {
                 yield return null;
             }
-            source.PlayOneShot(clip);
+            source.PlayOneShot(clip, DaggerfallUnity.Settings.SoundVolume);
         }
 
         #region Serialization

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -126,7 +126,8 @@ namespace DaggerfallWorkshop
             {
                 PreviewID = (int)dfUnity.SoundReader.GetSoundID(PreviewIndex);
                 PreviewClip = (SoundClips)PreviewIndex;
-                audioSource.PlayOneShot(dfUnity.SoundReader.GetAudioClip(PreviewIndex));
+                AudioClip clip = dfUnity.SoundReader.GetAudioClip(PreviewIndex);
+                DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(AudioSource, clip, 1.0f));
             }
         }
 
@@ -206,9 +207,18 @@ namespace DaggerfallWorkshop
                 if (clip)
                 {
                     audioSource.spatialBlend = spatialBlend;
-                    audioSource.PlayOneShot(clip, volumeScale * DaggerfallUnity.Settings.SoundVolume);
+                    DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(audioSource, clip, volumeScale * DaggerfallUnity.Settings.SoundVolume));
                 }
             }
+        }
+
+        private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip clip, float volume)
+        {
+            while (clip.loadState == AudioDataLoadState.Loading)
+            {
+                yield return null;
+            }
+            source.PlayOneShot(clip, volume);
         }
 
         /// <summary>

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -214,7 +214,8 @@ namespace DaggerfallWorkshop
 
         private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip clip, float volume)
         {
-            while (clip.loadState == AudioDataLoadState.Loading)
+            while (clip.loadState == AudioDataLoadState.Unloaded ||
+                   clip.loadState == AudioDataLoadState.Loading)
             {
                 yield return null;
             }

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -28,6 +28,8 @@ namespace DaggerfallWorkshop
     [RequireComponent(typeof(AudioSource))]
     public class DaggerfallAudioSource : MonoBehaviour
     {
+        const float audioClipMaxDelay = 0.150f; //give up if sound takes longer to load
+
         const int minIndex = 0;
         const int maxIndex = 458;
 
@@ -47,6 +49,7 @@ namespace DaggerfallWorkshop
         DaggerfallUnity dfUnity;
         AudioSource audioSource;
         AudioClip audioClip;
+
 
         // Will enable/disable AudioSource based on player proximity.
         // This works around having too many point audio sources in scene by
@@ -212,14 +215,18 @@ namespace DaggerfallWorkshop
             }
         }
 
-        private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip clip, float volume)
+        private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip audioClip, float volume)
         {
-            while (clip.loadState == AudioDataLoadState.Unloaded ||
-                   clip.loadState == AudioDataLoadState.Loading)
+            float loadWaitTimer = 0f;
+            while (audioClip.loadState == AudioDataLoadState.Unloaded ||
+                   audioClip.loadState == AudioDataLoadState.Loading)
             {
+                loadWaitTimer += Time.deltaTime;
+                if (loadWaitTimer > audioClipMaxDelay)
+                    yield break;
                 yield return null;
             }
-            source.PlayOneShot(clip, volume);
+            source.PlayOneShot(audioClip, volume);
         }
 
         /// <summary>

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -129,7 +129,7 @@ namespace DaggerfallWorkshop
                 PreviewID = (int)dfUnity.SoundReader.GetSoundID(PreviewIndex);
                 PreviewClip = (SoundClips)PreviewIndex;
                 AudioClip clip = dfUnity.SoundReader.GetAudioClip(PreviewIndex);
-                DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(AudioSource, clip, 1.0f));
+                DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(clip, 1.0f));
             }
         }
 
@@ -209,12 +209,12 @@ namespace DaggerfallWorkshop
                 if (clip)
                 {
                     audioSource.spatialBlend = spatialBlend;
-                    DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(audioSource, clip, volumeScale * DaggerfallUnity.Settings.SoundVolume));
+                    DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(clip, volumeScale * DaggerfallUnity.Settings.SoundVolume));
                 }
             }
         }
 
-        private IEnumerator PlayOneShotWhenReady(AudioSource source, AudioClip audioClip, float volume)
+        private IEnumerator PlayOneShotWhenReady(AudioClip audioClip, float volume)
         {
             float loadWaitTimer = 0f;
             while (audioClip.loadState == AudioDataLoadState.Unloaded ||
@@ -225,7 +225,7 @@ namespace DaggerfallWorkshop
                     yield break;
                 yield return null;
             }
-            source.PlayOneShot(audioClip, volume);
+            audioSource.PlayOneShot(audioClip, volume);
         }
 
         /// <summary>

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -50,7 +50,6 @@ namespace DaggerfallWorkshop
         AudioSource audioSource;
         AudioClip audioClip;
 
-
         // Will enable/disable AudioSource based on player proximity.
         // This works around having too many point audio sources in scene by
         // turning off audio sources the player cannot possibly hear.


### PR DESCRIPTION
Currently we can skip the first use of audioclips loaded from discrete files, because they're loaded asynchronously and may not be ready at the time of AudioSource.PlayOneShot().
See bug report https://forums.dfworkshop.net/viewtopic.php?f=24&t=1414
This patch wraps calls to PlayOneShot() with a coroutine so sound is played when ready, with a delay up to 150ms.

There's some code duplication here, could DaggerfallWorkshop.Game.Questing.Actions.PlaySound use DaggerfallWorkshop.DaggerfallAudioSource?