### PR TITLE
Non-quest classic rumor implementation

### DIFF
--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -44,7 +44,7 @@ namespace DaggerfallConnect.Arena2
         /// <summary>
         /// All region names.
         /// </summary>
-        private readonly string[] regionNames = {
+        private static readonly string[] regionNames = {
             "Alik'r Desert", "Dragontail Mountains", "Glenpoint Foothills", "Daggerfall Bluffs",
             "Yeorth Burrowland", "Dwynnen", "Ravennian Forest", "Devilrock",
             "Malekna Forest", "Isle of Balfiera", "Bantha", "Dak'fron",
@@ -209,7 +209,7 @@ namespace DaggerfallConnect.Arena2
         /// <summary>
         /// Gets all region names as string array.
         /// </summary>
-        public string[] RegionNames
+        public static string[] RegionNames
         {
             get { return regionNames; }
         }

--- a/Assets/Scripts/API/RumorFile.cs
+++ b/Assets/Scripts/API/RumorFile.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -52,7 +52,7 @@ namespace DaggerfallConnect.Arena2
             AllianceSignMessage = 26,
             EnemySignMessage = 27,
             WarSignMessage = 28,
-            Various = 100,
+            FactionRumor = 100,
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace DaggerfallConnect.Arena2
             public uint NPCID;
             public uint TextLength;
             public uint TimeLimit;
-            public string RumorText;
+            public byte[] RumorText;
         }
         #endregion
 
@@ -153,8 +153,7 @@ namespace DaggerfallConnect.Arena2
                 rumor.NPCID = reader.ReadUInt32();
                 rumor.TextLength = reader.ReadUInt32();
                 rumor.TimeLimit = reader.ReadUInt32();
-                rumor.RumorText = managedFile.ReadCString((int)reader.BaseStream.Position, (int)rumor.TextLength);
-                reader.BaseStream.Position += rumor.TextLength;
+                rumor.RumorText = reader.ReadBytes((int)rumor.TextLength);
 
                 rumors.Add(rumor);
             }

--- a/Assets/Scripts/API/Save/SaveGames.cs
+++ b/Assets/Scripts/API/Save/SaveGames.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -248,6 +248,9 @@ namespace DaggerfallConnect.Save
             rumorFile = new RumorFile();
             if (!rumorFile.Load(Path.Combine(saveGameDict[save], "RUMOR.DAT"), FileUsage.UseMemory, true))
                 UnityEngine.Debug.Log("Could not open RUMOR.DAT for index " + save);
+
+            for (int i = 0; i < rumorFile.rumors.Count; i++)
+                GameManager.Instance.TalkManager.ImportClassicRumor(rumorFile.rumors[i]);
 
             bioFile = new BioFile();
             if (!bioFile.Load(Path.Combine(saveGameDict[save], "BIO.DAT")))

--- a/Assets/Scripts/Editor/AtlasEditorWindow.cs
+++ b/Assets/Scripts/Editor/AtlasEditorWindow.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -145,7 +145,7 @@ namespace DaggerfallWorkshop
 
             if (regionNames.Length == 0)
             {
-                regionNames = (string[])dfUnity.ContentReader.MapFileReader.RegionNames.Clone();
+                regionNames = (string[])MapsFile.RegionNames.Clone();
                 System.Array.Sort(regionNames);
             }
 

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1436,6 +1436,10 @@ namespace DaggerfallWorkshop.Game.Entity
                                                         0, 0, 0, 0, 88, 94, 36, 94, 106, 84, 106, 106, 88, 98, 82, 98, 84, 94, 36, 88, 94, 36, 98, 84, 106,
                                                        88, 106, 88, 92, 84, 98, 88, 82, 94};
 
+            // Note: For some reason rumor updating is disabled in classic while the player is serving jail time. There's no clear reason for this,
+            // so not replicating that here.
+            GameManager.Instance.TalkManager.RefreshRumorMill();
+
             List<int> keys = new List<int>(factionData.FactionDict.Keys);
             foreach (int key in keys)
             {
@@ -1507,7 +1511,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 if ((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, allies[i]) * 3) / 5 + 70 < UnityEngine.Random.Range(0, 100 + 1))
                                 {
                                     factionData.EndFactionAllies(factionData.FactionDict[key].id, allies[i]);
-                                    // AddNewRumor 1402
+                                    GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, allies[i], -1, 100, 1402); // End faction allies
                                 }
                             }
                         }
