### PR TITLE
Vital indicators fixes

### DIFF
--- a/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
+++ b/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
@@ -89,9 +89,13 @@ namespace DaggerfallWorkshop.Game
 
         private void ResetVitals()
         {
-            previousMaxHealth = previousHealth = playerEntity.MaxHealth;
-            previousMaxFatigue = previousFatigue = playerEntity.MaxFatigue;
-            previousMaxMagicka = previousMagicka = playerEntity.MaxMagicka;
+            previousMaxHealth = playerEntity.MaxHealth;
+            previousMaxFatigue = playerEntity.MaxFatigue;
+            previousMaxMagicka = playerEntity.MaxMagicka;
+
+            previousHealth = playerEntity.CurrentHealth;
+            previousFatigue = playerEntity.CurrentFatigue;
+            previousMagicka = playerEntity.CurrentMagicka;
         }
 
         private void StreamingWorld_OnInitWorld()

--- a/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
+++ b/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
@@ -56,7 +56,7 @@ namespace DaggerfallWorkshop.Game
 
             // Use events to capture a couple of edge cases
             StreamingWorld.OnInitWorld += StreamingWorld_OnInitWorld;
-            SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
+            SaveLoadManager.OnLoad += SaveLoadManager_OnLoad;
             DaggerfallCourtWindow.OnCourtScreen += DaggerfallCourtWindow_OnCourtScreen;
         }
 
@@ -123,7 +123,7 @@ namespace DaggerfallWorkshop.Game
             ResetVitals();
         }
 
-        private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
+        private void SaveLoadManager_OnLoad(SaveData_v1 saveData)
         {
             // Loading a character with same MaxHealth but lower current health
             // would also trigger a sway on load

--- a/Assets/Scripts/Game/UserInterface/HUDVitals.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDVitals.cs
@@ -124,7 +124,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Components.Add(magickaBar);
             Components.Add(breathBar);
 
-            SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
+            VitalsChangeDetector.OnReset += VitalChangeDetector_OnReset;
         }
 
         public override void Update()
@@ -277,23 +277,24 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 breathBar.Color = new Color32(247, 239, 41, 255);
         }
 
-        private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
+        private void SynchronizeImmediately()
         {
-            PlayerEntityData_v1 pData = saveData.playerData.playerEntity;
-
             // sync health bar
-            healthBarLoss.Amount = pData.currentHealth / (float)pData.maxHealth;
+            healthBarLoss.Amount = playerEntity.CurrentHealth / (float)playerEntity.MaxHealth;
             healthBar.Amount = healthBarLoss.Amount;
+
             // sync fatigue bar
-            int maxFatigue = (pData.stats.LiveStrength + pData.stats.LiveEndurance) * 64;
-            fatigueBarLoss.Amount = pData.currentFatigue / (float)maxFatigue;
+            fatigueBarLoss.Amount = playerEntity.CurrentFatigue / (float)playerEntity.MaxFatigue;
             fatigueBar.Amount = fatigueBarLoss.Amount;
 
             // sync magicka bar
-            DFCareer career = pData.careerTemplate;
-            int maxMagicka = FormulaHelper.SpellPoints(pData.stats.LiveIntelligence, career.SpellPointMultiplierValue);
-            magickaBarLoss.Amount = pData.currentMagicka / (float)maxMagicka;
+            magickaBarLoss.Amount = playerEntity.CurrentMagicka / (float)playerEntity.MaxMagicka;
             magickaBar.Amount = magickaBarLoss.Amount;
+        }
+
+        private void VitalChangeDetector_OnReset()
+        {
+            SynchronizeImmediately();
         }
     }
 }


### PR DESCRIPTION
This patch fixes:
- reflecting relative health decrease when max health increase after a level up;
- gauges sometimes staying stuck with some highlighted change until stat really changes.

It detect, handle and propagate resets (discontinuities).
Standard code flow can then handle the continuous, normal case.

I checked that HUDVitals receives reset events correctly, other
VitalChangeDetector listeners may benefit from handling reset events
too.