### PR TITLE
Fixes

### DIFF
--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -331,7 +331,7 @@ namespace DaggerfallWorkshop.Game
                 // Otherwise it is easy for the target to ride on top of the arrow if it doesn't hit exactly head-on.
                 // Using a collider would probably be better.
                 Vector3 sphereCastDir;
-                if (enemySenses)
+                if (enemySenses && enemySenses.LastKnownTargetPos != EnemySenses.ResetPlayerPos)
                     sphereCastDir = (enemySenses.LastKnownTargetPos - goModel.transform.position).normalized;
                 else
                     sphereCastDir = goModel.transform.forward;
@@ -467,7 +467,11 @@ namespace DaggerfallWorkshop.Game
                     predictedPosition = enemySenses.PredictNextTargetPos(MovementSpeed);
                 else
                     predictedPosition = enemySenses.LastKnownTargetPos;
-                aimDirection = (predictedPosition - caster.transform.position).normalized;
+
+                if (predictedPosition == EnemySenses.ResetPlayerPos)
+                    aimDirection = caster.transform.forward;
+                else
+                    aimDirection = (predictedPosition - caster.transform.position).normalized;
             }
 
             return aimDirection;

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -231,9 +231,8 @@ namespace DaggerfallWorkshop.Game
             }
             mobile.FreezeAnims = false;
 
-            // Apply gravity to non-moving AI if active (has a combat target)
-            if (entityBehaviour.Target != null && !flies && !swims && mobile.Summary.EnemyState != MobileStates.Move
-                && mobile.Summary.EnemyState != MobileStates.Hurt)
+            // Apply gravity to non-moving AI if active (has a combat target) or nearby
+            if ((entityBehaviour.Target != null || senses.WouldBeSpawnedInClassic) && !flies && !swims)
             {
                 controller.SimpleMove(Vector3.zero);
             }


### PR DESCRIPTION
Two AI-related fixes:

1) Enemies were not reliably falling. This was because they didn't fall while in "moving" state, but now they do. Also not only enemies with combat targets but any nearby enemies (within classic spawning distance) will fall. (We could make all AI try to fall all the time, but previously when I tested that it hit the FPS pretty significantly, so I'm keeping it limited like this)

2) I got an error in DaggerfallMissile during testing. I don't know for sure but I think it was because the AI fetched the enemy position from EnemySenses for aiming, but the position had been reset due to the target becoming NULL (probably because it died). I added a fall-back if the enemy position returns the reset value which should fix this.