### PR TITLE
Identify classic vampire data, vampire quests

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -78,10 +78,13 @@ namespace DaggerfallConnect.Save
             doc.minMetalToHit = parsedData.minMetalToHit;
             doc.armorValues = parsedData.armorValues;
             doc.timeToBecomeVampireOrWerebeast = parsedData.timeToBecomeVampireOrWerebeast;
+            doc.hasStartedInitialVampireQuest = parsedData.hasStartedInitialVampireQuest;
+            doc.lastTimeVampireNeedToKillSatiated = parsedData.lastTimeVampireNeedToKillSatiated;
             doc.lastTimePlayerAteOrDrankAtTavern = parsedData.lastTimePlayerAteOrDrankAtTavern;
             doc.lastTimePlayerBoughtTraining = parsedData.lastTimePlayerBoughtTraining;
             doc.timeForThievesGuildLetter = parsedData.timeForThievesGuildLetter;
             doc.timeForDarkBrotherhoodLetter = parsedData.timeForDarkBrotherhoodLetter;
+            doc.vampireClan = parsedData.vampireClan;
             doc.darkBrotherhoodRequirementTally = parsedData.darkBrotherhoodRequirementTally;
             doc.thievesGuildRequirementTally = parsedData.thievesGuildRequirementTally;
             doc.biographyReactionMod = parsedData.biographyReactionMod;
@@ -169,8 +172,11 @@ namespace DaggerfallConnect.Save
             parsedData.race2 = ReadRace(reader);
             parsedData.timeToBecomeVampireOrWerebeast = reader.ReadUInt32();
 
+            reader.BaseStream.Position = 0x1f8;
+            parsedData.hasStartedInitialVampireQuest = reader.ReadByte();
+
             reader.BaseStream.Position = 0x1fd;
-            parsedData.timeStamp = reader.ReadUInt32();
+            parsedData.lastTimeVampireNeedToKillSatiated = reader.ReadUInt32();
 
             reader.BaseStream.Position = 0x205;
             parsedData.lastTimePlayerAteOrDrankAtTavern = reader.ReadUInt32();
@@ -180,6 +186,7 @@ namespace DaggerfallConnect.Save
             parsedData.timeForThievesGuildLetter = reader.ReadUInt32();
             parsedData.timeForDarkBrotherhoodLetter = reader.ReadUInt32();
             parsedData.shieldEffectAmount = reader.ReadUInt32();
+            parsedData.vampireClan = reader.ReadByte();
 
             reader.BaseStream.Position = 0x21f;
             parsedData.darkBrotherhoodRequirementTally = reader.ReadByte();
@@ -350,8 +357,9 @@ namespace DaggerfallConnect.Save
             public Int16 attackDamageMin5;
             public Int16 attackDamageMax5;*/
             public Races race2; // Stores character's original race for when returning from being a vampire, werewolf or wereboar
-            public UInt32 timeToBecomeVampireOrWerebeast; // Should equal three days after infection.
-            public UInt32 timeStamp; // Time of last kill by vampires and werewolves?
+            public UInt32 timeToBecomeVampireOrWerebeast; // Three days after infection.
+            public Byte hasStartedInitialVampireQuest;
+            public UInt32 lastTimeVampireNeedToKillSatiated;
             public UInt32 lastTimePlayerCastLycanthropy;
             public UInt32 lastTimePlayerAteOrDrankAtTavern;
             public UInt32 lastTimePlayerBoughtTraining;
@@ -359,7 +367,7 @@ namespace DaggerfallConnect.Save
             public UInt32 timeForDarkBrotherhoodLetter;
             public UInt32 shieldEffectAmount;
             public Byte vampireClan;
-            public Byte effectStrength; // Used for Open and Shade effects at least.
+            public Byte effectStrength; // Used for Open effect at least.
             public Byte darkBrotherhoodRequirementTally;
             public Byte thievesGuildRequirementTally;
             public SByte biographyReactionMod;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -40,6 +40,10 @@ namespace DaggerfallWorkshop.Game.Entity
         bool preventNormalizingReputations = false;
         bool isResting = false;
 
+        bool hasStartedInitialVampireQuest = false;
+        //byte vampireClan = 0;
+        //uint lastTimeVampireNeedToKillSatiated = 0;
+
         const int testPlayerLevel = 1;
         const string testPlayerName = "Nameless";
 
@@ -364,12 +368,11 @@ namespace DaggerfallWorkshop.Game.Entity
                 if (((i + lastGameMinutes) % 54720) == 0) // 38 days
                 {
                     RegionPowerAndConditionsUpdate(true);
-                    // GetVampireOrWerecreatureQuest(); Non-cure quest
+                    GetVampireOrWereCreatureQuest(false);
                 }
 