@@ -1527,7 +1531,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 if ((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, enemies[i]) * 3) / 5 > UnityEngine.Random.Range(0, 100 + 1))
                                 {
                                     factionData.EndFactionEnemies(factionData.FactionDict[key].id, enemies[i]);
-                                    // AddNewRumor 1403
+                                    GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, enemies[i], -1, 100, 1403); // End faction enemies
                                 }
                             }
                         }
@@ -1571,12 +1575,12 @@ namespace DaggerfallWorkshop.Game.Entity
                                     int powerSum = factionPowerMod + factionData.FactionDict[key].rulerPowerBonus;
                                     if ((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, random.id) * 3) / 5 > UnityEngine.Random.Range(0, 100 + 1))
                                     {
-                                        //if (factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province && factionData.FactionDict[key].region != -1)
-                                        //AddNewRumor 1481
-                                        //if (random.type == (int)FactionFile.FactionTypes.Province && random.region != -1)
-                                        //AddNewRumor 1481
+                                        if (factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province && factionData.FactionDict[key].region != -1)
+                                            GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, random.id, factionData.FactionDict[key].region, 26, 1481); // Factions start alliance sign message
+                                        if (random.type == (int)FactionFile.FactionTypes.Province && random.region != -1)
+                                            GameManager.Instance.TalkManager.AddNonQuestRumor(random.id, factionData.FactionDict[key].id, random.region, 26, 1481); // Factions start alliance sign message
                                         factionData.StartFactionAllies(factionData.FactionDict[key].id, i, random.id);
-                                        //AddNewRumor 1400
+                                        GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, random.id, -1, 100, 1400); // Factions start alliance
                                     }
                                 }
                                 break;
@@ -1610,8 +1614,8 @@ namespace DaggerfallWorkshop.Game.Entity
                                 }
                                 else if (regionData[factionData.FactionDict[key].region].Flags[(int)RegionDataFlags.WarBeginning])
                                 {
-                                    //AddNewRumor 1479
-                                    //AddNewRumor 1479
+                                    GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, warEnemyID, factionData.FactionDict[key].region, 0, 1479); // War started sign message
+                                    GameManager.Instance.TalkManager.AddNonQuestRumor(warEnemyID, factionData.FactionDict[key].id, warEnemy.region, 0, 1479); // War started sign message
                                     TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.WarOngoing);
                                     TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.WarOngoing);
                                 }
@@ -1644,20 +1648,20 @@ namespace DaggerfallWorkshop.Game.Entity
 
                                         if (combinedPower - combinedEnemyPower > combinedEnemyPower)
                                         {
-                                            // AddNewRumor 1408
+                                            GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, warEnemy.id, -1, 100, 1408); // War over
                                             factionData.ChangePower(factionData.FactionDict[key].id, warEnemy.power / 2);
                                             TurnOnConditionFlag(warEnemy.region, RegionDataFlags.WarLost);
                                             TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.WarWon);
                                         }
                                         else if (combinedEnemyPower - combinedPower > combinedPower)
                                         {
-                                            // AddNewRumor 1408
+                                            GameManager.Instance.TalkManager.AddNonQuestRumor(warEnemy.id, factionData.FactionDict[key].id, -1, 100, 1408); // War over
                                             factionData.ChangePower(warEnemy.id, factionData.FactionDict[key].power / 2);
                                             TurnOnConditionFlag(warEnemy.region, RegionDataFlags.WarWon);
                                             TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.WarLost);
                                         }
-                                        //else
-                                        //AddNewRumor 1407
+                                        else
+                                            GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, warEnemy.id, -1, 100, 1407); // War started/ongoing
                                     }
                                     else
                                     {
@@ -1712,18 +1716,19 @@ namespace DaggerfallWorkshop.Game.Entity
                                         int powerSum = factionPowerMod + factionData.FactionDict[key].rulerPowerBonus;
                                         if (mod + (powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, random.id) * 3) / 5 + 70 < UnityEngine.Random.Range(0, 100 + 1))
                                         {
-                                            //if (factionData.FactionDict[key].region != -1 && factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province)
-                                            //AddNewRumor 1482
-                                            //if (random.region != -1 && random.type == (int)FactionFile.FactionTypes.Province)
-                                            //AddNewRumor 1482
+                                            if (factionData.FactionDict[key].region != -1 && factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province)
+                                                GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, random.id, factionData.FactionDict[key].region, 27, 1482); // War started sign message
+                                            if (random.region != -1 && random.type == (int)FactionFile.FactionTypes.Province)
+                                                GameManager.Instance.TalkManager.AddNonQuestRumor(random.id, factionData.FactionDict[key].id, random.region, 27, 1482); // Enemy faction sign message
                                             factionData.StartFactionEnemies(factionData.FactionDict[key].id, i, random.id);
