### PR TITLE
factorize capacity computations

### DIFF
--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -73,7 +73,7 @@ namespace DaggerfallWorkshop.Game.Banking
 
     public static class DaggerfallBankManager
     {
-        public const int gold1kg = 400;
+        public const float goldUnitWeightInKg = 0.0025f;
         private const float deedSellMult = 0.85f;
         private const float housePriceMult = 1280f;
 
@@ -337,7 +337,7 @@ namespace DaggerfallWorkshop.Game.Banking
 
             // Check weight limit
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
-            if (playerEntity.CarriedWeight + (amount / gold1kg) > playerEntity.MaxEncumbrance)
+            if (playerEntity.CarriedWeight + (amount * goldUnitWeightInKg) > playerEntity.MaxEncumbrance)
                 return TransactionResult.TOO_HEAVY;
 
             BankAccounts[regionIndex].accountGold -= amount;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -152,7 +152,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public int DarkBrotherhoodRequirementTally { get { return darkBrotherhoodRequirementTally; } set { darkBrotherhoodRequirementTally = value; } }
         public uint TimeToBecomeVampireOrWerebeast { get { return timeToBecomeVampireOrWerebeast; } set { timeToBecomeVampireOrWerebeast = value; } }
         public uint LastTimePlayerAteOrDrankAtTavern { get { return lastTimePlayerAteOrDrankAtTavern; } set { lastTimePlayerAteOrDrankAtTavern = value; } }
-        public float CarriedWeight { get { return Items.GetWeight() + ((float)goldPieces / DaggerfallBankManager.gold1kg); } }
+        public float CarriedWeight { get { return Items.GetWeight() + (goldPieces * DaggerfallBankManager.goldUnitWeightInKg); } }
         public float WagonWeight { get { return WagonItems.GetWeight(); } }
         public RegionDataRecord[] RegionData { get { return regionData; } set { regionData = value; } }
         public uint LastGameMinutes { get { return lastGameMinutes; } set { lastGameMinutes = value; } }

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -532,6 +532,14 @@ namespace DaggerfallWorkshop.Game.Items
             return (TemplateIndex == templateIndex);
         }
 
+        // Horses, carts and arrows are not counted against encumbrance.
+        public float EffectiveUnitWeightInKg()
+        {
+            if (ItemGroup == ItemGroups.Transportation || TemplateIndex == (int)Weapons.Arrow)
+                return 0f;
+            return weightInKg;
+        }
+
         /// <summary>
         /// Determines if item is stackable.
         /// Only ingredients, gold pieces, oil and arrows are stackable,

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -96,13 +96,7 @@ namespace DaggerfallWorkshop.Game.Items
             float weight = 0;
             foreach (DaggerfallUnityItem item in items.Values)
             {
-                // Horses, carts and arrows are not counted against encumbrance.
-                if (item.ItemGroup != ItemGroups.Transportation && item.TemplateIndex != (int)Weapons.Arrow)
-                    weight += item.weightInKg * item.stackCount;
-
-                // Enemies carry around gold as an item, unlike the player
-                if (item.ItemGroup == ItemGroups.Currency)
-                    weight += item.stackCount / Banking.DaggerfallBankManager.gold1kg;
+                weight += item.stackCount * item.EffectiveUnitWeightInKg();
             }
             return weight;
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1279,10 +1279,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             int canCarry = ComputeCanHoldAmount(item.stackCount, item.EffectiveUnitWeightInKg(), playerEntity.MaxEncumbrance - GetCarriedWeight());
             if (canCarry <= 0)
             {
-                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
-                messageBox.SetText(HardStrings.cannotCarryAnymore);
-                messageBox.ClickAnywhereToClose = true;
-                messageBox.Show();
+                DaggerfallUI.MessageBox(HardStrings.cannotCarryAnymore);
             }
             return canCarry;
         }
@@ -1293,10 +1290,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             int canCarry = ComputeCanHoldAmount(item.stackCount, item.EffectiveUnitWeightInKg(), ItemHelper.wagonKgLimit - remoteItems.GetWeight());
             if (canCarry <= 0)
             {
-                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
-                messageBox.SetText(HardStrings.cannotHoldAnymore);
-                messageBox.ClickAnywhereToClose = true;
-                messageBox.Show();
+                DaggerfallUI.MessageBox(HardStrings.cannotHoldAnymore);
             }
             return canCarry;
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1164,10 +1164,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (goldToDrop > wagonCanHold)
                 {
                     goldToDrop = wagonCanHold;
-                    DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
-                    messageBox.SetText(String.Format(wagonFullGold, wagonCanHold));
-                    messageBox.ClickAnywhereToClose = true;
-                    messageBox.Show();
+                    DaggerfallUI.MessageBox(String.Format(wagonFullGold, wagonCanHold));
                 }
             }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -681,7 +681,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     case WindowModes.Sell:
                     case WindowModes.SellMagic:
-                        float goldWeight = (float)tradePrice / DaggerfallBankManager.gold1kg;
+                        float goldWeight = tradePrice * DaggerfallBankManager.goldUnitWeightInKg;
                         if (PlayerEntity.CarriedWeight + goldWeight <= PlayerEntity.MaxEncumbrance)
                         {
                             PlayerEntity.GoldPieces += tradePrice;

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -33,6 +33,7 @@ readMapTG,          The Thieves Guild have revealed the closely guarded where-ab
 readMapDB,          The Dark Brotherhood revealed the secret of some treasure-laden crypts located at somewhere called %map.
 readMapFail,        You have already recorded all locations in this region!
 howManyItems,       Pick how many items (max {0})?
+wagonFullGold,      Your wagon could only hold {0} gold pieces.
 lightDouse,         You douse the %it.
 lightLight,         You light the %it.
 lightDies,          Your %it flickers and dies.


### PR DESCRIPTION
Factorize capacity computations (player carry capacity, wagon hold
capacity, gold dropping into wagon), using floats to avoid rounding down
bugs.
Code that makes horse, wagon and arrows weightless was also factorized.

Gold dropping message was left as-is to preserve Daggerfall classic
behavior; However, when dropping gold into wagon, a post capacity check
was added: if the wagon cannot accomodate the amount, only the gold that
fits is dropped and a message is displayed.

Bug report https://forums.dfworkshop.net/viewtopic.php?f=24&t=1587

I found another bug while factorizing: gold weight was counted twice in
wagon, because it was handled with a special case when the common case
was sufficient.