### PR TITLE
reuse CheckLocationDiscovered to allow notebook fast travel

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -339,8 +339,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DFLocation location;
             if (DaggerfallUnity.Instance.ContentReader.GetLocation(regionName, name, out location))
             {
-                int mapPixelID = MapsFile.GetMapPixelIDFromLongitudeLatitude(location.MapTableData.Longitude, location.MapTableData.Latitude);
-                return GameManager.Instance.PlayerGPS.HasDiscoveredLocation(mapPixelID);
+                DFPosition mapPixel = MapsFile.LongitudeLatitudeToMapPixel(location.MapTableData.Longitude, location.MapTableData.Latitude);
+                ContentReader.MapSummary summary;
+                if (DaggerfallUnity.Instance.ContentReader.HasLocation(mapPixel.X, mapPixel.Y, out summary))
+                    return DaggerfallUI.Instance.DfTravelMapWindow.CheckLocationDiscovered(summary);
             }
             return false;
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -333,20 +333,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Private Methods
 
-        // Check if place is discovered, so it can be found on map.
-        private bool CanFindPlace(string regionName, string name)
-        {
-            DFLocation location;
-            if (DaggerfallUnity.Instance.ContentReader.GetLocation(regionName, name, out location))
-            {
-                DFPosition mapPixel = MapsFile.LongitudeLatitudeToMapPixel(location.MapTableData.Longitude, location.MapTableData.Latitude);
-                ContentReader.MapSummary summary;
-                if (DaggerfallUnity.Instance.ContentReader.HasLocation(mapPixel.X, mapPixel.Y, out summary))
-                    return DaggerfallUI.Instance.DfTravelMapWindow.CheckLocationDiscovered(summary);
-            }
-            return false;
-        }
-
         private void HandleClick(Vector2 position, bool remove = false)
         {
             if (entryLineMap == null)
@@ -372,7 +358,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     place.SiteDetails.locationName != GameManager.Instance.PlayerGPS.CurrentLocation.Name)
                 {
                     findPlaceName = place.SiteDetails.locationName;
-                    if (CanFindPlace(place.SiteDetails.regionName, findPlaceName))
+                    if (DaggerfallUI.Instance.DfTravelMapWindow.CanFindPlace(place.SiteDetails.regionName, findPlaceName))
                     {
                         findPlaceRegion = DaggerfallUnity.Instance.ContentReader.MapFileReader.GetRegionIndex(place.SiteDetails.regionName);
                         string entryStr = string.Format("{0} in {1} province", findPlaceName, place.SiteDetails.regionName);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -981,13 +981,28 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
 
         // checks if location with MapSummary summary is already discovered
-        public bool CheckLocationDiscovered(ContentReader.MapSummary summary)
+        bool checkLocationDiscovered(ContentReader.MapSummary summary)
         {
             if (GameManager.Instance.PlayerGPS.HasDiscoveredLocation(summary.ID) ||
                 summary.Discovered ||
                 revealUndiscoveredLocations == true)
             {
                 return true;
+            }
+            return false;
+        }
+
+
+        // Check if place is discovered, so it can be found on map.
+        public bool CanFindPlace(string regionName, string name)
+        {
+            DFLocation location;
+            if (DaggerfallUnity.Instance.ContentReader.GetLocation(regionName, name, out location))
+            {
+                DFPosition mapPixel = MapsFile.LongitudeLatitudeToMapPixel(location.MapTableData.Longitude, location.MapTableData.Latitude);
+                ContentReader.MapSummary summary;
+                if (DaggerfallUnity.Instance.ContentReader.HasLocation(mapPixel.X, mapPixel.Y, out summary))
+                    return checkLocationDiscovered(summary);
             }
             return false;
         }
@@ -1026,7 +1041,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                             ContentReader.MapSummary summary;
                             if (DaggerfallUnity.Instance.ContentReader.HasLocation(originX + x, originY + y, out summary))
                             {
-                                if (!CheckLocationDiscovered(summary))
+                                if (!checkLocationDiscovered(summary))
                                     continue;
 
                                 int index = GetPixelColorIndex(summary.LocationType);
@@ -1127,7 +1142,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         return;
 
                     // only make location selectable if it is already discovered
-                    if (!CheckLocationDiscovered(locationSummary))
+                    if (!checkLocationDiscovered(locationSummary))
                         return;
 
                     locationSelected = true;
@@ -1379,7 +1394,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (DaggerfallUnity.ContentReader.HasLocation(pos.X, pos.Y, out locationSummary))
                     {
                         // only make location searchable if it is already discovered
-                        if (!CheckLocationDiscovered(locationSummary))
+                        if (!checkLocationDiscovered(locationSummary))
                             continue;
 
                         return true;
@@ -1403,7 +1418,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (DaggerfallUnity.ContentReader.HasLocation(pos.X, pos.Y, out locationSummary))
                     {
                         // only make location searchable if it is already discovered
-                        if (!CheckLocationDiscovered(locationSummary))
+                        if (!checkLocationDiscovered(locationSummary))
                             continue;
 
                         return true;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -981,7 +981,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
 
         // checks if location with MapSummary summary is already discovered
-        bool checkLocationDiscovered(ContentReader.MapSummary summary)
+        public bool CheckLocationDiscovered(ContentReader.MapSummary summary)
         {
             if (GameManager.Instance.PlayerGPS.HasDiscoveredLocation(summary.ID) ||
                 summary.Discovered ||
@@ -1026,7 +1026,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                             ContentReader.MapSummary summary;
                             if (DaggerfallUnity.Instance.ContentReader.HasLocation(originX + x, originY + y, out summary))
                             {
-                                if (!checkLocationDiscovered(summary))
+                                if (!CheckLocationDiscovered(summary))
                                     continue;
 
                                 int index = GetPixelColorIndex(summary.LocationType);
@@ -1127,7 +1127,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         return;
 
                     // only make location selectable if it is already discovered
-                    if (!checkLocationDiscovered(locationSummary))
+                    if (!CheckLocationDiscovered(locationSummary))
                         return;
 
                     locationSelected = true;
@@ -1379,7 +1379,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (DaggerfallUnity.ContentReader.HasLocation(pos.X, pos.Y, out locationSummary))
                     {
                         // only make location searchable if it is already discovered
-                        if (!checkLocationDiscovered(locationSummary))
+                        if (!CheckLocationDiscovered(locationSummary))
                             continue;
 
                         return true;
@@ -1403,7 +1403,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (DaggerfallUnity.ContentReader.HasLocation(pos.X, pos.Y, out locationSummary))
                     {
                         // only make location searchable if it is already discovered
-                        if (!checkLocationDiscovered(locationSummary))
+                        if (!CheckLocationDiscovered(locationSummary))
                             continue;
 
                         return true;


### PR DESCRIPTION
#1084 made notebook fast travel checks too strict, for instance not allowing to fast travel to a town you didn't visit before.
Forums: https://forums.dfworkshop.net/viewtopic.php?f=28&t=1578&p=19594#p19575
This patch reuses DaggerfallTravelMapWindow.CheckLocationDiscovered(), I hope that's the right thing to do.
