### PR TITLE
Close spell merchant interface upon spell double-click only

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -743,15 +743,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 // Add to player entity spellbook
                 GameManager.Instance.PlayerEntity.AddSpell(offeredSpells[spellsListBox.SelectedIndex]);
-
-                // Drop back to HUD like classic
-                DaggerfallUI.Instance.PopToHUD();
             }
-            else
-            {
-                // Only close trade popup when user cancels trade
-                CloseWindow();
-            }
+            CloseWindow();
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -97,6 +97,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const SoundClips closeSpellBook = SoundClips.PageTurn;
 
         bool buyMode = false;
+        bool autoClose = false;
         int deleteSpellIndex = -1;
         KeyCode toggleClosedBinding;
         List<EffectBundleSettings> offeredSpells = new List<EffectBundleSettings>();
@@ -278,7 +279,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             spellsListBox.MaxCharacters = 22;
             spellsListBox.OnSelectItem += SpellsListBox_OnSelectItem;
             if (buyMode)
-                spellsListBox.OnMouseDoubleClick += BuyButton_OnMouseClick;
+                spellsListBox.OnMouseDoubleClick += SpellsListBox_OnMouseDoubleClick;
             else
                 spellsListBox.OnUseSelectedItem += SpellsListBox_OnUseSelectedItem;
             spellsListBox.OnMouseScrollDown += SpellsListBox_OnMouseScroll;
@@ -704,6 +705,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void BuyButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            autoClose = false;
+            BuySpellHandler();
+        }
+
+        private void SpellsListBox_OnMouseDoubleClick(BaseScreenComponent sender, Vector2 position)
+        {
+            autoClose = true;
+            BuySpellHandler();
+        }
+
+        private void BuySpellHandler()
+        {
             const int tradeMessageBaseId = 260;
             const int notEnoughGoldId = 454;
             int tradePrice = GetTradePrice();
@@ -744,7 +757,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // Add to player entity spellbook
                 GameManager.Instance.PlayerEntity.AddSpell(offeredSpells[spellsListBox.SelectedIndex]);
             }
-            CloseWindow();
+            if (autoClose)
+            {
+                // Drop back to HUD like classic
+                DaggerfallUI.Instance.PopToHUD();
+            }
+            else
+                CloseWindow();
         }
 
         #endregion


### PR DESCRIPTION
Bug report https://forums.dfworkshop.net/viewtopic.php?f=24&t=1375

It seems classic behavior has not been consistent between releases or something; But it matches the version I used, what I've seen in several streams, seems useful and it looks more consistent with other shops.

The patch is short but I'm not confident in my UI understanding, so please review.