### PR TITLE
 fixed bug with fog settings being changed by UnderwaterFog script breaking mods

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -276,10 +276,10 @@ namespace DaggerfallWorkshop.Game
                     underwaterFog.UpdateFog(blockWaterLevel);
                 }
             }
-            else if(underwaterFog != null && underwaterFog.originalFog != RenderSettings.fogMode)
-            {
-                underwaterFog.ResetFog();
-            }
+            //else if(underwaterFog != null && underwaterFog.HaveFogSettingsChanged())
+            //{
+            //    underwaterFog.ResetFog();
+            //}
 
 
             // Count down holiday text display

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -276,11 +276,6 @@ namespace DaggerfallWorkshop.Game
                     underwaterFog.UpdateFog(blockWaterLevel);
                 }
             }
-            //else if(underwaterFog != null && underwaterFog.HaveFogSettingsChanged())
-            //{
-            //    underwaterFog.ResetFog();
-            //}
-
 
             // Count down holiday text display
             if (holidayTextTimer > 0)

--- a/Assets/Scripts/Game/UnderwaterFog.cs
+++ b/Assets/Scripts/Game/UnderwaterFog.cs
@@ -15,7 +15,6 @@ namespace DaggerfallWorkshop.Game
         private float fogDensityMax;
 
         // store fog values to reset fog after leaving water
-        //private bool fogSettingsChanged = false;
         private FogMode originalFogMode;               
         private float originalFogDensity;
         private float originalFogStartDistance;
@@ -23,15 +22,6 @@ namespace DaggerfallWorkshop.Game
 
         // used to identify player transition from out of water to entering water
         private float oldFogT = 0.0f;
-
-        //public bool HaveFogSettingsChanged()
-        //{
-        //    //if (originalFogMode != RenderSettings.fogMode || originalFogDensity != RenderSettings.fogDensity || originalFogDensity != RenderSettings.fogStartDistance || originalFogDensity != RenderSettings.fogEndDistance)
-        //    if (fogSettingsChanged == true)
-        //        return true;
-        //    else
-        //        return false;
-        //}
 
         public UnderwaterFog()
         {
@@ -64,22 +54,9 @@ namespace DaggerfallWorkshop.Game
             else
                 fogT = 0.0f;
 
-            //// on player transition from out of water to entering water
-            //// (this is important: only backup fog values from before entering water
-            //// (otherwise water fog values will be backed up unintentionally))
-            //if (oldFogT == 0.0f && fogT > 0.0f)
-            //{
-            //    fogSettingsChanged = true;
-            //    originalFogMode = RenderSettings.fogMode;
-            //    originalFogDensity = RenderSettings.fogDensity;
-            //    originalFogStartDistance = RenderSettings.fogStartDistance;
-            //    originalFogEndDistance = RenderSettings.fogEndDistance;
-            //}
-            //oldFogT = fogT;
-
+            // backup fog settings when player is out of water or just entering water (oldFogT is in both cases zero)
             if (oldFogT == 0.0f)
             {
-                //fogSettingsChanged = true;
                 originalFogMode = RenderSettings.fogMode;
                 originalFogDensity = RenderSettings.fogDensity;
                 originalFogStartDistance = RenderSettings.fogStartDistance;
@@ -87,18 +64,14 @@ namespace DaggerfallWorkshop.Game
             }
             oldFogT = fogT;
 
-            //RenderSettings.fogMode = FogMode.Exponential;
-            //RenderSettings.fogDensity = Mathf.Lerp(fogDensityMin, fogDensityMax, fogT);
-            //RenderSettings.fogColor = waterFogColor;
-
-            // if player is entering water or submerged
+            // if player is submerged or entering water apply underwater fog
             if (fogT > 0.0f)
             {
                 RenderSettings.fogMode = FogMode.Exponential;
                 RenderSettings.fogDensity = Mathf.Lerp(fogDensityMin, fogDensityMax, fogT);
                 RenderSettings.fogColor = waterFogColor;
             }
-            else
+            else // otherwise restore old fog settings
             {
                 RenderSettings.fogMode = originalFogMode;
                 RenderSettings.fogDensity = originalFogDensity;
@@ -106,18 +79,5 @@ namespace DaggerfallWorkshop.Game
                 RenderSettings.fogEndDistance = originalFogEndDistance;
             }
         }
