### PR TITLE
notebook page to log onscreen messages (popup, middle screen)

### DIFF
--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs
@@ -40,6 +40,7 @@ namespace DaggerfallWorkshop.Game.Player
         List<TextFile.Token[]> finishedQuests = new List<TextFile.Token[]>();
 
         List<TextFile.Token[]> messages = new List<TextFile.Token[]>();
+        int nextMessageIndex = 0;
 
         #region Notes
 
@@ -139,7 +140,16 @@ namespace DaggerfallWorkshop.Game.Player
 
         public List<TextFile.Token[]> GetMessages()
         {
-            return new List<TextFile.Token[]>(messages);
+            List<TextFile.Token[]> result = new List<TextFile.Token[]>(messages.Count);
+            for (int current = nextMessageIndex; current < messages.Count; current++)
+            {
+                result.Add(messages[current]);
+            }
+            for (int current = 0; current < nextMessageIndex; current++)
+            {
+                result.Add(messages[current]);
+            }
+            return result;
         }
 
         public void AddMessage(string str)
@@ -147,11 +157,12 @@ namespace DaggerfallWorkshop.Game.Player
             if (!string.IsNullOrEmpty(str))
             {
                 List<TextFile.Token> message = CreateMessage(str);
-                messages.Add(message.ToArray());
-                // Use a circular buffer instead?
-                while (messages.Count > MaxMessageCount)
+                if (messages.Count < MaxMessageCount)
+                    messages.Add(message.ToArray());
+                else
                 {
-                    messages.RemoveAt(0);
+                    messages[nextMessageIndex] = message.ToArray();
+                    nextMessageIndex = (nextMessageIndex + 1) % MaxMessageCount;
                 }
             }
         }

--- a/Assets/Scripts/Game/Player/PlayerNotebook.cs
+++ b/Assets/Scripts/Game/Player/PlayerNotebook.cs
@@ -29,6 +29,7 @@ namespace DaggerfallWorkshop.Game.Player
         private const string PrefixQuestion = "Q:";
         private const string PrefixAnswer = "A:";
         const string textDatabase = "DaggerfallUI";
+        const int MaxMessageCount = 50;
 
         readonly static TextFile.Token NothingToken = new TextFile.Token() {
             formatting = TextFile.Formatting.Nothing,
@@ -37,6 +38,8 @@ namespace DaggerfallWorkshop.Game.Player
         List<TextFile.Token[]> notes = new List<TextFile.Token[]>();
 
         List<TextFile.Token[]> finishedQuests = new List<TextFile.Token[]>();
+
+        List<TextFile.Token[]> messages = new List<TextFile.Token[]>();
 
         #region Notes
 
@@ -132,6 +135,35 @@ namespace DaggerfallWorkshop.Game.Player
                 formatting = format,
             });
             note.Add(NothingToken);
+        }
+
+        public List<TextFile.Token[]> GetMessages()
+        {
+            return new List<TextFile.Token[]>(messages);
+        }
+
+        public void AddMessage(string str)
+        {
+            if (!string.IsNullOrEmpty(str))
+            {
+                List<TextFile.Token> message = CreateMessage(str);
+                messages.Add(message.ToArray());
+                // Use a circular buffer instead?
+                while (messages.Count > MaxMessageCount)
+                {
+                    messages.RemoveAt(0);
+                }
+            }
+        }
+
+        private static List<TextFile.Token> CreateMessage(string text)
+        {
+            List<TextFile.Token> message = new List<TextFile.Token>
+            {
+                TextFile.CreateFormatToken(TextFile.Formatting.JustifyCenter),
+                TextFile.CreateTextToken(text),
+            };
+            return message;
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterface/PopupText.cs
+++ b/Assets/Scripts/Game/UserInterface/PopupText.cs
@@ -105,6 +105,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             label.HorizontalAlignment = HorizontalAlignment.Center;
             label.Parent = Parent;
             textRows.AddLast(label);
+            GameManager.Instance.PlayerEntity.Notebook.AddMessage(text);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -244,6 +244,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             midScreenTextLabel.Text = message;
             midScreenTextTimer = 0;
             midScreenTextDelay = delay;
+            GameManager.Instance.PlayerEntity.Notebook.AddMessage(message);
         }
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -69,7 +69,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             ActiveQuests,
             FinshedQuests,
-            Notebook
+            Notebook,
+            Messages
         }
 
         #endregion
@@ -216,6 +217,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     case JournalDisplay.Notebook:
                         SetTextNotebook();
                         break;
+                    case JournalDisplay.Messages:
+                        SetTextMessages();
+                        break;
                 }
             }
         }
@@ -235,6 +239,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     DisplayMode = JournalDisplay.Notebook;
                     break;
                 case JournalDisplay.Notebook:
+                    DisplayMode = JournalDisplay.Messages;
+                    break;
+                case JournalDisplay.Messages:
                     DisplayMode = JournalDisplay.ActiveQuests;
                     break;
             }
@@ -545,6 +552,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             titleLabel.Text = TextManager.Instance.GetText(textDatabase, "notebook");
             titleLabel.ToolTipText = TextManager.Instance.GetText(textDatabase, "notebookInfo");
             SetTextWithListEntries(notes, maxLinesSmall);
+        }
+
+        private void SetTextMessages()
+        {
+            List<TextFile.Token[]> messages = GameManager.Instance.PlayerEntity.Notebook.GetMessages();
+            messageCount = messages.Count;
+            questLogLabel.TextScale = textScaleSmall;
+            titleLabel.Text = TextManager.Instance.GetText(textDatabase, "messages");
+            titleLabel.ToolTipText = TextManager.Instance.GetText(textDatabase, "messagesInfo");
+            SetTextWithListEntries(messages, maxLinesSmall);
         }
 
         private void SetTextWithListEntries(List<TextFile.Token[]> entries, int maxLines)

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -4,13 +4,15 @@ schema: *key,text
 
 - Journal window:
 
-dialogButtonInfo,   Switch between: Active Quests :: Finished Quests :: Notebook
+dialogButtonInfo,   Switch between: Active Quests; Finished Quests; Notebook; Messages
 activeQuests,       Active Quests
 activeQuestsInfo,   Click on an active quest that has a target location to initiate travel.
 finishedQuests,     Finished Quests
 finishedQuestsInfo, Click on an entry to move it. Right click to delete.
 notebook,           Notebook
 notebookInfo,       Click a note to move. Right click to delete. Click in-between to add a new note.
+messages,           Messages
+messagesInfo,       History of messages recently shown on screen
 confirmMoveHead,    Move entry
 confirmMove,        Do you want to change the position of this entry?
 confirmMove2,       (It will be moved to before the next entry clicked)


### PR DESCRIPTION
This is just a log of recent onscreen messages; The number of messages is bounded, and they are not persisted. The goal is just to provide a way to read messages that went by too fast.

Any way to get a more dense display?
Once text density is fixed, it would be great to set the maximum number of messages to exactly one screen, or to open the messages log to the last page.
