### PR TITLE
Fix NPCs to use parent factions for dialogue

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -766,7 +766,13 @@ namespace DaggerfallWorkshop.Game
             DaggerfallUI.Instance.TalkWindow.UpdateNameNPC();
 
             FactionFile.FactionData factionData;
-            GameManager.Instance.PlayerEntity.FactionData.GetFactionData(targetStaticNPC.Data.factionID, out factionData);            
+            GameManager.Instance.PlayerEntity.FactionData.GetFactionData(targetStaticNPC.Data.factionID, out factionData);
+
+            // Matched to classic. For dialogue, NPCs that are not of type 2, 7 or 9 use their first parent that is, if such a parent exists
+            for (int parentFactionID = 0; factionData.parent != 0 && factionData.type != 2 && factionData.type != 7 && factionData.type != 9; parentFactionID = factionData.parent)
+            {
+                GameManager.Instance.PlayerEntity.FactionData.GetFactionData(factionData.parent, out factionData);
+            }
 
             npcData = new NPCData();
             npcData.socialGroup = (FactionFile.SocialGroups)factionData.sgroup;


### PR DESCRIPTION
Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=1683.

The problem was the NPC in question is of the Order of the Lamp faction, which has a gguild of 10, or knightly order. The code would then try to look up a knightly order with the building faction of 40 (Mages Guild) and throw an exception.

When opening dialogue, for NPCs of a faction that is not of type 2, 7, or 9, classic will iterate up through their parents until it finds one that is of these factions (if there is one) and use that faction instead. With this behavior replicated, the NPC in the bug report will now use the parent faction of Mages Guild and give a Mages Guild greeting like in classic.