### PR TITLE
fix IndexOutOfRangeException in inventory

### DIFF
--- a/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
+++ b/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
@@ -346,6 +346,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 backgroundTexture = null;
                 animatedBackgroundTextures = value;
+                if (animatedBackgroundTextures != null && animationFrame >= animatedBackgroundTextures.Length)
+                    animationFrame = 0;
             }
         }
 


### PR DESCRIPTION
Sometimes made items blink when scrolling lists because the list was only partially refreshed (Draw() interrupted half way by the exception; This was self healing few frames later when animationFrame was back in valid range hence the flickering).

IndexOutOfRangeException: Array index is out of range.
  at DaggerfallWorkshop.Game.UserInterface.BaseScreenComponent.Draw ()
[0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Draw () [0x00000] in
<filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Draw () [0x00000] in
<filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Button.Draw () [0x00000] in
<filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Draw () [0x00000] in
<filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Draw () [0x00000] in
<filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Draw () [0x00000] in
<filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Draw () [0x00000] in
<filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.UserInterfaceWindow.Draw ()
[0x00000] in <filename unknown>:0
  at
DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallBaseWindow.Draw
() [0x00000] in <filename unknown>:0
  at
DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallPopupWindow.Draw
() [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.DaggerfallUI.OnGUI () [0x00000] in
<filename unknown>:0