### PR TITLE
Clean up EnemyMotor

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -59,10 +59,12 @@ namespace DaggerfallWorkshop.Game
         bool didClockwiseCheck;
         float lastTimeWasStuck;
         bool bashing;
+        bool hasBowAttack;
+        bool hasSpells;
 
         EnemySenses senses;
-        Vector3 targetPos;
-        Vector3 tempMovePos;
+        Vector3 destination;
+        Vector3 detourDestination;
         CharacterController controller;
         DaggerfallMobileUnit mobile;
         DaggerfallEntityBehaviour entityBehaviour;
@@ -117,6 +119,10 @@ namespace DaggerfallWorkshop.Game
             // Classic AI moves only as close as melee range
             if (!DaggerfallUnity.Settings.EnhancedCombatAI)
                 stopDistance = attack.MeleeDistance;
+
+            // Only need to check for ability to shoot bow once, and if no spells, only need to check for spells once.
+            hasBowAttack = mobile.Summary.Enemy.HasRangedAttack1 && mobile.Summary.Enemy.ID > 129 && mobile.Summary.Enemy.ID != 132;
+            hasSpells = entity.GetSpells().Length > 0;
         }
 
         void FixedUpdate()
@@ -147,13 +153,13 @@ namespace DaggerfallWorkshop.Game
             if (!entityBehaviour)
                 entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
 
-            if (attacker && senses)
+            // Assign target if don't already have target, or original target isn't seen or adjacent
+            if (attacker && senses && (senses.Target == null || !senses.TargetInSight || senses.DistanceToTarget > 2f))
             {
-                // Assign target if don't already have target, or original target isn't seen or adjacent
-                if (senses.Target == null || !senses.TargetInSight || senses.DistanceToTarget > 2f)
-                    senses.Target = attacker;
-                senses.LastKnownTargetPos = attacker.transform.position;
+                senses.Target = attacker;
+                senses.LastTarget = senses.Target;
                 senses.OldLastKnownTargetPos = attacker.transform.position;
+                senses.LastKnownTargetPos = attacker.transform.position;
                 senses.PredictedTargetPos = attacker.transform.position;
                 giveUpTimer = 200;
             }
@@ -292,19 +298,11 @@ namespace DaggerfallWorkshop.Game
                 {
                     Vector3 currentDirection = transform.forward;
                     currentDirection.y = 0;
-
-                    if (lastPosition == transform.position && lastDirection == currentDirection)
-                    {
-                        mobile.ChangeEnemyState(MobileStates.Idle);
-                        rotating = false;
-                    }
-                    else
-                        mobile.ChangeEnemyState(MobileStates.Move);
-
+                    rotating = lastDirection != currentDirection;
                     lastDirection = currentDirection;
                 }
-                // Movement is done at regular update rate, so check at regular update rate
-                else if (!rotating && lastPosition == transform.position)
+                // Movement is done at regular update rate, so check position at regular update rate
+                if (!rotating && lastPosition == transform.position)
                     mobile.ChangeEnemyState(MobileStates.Idle);
                 else
                     mobile.ChangeEnemyState(MobileStates.Move);
@@ -338,16 +336,16 @@ namespace DaggerfallWorkshop.Game
                 }
             }
 
-            bool targetPosIsEnemyPos = false;
+            bool clearPathToShootAtPredictedPos = false;
 
             // Get location to move towards. Either the combat target's position or, if trying to avoid an obstacle or fall,
             // a location to try to detour around the obstacle/fall.
             if (avoidObstaclesTimer == 0 && ClearPathToPosition(senses.PredictedTargetPos))
             {
-                targetPos = senses.PredictedTargetPos;
+                destination = senses.PredictedTargetPos;
                 // Flying enemies and slaughterfish aim for target face
                 if (flies || isLevitating || (swims && mobile.Summary.Enemy.ID == (int)MonsterCareers.Slaughterfish))
-                    targetPos.y += 0.9f;
+                    destination.y += 0.9f;
                 else
                 {
                     // Ground enemies target at their own height
@@ -355,47 +353,44 @@ namespace DaggerfallWorkshop.Game
                     // Otherwise, their target vector aims up towards the target
                     var targetController = senses.Target.GetComponent<CharacterController>();
                     var deltaHeight = (targetController.height - controller.height) / 2;
-                    targetPos.y -= deltaHeight;
+                    destination.y -= deltaHeight;
                 }
-                tempMovePos = targetPos;
-                targetPosIsEnemyPos = true;
+
+                clearPathToShootAtPredictedPos = true;
             }
             else if (DaggerfallUnity.Settings.EnhancedCombatAI && avoidObstaclesTimer == 0 && ClearPathToPosition(senses.LastKnownTargetPos))
             {
-                targetPos = senses.LastKnownTargetPos + (senses.LastPositionDiff * 2);
-                tempMovePos = targetPos;
+                destination = senses.LastKnownTargetPos + (senses.LastPositionDiff * 2);
             }
             // If detouring, use the detour position
             else if (avoidObstaclesTimer > 0)
             {
-                targetPos = tempMovePos;
+                destination = detourDestination;
             }
             // Otherwise, go straight
             else
             {
-                tempMovePos = transform.position + transform.forward * (stopDistance + .3f); // Move position needs to be a little further away (adding .3f) than stop distance so that AI will move, not stop
-                targetPos = tempMovePos;
+                destination = transform.position + transform.forward * (stopDistance + .3f); // Move position needs to be a little further away (adding .3f) than stop distance so that AI will move, not stop
             }
 
             // Get direction & distance.