+                                            GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, random.id, -1, 100, 1401); // Faction rivalry started
                                             if (factionData.FactionDict[key].region != -1 && factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province
                                                 && random.region != -1 && random.type == (int)FactionFile.FactionTypes.Province
                                                 && factionData.IsEnemyStatePermanentUntilWarOver(factionData.FactionDict[key], random))
                                             {
-                                                // AddNewRumor 1407
-                                                // AddNewRumor 1479
-                                                // AddNewRumor 1479
+                                                GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, random.id, -1, 100, 1407); // War started/ongoing
+                                                GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, random.id, factionData.FactionDict[key].region, 28, 1479); // War started sign message
+                                                GameManager.Instance.TalkManager.AddNonQuestRumor(random.id, factionData.FactionDict[key].id, random.region, 28, 1479); // War started sign message
                                                 TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.WarBeginning);
                                                 TurnOnConditionFlag(random.region, RegionDataFlags.WarBeginning);
                                             }
@@ -1740,11 +1745,11 @@ namespace DaggerfallWorkshop.Game.Entity
                             int mod = factionData.FactionDict[key].rulerPowerBonus / 3;
                             if (UnityEngine.Random.Range(0, 100 + 1) > mod + 70)
                             {
-                                //if (factionData.FactionDict[key].region != -1 && factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province)
-                                // AddNewRumor 1480
+                                if (factionData.FactionDict[key].region != -1 && factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province)
+                                    GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, -1, 12, 1480); // New ruler. Although unused, a regionID is defined for this rumor in classic.
                                 factionData.SetNewRulerData(factionData.FactionDict[key].id);
                                 // if ( PlayerIsRelatedToFaction(factionData.FactionDict[key]) )
-                                // AddNewRumor 1406
+                                // AddNewRumor 1406 // New faction leader
                             }
                         }
 
@@ -1767,12 +1772,21 @@ namespace DaggerfallWorkshop.Game.Entity
                             else if (regionData[factionData.FactionDict[key].region].Flags[(int)RegionDataFlags.FamineOngoing])
                             {
                                 if (UnityEngine.Random.Range(0, 100 + 1) < factionData.FactionDict[key].rulerPowerBonus / 5 + alliesPowerMod + factionData.FactionDict[key].power / 5)
+                                {
                                     TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.FamineEnding);
+                                    GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 7, 1477); // Famine sign message
+                                }
                             }
                             else if (regionData[factionData.FactionDict[key].region].Flags[(int)RegionDataFlags.FamineBeginning])
+                            {
                                 TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.FamineOngoing);
+                                GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 7, 1477); // Famine sign message
+                            }
                             else if (UnityEngine.Random.Range(1, 100 + 1) <= 2 && UnityEngine.Random.Range(0, 100 + 1) > factionData.FactionDict[key].rulerPowerBonus + alliesPowerMod)
+                            {
                                 TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.FamineBeginning);
+                                GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 7, 1477); // Famine sign message
+                            }
 
                             // Plague
                             FactionFile.FactionData temple;
@@ -1786,13 +1800,17 @@ namespace DaggerfallWorkshop.Game.Entity
                                     factionData.ChangePower(temple.id, -1);
                                 factionData.ChangePower(factionData.FactionDict[key].id, -1);
                                 if (UnityEngine.Random.Range(0, 100 + 1) < factionData.FactionDict[key].power / 5 + factionData.FactionDict[key].rulerPowerBonus / 5 + alliesPowerMod)
+                                {
                                     TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PlagueEnding);
+                                    GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 4, 1478); // Plague sign message
+                                }
                             }
                             else if (regionData[factionData.FactionDict[key].region].Flags[(int)RegionDataFlags.PlagueBeginning])
                             {
                                 if (temple.id != 0)
                                     factionData.ChangePower(temple.id, -1);
                                 factionData.ChangePower(factionData.FactionDict[key].id, -1);
+                                GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 4, 1478); // Plague sign message
                                 TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PlagueOngoing);
                             }
                             else if (UnityEngine.Random.Range(1, 100 + 1) <= 2 && UnityEngine.Random.Range(0, 100 + 1) > factionData.FactionDict[key].rulerPowerBonus + alliesPowerMod)
