### PR TITLE
TextureReplacement: Support for Height Map

### DIFF
--- a/Assets/Resources/AllowHeight.mat
+++ b/Assets/Resources/AllowHeight.mat
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: AllowHeight
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _PARALLAXMAP
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 2800000, guid: 6f46153f6f8ecaa4e849126d7e62c39b, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Resources/AllowHeight.mat.meta
+++ b/Assets/Resources/AllowHeight.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 256cf55bfcfaa054f87efe5c416f7c42
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop
         internal const string Fade                                  = "_ALPHABLEND_ON";
         internal const string Transparent                           = "_ALPHAPREMULTIPLY_ON";
         internal const string NormalMap                             = "_NORMALMAP";
+        internal const string HeightMap                             = "_PARALLAXMAP";
         internal const string Emission                              = "_EMISSION";
         internal const string MetallicGlossMap                      = "_METALLICGLOSSMAP";
     }
@@ -45,6 +46,7 @@ namespace DaggerfallWorkshop
         internal static readonly int Metallic                       = Shader.PropertyToID("_Metallic");    
         internal static readonly int MetallicGlossMap               = Shader.PropertyToID("_MetallicGlossMap");
         internal static readonly int BumpMap                        = Shader.PropertyToID("_BumpMap");
+        internal static readonly int HeightMap                      = Shader.PropertyToID("_ParallaxMap");
         internal static readonly int EmissionColor                  = Shader.PropertyToID("_EmissionColor");
         internal static readonly int EmissionMap                    = Shader.PropertyToID("_EmissionMap");
         internal static readonly int Mode                           = Shader.PropertyToID("_Mode");
@@ -54,7 +56,7 @@ namespace DaggerfallWorkshop
 
         internal static readonly int[] Textures = new int[]
         {
-            MainTex, EmissionMap, BumpMap, MetallicGlossMap
+            MainTex, EmissionMap, BumpMap, HeightMap, MetallicGlossMap
         };
     }
 

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -38,6 +38,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     {
         Albedo,
         Normal,
+        Height,
         Emission,
         MetallicGloss
     }
@@ -343,6 +344,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 metallicGloss.filterMode = MainFilterMode;
                 material.EnableKeyword(KeyWords.MetallicGlossMap);
                 material.SetTexture(Uniforms.MetallicGlossMap, metallicGloss);
+            }
+
+            // Height Map
+            Texture2D height;
+            if (TryImportTextureFromLooseFiles(archive, record, frame, TextureMap.Height, out height))
+            {
+                height.filterMode = MainFilterMode;
+                material.EnableKeyword(KeyWords.HeightMap);
+                material.SetTexture(Uniforms.HeightMap, height);
             }
 
             // Properties


### PR DESCRIPTION
This PR adds support for heightmaps as requested on forums. I used the name Height instead of Parallax because this is what's used for the inspector and Unity docs.