### PR TITLE
Texture replacement: allow readonly flag for loose files

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -1043,7 +1043,7 @@ namespace DaggerfallWorkshop.Game
 
             CifRciFile cifRciFile = new CifRciFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, true);
             Texture2D texture;
-            if (!TextureReplacement.TryImportCifRci(name, record, frame, out texture))
+            if (!TextureReplacement.TryImportCifRci(name, record, frame, true, out texture))
             {
                 cifRciFile.LoadPalette(Path.Combine(dfUnity.Arena2Path, cifRciFile.PaletteName));
                 DFBitmap bitmap = cifRciFile.GetDFBitmap(record, frame);

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -993,7 +993,7 @@ namespace DaggerfallWorkshop.Game
 
             ImgFile imgFile = new ImgFile(Path.Combine(dfUnity.Arena2Path, name), FileUsage.UseMemory, readOnly);
             Texture2D texture;
-            if (!TextureReplacement.TryImportImage(name, out texture))
+            if (!TextureReplacement.TryImportImage(name, readOnly, out texture))
             {
                 imgFile.LoadPalette(Path.Combine(dfUnity.Arena2Path, imgFile.PaletteName));
                 texture = GetTextureFromImg(imgFile, format, readOnly);

--- a/Assets/Scripts/Game/FPSSpellCasting.cs
+++ b/Assets/Scripts/Game/FPSSpellCasting.cs
@@ -183,7 +183,7 @@ namespace DaggerfallWorkshop.Game
             for (int record = 0; record < cifFile.RecordCount; record++)
             {
                 Texture2D texture;
-                if (!TextureReplacement.TryImportCifRci(filename, record, 0, out texture))
+                if (!TextureReplacement.TryImportCifRci(filename, record, 0, false, out texture))
                 {
                     // Get Color32 array
                     DFSize sz;

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -487,7 +487,7 @@ namespace DaggerfallWorkshop.Game
                     textures.Add(GetWeaponTexture2D(filename, record, frame, metalType, out rect, border, dilate));
 
                     Texture2D tex;
-                    if (TextureReplacement.TryImportCifRci(filename, record, frame, metalType, out tex))
+                    if (TextureReplacement.TryImportCifRci(filename, record, frame, metalType, false, out tex))
                     {
                         tex.filterMode = dfUnity.MaterialReader.MainFilterMode;
                         customTextures.Add(MaterialReader.MakeTextureKey(0, (byte)record, (byte)frame), tex);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -340,7 +340,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             // Load npc portrait
             string imageName = facePortraitArchive == FacePortraitArchive.CommonFaces ? portraitImgName : facesImgName;
-            if (!TextureReplacement.TryImportCifRci(imageName, recordId, 0, out texturePortrait))
+            if (!TextureReplacement.TryImportCifRci(imageName, recordId, 0, false, out texturePortrait))
             {
                 CifRciFile rciFile = new CifRciFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, imageName), FileUsage.UseMemory, false);
                 rciFile.LoadPalette(Path.Combine(DaggerfallUnity.Instance.Arena2Path, rciFile.PaletteName));

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -164,7 +164,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(int archive, int record, int frame, out Texture2D tex)
         {
-            return TryImportTexture(texturesPath, GetName(archive, record, frame), out tex);
+            return TryImportTexture(texturesPath, GetName(archive, record, frame), false, out tex);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(int archive, int record, int frame, TextureMap textureMap, out Texture2D tex)
         {
-            return TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap), out tex);
+            return TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap), false, out tex);
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         public static bool TryImportTexture(int archive, int record, int frame, TextureMap textureMap, TextureImport textureImport, out Texture2D tex)
         {
             tex = null;
-            return (textureImport == TextureImport.AllLocations && TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap), out tex))
+            return (textureImport == TextureImport.AllLocations && TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap), false, out tex))
                 || (textureImport == TextureImport.LooseFiles && TryImportTextureFromLooseFiles(archive, record, frame, textureMap, out tex));
         }
 
@@ -209,7 +209,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(int archive, int record, int frame, DyeColors dye, out Texture2D tex)
         {
-            return TryImportTexture(texturesPath, GetName(archive, record, frame, dye), out tex);
+            return TryImportTexture(texturesPath, GetName(archive, record, frame, dye), false, out tex);
         }
 
         /// <summary>
@@ -220,18 +220,19 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(string name, out Texture2D tex)
         {
-            return TryImportTexture(texturesPath, name, out tex);
+            return TryImportTexture(texturesPath, name, false, out tex);
         }
 
         /// <summary>
         /// Seek image from modding locations.
         /// </summary>
         /// <param name="name">Image name.</param>
