### PR TITLE
Potions initial implementation

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -85,6 +85,7 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(DumpBlock.name, DumpBlock.description, DumpBlock.usage, DumpBlock.Execute);
             ConsoleCommandsDatabase.RegisterCommand(DumpLocBlocks.name, DumpLocBlocks.description, DumpLocBlocks.usage, DumpLocBlocks.Execute);
             ConsoleCommandsDatabase.RegisterCommand(DumpBuilding.name, DumpBuilding.description, DumpBuilding.usage, DumpBuilding.Execute);
+            ConsoleCommandsDatabase.RegisterCommand(IngredientUsage.name, IngredientUsage.description, IngredientUsage.usage, IngredientUsage.Execute);
 
             ConsoleCommandsDatabase.RegisterCommand(PlayFLC.name, PlayFLC.description, PlayFLC.usage, PlayFLC.Execute);
         }
@@ -211,6 +212,23 @@ namespace Wenzil.Console
                     return "Building data written to " + Path.Combine(Application.persistentDataPath, fileName);
                 }
                 return error;
+            }
+        }
+
+        private static class IngredientUsage
+        {
+            public static readonly string name = "ingredUsage";
+            public static readonly string description = "Log analysis of potion recipe usage of ingredients";
+            public static readonly string usage = "ingredUsage";
+
+            public static string Execute(params string[] args)
+            {
+                if (args == null || args.Length > 0)
+                    return usage;
+
+                GameManager.Instance.EntityEffectBroker.LogRecipeIngredientUsage();
+
+                return "Finished";
             }
         }
 

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -218,7 +218,7 @@ namespace Wenzil.Console
         private static class IngredientUsage
         {
             public static readonly string name = "ingredUsage";
-            public static readonly string description = "Log analysis of potion recipe usage of ingredients";
+            public static readonly string description = "Log an analysis of potion recipe usage of ingredients";
             public static readonly string usage = "ingredUsage";
 
             public static string Execute(params string[] args)

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -321,6 +321,7 @@ namespace DaggerfallWorkshop.Game.Items
 
         /// <summary>
         /// Gets/sets the key of the potion recipe allocated to this item.
+        /// Has a side effect of populating the item value from the recipe price. (due to value not being encapsulated)
         /// </summary>
         public int PotionRecipeKey
         {

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -45,6 +45,7 @@ namespace DaggerfallWorkshop.Game.Items
         public DaggerfallEnchantment[] legacyMagic = null;
         public int stackCount = 1;
         public Poisons poisonType = Poisons.None;
+        public int potionRecipe;
 
         // Private item fields
         int playerTextureArchive;
@@ -681,6 +682,7 @@ namespace DaggerfallWorkshop.Game.Items
             data.poisonType = poisonType;
             if ((int)poisonType < MagicAndEffects.MagicEffects.PoisonEffect.startValue)
                 data.poisonType = Poisons.None;
+            data.potionRecipe = potionRecipe;
             data.repairData = repairData.GetSaveData();
 
             return data;
@@ -1325,6 +1327,7 @@ namespace DaggerfallWorkshop.Game.Items
             poisonType = data.poisonType;
             if ((int)data.poisonType < MagicAndEffects.MagicEffects.PoisonEffect.startValue)
                 poisonType = Poisons.None;
+            potionRecipe = data.potionRecipe;
             repairData.RestoreRepairData(data.repairData);
         }
 

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -321,7 +321,7 @@ namespace DaggerfallWorkshop.Game.Items
 
         /// <summary>
         /// Gets/sets the key of the potion recipe allocated to this item.
-        /// Has a side effect of populating the item value from the recipe price. (due to value not being encapsulated)
+        /// Has a side effect (ugh, sorry) of populating the item value from the recipe price. (due to value not being encapsulated)
         /// </summary>
         public int PotionRecipeKey
         {

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -203,36 +203,31 @@ namespace DaggerfallWorkshop.Game.Items
 
             public override string Potion()
             {   // %po
+                string potionName = "Unknown Powers";
                 PotionRecipe potionRecipe = GameManager.Instance.EntityEffectBroker.GetPotionRecipe(parent.potionRecipeKey);
                 if (potionRecipe != null)
-                {
-                    if (parent.IsPotionRecipe)
-                        return potionRecipe.DisplayName;                                          // "Potion recipe for %po"
-                    else if (parent.IsPotion)
-                        return HardStrings.potionOf.Replace("%po", potionRecipe.DisplayName);     // "Potion of %po" (255=Unknown Powers)
-                }
+                    potionName = potionRecipe.DisplayName;
 
-                KeyValuePair<string, Recipe[]> mapping = DaggerfallUnity.Instance.ItemHelper.getPotionRecipesByID(parent.typeDependentData);
-                recipeArray = mapping.Value;
-                if (parent.TemplateIndex == (int)MiscItems.Potion_recipe)
-                    return mapping.Key;                                          // "Potion recipe for %po"
-                else if (parent.TemplateIndex == (int)UselessItems1.Glass_Bottle)
-                    return HardStrings.potionOf.Replace("%po", mapping.Key);     // "Potion of %po" (255=Unknown Powers)
+                if (parent.IsPotionRecipe)
+                    return potionName;                                          // "Potion recipe for %po"
+                else if (parent.IsPotion)
+                    return HardStrings.potionOf.Replace("%po", potionName);     // "Potion of %po" (255=Unknown Powers)
+
                 throw new NotImplementedException();
             }
 
             public override TextFile.Token[] PotionRecipeIngredients(TextFile.Formatting format)
             {
-                // InconsolableCellist:
-                // Potions can have multiple recipes, and it's unclear how this variation is stored
-                // The actual variation could be stored in the currentVariation field, but I haven't been able find any recipes
-                // in the game that aren't just the first recipe in the list; for now we'll just pick the first one here
                 List<TextFile.Token> ingredientsTokens = new List<TextFile.Token>();
-                Ingredient[] ingredients = recipeArray[0].ingredients;
-                for (int i = 0; i < ingredients.Length; ++i)
+                PotionRecipe potionRecipe = GameManager.Instance.EntityEffectBroker.GetPotionRecipe(parent.potionRecipeKey);
+                if (potionRecipe != null)
                 {
-                    ingredientsTokens.Add(TextFile.CreateTextToken(ingredients[i].name));
-                    ingredientsTokens.Add(TextFile.CreateFormatToken(format));
+                    foreach (PotionRecipe.Ingredient ingredient in potionRecipe.Ingredients)
+                    {
+                        ItemTemplate ingredientTemplate = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ingredient.id);
+                        ingredientsTokens.Add(TextFile.CreateTextToken(ingredientTemplate.name));
+                        ingredientsTokens.Add(TextFile.CreateFormatToken(format));
+                    }
                 }
                 return ingredientsTokens.ToArray();
             }

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -201,22 +201,23 @@ namespace DaggerfallWorkshop.Game.Items
                 return soul.Name;
             }
 
-            private int[] classicRecipeMapping = { 0, 0, 5522181, 0, 0, 0, 0, 0, 0, 0, 0, 4937009, 0, 0, 0, 0, 0, 0, 0, 0 };
-
             public override string Potion()
             {   // %po
-                // Convert classic recipes to DFU Effect hashcode.
-                if (parent.potionRecipe == 0 && parent.typeDependentData < classicRecipeMapping.Length)
-                    parent.potionRecipe = classicRecipeMapping[parent.typeDependentData];
-
-                PotionRecipe potionRecipe = GameManager.Instance.EntityEffectBroker.GetPotionRecipe(parent.potionRecipe);
+                PotionRecipe potionRecipe = GameManager.Instance.EntityEffectBroker.GetPotionRecipe(parent.potionRecipeKey);
+                if (potionRecipe != null)
+                {
+                    if (parent.IsPotionRecipe)
+                        return potionRecipe.DisplayName;                                          // "Potion recipe for %po"
+                    else if (parent.IsPotion)
+                        return HardStrings.potionOf.Replace("%po", potionRecipe.DisplayName);     // "Potion of %po" (255=Unknown Powers)
+                }
 
                 KeyValuePair<string, Recipe[]> mapping = DaggerfallUnity.Instance.ItemHelper.getPotionRecipesByID(parent.typeDependentData);
                 recipeArray = mapping.Value;
                 if (parent.TemplateIndex == (int)MiscItems.Potion_recipe)
                     return mapping.Key;                                          // "Potion recipe for %po"
                 else if (parent.TemplateIndex == (int)UselessItems1.Glass_Bottle)
-                    return HardStrings.potionOf.Replace("%po", potionRecipe == null ? mapping.Key : potionRecipe.DisplayName);     // "Potion of %po" (255=Unknown Powers)
+                    return HardStrings.potionOf.Replace("%po", mapping.Key);     // "Potion of %po" (255=Unknown Powers)
                 throw new NotImplementedException();
             }
 

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -203,7 +203,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             public override string Potion()
             {   // %po
-                string potionName = "Unknown Powers";
+                string potionName = PotionRecipe.UnknownPowers;
                 PotionRecipe potionRecipe = GameManager.Instance.EntityEffectBroker.GetPotionRecipe(parent.potionRecipeKey);
                 if (potionRecipe != null)
                     potionName = potionRecipe.DisplayName;

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -15,6 +15,7 @@ using DaggerfallConnect.FallExe;
 using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Utility.AssetInjection;
+using DaggerfallWorkshop.Game.MagicAndEffects;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -200,14 +201,22 @@ namespace DaggerfallWorkshop.Game.Items
                 return soul.Name;
             }
 
