### PR TITLE
Rain and thunder

### DIFF
--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -162,43 +162,12 @@ namespace DaggerfallWorkshop.Game
             return audioSource;
         }
 
-        private IEnumerator PlayWhenReady(AudioClip audioClip, float volume)
-        {
-            float loadWaitTimer = 0f;
-            while (audioClip.loadState == AudioDataLoadState.Unloaded ||
-                   audioClip.loadState == AudioDataLoadState.Loading)
-            {
-                loadWaitTimer += Time.deltaTime;
-                if (loadWaitTimer > DaggerfallAudioSource.audioClipMaxDelay)
-                    yield break;
-                yield return null;
-            }
-            loopAudioSource.volume = volume;
-            loopAudioSource.Play();
-        }
-
-        private IEnumerator PlayOneShotWhenReady(AudioClip audioClip, float volume)
-        {
-            float loadWaitTimer = 0f;
-            while (audioClip.loadState == AudioDataLoadState.Unloaded ||
-                   audioClip.loadState == AudioDataLoadState.Loading)
-            {
-                loadWaitTimer += Time.deltaTime;
-                if (loadWaitTimer > DaggerfallAudioSource.audioClipMaxDelay)
-                    yield break;
-                yield return null;
-            }
-            ambientAudioSource.volume = volume;
-            ambientAudioSource.PlayOneShot(audioClip);
-        }
-
         private AudioClip PlayLoop(SoundClips clip, float volumeScale)
         {
             AudioClip loopClip = dfAudioSource.GetAudioClip((int)clip);
-            loopAudioSource.clip = loopClip;
             loopAudioSource.loop = true;
             loopAudioSource.spatialBlend = 0;
-            DaggerfallUnity.Instance.StartCoroutine(PlayWhenReady(loopClip, volumeScale * DaggerfallUnity.Settings.SoundVolume));
+            loopAudioSource.PlayWhenReady(loopClip, volumeScale);
             return loopClip;
         }
 
@@ -206,7 +175,7 @@ namespace DaggerfallWorkshop.Game
         {
             AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
             ambientAudioSource.spatialBlend = 0;
-            DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(audioClip, volumeScale * DaggerfallUnity.Settings.SoundVolume));
+            ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
         }
 
         private void SpatializedPlayOneShot(SoundClips clip, Vector3 position, float volumeScale)
@@ -214,7 +183,7 @@ namespace DaggerfallWorkshop.Game
             AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
             ambientAudioSource.transform.position = position;
             ambientAudioSource.spatialBlend = 1f;
-            DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(audioClip, volumeScale * DaggerfallUnity.Settings.SoundVolume));
+            ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
         }
 
         private void PlayEffects()

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -134,7 +134,7 @@ namespace DaggerfallWorkshop.Game
                         Vector3 waterSoundPosition = playerBehaviour.transform.position;
                         waterSoundPosition.y = playerEnterExit.blockWaterLevel * -1 * MeshReader.GlobalScale;
                         waterSoundPosition.x += Random.Range(-3, 3);
-                        waterSoundPosition.y += Random.Range(-3, 3);
+                        waterSoundPosition.z += Random.Range(-3, 3);
                         SpatializedPlayOneShot(SoundClips.WaterGentle, waterSoundPosition, 3f);
                     }
 

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -11,7 +11,6 @@
 
 using UnityEngine;
 using System.Collections;
-using System;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -405,27 +404,6 @@ namespace DaggerfallWorkshop.Game
             }
 
             lastPresets = Presets;
-            //dfAudioSource.SetSound(-1, AudioPresets.OnDemand, 0);
-            //if (!ReadyCheck() || !ambientAudioSource.enabled)
-                //return;
-        }
-
-        private bool ReadyCheck()
-        {
-            // Ensure we have a DaggerfallUnity reference
-            if (dfUnity == null)
-                dfUnity = DaggerfallUnity.Instance;
-            if (!dfUnity.IsReady)
-                return false;
-
-            // Get audio source
-            if (ambientAudioSource == null)
-            {
-                DaggerfallUnity.LogMessage("ambientAudioSource: not ready.");
-                return false;
-            }
-
-            return true;
         }
 
         #endregion

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -34,6 +34,7 @@ namespace DaggerfallWorkshop.Game
         DaggerfallAudioSource dfAudioSource;
         AudioSource loopAudioSource;
         AudioSource ambientAudioSource;
