### PR TITLE
warn the player before taking back an item not fully repaired

### DIFF
--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -38,6 +38,7 @@ wagonFullGold,      Your wagon could only hold {0} gold pieces.
 itemsIdentified,    Items identified.
 repairDone,         DONE
 repairDays,         %d days
+interruptRepair,    Take back that item before it's repaired?
 repairNote,         Left my {0} for repair at {1}.
 doesntNeedIdentify, This does not need to be identified.
 stealSuccess,       You are successful.


### PR DESCRIPTION
Some people seem so used to instantaneous repairs that they get their items back before they're repaired; A warning seems appropriate.
Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=1765&p=21086#p21086