### PR TITLE
Match enemy melee detection to classic

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -180,8 +180,9 @@ namespace DaggerfallWorkshop.Game
 
                 damage = 0;
 
-                // Are we still in range and facing target? Then apply melee damage.
-                if (senses.Target != null && senses.DistanceToTarget <= MeleeDistance && senses.TargetInSight)
+                // Melee hit detection, matched to classic
+                if (senses.Target != null && senses.TargetInSight && senses.DistanceToTarget <= 0.25f
+                    || (senses.DistanceToTarget <= MeleeDistance && senses.TargetIsWithinYawAngle(35.156f, senses.Target.transform.position)))
                 {
                     if (senses.Target == GameManager.Instance.PlayerEntityBehaviour)
                         damage = ApplyDamageToPlayer(weapon);

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -139,7 +139,7 @@ namespace DaggerfallWorkshop.Game
         private bool MeleeAnimation()
         {
             // Are we in range and facing target? Then start attack.
-            if (senses.TargetInSight && senses.DetectedTarget)
+            if (senses.DetectedTarget && senses.TargetIsWithinYawAngle(22.5f, senses.LastKnownTargetPos))
             {
                 // Take the rate of target approach into account when deciding if to attack
                 if (senses.DistanceToTarget >= MeleeDistance + senses.TargetRateOfApproach)

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -469,7 +469,7 @@ namespace DaggerfallWorkshop.Game
             }
             // Back away from combat target if right next to it, or if decided to retreat and enemy is too close.
             // Classic AI never backs awwy.
-            else if (DaggerfallUnity.Settings.EnhancedCombatAI && senses.TargetInSight && (distance < stopDistance * .50 ||
+            else if (DaggerfallUnity.Settings.EnhancedCombatAI && senses.TargetInSight && (distance < stopDistance * .8f ||
                 (!moveInForAttack && distance < (stopDistance * retreatDistanceMultiplier))))
             {
                 // If state change timer is done, or we are already executing a retreat, we can move immediately


### PR DESCRIPTION
For https://forums.dfworkshop.net/viewtopic.php?f=24&t=1531. (I'm going to say, fixes it)

Did this in 3 steps.

1. Matched enemy hit registration calculation to classic. Before you could be hit as long as you were in the enemy FOV, so essentially in a 180 degree arc. Now you have to be in about a 70 degree arc, same as classic (unless enemy is right on top of you (= less than .25f distance), then it hits regardless. This is also matched to classic)

2. After doing the above, I noticed that enemies still initiated the melee animation based on target being in the 180 degree arc. Now they do so with a 45 degree arc, same as classic. (The actual hit registration happens with a 70 degree arc as mentioned above)

3. After doing both of the above, I noticed that enemies pursuing the player could end up really close to the screen and would stay there (This became more evident, because they would no longer initiate an attack while close to the player and outside of the 45 degree arc, and would instead continue approaching the player) . They would get very close because they pursue based on the target's predicted location and use that predicted spot for the distance calculation, which will be behind the player or beside the player if the player is backing up, going sideways, etc. as I was in testing. At first I fixed this by using the actual distance to the target, and this worked to stop them from getting so close, but I wondered why enemies hadn't backed up when too close even though I already had a mechanism for this in EnemyMotor for some time now. I found that the existing mechanism was requiring the enemy to be excessively close before making the enemy back up, so I decided to instead fix this issue by starting back up behavior from a little farther away. This was a simpler fix and I also kind of like the effect of pursuing enemy's getting up in the screen and then backing up a step or two if you stop moving and they have gotten too close to you. Classic AI mode doesn't predict target location or do any backing up so it should be unaffected.