### PR TITLE
new experimental ini file setting "TerrainHeightmapPixelError" introduced

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -80,6 +80,7 @@ StartInDungeon=True
 
 [Experimental]
 TerrainDistance=3
+TerrainHeightmapPixelError=5
 
 [Enhancements]
 LypyL_GameConsole=True

--- a/Assets/Scripts/Game/WeatherManager.cs
+++ b/Assets/Scripts/Game/WeatherManager.cs
@@ -56,7 +56,7 @@ namespace DaggerfallWorkshop.Game
         public FogSettings SunnyFogSettings = new FogSettings { fogMode = FogMode.Linear, density = 0.0f, startDistance = 0, endDistance = 2400, excludeSkybox = true };
         public FogSettings OvercastFogSettings = new FogSettings { fogMode = FogMode.Linear, density = 0.0f, startDistance = 0, endDistance = 2400, excludeSkybox = true };
         public FogSettings RainyFogSettings = new FogSettings { fogMode = FogMode.Exponential, density = 0.003f, startDistance = 0, endDistance = 0, excludeSkybox = true };
-        public FogSettings SnowyFogSettings = new FogSettings { fogMode = FogMode.Exponential, density = 0.003f, startDistance = 0, endDistance = 0, excludeSkybox = true };
+        public FogSettings SnowyFogSettings = new FogSettings { fogMode = FogMode.Exponential, density = 0.005f, startDistance = 0, endDistance = 0, excludeSkybox = true };
         public FogSettings HeavyFogSettings = new FogSettings { fogMode = FogMode.Exponential, density = 0.05f, startDistance = 0, endDistance = 0, excludeSkybox = false };
 
         DaggerfallUnity _dfUnity;
@@ -175,6 +175,12 @@ namespace DaggerfallWorkshop.Game
         #endregion
 
         #region Rain
+
+        public void SetOvercast()
+        {
+            SetFog(OvercastFogSettings);
+            IsOvercast = true;
+        }
 
         public void SetRainOvercast()
         {
@@ -361,7 +367,7 @@ namespace DaggerfallWorkshop.Game
                     break;
 
                 case WeatherType.Overcast:
-                    SetRainOvercast();
+                    SetOvercast();
                     break;
 
                 case WeatherType.Fog:

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -143,6 +143,8 @@ namespace DaggerfallWorkshop
         // [Experimental]
         public int TerrainDistance { get; set; }
 
+        public float TerrainHeightmapPixelError { get; set; }
+
         // [Enhancements]
         public bool LypyL_GameConsole { get; set; }
         public bool LypyL_ModSystem { get; set; }
@@ -244,6 +246,7 @@ namespace DaggerfallWorkshop
             StartInDungeon = GetBool(sectionStartup, "StartInDungeon");
 
             TerrainDistance = GetInt(sectionExperimental, "TerrainDistance", 1, 4);
+            TerrainHeightmapPixelError = GetFloat(sectionExperimental, "TerrainHeightmapPixelError", 1, 10);
 
             LypyL_GameConsole = GetBool(sectionEnhancements, "LypyL_GameConsole");
             LypyL_ModSystem = GetBool(sectionEnhancements, "LypyL_ModSystem");
@@ -336,6 +339,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionStartup, "StartInDungeon", StartInDungeon);
 
             SetInt(sectionExperimental, "TerrainDistance", TerrainDistance);
+            SetFloat(sectionExperimental, "TerrainHeightmapPixelError", TerrainHeightmapPixelError);
 
             SetBool(sectionEnhancements, "LypyL_GameConsole", LypyL_GameConsole);
             SetBool(sectionEnhancements, "LypyL_ModSystem", LypyL_ModSystem);

--- a/Assets/Scripts/Terrain/DaggerfallTerrain.cs
+++ b/Assets/Scripts/Terrain/DaggerfallTerrain.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -70,7 +70,21 @@ namespace DaggerfallWorkshop
         int currentWorldClimate = -1;
         DaggerfallDateTime.Seasons season = DaggerfallDateTime.Seasons.Summer;
         bool ready;
-        
+
+        private float heightMapPixelError = 5; // just a default value in case ini value reading fails (so value will be overwritten by ini file value)
+
+        public float HeightMapPixelError
+        {
+            get { return heightMapPixelError; }
+            set { heightMapPixelError = value; }
+        }
+
+
+        void Awake()
+        {
+            HeightMapPixelError = DaggerfallUnity.Settings.TerrainHeightmapPixelError;
+        }
+
         void Start()
         {
             UpdateNeighbours();
@@ -263,6 +277,7 @@ namespace DaggerfallWorkshop
                 terrain.terrainData = terrainData;
                 terrain.GetComponent<TerrainCollider>().terrainData = terrainData;
                 terrain.basemapDistance = basemapDistance;
+                terrain.heightmapPixelError = heightMapPixelError;
             }
 
             // Promote tileMap


### PR DESCRIPTION
new experimental ini file setting "TerrainHeightmapPixelError" introduced
this setting can be used to prevent inaccuracies with location placement on terrain - lower values are better, 1 is best
default is 5 (as before) but we can try to lower it to 1