### PR TITLE
Updates TweenToStart & TweenToEnd methods in DaggerfallAction

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallAction.cs
+++ b/Assets/Scripts/Internal/DaggerfallAction.cs
@@ -325,14 +325,14 @@ namespace DaggerfallWorkshop
             Hashtable rotateParams = __ExternalAssets.iTween.Hash(
                  "amount", new Vector3(ActionRotation.x / 360f, ActionRotation.y / 360f, ActionRotation.z / 360f),
                 "space", ActionSpace,
-                "time", Duration,
+                "time", duration,
                  "easetype", __ExternalAssets.iTween.EaseType.linear,
                 "oncomplete", "SetState",
                 "oncompleteparams", ActionState.End);
 
             Hashtable moveParams = __ExternalAssets.iTween.Hash(
                 "position", StartingPosition + ActionTranslation,
-                "time", Duration,
+                "time", duration,
                 "easetype", __ExternalAssets.iTween.EaseType.linear,
                 "oncomplete", "SetState",
                 "oncompleteparams", ActionState.End);
@@ -348,14 +348,14 @@ namespace DaggerfallWorkshop
             Hashtable rotateParams = __ExternalAssets.iTween.Hash(
                  "amount", new Vector3(-ActionRotation.x / 360f, -ActionRotation.y / 360f, -ActionRotation.z / 360f),
                 "space", ActionSpace,
-                "time", Duration,
+                "time", duration,
                  "easetype", __ExternalAssets.iTween.EaseType.linear,
                 "oncomplete", "SetState",
                 "oncompleteparams", ActionState.Start);
 
             Hashtable moveParams = __ExternalAssets.iTween.Hash(
                 "position", startingPosition,
-                "time", Duration,
+                "time", duration,
                 "easetype", __ExternalAssets.iTween.EaseType.linear,
                 "oncomplete", "SetState",
                 "oncompleteparams", ActionState.Start);


### PR DESCRIPTION
Previously these methods were using the class member Duration instead of the function parameter duration for tweening.