+        private Coroutine relativePositionCoroutine = null;
 
         SoundClips[] ambientSounds;
         AudioClip rainLoop;
@@ -191,7 +192,9 @@ namespace DaggerfallWorkshop.Game
             AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
             ambientAudioSource.spatialBlend = 1f;
             ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
-            StartCoroutine(UpdateAmbientSoundRelativePosition(relativePosition));
+            if (relativePositionCoroutine != null)
+                StopCoroutine(relativePositionCoroutine);
+            relativePositionCoroutine = StartCoroutine(UpdateAmbientSoundRelativePosition(relativePosition));
         }
 
         private IEnumerator UpdateAmbientSoundRelativePosition(Vector3 relativePosition)

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -186,6 +186,23 @@ namespace DaggerfallWorkshop.Game
             ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
         }
 
+        private void RelativePlayOneShot(SoundClips clip, Vector3 relativePosition, float volumeScale)
+        {
+            AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
+            ambientAudioSource.spatialBlend = 1f;
+            ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
+            StartCoroutine(UpdateAmbientSoundRelativePosition(relativePosition));
+        }
+
+        private IEnumerator UpdateAmbientSoundRelativePosition(Vector3 relativePosition)
+        {
+            while (ambientAudioSource.isPlaying)
+            {
+                ambientAudioSource.transform.position = playerBehaviour.transform.position + relativePosition;
+                yield return new WaitForEndOfFrame();
+            }
+        }
+
         private void PlaySomewhereAround(SoundClips clip, float volumeScale)
         {
             Vector3 randomPos = playerBehaviour.transform.position +
@@ -196,9 +213,8 @@ namespace DaggerfallWorkshop.Game
         private void PlaySomewhereOnHorizon(SoundClips clip, float volumeScale)
         {
             // Somewhere around, 20° above horizon
-            Vector3 randomPos = playerBehaviour.transform.position +
-                Quaternion.AngleAxis(Random.Range(0f, 360f), Vector3.up) * new Vector3(0.94f, 0.34f, 0f);
-            SpatializedPlayOneShot(clip, randomPos, volumeScale);
+            Vector3 randomPos = Quaternion.AngleAxis(Random.Range(0f, 360f), Vector3.up) * new Vector3(0.94f, 0.34f, 0f);
+            RelativePlayOneShot(clip, randomPos, volumeScale);
         }
 
         private void PlayEffects()

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -44,7 +44,6 @@ namespace DaggerfallWorkshop.Game
         AmbientSoundPresets lastPresets;
         Entity.DaggerfallEntityBehaviour playerBehaviour;
         PlayerEnterExit playerEnterExit;
-        private DaggerfallUnity dfUnity;
 
         public enum AmbientSoundPresets
         {
@@ -63,7 +62,6 @@ namespace DaggerfallWorkshop.Game
             loopAudioSource = GetNewAudioSource();
             ambientAudioSource = GetNewAudioSource();
 
-            // dfAudioSource.Preset = AudioPresets.OnDemand;
             ApplyPresets();
             StartWaiting();
             playerBehaviour = GameManager.Instance.PlayerEntityBehaviour;
@@ -161,7 +159,6 @@ namespace DaggerfallWorkshop.Game
             audioSource.dopplerLevel = 0f;
             audioSource.spatialBlend = 0f;
             audioSource.volume = DaggerfallUnity.Settings.SoundVolume;
-            Debug.Log("GetNewAudioSource:" + audioSource);
             return audioSource;
         }
 

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -343,7 +343,7 @@ namespace DaggerfallWorkshop.Game
 
             // Delay for sound effect
             if (soundDelay > 0)
-                yield return new WaitForSeconds(1f / soundDelay);
+                yield return new WaitForSeconds(soundDelay);
 
             // Play sound effect
             AmbientPlayOneShot(clip, 1f);

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -186,6 +186,21 @@ namespace DaggerfallWorkshop.Game
             ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
         }
 
