### PR TITLE
fix item info panel discrepancy for stacks

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -99,7 +99,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             public override string Worth()
             {
-                return parent.value.ToString();
+                return (parent.value * parent.stackCount).ToString();
             }
 
             public override string Material()


### PR DESCRIPTION
When describing a stack, weight is the total weight of the stack, but the price is unitary price; that's not consistent.
It can be fixed in several ways, that patch uses total price.