+            private int[] classicRecipeMapping = { 0, 0, 5522181, 0, 0, 0, 0, 0, 0, 0, 0, 4937009, 0, 0, 0, 0, 0, 0, 0, 0 };
+
             public override string Potion()
             {   // %po
+                // Convert classic recipes to DFU Effect hashcode.
+                if (parent.potionRecipe == 0 && parent.typeDependentData < classicRecipeMapping.Length)
+                    parent.potionRecipe = classicRecipeMapping[parent.typeDependentData];
+
+                PotionRecipe potionRecipe = GameManager.Instance.EntityEffectBroker.GetPotionRecipe(parent.potionRecipe);
+
                 KeyValuePair<string, Recipe[]> mapping = DaggerfallUnity.Instance.ItemHelper.getPotionRecipesByID(parent.typeDependentData);
                 recipeArray = mapping.Value;
                 if (parent.TemplateIndex == (int)MiscItems.Potion_recipe)
                     return mapping.Key;                                          // "Potion recipe for %po"
                 else if (parent.TemplateIndex == (int)UselessItems1.Glass_Bottle)
-                    return HardStrings.potionOf.Replace("%po", mapping.Key);     // "Potion of %po"
+                    return HardStrings.potionOf.Replace("%po", potionRecipe == null ? mapping.Key : potionRecipe.DisplayName);     // "Potion of %po" (255=Unknown Powers)
                 throw new NotImplementedException();
             }
 

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -714,37 +714,34 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
-        /// Creates a potion
+        /// Creates a potion.
         /// </summary>
         /// <param name="recipe">Recipe index for the potion</param>
-        /// <returns>DaggerfallUnityItem</returns>
+        /// <returns>Potion DaggerfallUnityItem</returns>
         public static DaggerfallUnityItem CreatePotion(int recipeKey)
         {
             return new DaggerfallUnityItem(ItemGroups.UselessItems1, 1) { PotionRecipeKey = recipeKey };
         }
 
         /// <summary>
-        /// Creates a potion
+        /// Creates a random potion from all registered recipes.
         /// </summary>
-        /// <param name="recipe">Recipe index for the potion</param>
-        /// <returns>DaggerfallUnityItem</returns>
-        public static DaggerfallUnityItem CreatePotion(byte recipe)
+        /// <returns>Potion DaggerfallUnityItem</returns>
+        public static DaggerfallUnityItem CreateRandomPotion()
         {
-            return new DaggerfallUnityItem(ItemGroups.UselessItems1, 1)
-            {
-                typeDependentData = recipe,
-                value = potionValues[recipe],
-            };
+            List<int> recipeKeys = GameManager.Instance.EntityEffectBroker.GetPotionRecipeKeys();
+            int recipeIdx = UnityEngine.Random.Range(0, recipeKeys.Count);
+            return CreatePotion(recipeKeys[recipeIdx]);
         }
 
         /// <summary>
-        /// Creates a random classic potion
+        /// Creates a random (classic) potion
         /// </summary>
-        /// <returns>DaggerfallUnityItem</returns>
-        public static DaggerfallUnityItem CreateRandomPotion()
+        /// <returns>Potion DaggerfallUnityItem</returns>
+        public static DaggerfallUnityItem CreateRandomClassicPotion()
         {
-            byte recipe = (byte)UnityEngine.Random.Range(0, 20);
-            return CreatePotion(recipe);
+            int recipeIdx = UnityEngine.Random.Range(0, MagicAndEffects.PotionRecipe.classicRecipeKeys.Length);
+            return CreatePotion(MagicAndEffects.PotionRecipe.classicRecipeKeys[recipeIdx]);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -49,9 +49,6 @@ namespace DaggerfallWorkshop.Game.Items
         // Enchantment point multipliers by material type. Iron through Daedric. Enchantment points is baseEnchanmentPoints * value / 4.
         static readonly short[] enchantmentPointMultipliersByMaterial = { 3, 4, 7, 5, 6, 5, 7, 8, 10, 12 };
 
-        // Value of potions indexed by recipe
-        static readonly ushort[] potionValues = { 25, 50, 50, 50, 75, 75, 75, 75, 100, 100, 100, 100, 125, 125, 125, 200, 200, 200, 250, 500 };
-
         // Enchantment point/gold value data for item powers
         static readonly int[] extraSpellPtsEnchantPts = { 0x1F4, 0x1F4, 0x1F4, 0x1F4, 0xC8, 0xC8, 0xC8, 0x2BC, 0x320, 0x384, 0x3E8 };
         static readonly int[] potentVsEnchantPts = { 0x320, 0x384, 0x3E8, 0x4B0 };

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -718,6 +718,16 @@ namespace DaggerfallWorkshop.Game.Items
         /// </summary>
         /// <param name="recipe">Recipe index for the potion</param>
         /// <returns>DaggerfallUnityItem</returns>
+        public static DaggerfallUnityItem CreatePotion(int recipeKey)
+        {
+            return new DaggerfallUnityItem(ItemGroups.UselessItems1, 1) { PotionRecipeKey = recipeKey };
+        }
+
+        /// <summary>
+        /// Creates a potion
+        /// </summary>
+        /// <param name="recipe">Recipe index for the potion</param>
+        /// <returns>DaggerfallUnityItem</returns>
         public static DaggerfallUnityItem CreatePotion(byte recipe)
         {
             return new DaggerfallUnityItem(ItemGroups.UselessItems1, 1)
@@ -728,7 +738,7 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
-        /// Creates a random potion
+        /// Creates a random classic potion
         /// </summary>
         /// <returns>DaggerfallUnityItem</returns>
         public static DaggerfallUnityItem CreateRandomPotion()

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -281,6 +281,23 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
+        /// Removes one item from this collection, decrementing stack count.
+        /// </summary>
+        /// <param name="item">Item to remove. Must exist inside this collection.</param>
+        public void RemoveOne(DaggerfallUnityItem item)
+        {
+            if (item == null)
+                return;
+
+            if (items.Contains(item.UID))
+            {
+                item.stackCount--;
+                if (item.stackCount <= 0)
+                    RemoveItem(item);
+            }
+        }
+
+        /// <summary>
         /// Reorders item in collection.
         /// </summary>
         /// <param name="item">Item to reorder. Must exist inside this collection.</param>
@@ -589,7 +606,8 @@ namespace DaggerfallWorkshop.Game.Items
             foreach (DaggerfallUnityItem checkItem in items.Values)
             {
                 if (checkItem != item && 
-                    checkItem.ItemGroup == itemGroup && checkItem.GroupIndex == groupIndex && 
+                    checkItem.ItemGroup == itemGroup && checkItem.GroupIndex == groupIndex &&
+                    checkItem.PotionRecipeKey == item.PotionRecipeKey &&
                     checkItem.IsStackable())
                     return checkItem;
             }

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -42,7 +42,6 @@ namespace DaggerfallWorkshop.Game.Items
         const string magicItemTemplatesFilename = "MagicItemTemplates";
         const string containerIconsFilename = "INVE16I0.CIF";
         const string bookMappingFilename = "books";
-        const string recipeMappingFilename = "PotionRecipes";
 
         const int artifactMaleTextureArchive = 432;
         const int artifactFemaleTextureArchive = 433;
@@ -53,7 +52,6 @@ namespace DaggerfallWorkshop.Game.Items
         readonly Dictionary<int, ImageData> itemImages = new Dictionary<int, ImageData>();
         readonly Dictionary<InventoryContainerImages, ImageData> containerImages = new Dictionary<InventoryContainerImages, ImageData>();
         readonly Dictionary<int, String> bookIDNameMapping = new Dictionary<int, String>();
-        readonly Dictionary<int, RecipeMapping> potionRecipeMapping = new Dictionary<int, RecipeMapping>();
 
         #endregion
 
@@ -64,7 +62,6 @@ namespace DaggerfallWorkshop.Game.Items
             LoadItemTemplates();
             LoadMagicItemTemplates();
             LoadBookIDNameMapping();
-            LoadPotionRecipeIDMapping();
         }
 
         #endregion
@@ -405,18 +402,6 @@ namespace DaggerfallWorkshop.Game.Items
         {
             string title = "";
             return bookIDNameMapping.TryGetValue(id, out title) ? title : defaultBookName;
-        }
-
-        /// <summary>
-        /// Gets the recipe(s) for a potion based on the recipe's ID
-        /// </summary>
-        /// <param name="id">The ID of the requested potion recipe</param>
-        /// <returns>A KeyValuePair<string, Recipe[]>, where the string is the name of the recipe and the Recipe array contains the different ways it can be made</returns>
-        public KeyValuePair<string, Recipe[]> getPotionRecipesByID(int id)
-        {
-            RecipeMapping mapping;
-            potionRecipeMapping.TryGetValue(id, out mapping);
-            return new KeyValuePair<string, Recipe[]>(mapping.name, mapping.recipes);
         }
 
         /// <summary>
@@ -1157,29 +1142,6 @@ namespace DaggerfallWorkshop.Game.Items
             catch
             {
                 Debug.Log("Could not load the BookIDName mapping from Resources. Check file exists and is in correct format.");
-            }
-        }
-
-        /// <summary>
-        /// Loads potion recipe ID mappings from JSON file. This is used whenever you need to read the content of a potion recipe item
-        /// It should be called once to initilaize the internal data structures used for potion-related helper functions.
-        /// This data was obtained by looking at the internal array of potion objects in the FALL.EXE file and combining it
-        /// with a known resource for potion ingredients. The IDs in the file correspond to the DFU IDs in the ItemTemplates.txt
-        /// </summary>
-        void LoadPotionRecipeIDMapping()
-        {
-            try
-            {
-                TextAsset recipeNames = Resources.Load<TextAsset>(recipeMappingFilename);
-                List<RecipeMapping> mappings = SaveLoadManager.Deserialize(typeof(List<RecipeMapping>), recipeNames.text) as List<RecipeMapping>;
-                for (int x = 0; x < mappings.Count; ++x)
-                {
-                    potionRecipeMapping.Add(x, mappings[x]);
-                }
-            }
-            catch (Exception e)
-            {
-                Debug.Log("Could not load the Potion recipe mapping from Resources. Check file exists and is in correct format. " + e.ToString());
             }
         }
 

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -198,7 +198,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             // Resolve potion names
-            if (item.ItemGroup == ItemGroups.UselessItems1 && item.TemplateIndex == (int)UselessItems1.Glass_Bottle)
+            if (item.IsPotion)
                 return MacroHelper.GetValue("%po", item);
 
             // Resolve quest letters, get last 2 lines which should be the signoff
