### PR TITLE
Improve AI pursuit

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -877,7 +877,8 @@ namespace DaggerfallWorkshop.Game
             tempMovePos = transform.position + testMove.normalized * 2;
             tempMovePos.y = transform.position.y;
 
-            avoidObstaclesTimer = 0.25f;
+            if (avoidObstaclesTimer == 0)
+                avoidObstaclesTimer = 0.25f;
             lastTimeWasStuck = Time.time;
             moveInForAttack = true;
         }

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -360,7 +360,7 @@ namespace DaggerfallWorkshop.Game
                 tempMovePos = targetPos;
                 targetPosIsEnemyPos = true;
             }
-            else if (avoidObstaclesTimer == 0 && ClearPathToPosition(senses.LastKnownTargetPos))
+            else if (DaggerfallUnity.Settings.EnhancedCombatAI && avoidObstaclesTimer == 0 && ClearPathToPosition(senses.LastKnownTargetPos))
             {
                 targetPos = senses.LastKnownTargetPos + (senses.LastPositionDiff * 2);
                 tempMovePos = targetPos;
@@ -373,7 +373,7 @@ namespace DaggerfallWorkshop.Game
             // Otherwise, go straight
             else
             {
-                tempMovePos = transform.position + transform.forward * 2;
+                tempMovePos = transform.position + transform.forward * (stopDistance + .3f); // Move position needs to be a little further away (adding .3f) than stop distance so that AI will move, not stop
                 targetPos = tempMovePos;
             }
 

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -131,6 +131,12 @@ namespace DaggerfallWorkshop.Game
             set { oldLastKnownTargetPos = value; }
         }
 
+        public Vector3 LastPositionDiff
+        {
+            get { return lastPositionDiff; }
+            set { lastPositionDiff = value; }
+        }
+
         public Vector3 PredictedTargetPos
         {
             get { return predictedTargetPos; }

--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -72,13 +72,13 @@ namespace DaggerfallWorkshop.Game
 
                     // Limit maximum controller height
                     // Some particularly tall sprites (e.g. giants) require this hack to get through doors
-                    if (controller.height > 1.78f)
+                    if (controller.height > 1.65f)
                     {
                         // Adjust center so that sprite doesn't sink into the ground
                         Vector3 newCenter = controller.center;
-                        newCenter.y += (1.78f - controller.height) / 2;
+                        newCenter.y += (1.65f - controller.height) / 2;
                         controller.center = newCenter;
-                        controller.height = 1.78f;
+                        controller.height = 1.65f;
                     }
 
                     controller.gameObject.layer = LayerMask.NameToLayer("Enemies");


### PR DESCRIPTION
1. Adjusted enemy controller height limit down to 1.65f. I had to limit it to this for the enemy thief in Privateer's Hold to really be able to get through the doorway every time without hitching up for a second .

2. Fixed problem with enemies refusing to follow player down staircase corridors because the obstacle check would see the sloping wall in front of them as an obstacle and they would stop moving downwards.

3. Enemies will only try to get to Occasionally I saw enemies wandering off down a wall looking for a way to get to me. Also they would often not follow the player well around corners due to the prediction logic. They now use the last place they saw their target if they don't have a clear path to the predicted spot, which addresses both of these.