### PR TITLE
Prevent paying repair price several times

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -796,7 +796,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         break;
 
                     case WindowModes.Identify:
-                        PlayerEntity.DeductGoldAmount(GetTradePrice());
+                        PlayerEntity.DeductGoldAmount(tradePrice);
                         for (int i = 0; i < remoteItems.Count; i++)
                         {
                             DaggerfallUnityItem item = remoteItems.GetItem(i);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -384,7 +384,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                             cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality);
                             break;
                         case WindowModes.Repair:
-                            cost += FormulaHelper.CalculateItemRepairCost(item.value, buildingDiscoveryData.quality, item.currentCondition, item.maxCondition, guild) * item.stackCount;
+                            if (!item.RepairData.IsBeingRepaired())
+                                cost += FormulaHelper.CalculateItemRepairCost(item.value, buildingDiscoveryData.quality, item.currentCondition, item.maxCondition, guild) * item.stackCount;
                             break;
                         case WindowModes.Identify:
                             if (!item.IsIdentified)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -352,21 +352,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void UpdateCostAndGold()
         {
+            bool modeActionEnabled = false;
             cost = 0;
-
-            // Identify spell remains free
-            if (usingIdentifySpell)
-            {
-                costLabel.Text = cost.ToString();
-                goldLabel.Text = PlayerEntity.GetGoldAmount().ToString();
-                return;
-            }
 
             if (windowMode == WindowModes.Buy && basketItems != null)
             {
                 for (int i = 0; i < basketItems.Count; i++)
                 {
                     DaggerfallUnityItem item = basketItems.GetItem(i);
+                    modeActionEnabled = true;
                     cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality) * item.stackCount;
                 }
             }
@@ -378,34 +372,53 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     switch (windowMode)
                     {
                         case WindowModes.Sell:
+                            modeActionEnabled = true;
                             cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality) * item.stackCount;
                             break;
                         case WindowModes.SellMagic: // TODO: Fencing base price higher and guild rep affects it. Implement new formula or can this be used?
+                            modeActionEnabled = true;
                             cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality);
                             break;
                         case WindowModes.Repair:
                             if (!item.RepairData.IsBeingRepaired())
+                            {
+                                modeActionEnabled = true;
                                 cost += FormulaHelper.CalculateItemRepairCost(item.value, buildingDiscoveryData.quality, item.currentCondition, item.maxCondition, guild) * item.stackCount;
+                            }
                             break;
                         case WindowModes.Identify:
                             if (!item.IsIdentified)
-                                cost += FormulaHelper.CalculateItemIdentifyCost(item.value, guild);
+                            {
+                                modeActionEnabled = true;
+                                // Identify spell remains free
+                                if (!usingIdentifySpell)
+                                    cost += FormulaHelper.CalculateItemIdentifyCost(item.value, guild);
+                            }
                             break;
                     }
                 }
             }
             costLabel.Text = cost.ToString();
             goldLabel.Text = PlayerEntity.GetGoldAmount().ToString();
+            modeActionButton.Enabled = modeActionEnabled;
         }
 
         private int GetTradePrice()
         {
-            if (windowMode == WindowModes.Sell || windowMode == WindowModes.SellMagic)
-                return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, true);
-            else if (windowMode == WindowModes.Identify)
-                return cost;
-            else
-                return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, false);
+            switch (windowMode)
+            {
+                case WindowModes.Buy:
+                case WindowModes.Repair:
+                    return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, false);
+
+                case WindowModes.Sell:
+                case WindowModes.SellMagic:
+                    return FormulaHelper.CalculateTradePrice(cost, buildingDiscoveryData.quality, true);
+
+                case WindowModes.Identify:
+                    return cost;
+            }
+            throw new Exception("Unexpected windowMode");
         }
 
         #endregion
@@ -718,7 +731,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     remoteItems.GetItem(i).IdentifyItem();
                 DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "itemsIdentified"));
             }
-            else if (cost > 0 || ((windowMode == WindowModes.Repair || windowMode == WindowModes.Identify) && remoteItems.Count > 0))
+            else
                 ShowTradePopup();
         }
 


### PR DESCRIPTION
cost only takes into account items that are not already being repaired
Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=1828

If they're only already repaired items in the remote list, test L721 does not prevent a display a "it will cost 0 gold" trade window in you click on REPAIR button. The same situation happens with identification, so this test could be improved, but I don't understand that code well enough.

Also, I don't understand how repair price seems correct in game (equal to "cost", as computed by UpdateCostAndGold()), when the deduced amount L765 is the value of GetTradePrice() that does not handle the case windowMode == WindowModes.Repair