@@ -558,7 +558,7 @@ namespace DaggerfallWorkshop.Game.Items
 
                 case ItemGroups.MiscItems:
                     // A few items in the MiscItems group have their own text display
-                    if (item.TemplateIndex == (int)MiscItems.Potion_recipe)
+                    if (item.IsPotionRecipe)
                         return GetPotionRecipeTokens();                             // Handle potion recipes
                     else if (item.TemplateIndex == (int)MiscItems.House_Deed)
                         return textProvider.GetRSCTokens(houseDeedTextId);          // Handle house deeds
@@ -572,8 +572,7 @@ namespace DaggerfallWorkshop.Game.Items
                 default:
                     // Handle potions in glass bottles
                     // In classic, the check is whether RecordRoot.SublistHead is non-null and of PotionMix type.
-                    // TODO: Do we need it or will glass bottles with typedependentdata cover it?
-                    if (item.ItemGroup == ItemGroups.UselessItems1 && item.TemplateIndex == (int)UselessItems1.Glass_Bottle)
+                    if (item.IsPotion)
                         return textProvider.GetRSCTokens(potionTextId);
 
                     // Handle Azura's Star

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/ElementalResistance.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/ElementalResistance.cs
@@ -200,7 +200,6 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 
             entityBehaviour.Entity.SetResistanceFlag(variantProperties[currentVariant].elementResisted, true);
             entityBehaviour.Entity.SetResistanceChance(variantProperties[currentVariant].elementResisted, ChanceValue());
-            //UnityEngine.Debug.LogFormat("{0} started with chance {1}", Key, ChanceValue());
         }
 
         void StopResisting()

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/ElementalResistance.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/ElementalResistance.cs
@@ -35,6 +35,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             public DFCareer.Elements elementResisted;
             public EffectProperties effectProperties;
+            public PotionProperties potionProperties;
         }
 
         #endregion
@@ -55,6 +56,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         public DFCareer.Elements ElementResisted
         {
             get { return variantProperties[currentVariant].elementResisted; }
+        }
+
+        public override PotionProperties PotionProperties
+        {
+            get { return variantProperties[currentVariant].potionProperties; }
         }
 
         #endregion
@@ -85,10 +91,12 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 
         public override void SetPotionProperties()
         {
+            EffectSettings resistSettings = SetEffectChance(DefaultEffectSettings(), 100, 1, 1);
+
             PotionRecipe resistFire = new PotionRecipe(
                 TextManager.Instance.GetText(textDatabase, "resistFire"),
                 75,
-                DefaultEffectSettings(),
+                resistSettings,
                 (int)Items.MiscellaneousIngredients1.Ichor,
                 (int)Items.Gems.Amber,
                 (int)Items.PlantIngredients1.Red_flowers,
@@ -98,14 +106,34 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             PotionRecipe resistFrost = new PotionRecipe(
                 TextManager.Instance.GetText(textDatabase, "resistFrost"),
                 75,
-                DefaultEffectSettings(),
+                resistSettings,
                 (int)Items.MiscellaneousIngredients1.Ichor,
                 (int)Items.Gems.Turquoise,
                 (int)Items.PlantIngredients1.Pine_branch,
                 (int)Items.PlantIngredients2.White_rose);
 
-            // Assign recipes
-            AssignPotionRecipes(resistFire, resistFrost);
+            PotionRecipe resistShock = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "resistShock"),
+                75,
+                resistSettings,
+                (int)Items.MiscellaneousIngredients1.Ichor,
+                (int)Items.MetalIngredients.Lodestone,
+                (int)Items.PlantIngredients1.Red_berries);
+
+            EffectSettings poisonResistSettings = SetEffectChance(DefaultEffectSettings(), 5, 19, 1);
+            PotionRecipe resistPoison = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "resistPoison"),
+                125,
+                poisonResistSettings,
+                (int)Items.MiscellaneousIngredients1.Ichor,
+                (int)Items.CreatureIngredients1.Snake_venom,
+                (int)Items.PlantIngredients1.Golden_poppy);
+
+            // Assign potion recipes
+            variantProperties[(int)DFCareer.Elements.Fire].potionProperties.Recipes = new PotionRecipe[] { resistFire };
+            variantProperties[(int)DFCareer.Elements.Frost].potionProperties.Recipes = new PotionRecipe[] { resistFrost };
+            variantProperties[(int)DFCareer.Elements.Shock].potionProperties.Recipes = new PotionRecipe[] { resistShock };
+            variantProperties[(int)DFCareer.Elements.DiseaseOrPoison].potionProperties.Recipes = new PotionRecipe[] { resistPoison };
         }
 
         protected override bool IsLikeKind(IncumbentEffect other)
@@ -172,6 +200,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 
             entityBehaviour.Entity.SetResistanceFlag(variantProperties[currentVariant].elementResisted, true);
             entityBehaviour.Entity.SetResistanceChance(variantProperties[currentVariant].elementResisted, ChanceValue());
+            //UnityEngine.Debug.LogFormat("{0} started with chance {1}", Key, ChanceValue());
         }
 
         void StopResisting()

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/ElementalResistance.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/ElementalResistance.cs
@@ -69,7 +69,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             properties.SupportChance = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = EntityEffectBroker.ElementFlags_MagicOnly;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Alteration;
             properties.DurationCosts = MakeEffectCosts(100, 100);
             properties.ChanceCosts = MakeEffectCosts(8, 100);
@@ -81,6 +81,31 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             SetVariantProperties(DFCareer.Elements.DiseaseOrPoison);
             SetVariantProperties(DFCareer.Elements.Shock);
             SetVariantProperties(DFCareer.Elements.Magic);
+        }
+
+        public override void SetPotionProperties()
+        {
+            PotionRecipe resistFire = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "resistFire"),
+                75,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Ichor,
+                (int)Items.Gems.Amber,
+                (int)Items.PlantIngredients1.Red_flowers,
+                (int)Items.CreatureIngredients1.Fairy_dragon_scales,
+                (int)Items.PlantIngredients2.Cactus);
+
+            PotionRecipe resistFrost = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "resistFrost"),
+                75,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Ichor,
+                (int)Items.Gems.Turquoise,
+                (int)Items.PlantIngredients1.Pine_branch,
+                (int)Items.PlantIngredients2.White_rose);
+
+            // Assign recipes
+            AssignPotionRecipes(resistFire, resistFrost);
         }
 
         protected override bool IsLikeKind(IncumbentEffect other)

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/Slowfall.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/Slowfall.cs
@@ -19,23 +19,35 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
     /// </summary>
     public class Slowfall : IncumbentEffect
     {
-        const string textDatabase = "ClassicEffects";
         bool awakeAlert = true;
 
         public override void SetProperties()
         {
             properties.Key = "Slowfall";
             properties.ClassicKey = MakeClassicKey(25, 255);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "slowfall");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "slowfall");
             properties.SubGroupName = string.Empty;
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1575);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1275);
             properties.SupportDuration = true;
             properties.AllowedTargets = TargetTypes.CasterOnly;
             properties.AllowedElements = ElementTypes.Magic;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Alteration;
             properties.DurationCosts = MakeEffectCosts(20, 100);
+        }
+
+        public override void SetPotionProperties()
+        {
+            PotionRecipe slowFalling = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "slowFalling"),
+                100,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Pure_water,
+                (int)Items.PlantIngredients2.White_poppy,
+                (int)Items.PlantIngredients2.Black_poppy);
+
+            AssignPotionRecipes(slowFalling);
         }
 
         public override void ConstantEffect()

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/WaterBreathing.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/WaterBreathing.cs
@@ -23,16 +23,29 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "WaterBreathing";
             properties.ClassicKey = MakeClassicKey(30, 255);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "waterBreathing");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "waterBreathing");
             properties.SubGroupName = string.Empty;
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1582);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1282);
             properties.SupportDuration = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = ElementTypes.Magic;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Alteration;
             properties.DurationCosts = MakeEffectCosts(20, 8);
+        }
+
+        public override void SetPotionProperties()
+        {
+            PotionRecipe waterBreathing = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "waterBreathing"),
+                100,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Rain_water,
+                (int)Items.MiscellaneousIngredients1.Elixir_vitae,
+                (int)Items.MiscellaneousIngredients2.Ivory);
+
+            AssignPotionRecipes(waterBreathing);
         }
 
         public override void ConstantEffect()

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/ChameleonNormal.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/ChameleonNormal.cs
@@ -23,19 +23,34 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "Chameleon-Normal";
             properties.ClassicKey = MakeClassicKey(23, 0);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "chameleon");
