### PR TITLE
Make enemy height change only temporary

### DIFF
--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -70,17 +70,6 @@ namespace DaggerfallWorkshop.Game
                     if (dfMobile.Summary.Enemy.Behaviour == MobileBehaviour.Flying)
                         controller.height /= 2f;
 
-                    // Limit maximum controller height
-                    // Some particularly tall sprites (e.g. giants) require this hack to get through doors
-                    if (controller.height > 1.65f)
-                    {
-                        // Adjust center so that sprite doesn't sink into the ground
-                        Vector3 newCenter = controller.center;
-                        newCenter.y += (1.65f - controller.height) / 2;
-                        controller.center = newCenter;
-                        controller.height = 1.65f;
-                    }
-
                     controller.gameObject.layer = LayerMask.NameToLayer("Enemies");
                 }
 


### PR DESCRIPTION
The changes I made to enemy collider height to allow them to fit through doors caused an issue where the upper part of the enemy would no longer respond to collisions such as arrows or clicking on them for the "You see a %s" message. The taller the enemy the more noticeable the problem would be. It was particularly noticeable with dreughs.

The only solution that came to mind is an imperfect one, but better than what we have currently. That is to only temporarily change collider height for half a second when an enemy brushes up against something. It will then return to normal if after the half-second the enemy is no longer touching anything.

This fixes the dreugh part of
https://forums.dfworkshop.net/viewtopic.php?f=24&t=1751