-
-        //public void ResetFog()
-        //{ 
-        //    sky.SetSkyFogColor(sky.skyColors);
-        //    if (fogSettingsChanged == true)
-        //    {
-        //        RenderSettings.fogMode = originalFogMode;
-        //        RenderSettings.fogDensity = originalFogDensity;
-        //        RenderSettings.fogStartDistance = originalFogStartDistance;
-        //        RenderSettings.fogEndDistance = originalFogEndDistance;
-        //        fogSettingsChanged = false;
-        //    }
-        //}
     }
 }

--- a/Assets/Scripts/Game/UnderwaterFog.cs
+++ b/Assets/Scripts/Game/UnderwaterFog.cs
@@ -13,7 +13,25 @@ namespace DaggerfallWorkshop.Game
         public Color waterFogColor { get; set; }
         private float fogDensityMin;
         private float fogDensityMax;
-        public readonly FogMode originalFog = RenderSettings.fogMode;
+
+        // store fog values to reset fog after leaving water
+        //private bool fogSettingsChanged = false;
+        private FogMode originalFogMode;               
+        private float originalFogDensity;
+        private float originalFogStartDistance;
+        private float originalFogEndDistance;
+
+        // used to identify player transition from out of water to entering water
+        private float oldFogT = 0.0f;
+
+        //public bool HaveFogSettingsChanged()
+        //{
+        //    //if (originalFogMode != RenderSettings.fogMode || originalFogDensity != RenderSettings.fogDensity || originalFogDensity != RenderSettings.fogStartDistance || originalFogDensity != RenderSettings.fogEndDistance)
+        //    if (fogSettingsChanged == true)
+        //        return true;
+        //    else
+        //        return false;
+        //}
 
         public UnderwaterFog()
         {
@@ -24,6 +42,10 @@ namespace DaggerfallWorkshop.Game
             waterFogColor = new Color(0.25f, 0.55f, 0.79f, 1);
             fogDensityMin = 0f;
             fogDensityMax = 0.23f;
+            originalFogMode = RenderSettings.fogMode;
+            originalFogDensity = RenderSettings.fogDensity;
+            originalFogStartDistance = RenderSettings.fogStartDistance;
+            originalFogEndDistance = RenderSettings.fogEndDistance;
         }
 
         public void UpdateFog(float waterLevel)
@@ -37,17 +59,65 @@ namespace DaggerfallWorkshop.Game
 
             float clampedCamYPos = Mathf.Clamp(adjustedCamYPos, waterExitThreshold, waterEntryThreshold);
 
-            fogT = 1 - ((clampedCamYPos - waterExitThreshold) / (waterEntryThreshold - waterExitThreshold));
+            if (waterEntryThreshold - waterExitThreshold != 0.0f)
+                fogT = 1 - ((clampedCamYPos - waterExitThreshold) / (waterEntryThreshold - waterExitThreshold));
+            else
+                fogT = 0.0f;
 
