### PR TITLE
LoadID collision fix for dungeons with repeating blocks

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableActionDoor.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableActionDoor.cs
@@ -42,9 +42,9 @@ namespace DaggerfallWorkshop.Game.Serialization
             if (LoadID != 0)
             {
                 // Using same hack ID fix as SerializableEnemy
-                if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon)
+                if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && actionDoor)
                 {
-                    if (actionDoor && SaveLoadManager.StateManager.ContainsActionDoor(actionDoor.LoadID))
+                    while (SaveLoadManager.StateManager.ContainsActionDoor(actionDoor.LoadID))
                         actionDoor.LoadID++;
                 }
 

--- a/Assets/Scripts/Game/Serialization/SerializableEnemy.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableEnemy.cs
@@ -52,7 +52,7 @@ namespace DaggerfallWorkshop.Game.Serialization
                 // Only fixing for enemies now - will look for a better solution in the future
                 if (enemy && GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon)
                 {
-                    if (SaveLoadManager.StateManager.ContainsEnemy(enemy.LoadID))
+                    while (SaveLoadManager.StateManager.ContainsEnemy(enemy.LoadID))
                         enemy.LoadID++;
                 }
 


### PR DESCRIPTION
Currently in dungeons that have the same block 3 or more times will have colliding LoadIDs that result in some objects not being serialized for saving.  An example dungeon with this problem is The House of Baron Garulaus in Daggerfall.  This change simply increments the LoadID until it's unique.