### PR TITLE
Fix some issues with purchasing interface

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -560,11 +560,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         break;
 
                     case WindowModes.Buy:
-                        if (usingWagon)
-                        {
-                            TransferItem(item, localItems, PlayerEntity.Items, CanCarryAmount(item), equip: true);
-                        }
-                        else
+                        if (usingWagon)     // Allows player to get & equip stuff from cart while purchasing.
+                            TransferItem(item, localItems, PlayerEntity.Items, CanCarryAmount(item), equip: !item.IsAStack());
+                        else                // Allows player to equip and unequip while purchasing.
                             EquipItem(item);
                         break;
 
@@ -596,17 +594,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Handle click based on action
             if (selectedActionMode == ActionModes.Select)
             {
-                int canCarry = CanCarryAmount(item);
-                if (usingWagon)
-                {
-                    canCarry = Math.Max(canCarry, WagonCanHoldAmount(item));
-                }
                 if (windowMode == WindowModes.Buy)
-                {
-                    TransferItem(item, remoteItems, basketItems, canCarry, equip: !item.IsAStack());
-                } else {
-                    TransferItem(item, remoteItems, localItems, canCarry);
-                }
+                    TransferItem(item, remoteItems, basketItems, CanCarryAmount(item), equip: !item.IsAStack());
+                else
+                    TransferItem(item, remoteItems, localItems, usingWagon ? WagonCanHoldAmount(item) : CanCarryAmount(item));
             }
             else if (selectedActionMode == ActionModes.Info)
             {
@@ -667,7 +658,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {   // No trade when using a spell, just identify immediately
                 for (int i = 0; i < remoteItems.Count; i++)
                     remoteItems.GetItem(i).IdentifyItem();
-                DaggerfallUI.MessageBox("Items identified.");
+                DaggerfallUI.MessageBox(TextManager.Instance.GetText("DaggerfallUI", "itemsIdentified"));
             }
             else if (cost > 0 || ((windowMode == WindowModes.Repair || windowMode == WindowModes.Identify) && remoteItems.Count > 0))
                 ShowTradePopup();

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -26,7 +26,7 @@ finishQuestHeader,  {0} {1} at {2}:
 quest,              Quest
 noteHeader,         {0} in {1}:
 
-- Inventory window:
+- Inventory & trade windows:
 
 readMap,            Discovered the location of %map after studying a map.
 readMapTG,          The Thieves Guild have revealed the closely guarded where-abouts of a treasure trove called %map.
@@ -47,3 +47,4 @@ arSrc,              armor rating
 arRep,              armor
 northern,           (northern)
 southern,           (southern)
+itemsIdentified,    Items identified.


### PR DESCRIPTION
* Only try to equip non stacks from cart when purchasing.
* Only check player encumbrance for weight when retrieving from cart during purchasing.
* Prevent double can't carry messages. (same fix as PR #1015) 
* Move text string into textfile.