-            var direction = (targetPos - transform.position).normalized;
-            float distance = (targetPos - transform.position).magnitude;
+            var direction = (destination - transform.position).normalized;
+            float distance = (destination - transform.position).magnitude;
 
             // Ranged attacks
-            if (targetPosIsEnemyPos && senses.DetectedTarget && 360 * MeshReader.GlobalScale < senses.DistanceToTarget && senses.DistanceToTarget < 2048 * MeshReader.GlobalScale)
+            if ((hasBowAttack || hasSpells) && clearPathToShootAtPredictedPos && senses.TargetInSight && senses.DetectedTarget && 360 * MeshReader.GlobalScale < senses.DistanceToTarget && senses.DistanceToTarget < 2048 * MeshReader.GlobalScale)
             {
-                bool evaluateBow = mobile.Summary.Enemy.HasRangedAttack1 && mobile.Summary.Enemy.ID > 129 && mobile.Summary.Enemy.ID != 132;
-                bool evaluateRangedMagic = false;
-                if (!evaluateBow)
-                    evaluateRangedMagic = CanCastRangedSpell();
+                bool rangedMagicAvailable = false;
+                if (!hasBowAttack && hasSpells)
+                    rangedMagicAvailable = CanCastRangedSpell();
 
-                if (evaluateBow || evaluateRangedMagic)
+                if (hasBowAttack || rangedMagicAvailable)
                 {
                     if (classicUpdate && senses.TargetIsWithinYawAngle(22.5f, senses.LastKnownTargetPos))
                     {
                         if (!isPlayingOneShot)
                         {
-                            if (evaluateBow)
+                            if (hasBowAttack)
                             {
                                 // Random chance to shoot bow
                                 if (DFRandom.rand() < 1000)
@@ -422,8 +417,8 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Touch spells
-            if (targetPosIsEnemyPos && senses.TargetInSight && senses.DetectedTarget && attack.MeleeTimer == 0 && senses.DistanceToTarget <= attack.MeleeDistance +
-                senses.TargetRateOfApproach && CanCastTouchSpell() && entityEffectManager.SetReadySpell(selectedSpell))
+            if (senses.TargetInSight && senses.DetectedTarget && attack.MeleeTimer == 0 && senses.DistanceToTarget <= attack.MeleeDistance
+                + senses.TargetRateOfApproach && CanCastTouchSpell() && entityEffectManager.SetReadySpell(selectedSpell))
             {
                 if (mobile.Summary.EnemyState != MobileStates.Spell)
                     mobile.ChangeEnemyState(MobileStates.Spell);
@@ -440,7 +435,7 @@ namespace DaggerfallWorkshop.Game
             if (moveInForAttackTimer > 0)
                 moveInForAttackTimer -= Time.deltaTime;
 
-            if (avoidObstaclesTimer > 0 && senses.TargetIsWithinYawAngle(5.625f, targetPos))
+            if (avoidObstaclesTimer > 0 && senses.TargetIsWithinYawAngle(5.625f, destination))
                 avoidObstaclesTimer -= Time.deltaTime;
             if (avoidObstaclesTimer < 0)
                 avoidObstaclesTimer = 0;
@@ -469,7 +464,7 @@ namespace DaggerfallWorkshop.Game
                 if (changeStateTimer <= 0 || pursuing)
                     AttemptMove(direction, moveSpeed);
                 // Otherwise, look at target until timer finishes
-                else if (!senses.TargetIsWithinYawAngle(22.5f, targetPos))
+                else if (!senses.TargetIsWithinYawAngle(22.5f, destination))
                     TurnToTarget(direction);
             }
             // Back away from combat target if right next to it, or if decided to retreat and enemy is too close.
@@ -481,18 +476,17 @@ namespace DaggerfallWorkshop.Game
                 if (changeStateTimer <= 0 || retreating)
                     AttemptMove(direction, moveSpeed / 2, true);
                 // Otherwise, look at target until timer finishes
-                else if (!senses.TargetIsWithinYawAngle(22.5f, targetPos))
-                    TurnToTarget(direction.normalized);
+                else if (!senses.TargetIsWithinYawAngle(22.5f, destination))
+                    TurnToTarget(direction);
             }
             // Not moving, just look at target
-            else if (!senses.TargetIsWithinYawAngle(22.5f, targetPos))
-                TurnToTarget(direction.normalized);
+            else if (!senses.TargetIsWithinYawAngle(22.5f, destination))
+                TurnToTarget(direction);
             else // Not moving, and no need to turn
             {
                 SetChangeStateTimer();
                 pursuing = false;
                 retreating = false;
-                avoidObstaclesTimer = 0;
             }
         }
 
@@ -503,15 +497,15 @@ namespace DaggerfallWorkshop.Game
         bool ClearPathToPosition(Vector3 location, float dist = 30)
         {
             Vector3 sphereCastDir = (location - transform.position).normalized;
-            RaycastHit hit;
-
             Vector3 sphereCastDir2d = sphereCastDir;
             sphereCastDir2d.y = 0;
+            RayCheckForObstacle(sphereCastDir2d);
             RayCheckForFall(sphereCastDir2d);
 
-            if (fallDetected)
+            if (obstacleDetected || fallDetected)
                 return false;
 
+            RaycastHit hit;
             if (Physics.SphereCast(transform.position, controller.radius / 2, sphereCastDir, out hit, dist))
             {
                 DaggerfallEntityBehaviour hitTarget = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
@@ -562,7 +556,7 @@ namespace DaggerfallWorkshop.Game
                 return false;
 
             // Check that there is a clear path to shoot a spell
-            float spellMovementSpeed = 15; // All range spells are currently 15 speed
+            float spellMovementSpeed = 25; // All range spells are currently 25 speed
             Vector3 sphereCastDir = senses.PredictNextTargetPos(spellMovementSpeed);
             if (sphereCastDir == EnemySenses.ResetPlayerPos)
                 return false;
@@ -689,7 +683,7 @@ namespace DaggerfallWorkshop.Game
                 pursuing = false;
             }
 
-            if (!senses.TargetIsWithinYawAngle(5.625f, targetPos))
+            if (!senses.TargetIsWithinYawAngle(5.625f, destination))
             {
                 TurnToTarget(direction.normalized);
                 // Classic always turns in place. Enhanced only does so if enemy is not in sight,
@@ -762,17 +756,8 @@ namespace DaggerfallWorkshop.Game
             {
                 if (swims)
                     WaterMove(motion);
-                else if (flies || isLevitating)
-                    controller.Move(motion * Time.deltaTime);
                 else
                     controller.Move(motion * Time.deltaTime);
-            }
-
-            // Reset clockwise check if we've been clear of obstacles/falls for a while
-            if (Time.time - lastTimeWasStuck > 2f)
-            {
-                checkingClockwiseTimer = 0;
-                didClockwiseCheck = false;
             }
         }
 
@@ -783,12 +768,18 @@ namespace DaggerfallWorkshop.Game
             float angle;
             Vector3 testMove;
 
+            // Reset clockwise check if we've been clear of obstacles/falls for a while
+            if (Time.time - lastTimeWasStuck > 2f)
+            {
+                checkingClockwiseTimer = 0;
+                didClockwiseCheck = false;
+            }
+
             if (checkingClockwiseTimer == 0)
             {
                 if (!didClockwiseCheck)
                 {
                     // Check 45 degrees in both ways first
-
                     // Pick first direction to check randomly
                     if (Random.Range(0, 1) == 0)
                         angle = 45;
@@ -802,7 +793,7 @@ namespace DaggerfallWorkshop.Game
                     if (!obstacleDetected && !fallDetected)
                     {
                         // First direction was clear, use that way
-                        if (angle > 0)
+                        if (angle == 45)
                         {
                             checkingClockwise = true;
                         }
@@ -819,11 +810,18 @@ namespace DaggerfallWorkshop.Game
                         RayCheckForFall(testMove);
 
                         if (!obstacleDetected && !fallDetected)
-                            checkingClockwise = !checkingClockwise;
+                        {
+                            if (angle == 45)
+                            {
+                                checkingClockwise = true;
+                            }
+                            else
+                                checkingClockwise = false;
+                        }
                         else
                         {
                             // Both 45 degrees checks failed, pick clockwise/counterclockwise based on angle to target
-                            Vector3 toTarget = targetPos - transform.position;
+                            Vector3 toTarget = destination - transform.position;
                             Vector3 directionToTarget = toTarget.normalized;
                             angle = Vector3.SignedAngle(directionToTarget, motion2d, Vector3.up);
 
@@ -846,25 +844,20 @@ namespace DaggerfallWorkshop.Game
                 }
             }
 
-            if (checkingClockwise)
-                angle = 10;
-            else
-                angle = -10;
-
+            angle = 0;
             int count = 0;
             testMove = Vector3.zero;
 
-            while (obstacleDetected || fallDetected)
+            do
             {
-                testMove = Quaternion.AngleAxis(angle, Vector3.up) * motion2d;
-
-                RayCheckForObstacle(testMove);
-                RayCheckForFall(testMove);
-
                 if (checkingClockwise)
                     angle += 10;
                 else
                     angle -= 10;
+
+                testMove = Quaternion.AngleAxis(angle, Vector3.up) * motion2d;
+                RayCheckForObstacle(testMove);
+                RayCheckForFall(testMove);
 
                 // Break out of loop if can't find anywhere to go
                 count++;
@@ -873,14 +866,14 @@ namespace DaggerfallWorkshop.Game
                     break;
                 }
             }
+            while (obstacleDetected || fallDetected);
 
-            tempMovePos = transform.position + testMove.normalized * 2;
-            tempMovePos.y = transform.position.y;
+            detourDestination = transform.position + testMove.normalized * 2;
+            detourDestination.y = transform.position.y;
 
             if (avoidObstaclesTimer == 0)
                 avoidObstaclesTimer = 0.25f;
             lastTimeWasStuck = Time.time;
-            moveInForAttack = true;
         }
 
         void RayCheckForObstacle(Vector3 direction)
@@ -919,7 +912,7 @@ namespace DaggerfallWorkshop.Game
                 {
                     obstacleDetected = false;
                     foundDoor = true;
-                    if (senses.TargetIsWithinYawAngle(5.625f, door.transform.position))
+                    if (senses.TargetIsWithinYawAngle(22.5f, door.transform.position))
                     {
                         senses.LastKnownDoor = door;
                         senses.DistanceToDoor = Vector3.Distance(transform.position, door.transform.position);
@@ -1063,7 +1056,6 @@ namespace DaggerfallWorkshop.Game
             if (classicUpdate)
             {
                 transform.forward = Vector3.RotateTowards(transform.forward, targetDirection, turnSpeed * Mathf.Deg2Rad, 0.0f);
-                rotating = true;
             }
         }
 

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -83,6 +83,12 @@ namespace DaggerfallWorkshop.Game
             set { target = value; }
         }
 
+        public DaggerfallEntityBehaviour LastTarget
+        {
+            get { return lastTarget; }
+            set { lastTarget = value; }
+        }
+
         DaggerfallEntityBehaviour Player
         {
             get { return GameManager.Instance.PlayerEntityBehaviour; }


### PR DESCRIPTION
EnemyMotor, although generally working okay, had become somewhat of a mess as I've been adding and changing bits of it. I went back over the code execution and made several small cleanups, fixes and a few optimizations.

Fix up MakeEnemyHostileToAttacker()
Simplify rotating check
Use more accurate variable names
Don't do bow or spell attack checks when not available
Remove pointless variable assignments
Remove pointless normalizations
Remove pointless move() call
Move clockwiseCheck reset to FindDetour() so it's only done when needed
Correct assumed spell projectile speed
Use do-while loop in FindDetour so operations done in correct order
Fall check assumes obstacle check was just done, so do before fall check
Use wider angle for detecting doors to open so AI can open them more
easily