### PR TITLE
AI uses last target after current one dies + cleanup

### DIFF
--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -295,7 +295,7 @@ namespace DaggerfallWorkshop.Game
                             DaggerfallEntityBehaviour entityBehaviour = null;
                             if (arrowHit.transform)
                                 entityBehaviour = arrowHit.transform.GetComponent<DaggerfallEntityBehaviour>();
-                            if (entityBehaviour == caster.Target)
+                            if (entityBehaviour == caster.GetComponent<EnemySenses>().Target)
                             {
                                 EnemyAttack attack = caster.GetComponent<EnemyAttack>();
                                 if (attack)

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -121,17 +121,17 @@ namespace DaggerfallWorkshop.Game
 
         public void BowDamage(Vector3 direction)
         {
-            if (entityBehaviour.Target == null)
+            if (senses.Target == null)
                 return;
 
             EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
-            if (entityBehaviour.Target == GameManager.Instance.PlayerEntityBehaviour)
+            if (senses.Target == GameManager.Instance.PlayerEntityBehaviour)
                 damage = ApplyDamageToPlayer(entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand));
             else
                 damage = ApplyDamageToNonPlayer(entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand), direction, true);
 
             Items.DaggerfallUnityItem arrow = Items.ItemBuilder.CreateItem(Items.ItemGroups.Weapons, (int)Items.Weapons.Arrow);
-            entityBehaviour.Target.Entity.Items.AddItem(arrow);
+            senses.Target.Entity.Items.AddItem(arrow);
         }
 
         #region Private Methods
@@ -167,8 +167,8 @@ namespace DaggerfallWorkshop.Game
                 EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
                 EnemyEntity targetEntity = null;
 
-                if (entityBehaviour.Target != null && entityBehaviour.Target != GameManager.Instance.PlayerEntityBehaviour)
-                    targetEntity = entityBehaviour.Target.Entity as EnemyEntity;
+                if (senses.Target != null && senses.Target != GameManager.Instance.PlayerEntityBehaviour)
+                    targetEntity = senses.Target.Entity as EnemyEntity;
 
                 // Switch to hand-to-hand if enemy is immune to weapon
                 Items.DaggerfallUnityItem weapon = entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
@@ -181,9 +181,9 @@ namespace DaggerfallWorkshop.Game
                 damage = 0;
 
                 // Are we still in range and facing target? Then apply melee damage.