-            properties.SubGroupName = TextManager.Instance.GetText("ClassicEffects", "normal");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "chameleon");
+            properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "normal");
             properties.DisplayName = string.Format("{0} ({1})", properties.GroupName, properties.SubGroupName);
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1571);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1271);
             properties.SupportDuration = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = EntityEffectBroker.ElementFlags_MagicOnly;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Illusion;
             properties.DurationCosts = MakeEffectCosts(20, 80);
             concealmentFlag = MagicalConcealmentFlags.BlendingNormal;
             startConcealmentMessageKey = "youAreBlending";
+        }
+
+        public override void SetPotionProperties()
+        {
+            PotionRecipe chameleonForm = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "chameleonForm"),
+                200,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Rain_water,
+                (int)Items.MiscellaneousIngredients1.Nectar,
+                (int)Items.PlantIngredients2.Green_leaves,
+                (int)Items.PlantIngredients2.Yellow_flowers,
+                (int)Items.PlantIngredients2.Red_berries);
+
+            AssignPotionRecipes(chameleonForm);
         }
 
         protected override bool IsLikeKind(IncumbentEffect other)

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/InvisibilityNormal.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/InvisibilityNormal.cs
@@ -19,9 +19,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
     /// </summary>
     public class InvisibilityNormal : ConcealmentEffect
     {
+        public static readonly string PublicKey = "Invisibility-Normal";
+
         public override void SetProperties()
         {
-            properties.Key = "Invisibility-Normal";
+            properties.Key = PublicKey;
             properties.ClassicKey = MakeClassicKey(13, 0);
             properties.GroupName = TextManager.Instance.GetText(textDatabase, "invisibility");
             properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "normal");

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/InvisibilityNormal.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/InvisibilityNormal.cs
@@ -23,19 +23,33 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "Invisibility-Normal";
             properties.ClassicKey = MakeClassicKey(13, 0);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "invisibility");
-            properties.SubGroupName = TextManager.Instance.GetText("ClassicEffects", "normal");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "invisibility");
+            properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "normal");
             properties.DisplayName = string.Format("{0} ({1})", properties.GroupName, properties.SubGroupName);
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1560);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1260);
             properties.SupportDuration = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = EntityEffectBroker.ElementFlags_MagicOnly;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Illusion;
             properties.DurationCosts = MakeEffectCosts(40, 120);
             concealmentFlag = MagicalConcealmentFlags.InvisibleNormal;
             startConcealmentMessageKey = "youAreInvisible";
+        }
+
+        public override void SetPotionProperties()
+        {
+            PotionRecipe invisibility = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "invisibility"),
+                250,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Rain_water,
+                (int)Items.MiscellaneousIngredients1.Nectar,
+                (int)Items.CreatureIngredients1.Ectoplasm,
+                (int)Items.Gems.Diamond);
+
+            AssignPotionRecipes(invisibility);
         }
 
         protected override bool IsLikeKind(IncumbentEffect other)

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/ShadowNormal.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/ShadowNormal.cs
@@ -23,19 +23,33 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "Shadow-Normal";
             properties.ClassicKey = MakeClassicKey(24, 0);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "shadow");
-            properties.SubGroupName = TextManager.Instance.GetText("ClassicEffects", "normal");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "shadow");
+            properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "normal");
             properties.DisplayName = string.Format("{0} ({1})", properties.GroupName, properties.SubGroupName);
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1573);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1273);
             properties.SupportDuration = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = EntityEffectBroker.ElementFlags_MagicOnly;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Illusion;
             properties.DurationCosts = MakeEffectCosts(20, 80);
             concealmentFlag = MagicalConcealmentFlags.ShadeNormal;
             startConcealmentMessageKey = "youAreAShade";
+        }
+
+        public override void SetPotionProperties()
+        {
+            PotionRecipe shadowForm = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "shadowForm"),
+                200,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Rain_water,
+                (int)Items.MiscellaneousIngredients1.Nectar,
+                (int)Items.Gems.Malachite,
+                (int)Items.PlantIngredients2.Black_rose);
+
+            AssignPotionRecipes(shadowForm);
         }
 
         protected override bool IsLikeKind(IncumbentEffect other)

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/CureDisease.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/CureDisease.cs
@@ -37,10 +37,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 
         public override void SetPotionProperties()
         {
+            EffectSettings cureSettings = SetEffectChance(DefaultEffectSettings(), 1, 10, 1);
             PotionRecipe cureDisease = new PotionRecipe(
                 TextManager.Instance.GetText(textDatabase, "cureDisease"),
                 100,
-                DefaultEffectSettings(),
+                cureSettings,
                 (int)Items.MiscellaneousIngredients1.Elixir_vitae,
                 (int)Items.PlantIngredients2.Fig,
                 (int)Items.MiscellaneousIngredients1.Big_tooth);

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/CureDisease.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/CureDisease.cs
@@ -46,7 +46,24 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                 (int)Items.PlantIngredients2.Fig,
                 (int)Items.MiscellaneousIngredients1.Big_tooth);
 
-            AssignPotionRecipes(cureDisease);
+            EffectSettings purificationSettings = SetEffectChance(DefaultEffectSettings(), 1, 10, 1);
+            purificationSettings = SetEffectMagnitude(purificationSettings, 5, 5, 19, 19, 1);
+            PotionRecipe purification = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "purification"),
+                500,
+                purificationSettings,
+                (int)Items.MiscellaneousIngredients1.Elixir_vitae,
+                (int)Items.MiscellaneousIngredients1.Nectar,
+                (int)Items.MiscellaneousIngredients1.Rain_water,
+                (int)Items.PlantIngredients2.Fig,
+                (int)Items.MiscellaneousIngredients1.Big_tooth,
+                (int)Items.CreatureIngredients1.Ectoplasm,
+                (int)Items.Gems.Diamond,
+                (int)Items.CreatureIngredients2.Mummy_wrappings);
+            purification.AddSecondaryEffect(HealHealth.PublicKey);
+            purification.AddSecondaryEffect(InvisibilityNormal.PublicKey);
+
+            AssignPotionRecipes(cureDisease, purification);
         }
 
         public override void MagicRound()
@@ -61,7 +78,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             // Implement effect
             manager.CureAllDiseases();
 
-            //Debug.LogFormat("Cured entity of all diseases");
+            UnityEngine.Debug.LogFormat("Cured entity of all diseases");
         }
     }
 }

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/CureDisease.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/CureDisease.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -23,16 +23,29 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "Cure-Disease";
             properties.ClassicKey = MakeClassicKey(3, 0);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "cure");
-            properties.SubGroupName = TextManager.Instance.GetText("ClassicEffects", "disease");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "cure");
+            properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "disease");
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1509);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1209);
             properties.SupportChance = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = EntityEffectBroker.ElementFlags_MagicOnly;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Restoration;
             properties.ChanceCosts = MakeEffectCosts(8, 100);
+        }
+
+        public override void SetPotionProperties()
+        {
+            PotionRecipe cureDisease = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "cureDisease"),
+                100,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Elixir_vitae,
+                (int)Items.PlantIngredients2.Fig,
+                (int)Items.MiscellaneousIngredients1.Big_tooth);
+
+            AssignPotionRecipes(cureDisease);
         }
 
         public override void MagicRound()

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/CurePoison.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/CurePoison.cs
@@ -23,16 +23,31 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "Cure-Poison";
             properties.ClassicKey = MakeClassicKey(3, 1);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "cure");
-            properties.SubGroupName = TextManager.Instance.GetText("ClassicEffects", "poison");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "cure");
+            properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "poison");
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1510);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1210);
             properties.SupportChance = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = EntityEffectBroker.ElementFlags_MagicOnly;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Restoration;
             properties.ChanceCosts = MakeEffectCosts(8, 100);
+        }
+
+        public override void SetPotionProperties()
+        {
+            EffectSettings cureSettings = SetEffectChance(DefaultEffectSettings(), 5, 19, 1);
+            PotionRecipe curePoison = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "curePoison"),
+                200,
+                cureSettings,
+                (int)Items.MiscellaneousIngredients1.Ichor,
+                (int)Items.CreatureIngredients2.Giant_scorpion_stinger,
+                (int)Items.MiscellaneousIngredients1.Small_tooth,
+                (int)Items.MiscellaneousIngredients2.Pearl);
+
+            AssignPotionRecipes(curePoison);
         }
 
         public override void MagicRound()

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/FortifyStrength.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/FortifyStrength.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -22,19 +22,35 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "Fortify-Strength";
             properties.ClassicKey = MakeClassicKey(9, 0);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "fortifyAttribute");
-            properties.SubGroupName = TextManager.Instance.GetText("ClassicEffects", "strength");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "fortifyAttribute");
+            properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "strength");
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1532);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1232);
             properties.SupportDuration = true;
             properties.SupportMagnitude = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = EntityEffectBroker.ElementFlags_MagicOnly;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Restoration;
             properties.DurationCosts = MakeEffectCosts(28, 100);
             properties.MagnitudeCosts = MakeEffectCosts(40, 120);
             fortifyStat = DFCareer.Stats.Strength;
