### PR TITLE
Make town population textures from areas with 'MountainWoods' climate value match classic

### DIFF
--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -456,8 +456,8 @@ namespace DaggerfallConnect.Arena2
                     settings.GroundArchive = 102;
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_TemperateWoodland;
                     settings.SkyBase = 16;
-                    settings.People = FactionFile.FactionRaces.Nord;
-                    settings.Names = FactionFile.FactionRaces.Nord;
+                    settings.People = FactionFile.FactionRaces.Breton;
+                    settings.Names = FactionFile.FactionRaces.Breton;
                     break;
                 case (int)Climates.Woodlands:
                     settings.ClimateType = DFLocation.ClimateBaseType.Temperate;


### PR DESCRIPTION
In classic, areas under climate value equal or above 230 (MountainWoods) use Breton race and names for town people.
This fixes DFU to match classic.
Actually, another difference with classic I couldn't fix yet is that town people names should not be generated according to climate values. E.g. in classic, Dragontail people use Nord textures (climate value 226, Mountain) with Redguard names, whereas Wrothgarian people (same climate value) use Nord textures with Breton names.