### PR TITLE
Don't allow aquatic enemies to spawn out of water

### DIFF
--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -503,7 +503,7 @@ namespace DaggerfallWorkshop.Utility
             // Add enemies
             if (importEnemies)
             {
-                RDBLayout.AddFixedEnemies(go, editorObjects, ref blockData);
+                RDBLayout.AddFixedEnemies(go, editorObjects, ref blockData, startMarkers);
                 RDBLayout.AddRandomEnemies(go, editorObjects, dungeonType, monsterPower, ref blockData, startMarkers, monsterVariance, seed);
             }
 


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=1515.

The problem was that this particular slaughterfish is a fixed enemy, and no check was done in DF Unity for fixed enemies spawning out of water, only for random enemies.
Classic doesn't allow any aquatic enemies to spawn out of water, regardless if they are fixed or random.