+        private void PlaySomewhereAround(SoundClips clip, float volumeScale)
+        {
+            Vector3 randomPos = playerBehaviour.transform.position +
+                Random.onUnitSphere * 5.2f;
+            SpatializedPlayOneShot(clip, randomPos, volumeScale);
+        }
+
+        private void PlaySomewhereOnHorizon(SoundClips clip, float volumeScale)
+        {
+            // Somewhere around, 20° above horizon
+            Vector3 randomPos = playerBehaviour.transform.position +
+                Quaternion.AngleAxis(Random.Range(0f, 360f), Vector3.up) * new Vector3(0.94f, 0.34f, 0f);
+            SpatializedPlayOneShot(clip, randomPos, volumeScale);
+        }
+
         private void PlayEffects()
         {
             // Do nothing if audio not setup
@@ -196,10 +211,22 @@ namespace DaggerfallWorkshop.Game
             int index = random.Next(0, ambientSounds.Length);
 
             // Play effect
-            if (Presets == AmbientSoundPresets.Storm && PlayLightningEffect)
+            if (Presets == AmbientSoundPresets.Storm)
             {
-                // Play lightning effects together with appropriate sounds
-                StartCoroutine(PlayLightningEffects(index));
+                if (PlayLightningEffect)
+                {
+                    // Play lightning effects together with appropriate sounds
+                    StartCoroutine(PlayLightningEffects(index));
+                }
+                else
+                {
+                    // Play ambient sound as a one-shot 3D sound
+                    SoundClips clip = ambientSounds[index];
+                    PlaySomewhereOnHorizon(clip, 5f);
+
+                    // AmbientPlayOneShot(clip, 5f);
+                    RaiseOnPlayEffectEvent(clip);
+                }
             }
             else
             {
@@ -216,27 +243,7 @@ namespace DaggerfallWorkshop.Game
 
                 // Play ambient sound as a one-shot 3D sound
                 SoundClips clip = ambientSounds[index];
-                Vector3 randomPos = playerBehaviour.transform.position;
-                bool positiveChange = Random.Range(0, 1) == 0;
-                if (positiveChange)
-                    randomPos.x += 3;
-                else
-                    randomPos.x += -3;
-
-                positiveChange = Random.Range(0, 1) == 0;
-
-                if (positiveChange)
-                    randomPos.y += 3;
-                else
-                    randomPos.y += -3;
-
-                positiveChange = Random.Range(0, 1) == 0;
-                if (positiveChange)
-                    randomPos.z += 3;
-                else
-                    randomPos.z += -3;
-
-                SpatializedPlayOneShot(clip, randomPos, 5f);
+                PlaySomewhereAround(clip, 5f);
                 RaiseOnPlayEffectEvent(clip);
             }
         }
@@ -312,7 +319,7 @@ namespace DaggerfallWorkshop.Game
                 yield return new WaitForSeconds(soundDelay);
 
             // Play sound effect
-            AmbientPlayOneShot(clip, 1f);
+            PlaySomewhereOnHorizon(clip, 5f);
 
             // Raise event
             RaiseOnPlayEffectEvent(clip);

