### PR TITLE
Allow standing on surfaces in water

### DIFF
--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -128,8 +128,8 @@ namespace DaggerfallWorkshop.Game
             }
             else if (!riding && !onWater)
             {
-                // if we crouch out of water
-                if (!swimming && pressedCrouch)
+                // if we crouch out of water or while on solid ground
+                if ((!swimming || playerMotor.IsGrounded) && pressedCrouch)
                 {
                     timerMax = timerFast;
                     // Toggle crouching
@@ -137,6 +137,7 @@ namespace DaggerfallWorkshop.Game
                         heightAction = HeightChangeAction.DoStanding;
                     else
                         heightAction = HeightChangeAction.DoCrouching;
+                    forcedSwimCrouch = false;
                 }
                 // if climbing, force into standing
                 else if (climbing)
@@ -147,7 +148,7 @@ namespace DaggerfallWorkshop.Game
                     forcedSwimCrouch = false;
                 }
                 // if swimming but not crouching, crouch.
-                else if (swimming && !forcedSwimCrouch)
+                else if (swimming && !forcedSwimCrouch && !playerMotor.IsGrounded)
                 {
                     timerMax = timerMedium;
                     if (!crouching)

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -230,6 +230,9 @@ namespace DaggerfallWorkshop.Game
 
         void FixedUpdate()
         {
+            // Check if on a solid surface
+            grounded = (collisionFlags & CollisionFlags.Below) != 0;
+
             // Clear movement
             if (cancelMovement)
             {
@@ -288,7 +291,6 @@ namespace DaggerfallWorkshop.Game
             acrobatMotor.HitHead(ref moveDirection);
 
             groundMotor.MoveWithMovingPlatform(moveDirection);
-            grounded = (collisionFlags & CollisionFlags.Below) != 0;
         }
 
         void Update()


### PR DESCRIPTION
Fix for https://forums.dfworkshop.net/viewtopic.php?f=24&t=1506&p=17372#p17372.

Also, not a priority or anything, but I think ideally the forced crouch on entering water should be optional, so that behavior closer to classic is still usable.