### PR TITLE
highlight recently increased skills

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
@@ -72,9 +72,6 @@ namespace DaggerfallWorkshop.Game.Entity
         // This is designed so that effects are never operating on permanent skill values
         int[] mods = new int[Count];
 
-        // Skills to highlight
-        bool[] recentlyIncreased = new bool[Count];
-
         #endregion
 
         #region Constructors
@@ -98,7 +95,6 @@ namespace DaggerfallWorkshop.Game.Entity
                 SetPermanentSkillValue(i, (short)UnityEngine.Random.Range(minDefaultValue, maxDefaultValue + 1));
             }
             Array.Clear(mods, 0, Count);
-            Array.Clear(recentlyIncreased, 0, Count);
         }
 
         /// <summary>
@@ -254,21 +250,6 @@ namespace DaggerfallWorkshop.Game.Entity
                 default:
                     return 0;
             }
-        }
-
-        public bool GetSkillRecentlyIncreased(DFCareer.Skills skill)
-        {
-            return recentlyIncreased[(int)skill];
-        }
-
-        public void SetSkillRecentlyIncreased(int index)
-        {
-            recentlyIncreased[index] = true;
-        }
-
-        public void ResetSkillsRecentlyIncreased()
-        {
-            Array.Clear(recentlyIncreased, 0, Count);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
@@ -72,6 +72,9 @@ namespace DaggerfallWorkshop.Game.Entity
         // This is designed so that effects are never operating on permanent skill values
         int[] mods = new int[Count];
 
+        // Skills to highlight
+        bool[] recentlyIncreased = new bool[Count];
+
         #endregion
 
         #region Constructors
@@ -95,6 +98,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 SetPermanentSkillValue(i, (short)UnityEngine.Random.Range(minDefaultValue, maxDefaultValue + 1));
             }
             Array.Clear(mods, 0, Count);
+            Array.Clear(recentlyIncreased, 0, Count);
         }
 
         /// <summary>
@@ -250,6 +254,21 @@ namespace DaggerfallWorkshop.Game.Entity
                 default:
                     return 0;
             }