-                // TODO: Get vampire/werecreature quest
-                //if (((i + lastGameMinutes) % 120960) == 0) // 84 days
-                //    GetVampireOrWerecreatureQuest(); cure quest
+                if (((i + lastGameMinutes) % 120960) == 0) // 84 days
+                    GetVampireOrWereCreatureQuest(true);
             }
 
             // TODO: Right now enemy spawns are only prevented when time has been raised for
@@ -435,6 +438,62 @@ namespace DaggerfallWorkshop.Game.Entity
             {
                 haveShownSurrenderToGuardsDialogue = false;
             }
+        }
+
+        // Recreation of vampire/werecreature quest starter from classic
+        // Notes:
+        // 1) In classic the initial quest can happen multiple times but this is probably a mistake.
+        // 2) Additional quests will come regardless of whether the initial quest was completed or failed, as the bool is set
+        //    when the initial quest begins, not on successful completion.
+        void GetVampireOrWereCreatureQuest(bool isCureQuest)
+        {
+            if (Race == Races.Vampire)
+            {
+                if (isCureQuest)
+                {
+                    if (DFRandom.random_range_inclusive(10, 100) < 30)
+                        Questing.QuestMachine.Instance.InstantiateQuest("$CUREVAM");
+                }
+                else if (hasStartedInitialVampireQuest)
+                {
+                    // Do a quest starting with "P0B" for player's level
+                    // TODO: Merge with rest of quest-loading code
+                    string[] vampireQuests = { "P0B00L01", "P0B00L03", "P0B00L04", "P0B00L06", "P0B01L02", "P0B10L07", "P0B10L08", "P0B10L10", "P0B20L09" };
+                    List<string> vQList = new List<string>(vampireQuests);
+                    if (DFRandom.random_range_inclusive(1, 100) < 50)
+                    {
+                        bool found = false;
+                        string choice = string.Empty;
+                        while (!found && vQList.Count > 0)
+                        {
+                            int index = UnityEngine.Random.Range(0, vQList.Count);
+                            choice = vQList[index];
+                            // 4th letter of name is the minimum level the player must be to get the quest
+                            if (choice[3] - 48 <= level)
+                            {
+                                found = true;
+                            }
+                            else
+                                vQList.RemoveAt(index);
+                        }
+
+                        if (found)
+                            Questing.QuestMachine.Instance.InstantiateQuest(choice);
+                    }
+                }
+                else if (DFRandom.random_range_inclusive(1, 100) < 50)
+                {
+                    Questing.QuestMachine.Instance.InstantiateQuest("P0A01L00");
+                    hasStartedInitialVampireQuest = true;
+                }
+            }
+            /*else
+            {
+                if (playerIsWereCreature && isCureQuest && DFRandom.random_range_inclusive(1, 100) < 30)
+                {
+                    Questing.QuestMachine.Instance.InstantiateQuest("$CUREWER");
+                }
+            }*/
         }
 
         public bool IntermittentEnemySpawn(uint Minutes)
@@ -721,6 +780,9 @@ namespace DaggerfallWorkshop.Game.Entity
             this.timeForDarkBrotherhoodLetter = character.timeForDarkBrotherhoodLetter;
             this.darkBrotherhoodRequirementTally = character.darkBrotherhoodRequirementTally;
             this.thievesGuildRequirementTally = character.thievesGuildRequirementTally;
+            this.hasStartedInitialVampireQuest = character.hasStartedInitialVampireQuest != 0;
+            //this.vampireClan = character.vampireClan;
+            //this.lastTimeVampireNeedToKillSatiated = character.lastTimeVampireNeedToKillSatiated;
 
             BackStory = character.backStory;
 

--- a/Assets/Scripts/Game/Entities/RaceTemplate.cs
+++ b/Assets/Scripts/Game/Entities/RaceTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -62,7 +62,7 @@ namespace DaggerfallWorkshop.Game.Entity
             WoodElf woodElf = new WoodElf();
             Khajiit khajiit = new Khajiit();
             Argonian argonian = new Argonian();
-            //Vampire vampire = new Vampire();          // TODO: Uncomment later when paper doll and morphology support completed
+            Vampire vampire = new Vampire();          // TODO: Uncomment later when paper doll and morphology support completed
             //Werewolf werewolf = new Werewolf();
             //Wereboar wereboar = new Wereboar();
 
