### PR TITLE
Optimise applying climate settings for locations and asset injection checks

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -57,6 +57,7 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(SetHealth.name, SetHealth.description, SetHealth.usage, SetHealth.Execute);
 
             ConsoleCommandsDatabase.RegisterCommand(ResetAssets.name, ResetAssets.description, ResetAssets.usage, ResetAssets.Execute);
+            ConsoleCommandsDatabase.RegisterCommand(RetryAssetImports.name, RetryAssetImports.description, RetryAssetImports.usage, RetryAssetImports.Execute);
 
             ConsoleCommandsDatabase.RegisterCommand(SetWalkSpeed.name, SetWalkSpeed.description, SetWalkSpeed.usage, SetWalkSpeed.Execute);
             ConsoleCommandsDatabase.RegisterCommand(SetMouseSensitivity.name, SetMouseSensitivity.description, SetMouseSensitivity.usage, SetMouseSensitivity.Execute);
@@ -351,6 +352,21 @@ namespace Wenzil.Console
                 SaveLoadManager.Instance.QuickSave(true);
 
                 return "Cleared cache and reloaded world.";
+            }
+        }
+
+        private static class RetryAssetImports
+        {
+            public static readonly string name = "retry_assets";
+            public static readonly string error = "Could not retry asset imports";
+            public static readonly string description = "Clears records of import attempts for assets from loose files and mods.";
+            public static readonly string usage = "retry_assets";
+
+            public static string Execute(params string[] args)
+            {
+                MeshReplacement.RetryAssetImports();
+
+                return "Cleared records of import attempts for assets from loose files and mods.";
             }
         }
 

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -31,6 +31,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static Func<Color32> getTreeColorCallback = () => Color.Lerp(Color.white, Color.grey, Random.value);
         static Action<Terrain> setTreesSettingsCallback = SetTreesSettings;
 
+        static HashSet<string> triedBillboards = new HashSet<string>();
+        static HashSet<string[]> triedModels = new HashSet<string[]>();
+
         #endregion
 
         #region Properties
@@ -53,6 +56,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         #endregion
 
         #region Public Methods
+
+        public static void RetryAssetImports()
+        {
+            triedBillboards.Clear();
+            triedModels.Clear();
+        }
 
         /// <summary>
         /// Seek and import a GameObject from mods to replace a Daggerfall mesh.
@@ -196,7 +205,16 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             if (DaggerfallUnity.Settings.AssetInjection)
             {
                 if (ModManager.Instance != null)
-                    return ModManager.Instance.TryGetAsset(GetName(modelID), clone, out go);
+                {
+                    string[] names = GetName(modelID);
+                    if (!triedModels.Contains(names))
+                    {
+                        bool found = ModManager.Instance.TryGetAsset(names, clone, out go);
+                        if (!found)
+                            triedModels.Add(names);
+                        return found;
+                    }
+                }
             }
 
             go = null;
@@ -211,7 +229,16 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             if (DaggerfallUnity.Settings.AssetInjection)
             {
                 if (ModManager.Instance != null)
-                    return ModManager.Instance.TryGetAsset(GetName(archive, record), clone, out go);
+                {
+                    string name = GetName(archive, record);
+                    if (!triedBillboards.Contains(name))
+                    {
+                        bool found = ModManager.Instance.TryGetAsset(name, clone, out go);
+                        if (!found)
+                            triedBillboards.Add(name);
+                        return found;
+                    }
+                }
             }
 
             go = null;

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -31,8 +31,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         static Func<Color32> getTreeColorCallback = () => Color.Lerp(Color.white, Color.grey, Random.value);
         static Action<Terrain> setTreesSettingsCallback = SetTreesSettings;
 
-        static HashSet<string> triedBillboards = new HashSet<string>();
-        static HashSet<string[]> triedModels = new HashSet<string[]>();
+        static HashSet<Vector2Int> triedBillboards = new HashSet<Vector2Int>();
+        static HashSet<uint> triedModels = new HashSet<uint>();
 
         #endregion
 
@@ -206,12 +206,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             {
                 if (ModManager.Instance != null)
                 {
-                    string[] names = GetName(modelID);
-                    if (!triedModels.Contains(names))
+                    if (!triedModels.Contains(modelID))
                     {
-                        bool found = ModManager.Instance.TryGetAsset(names, clone, out go);
+                        bool found = ModManager.Instance.TryGetAsset(GetName(modelID), clone, out go);
                         if (!found)
-                            triedModels.Add(names);
+                            triedModels.Add(modelID);
                         return found;
                     }
                 }
@@ -230,12 +229,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             {
                 if (ModManager.Instance != null)
                 {
-                    string name = GetName(archive, record);
-                    if (!triedBillboards.Contains(name))
+                    Vector2Int billboardIdx = new Vector2Int(archive, record);
+                    if (!triedBillboards.Contains(billboardIdx))
                     {
-                        bool found = ModManager.Instance.TryGetAsset(name, clone, out go);
+                        bool found = ModManager.Instance.TryGetAsset(GetName(archive, record), clone, out go);
                         if (!found)
-                            triedBillboards.Add(name);
+                            triedBillboards.Add(billboardIdx);
                         return found;
                     }
                 }


### PR DESCRIPTION
1)
If not yielding across frames, only apply climate settings once dfLocation is completely initialised instead of for every block. This needs to be verified as logically correct before merging. I'm pretty sure that it can be moved but I don't have a deep enough understanding of this code to be absolutely sure

Also improved layout times diagnostics.

This optimisation almost halves the time it takes to construct a city location when exiting buildings after loading an interior save. I stumbled across it when analysing the exterior world code to see how it might have parallelisation applied. 

2)
Only check for assets to be injected once by keeping a record of tried assets. This halves the time taken to layout terrain because of the sheer number (hundreds of thousands) of them. Most players will have asset injection switched on, and I think it's okay to check each asset once only.

Also I added a command to clear the cache of asset names, although you don't appear to be able to change assets and have them loaded by Unity without restarting the game so not sure it's particularly useful.