+        }
+
+        public override void SetPotionProperties()
+        {
+            // Magnitude 1-1 + 14-14 per 1 levels
+            EffectSettings orcStrengthSettings = SetEffectMagnitude(DefaultEffectSettings(), 1, 1, 14, 14, 1);
+            PotionRecipe orcStrength = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "orcStrength"),
+                50,
+                orcStrengthSettings,
+                (int)Items.CreatureIngredients1.Orcs_blood,
+                (int)Items.MetalIngredients.Iron,
+                (int)Items.MiscellaneousIngredients1.Pure_water);
+
+            // Assign recipe
+            AssignPotionRecipes(orcStrength);
         }
     }
 }

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/FreeAction.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/FreeAction.cs
@@ -23,16 +23,31 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "FreeAction";
             properties.ClassicKey = MakeClassicKey(28, 255);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "freeAction");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "freeAction");
             properties.SubGroupName = string.Empty;
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1576);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1276);
             properties.SupportDuration = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = ElementTypes.Magic;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Restoration;
             properties.DurationCosts = MakeEffectCosts(20, 8);
+        }
+
+        public override void SetPotionProperties()
+        {
+            EffectSettings cureSettings = SetEffectChance(DefaultEffectSettings(), 5, 19, 1);
+            PotionRecipe freeAction = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "freeAction"),
+                125,
+                cureSettings,
+                (int)Items.MiscellaneousIngredients1.Ichor,
+                (int)Items.CreatureIngredients1.Spider_venom,
+                (int)Items.PlantIngredients1.Twigs,
+                (int)Items.PlantIngredients2.Bamboo);
+
+            AssignPotionRecipes(freeAction);
         }
 
         public override void ConstantEffect()

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealFatigue.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealFatigue.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -23,16 +23,32 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "Heal-Fatigue";
             properties.ClassicKey = MakeClassicKey(10, 9);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "heal");
-            properties.SubGroupName = TextManager.Instance.GetText("ClassicEffects", "fatigue");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "heal");
+            properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "fatigue");
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1549);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1249);
             properties.SupportMagnitude = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = EntityEffectBroker.ElementFlags_MagicOnly;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Restoration;
             properties.MagnitudeCosts = MakeEffectCosts(8, 28);
+        }
+
+        public override void SetPotionProperties()
+        {
+            // Magnitude 5-5 + 4-4 per 1 levels
+            EffectSettings staminaSettings = SetEffectMagnitude(DefaultEffectSettings(), 5, 5, 4, 4, 1);
+            PotionRecipe stamina = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "stamina"),
+                25,
+                staminaSettings,
+                (int)Items.MiscellaneousIngredients1.Pure_water,
+                (int)Items.PlantIngredients2.Aloe,
+                (int)Items.PlantIngredients2.Ginkgo_leaves);
+
+            // Assign recipe
+            AssignPotionRecipes(stamina);
         }
 
         public override void MagicRound()

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealHealth.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealHealth.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -40,6 +40,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             // First recipe variant: Magnitude 5-5 + 9-9 per 1 levels
             EffectSettings recipe1Settings = SetEffectMagnitude(DefaultEffectSettings(), 5, 5, 9, 9, 1);
             PotionRecipe recipe1 = new PotionRecipe(
+                "Healing",
                 recipe1Settings,
                 (int)Items.MiscellaneousIngredients1.Elixir_vitae,
                 (int)Items.PlantIngredients1.Yellow_berries,
@@ -49,6 +50,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             // Second recipe variant: Magnitude 5-5 + 19-19 per 1 levels
             EffectSettings recipe2Settings = SetEffectMagnitude(DefaultEffectSettings(), 5, 5, 19, 19, 1);
             PotionRecipe recipe2 = new PotionRecipe(
+                "Heal True",
                 recipe2Settings,
                 (int)Items.PlantIngredients1.Pine_branch,
                 (int)Items.PlantIngredients1.Red_berries,

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealHealth.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealHealth.cs
@@ -23,8 +23,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "Heal-Health";
             properties.ClassicKey = MakeClassicKey(10, 8);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "heal");
-            properties.SubGroupName = TextManager.Instance.GetText("ClassicEffects", "health");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "heal");
+            properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "health");
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1548);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1248);
             properties.SupportMagnitude = true;
@@ -38,27 +38,29 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         public override void SetPotionProperties()
         {
             // First recipe variant: Magnitude 5-5 + 9-9 per 1 levels
-            EffectSettings recipe1Settings = SetEffectMagnitude(DefaultEffectSettings(), 5, 5, 9, 9, 1);
-            PotionRecipe recipe1 = new PotionRecipe(
-                "Healing",
-                recipe1Settings,
+            EffectSettings healingSettings = SetEffectMagnitude(DefaultEffectSettings(), 5, 5, 9, 9, 1);
+            PotionRecipe healing = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "healing"),
+                50,
+                healingSettings,
                 (int)Items.MiscellaneousIngredients1.Elixir_vitae,
-                (int)Items.PlantIngredients1.Yellow_berries,
+                (int)Items.PlantIngredients1.Red_berries,
                 (int)Items.MetalIngredients.Mercury,
                 (int)Items.CreatureIngredients1.Troll_blood);
 
             // Second recipe variant: Magnitude 5-5 + 19-19 per 1 levels
-            EffectSettings recipe2Settings = SetEffectMagnitude(DefaultEffectSettings(), 5, 5, 19, 19, 1);
-            PotionRecipe recipe2 = new PotionRecipe(
-                "Heal True",
-                recipe2Settings,
-                (int)Items.PlantIngredients1.Pine_branch,
+            EffectSettings healTrueSettings = SetEffectMagnitude(DefaultEffectSettings(), 5, 5, 19, 19, 1);
+            PotionRecipe healTrue = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "healTrue"),
+                100,
+                healTrueSettings,
+                (int)Items.MiscellaneousIngredients1.Elixir_vitae,
                 (int)Items.PlantIngredients1.Red_berries,
-                (int)Items.CreatureIngredients3.Unicorn_horn,
-                (int)Items.MiscellaneousIngredients1.Pure_water);
+                (int)Items.PlantIngredients1.Pine_branch,
+                (int)Items.CreatureIngredients3.Unicorn_horn);
 
             // Assign recipes
-            AssignPotionRecipes(recipe1, recipe2);
+            AssignPotionRecipes(healing, healTrue);
         }
 
         public override void MagicRound()
@@ -74,7 +76,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             int magnitude = GetMagnitude(caster);
             entityBehaviour.Entity.IncreaseHealth(magnitude);
 
-            //Debug.LogFormat("{0} incremented {1}'s health by {2} points", Key, entityBehaviour.EntityType.ToString(), magnitude);
+            UnityEngine.Debug.LogFormat("{0} incremented {1}'s health by {2} points", Key, entityBehaviour.EntityType.ToString(), magnitude);
         }
     }
 }

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealHealth.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealHealth.cs
@@ -19,9 +19,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
     /// </summary>
     public class HealHealth : BaseEntityEffect
     {
+        public static readonly string PublicKey = "Heal-Health";
+
         public override void SetProperties()
         {
-            properties.Key = "Heal-Health";
+            properties.Key = PublicKey;
             properties.ClassicKey = MakeClassicKey(10, 8);
             properties.GroupName = TextManager.Instance.GetText(textDatabase, "heal");
             properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "health");

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealSpellPoints.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealSpellPoints.cs
@@ -1,0 +1,70 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Hazelnut
+// Contributors:    
+// 
+// Notes:
+//
+
+using DaggerfallWorkshop.Game.Entity;
+
+namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
+{
+    /// <summary>
+    /// Heal - Magicka
+    /// </summary>
+    public class HealSpellPoints : BaseEntityEffect
+    {
+        public override void SetProperties()
+        {
+            properties.Key = "Heal-SpellPoints";
+            //properties.ClassicKey = MakeClassicKey(10, 9);
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "heal");
+            properties.SubGroupName = TextManager.Instance.GetText(textDatabase, "spellPoints");
+            //properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1549);
+            //properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1249);
+            properties.SupportMagnitude = true;
+            properties.AllowedTargets = EntityEffectBroker.TargetFlags_Self;
+            properties.AllowedElements = EntityEffectBroker.ElementFlags_MagicOnly;
+            properties.AllowedCraftingStations = MagicCraftingStations.PotionMaker;
+            //properties.MagicSkill = DFCareer.MagicSkills.Restoration;
+            //properties.MagnitudeCosts = MakeEffectCosts(8, 28);
+        }
+
+        public override void SetPotionProperties()
+        {
+            // Magnitude 5-5 + 4-4 per 1 levels
+            EffectSettings restorePowerSettings = SetEffectMagnitude(DefaultEffectSettings(), 5, 5, 4, 4, 1);
+            PotionRecipe restorePower = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "restorePower"),
+                75,
+                restorePowerSettings,
+                (int)Items.MiscellaneousIngredients1.Nectar,
+                (int)Items.MetalIngredients.Silver,
+                (int)Items.CreatureIngredients1.Werewolfs_blood,
+                (int)Items.CreatureIngredients1.Saints_hair);
+
+            // Assign recipe
+            AssignPotionRecipes(restorePower);
+        }
+
+        public override void MagicRound()
+        {
+            base.MagicRound();
+
+            // Get peered entity gameobject
+            DaggerfallEntityBehaviour entityBehaviour = GetPeeredEntityBehaviour(manager);
+            if (!entityBehaviour)
+                return;
+
+            // Implement effect
+            int magnitude = GetMagnitude(caster);
+            entityBehaviour.Entity.IncreaseMagicka(magnitude);
+
+            UnityEngine.Debug.LogFormat("{0} incremented {1}'s magicka by {2} points", Key, entityBehaviour.EntityType.ToString(), magnitude);
+        }
+    }
+}

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealSpellPoints.cs.meta
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/HealSpellPoints.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10d4cfd81f280174ba8339996615ae88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/SpellAbsorption.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/SpellAbsorption.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -22,7 +22,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "SpellAbsorption";
             properties.ClassicKey = MakeClassicKey(20, 255);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "spellAbsorption");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "spellAbsorption");
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1568);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1268);
             properties.SupportDuration = true;

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Thaumaturgy/Levitate.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Thaumaturgy/Levitate.cs
@@ -23,16 +23,29 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "Levitate";
             properties.ClassicKey = MakeClassicKey(14, 255);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "levitate");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "levitate");
             properties.SubGroupName = string.Empty;
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1562);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1262);
             properties.SupportDuration = true;
             properties.AllowedTargets = TargetTypes.CasterOnly;
             properties.AllowedElements = ElementTypes.Magic;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Thaumaturgy;
             properties.DurationCosts = MakeEffectCosts(60, 100);