--- a/Assets/Scripts/Internal/AudioSourceExtensionMethods.cs
+++ b/Assets/Scripts/Internal/AudioSourceExtensionMethods.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using DaggerfallWorkshop;
+
+namespace UnityEngine
+{
+    public static class AudioSourceExtensionMethods
+    {
+        private const float audioClipMaxDelay = 0.150f; //give up if sound takes longer to load
+
+        public static void PlayWhenReady(this AudioSource audioSource, AudioClip audioClip, float volumeScale)
+        {
+            DaggerfallUnity.Instance.StartCoroutine(audioSource.PlayWhenReadyCoroutine(audioClip, volumeScale * DaggerfallUnity.Settings.SoundVolume));
+        }
+
+        private static IEnumerator PlayWhenReadyCoroutine(this AudioSource audioSource, AudioClip audioClip, float volume)
+        {
+            float loadWaitTimer = 0f;
+            while (audioClip.loadState == AudioDataLoadState.Unloaded ||
+                   audioClip.loadState == AudioDataLoadState.Loading)
+            {
+                loadWaitTimer += Time.deltaTime;
+                if (loadWaitTimer > audioClipMaxDelay)
+                    yield break;
+                yield return null;
+            }
+            audioSource.clip = audioClip;
+            audioSource.volume = volume;
+            audioSource.Play();
+        }
+
+        public static void PlayOneShotWhenReady(this AudioSource audioSource, AudioClip audioClip, float volumeScale)
+        {
+            DaggerfallUnity.Instance.StartCoroutine(audioSource.PlayOneShotWhenReadyCoroutine(audioClip, volumeScale * DaggerfallUnity.Settings.SoundVolume));
+        }
+
+        private static IEnumerator PlayOneShotWhenReadyCoroutine(this AudioSource audioSource, AudioClip audioClip, float volume)
+        {
+            float loadWaitTimer = 0f;
+            while (audioClip.loadState == AudioDataLoadState.Unloaded ||
+                   audioClip.loadState == AudioDataLoadState.Loading)
+            {
+                loadWaitTimer += Time.deltaTime;
+                if (loadWaitTimer > audioClipMaxDelay)
+                    yield break;
+                yield return null;
+            }
+            audioSource.volume = volume;
+            audioSource.PlayOneShot(audioClip);
+        }
+
+    }
+}

--- a/Assets/Scripts/Internal/AudioSourceExtensionMethods.cs.meta
+++ b/Assets/Scripts/Internal/AudioSourceExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca5163e9e42c44d588ec65598f1b6cc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -28,8 +28,6 @@ namespace DaggerfallWorkshop
     [RequireComponent(typeof(AudioSource))]
     public class DaggerfallAudioSource : MonoBehaviour
     {
-        public const float audioClipMaxDelay = 0.150f; //give up if sound takes longer to load
-
         const int minIndex = 0;
         const int maxIndex = 458;
 
@@ -129,7 +127,7 @@ namespace DaggerfallWorkshop
                 PreviewID = (int)dfUnity.SoundReader.GetSoundID(PreviewIndex);
                 PreviewClip = (SoundClips)PreviewIndex;
                 AudioClip clip = dfUnity.SoundReader.GetAudioClip(PreviewIndex);
-                DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(clip, 1.0f));
+                audioSource.PlayOneShotWhenReady(clip, 1.0f);
             }
         }
 
@@ -209,23 +207,9 @@ namespace DaggerfallWorkshop
                 if (clip)
                 {
                     audioSource.spatialBlend = spatialBlend;
-                    DaggerfallUnity.Instance.StartCoroutine(PlayOneShotWhenReady(clip, volumeScale * DaggerfallUnity.Settings.SoundVolume));
+                    audioSource.PlayOneShotWhenReady(clip, volumeScale);
                 }
             }
-        }
-
-        private IEnumerator PlayOneShotWhenReady(AudioClip audioClip, float volume)
-        {
-            float loadWaitTimer = 0f;
-            while (audioClip.loadState == AudioDataLoadState.Unloaded ||
-                   audioClip.loadState == AudioDataLoadState.Loading)
-            {
-                loadWaitTimer += Time.deltaTime;
-                if (loadWaitTimer > audioClipMaxDelay)
-                    yield break;
-                yield return null;
-            }
-            audioSource.PlayOneShot(audioClip, volume);
         }
 
         /// <summary>

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -28,7 +28,7 @@ namespace DaggerfallWorkshop
     [RequireComponent(typeof(AudioSource))]
     public class DaggerfallAudioSource : MonoBehaviour
     {
-        const float audioClipMaxDelay = 0.150f; //give up if sound takes longer to load
+        public const float audioClipMaxDelay = 0.150f; //give up if sound takes longer to load
 
         const int minIndex = 0;
         const int maxIndex = 458;


### PR DESCRIPTION
Allows ambient sound effects and ambient sound loops to play at the same time.

Main issue I have with that code is that I needed to duplicate some of DaggerfallAudioSource features (to work correctly with modded sounds), so it'd better be factorized at some point...

(Lost a lot of time because the compiler was silently failing (Monodevelop added "using System" that made "Random." ambiguous) so I kept running the last version of the game that compiled, not understanding why my changes had no effect :( )