### PR TITLE
Fix enemies bouncing down inclines

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -204,13 +204,6 @@ namespace DaggerfallWorkshop.Game
             }
             mobile.FreezeAnims = false;
 
-            // Apply gravity
-            if (!flies && !swims && !controller.isGrounded)
-            {
-                controller.SimpleMove(Vector3.zero);
-                return;
-            }
-
             // If hit, get knocked back
             if (knockBackSpeed > 0)
             {
@@ -258,6 +251,18 @@ namespace DaggerfallWorkshop.Game
                 }
 
                 return;
+            }
+
+            // Apply gravity
+            if (!flies && !swims && !isLevitating && !controller.isGrounded)
+            {
+                controller.SimpleMove(Vector3.zero);
+
+                // Only return if actually falling. Sometimes mobiles can get stuck where they are !isGrounded but SimpleMove(Vector3.zero) doesn't help.
+                // Allowing them to continue and attempt a Move() in the code below frees them, but we don't want to allow that if we can avoid it so they aren't moving
+                // while falling, which can also accelerate the fall due to anti-bounce downward movement in Move().
+                if (lastPosition != transform.position)
+                    return;
             }
 
             // Monster speed of movement follows the same formula as for when the player walks
@@ -682,10 +687,14 @@ namespace DaggerfallWorkshop.Game
                     return;
             }
 
-            // Slower movement when backing up
-            Vector3 motion = direction * moveSpeed;
             if (backAway)
-                motion *= -1;
+                direction *= -1;
+
+            // Move downward some to eliminate bouncing down inclines
+            if (!flies && !swims && !isLevitating && controller.isGrounded)
+                direction.y = -2f;
+
+            Vector3 motion = direction * moveSpeed;
 
             // If using enhanced combat, avoid moving directly below targets
             if (!backAway && DaggerfallUnity.Settings.EnhancedCombatAI && avoidObstaclesTimer == 0)
@@ -746,7 +755,7 @@ namespace DaggerfallWorkshop.Game
                 else if (flies || isLevitating)
                     controller.Move(motion * Time.deltaTime);
                 else
-                    controller.SimpleMove(motion);
+                    controller.Move(motion * Time.deltaTime);
             }
 
             // Reset clockwise check if we've been clear of obstacles/falls for a while


### PR DESCRIPTION
This fixes the issue of enemies bouncing down inclines, which has existed for a long time. (I was sure I had made a bug report for it on the forums, but I can't find it now). This problem was also visually exacerbated by my recent AI update, since I put AI on hold while falling, so enemies could be bouncing down stairs while not even facing at the player, since their AI won't update while falling to turn toward the player.

I switched land-based enemies to use Move() with a downward element, similar to the player, rather than SimpleMove().

Also, for some reason, the SimpleMove(Vector3.zero) that I have been using for gravity sometimes will never get a mobile to have controller.isGrounded be true, and a mobile can get stuck.

I managed to fix this by comparing against the transform.position of the last frame and only aborting the rest of the AI update if the AI is actually being moved by SimpleMove(Vector3.zero) (i.e., is actually falling, and not just stuck). If the AI update is allowed to continue then a Move() will be attempted and the AI will get unstuck. Kind of hacky, but it works and its the best I could come up after lots of trial and error.

Also made sure knockback takes effect even if an enemy is hit while falling.