-                if (entityBehaviour.Target != null && senses.DistanceToTarget <= MeleeDistance && senses.TargetInSight)
+                if (senses.Target != null && senses.DistanceToTarget <= MeleeDistance && senses.TargetInSight)
                 {
-                    if (entityBehaviour.Target == GameManager.Instance.PlayerEntityBehaviour)
+                    if (senses.Target == GameManager.Instance.PlayerEntityBehaviour)
                         damage = ApplyDamageToPlayer(weapon);
                     else
                         damage = ApplyDamageToNonPlayer(weapon, transform.forward);
@@ -312,13 +312,13 @@ namespace DaggerfallWorkshop.Game
 
         private int ApplyDamageToNonPlayer(Items.DaggerfallUnityItem weapon, Vector3 direction, bool bowAttack = false)
         {
-            if (entityBehaviour.Target == null)
+            if (senses.Target == null)
                 return 0;
             // TODO: Merge with hit code in WeaponManager to eliminate duplicate code
             EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
-            EnemyEntity targetEntity = entityBehaviour.Target.Entity as EnemyEntity;
-            EnemySounds targetSounds = entityBehaviour.Target.GetComponent<EnemySounds>();
-            EnemyMotor targetMotor = entityBehaviour.Target.transform.GetComponent<EnemyMotor>();
+            EnemyEntity targetEntity = senses.Target.Entity as EnemyEntity;
+            EnemySounds targetSounds = senses.Target.GetComponent<EnemySounds>();
+            EnemyMotor targetMotor = senses.Target.transform.GetComponent<EnemyMotor>();
 
             // Calculate damage
             damage = FormulaHelper.CalculateAttackDamage(entity, targetEntity, weapon, -1);
@@ -332,10 +332,10 @@ namespace DaggerfallWorkshop.Game
             {
                 targetSounds.PlayHitSound(weapon);
 
-                EnemyBlood blood = entityBehaviour.Target.transform.GetComponent<EnemyBlood>();
+                EnemyBlood blood = senses.Target.transform.GetComponent<EnemyBlood>();
 
-                Vector3 bloodPos = entityBehaviour.Target.transform.position;
-                CharacterController targetController = entityBehaviour.Target.transform.GetComponent<CharacterController>();
+                Vector3 bloodPos = senses.Target.transform.position;
+                CharacterController targetController = senses.Target.transform.GetComponent<CharacterController>();
                 bloodPos.y += targetController.height / 8;
 
                 if (blood)
@@ -365,9 +365,9 @@ namespace DaggerfallWorkshop.Game
                     }
                 }
 
-                if (DaggerfallUnity.Settings.CombatVoices && entityBehaviour.Target.EntityType == EntityTypes.EnemyClass && Random.Range(1, 101) <= 40)
+                if (DaggerfallUnity.Settings.CombatVoices && senses.Target.EntityType == EntityTypes.EnemyClass && Random.Range(1, 101) <= 40)
                 {
-                    DaggerfallMobileUnit targetMobileUnit = entityBehaviour.Target.GetComponentInChildren<DaggerfallMobileUnit>();
+                    DaggerfallMobileUnit targetMobileUnit = senses.Target.GetComponentInChildren<DaggerfallMobileUnit>();
                     Genders gender;
                     if (targetMobileUnit.Summary.Enemy.Gender == MobileGender.Male || targetEntity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
                         gender = Genders.Male;

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -150,8 +150,8 @@ namespace DaggerfallWorkshop.Game
             if (attacker && senses)
             {
                 // Assign target if don't already have target, or original target isn't seen or adjacent
-                if (entityBehaviour.Target == null || !senses.TargetInSight || senses.DistanceToTarget > 2f)
-                    entityBehaviour.Target = attacker;
+                if (senses.Target == null || !senses.TargetInSight || senses.DistanceToTarget > 2f)
+                    senses.Target = attacker;
                 senses.LastKnownTargetPos = attacker.transform.position;
                 senses.OldLastKnownTargetPos = attacker.transform.position;
                 senses.PredictedTargetPos = attacker.transform.position;
@@ -313,7 +313,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Do nothing if no target or after giving up finding the target or if target position hasn't been acquired yet
-            if (entityBehaviour.Target == null || giveUpTimer == 0 || senses.PredictedTargetPos == EnemySenses.ResetPlayerPos)
+            if (senses.Target == null || giveUpTimer == 0 || senses.PredictedTargetPos == EnemySenses.ResetPlayerPos)
             {
                 SetChangeStateTimer();
                 bashing = false;
@@ -353,7 +353,7 @@ namespace DaggerfallWorkshop.Game
                     // Ground enemies target at their own height
                     // This avoids short enemies from stepping on each other as they approach the target
                     // Otherwise, their target vector aims up towards the target
-                    var targetController = entityBehaviour.Target.GetComponent<CharacterController>();
+                    var targetController = senses.Target.GetComponent<CharacterController>();
                     var deltaHeight = (targetController.height - controller.height) / 2;
                     targetPos.y -= deltaHeight;
                 }
@@ -503,7 +503,7 @@ namespace DaggerfallWorkshop.Game
             if (Physics.SphereCast(transform.position, controller.radius / 2, sphereCastDir, out hit, dist))
             {
                 DaggerfallEntityBehaviour hitTarget = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
-                if (hitTarget == entityBehaviour.Target)
+                if (hitTarget == senses.Target)
                     return true;
 
                 return false;
@@ -564,7 +564,7 @@ namespace DaggerfallWorkshop.Game
                 DaggerfallEntityBehaviour hitTarget = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
 
                 // Clear path to target
-                if (hitTarget == entityBehaviour.Target)
+                if (hitTarget == senses.Target)
                     return true;
 
                 // Something in the way
@@ -633,9 +633,9 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         bool EffectsAlreadyOnTarget(EntityEffectBundle spell)
         {
-            if (entityBehaviour.Target)
+            if (senses.Target)
             {
-                EntityEffectManager targetEffectManager = entityBehaviour.Target.GetComponent<EntityEffectManager>();
+                EntityEffectManager targetEffectManager = senses.Target.GetComponent<EntityEffectManager>();
                 LiveEffectBundle[] bundles = targetEffectManager.EffectBundles;
 
                 for (int i = 0; i < spell.Settings.Effects.Length; i++)
@@ -900,7 +900,7 @@ namespace DaggerfallWorkshop.Game
                 }
 
                 DaggerfallEntityBehaviour entityBehaviour2 = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
-                if (entityBehaviour2 == entityBehaviour.Target)
+                if (entityBehaviour2 == senses.Target)
                     obstacleDetected = false;
 
                 DaggerfallActionDoor door = hit.transform.GetComponent<DaggerfallActionDoor>();
@@ -959,9 +959,9 @@ namespace DaggerfallWorkshop.Game
             }
 
             // No retreat if enemy is paralyzed
-            if (entityBehaviour.Target != null)
+            if (senses.Target != null)
             {
-                EntityEffectManager targetEffectManager = entityBehaviour.Target.GetComponent<EntityEffectManager>();
+                EntityEffectManager targetEffectManager = senses.Target.GetComponent<EntityEffectManager>();
                 if (targetEffectManager.FindIncumbentEffect<MagicAndEffects.MagicEffects.Paralyze>() != null)
                 {
                     moveInForAttack = true;
@@ -976,7 +976,7 @@ namespace DaggerfallWorkshop.Game
                 }
 
                 // No retreat if enemy is player with bow or weapon not out
-                if (entityBehaviour.Target == GameManager.Instance.PlayerEntityBehaviour
+                if (senses.Target == GameManager.Instance.PlayerEntityBehaviour
                     && GameManager.Instance.WeaponManager.ScreenWeapon
                     && (GameManager.Instance.WeaponManager.ScreenWeapon.WeaponType == WeaponTypes.Bow
                     || !GameManager.Instance.WeaponManager.ScreenWeapon.ShowWeapon))
@@ -994,7 +994,7 @@ namespace DaggerfallWorkshop.Game
 
             // Level difference affects likelihood of backing away.
             moveInForAttackTimer = Random.Range(1, 3);
-            int levelMod = (entity.Level - entityBehaviour.Target.Entity.Level) / 2;
+            int levelMod = (entity.Level - senses.Target.Entity.Level) / 2;
             if (levelMod > 4)
                 levelMod = 4;
             if (levelMod < -4)

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -299,6 +299,10 @@ namespace DaggerfallWorkshop.Game
                     targetRateOfApproach = 0;
                     distanceToTarget = 0;
                     targetSenses = null;
+
+                    // If had a valid target before, resume pursuing it. Looks better to first finish any attack animation.
+                    if (lastTarget != null && lastTarget.Entity.CurrentHealth > 0 && !mobile.IsPlayingOneShot())
+                        target = lastTarget;
                 }
 
                 if ((motor.IsHostile && target == null) || classicTargetUpdateTimer > 10) // Timing is 200 in classic, about 10 seconds.

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -42,7 +42,9 @@ namespace DaggerfallWorkshop.Game
         Vector3 directionToTarget;
         float distanceToPlayer;
         float distanceToTarget;
+        DaggerfallEntityBehaviour target;
         DaggerfallEntityBehaviour lastTarget;
+        EnemySenses targetSenses;
         float lastDistanceToTarget;
         float targetRateOfApproach;
         Vector3 lastKnownTargetPos;
@@ -74,6 +76,12 @@ namespace DaggerfallWorkshop.Game
         float classicSpawnYDistLower = 0f;
         float classicDespawnXZDist = 0f;
         float classicDespawnYDist = 0f;
+
+        public DaggerfallEntityBehaviour Target
+        {
+            get { return target; }
+            set { target = value; }
+        }
 
         DaggerfallEntityBehaviour Player
         {
@@ -272,15 +280,17 @@ namespace DaggerfallWorkshop.Game
             {
                 classicTargetUpdateTimer += Time.deltaTime / systemTimerUpdatesDivisor;
 
-                if (entityBehaviour.Target != null && entityBehaviour.Target.Entity.CurrentHealth <= 0)
-                    entityBehaviour.Target = null;
+                if (target != null && target.Entity.CurrentHealth <= 0)
+                {
+                    target = null;
+                }
 
                 // NoTarget mode
-                if ((GameManager.Instance.PlayerEntity.NoTargetMode || !motor.IsHostile) && entityBehaviour.Target == Player)
-                    entityBehaviour.Target = null;
+                if ((GameManager.Instance.PlayerEntity.NoTargetMode || !motor.IsHostile) && target == Player)
+                    target = null;
 
                 // Reset these values if no target
-                if (entityBehaviour.Target == null)
+                if (target == null)
                 {
                     lastKnownTargetPos = ResetPlayerPos;
                     predictedTargetPos = ResetPlayerPos;
@@ -288,28 +298,33 @@ namespace DaggerfallWorkshop.Game
                     lastDistanceToTarget = 0;
                     targetRateOfApproach = 0;
                     distanceToTarget = 0;
+                    targetSenses = null;
                 }
 
-                if ((motor.IsHostile && entityBehaviour.Target == null) || classicTargetUpdateTimer > 10) // Timing is 200 in classic, about 10 seconds.
+                if ((motor.IsHostile && target == null) || classicTargetUpdateTimer > 10) // Timing is 200 in classic, about 10 seconds.
                 {
                     classicTargetUpdateTimer = 0f;
 
                     // Is enemy in area around player or can see player?
                     if (wouldBeSpawnedInClassic || playerInSight)
                     {
-                        entityBehaviour.Target = GetTarget();
+                        target = GetTarget();
+                        if (target != null && target != Player)
+                            targetSenses = target.GetComponent<EnemySenses>();
+                        else
+                            targetSenses = null;
                     }
 
                     // Make targeted character also target this character if it doesn't have a target yet.
-                    if (entityBehaviour.Target != null && entityBehaviour.Target.Target == null)
+                    if (target != null && targetSenses && targetSenses.Target == null)
                     {
-                        entityBehaviour.Target.Target = entityBehaviour;
+                        targetSenses.Target = entityBehaviour;
                     }
                 }
 
                 // Compare change in target position to give AI some ability to read opponent's movements
 
-                if (entityBehaviour.Target != null && entityBehaviour.Target == lastTarget)
+                if (target != null && target == lastTarget)
                 {
                     if (DaggerfallUnity.Settings.EnhancedCombatAI)
                         targetRateOfApproach = (lastDistanceToTarget - distanceToTarget);
@@ -320,10 +335,10 @@ namespace DaggerfallWorkshop.Game
                     targetRateOfApproach = 0;
                 }
 
-                if (entityBehaviour.Target != null)
+                if (target != null)
                 {
                     lastDistanceToTarget = distanceToTarget;
-                    lastTarget = entityBehaviour.Target;
+                    lastTarget = target;
                 }
             }
 
@@ -343,8 +358,8 @@ namespace DaggerfallWorkshop.Game
                 }
 
                 Vector3 toTarget = ResetPlayerPos;
-                if (entityBehaviour.Target != null)
-                    toTarget = entityBehaviour.Target.transform.position - transform.position;
+                if (target != null)
+                    toTarget = target.transform.position - transform.position;
 
                 if (toTarget != ResetPlayerPos)
                 {
@@ -352,19 +367,19 @@ namespace DaggerfallWorkshop.Game
                     directionToTarget = toTarget.normalized;
                 }
 
-                if (entityBehaviour.Target == null)
+                if (target == null)
                 {
                     targetInSight = false;
                     detectedTarget = false;
                     return;
                 }
 
-                targetInSight = CanSeeTarget(entityBehaviour.Target);
+                targetInSight = CanSeeTarget(target);
 
                 // Classic stealth mechanics would be interfered with by hearing, so only enable
                 // hearing if the enemy has detected the target. If target is visible we can omit hearing.
                 if (detectedTarget && !targetInSight)
-                    targetInEarshot = CanHearTarget(entityBehaviour.Target);
+                    targetInEarshot = CanHearTarget(target);
                 else
                     targetInEarshot = false;
 
@@ -384,7 +399,7 @@ namespace DaggerfallWorkshop.Game
                 if (!blockedByIllusionEffect && (targetInSight || targetInEarshot))
                 {
                     detectedTarget = true;
-                    lastKnownTargetPos = entityBehaviour.Target.transform.position;
+                    lastKnownTargetPos = target.transform.position;
                     lastHadLOSTimer = 200f;
                 }
                 else if (!blockedByIllusionEffect && StealthCheck())
@@ -395,7 +410,7 @@ namespace DaggerfallWorkshop.Game
                     // actual LOS for a while. This gives better pursuit behavior since enemies
                     // will go to the last spot they saw the player instead of walking into walls.
                     if (lastHadLOSTimer <= 0)
-                        lastKnownTargetPos = entityBehaviour.Target.transform.position;
+                        lastKnownTargetPos = target.transform.position;
                 }
                 else
                     detectedTarget = false;
@@ -413,7 +428,7 @@ namespace DaggerfallWorkshop.Game
                     predictedTargetPos = PredictNextTargetPos(moveSpeed);
                 }
 
-                if (detectedTarget && !hasEncounteredPlayer && entityBehaviour.Target == Player)
+                if (detectedTarget && !hasEncounteredPlayer && target == Player)
                 {
                     hasEncounteredPlayer = true;
 
@@ -526,7 +541,7 @@ namespace DaggerfallWorkshop.Game
             if (gameMinutes == timeOfLastStealthCheck)
                 return detectedTarget;
 
-            if (entityBehaviour.Target == Player)
+            if (target == Player)
             {
                 PlayerMotor playerMotor = GameManager.Instance.PlayerMotor;
                 if (playerMotor.IsMovingLessThanHalfSpeed)
@@ -547,7 +562,7 @@ namespace DaggerfallWorkshop.Game
 
             timeOfLastStealthCheck = gameMinutes;
 
-            int stealthRoll = 2 * ((int)(distanceToTarget / MeshReader.GlobalScale) * entityBehaviour.Target.Entity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth) >> 10);
+            int stealthRoll = 2 * ((int)(distanceToTarget / MeshReader.GlobalScale) * target.Entity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth) >> 10);
 
             return Random.Range(1, 101) > stealthRoll;
         }
@@ -562,16 +577,16 @@ namespace DaggerfallWorkshop.Game
 
             // If not one of the above enemy types, and target has invisibility,
             // detection is always blocked.
-            if (entityBehaviour.Target.Entity.IsInvisible)
+            if (target.Entity.IsInvisible)
                 return true;
 
             // If target doesn't have any illusion effect, detection is not blocked.
-            if (!entityBehaviour.Target.Entity.IsBlending && !entityBehaviour.Target.Entity.IsAShade)
+            if (!target.Entity.IsBlending && !target.Entity.IsAShade)
                 return false;
 
             // Target has either chameleon or shade. Try to see through it.
             int chance;
-            if (entityBehaviour.Target.Entity.IsBlending)
+            if (target.Entity.IsBlending)
                 chance = 8;
             else // is a shade
                 chance = 4;
@@ -600,13 +615,13 @@ namespace DaggerfallWorkshop.Game
 
             Vector3 targetDirection2D;
 
-            if (entityBehaviour.Target == Player)
+            if (target == Player)
             {
                 Camera mainCamera = GameObject.FindGameObjectWithTag("MainCamera").GetComponent<Camera>();
                 targetDirection2D = -new Vector3(mainCamera.transform.forward.x, 0, mainCamera.transform.forward.z);
             }
             else
-                targetDirection2D = -new Vector3(entityBehaviour.Target.transform.forward.x, 0, entityBehaviour.Target.transform.forward.z);
+                targetDirection2D = -new Vector3(target.transform.forward.x, 0, target.transform.forward.z);
 
             float angle = Vector3.Angle(directionToLastKnownTarget2D, targetDirection2D);
 
@@ -702,7 +717,7 @@ namespace DaggerfallWorkshop.Game
                     float priority = 0;
 
                     // Add 5 priority if this potential target isn't already targeting someone
-                    if (targetBehaviour.Target == null)
+                    if (targetSenses && targetSenses.Target == null)
                         priority += 5;
 
                     if (see)

--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -26,7 +26,6 @@ namespace DaggerfallWorkshop.Game.Entity
         EntityTypes lastEntityType = EntityTypes.None;
         DaggerfallEntity entity = null;
         DaggerfallLoot corpseLootContainer = null;
-        DaggerfallEntityBehaviour target = null;
 
         #endregion
 
@@ -39,12 +38,6 @@ namespace DaggerfallWorkshop.Game.Entity
         {
             get { return entity; }
             set { SetEntityValue(value); }
-        }
-
-        public DaggerfallEntityBehaviour Target
-        {
-            get { return target; }
-            set { target = value; }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -566,7 +566,7 @@ namespace DaggerfallWorkshop.Game
                     if (enemySenses)
                     {
                         // Can enemy see player or is close enough they would be spawned in classic?
-                        if ((entityBehaviour.Target == Instance.PlayerEntityBehaviour && enemySenses.TargetInSight) || enemySenses.WouldBeSpawnedInClassic)
+                        if ((enemySenses.Target == Instance.PlayerEntityBehaviour && enemySenses.TargetInSight) || enemySenses.WouldBeSpawnedInClassic)
                         {
                             areEnemiesNearby = true;
                             break;


### PR DESCRIPTION
New functionality is that AI will now switch to its last combat target if the current one dies. This addresses the following situation I noticed during testing:

1) Enemy A follows me into room with Enemy B
2) Enemy A switches target to Enemy B, kills it with back turned to me
3) Enemy A now stands there without target. Looks stupid because it should remember me, who it was pursuing mere seconds ago.

Also, moved the storage of enemy target from DaggerfallEntityBehaviour to EnemySenses, which is mainly what uses it. The previous combat target was already stored in EnemySenses.