### PR TITLE
Fixes missing streaming world locations

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -968,7 +968,7 @@ namespace DaggerfallWorkshop
                     {
                         terrainArray[i].mapPixelX = int.MinValue;
                         terrainArray[i].mapPixelY = int.MinValue;
-                        terrainArray[i].updateLocation = false;
+                        terrainArray[i].updateLocation = terrainArray[i].hasLocation;
                     }
                 }
             }


### PR DESCRIPTION

Relevant bug reports:

https://forums.dfworkshop.net/viewtopic.php?f=24&t=1628

https://forums.dfworkshop.net/viewtopic.php?f=24&t=1645

Issue occurs when terrain objects become pooled & their locations are cleaned up. Because updateLocation was being set to false the locations were not being recreated.