### PR TITLE
Use a single timer for classic update simulation

### DIFF
--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -125,7 +125,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Play water sound effects. Timing based on classic.
-            if (waterWaitCounter > Entity.PlayerEntity.ClassicUpdateInterval)
+            if (waterWaitCounter > GameManager.classicUpdateInterval)
             {
                 if (playerEnterExit && playerEnterExit.blockWaterLevel != 10000)
                 {

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -36,8 +36,6 @@ namespace DaggerfallWorkshop.Game
         DaggerfallMobileUnit mobile;
         DaggerfallEntityBehaviour entityBehaviour;
         int damage = 0;
-        float classicUpdateTimer = 0f;
-        bool classicUpdate = false;
 
         void Start()
         {
@@ -46,18 +44,6 @@ namespace DaggerfallWorkshop.Game
             sounds = GetComponent<EnemySounds>();
             mobile = GetComponentInChildren<DaggerfallMobileUnit>();
             entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
-        }
-
-        void FixedUpdate()
-        {
-            classicUpdateTimer += Time.deltaTime;
-            if (classicUpdateTimer >= PlayerEntity.ClassicUpdateInterval)
-            {
-                classicUpdateTimer = 0;
-                classicUpdate = true;
-            }
-            else
-                classicUpdate = false;
         }
 
         void Update()
@@ -90,7 +76,7 @@ namespace DaggerfallWorkshop.Game
 
             // Note: Speed comparison here is reversed from classic. Classic's way makes fewer attack
             // attempts at higher speeds, so it seems backwards.
-            if (classicUpdate && (DFRandom.rand() % speed >= (speed >> 3) + 6 && MeleeTimer == 0))
+            if (GameManager.ClassicUpdate && (DFRandom.rand() % speed >= (speed >> 3) + 6 && MeleeTimer == 0))
             {
                 if (!MeleeAnimation())
                     return;

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -36,8 +36,6 @@ namespace DaggerfallWorkshop.Game
         bool swims;                                 // The enemy can swim
         bool pausePursuit;                          // pause to wait for the player to come closer to ground
         bool isLevitating;                          // Allow non-flying enemy to levitate
-        float classicUpdateTimer;                   // Timer for matching classic's update loop
-        bool classicUpdate;                         // True when reached a classic update
         float knockBackSpeed;                       // While non-zero, this enemy will be knocked backwards at this speed
         Vector3 knockBackDirection;                 // Direction to travel while being knocked back
         float moveInForAttackTimer;                 // Time until next pursue/retreat decision
@@ -121,15 +119,6 @@ namespace DaggerfallWorkshop.Game
 
         void FixedUpdate()
         {
-            classicUpdateTimer += Time.deltaTime;
-            if (classicUpdateTimer >= PlayerEntity.ClassicUpdateInterval)
-            {
-                classicUpdateTimer = 0;
-                classicUpdate = true;
-            }
-            else
-                classicUpdate = false;
-
             Move();
             OpenDoors();
         }
@@ -234,7 +223,7 @@ namespace DaggerfallWorkshop.Game
                     controller.SimpleMove(motion);
 
                 // Remove remaining knockback and restore animation
-                if (classicUpdate)
+                if (GameManager.ClassicUpdate)
                 {
                     knockBackSpeed -= (5 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10));
                     if (knockBackSpeed <= (5 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10))
@@ -281,14 +270,14 @@ namespace DaggerfallWorkshop.Game
                 giveUpTimer = 200;
 
             // GiveUpTimer value is from classic, so decrease at the speed of classic's update loop
-            if (classicUpdate && !senses.DetectedTarget && giveUpTimer > 0)
+            if (GameManager.ClassicUpdate && !senses.DetectedTarget && giveUpTimer > 0)
                 giveUpTimer--;
 
             // Change to idle animation if haven't moved or rotated
             if (!mobile.IsPlayingOneShot())
             {
                 // Rotation is done at classic update rate, so check at classic update rate
-                if (classicUpdate)
+                if (GameManager.ClassicUpdate)
                 {
                     Vector3 currentDirection = transform.forward;
                     currentDirection.y = 0;
@@ -328,7 +317,7 @@ namespace DaggerfallWorkshop.Game
                 else
                 {
                     int speed = entity.Stats.LiveSpeed;
-                    if (classicUpdate && DFRandom.rand() % speed >= (speed >> 3) + 6 && attack.MeleeTimer == 0)
+                    if (GameManager.ClassicUpdate && DFRandom.rand() % speed >= (speed >> 3) + 6 && attack.MeleeTimer == 0)
                     {
                         mobile.ChangeEnemyState(MobileStates.PrimaryAttack);
                         attack.ResetMeleeTimer();
@@ -391,7 +380,7 @@ namespace DaggerfallWorkshop.Game
 
                 if (evaluateBow || evaluateRangedMagic)
                 {
-                    if (classicUpdate && senses.TargetIsWithinYawAngle(22.5f, senses.LastKnownTargetPos))
+                    if (GameManager.ClassicUpdate && senses.TargetIsWithinYawAngle(22.5f, senses.LastKnownTargetPos))
                     {
                         if (!isPlayingOneShot)
                         {
@@ -1060,7 +1049,7 @@ namespace DaggerfallWorkshop.Game
             const float turnSpeed = 20f;
             //Classic speed is 11.25f, too slow for Daggerfall Unity's agile player movement
 
-            if (classicUpdate)
+            if (GameManager.ClassicUpdate)
             {
                 transform.forward = Vector3.RotateTowards(transform.forward, targetDirection, turnSpeed * Mathf.Deg2Rad, 0.0f);
                 rotating = true;

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -62,8 +62,6 @@ namespace DaggerfallWorkshop.Game
         bool blockedByIllusionEffect = false;
         float lastHadLOSTimer = 0f;
 
-        float classicUpdateTimer = 0f;
-        bool classicUpdate = false;
         float targetPosPredictTimer = 0f;
         bool targetPosPredict = false;
 
@@ -211,15 +209,6 @@ namespace DaggerfallWorkshop.Game
 
         void FixedUpdate()
         {
-            classicUpdateTimer += Time.deltaTime;
-            if (classicUpdateTimer >= PlayerEntity.ClassicUpdateInterval)
-            {
-                classicUpdateTimer = 0;
-                classicUpdate = true;
-            }
-            else
-                classicUpdate = false;
-
             targetPosPredictTimer += Time.deltaTime;
             if (targetPosPredictTimer >= predictionInterval)
             {
@@ -230,12 +219,12 @@ namespace DaggerfallWorkshop.Game
                 targetPosPredict = false;
 
             // Reset whether enemy would be spawned or not in classic.
-            if (classicUpdate)
+            if (GameManager.ClassicUpdate)
                 wouldBeSpawnedInClassic = false;
 
             // Update whether enemy would be spawned or not in classic.
             // Only check if within the maximum possible distance (Just under 1094 classic units)
-            if (classicUpdate && distanceToPlayer < 1094 * MeshReader.GlobalScale)
+            if (GameManager.ClassicUpdate && distanceToPlayer < 1094 * MeshReader.GlobalScale)
             {
                 float upperXZ = 0;
                 float upperY = 0;
@@ -282,7 +271,7 @@ namespace DaggerfallWorkshop.Game
                 }
             }
 
-            if (classicUpdate)
+            if (GameManager.ClassicUpdate)
             {
                 classicTargetUpdateTimer += Time.deltaTime / systemTimerUpdatesDivisor;
 
@@ -404,7 +393,7 @@ namespace DaggerfallWorkshop.Game
                 // to detect the player during one of the many AI updates. Here, the enemy has to
                 // successfully see through the illusion spell each classic update to continue
                 // to know where the player is.
-                if (classicUpdate)
+                if (GameManager.ClassicUpdate)
                 {
                     blockedByIllusionEffect = BlockedByIllusionEffect();
                     if (lastHadLOSTimer > 0)

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -109,8 +109,6 @@ namespace DaggerfallWorkshop.Game.Entity
         public const int SwimmingFatigueLoss = 44;
         public const int JumpingFatigueLoss = 11;
 
-        private float classicUpdateTimer = 0f;
-        public const float ClassicUpdateInterval = 0.0625f; // Update every 1/16 of a second. An approximation of classic's update loop, which varies with framerate.
         private int breathUpdateTally = 0;
         private int runningTallyCounter = 0;
         private float guardsArriveCountdown = 0;
@@ -244,16 +242,6 @@ namespace DaggerfallWorkshop.Game.Entity
             if (CurrentHealth <= 0)
                 return;
 
-            bool classicUpdate = false;
-
-            if (classicUpdateTimer < ClassicUpdateInterval)
-                classicUpdateTimer += Time.deltaTime;
-            else
-            {
-                classicUpdateTimer = 0;
-                classicUpdate = true;
-            }
-
             if (guardsArriveCountdown > 0)
             {
                 guardsArriveCountdown -= Time.deltaTime;
@@ -306,7 +294,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 }
 
                 // Handle events that are called by classic's update loop
-                if (classicUpdate)
+                if (GameManager.ClassicUpdate)
                 {
                     // Tally running skill. Running tallies so quickly in classic that it might be a bug or oversight.
                     // Here we use a rate of 1/4 that observed for classic.

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -377,7 +377,7 @@ namespace DaggerfallWorkshop.Game
                 if (player != null)
                 {
                     if (WeaponType == WeaponTypes.Bow)
-                        time = Entity.PlayerEntity.ClassicUpdateInterval;
+                        time = GameManager.classicUpdateInterval;
                     else
                     {
                         speed = 3 * (115 - player.Stats.LiveSpeed);

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -34,10 +34,13 @@ namespace DaggerfallWorkshop.Game
     public class GameManager : MonoBehaviour
     {
         #region Fields
+        public const float classicUpdateInterval = 0.0625f;        // Update every 1/16 of a second. An approximation of classic's update loop, which varies with framerate.
 
         public bool Verbose = false;
         bool isGamePaused = false;
         float savedTimeScale;
+        float classicUpdateTimer = 0;                       // Timer for matching classic's update loop
+        bool classicUpdate = false;                         // True when reached a classic update
         //Texture2D pauseScreenshot;
 
         GameObject playerObject = null;
@@ -93,6 +96,11 @@ namespace DaggerfallWorkshop.Game
         public static bool IsGamePaused
         {
             get { return Instance.isGamePaused; }
+        }
+
+        public static bool ClassicUpdate
+        {
+            get { return Instance.classicUpdate; }
         }
 
         public StateManager StateManager
@@ -442,6 +450,16 @@ namespace DaggerfallWorkshop.Game
         {
             if (!IsPlayingGame())
                 return;
+
+            // Update timer that approximates the timing of original Daggerfall's game update loop
+            classicUpdateTimer += Time.deltaTime;
+            if (classicUpdateTimer >= classicUpdateInterval)
+            {
+                classicUpdateTimer = 0;
+                classicUpdate = true;
+            }
+            else
+                classicUpdate = false;
 
             // Post message to open options dialog on escape during gameplay
             if (Input.GetKeyDown(KeyCode.Escape))

--- a/Assets/Scripts/Internal/DaggerfallAudioSource.cs
+++ b/Assets/Scripts/Internal/DaggerfallAudioSource.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -57,7 +57,6 @@ namespace DaggerfallWorkshop
         // Sets looping sound to only play randomly and on a slower update matched to classic.
         // Only used for animal sounds.
         private bool playRandomly = false;
-        private float classicUpdateTimer = 0f;
 
         public bool IsReady
         {
@@ -95,21 +94,8 @@ namespace DaggerfallWorkshop
                 audioSource.volume = DaggerfallUnity.Settings.SoundVolume;
 
                 // Handle random play
-                if (audioSource.enabled && playRandomly)
-                {
-                    bool classicUpdate = false;
-
-                    if (classicUpdateTimer < Game.Entity.PlayerEntity.ClassicUpdateInterval)
-                        classicUpdateTimer += Time.deltaTime;
-                    else
-                    {
-                        classicUpdateTimer = 0;
-                        classicUpdate = true;
-                    }
-
-                    if (classicUpdate && DFRandom.rand() <= 100)
-                        audioSource.Play();
-                }
+                if (audioSource.enabled && playRandomly && Game.GameManager.ClassicUpdate && DFRandom.rand() <= 100)
+                    audioSource.Play();
             }
         }
 


### PR DESCRIPTION
Combines all the classic timer updating I had put into separate files into a single timer in GameManager, since only one is needed.

If GameManager isn't where you would want this, I can move it somewhere else.

Should merge cleanly with https://github.com/Interkarma/daggerfall-unity/pull/1184.