### PR TITLE
Match triggered spell shot origin to classic

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallAction.cs
+++ b/Assets/Scripts/Internal/DaggerfallAction.cs
@@ -474,7 +474,9 @@ namespace DaggerfallWorkshop
                             // Spell is fired at player, at strength of player level, from triggering object
                             DaggerfallMissile missile = GameManager.Instance.PlayerEffectManager.InstantiateSpellMissile(bundleSettings.ElementType);
                             missile.Payload = new EntityEffectBundle(bundleSettings, GameManager.Instance.PlayerEntityBehaviour);
-                            missile.CustomAimPosition = thisAction.transform.position;
+                            Vector3 customAimPosition = thisAction.transform.position;
+                            customAimPosition.y += 40 * MeshReader.GlobalScale;
+                            missile.CustomAimPosition = customAimPosition;
                             missile.CustomAimDirection = Vector3.Normalize(GameManager.Instance.PlayerObject.transform.position - thisAction.transform.position);
                         }
                     }


### PR DESCRIPTION
Implements what I mentioned here:
https://github.com/Interkarma/daggerfall-unity/commit/164d88312d6048f3be073094f1e8771fa3767329

I tested Direnni Tower and the spell seems to be coming from the same position as classic now.