### PR TITLE
Stop enemies attacking magically-concealed target

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -139,7 +139,7 @@ namespace DaggerfallWorkshop.Game
         private bool MeleeAnimation()
         {
             // Are we in range and facing target? Then start attack.
-            if (senses.TargetInSight)
+            if (senses.TargetInSight && senses.DetectedTarget)
             {
                 // Take the rate of target approach into account when deciding if to attack
                 if (senses.DistanceToTarget >= MeleeDistance + senses.TargetRateOfApproach)

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -377,7 +377,7 @@ namespace DaggerfallWorkshop.Game
             float distance = (targetPos - transform.position).magnitude;
 
             // Ranged attacks
-            if (targetPosIsEnemyPos && senses.TargetInSight && 360 * MeshReader.GlobalScale < senses.DistanceToTarget && senses.DistanceToTarget < 2048 * MeshReader.GlobalScale)
+            if (targetPosIsEnemyPos && senses.DetectedTarget && 360 * MeshReader.GlobalScale < senses.DistanceToTarget && senses.DistanceToTarget < 2048 * MeshReader.GlobalScale)
             {
                 bool evaluateBow = mobile.Summary.Enemy.HasRangedAttack1 && mobile.Summary.Enemy.ID > 129 && mobile.Summary.Enemy.ID != 132;
                 bool evaluateRangedMagic = false;
@@ -417,7 +417,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Touch spells
-            if (targetPosIsEnemyPos && senses.TargetInSight && attack.MeleeTimer == 0 && senses.DistanceToTarget <= attack.MeleeDistance +
+            if (targetPosIsEnemyPos && senses.TargetInSight && senses.DetectedTarget && attack.MeleeTimer == 0 && senses.DistanceToTarget <= attack.MeleeDistance +
                 senses.TargetRateOfApproach && CanCastTouchSpell() && entityEffectManager.SetReadySpell(selectedSpell))
             {
                 if (mobile.Summary.EnemyState != MobileStates.Spell)


### PR DESCRIPTION
Fixes these problems:

- Melee attack completely ignored magical concealment, so enemies would still do a melee attack if you got close to them

- Ranged attacks and spells would still happen regardless of magical concealment as long as the enemy's "give up timer" for pursuing the target had not run out yet. If an enemy could see you (priming the give up timer to maximum), and you then cast Invisibility (can no longer see you so give up timer starts to run out), they would still do these attacks for the next several seconds until the timer reached 0.