### PR TITLE
Swimming fixes

### DIFF
--- a/Assets/Scripts/Game/LevitateMotor.cs
+++ b/Assets/Scripts/Game/LevitateMotor.cs
@@ -77,11 +77,14 @@ namespace DaggerfallWorkshop.Game
 
             // Up/down
             Vector3 upDownVector = new Vector3 (0, 0, 0);
-            if (InputManager.Instance.HasAction(InputManager.Actions.Jump) || InputManager.Instance.HasAction(InputManager.Actions.FloatUp))
-                upDownVector = upDownVector + Vector3.up;
-            if (InputManager.Instance.HasAction(InputManager.Actions.Crouch) || InputManager.Instance.HasAction(InputManager.Actions.FloatDown) ||
-                !climbingMotor.IsClimbing && GameManager.Instance.PlayerEnterExit.IsPlayerSwimming && (GameManager.Instance.PlayerEntity.CarriedWeight * 4) > 250)
-                upDownVector = upDownVector + Vector3.down;
+
+            if (playerSwimming && GameManager.Instance.PlayerEntity.CarriedWeight * 4 > 250 && !climbingMotor.IsClimbing && !GameManager.Instance.PlayerEntity.GodMode)
+                upDownVector += Vector3.down;
+            else if (InputManager.Instance.HasAction(InputManager.Actions.Jump) || InputManager.Instance.HasAction(InputManager.Actions.FloatUp))
+                upDownVector += Vector3.up;
+            else if (InputManager.Instance.HasAction(InputManager.Actions.Crouch) || InputManager.Instance.HasAction(InputManager.Actions.FloatDown))
+                upDownVector += Vector3.down;
+
             AddMovement(upDownVector, true);
 
             // Execute movement
@@ -103,6 +106,10 @@ namespace DaggerfallWorkshop.Game
 
         void AddMovement(Vector3 direction, bool upOrDown = false)
         {
+            // No up or down movement without using a float up/float down key or sinking from encumbrance
+            if (!upOrDown)
+                direction.y = 0;
+
             if (playerSwimming && GameManager.Instance.PlayerEntity.IsWaterWalking)
             {
                 // Swimming with water walking on makes player move at normal speed in water
@@ -118,14 +125,10 @@ namespace DaggerfallWorkshop.Game
                 !playerLevitating)
                     direction.y = 0;
 
-                Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+                // There's a fixed speed for up/down movement in classic (use moveSpeed = 2 here to replicate)
                 float baseSpeed = speedChanger.GetBaseSpeed();
                 moveSpeed = speedChanger.GetSwimSpeed(baseSpeed);
             }
-
-            // There's a fixed speed for up/down movement
-            if (upOrDown)
-                moveSpeed = 80f / PlayerSpeedChanger.classicToUnitySpeedUnitRatio;
 
             moveDirection += direction * moveSpeed;
 

--- a/Assets/Scripts/Game/LevitateMotor.cs
+++ b/Assets/Scripts/Game/LevitateMotor.cs
@@ -106,8 +106,8 @@ namespace DaggerfallWorkshop.Game
 
         void AddMovement(Vector3 direction, bool upOrDown = false)
         {
-            // No up or down movement without using a float up/float down key or sinking from encumbrance
-            if (!upOrDown)
+            // No up or down movement while swimming without using a float up/float down key or sinking from encumbrance
+            if (!upOrDown && playerSwimming)
                 direction.y = 0;
 
             if (playerSwimming && GameManager.Instance.PlayerEntity.IsWaterWalking)


### PR DESCRIPTION
Mainly, this fixes that the player was able to cheat past the swimming encumbrance limit by looking up and moving forward while pressing jump or float up.

This is fixed by this PR by not allowing up/down movement from forward/reverse, which also matches classic.

GodMode now ignores the encumbrance limit since it can be a nuisance when testing.

Interkarma, if you'd prefer to be able to move up and down using forward/reverse, I can try to think up a solution that keeps that ability. In real life you kind of have to specifically aim for it to swim up or down (well I do anyway) so I don't mind float up/float down being a specific action here. Another idea is to use this float up/float down behavior for swimming, but allow forward/reverse for levitate. Right now this PR is following classic and doing float up/float down for both swimming and levitation.

Also swimming/levitate now uses the swimming/levitate speed for up/down, not fixed a fixed speed like classic. Classic's speed is still noted in a comment, but I can't see why, for example, a better swimming player character can swim faster horizontally but not vertically.

Another small difference from classic: In classic even when encumbered in water, you can stop the downward movement and stay at your current height by holding the float up key, although you can't go up. We can't know for sure, but I suspect this was probably not intended, considering the "You are carrying too much to stay afloat" message (although that message is from the demo and didn't make it to the release version) and that doing this trick allows you to "stay afloat" at your current height, so this PR doesn't allow it.