@@ -1800,6 +1818,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 if (temple.id != 0)
                                     factionData.ChangePower(temple.id, -1);
                                 factionData.ChangePower(factionData.FactionDict[key].id, -1);
+                                GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 4, 1478); // Plague sign message
                                 TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PlagueBeginning);
                             }
 
@@ -1815,6 +1834,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                     regionData[factionData.FactionDict[key].region].IDOfPersecutedTemple = (ushort)temple.id;
                                     TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PersecutedTemple);
                                     factionData.ChangePower(temple.id, -1);
+                                    GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 18, 1476); // Persecuted temple sign message
                                 }
                             }
 
@@ -1834,6 +1854,7 @@ namespace DaggerfallWorkshop.Game.Entity
                             {
                                 TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.CrimeWave);
                                 factionData.ChangePower(factionData.FactionDict[key].id, -1);
+                                GameManager.Instance.TalkManager.AddNonQuestRumor(0, 0, factionData.FactionDict[key].region, 11, 1410); // Crime wave
                             }
 
                             // Witch burnings
@@ -1849,6 +1870,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 {
                                     TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.WitchBurnings);
                                     factionData.ChangePower(witches.id, -1);
+                                    GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 10, 1475); // Witch burnings sign message
                                 }
                             }
                         }
@@ -1896,6 +1918,18 @@ namespace DaggerfallWorkshop.Game.Entity
                             factionData.ChangePower(merchants.id, 1);
                     }
                 }
+            }
+
+            if (updateConditions)
+            {
+                // These rumors are always available
+                GameManager.Instance.TalkManager.AddNonQuestRumor(0, 0, -1, 100, 1450);
+                GameManager.Instance.TalkManager.AddNonQuestRumor(0, 0, -1, 100, 1451);
+                GameManager.Instance.TalkManager.AddNonQuestRumor(0, 0, -1, 100, 1452);
+                GameManager.Instance.TalkManager.AddNonQuestRumor(0, 0, -1, 100, 1453);
+                GameManager.Instance.TalkManager.AddNonQuestRumor(0, 0, -1, 100, 1454);
+                GameManager.Instance.TalkManager.AddNonQuestRumor(0, 0, -1, 100, 1455);
+                GameManager.Instance.TalkManager.AddNonQuestRumor(0, 0, -1, 100, 1456);
             }
         }
 

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2123,11 +2123,14 @@ namespace DaggerfallWorkshop.Game
             // search for orphaned entries in rumor mill
             for (int i = listRumorMill.Count - 1; i >= 0; i--)
             {
-                ulong questID = listRumorMill[i].questID;
-                if (GameManager.Instance.QuestMachine.GetQuest(questID) == null)
+                if (listRumorMill[i].rumorType == RumorType.QuestRumorMill || listRumorMill[i].rumorType == RumorType.QuestProgressRumor)
                 {
-                    Debug.Log(String.Format("save data contains orphaned rumors for quest with id {0}. Removing these rumors...", questID));
-                    listRumorMill.Remove(listRumorMill[i]);
+                    ulong questID = listRumorMill[i].questID;
+                    if (GameManager.Instance.QuestMachine.GetQuest(questID) == null)
+                    {
+                        Debug.Log(String.Format("save data contains orphaned rumors for quest with id {0}. Removing these rumors...", questID));
+                        listRumorMill.Remove(listRumorMill[i]);
+                    }
                 }
             }
 

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -360,6 +360,7 @@ namespace DaggerfallWorkshop.Game
             public RumorType rumorType;            
             public List<TextFile.Token[]> listRumorVariants;
             public ulong questID; // questID used for RumorType::QuestProgressRumor and RumorType::QuestRumorMill, otherwise not set
+            public ulong timeLimit; // Classic game minute after which this rumor expires
         }
         // list of rumors in rumor mill
         List<RumorMillEntry> listRumorMill = new List<RumorMillEntry>();