+        }
+
+        public override void SetPotionProperties()
+        {
+            PotionRecipe levitation = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "levitation"),
+                125,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Pure_water,
+                (int)Items.MiscellaneousIngredients1.Nectar,
+                (int)Items.CreatureIngredients1.Ectoplasm);
+
+            AssignPotionRecipes(levitation);
         }
 
         public override void ConstantEffect()

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Thaumaturgy/WaterWalking.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Thaumaturgy/WaterWalking.cs
@@ -23,16 +23,30 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
             properties.Key = "WaterWalking";
             properties.ClassicKey = MakeClassicKey(31, 255);
-            properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "waterWalking");
+            properties.GroupName = TextManager.Instance.GetText(textDatabase, "waterWalking");
             properties.SubGroupName = string.Empty;
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1583);
             properties.SpellBookDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1283);
             properties.SupportDuration = true;
             properties.AllowedTargets = EntityEffectBroker.TargetFlags_All;
             properties.AllowedElements = ElementTypes.Magic;
-            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker;
+            properties.AllowedCraftingStations = MagicCraftingStations.SpellMaker | MagicCraftingStations.PotionMaker;
             properties.MagicSkill = DFCareer.MagicSkills.Thaumaturgy;
             properties.DurationCosts = MakeEffectCosts(20, 8);
+        }
+
+        public override void SetPotionProperties()
+        {
+            PotionRecipe waterWalking = new PotionRecipe(
+                TextManager.Instance.GetText(textDatabase, "waterWalking"),
+                50,
+                DefaultEffectSettings(),
+                (int)Items.MiscellaneousIngredients1.Pure_water,
+                (int)Items.PlantIngredients2.Palm,
+                (int)Items.PlantIngredients1.Yellow_rose,
+                (int)Items.MetalIngredients.Sulphur);
+
+            AssignPotionRecipes(waterWalking);
         }
 
         public override void ConstantEffect()

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
@@ -164,6 +164,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
     {
         #region Fields
 
+        protected const string textDatabase = "ClassicEffects";
+
         protected EffectProperties properties = new EffectProperties();
         protected EffectSettings settings = new EffectSettings();
         protected PotionProperties potionProperties = new PotionProperties();

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
@@ -236,7 +236,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             set { settings = value; }
         }
 
-        public PotionProperties PotionProperties
+        public virtual PotionProperties PotionProperties
         {
             get { return potionProperties; }
         }
@@ -599,6 +599,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         protected int ChanceValue()
         {
             int casterLevel = (caster) ? caster.Entity.Level : 1;
+            //Debug.LogFormat("{5} ChanceValue {0} = base + plus * (level/chancePerLevel) = {1} + {2} * ({3}/{4})", settings.ChanceBase + settings.ChancePlus * (int)Mathf.Floor(casterLevel / settings.ChancePerLevel), settings.ChanceBase, settings.ChancePlus, casterLevel, settings.ChancePerLevel, Key);
             return settings.ChanceBase + settings.ChancePlus * (int)Mathf.Floor(casterLevel / settings.ChancePerLevel);
         }
 

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -246,6 +246,17 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             return null;
         }
 
+        public PotionRecipe GetPotionRecipe(int recipeKey)
+        {
+            if (potionEffectTemplates.ContainsKey(recipeKey))
+            {
+                foreach (PotionRecipe recipe in potionEffectTemplates[recipeKey].PotionProperties.Recipes)
+                    if (recipe.GetHashCode() == recipeKey)
+                        return recipe;
+            }
+            return null;
+        }
+
         /// <summary>
         /// Gets group names of registered effects.
         /// </summary>

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -262,6 +262,10 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             return null;
         }
 
+        /// <summary>
+        /// Get recipeKeys for all registered potion recipes.
+        /// </summary>
+        /// <returns>List of int recipeKeys</returns>
         public List<int> GetPotionRecipeKeys()
         {
             return new List<int>(potionEffectTemplates.Keys);

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -246,11 +246,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             return null;
         }
 
-        public PotionRecipe GetPotionRecipe(PotionRecipe recipe)
-        {
-            return GetPotionRecipe(recipe.GetHashCode());
-        }
-
+        /// <summary>
+        /// Gets PotionRecipe from effect that matches the recipeKey provided.
+        /// </summary>
+        /// <param name="recipeKey">Hashcode of a set of ingredients.</param>
+        /// <returns>PotionRecipe if the key matches one from an effect, otherwise null.</returns>
         public PotionRecipe GetPotionRecipe(int recipeKey)
         {
             if (potionEffectTemplates.ContainsKey(recipeKey))
@@ -262,6 +262,15 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             return null;
         }
 
+        public List<int> GetPotionRecipeKeys()
+        {
+            return new List<int>(potionEffectTemplates.Keys);
+        }
+
+        /// <summary>
+        /// Logs a summary of how many recipes ingredients are used in so new recipes can choose to use little used ingredients.
+        /// Intended for mod devs, used by invoking 'ingredUsage' console command.
+        /// </summary>
         public void LogRecipeIngredientUsage()
         {
             Dictionary<int, int> ingredCounts = new Dictionary<int, int>();

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -239,11 +239,16 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             if (recipe != null)
             {
                 int recipeKey = recipe.GetHashCode();
-                if (!potionEffectTemplates.ContainsKey(recipeKey))
+                if (potionEffectTemplates.ContainsKey(recipeKey))
                     return potionEffectTemplates[recipeKey];
             }
 
             return null;
+        }
+
+        public PotionRecipe GetPotionRecipe(PotionRecipe recipe)
+        {
+            return GetPotionRecipe(recipe.GetHashCode());
         }
 
         public PotionRecipe GetPotionRecipe(int recipeKey)

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -262,6 +262,27 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             return null;
         }
 
+        public void LogRecipeIngredientUsage()
+        {
+            Dictionary<int, int> ingredCounts = new Dictionary<int, int>();
+            foreach (int key in potionEffectTemplates.Keys)
+            {
+                PotionRecipe potionRecipe = GetPotionRecipe(key);
+                foreach (PotionRecipe.Ingredient ingred in potionRecipe.Ingredients)
+                {
+                    if (ingredCounts.ContainsKey(ingred.id))
+                        ingredCounts[ingred.id]++;
+                    else
+                        ingredCounts.Add(ingred.id, 1);
+                }
+            }
+            foreach (int key in ingredCounts.Keys)
+            {
+                DaggerfallConnect.FallExe.ItemTemplate ingredientTemplate = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(key);
+                Debug.LogFormat("{0} recipes use: {1}", ingredCounts[key], ingredientTemplate.name);
+            }
+        }
+
         /// <summary>
         /// Gets group names of registered effects.
         /// </summary>

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -635,6 +635,30 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
         #endregion
 
+        #region Potions
+
+        public void DrinkPotion(DaggerfallUnityItem item)
+        {
+            // Item must be a valid potion
+            if (item == null || item.potionRecipe == 0)
+                return;
+
+            PotionRecipe potionRecipe = GameManager.Instance.EntityEffectBroker.GetPotionRecipe(item.potionRecipe);
+
+            EffectBundleSettings bundleSettings = new EffectBundleSettings()
+            {
+                Version = EntityEffectBroker.CurrentSpellVersion,
+                BundleType = BundleTypes.Potion,
+                Effects = new EffectEntry[] { new EffectEntry(potionRecipe.DisplayName, potionRecipe.Settings) },
+            };
+
+            // Assign bundle
+            EntityEffectBundle bundle = new EntityEffectBundle(bundleSettings, entityBehaviour);
+            AssignBundle(bundle);
+        }
+
+        #endregion
+
         #region Magic Items
 
         /// <summary>

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -640,21 +640,27 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public void DrinkPotion(DaggerfallUnityItem item)
         {
             // Item must be a valid potion
-            if (item == null || item.potionRecipe == 0)
+            if (item == null || item.PotionRecipeKey == 0)
                 return;
 
-            PotionRecipe potionRecipe = GameManager.Instance.EntityEffectBroker.GetPotionRecipe(item.potionRecipe);
+            PotionRecipe potionRecipe = GameManager.Instance.EntityEffectBroker.GetPotionRecipe(item.PotionRecipeKey);
+            IEntityEffect potionEffect = GameManager.Instance.EntityEffectBroker.GetPotionRecipeEffect(potionRecipe);
 
             EffectBundleSettings bundleSettings = new EffectBundleSettings()
             {
                 Version = EntityEffectBroker.CurrentSpellVersion,
                 BundleType = BundleTypes.Potion,
-                Effects = new EffectEntry[] { new EffectEntry(potionRecipe.DisplayName, potionRecipe.Settings) },
+                TargetType = TargetTypes.CasterOnly,
+                Effects = new EffectEntry[] { new EffectEntry(potionEffect.Key, potionRecipe.Settings) },
             };
 
             // Assign bundle
             EntityEffectBundle bundle = new EntityEffectBundle(bundleSettings, entityBehaviour);
             AssignBundle(bundle);
+
+            // Play cast sound on drink for player only
+            if (IsPlayerEntity)
+                PlayCastSound(entityBehaviour, GetCastSoundID(ElementTypes.Magic));
         }
 
         #endregion

