### PR TITLE
Add null check for dfLocation

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -638,6 +638,9 @@ namespace DaggerfallWorkshop.Game.Entity
             if (GameManager.Instance.HowManyEnemiesOfType(MobileTypes.Knight_CityWatch) > 0)
             {
                 DaggerfallLocation dfLocation = GameManager.Instance.StreamingWorld.CurrentPlayerLocationObject;
+                if (dfLocation == null)
+                    return;
+
                 PopulationManager populationManager = dfLocation.GetComponent<PopulationManager>();
                 if (populationManager == null)
                     return;


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=1617.

Looks like the problem was that if you went far enough away from town and the current dfLocation became null, there would be a null reference.