### PR TITLE
EnemySenses fixes and cleanup

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -146,7 +146,7 @@ namespace DaggerfallWorkshop.Game
             if (attacker && senses && (senses.Target == null || !senses.TargetInSight || senses.DistanceToTarget > 2f))
             {
                 senses.Target = attacker;
-                senses.LastTarget = senses.Target;
+                senses.SecondaryTarget = senses.Target;
                 senses.OldLastKnownTargetPos = attacker.transform.position;
                 senses.LastKnownTargetPos = attacker.transform.position;
                 senses.PredictedTargetPos = attacker.transform.position;


### PR DESCRIPTION
Minor fixes and cleanup for `EnemySenses`. With enhanced combat on, enemies will now acquire a secondary target that they will switch to if the primary dies, to eliminate them standing still and looking foolish because they had "tunnel vision" and only focused on one target, ignoring everyone else around them. Now they will appear to have a little better situational awareness, since they will switch to another target immediately if they saw it while pursuing the primary target.

I had meant for a more basic version of this feature to already exist, but it wasn't working correctly. This replaces it.

List of fixes:

`lastTarget` was being used inconsistently. Created a new `targetLastUpdate`
variable for tracking whether current target is the same as last update.
`lastTarget` renamed to `secondaryTarget` and holds a secondary target the
AI can switch to if the current one dies, if enhanced combatAI is on.
Fixed `wouldBeSpawnedInClassic` being reset to false every update making only spawn distance values, never despawn values, be used for checking if enemies are in the classic existence range.
Lower frequency of target searches. Not necessary to do so frequently,
and a small delay may be better anyway because of the fade-in time when loading a saved game made while in combat.
If target is player, re-use `toPlayer` sight check results.
Move code using results of player LOS check to after check in execution order,
rather than coming later due to being conditioned on slower classic
update timing, for readability.