### PR TITLE
Travel map update

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -312,7 +312,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 Debug.Log("Find " + findPlaceName + findPlaceRegion);
                 this.CloseWindow();
-                DaggerfallUI.Instance.DfTravelMapWindow.GotoLocation(findPlaceName, findPlaceRegion);
+                DaggerfallUI.Instance.DfTravelMapWindow.SetGotoLocation(findPlaceName, findPlaceRegion);
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenTravelMapWindow);
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -35,12 +35,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         TravelTimeCalculator travelTimeCalculator = new TravelTimeCalculator();
 
         Color32 toggleColor = new Color32(85, 117, 48, 255);
+        Color32 notToggledColor = new Color32(130, 22, 0, 255);
 
         Panel travelPanel;
-        Panel speedToggleColorPanel;
-        Panel transportToggleColorPanel;
-        Panel sleepToggleColorPanel;
-
         Button beginButton;
         Button exitButton;
         Button speedToggleButton;
@@ -57,16 +54,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Rect transportButtonRect    = new Rect(163, 51, 108, 20);
         Rect innsButtonRect         = new Rect(50, 83, 108, 9);
         Rect campoutButtonRect      = new Rect(163, 83, 108, 9);
-
-        Vector2 colorPanelSize      = new Vector2(4.5f, 5f);
-        Vector2 cautiousPanelPos    = new Vector2(52, 53.25f);
-        Vector2 recklessPanelPos    = new Vector2(52, 63.25f);
-        Vector2 innPanelPos         = new Vector2(52, 85.25f);
-        Vector2 campoutPos          = new Vector2(165, 85.25f);
-        Vector2 footPos             = new Vector2(165, 53.25f);
-        Vector2 shipPos             = new Vector2(165, 63.25f);
         DFPosition endPos           = new DFPosition(109, 158);
-
         TextLabel availableGoldLabel;
         TextLabel tripCostLabel;
         TextLabel travelTimeLabel;
@@ -113,7 +101,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Setup();
 
-            nativeTexture = DaggerfallUI.GetTextureFromImg(nativeImgName);
+            nativeTexture = DaggerfallUI.GetTextureFromImg(nativeImgName, TextureFormat.ARGB32, false);
             if (!nativeTexture)
                 throw new System.Exception("DaggerfallTravelMap: Could not load native texture.");
 
@@ -121,24 +109,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             travelPanel = DaggerfallUI.AddPanel(nativePanelRect, NativePanel);
             travelPanel.BackgroundTexture = nativeTexture;
+            travelPanel.BackgroundColor = Color.black;
 
-            availableGoldLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(148, 97), "0", NativePanel);
+            availableGoldLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(100, 68), "0", travelPanel);
             availableGoldLabel.MaxCharacters = 12;
 
-            tripCostLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(117,107), "0", NativePanel);
+            tripCostLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(68,78), "0", travelPanel);
             tripCostLabel.MaxCharacters = 18;
 
-            travelTimeLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(129,117), "0", NativePanel);
+            travelTimeLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(80,88), "0", travelPanel);
             travelTimeLabel.MaxCharacters = 16;
-
-            speedToggleColorPanel = DaggerfallUI.AddPanel(new Rect(cautiousPanelPos, colorPanelSize), NativePanel);
-            speedToggleColorPanel.BackgroundColor = toggleColor;
-
-            sleepToggleColorPanel = DaggerfallUI.AddPanel(new Rect(innPanelPos, colorPanelSize), NativePanel);
-            sleepToggleColorPanel.BackgroundColor = toggleColor;
-
-            transportToggleColorPanel = DaggerfallUI.AddPanel(new Rect(footPos, colorPanelSize), NativePanel);
-            transportToggleColorPanel.BackgroundColor = toggleColor;
 
             SetupButtons();
             Refresh();
@@ -213,25 +193,51 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         //Update when player pushes buttons etc.
         void Refresh()
         {
-            UpdateTogglePanels();
+            UpdateToggles();
             UpdateLabels();
         }
 
-        //Updates the positions for the panels to indicate which button is selected
-        void UpdateTogglePanels()
+        void UpdateToggles()
         {
-            if (speedCautious)
-                speedToggleColorPanel.Position = cautiousPanelPos;
-            else
-                speedToggleColorPanel.Position = recklessPanelPos;
-            if (sleepModeInn)
-                sleepToggleColorPanel.Position = innPanelPos;
-            else
-                sleepToggleColorPanel.Position = campoutPos;
-            if (travelShip)
-                transportToggleColorPanel.Position = shipPos;
-            else
-                transportToggleColorPanel.Position = footPos;
+            if (speedCautious){
+                UpdateToggle(3,67,4,4,toggleColor);            //cautious
+                UpdateToggle(3,57, 4,4,notToggledColor);        //reckless
+            }
+            else{
+                UpdateToggle(3,67,4,4,notToggledColor);
+                UpdateToggle(3,57, 4,4,toggleColor);
+            }
+            if (sleepModeInn){
+                UpdateToggle(3,35,4,4,toggleColor);            //inn
+                UpdateToggle(116, 35, 4,4, notToggledColor);    //camp
+            }
+            else{
+                UpdateToggle(3,35,4,4,notToggledColor);
+                UpdateToggle(116, 35, 4,4, toggleColor);
+            }
+            if (travelShip){
+                UpdateToggle(116, 57, 4,4, toggleColor);       //ship
+                UpdateToggle(116, 67,4,4,notToggledColor);      //foot/horse
+            }
+            else{
+                UpdateToggle(116, 57, 4,4, notToggledColor);
+                UpdateToggle(116, 67,4,4,toggleColor);
+            }
+        }
+
+        //updates texture based on travel options selected
+        void UpdateToggle(int startX, int startY, int width, int height, Color32 color)
+        {
+            int textureWidth = nativeTexture.width;
+
+            for(int x = startX; x < startX+width; x++)
+            {
+                for(int y = startY; y < startY+height; y++)
+                {
+                    nativeTexture.SetPixel(x,y,color);
+                }
+            }
+            nativeTexture.Apply();
         }
 
         //Updates text labels


### PR DESCRIPTION
Minor bug fixes and functional improvements to the travel map & travel pop up window.

Travel popup window now shows travel option toggles correctly regardless of aspect ratio.  

Corrected a bug that was causing the find location routine from breaking the at button in the region view.  

The location list picker should now only displays locations known to the player.

Changed scrolling mode while zoomed in to be a toggle on/off.