+        }
+
+        public bool GetSkillRecentlyIncreased(DFCareer.Skills skill)
+        {
+            return recentlyIncreased[(int)skill];
+        }
+
+        public void SetSkillRecentlyIncreased(int index)
+        {
+            recentlyIncreased[index] = true;
+        }
+
+        public void ResetSkillsRecentlyIncreased()
+        {
+            Array.Clear(recentlyIncreased, 0, Count);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -64,8 +64,7 @@ namespace DaggerfallWorkshop.Game.Entity
         protected PlayerNotebook notebook = new PlayerNotebook();
 
         protected short[] skillUses;
-        protected uint skillsRaisedThisLevel1 = 0;
-        protected uint skillsRaisedThisLevel2 = 0;
+        protected uint[] skillsRecentlyRaised = new uint[2];
         protected uint timeOfLastSkillIncreaseCheck = 0;
         protected uint timeOfLastSkillTraining = 0;
 
@@ -144,6 +143,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public PersistentGlobalVars GlobalVars { get { return globalVars; } }
         public PlayerNotebook Notebook { get { return notebook; } }
         public short[] SkillUses { get { return skillUses; } set { skillUses = value; } }
+        public uint[] SkillsRecentlyRaised { get { return skillsRecentlyRaised; } set { skillsRecentlyRaised = value; } }
         public uint TimeOfLastSkillIncreaseCheck { get { return timeOfLastSkillIncreaseCheck; } set { timeOfLastSkillIncreaseCheck = value; } }
         public uint TimeOfLastSkillTraining { get { return timeOfLastSkillTraining; } set { timeOfLastSkillTraining = value; } }
         public uint TimeOfLastStealthCheck { get { return timeOfLastStealthCheck; } set { timeOfLastStealthCheck = value; } }
@@ -189,6 +189,21 @@ namespace DaggerfallWorkshop.Game.Entity
         #endregion
 
         #region Public Methods
+
+        public bool GetSkillRecentlyIncreased(DFCareer.Skills skill)
+        {
+            return (skillsRecentlyRaised[(int)skill / 32] & (1 << ((int)skill % 32))) != 0;
+        }
+
+        public void SetSkillRecentlyIncreased(int index)
+        {
+            skillsRecentlyRaised[index / 32] |= (uint)(1 << (index % 32));
+        }
+
+        public void ResetSkillsRecentlyRaised()
+        {
+            Array.Clear(skillsRecentlyRaised, 0, 2);
+        }
 
         public RaceTemplate GetLiveRaceTemplate()
         {
@@ -778,8 +793,8 @@ namespace DaggerfallWorkshop.Game.Entity
             this.sGroupReputations[4] = character.reputationUnderworld;
             this.currentFatigue = character.currentFatigue;
             this.skillUses = character.skillUses;
-            this.skillsRaisedThisLevel1 = character.skillsRaisedThisLevel1;
-            this.skillsRaisedThisLevel2 = character.skillsRaisedThisLevel2;
+            this.skillsRecentlyRaised[0] = character.skillsRaisedThisLevel1;
+            this.skillsRecentlyRaised[1] = character.skillsRaisedThisLevel2;
             this.startingLevelUpSkillSum = character.startingLevelUpSkillSum;
             this.minMetalToHit = (WeaponMaterialTypes)character.minMetalToHit;
             this.armorValues = character.armorValues;
@@ -1201,7 +1216,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     if (skills.GetPermanentSkillValue(i) < 100 && (skills.GetPermanentSkillValue(i) < 95 || !AlreadyMasteredASkill()))
                     {
                         skills.SetPermanentSkillValue(i, (short)(skills.GetPermanentSkillValue(i) + 1));
-                        skills.SetSkillRecentlyIncreased(i);
+                        SetSkillRecentlyIncreased(i);
                         SetCurrentLevelUpSkillSum();
                         DaggerfallUI.Instance.PopupMessage(HardStrings.skillImprove.Replace("%s", DaggerfallUnity.Instance.TextProvider.GetSkillName((DFCareer.Skills)i)));
                         if (skills.GetPermanentSkillValue(i) == 100)

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1201,6 +1201,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     if (skills.GetPermanentSkillValue(i) < 100 && (skills.GetPermanentSkillValue(i) < 95 || !AlreadyMasteredASkill()))
                     {
                         skills.SetPermanentSkillValue(i, (short)(skills.GetPermanentSkillValue(i) + 1));
+                        skills.SetSkillRecentlyIncreased(i);
                         SetCurrentLevelUpSkillSum();
                         DaggerfallUI.Instance.PopupMessage(HardStrings.skillImprove.Replace("%s", DaggerfallUnity.Instance.TextProvider.GetSkillName((DFCareer.Skills)i)));
                         if (skills.GetPermanentSkillValue(i) == 100)

--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -80,6 +80,8 @@ namespace DaggerfallWorkshop.Game.Player
             startingLevelUpSkillSum = 0;
             faceIndex = 0;
             skillUses = new short[DaggerfallSkills.Count];
+            skillsRaisedThisLevel1 = 0;
+            skillsRaisedThisLevel2 = 0;
             for (int i = 0; i < armorValues.Length; i++)
             {
                 armorValues[i] = 100;

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -168,6 +168,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public int currentBreath;
         public short[] skillUses;
         public uint timeOfLastSkillIncreaseCheck;
+        public uint[] skillsRecentlyRaised;
         public int startingLevelUpSkillSum;
         public ulong[] equipTable;
         public ItemData_v1[] items;

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -122,6 +122,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             data.playerEntity.currentBreath = entity.CurrentBreath;
             data.playerEntity.skillUses = entity.SkillUses;
             data.playerEntity.timeOfLastSkillIncreaseCheck = entity.TimeOfLastSkillIncreaseCheck;
+            data.playerEntity.skillsRecentlyRaised = entity.SkillsRecentlyRaised;
             data.playerEntity.timeOfLastSkillTraining = entity.TimeOfLastSkillTraining;
             data.playerEntity.startingLevelUpSkillSum = entity.StartingLevelUpSkillSum;
             data.playerEntity.equipTable = entity.ItemEquipTable.SerializeEquipTable();
@@ -270,6 +271,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.SetMagicka(data.playerEntity.currentMagicka, true);
             entity.CurrentBreath = data.playerEntity.currentBreath;
             entity.SkillUses = data.playerEntity.skillUses;
+            entity.SkillsRecentlyRaised = (data.playerEntity.skillsRecentlyRaised != null ? data.playerEntity.skillsRecentlyRaised : new uint[2]);
             entity.TimeOfLastSkillIncreaseCheck = data.playerEntity.timeOfLastSkillIncreaseCheck;
             entity.TimeOfLastSkillTraining = data.playerEntity.timeOfLastSkillTraining;
             entity.StartingLevelUpSkillSum = data.playerEntity.startingLevelUpSkillSum;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -349,7 +349,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
 
             DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
-            messageBox.SetHighlightColor(Color.white);
+            messageBox.SetHighlightColor(DaggerfallUI.DaggerfallUnityStatIncreasedTextColor);
             messageBox.SetTextTokens(tokens.ToArray(), null, false);
             messageBox.ClickAnywhereToClose = true;
             messageBox.Show();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -226,6 +226,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             base.CancelWindow();
         }
 
+        public override void OnPop()
+        {
+            base.OnPop();
+            if (!leveling)
+                playerEntity.Skills.ResetSkillsRecentlyIncreased();
+            leveling = false;
+        }
+
         #endregion
 
         #region Private Methods
@@ -242,20 +250,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         // Creates formatting tokens for skill popups
         TextFile.Token[] CreateSkillTokens(DFCareer.Skills skill, bool twoColumn = false, int startPosition = 0)
         {
+            bool highlight = playerEntity.Skills.GetSkillRecentlyIncreased(skill);
+
             List<TextFile.Token> tokens = new List<TextFile.Token>();
+            TextFile.Formatting formatting = highlight ? TextFile.Formatting.TextHighlight : TextFile.Formatting.Text;
 
             TextFile.Token skillNameToken = new TextFile.Token();
+            skillNameToken.formatting = formatting;
             skillNameToken.text = DaggerfallUnity.Instance.TextProvider.GetSkillName(skill);
-            skillNameToken.formatting = TextFile.Formatting.Text;
 
             TextFile.Token skillValueToken = new TextFile.Token();
+            skillValueToken.formatting = formatting;
             skillValueToken.text = string.Format("{0}%", playerEntity.Skills.GetLiveSkillValue(skill));
-            skillValueToken.formatting = TextFile.Formatting.Text;
 
             DFCareer.Stats primaryStat = DaggerfallSkills.GetPrimaryStat(skill);
             TextFile.Token skillPrimaryStatToken = new TextFile.Token();
+            skillPrimaryStatToken.formatting = formatting;
             skillPrimaryStatToken.text = DaggerfallUnity.Instance.TextProvider.GetAbbreviatedStatName(primaryStat);
-            skillPrimaryStatToken.formatting = TextFile.Formatting.Text;
 
             TextFile.Token positioningToken = new TextFile.Token();
             positioningToken.formatting = TextFile.Formatting.PositionPrefix;
@@ -338,6 +349,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
 
             DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
+            messageBox.SetHighlightColor(Color.white);
             messageBox.SetTextTokens(tokens.ToArray(), null, false);
             messageBox.ClickAnywhereToClose = true;
             messageBox.Show();
@@ -456,7 +468,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else
             {
-                leveling = false;
                 PlayerEntity.Stats = statsRollout.WorkingStats;
                 NativePanel.Components.Remove(statsRollout);
                 return true;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -230,7 +230,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.OnPop();
             if (!leveling)
-                playerEntity.Skills.ResetSkillsRecentlyIncreased();
+                playerEntity.ResetSkillsRecentlyRaised();
             leveling = false;
         }
 
@@ -250,7 +250,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         // Creates formatting tokens for skill popups
         TextFile.Token[] CreateSkillTokens(DFCareer.Skills skill, bool twoColumn = false, int startPosition = 0)
         {
-            bool highlight = playerEntity.Skills.GetSkillRecentlyIncreased(skill);
+            bool highlight = playerEntity.GetSkillRecentlyIncreased(skill);
 
             List<TextFile.Token> tokens = new List<TextFile.Token>();
             TextFile.Formatting formatting = highlight ? TextFile.Formatting.TextHighlight : TextFile.Formatting.Text;


### PR DESCRIPTION
When opening the character sheet, highlight all the skills that have
increased since the last time you opened the character sheet.

Exclude character sheet opening automatically triggered by level ups.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=1834