+        /// <param name="readOnly">Release copy on system memory after uploading to gpu.</param>
         /// <param name="tex">Imported image as texture.</param>
         /// <returns>True if image imported.</returns>
-        public static bool TryImportImage(string name, out Texture2D tex)
+        public static bool TryImportImage(string name, bool readOnly, out Texture2D tex)
         {
-            return TryImportTexture(imgPath, name, out tex);
+            return TryImportTexture(imgPath, name, readOnly, out tex);
         }
 
         /// <summary>
@@ -244,7 +245,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if CifRci imported.</returns>
         public static bool TryImportCifRci(string name, int record, int frame, out Texture2D tex)
         {
-            return TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame), out tex);
+            return TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame), false, out tex);
         }
 
         /// <summary>
@@ -258,7 +259,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if CifRci imported.</returns>
         public static bool TryImportCifRci(string name, int record, int frame, MetalTypes metalType, out Texture2D tex)
         {
-            return TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame, metalType), out tex);
+            return TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame, metalType), false, out tex);
         }
 
         /// <summary>
@@ -303,15 +304,16 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="mipMaps">Enable mipmaps?</param>
         /// <param name="encodeAsNormalMap">Convert from RGB to DTXnm.</param>
         /// <param name="tex">Imported texture.</param>
+        /// <param name="readOnly">Release copy on system memory after uploading to gpu.</param>
         /// <returns>True if texture exists and has been imported.</returns>
-        public static bool TryImportTextureFromDisk(string path, bool mipMaps, bool encodeAsNormalMap, out Texture2D tex)
+        public static bool TryImportTextureFromDisk(string path, bool mipMaps, bool encodeAsNormalMap, out Texture2D tex, bool readOnly = true)
         {
             if (!path.EndsWith(extension))
                 path += extension;
 
             if (File.Exists(path))
             {
-                tex = ImportTextureFromDisk(path, mipMaps, encodeAsNormalMap);
+                tex = ImportTextureFromDisk(path, mipMaps, encodeAsNormalMap, readOnly);
                 return true;
             }
 
@@ -748,14 +750,19 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// </summary>
         /// <param name="path">Path on disk (loose files only).</param>
         /// <param name="name">Name of texture.</param>
+        /// <param name="readOnly">Release copy on system memory after uploading to gpu.</param>
         /// <param name="tex">Imported texture.</param>
+        /// <remarks>
+        /// The <paramref name="readOnly"/> flag is only respected by loose files. It is up to mod authors
+        /// to ensure that textures from asset bundles have `Read/Write Enabled` flag set when required.
+        /// </remarks>
         /// <returns>True if texture imported.</returns>
-        private static bool TryImportTexture(string path, string name, out Texture2D tex)
+        private static bool TryImportTexture(string path, string name, bool readOnly, out Texture2D tex)
         {
             if (DaggerfallUnity.Settings.AssetInjection)
             {
                 // Seek from loose files
-                if (TryImportTextureFromDisk(Path.Combine(path, name), false, false, out tex))
+                if (TryImportTextureFromDisk(Path.Combine(path, name), false, false, out tex, readOnly))
                     return true;
 
                 // Seek from mods
@@ -778,11 +785,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         {
             int frame = 0;
             Texture2D tex;
-            if (TryImportTexture(path, getName(frame), out tex))
+            if (TryImportTexture(path, getName(frame), false, out tex))
             {
                 var textures = new List<Texture2D>();
                 do textures.Add(tex);
-                while (TryImportTexture(path, getName(++frame), out tex));
+                while (TryImportTexture(path, getName(++frame), false, out tex));
                 texFrames = textures.ToArray();
                 return true;
             }
@@ -798,12 +805,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="fileName">Name of texture file.</param>
         /// <param name="mipMaps">Enable mipmaps?</param>
         /// <param name="encodeAsNormalMap">Convert from RGB to DTXnm.</param>
+        /// <param name="readOnly">Release copy on system memory after uploading to gpu.</param>
         /// <returns>Imported texture2D.</returns>
-        private static Texture2D ImportTextureFromDisk(string path, bool mipMaps = false, bool encodeAsNormalMap = false)
+        private static Texture2D ImportTextureFromDisk(string path, bool mipMaps = false, bool encodeAsNormalMap = false, bool readOnly = true)
         {
             // Load texture file
             Texture2D tex = new Texture2D(4, 4, TextureFormat, mipMaps);
-            if (!tex.LoadImage(File.ReadAllBytes(path)))
+            if (!tex.LoadImage(File.ReadAllBytes(path), readOnly && !encodeAsNormalMap))
                 Debug.LogErrorFormat("Failed to import texture data at {0}", path);
 
             if (encodeAsNormalMap)
@@ -816,7 +824,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     colours[i].r = colours[i].b = colours[i].g;
                 }
                 tex.SetPixels32(colours);
-                tex.Apply();
+                tex.Apply(true, readOnly);
             }
 
 #if DEBUG_TEXTURE_FORMAT

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -241,11 +241,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="name">Image name.</param>
         /// <param name="record">Record index.</param>
         /// <param name="frame">Animation frame index</param>
+        /// <param name="readOnly">Release copy on system memory after uploading to gpu.</param>
         /// <param name="tex">Imported image as texture.</param>
         /// <returns>True if CifRci imported.</returns>
-        public static bool TryImportCifRci(string name, int record, int frame, out Texture2D tex)
+        public static bool TryImportCifRci(string name, int record, int frame, bool readOnly, out Texture2D tex)
         {
-            return TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame), false, out tex);
+            return TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame), readOnly, out tex);
         }
 
         /// <summary>
