### PR TITLE
Can always put arrows into cart

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1293,7 +1293,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // Check cart weight limit
             int canCarry = item.stackCount;
-            if (item.ItemGroup != ItemGroups.Transportation && item.weightInKg != 0)
+            if (item.ItemGroup != ItemGroups.Transportation && item.TemplateIndex != (int)Weapons.Arrow && item.weightInKg != 0)
             {
                 canCarry = Math.Min(canCarry, (int)((ItemHelper.wagonKgLimit - remoteItems.GetWeight()) / item.weightInKg));
             }


### PR DESCRIPTION
Since arrows weight is not accounted for, they can always be put back into cart
Bug report  https://forums.dfworkshop.net/viewtopic.php?f=24&t=1532