### PR TITLE
Bash exterior doors

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    Allofich
+// Contributors:    Allofich, Numidium
 // 
 // Notes:
 //

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -565,7 +565,6 @@ namespace DaggerfallWorkshop.Game
             StaticDoor door;
             if (doors && doors.HasHit(hit.point, out door))
             {
-                PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
                 DaggerfallAudioSource dfAudioSource = GetComponent<DaggerfallAudioSource>();
                 if (dfAudioSource != null)
                     dfAudioSource.PlayOneShot(SoundClips.PlayerDoorBash);
@@ -580,6 +579,7 @@ namespace DaggerfallWorkshop.Game
                     return true;
                 }
                 // Bashing doors in cities is a crime
+                PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
                 playerEntity.CrimeCommitted = PlayerEntity.Crimes.Attempted_Breaking_And_Entering;
                 playerEntity.SpawnCityGuards(false);
             }

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -558,6 +558,34 @@ namespace DaggerfallWorkshop.Game
             clickDelayStartTime = Time.realtimeSinceStartup;
         }
 
+        public bool AttemptExteriorDoorBash(RaycastHit hit)
+        {
+            Transform doorOwner;
+            DaggerfallStaticDoors doors = GetDoors(hit.transform, out doorOwner);
+            StaticDoor door;
+            if (doors && doors.HasHit(hit.point, out door))
+            {
+                PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+                DaggerfallAudioSource dfAudioSource = GetComponent<DaggerfallAudioSource>();
+                if (dfAudioSource != null)
+                    dfAudioSource.PlayOneShot(SoundClips.PlayerDoorBash);
+
+                // Roll for chance to open
+                // TODO: Factor door lock value into chance to open
+                int chance = 20;
+                int roll = Random.Range(1, 101);
+                if (roll <= chance)
+                {
+                    TransitionInterior(doorOwner, door, true);
+                    return true;
+                }
+                // Bashing doors in cities is a crime
+                playerEntity.CrimeCommitted = PlayerEntity.Crimes.Attempted_Breaking_And_Entering;
+                playerEntity.SpawnCityGuards(false);
+            }
+            return false;
+        }
+
         private void HandleLootContainer(RaycastHit hit, DaggerfallLoot loot)
         {
             // Check if close enough to activate for all types, except for corpses

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors: Numidium   
 // 
 // Notes:
 //

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -414,6 +414,12 @@ namespace DaggerfallWorkshop.Game
                 return false;
             }
 
+            // Check if player hit a static exterior door
+            if (GameManager.Instance.PlayerActivate.AttemptExteriorDoorBash(hit))
+            {
+                return false;
+            }
+
             // Set up for use below
             DaggerfallEntityBehaviour entityBehaviour = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
             DaggerfallMobileUnit entityMobileUnit = hit.transform.GetComponentInChildren<DaggerfallMobileUnit>();


### PR DESCRIPTION
Currently uses the best open chance to determine a successful bash.  I used the same formula regardless of whether the door is locked since unlocked doors aren't automatically kicked open on the first try in classic.