### PR TITLE
Fix out-of-range exception when talking to NPCs

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -654,7 +654,7 @@ namespace DaggerfallWorkshop.Game
             reactionToPlayer = NPCfaction.rep;
             reactionToPlayer += player.BiographyReactionMod;
 
-            if (NPCfaction.sgroup < player.SGroupReputations.Length) // one of the five general social groups
+            if ((int)socialGroup < player.SGroupReputations.Length) // one of the five general social groups
                 reactionToPlayer += player.SGroupReputations[(int)socialGroup];
 
             return (reactionToPlayer);


### PR DESCRIPTION
Was getting an exception when talking to guild NPCs, who had sGroup of 7. There was already a check, but it was not on the same value used for accessing the array, so the exception wasn't being stopped.