@@ -75,7 +75,7 @@ namespace DaggerfallWorkshop.Game.Entity
             raceDict.Add(woodElf.ID, woodElf);
             raceDict.Add(khajiit.ID, khajiit);
             raceDict.Add(argonian.ID, argonian);
-            //raceDict.Add(vampire.ID, vampire);      // TODO: Uncomment later when paper doll and morphology support completed
+            raceDict.Add(vampire.ID, vampire);      // TODO: Uncomment later when paper doll and morphology support completed
             //raceDict.Add(werewolf.ID, werewolf);
             //raceDict.Add(wereboar.ID, wereboar);
 
@@ -267,6 +267,15 @@ namespace DaggerfallWorkshop.Game.Entity
             ClipID = 0;
 
             PaperDollBackground = "SCBG08I0.IMG";
+
+            // Temporarily using Breton so that classic saves can be imported.
+            PaperDollBodyMaleUnclothed = "BODY00I0.IMG";
+            PaperDollBodyMaleClothed = "BODY00I1.IMG";
+            PaperDollBodyFemaleUnclothed = "BODY10I0.IMG";
+            PaperDollBodyFemaleClothed = "BODY10I1.IMG";
+
+            PaperDollHeadsMale = "FACE00I0.CIF";
+            PaperDollHeadsFemale = "FACE10I0.CIF";
 
             // TODO:
             //  * Paper doll body to match base race

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -48,9 +48,12 @@ namespace DaggerfallWorkshop.Game.Player
         public uint lastTimePlayerBoughtTraining;
         public uint timeForThievesGuildLetter;
         public uint timeForDarkBrotherhoodLetter;
+        public byte vampireClan;
         public byte darkBrotherhoodRequirementTally;
         public byte thievesGuildRequirementTally;
         public uint timeToBecomeVampireOrWerebeast;
+        public byte hasStartedInitialVampireQuest;
+        public uint lastTimeVampireNeedToKillSatiated;
         public uint lastTimePlayerAteOrDrankAtTavern;
         public sbyte biographyReactionMod;
         public List<string> biographyEffects;


### PR DESCRIPTION
This provides functionality/information for vampire mechanics from classic. Interkarma, please feel free to refactor anything you like, or if this can't merge cleanly with local WIP code you have, just use it as a reference or something.

What's in here:

- Identify and import 3 vampire-related data pieces from classic saves.
1) Last time that need to kill was satiated
2) Vampire clan
3) Whether or not initial vampire quest has been initiated

This data is not serialized in PlayerEntity yet. 1) and 2) are commented out in PlayerEntity, but 3) is used for the quest logic.

- Uncommented Vampire race and temporarily using Breton graphics, to allow for opening classic vampire saves to aid in testing against classic.

(Note that if you load a classic vampire, they will gain several levels because their skill bonuses are imported as if they are the real skill levels. Classic temporarily undoes vampire/werecreature skill bonuses when calculating skill advances/level ups, then reapplies them. This is something we'll need to handle when importing classic vampires)

- Run vampire quests the same as classic + bug fixes.
Non-cure quests can appear every 38 days, as I think they were supposed to, instead of every 266 days which I think is how often they can happen in classic. This has been noted in a comment in PlayerEntity for a while now. Cure quests can appear every 84 days, same as classic. Quests can occur at the same chances as in classic. The initial quest only happens once, unlike classic. (If it's possible to re-become a vampire after being cured, probably the initial quest should happen again, haven't done that yet)

The initial quest and cure quest are always the same, but there are also other quests. Unfortunately, I've never touched the quest code in DF Unity before, so I'm not sure how to handle selecting a quest through it. I put together a simple function that calls one of the quests, but it's hard-coded. I'm sure we'll want to move that. Werecreatures only have the cure quest, and I put that in as well, commented out.

BTW, I think the current quest selection incorrectly treats the 4th and 5th characters of a quest name as the required faction reputation to get that quest. Actually the 4th char is either a level requirement or a rank requirement. The char's ASCII value - 48 is compared to the level/rank. (As I did in the function I added for the vampire quests).

Rank requirement:
Fighters Guild
Dark Brotherhood
Temple
Thieves Guild

Level requirement:
Knightly Order
Mages Guild
Royalty
Coven
Merchant
Vampire

The only purpose I know of the 5th char is that if it is 'X' or 'Y' it will not be selected when ChildGard is on. Ones with 'X' all either have Daedra Seducers or Harpies in them (maybe harpies had or were planned for a more explicit graphic before?). No classic quests use 'Y'.

Examples:
N0B40Y07 = Mages Guild, available to level 4 and higher.
O0B2XY04 = Thieves Guild quest that can have a daedra seducer. Censored in ChildGard mode.
