### PR TITLE
Fix chain greaves graphic

### DIFF
--- a/Assets/Resources/ItemTemplates.txt
+++ b/Assets/Resources/ItemTemplates.txt
@@ -2088,7 +2088,7 @@
         "basePrice": 80,
         "enchantmentPoints": 50,
         "rarity": 3,
-        "variants": 6,
+        "variants": 7,
         "drawOrderOrEffect": 30,
         "isBluntWeapon": false,
         "isLiquid": false,


### PR DESCRIPTION
Fixes first part of https://forums.dfworkshop.net/viewtopic.php?f=24&t=1660&sid=5ee3de52dcc231329e59ee68733ff5e8.

The issue is that chain greaves use greaves variant 6, but the `TotalVariants` gotten from `ItemTemplates.txt` is 6, and in `DaggerfallUnityItem.cs` the below code modifies the variant to 5:

```
        /// <summary>
        /// Sets current variant and clamps within valid range.
        /// </summary>
        void SetCurrentVariant(int variant)
        {
            if (variant < 0)
                currentVariant = 0;
            else if (variant >= TotalVariants)
                currentVariant = TotalVariants - 1;
            else
                currentVariant = variant;
        }
```

The reason why it works in classic, is that classic does not use the item templates data for armor variants, it only uses it for clothes variants. Armor variants are hard-coded. Changing the `(variant >= TotalVariants)` check to only apply to clothing also fixes this issue, but it might cause a problem elsewhere so I thought upping the greaves variant count by 1 was a safer and nicer-looking solution. Other than greaves all of the classic item template data for armor variants is correct anyway.