### PR TITLE
Account for frost daedra melee hit frame

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -307,6 +307,14 @@ namespace DaggerfallWorkshop
                 // Set back to idle (which every enemy has in one form or another)
                 summary.EnemyState = MobileStates.Idle;
                 summary.StateAnims = GetStateAnims(summary.EnemyState);
+            }
+
+            // One of the frost daedra's sets of attack frames starts with the hit frame (-1), so we need to check for that right away before updating orientation.
+            if (currentFrame == -1 && summary.EnemyState == MobileStates.PrimaryAttack)
+            {
+                doMeleeDamage = true;
+                if (frameIterator < summary.StateAnimFrames.Length)
+                    currentFrame = summary.StateAnimFrames[frameIterator++];
             }
 
             // Orient enemy relative to camera


### PR DESCRIPTION
Fix for https://forums.dfworkshop.net/viewtopic.php?f=24&t=1720&sid=39928d1297b723ceeefe6d27d6644408.

I wasn't getting an exception but I was getting the messed up aspect ratio, and noticed what the problem was. The frost daedra is unique in having an attack animation sequence that starts with the hit frame. When I set up the animation sequences that I got from the original .ANC files, I used "-1" to represent the hit frame (in the actual .ANC files it's the sequence `02 01 00` for a melee animation's hit frame and `02 02 00` for a bow animation's frame to release the arrow). I account for the "-1" value in `AnimateEnemy()` (which in this case will initiate a melee hit and then skips over to the next value in the frame sequence) but in the setup where `UpdateOrientation()` is called, the value of "-1" was just used as it was and the program tried to access out of the animation range.