### PR TITLE
TextureReplacement: disable emission maps on non-emissive lights

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -384,10 +384,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
             if (summary.ImportedTextures.HasImportedTextures = hasImportedTextures)
             {
-                // Set texture on material
+                // Set textures on material; emission is always overriden, with actual texture or null.
                 meshRenderer.material.SetTexture(Uniforms.MainTex, albedo);
-                if (isEmissive)
-                    meshRenderer.material.SetTexture(Uniforms.EmissionMap, emission);
+                meshRenderer.material.SetTexture(Uniforms.EmissionMap, emission);
+                if (!isEmissive)
+                    meshRenderer.material.DisableKeyword(KeyWords.Emission);
 
                 // Import animation frames
                 var albedoTextures = new List<Texture2D>();


### PR DESCRIPTION
The light archive contains emissive and non emissive textures. If we want to allow replacing individual textures, we need to load the atlas and override only the imported textures. This includes the emission atlas.