### PR TITLE
better stack splitting default value

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -186,6 +186,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         KeyCode toggleClosedBinding;
         bool controlPressed = false;
+        private int maxAmount;
 
         #endregion
 
@@ -1338,9 +1339,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     questItem.PlayerDropped = false;
             }
 
-            if (maxAmount == null)
-                maxAmount = item.stackCount;
-            if (maxAmount <= 0)
+            this.maxAmount = maxAmount ?? item.stackCount;
+            if (this.maxAmount <= 0)
                 return;
 
             bool splitRequired = maxAmount < item.stackCount;
@@ -1352,18 +1352,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     stackFrom = from;
                     stackTo = to;
                     stackEquip = equip;
+                    string defaultValue = controlPressed ? "0" : this.maxAmount.ToString();
 
                     // Key will probably be released while messagebox is open
                     controlPressed = false;
 
                     // Show message box
                     DaggerfallInputMessageBox mb = new DaggerfallInputMessageBox(uiManager, this);
-                    mb.SetTextBoxLabel(String.Format(TextManager.Instance.GetText(textDatabase, "howManyItems"), maxAmount));
+                    mb.SetTextBoxLabel(String.Format(TextManager.Instance.GetText(textDatabase, "howManyItems"), this.maxAmount));
                     mb.TextPanelDistanceY = 0;
                     mb.InputDistanceX = 15;
                     mb.TextBox.Numeric = true;
                     mb.TextBox.MaxCharacters = 8;
-                    mb.TextBox.Text = "0";
+                    mb.TextBox.Text = defaultValue;
                     mb.OnGotUserInput += SplitStackPopup_OnGotUserInput;
                     mb.Show();
                     return;
@@ -1380,7 +1381,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Determine how many items to split
             int count = 0;
             bool result = int.TryParse(input, out count);
-            if (!result)
+            if (!result || count > maxAmount)
                 return;
 
             DaggerfallUnityItem item = stackFrom.SplitStack(stackItem, count);


### PR DESCRIPTION
- Default input value is now the maximum allowed value if stack
splitting is called because of player encumbrance.

- Stack splitting itself checks that you don't try to remove more than
the size of the stack, but encumbrance may enforce an even lower limit;
This wasn't correctly checked after user input.