--- a/Assets/Scripts/Game/MagicAndEffects/MagicAndEffectsEnums.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/MagicAndEffectsEnums.cs
@@ -69,6 +69,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         Disease,
         Poison,
         HeldMagicItem,
+        Potion,
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
@@ -37,7 +37,14 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
         #region Properties
 
+        /// <summary>
+        /// The display name of this potion recipe.
+        /// </summary>
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The price of this potion recipe.
+        /// </summary>
         public int Price { get; set; }
 
         /// <summary>
@@ -50,7 +57,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         }
 
         /// <summary>
-        /// Gets or sets potion recipe ingredients.
+        /// Gets or sets potion recipe ingredients. Ingredients must be sorted by id.
         /// </summary>
         public Ingredient[] Ingredients
         {
@@ -87,7 +94,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         }
 
         /// <summary>
-        /// Ingredient[] array constructor - for finding and comparisons only.
+        /// Ingredient[] array constructor - for finding and comparisons.
         /// </summary>
         /// <param name="ids">Ingredient ids list.</param>
         public PotionRecipe(List<int> ids)

--- a/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
@@ -26,12 +26,13 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         //  Stamina, Orc Strength, Healing, Waterwalking, Restore Power, Resist Fire, Resist Frost, Resist Shock, Cure Disease, Slow Falling,
         //  Water Breathing, Heal True, Levitation, Resist Poison, Free Action, Cure Poison, Chaemelon Form, Shadow Form, Invisibility, Purification
         public static readonly int[] classicRecipeKeys = { 221871, 239524, 4975678, 5017404, 5188896, 111516185, 4826108, 216843, 224588, 220192,
-                                                           240081, 4937012, 228890, 221117, 4870452, 5361377, 112080144, 4842851, 4815872, 0 };
+                                                           240081, 4937012, 228890, 221117, 4870452, 5361377, 112080144, 4842851, 4815872, 2031019196 };
 
         #region Fields
 
         EffectSettings settings;
         Ingredient[] ingredients = null;
+        List<string> secondaryEffects;
 
         #endregion
 
@@ -63,6 +64,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         {
             get { return ingredients; }
             set { ingredients = value; }
+        }
+
+        public List<string> SecondaryEffects
+        {
+            get { return secondaryEffects; }
         }
 
         #endregion
@@ -208,6 +214,13 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public bool HasRecipe()
         {
             return (ingredients != null && ingredients.Length > 0);
+        }
+
+        public void AddSecondaryEffect(string effectKey)
+        {
+            if (secondaryEffects == null)
+                secondaryEffects = new List<string>();
+            secondaryEffects.Add(effectKey);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -29,6 +29,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         #endregion
 
         #region Properties
+
+        public string DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets effect settings for this recipe.
@@ -74,10 +76,12 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// <summary>
         /// int[] array of item template IDs constructor.
         /// </summary>
+        /// <param name="displayName">Potion name to use for this recipe.</param>
         /// <param name="settings">Settings for this potion recipe.</param>
         /// <param name="ids">Array of item template IDs.</param>
-        public PotionRecipe(EffectSettings settings, params int[] ids)
+        public PotionRecipe(string displayName, EffectSettings settings, params int[] ids)
         {
+            DisplayName = displayName;
             this.settings = settings;
             if (ids != null && ids.Length > 0)
             {

--- a/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
@@ -25,7 +25,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         // Classic potion recipe mapping to DFU recipe keys:
         //  Stamina, Orc Strength, Healing, Waterwalking, Restore Power, Resist Fire, Resist Frost, Resist Shock, Cure Disease, Slow Falling,
         //  Water Breathing, Heal True, Levitation, Resist Poison, Free Action, Cure Poison, Chaemelon Form, Shadow Form, Invisibility, Purification
-        public static readonly int[] classicRecipeKeys = { 0, 0, 4975678, 0, 0, 111516185, 4826108, 0, 224588, 220192, 0, 4937012, 0, 0, 0, 0, 0, 0, 0, 0 };
+        public static readonly int[] classicRecipeKeys = { 221871, 239524, 4975678, 5017404, 5188896, 111516185, 4826108, 216843, 224588, 220192,
+                                                           240081, 4937012, 228890, 221117, 4870452, 5361377, 112080144, 4842851, 4815872, 0 };
 
         #region Fields
 

--- a/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
@@ -28,6 +28,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public static readonly int[] classicRecipeKeys = { 221871, 239524, 4975678, 5017404, 5188896, 111516185, 4826108, 216843, 224588, 220192,
                                                            240081, 4937012, 228890, 221117, 4870452, 5361377, 112080144, 4842851, 4815872, 2031019196 };
 
+        public static readonly string UnknownPowers = "Unknown Powers";
+
         #region Fields
 
         EffectSettings settings;

--- a/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
@@ -9,6 +9,7 @@
 // Notes:
 //
 
+using System;
 using System.Collections.Generic;
 using DaggerfallConnect.FallExe;
 
@@ -21,6 +22,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
     /// </summary>
     public class PotionRecipe : IEqualityComparer<PotionRecipe.Ingredient[]>
     {
+        // Classic potion recipe mapping to DFU recipe keys:
+        //  Stamina, Orc Strength, Healing, Waterwalking, Restore Power, Resist Fire, Resist Frost, Resist Shock, Cure Disease, Slow Falling,
+        //  Water Breathing, Heal True, Levitation, Resist Poison, Free Action, Cure Poison, Chaemelon Form, Shadow Form, Invisibility, Purification
+        public static readonly int[] classicRecipeKeys = { 0, 0, 4975678, 0, 0, 0, 0, 0, 0, 0, 0, 4937012, 0, 0, 0, 0, 0, 0, 0, 0 };
+
         #region Fields
 
         EffectSettings settings;
@@ -31,6 +37,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         #region Properties
 
         public string DisplayName { get; set; }
+        public int Price { get; set; }
 
         /// <summary>
         /// Gets or sets effect settings for this recipe.
@@ -65,24 +72,47 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// <summary>
         /// Ingredient[] array constructor.
         /// </summary>
+        /// <param name="displayName">Potion name to use for this recipe.</param>
+        /// <param name="price">Value of potion in gp.</param>
         /// <param name="settings">Settings for this potion recipe.</param>
         /// <param name="ingredients">Ingredient array.</param>
-        public PotionRecipe(EffectSettings settings, params Ingredient[] ingredients)
+        public PotionRecipe(string displayName, int price, EffectSettings settings, params Ingredient[] ingredients)
         {
+            DisplayName = displayName;
+            Price = price;
             this.settings = settings;
+            Array.Sort(ingredients);
             this.ingredients = ingredients;
+        }
+
+        /// <summary>
+        /// Ingredient[] array constructor - for finding and comparisons only.
+        /// </summary>
+        /// <param name="ids">Ingredient ids list.</param>
+        public PotionRecipe(List<int> ids)
+        {
+            ids.Sort();
+            if (ids != null && ids.Count > 0)
+            {
+                ingredients = new Ingredient[ids.Count];
+                for (int i = 0; i < ids.Count; i++)
+                    ingredients[i].id = ids[i];
+            }
         }
 
         /// <summary>
         /// int[] array of item template IDs constructor.
         /// </summary>
         /// <param name="displayName">Potion name to use for this recipe.</param>
+        /// <param name="price">Value of potion in gp.</param>
         /// <param name="settings">Settings for this potion recipe.</param>
         /// <param name="ids">Array of item template IDs.</param>
-        public PotionRecipe(string displayName, EffectSettings settings, params int[] ids)
+        public PotionRecipe(string displayName, int price, EffectSettings settings, params int[] ids)
         {
             DisplayName = displayName;
+            Price = price;
             this.settings = settings;
+            Array.Sort(ids);
             if (ids != null && ids.Length > 0)
             {
                 ingredients = new Ingredient[ids.Length];

--- a/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/PotionRecipe.cs
@@ -25,7 +25,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         // Classic potion recipe mapping to DFU recipe keys:
         //  Stamina, Orc Strength, Healing, Waterwalking, Restore Power, Resist Fire, Resist Frost, Resist Shock, Cure Disease, Slow Falling,
         //  Water Breathing, Heal True, Levitation, Resist Poison, Free Action, Cure Poison, Chaemelon Form, Shadow Form, Invisibility, Purification
-        public static readonly int[] classicRecipeKeys = { 0, 0, 4975678, 0, 0, 0, 0, 0, 0, 0, 0, 4937012, 0, 0, 0, 0, 0, 0, 0, 0 };
+        public static readonly int[] classicRecipeKeys = { 0, 0, 4975678, 0, 0, 111516185, 4826108, 0, 224588, 220192, 0, 4937012, 0, 0, 0, 0, 0, 0, 0, 0 };
 
         #region Fields
 

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -274,6 +274,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public MobileTypes trappedSoulType;
         public string className;
         public Poisons poisonType = Poisons.None;
+        public int potionRecipe;
         public ItemRepairData_v1 repairData;
     }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -305,8 +305,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
 
                 case GuildServices.MakePotions:
-                    CloseWindow();
-                    uiManager.PushWindow(DaggerfallUI.Instance.DfPotionMakerWindow);
+                    MakePotionService();
                     break;
 
                 case GuildServices.BuySpells:
@@ -690,6 +689,25 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 else
                     DaggerfallUI.MessageBox(NotEnoughGoldId);
             }
+        }
+
+        #endregion
+
+        #region Service Handling: Make Potions
+
+        private void MakePotionService()
+        {
+            // Open potion mixer window if player has some ingredients
+            CloseWindow();
+            for (int i = 0; i < playerEntity.Items.Count; i++)
+            {
+                if (playerEntity.Items.GetItem(i).IsIngredient)
+                {
+                    uiManager.PushWindow(DaggerfallUI.Instance.DfPotionMakerWindow);
+                    return;
+                }
+            }
+            DaggerfallUI.MessageBox(34);
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1526,6 +1526,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 DaggerfallUI.Instance.BookReaderWindow.BookTarget = item;
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenBookReaderWindow);
             }
+            else if (item.ItemGroup == ItemGroups.UselessItems1 && item.TemplateIndex == (int)UselessItems1.Glass_Bottle)
+            {   // Handle drinking magic potions
+                GameManager.Instance.PlayerEffectManager.DrinkPotion(item);
+                DaggerfallUI.MessageBox("potion: " + item.typeDependentData); /*
+                MagicAndEffects.MagicEffects.HealHealth heal = new MagicAndEffects.MagicEffects.HealHealth();
+                Debug.Log(heal.PotionProperties.Recipes[0].GetHashCode());
+                Debug.Log(heal.PotionProperties.Recipes[1].GetHashCode());*/
+            }
             else if (item.ItemGroup == ItemGroups.MiscItems && item.TemplateIndex == (int)MiscItems.Potion_recipe)
             {
                 // TODO: There may be other objects that result in this dialog box, but for now I'm sure this one says it.

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1430,7 +1430,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
                 messageBox.SetTextTokens(tokens, item);
 
-                if (item.TemplateIndex == (int)MiscItems.Potion_recipe)
+                if (item.IsPotionRecipe)
                 {   // Setup the next message box with the potion recipe ingredients list.
                     DaggerfallMessageBox messageBoxRecipe = new DaggerfallMessageBox(uiManager, messageBox);
                     messageBoxRecipe.SetTextTokens(item.GetMacroDataSource().PotionRecipeIngredients(TextFile.Formatting.JustifyCenter));
@@ -1526,15 +1526,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 DaggerfallUI.Instance.BookReaderWindow.BookTarget = item;
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenBookReaderWindow);
             }
-            else if (item.ItemGroup == ItemGroups.UselessItems1 && item.TemplateIndex == (int)UselessItems1.Glass_Bottle)
+            else if (item.IsPotion)
             {   // Handle drinking magic potions
                 GameManager.Instance.PlayerEffectManager.DrinkPotion(item);
-                DaggerfallUI.MessageBox("potion: " + item.typeDependentData); /*
-                MagicAndEffects.MagicEffects.HealHealth heal = new MagicAndEffects.MagicEffects.HealHealth();
-                Debug.Log(heal.PotionProperties.Recipes[0].GetHashCode());
-                Debug.Log(heal.PotionProperties.Recipes[1].GetHashCode());*/
+                collection.RemoveOne(item);
             }
-            else if (item.ItemGroup == ItemGroups.MiscItems && item.TemplateIndex == (int)MiscItems.Potion_recipe)
+            else if (item.IsPotionRecipe)
             {
                 // TODO: There may be other objects that result in this dialog box, but for now I'm sure this one says it.
                 // -IC122016

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -254,7 +254,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 GameManager.Instance.PlayerEntity.Items.AddItem(ItemBuilder.CreatePotion(recipeKey));
             }
             else
-                GameManager.Instance.PlayerEntity.Items.AddItem(ItemBuilder.CreatePotion(0));
+            {
+                // Changed from classic, don't create useless 'Unknown Powers' potions.
+                //GameManager.Instance.PlayerEntity.Items.AddItem(ItemBuilder.CreatePotion(0));
+                DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "ingredientsWasted"));
+                return;
+            }
 
             // Remove item from player inventory unless a stack remains.
             foreach (DaggerfallUnityItem item in cauldron)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -253,6 +253,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 Debug.LogFormat("Potion matched: {0}", potionRecipe.DisplayName);
                 GameManager.Instance.PlayerEntity.Items.AddItem(ItemBuilder.CreatePotion(recipeKey));
             }
