### PR TITLE
Fix exception using "Copy to logbook" with no message selected

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -1494,6 +1494,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         private void ButtonLogbook_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            if (listboxConversation.SelectedIndex < 0)
+                return;
+
             if (!copyIndexes.Contains(listboxConversation.SelectedIndex))
             {
                 copyIndexes.Add(listboxConversation.SelectedIndex);


### PR DESCRIPTION
Found that one because of clicks going thru (https://forums.dfworkshop.net/viewtopic.php?f=24&t=1153) but anybody can just click on the "copy to log" button and trigger it, too
When the talk window is closed, the whole interface freezes and the game must be killed

ArgumentOutOfRangeException: Argument is out of range.
Parameter name: index
  at System.Collections.Generic.List`1[DaggerfallWorkshop.Game.UserInterface.ListBox+ListItem].get_Item (Int32 index) [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.ListBox.GetItem (Int32 index) [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.DaggerfallTalkWindow.OnPop () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.UserInterfaceManager.RemoveWindow () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.UserInterfaceManager.PopWindow () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.UserInterfaceWindow.CloseWindow () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.DaggerfallTalkWindow.ButtonGoodbye_OnMouseClick (DaggerfallWorkshop.Game.UserInterface.BaseScreenComponent sender, Vector2 position) [0x00000] in <filename unknown>:0
  at (wrapper delegate-invoke) DaggerfallWorkshop.Game.UserInterface.BaseScreenComponent/OnMouseClickHandler:invoke_void__this___BaseScreenComponent_Vector2 (DaggerfallWorkshop.Game.UserInterface.BaseScreenComponent,UnityEngine.Vector2)
  at DaggerfallWorkshop.Game.UserInterface.BaseScreenComponent.MouseClick (Vector2 clickPosition) [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.BaseScreenComponent.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Button.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.Panel.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.UserInterfaceWindow.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallBaseWindow.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallPopupWindow.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.UserInterface.DaggerfallTalkWindow.Update () [0x00000] in <filename unknown>:0
  at DaggerfallWorkshop.Game.DaggerfallUI.Update () [0x00000] in <filename unknown>:0