### PR TITLE
Account for change in center of collider after height adjustment

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -333,9 +333,8 @@ namespace DaggerfallWorkshop.Game
                 targetSounds.PlayHitSound(weapon);
 
                 EnemyBlood blood = senses.Target.transform.GetComponent<EnemyBlood>();
-
-                Vector3 bloodPos = senses.Target.transform.position;
                 CharacterController targetController = senses.Target.transform.GetComponent<CharacterController>();
+                Vector3 bloodPos = senses.Target.transform.position + targetController.center;
                 bloodPos.y += targetController.height / 8;
 
                 if (blood)

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -876,7 +876,7 @@ namespace DaggerfallWorkshop.Game
             obstacleDetected = false;
             RaycastHit hit;
             int checkDistance = 2;
-            Vector3 rayOrigin = transform.position;
+            Vector3 rayOrigin = transform.position + controller.center;
             rayOrigin.y -= controller.height / 3;
             foundUpwardSlope = false;
             foundDoor = false;

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -768,12 +768,12 @@ namespace DaggerfallWorkshop.Game
 
                     // Set origin of ray to approximate eye position
                     CharacterController controller = entityBehaviour.transform.GetComponent<CharacterController>();
-                    Vector3 eyePos = transform.position;
+                    Vector3 eyePos = transform.position + controller.center;
                     eyePos.y += controller.height / 3;
 
                     // Set destination to the target's approximate eye position
                     controller = target.transform.GetComponent<CharacterController>();
-                    Vector3 targetEyePos = target.transform.position;
+                    Vector3 targetEyePos = target.transform.position + controller.center;
                     targetEyePos.y += controller.height / 3;
 
                     // Check if can see.

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1533,8 +1533,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             {
                 EnemyBlood sparkles = readySpell.CasterEntityBehaviour.GetComponent<EnemyBlood>();
 
-                Vector3 sparklesPos = entityBehaviour.transform.position;
                 CharacterController targetController = entityBehaviour.transform.GetComponent<CharacterController>();
+                Vector3 sparklesPos = entityBehaviour.transform.position + targetController.center;
                 sparklesPos.y += targetController.height / 8;
 
                 if (sparkles)

--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -72,13 +72,13 @@ namespace DaggerfallWorkshop.Game
 
                     // Limit maximum controller height
                     // Some particularly tall sprites (e.g. giants) require this hack to get through doors
-                    if (controller.height > 1.75f)
+                    if (controller.height > 1.78f)
                     {
                         // Adjust center so that sprite doesn't sink into the ground
                         Vector3 newCenter = controller.center;
-                        newCenter.y += (1.75f - controller.height) / 2;
+                        newCenter.y += (1.78f - controller.height) / 2;
                         controller.center = newCenter;
-                        controller.height = 1.75f;
+                        controller.height = 1.78f;
                     }
 
                     controller.gameObject.layer = LayerMask.NameToLayer("Enemies");


### PR DESCRIPTION
https://github.com/Interkarma/daggerfall-unity/pull/1120 caused a problem because the adjusted center of the collider interfered with a few calculations that used transform.position and colliders. Specifically, I noticed a Thief and an Orc were no longer able to see each other to fight and would simply stand there looking at each other.

The change in center of the collider is now accounted for.

Also, I found that the player's collider is height 1.78. Enemies now use this value as well. I confirmed the Thief in Privateer's Hold can fit through the door with this value.