### PR TITLE
Loose objects cleanup fix

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -977,8 +977,8 @@ namespace DaggerfallWorkshop
         // Destroy any loose objects outside of range
         private void CollectLooseObjects(bool collectAll = false)
         {
-            int i = 0;
-            while (i < looseObjectsList.Count)
+            // Walk list backward to RemoveAt doesn't shift unprocessed items
+            for (int i = looseObjectsList.Count; i-- > 0; )
             {
                 if (!IsInRange(looseObjectsList[i].mapPixelX, looseObjectsList[i].mapPixelY) || collectAll)
                 {
@@ -989,8 +989,6 @@ namespace DaggerfallWorkshop
                     }
                     looseObjectsList.RemoveAt(i);
                 }
-                else
-                    i++;
             }
         }
 

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -977,7 +977,8 @@ namespace DaggerfallWorkshop
         // Destroy any loose objects outside of range
         private void CollectLooseObjects(bool collectAll = false)
         {
-            for (int i = 0; i < looseObjectsList.Count; i++)
+            int i = 0;
+            while (i < looseObjectsList.Count)
             {
                 if (!IsInRange(looseObjectsList[i].mapPixelX, looseObjectsList[i].mapPixelY) || collectAll)
                 {
@@ -988,6 +989,8 @@ namespace DaggerfallWorkshop
                     }
                     looseObjectsList.RemoveAt(i);
                 }
+                else
+                    i++;
             }
         }
 


### PR DESCRIPTION
Not sure it's the final word on that problem, but there's a bug in
CollectLooseObjects() because it uses RemoveAt(i) in a for loop, so if
two consecutive items need to be removed the second will be missed
because RemoveAt(i) will have shifted it down

Bug report https://forums.dfworkshop.net/viewtopic.php?f=28&p=18052#p18051