@@ -2231,6 +2232,46 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
+        public void ImportClassicRumor(RumorFile.DaggerfallRumor rumor)
+        {
+            if (listRumorMill == null)
+                listRumorMill = new List<RumorMillEntry>();
+
+            RumorMillEntry entry = new RumorMillEntry();
+
+            TextFile.Token[] tokens = TextFile.ReadTokens(ref rumor.RumorText, 0, TextFile.Formatting.EndOfRecord);
+
+            if ((rumor.Flags & 4) != 0) // A quest rumor, don't import for now
+                return;
+
+            if ((rumor.Flags & 1) != 0) // A sign message, don't import for now
+                return;
+
+            if (rumor.NPCID != 0) // A post-quest greeting specific to a particular NPC. Don't import for now.
+                return;
+
+            entry.rumorType = RumorType.CommonRumor;
+            entry.listRumorVariants = new List<TextFile.Token[]>();
+            entry.listRumorVariants.Add(tokens);
+
+            listRumorMill.Add(entry);
+        }
+
+        public void AddCommonRumor(int textID)
+        {
+            if (listRumorMill == null)
+                listRumorMill = new List<RumorMillEntry>();
+            RumorMillEntry entry = new RumorMillEntry();
+
+            TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(textID);
+
+            entry.rumorType = RumorType.CommonRumor;
+            entry.listRumorVariants = new List<TextFile.Token[]>();
+            entry.listRumorVariants.Add(tokens);
+            entry.timeLimit = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime() + 43140;
+
+            listRumorMill.Add(entry);
+        }
 
         private void SetupRumorMill()
         {

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -247,17 +247,19 @@ namespace DaggerfallWorkshop.Utility
 
         #region fields (some macros need state (e.g. %fn2 depends on %fn1)
 
-        static int idFaction1InNews = -1;
-        static int idFaction1Ruler = -1;
+        static int idFaction1 = -1;
+        static int idFaction2 = -1;
+        static int idRegion = -1;
 
         #endregion
 
         #region Public Utility Functions
 
-        public static void ResetFactionAndRulerIds()
+        public static void SetFactionIdsAndRegionID(int faction1, int faction2, int region)
         {
-            idFaction1InNews = -1;
-            idFaction1Ruler = -1;
+            idFaction1 = faction1;
+            idFaction2 = faction2;
+            idRegion = region;
         }
 
         public static string GetFirstname(string name)
@@ -827,30 +829,16 @@ namespace DaggerfallWorkshop.Utility
         public static string AFactionInNews(IMacroContextProvider mcp)
         {   // %fx1
             PersistentFactionData factions = GameManager.Instance.PlayerEntity.FactionData;
-            int id;
-            if (idFaction1Ruler == -1) // no previous %ol1
-            {
-                id = UnityEngine.Random.Range(0, TalkManager.factionsUsedForFactionInNews.Count - 1);
-                idFaction1InNews = id;
-            }
-            else
-            {
-                id = idFaction1Ruler;
-            }
             FactionFile.FactionData fd;
-            factions.GetFactionData((int)TalkManager.factionsUsedForFactionInNews[id], out fd);
+            factions.GetFactionData(idFaction1, out fd);
             return fd.name;
         }
 
         public static string AnotherFactionInNews(IMacroContextProvider mcp)
         {   // %fx2
             PersistentFactionData factions = GameManager.Instance.PlayerEntity.FactionData;
-            // get random number between 0 and factionsUsedForFactionInNews.Count - 2 now since we might add a + 1 for an id >= idFaction1InNews later to prevent same faction as for %fx1
-            int id = UnityEngine.Random.Range(0, TalkManager.factionsUsedForFactionInNews.Count - 1);
             FactionFile.FactionData fd;
-            if (id >= idFaction1InNews) // make sure to create an id != idFaction1InNews
-                id += 1; // by just adding 1 if id >= idFaction1InNews -> so we will end up with an id in ranges [0, idFaction1InNews) union (idFaction1InNews, factionsUsedForFactionInNews.Count]
-            factions.GetFactionData((int)TalkManager.factionsUsedForFactionInNews[id], out fd);
+            factions.GetFactionData(idFaction2, out fd);
             return fd.name;
         }
 
@@ -862,59 +850,24 @@ namespace DaggerfallWorkshop.Utility
 
         public static string OldLordOfFaction1(IMacroContextProvider mcp)
         {   // %ol1
-            int id;
-            if (idFaction1Ruler == -1)
-            {
-                id = UnityEngine.Random.Range(0, TalkManager.factionsUsedForRulers.Count - 1);
-                idFaction1Ruler = id;
-            }
-            else
-            {
-                id = idFaction1Ruler;
-            }
-            return GetLordNameForFaction((int)TalkManager.factionsUsedForRulers[id]);
+            return GetLordNameForFaction(idFaction1);
         }
 
         public static string LordOfFaction1(IMacroContextProvider mcp)
         {   // %fl1
-            int id;
-            if (idFaction1Ruler == -1)
-            {
-                id = UnityEngine.Random.Range(0, TalkManager.factionsUsedForRulers.Count - 1);
-                idFaction1Ruler = id;
-            }
-            else
-            {
-                id = idFaction1Ruler;
-            }
-            return GetLordNameForFaction((int)TalkManager.factionsUsedForRulers[id]);
+            return GetLordNameForFaction(idFaction1);
         }
 
         public static string LordOfFaction2(IMacroContextProvider mcp)
         {   // %fl2
-            // get random number between 0 and factionsUsedForRulers.Count - 2 now since we might add a + 1 for an id >= idFaction1Ruler later to prevent same faction as for %fl1
-            int id = UnityEngine.Random.Range(0, TalkManager.factionsUsedForRulers.Count - 2);
-            if (id >= idFaction1Ruler) // make sure to create an id != idFaction1Ruler
-                id += 1; // by just adding 1 if id >= idFaction1InNews -> so we will end up with an id in ranges [0, idFaction1Ruler) union (idFaction1InNews, factionsUsedForFactionRulers.Count]
-            return GetLordNameForFaction((int)TalkManager.factionsUsedForRulers[id]);
+            return GetLordNameForFaction(idFaction2);
         }
 
         public static string TitleOfLordOfFaction1(IMacroContextProvider mcp)
         {   // %lt1
-            int id;
-            if (idFaction1Ruler == -1)
-            {
-                id = UnityEngine.Random.Range(0, TalkManager.factionsUsedForRulers.Count - 1);
-                idFaction1Ruler = id;
-            }
-            else
-            {
-                id = idFaction1Ruler;
-            }
-
             PersistentFactionData factions = GameManager.Instance.PlayerEntity.FactionData;
             FactionFile.FactionData fd;
-            factions.GetFactionData((int)TalkManager.factionsUsedForRulers[id], out fd);
+            factions.GetFactionData(idFaction1, out fd);
 
             switch (fd.ruler)
             {
@@ -949,13 +902,9 @@ namespace DaggerfallWorkshop.Utility
 
         public static string RegionInContext(IMacroContextProvider mcp)
         {   // %reg
-            if (idFaction1Ruler != -1)
+            if (idRegion != -1)
             {
-                //return DaggerfallUnity.Instance.ContentReader.MapFileReader.GetRegionName((int)TalkManager.factionsUsedForRulers[idFaction1Ruler]); // not mapping to same regions for some reason as FactionFile.FactionIDs enum
-                string regionName = Enum.GetName(typeof(FactionFile.FactionIDs), (FactionFile.FactionIDs)TalkManager.factionsUsedForRulers[idFaction1Ruler]);
-                regionName = regionName.Replace('_', ' ');
-                return regionName;
-
+                return MapsFile.RegionNames[idRegion];
             }
             else
                 return CurrentRegion(mcp);


### PR DESCRIPTION
Features:
1. Imports non-quest rumors from classic, including their time limit, flags, etc. Quest rumors are not imported since this is pointless unless we also import quest status from classic saves.
Note that due to a mistake in classic (which I've mentioned before), non-quest rumors are very rarely updated in classic and you will often not have any in saved games where you have progressed in the game. You can be guaranteed to have non-quest rumors for import if you make a new character, for about the first game month until the rumors expire.

2. Non-quest rumors now have time limits, the same as those in classic. They last for about a month.

3. Flag data from classic data recreated. This has things set up for signboard messages, whenever clicking on signboards becomes supported.

4. Non-quest rumors are now created for the various background events that occur, same as classic. Several of these are signboard messages and can't be seen yet.

5. Some simplification and correction to macro resolution for rumors. Rumors store the relevant factions and region IDs at the time of their creation in classic, and this is recreated now.

6. Some rumors that are always created on every background events update in classic (about witches, daedra, vampires, thieves guild and dark brotherhood, artifacts, etc.) and were probably supposed to always be available, are created now.

When you first load a saved game, you may have to first do some fast traveling and get the background events update to fire before the new non-quest rumors are generated. Until then NPCs will just say "I try not to spread rumors", etc. This should only be an issue until new saves are made with the updated rumor data.