### PR TITLE
Match armor dye colors to classic

### DIFF
--- a/Assets/Scripts/DaggerfallUnityEnums.cs
+++ b/Assets/Scripts/DaggerfallUnityEnums.cs
@@ -349,7 +349,6 @@ namespace DaggerfallWorkshop
         None,
         Iron,
         Steel,
-        Chain,
         Silver,
         Elven,
         Dwarven,
@@ -384,9 +383,11 @@ namespace DaggerfallWorkshop
         // Weapon and armour dyes
         Iron = 15,
         Steel = 16,
-        Chain = 17,
+        Chain = 18, // This enum kept for compatibility with older saves
         Unchanged = 18,
-        SilverOrElven = 19,
+        SilverOrElven = 18, // This enum kept for compatibility with older saves
+        Silver = 18,
+        Elven = 19,
         Dwarven = 20,
         Mithril = 21,
         Adamantium = 22,

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -1322,9 +1322,6 @@ namespace DaggerfallWorkshop.Game.Items
             // TEST: Force dye color to match material of imported weapons & armor
             // This is to fix cases where dye colour may be set incorrectly on imported item
             dyeColor = DaggerfallUnity.Instance.ItemHelper.GetDyeColor(this);
-
-            // Fix leather helms
-            ItemBuilder.FixLeatherHelm(this);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -419,7 +419,6 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             newItem.dyeColor = DaggerfallUnity.Instance.ItemHelper.GetArmorDyeColor((ArmorMaterialTypes)newItem.nativeMaterialValue);
-            FixLeatherHelm(newItem);
 
             // Adjust for variant
             if (variant >= 0)
@@ -470,7 +469,6 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             newItem.dyeColor = DaggerfallUnity.Instance.ItemHelper.GetArmorDyeColor(material);
-            FixLeatherHelm(newItem);
             RandomizeArmorVariant(newItem);
 
             return newItem;
@@ -794,17 +792,6 @@ namespace DaggerfallWorkshop.Game.Items
                 variant = UnityEngine.Random.Range(0, item.ItemTemplate.variants);
 
             SetVariant(item, variant);
-        }
-
-        /// <summary>
-        /// Set leather helms to use chain dye.
-        /// Daggerfall seems to do this also as "leather" helms have the chain tint in-game.
-        /// Might need to revisit this later.
-        /// </summary>
-        public static void FixLeatherHelm(DaggerfallUnityItem item)
-        {
-            if (item.TemplateIndex == (int)Armor.Helm && (ArmorMaterialTypes)item.nativeMaterialValue == ArmorMaterialTypes.Leather)
-                item.dyeColor = DyeColors.Chain;
         }
 
         #endregion

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -744,9 +744,6 @@ namespace DaggerfallWorkshop.Game.Items
                         return MetalTypes.Iron;
                     case ArmorMaterialTypes.Steel:
                         return MetalTypes.Steel;
-                    case ArmorMaterialTypes.Chain:
-                    case ArmorMaterialTypes.Chain2:
-                        return MetalTypes.Chain;
                     case ArmorMaterialTypes.Silver:
                         return MetalTypes.Silver;
                     case ArmorMaterialTypes.Elven:
@@ -803,8 +800,9 @@ namespace DaggerfallWorkshop.Game.Items
                 case WeaponMaterialTypes.Steel:
                     return DyeColors.Steel;
                 case WeaponMaterialTypes.Silver:
+                    return DyeColors.Silver;
                 case WeaponMaterialTypes.Elven:
-                    return DyeColors.SilverOrElven;
+                    return DyeColors.Elven;
                 case WeaponMaterialTypes.Dwarven:
                     return DyeColors.Dwarven;
                 case WeaponMaterialTypes.Mithril:
@@ -832,16 +830,14 @@ namespace DaggerfallWorkshop.Game.Items
         {
             switch (material)
             {
-                case ArmorMaterialTypes.Chain:
-                case ArmorMaterialTypes.Chain2:
-                    return DyeColors.Chain;
                 case ArmorMaterialTypes.Iron:
                     return DyeColors.Iron;
                 case ArmorMaterialTypes.Steel:
                     return DyeColors.Steel;
                 case ArmorMaterialTypes.Silver:
+                    return DyeColors.Silver;
                 case ArmorMaterialTypes.Elven:
-                    return DyeColors.SilverOrElven;
+                    return DyeColors.Elven;
                 case ArmorMaterialTypes.Dwarven:
                     return DyeColors.Dwarven;
                 case ArmorMaterialTypes.Mithril:

--- a/Assets/Scripts/Utility/ImageProcessing.cs
+++ b/Assets/Scripts/Utility/ImageProcessing.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System.IO;
 using System.Collections;
 using DaggerfallConnect;
@@ -530,10 +530,10 @@ namespace DaggerfallWorkshop.Utility
                         return GetMetalColorTable(MetalTypes.Iron);
                     case DyeColors.Steel:
                         return GetMetalColorTable(MetalTypes.Steel);
-                    case DyeColors.Chain:
-                        return GetMetalColorTable(MetalTypes.Chain);
-                    case DyeColors.SilverOrElven:
+                    case DyeColors.Silver:
                         return GetMetalColorTable(MetalTypes.Silver);
+                    case DyeColors.Elven:
+                        return GetMetalColorTable(MetalTypes.Elven);
                     case DyeColors.Dwarven:
                         return GetMetalColorTable(MetalTypes.Dwarven);
                     case DyeColors.Mithril:
@@ -568,10 +568,11 @@ namespace DaggerfallWorkshop.Utility
                 case MetalTypes.Steel:
                     indices = new byte[] { 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x7E, 0x7F };
                     break;
-                case MetalTypes.Chain:
                 case MetalTypes.Silver:
-                case MetalTypes.Elven:
                     indices = new byte[] { 0xE0, 0x70, 0x50, 0x71, 0x51, 0x72, 0x73, 0x52, 0x74, 0x53, 0x75, 0x54, 0x55, 0x56, 0x57, 0x58 };
+                    break;
+                case MetalTypes.Elven:
+                    indices = new byte[] { 0xE0, 0x70, 0x50, 0x71, 0x51, 0x72, 0x73, 0x52, 0x74, 0x53, 0x75, 0x54, 0x76, 0x56, 0x77, 0x78 };
                     break;
                 case MetalTypes.Dwarven:
                     indices = new byte[] { 0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9A, 0x9B, 0x9C, 0x9D, 0x9E, 0x9F };
@@ -586,7 +587,7 @@ namespace DaggerfallWorkshop.Utility
                     indices = new byte[] { 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x7E, 0x7F, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE };
                     break;
                 case MetalTypes.Orcish:
-                    indices = new byte[] { 0xA2, 0xA3, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD };
+                    indices = new byte[] { 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD };
                     break;
                 case MetalTypes.Daedric:
                     indices = new byte[] { 0xEF, 0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE };
@@ -610,10 +611,10 @@ namespace DaggerfallWorkshop.Utility
                     return DyeColors.Iron;
                 case MetalTypes.Steel:
                     return DyeColors.Steel;
-                case MetalTypes.Chain:
                 case MetalTypes.Silver:
+                    return DyeColors.Silver;
                 case MetalTypes.Elven:
-                    return DyeColors.SilverOrElven;
+                    return DyeColors.Elven;
                 case MetalTypes.Dwarven:
                     return DyeColors.Dwarven;
                 case MetalTypes.Mithril:


### PR DESCRIPTION
Fixes the second part of https://forums.dfworkshop.net/viewtopic.php?f=24&t=1660&sid=5ee3de52dcc231329e59ee68733ff5e8

DF Unity was using "Steel" dye as the default, unchanged, color, but classic uses "Silver" dye. This is used for both leather and classic. Removed the LeatherHelm fix as it's no longer necessary.

Also, DF Unity displayed Silver and Elven dyes as the same color (both as Silver), but Elven is different. Elven/Silver items from existing DF Unity saves will still appear as Silver. Also, the Orcish dye differed from classic. Any intentional changes?

Color comparisons attached. Left = master branch. Right = this PR (same as classic)

Leather
![leather](https://user-images.githubusercontent.com/19624336/50571559-00033380-0df1-11e9-829e-8d2ca2b6079e.jpg)

Elven
![elven](https://user-images.githubusercontent.com/19624336/50571561-072a4180-0df1-11e9-9c0c-98ca5222d71e.jpg)

Orcish
![orcish](https://user-images.githubusercontent.com/19624336/50571565-21fcb600-0df1-11e9-944b-5cc6da4087e7.jpg)
