### PR TITLE
Fix problems with AI movement prediction

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -487,16 +487,15 @@ namespace DaggerfallWorkshop.Game
         }
 
         /// <summary>
-        /// Returns whether there is a clear path from the current location to the given location. True if clear
+        /// Returns whether there is a clear path to move the given distance from the current location towards the given location. True if clear
         /// or if combat target is the first obstacle hit.
         /// </summary>
-        bool ClearPathToPosition(Vector3 location)
+        bool ClearPathToPosition(Vector3 location, float dist = 2)
         {
-            float sphereCastDist = (location - transform.position).magnitude;
             Vector3 sphereCastDir = (location - transform.position).normalized;
             RaycastHit hit;
 
-            if (Physics.SphereCast(transform.position, controller.radius / 2, sphereCastDir, out hit, sphereCastDist))
+            if (Physics.SphereCast(transform.position, controller.radius / 2, sphereCastDir, out hit, dist))
             {
                 DaggerfallEntityBehaviour hitTarget = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
                 if (hitTarget == entityBehaviour.Target)


### PR DESCRIPTION
Fixes to AI movement prediction:
- Due to recent AI PR(s), AI weren't using prediction anymore when they didn't have LOS to the target
- Because of not accounting correctly for the lead on movement prediction (based on time to intercept the target), the iterative prediction when target isn't seen would make bogus predictions
- Enemies stop if their prediction takes them too far, helps with the issue of enemies wandering off during combat.
- Some cleanup