@@ -255,9 +256,10 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="record">Record index.</param>
         /// <param name="frame">Animation frame index</param>
         /// <param name="metalType">Metal type.</param>
+        /// <param name="readOnly">Release copy on system memory after uploading to gpu.</param>
         /// <param name="tex">Imported image as texture.</param>
         /// <returns>True if CifRci imported.</returns>
-        public static bool TryImportCifRci(string name, int record, int frame, MetalTypes metalType, out Texture2D tex)
+        public static bool TryImportCifRci(string name, int record, int frame, MetalTypes metalType, bool readOnly, out Texture2D tex)
         {
             return TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame, metalType), false, out tex);
         }

--- a/Assets/Scripts/Utility/ImageReader.cs
+++ b/Assets/Scripts/Utility/ImageReader.cs
@@ -318,7 +318,7 @@ namespace DaggerfallWorkshop.Utility
                     imageData.size = cifFile.GetSize(record);
 
                     // Texture pack support
-                    if (createTexture && AssetInjection.TextureReplacement.TryImportCifRci(filename, record, frame, out imageData.texture))
+                    if (createTexture && AssetInjection.TextureReplacement.TryImportCifRci(filename, record, frame, false, out imageData.texture))
                         createTexture = false;
 
                     break;
@@ -333,7 +333,7 @@ namespace DaggerfallWorkshop.Utility
                     imageData.size = cfaFile.GetSize(record);
 
                     // Texture pack support
-                    if (createTexture && AssetInjection.TextureReplacement.TryImportCifRci(filename, record, frame, out imageData.texture))
+                    if (createTexture && AssetInjection.TextureReplacement.TryImportCifRci(filename, record, frame, false, out imageData.texture))
                         createTexture = false;
 
                     break;

--- a/Assets/Scripts/Utility/ImageReader.cs
+++ b/Assets/Scripts/Utility/ImageReader.cs
@@ -303,7 +303,7 @@ namespace DaggerfallWorkshop.Utility
                     imageData.size = imgFile.GetSize(0);
 
                     // Texture pack support
-                    if (createTexture && AssetInjection.TextureReplacement.TryImportImage(filename, out imageData.texture))
+                    if (createTexture && AssetInjection.TextureReplacement.TryImportImage(filename, false, out imageData.texture))
                         createTexture = false;
 
                     break;

--- a/Assets/Scripts/Utility/TextureReader.cs
+++ b/Assets/Scripts/Utility/TextureReader.cs
@@ -89,7 +89,7 @@ namespace DaggerfallWorkshop.Utility
             if (TextureReplacement.TryImportImage(image.FileName, makeNoLongerReadable, out texture))
                 return texture;
 
-            if (TextureReplacement.TryImportCifRci(image.FileName, record, frame, out texture))
+            if (TextureReplacement.TryImportCifRci(image.FileName, record, frame, makeNoLongerReadable, out texture))
                 return texture;
 
             DFSize sz;

--- a/Assets/Scripts/Utility/TextureReader.cs
+++ b/Assets/Scripts/Utility/TextureReader.cs
@@ -86,7 +86,7 @@ namespace DaggerfallWorkshop.Utility
             }
 
             Texture2D texture;
-            if (TextureReplacement.TryImportImage(image.FileName, out texture))
+            if (TextureReplacement.TryImportImage(image.FileName, makeNoLongerReadable, out texture))
                 return texture;
 
             if (TextureReplacement.TryImportCifRci(image.FileName, record, frame, out texture))


### PR DESCRIPTION
This PR allows to specify readonly flag for individual textures used by UI when image data is imported from loose files. We have no control over asset bundles so this is still up to mod authors.