+            else
+                GameManager.Instance.PlayerEntity.Items.AddItem(ItemBuilder.CreatePotion(0));
 
             // Remove item from player inventory unless a stack remains.
             foreach (DaggerfallUnityItem item in cauldron)

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -327,12 +327,7 @@ namespace DaggerfallWorkshop.Game
                 // Remove arrow
                 ItemCollection playerItems = playerEntity.Items;
                 DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow);
-                if (arrow != null)
-                {
-                    arrow.stackCount--;
-                    if (arrow.stackCount <= 0)
-                        playerItems.RemoveItem(arrow);
-                }
+                playerItems.RemoveOne(arrow);
             }
             else if (!isDamageFinished && ScreenWeapon.GetCurrentFrame() == ScreenWeapon.GetHitFrame())
             {

--- a/Assets/StreamingAssets/Text/ClassicEffects.txt
+++ b/Assets/StreamingAssets/Text/ClassicEffects.txt
@@ -104,22 +104,18 @@ openFailed,                 Lock is too powerful.
 stamina,                    Stamina
 orcStrength,                Orc Strength
 healing,                    Healing
-waterwalking,               Waterwalking
 restorePower,               Restore Power
 resistFire,                 Resist Fire
 resistFrost,                Resist Frost
 resistShock,                Resist Shock
 cureDisease,                Cure Disease
 slowFalling,                Slow Falling
--waterBreathing,             Water Breathing
 healTrue,                   Heal True
 levitation,                 Levitation
 resistPoison,               Resist Poison
--freeAction,                 Free Action
 curePoison,                 Cure Poison
 chameleonForm,              Chameleon Form
 shadowForm,                 Shadow Form
--invisibility,              Invisibility
 purification,               Purification
 
 potionMixed,                Your potion has been mixed.

--- a/Assets/StreamingAssets/Text/ClassicEffects.txt
+++ b/Assets/StreamingAssets/Text/ClassicEffects.txt
@@ -99,7 +99,7 @@ doorLocked,                 Door is now locked.
 doorAlreadyLocked,          Door already locked.
 openFailed,                 Lock is too powerful.
 
-- Potions:
+- Potion names:
 
 stamina,                    Stamina
 orcStrength,                Orc Strength
@@ -117,6 +117,3 @@ curePoison,                 Cure Poison
 chameleonForm,              Chameleon Form
 shadowForm,                 Shadow Form
 purification,               Purification
-
-potionMixed,                Your potion has been mixed.
-indredientsWasted,          Those ingredients did not concoct an effective potion and are wasted.

--- a/Assets/StreamingAssets/Text/ClassicEffects.txt
+++ b/Assets/StreamingAssets/Text/ClassicEffects.txt
@@ -119,3 +119,4 @@ shadowForm,                 Shadow Form
 purification,               Purification
 
 potionMixed,                Your potion has been mixed.
+indredientsWasted,          Those ingredients did not concoct an effective potion and are wasted.

--- a/Assets/StreamingAssets/Text/ClassicEffects.txt
+++ b/Assets/StreamingAssets/Text/ClassicEffects.txt
@@ -98,3 +98,28 @@ readyToOpen,                Ready to open.
 doorLocked,                 Door is now locked.
 doorAlreadyLocked,          Door already locked.
 openFailed,                 Lock is too powerful.
+
+- Potions:
+
+stamina,                    Stamina
+orcStrength,                Orc Strength
+healing,                    Healing
+waterwalking,               Waterwalking
+restorePower,               Restore Power
+resistFire,                 Resist Fire
+resistFrost,                Resist Frost
+resistShock,                Resist Shock
+cureDisease,                Cure Disease
+slowFalling,                Slow Falling
+-waterBreathing,             Water Breathing
+healTrue,                   Heal True
+levitation,                 Levitation
+resistPoison,               Resist Poison
+-freeAction,                 Free Action
+curePoison,                 Cure Poison
+chameleonForm,              Chameleon Form
+shadowForm,                 Shadow Form
+-invisibility,              Invisibility
+purification,               Purification
+
+potionMixed,                Your potion has been mixed.

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -60,3 +60,9 @@ arSrc,              armor rating
 arRep,              armor
 northern,           (northern)
 southern,           (southern)
+
+- Potion mixing window:
+
+noRecipes,                  You have no recipes.
+potionMixed,                Your potion has been mixed.
+indredientsWasted,          Those ingredients did not concoct an effective potion and are wasted.


### PR DESCRIPTION
- All classic potions can be mixed.
- All classic potions can be drunk and the effects work.
- Failed potions are not created and a new message is displayed. (change from classic)
- We need to decide whether to restrict random potions in loot. Should they be restricted to classic ones only? I have a function for all and another for classic only - one could be used for mixing and purchasing, with the classic one used for loot. Opinions?
- Also added removeOne function to item collection which decrements stack and only removed item object when reaches 0. Please use it going forward where appropriate. Ta.
- Need to discuss mechanism for mult-effect potions @Interkarma - see the review comments.
