### PR TITLE
Arrive from expected direction after fast travelling

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -282,7 +282,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Cache scene first, if fast travelling while on ship.
             if (GameManager.Instance.TransportManager.IsOnShip())
                 SaveLoadManager.CacheScene(GameManager.Instance.StreamingWorld.SceneName);
-            GameManager.Instance.StreamingWorld.TeleportToCoordinates((int)endPos.X, (int)endPos.Y, StreamingWorld.RepositionMethods.RandomStartMarker);
+            GameManager.Instance.StreamingWorld.TeleportToCoordinates((int)endPos.X, (int)endPos.Y, StreamingWorld.RepositionMethods.DirectionFromStartMarker);
 
             if (speedCautious)
             {

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -220,6 +220,7 @@ namespace DaggerfallWorkshop
             Offset,
             DungeonEntrance,
             RandomStartMarker,
+            DirectionFromStartMarker,
         }
 
         #endregion
@@ -269,6 +270,7 @@ namespace DaggerfallWorkshop
             {
                 switch (autoRepositionMethod)
                 {
+                    case RepositionMethods.DirectionFromStartMarker:
                     case RepositionMethods.RandomStartMarker:
                         PositionPlayerToLocation();
                         break;
@@ -1010,8 +1012,12 @@ namespace DaggerfallWorkshop
         // Teleports to map pixel with an optional reset or autoreposition
         void TeleportToMapPixel(int mapPixelX, int mapPixelY, Vector3 repositionOffset, RepositionMethods autoReposition)
         {
-            travelStartX = LocalPlayerGPS.WorldX;
-            travelStartZ = LocalPlayerGPS.WorldZ;
+            if (autoReposition == RepositionMethods.DirectionFromStartMarker)
+            {
+                // Save travel origin
+                travelStartX = LocalPlayerGPS.WorldX;
+                travelStartZ = LocalPlayerGPS.WorldZ;
+            }
             DFPosition worldPos = MapsFile.MapPixelToWorldCoord(mapPixelX, mapPixelY);
             LocalPlayerGPS.WorldX = worldPos.X;
             LocalPlayerGPS.WorldZ = worldPos.Y;
@@ -1372,11 +1378,11 @@ namespace DaggerfallWorkshop
             int side;
             if (travelStartX == null || travelStartZ == null)
             {
-                Debug.Log("Travel from an unknown location, picking a random direction");
                 side = UnityEngine.Random.Range(0, 4);
             }
             else
             {
+                // use travel origin as a facing hint
                 int worldDeltaX = LocalPlayerGPS.WorldX - (int)travelStartX;
                 int worldDeltaZ = LocalPlayerGPS.WorldZ - (int)travelStartZ;
 
@@ -1385,8 +1391,8 @@ namespace DaggerfallWorkshop
                 else if (Math.Abs(worldDeltaX) > Math.Abs(worldDeltaZ))
                     side = worldDeltaX > 0 ? 3 : 2;
                 else
-                    side = worldDeltaZ > 0 ? 0 : 1;
-                Debug.Log(String.Format("{0},{1} => {2},{3}: facing {4}", (int)travelStartX, (int)travelStartZ, LocalPlayerGPS.WorldX, LocalPlayerGPS.WorldZ, side));
+                    side = worldDeltaZ > 0 ? 1 : 0;
+                // Debug.Log(String.Format("{0},{1} => {2},{3}: facing {4}", (int)travelStartX, (int)travelStartZ, LocalPlayerGPS.WorldX, LocalPlayerGPS.WorldZ, side));
                 travelStartX = null;
                 travelStartZ = null;
             }

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -1390,12 +1390,12 @@ namespace DaggerfallWorkshop
                 {
                     int px = Math.Abs(worldDeltaX);
                     int pz = Math.Abs(worldDeltaZ);
-                    // if travel start is distant enough, chances of hitting square faces are
+                    // if travel start is distant enough, chances of hitting square sides are
                     // approximatively px/(px+pz) and pz/(px+pz)
                     int random = UnityEngine.Random.Range(0, px + pz);
                     if (px > pz)
                     {
-                        // direction is mainly E-W, do we hit square front face?
+                        // direction is mainly E-W, do we hit square front side?
                         if (random < px)
                             side = worldDeltaX > 0 ? 3 : 2;
                         else
@@ -1403,7 +1403,7 @@ namespace DaggerfallWorkshop
                     }
                     else
                     {
-                        // direction is mainly N-S, do we hit square front face?
+                        // direction is mainly N-S, do we hit square front side?
                         if (random < pz)
                             side = worldDeltaZ > 0 ? 1 : 0;
                         else

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -104,6 +104,7 @@ namespace DaggerfallWorkshop
 
         DaggerfallLocation currentPlayerLocationObject;
         int playerTilemapIndex = -1;
+        private DFPosition previousMapPixel;
 
         #endregion
 
@@ -1007,6 +1008,7 @@ namespace DaggerfallWorkshop
         // Teleports to map pixel with an optional reset or autoreposition
         void TeleportToMapPixel(int mapPixelX, int mapPixelY, Vector3 repositionOffset, RepositionMethods autoReposition)
         {
+            previousMapPixel = LocalPlayerGPS.CurrentMapPixel;
             DFPosition worldPos = MapsFile.MapPixelToWorldCoord(mapPixelX, mapPixelY);
             LocalPlayerGPS.WorldX = worldPos.X;
             LocalPlayerGPS.WorldZ = worldPos.Y;
@@ -1363,7 +1365,17 @@ namespace DaggerfallWorkshop
             // A better implementation would base on previous coordinates
             // e.g. if new location is east of old location then player starts at west edge of new location
             UnityEngine.Random.InitState(DateTime.Now.Millisecond);
-            int side = UnityEngine.Random.Range(0, 4);
+
+            int mapDeltaX = mapPixelX - previousMapPixel.X;
+            int mapDeltaY = mapPixelY - previousMapPixel.Y;
+
+            int side;
+            if (mapDeltaX == 0 && mapDeltaY == 0)
+                side = UnityEngine.Random.Range(0, 4);
+            else if (Math.Abs(mapDeltaX) > Math.Abs(mapDeltaY))
+                side = mapDeltaX > 0 ? 3 : 2;
+            else
+                side = mapDeltaY > 0 ? 0 : 1;
 
             // Get half width and height
             float halfWidth = (float)mapWidth * 0.5f * RMBLayout.RMBSide;

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -1370,14 +1370,12 @@ namespace DaggerfallWorkshop
             int mapHeight,
             bool useNearestStartMarker = false)
         {
-            // Randomly pick one side of location to spawn
-            // A better implementation would base on previous coordinates
-            // e.g. if new location is east of old location then player starts at west edge of new location
             UnityEngine.Random.InitState(DateTime.Now.Millisecond);
 
             int side;
             if (travelStartX == null || travelStartZ == null)
             {
+                // Randomly pick one side of location to spawn
                 side = UnityEngine.Random.Range(0, 4);
             }
             else
@@ -1388,10 +1386,30 @@ namespace DaggerfallWorkshop
 
                 if (worldDeltaX == 0 && worldDeltaZ == 0)
                     side = UnityEngine.Random.Range(0, 4);
-                else if (Math.Abs(worldDeltaX) > Math.Abs(worldDeltaZ))
-                    side = worldDeltaX > 0 ? 3 : 2;
                 else
-                    side = worldDeltaZ > 0 ? 1 : 0;
+                {
+                    int px = Math.Abs(worldDeltaX);
+                    int pz = Math.Abs(worldDeltaZ);
+                    // if travel start is distant enough, chances of hitting square faces are
+                    // approximatively px/(px+pz) and pz/(px+pz)
+                    int random = UnityEngine.Random.Range(0, px + pz);
+                    if (px > pz)
+                    {
+                        // direction is mainly E-W, do we hit square front face?
+                        if (random < px)
+                            side = worldDeltaX > 0 ? 3 : 2;
+                        else
+                            side = worldDeltaZ > 0 ? 1 : 0;
+                    }
+                    else
+                    {
+                        // direction is mainly N-S, do we hit square front face?
+                        if (random < pz)
+                            side = worldDeltaZ > 0 ? 1 : 0;
+                        else
+                            side = worldDeltaX > 0 ? 3 : 2;
+                    }
+                }
                 // Debug.Log(String.Format("{0},{1} => {2},{3}: facing {4}", (int)travelStartX, (int)travelStartZ, LocalPlayerGPS.WorldX, LocalPlayerGPS.WorldZ, side));
                 travelStartX = null;
                 travelStartZ = null;


### PR DESCRIPTION
Player can be relocated "to a random marker" in 6 cases:
- when entering/exiting buildings and dungeons;
- after fast travel;
- when going from/to ship;
- when teleported;
- when expelled by court;
- using "location" console command.

This patch implements start coordinates saving, and selection of facing
based on those coordinates as a new RelocationMethod; And then use this
method for fast travel case only.

There's some comment near entering/leaving buildings
(PlayerEnterExit.Respawner) that suggests that the closest start marker
should be chosen, but it's unclear if this new RelocationMethod could
help.