### PR TITLE
Stream ogg songs from disk

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
@@ -57,7 +57,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if song is found.</returns>
         public static bool TryImportSong(SongFiles song, out AudioClip audioClip)
         {
-            return TryImportAudioClip(song.ToString(), ".ogg", out audioClip);
+            return TryImportAudioClip(song.ToString(), ".ogg", out audioClip, streaming: true);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <summary>
         /// Import sound data from modding locations as an audio clip.
         /// </summary>
-        private static bool TryImportAudioClip(string name, string extension, out AudioClip audioClip)
+        private static bool TryImportAudioClip(string name, string extension, out AudioClip audioClip, bool streaming = false)
         {
             if (DaggerfallUnity.Settings.AssetInjection)
             {
@@ -87,8 +87,14 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 if (File.Exists(path))
                 {
                     WWW www = new WWW("file://" + path);
-                    audioClip = www.GetAudioClip();
-                    DaggerfallUnity.Instance.StartCoroutine(LoadAudioData(www, audioClip));
+                    if (streaming) {
+                        audioClip = www.GetAudioClip(true, true);
+                    }
+                    else
+                    {
+                        audioClip = www.GetAudioClip();
+                        DaggerfallUnity.Instance.StartCoroutine(LoadAudioData(www, audioClip));
+                    }
                     return true;
                 }
 

--- a/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
@@ -46,7 +46,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if sound is found.</returns>
         public static bool TryImportSound(SoundClips sound, out AudioClip audioClip)
         {
-            return TryImportAudioClip(sound.ToString(), ".wav", out audioClip);
+            return TryImportAudioClip(sound.ToString(), ".wav", false, out audioClip);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if song is found.</returns>
         public static bool TryImportSong(SongFiles song, out AudioClip audioClip)
         {
-            return TryImportAudioClip(song.ToString(), ".ogg", out audioClip, streaming: true);
+            return TryImportAudioClip(song.ToString(), ".ogg", true, out audioClip);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <summary>
         /// Import sound data from modding locations as an audio clip.
         /// </summary>
-        private static bool TryImportAudioClip(string name, string extension, out AudioClip audioClip, bool streaming = false)
+        private static bool TryImportAudioClip(string name, string extension, bool streaming, out AudioClip audioClip)
         {
             if (DaggerfallUnity.Settings.AssetInjection)
             {


### PR DESCRIPTION
MidnightPrince assembled a kickass soundscape for Daggerfall Unity
https://forums.dfworkshop.net/viewtopic.php?f=14&t=1347#p16078

All songs are replaced with OGG music, and there's a noticeable frames drop when songs (re)start.
This patch uses Unity audioClip streaming for digital songs.