-            RenderSettings.fogColor = waterFogColor;
-            RenderSettings.fogMode = FogMode.Exponential;
-            RenderSettings.fogDensity = Mathf.Lerp(fogDensityMin, fogDensityMax, fogT);
+            //// on player transition from out of water to entering water
+            //// (this is important: only backup fog values from before entering water
+            //// (otherwise water fog values will be backed up unintentionally))
+            //if (oldFogT == 0.0f && fogT > 0.0f)
+            //{
+            //    fogSettingsChanged = true;
+            //    originalFogMode = RenderSettings.fogMode;
+            //    originalFogDensity = RenderSettings.fogDensity;
+            //    originalFogStartDistance = RenderSettings.fogStartDistance;
+            //    originalFogEndDistance = RenderSettings.fogEndDistance;
+            //}
+            //oldFogT = fogT;
+
+            if (oldFogT == 0.0f)
+            {
+                //fogSettingsChanged = true;
+                originalFogMode = RenderSettings.fogMode;
+                originalFogDensity = RenderSettings.fogDensity;
+                originalFogStartDistance = RenderSettings.fogStartDistance;
+                originalFogEndDistance = RenderSettings.fogEndDistance;
+            }
+            oldFogT = fogT;
+
+            //RenderSettings.fogMode = FogMode.Exponential;
+            //RenderSettings.fogDensity = Mathf.Lerp(fogDensityMin, fogDensityMax, fogT);
+            //RenderSettings.fogColor = waterFogColor;
+
+            // if player is entering water or submerged
+            if (fogT > 0.0f)
+            {
+                RenderSettings.fogMode = FogMode.Exponential;
+                RenderSettings.fogDensity = Mathf.Lerp(fogDensityMin, fogDensityMax, fogT);
+                RenderSettings.fogColor = waterFogColor;
+            }
+            else
+            {
+                RenderSettings.fogMode = originalFogMode;
+                RenderSettings.fogDensity = originalFogDensity;
+                RenderSettings.fogStartDistance = originalFogStartDistance;
+                RenderSettings.fogEndDistance = originalFogEndDistance;
+            }
         }
 
-        public void ResetFog()
-        { 
-            sky.SetSkyFogColor(sky.skyColors);
-            RenderSettings.fogMode = originalFog;
-        }
+        //public void ResetFog()
+        //{ 
+        //    sky.SetSkyFogColor(sky.skyColors);
+        //    if (fogSettingsChanged == true)
+        //    {
+        //        RenderSettings.fogMode = originalFogMode;
+        //        RenderSettings.fogDensity = originalFogDensity;
+        //        RenderSettings.fogStartDistance = originalFogStartDistance;
+        //        RenderSettings.fogEndDistance = originalFogEndDistance;
+        //        fogSettingsChanged = false;
+        //    }
+        //}
     }
 }

--- a/Assets/Scripts/Game/UnderwaterFog.cs
+++ b/Assets/Scripts/Game/UnderwaterFog.cs
@@ -19,6 +19,7 @@ namespace DaggerfallWorkshop.Game
         private float originalFogDensity;
         private float originalFogStartDistance;
         private float originalFogEndDistance;
+        private Color originalFogColor;
 
         // used to identify player transition from out of water to entering water
         private float oldFogT = 0.0f;
@@ -32,10 +33,12 @@ namespace DaggerfallWorkshop.Game
             waterFogColor = new Color(0.25f, 0.55f, 0.79f, 1);
             fogDensityMin = 0f;
             fogDensityMax = 0.23f;
+            // get initial (backup) values - will be overwritten (this is just a safety net mechanism so we start out with some values)
             originalFogMode = RenderSettings.fogMode;
             originalFogDensity = RenderSettings.fogDensity;
             originalFogStartDistance = RenderSettings.fogStartDistance;
             originalFogEndDistance = RenderSettings.fogEndDistance;
+            originalFogColor = RenderSettings.fogColor;
         }
 
         public void UpdateFog(float waterLevel)
@@ -61,6 +64,7 @@ namespace DaggerfallWorkshop.Game
                 originalFogDensity = RenderSettings.fogDensity;
                 originalFogStartDistance = RenderSettings.fogStartDistance;
                 originalFogEndDistance = RenderSettings.fogEndDistance;
+                originalFogColor = RenderSettings.fogColor;
             }
             oldFogT = fogT;
 
@@ -77,6 +81,7 @@ namespace DaggerfallWorkshop.Game
                 RenderSettings.fogDensity = originalFogDensity;
                 RenderSettings.fogStartDistance = originalFogStartDistance;
                 RenderSettings.fogEndDistance = originalFogEndDistance;
+                RenderSettings.fogColor = originalFogColor;
             }
         }
     }


### PR DESCRIPTION
underwater fog script no longer changes fog settings when outside water or even worse when player is in an exterior location
underwater fog script now stores old fog values before entering water and restores them when leaving water
works with mods now