### PR TITLE
Make arrows use colliders for hit checks

### DIFF
--- a/Assets/Prefabs/Missiles/ArrowMissile.prefab
+++ b/Assets/Prefabs/Missiles/ArrowMissile.prefab
@@ -25,6 +25,7 @@ GameObject:
   - component: {fileID: 108732554255048532}
   - component: {fileID: 114624404217668130}
   - component: {fileID: 54102960107042576}
+  - component: {fileID: 64298782196861766}
   m_Layer: 0
   m_Name: ArrowMissile
   m_TagString: Untagged
@@ -60,6 +61,20 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!64 &64298782196861766
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1712884651827938}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 1
+  m_CookingOptions: 14
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 0}
 --- !u!82 &82343321333735398
 AudioSource:
   m_ObjectHideFlags: 1
@@ -242,7 +257,7 @@ SphereCollider:
   m_GameObject: {fileID: 1712884651827938}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 0.4
   m_Center: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
Combined with https://github.com/Interkarma/daggerfall-unity/pull/1195, this fixes the other issue in https://forums.dfworkshop.net/viewtopic.php?f=24&t=1751 (about the bats).

1. Use colliders instead of ray casts for arrows.
- Enemies pushed around ("Jedi reflexes" of the bug report) less
- Shooting enemies at point-blank range will register hits better now (will still go through them if they are right next to you, but that doesn't bother me too much as it is unrealistic to shoot from that close anyway)
- Maybe a little better performance?, since instead of doing raycasts the collider that existed on the arrows is used.
- Maybe more reliable hit detection, although the ray-cast solution seemed to be working for me except at point-blank ranges.

2. Moved arrow disabling and damage to be called immediately on collision instead of in the update loop
- Together with the above, seems to have (possibly) fixed completely the issue of enemies being pushed by the arrow

3. Can no longer bash doors with arrows, as it didn't make much sense