### PR TITLE
give more time for sound loops to load

### DIFF
--- a/Assets/Scripts/Internal/AudioSourceExtensionMethods.cs
+++ b/Assets/Scripts/Internal/AudioSourceExtensionMethods.cs
@@ -6,6 +6,7 @@ namespace UnityEngine
     public static class AudioSourceExtensionMethods
     {
         private const float audioClipMaxDelay = 0.150f; //give up if sound takes longer to load
+        private const float audioLoopMaxDelay = 2.0f; // don't care as much about loops accuracy
 
         public static void PlayWhenReady(this AudioSource audioSource, AudioClip audioClip, float volumeScale)
         {
@@ -19,7 +20,7 @@ namespace UnityEngine
                    audioClip.loadState == AudioDataLoadState.Loading)
             {
                 loadWaitTimer += Time.deltaTime;
-                if (loadWaitTimer > audioClipMaxDelay)
+                if (loadWaitTimer > audioLoopMaxDelay)
                     yield break;
                 yield return null;
             }


### PR DESCRIPTION
Modded loops can be heavier than sound effects to load, and we don't care as much that they start right on time;
So increase the time limit for playing them (hopefully 2s is plenty; I prefer some timeout to no timeout)
Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=1776