### PR TITLE
random Random.Range() fixes

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -843,8 +843,8 @@ namespace Wenzil.Console
                                 int xpos, ypos;
                                 while (true)
                                 {
-                                    xpos = UnityEngine.Random.Range(0, MapsFile.MaxMapPixelX - 1);
-                                    ypos = UnityEngine.Random.Range(0, MapsFile.MaxMapPixelY - 1);
+                                    xpos = UnityEngine.Random.Range(0, MapsFile.MaxMapPixelX);
+                                    ypos = UnityEngine.Random.Range(0, MapsFile.MaxMapPixelY);
                                     DaggerfallWorkshop.Utility.ContentReader.MapSummary mapSummary;
                                     if (DaggerfallWorkshop.DaggerfallUnity.Instance.ContentReader.HasLocation(xpos, ypos, out mapSummary))
                                     {
@@ -1546,7 +1546,7 @@ namespace Wenzil.Console
             private static T RandomEnumValue<T>()
             {
                 var v = Enum.GetValues(typeof(T));
-                return (T)v.GetValue(UnityEngine.Random.Range(0, v.Length - 1));
+                return (T)v.GetValue(UnityEngine.Random.Range(0, v.Length));
             }
         }
 

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -134,8 +134,8 @@ namespace DaggerfallWorkshop.Game
                     {
                         Vector3 waterSoundPosition = playerBehaviour.transform.position;
                         waterSoundPosition.y = playerEnterExit.blockWaterLevel * -1 * MeshReader.GlobalScale;
-                        waterSoundPosition.x += Random.Range(-3, 3);
-                        waterSoundPosition.z += Random.Range(-3, 3);
+                        waterSoundPosition.x += Random.Range(-3f, 3f);
+                        waterSoundPosition.z += Random.Range(-3f, 3f);
                         SpatializedPlayOneShot(SoundClips.WaterGentle, waterSoundPosition, 3f);
                     }
 

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -87,7 +87,7 @@ namespace DaggerfallWorkshop.Game
 
         public void ResetMeleeTimer()
         {
-            MeleeTimer = Random.Range(1500, 3001);
+            MeleeTimer = Random.Range(1500, 3000 + 1);
             MeleeTimer -= 50 * (GameManager.Instance.PlayerEntity.Level - 10);
 
             // Note: In classic, what happens here is
@@ -185,7 +185,7 @@ namespace DaggerfallWorkshop.Game
                     sounds.PlayMissSound(weapon);
                 }
 
-                if (DaggerfallUnity.Settings.CombatVoices && entity.EntityType == EntityTypes.EnemyClass && Random.Range(1, 101) <= 20)
+                if (DaggerfallUnity.Settings.CombatVoices && entity.EntityType == EntityTypes.EnemyClass && Random.Range(1, 100 + 1) <= 20)
                 {
                     Genders gender;
                     if (mobile.Summary.Enemy.Gender == MobileGender.Male || entity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
@@ -317,7 +317,7 @@ namespace DaggerfallWorkshop.Game
                     }
                 }
 
-                if (DaggerfallUnity.Settings.CombatVoices && senses.Target.EntityType == EntityTypes.EnemyClass && Random.Range(1, 101) <= 40)
+                if (DaggerfallUnity.Settings.CombatVoices && senses.Target.EntityType == EntityTypes.EnemyClass && Random.Range(1, 100 + 1) <= 40)
                 {
                     DaggerfallMobileUnit targetMobileUnit = senses.Target.GetComponentInChildren<DaggerfallMobileUnit>();
                     Genders gender;

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -16,6 +16,7 @@ using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.MagicAndEffects;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -185,7 +186,7 @@ namespace DaggerfallWorkshop.Game
                     sounds.PlayMissSound(weapon);
                 }
 
-                if (DaggerfallUnity.Settings.CombatVoices && entity.EntityType == EntityTypes.EnemyClass && Random.Range(1, 100 + 1) <= 20)
+                if (DaggerfallUnity.Settings.CombatVoices && entity.EntityType == EntityTypes.EnemyClass && Dice100.SuccessRoll(20))
                 {
                     Genders gender;
                     if (mobile.Summary.Enemy.Gender == MobileGender.Male || entity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
@@ -317,7 +318,7 @@ namespace DaggerfallWorkshop.Game
                     }
                 }
 
-                if (DaggerfallUnity.Settings.CombatVoices && senses.Target.EntityType == EntityTypes.EnemyClass && Random.Range(1, 100 + 1) <= 40)
+                if (DaggerfallUnity.Settings.CombatVoices && senses.Target.EntityType == EntityTypes.EnemyClass && Dice100.SuccessRoll(40))
                 {
                     DaggerfallMobileUnit targetMobileUnit = senses.Target.GetComponentInChildren<DaggerfallMobileUnit>();
                     Genders gender;

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -770,7 +770,7 @@ namespace DaggerfallWorkshop.Game
                 {
                     // Check 45 degrees in both ways first
                     // Pick first direction to check randomly
-                    if (Random.Range(0, 1) == 0)
+                    if (Random.Range(0, 2) == 0)
                         angle = 45;
                     else
                         angle = -45;

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -15,6 +15,7 @@ using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallConnect;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Questing;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -572,9 +573,9 @@ namespace DaggerfallWorkshop.Game
 
             timeOfLastStealthCheck = gameMinutes;
 
-            int stealthRoll = 2 * ((int)(distanceToTarget / MeshReader.GlobalScale) * target.Entity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth) >> 10);
+            int stealthChance = 2 * ((int)(distanceToTarget / MeshReader.GlobalScale) * target.Entity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth) >> 10);
 
-            return Random.Range(1, 100 + 1) > stealthRoll;
+            return Dice100.FailedRoll(stealthChance);
         }
 
         public bool BlockedByIllusionEffect()
@@ -601,7 +602,7 @@ namespace DaggerfallWorkshop.Game
             else // is a shade
                 chance = 4;
 
-            return Random.Range(1, 100 + 1) > chance;
+            return Dice100.FailedRoll(chance);
         }
 
         public bool TargetIsWithinYawAngle(float targetAngle, Vector3 targetPos)

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -574,7 +574,7 @@ namespace DaggerfallWorkshop.Game
 
             int stealthRoll = 2 * ((int)(distanceToTarget / MeshReader.GlobalScale) * target.Entity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth) >> 10);
 
-            return Random.Range(1, 101) > stealthRoll;
+            return Random.Range(1, 100 + 1) > stealthRoll;
         }
 
         public bool BlockedByIllusionEffect()
@@ -601,7 +601,7 @@ namespace DaggerfallWorkshop.Game
             else // is a shade
                 chance = 4;
 
-            return Random.Range(1, 101) > chance;
+            return Random.Range(1, 100 + 1) > chance;
         }
 
         public bool TargetIsWithinYawAngle(float targetAngle, Vector3 targetPos)

--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -67,7 +67,7 @@ namespace DaggerfallWorkshop.Game
                 AttackSound = (SoundClips)mobile.Summary.Enemy.AttackSound;
             }
 
-            RaceForSounds = (Entity.Races)Random.Range(1, 6);
+            RaceForSounds = (Entity.Races)Random.Range(1, 5 + 1);
 
             // Start attract timer
             StartWaiting();

--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -194,7 +194,7 @@ namespace DaggerfallWorkshop.Game
         private void StartWaiting()
         {
             // Reset countdown to next sound
-            waitTime = Random.Range(MinAttractDelay, MaxAttractDelay);
+            waitTime = Random.Range(MinAttractDelay, MaxAttractDelay + 1);
             waitCounter = 0;
         }
 

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -15,6 +15,7 @@ using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallConnect.Save;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Entity
 {
@@ -444,7 +445,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     if (Dice100.SuccessRoll(chanceToPoison))
                     {
                         // Apply poison
-                        weapon.poisonType = (Items.Poisons)UnityEngine.Random.Range(128, 136);
+                        weapon.poisonType = (Items.Poisons)UnityEngine.Random.Range(128, 135 + 1);
                     }
                 }
             }

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -316,14 +316,14 @@ namespace DaggerfallWorkshop.Game.Entity
 
                 // left-hand shield
                 item = UnityEngine.Random.Range((int)Game.Items.Armor.Buckler, (int)(Game.Items.Armor.Round_Shield) + 1);
-                if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
+                if (Dice100.SuccessRoll(chance))
                 {
                     Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, (Items.Armor)item, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                     ItemEquipTable.EquipItem(armor, true, false);
                     items.AddItem(armor);
                 }
                 // left-hand weapon
-                else if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
+                else if (Dice100.SuccessRoll(chance))
                 {
                     item = UnityEngine.Random.Range((int)Game.Items.Weapons.Dagger, (int)(Game.Items.Weapons.Shortsword) + 1);
                     weapon = Game.Items.ItemBuilder.CreateWeapon((Items.Weapons)item, Game.Items.ItemBuilder.RandomMaterial(itemLevel));
@@ -345,42 +345,42 @@ namespace DaggerfallWorkshop.Game.Entity
                     chance = 90;
             }
             // helm
-            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
+            if (Dice100.SuccessRoll(chance))
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Helm, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // right pauldron
-            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
+            if (Dice100.SuccessRoll(chance))
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Right_Pauldron, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // left pauldron
-            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
+            if (Dice100.SuccessRoll(chance))
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Left_Pauldron, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // cuirass
-            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
+            if (Dice100.SuccessRoll(chance))
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Cuirass, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // greaves
-            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
+            if (Dice100.SuccessRoll(chance))
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Greaves, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // boots
-            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
+            if (Dice100.SuccessRoll(chance))
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Boots, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
@@ -441,7 +441,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     if (mobileEnemy.ID == (int)MobileTypes.Assassin)
                         chanceToPoison = 60;
 
-                    if (UnityEngine.Random.Range(1, 100 + 1) < chanceToPoison)
+                    if (Dice100.SuccessRoll(chanceToPoison))
                     {
                         // Apply poison
                         weapon.poisonType = (Items.Poisons)UnityEngine.Random.Range(128, 136);

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -316,14 +316,14 @@ namespace DaggerfallWorkshop.Game.Entity
 
                 // left-hand shield
                 item = UnityEngine.Random.Range((int)Game.Items.Armor.Buckler, (int)(Game.Items.Armor.Round_Shield) + 1);
-                if (UnityEngine.Random.Range(1, 101) <= chance)
+                if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
                 {
                     Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, (Items.Armor)item, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                     ItemEquipTable.EquipItem(armor, true, false);
                     items.AddItem(armor);
                 }
                 // left-hand weapon
-                else if (UnityEngine.Random.Range(1, 101) <= chance)
+                else if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
                 {
                     item = UnityEngine.Random.Range((int)Game.Items.Weapons.Dagger, (int)(Game.Items.Weapons.Shortsword) + 1);
                     weapon = Game.Items.ItemBuilder.CreateWeapon((Items.Weapons)item, Game.Items.ItemBuilder.RandomMaterial(itemLevel));
@@ -345,42 +345,42 @@ namespace DaggerfallWorkshop.Game.Entity
                     chance = 90;
             }
             // helm
-            if (UnityEngine.Random.Range(1, 101) <= chance)
+            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Helm, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // right pauldron
-            if (UnityEngine.Random.Range(1, 101) <= chance)
+            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Right_Pauldron, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // left pauldron
-            if (UnityEngine.Random.Range(1, 101) <= chance)
+            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Left_Pauldron, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // cuirass
-            if (UnityEngine.Random.Range(1, 101) <= chance)
+            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Cuirass, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // greaves
-            if (UnityEngine.Random.Range(1, 101) <= chance)
+            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Greaves, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
                 items.AddItem(armor);
             }
             // boots
-            if (UnityEngine.Random.Range(1, 101) <= chance)
+            if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
             {
                 Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Boots, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
                 ItemEquipTable.EquipItem(armor, true, false);
@@ -441,7 +441,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     if (mobileEnemy.ID == (int)MobileTypes.Assassin)
                         chanceToPoison = 60;
 
-                    if (UnityEngine.Random.Range(1, 101) < chanceToPoison)
+                    if (UnityEngine.Random.Range(1, 100 + 1) < chanceToPoison)
                     {
                         // Apply poison
                         weapon.poisonType = (Items.Poisons)UnityEngine.Random.Range(128, 136);

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -406,14 +406,14 @@ namespace DaggerfallWorkshop.Game.Entity
 
                     // Handle guards appearing for low-legal rep player
                     int regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
-                    if (regionData[regionIndex].LegalRep < -10 && UnityEngine.Random.Range(1, 101) < 5)
+                    if (regionData[regionIndex].LegalRep < -10 && UnityEngine.Random.Range(1, 100 + 1) < 5)
                     {
                         crimeCommitted = Crimes.Criminal_Conspiracy;
                         SpawnCityGuards(false);
                     }
 
                     // Handle guards appearing for banished player
-                    if ((regionData[regionIndex].SeverePunishmentFlags & 1) != 0 && UnityEngine.Random.Range(1, 101) < 10)
+                    if ((regionData[regionIndex].SeverePunishmentFlags & 1) != 0 && UnityEngine.Random.Range(1, 100 + 1) < 10)
                     {
                         crimeCommitted = Crimes.Criminal_Conspiracy;
                         SpawnCityGuards(false);
@@ -673,7 +673,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     // Player seen by a non-guard NPC but not by any guard NPCs. Start a countdown until guards arrive.
                     if (!seenByGuard && seen)
                     {
-                        guardsArriveCountdown = UnityEngine.Random.Range(5, 11);
+                        guardsArriveCountdown = UnityEngine.Random.Range(5, 10 + 1);
                         // Also track location so guards don't appear if player leaves during countdown
                         guardsArriveCountdownLocation = dfLocation;
                     }

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -281,7 +281,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         amount = (int)(RunningFatigueLoss * fatigueLossMultiplier);
                     else if (GameManager.Instance.PlayerEnterExit.IsPlayerSwimming)
                     {
-                        if (Race != Races.Argonian && UnityEngine.Random.Range(1, 100 + 1) > Skills.GetLiveSkillValue(DFCareer.Skills.Swimming))
+                        if (Race != Races.Argonian && Dice100.FailedRoll(Skills.GetLiveSkillValue(DFCareer.Skills.Swimming)))
                             amount = (int)(SwimmingFatigueLoss * fatigueLossMultiplier);
                         TallySkill(DFCareer.Skills.Swimming, 1);
                     }
@@ -406,14 +406,14 @@ namespace DaggerfallWorkshop.Game.Entity
 
                     // Handle guards appearing for low-legal rep player
                     int regionIndex = GameManager.Instance.PlayerGPS.CurrentRegionIndex;
-                    if (regionData[regionIndex].LegalRep < -10 && UnityEngine.Random.Range(1, 100 + 1) < 5)
+                    if (regionData[regionIndex].LegalRep < -10 && Dice100.SuccessRoll(5))
                     {
                         crimeCommitted = Crimes.Criminal_Conspiracy;
                         SpawnCityGuards(false);
                     }
 
                     // Handle guards appearing for banished player
-                    if ((regionData[regionIndex].SeverePunishmentFlags & 1) != 0 && UnityEngine.Random.Range(1, 100 + 1) < 10)
+                    if ((regionData[regionIndex].SeverePunishmentFlags & 1) != 0 && Dice100.SuccessRoll(10))
                     {
                         crimeCommitted = Crimes.Criminal_Conspiracy;
                         SpawnCityGuards(false);
@@ -1467,7 +1467,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     }
 
                     // Raise or lower power based on power of parent, allies, random power bonus and enemies
-                    if (parentPowerMod + alliesPowerMod + factionData.FactionDict[key].rulerPowerBonus - enemiesPowerMod <= UnityEngine.Random.Range(0, 100 + 1))
+                    if (Dice100.FailedRoll(parentPowerMod + alliesPowerMod + factionData.FactionDict[key].rulerPowerBonus - enemiesPowerMod))
                         factionData.ChangePower(factionData.FactionDict[key].id, -1);
                     else
                         factionData.ChangePower(factionData.FactionDict[key].id, 1);
@@ -1496,7 +1496,7 @@ namespace DaggerfallWorkshop.Game.Entity
                             if (allies[i] != 0)
                             {
                                 int powerSum = factionPowerMod + factionData.FactionDict[key].rulerPowerBonus;
-                                if ((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, allies[i]) * 3) / 5 + 70 < UnityEngine.Random.Range(0, 100 + 1))
+                                if (Dice100.FailedRoll((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, allies[i]) * 3) / 5 + 70))
                                 {
                                     factionData.EndFactionAllies(factionData.FactionDict[key].id, allies[i]);
                                     GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, allies[i], -1, 100, 1402); // End faction allies
@@ -1516,7 +1516,7 @@ namespace DaggerfallWorkshop.Game.Entity
                             if (FactionData.GetFactionData(enemies[i], out enemy) && !factionData.IsEnemyStatePermanentUntilWarOver(factionData.FactionDict[key], enemy))
                             {
                                 int powerSum = factionPowerMod + factionData.FactionDict[key].rulerPowerBonus;
-                                if ((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, enemies[i]) * 3) / 5 > UnityEngine.Random.Range(0, 100 + 1))
+                                if (Dice100.SuccessRoll((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, enemies[i]) * 3) / 5))
                                 {
                                     factionData.EndFactionEnemies(factionData.FactionDict[key].id, enemies[i]);
                                     GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, enemies[i], -1, 100, 1403); // End faction enemies
@@ -1561,7 +1561,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                       && factionData.GetFaction2ARelationToFaction1(factionData.FactionDict[key].id, random.id) == 0)
                                 {
                                     int powerSum = factionPowerMod + factionData.FactionDict[key].rulerPowerBonus;
-                                    if ((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, random.id) * 3) / 5 > UnityEngine.Random.Range(0, 100 + 1))
+                                    if (Dice100.SuccessRoll((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, random.id) * 3) / 5))
                                     {
                                         if (factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province && factionData.FactionDict[key].region != -1)
                                             GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, random.id, factionData.FactionDict[key].region, 26, 1481); // Factions start alliance sign message
@@ -1609,7 +1609,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 }
                                 else if (regionData[factionData.FactionDict[key].region].Flags[(int)RegionDataFlags.WarOngoing])
                                 {
-                                    if (UnityEngine.Random.Range(1, 100 + 1) > 5)
+                                    if (Dice100.FailedRoll(5))
                                     {
                                         int combinedPower = factionData.FactionDict[key].power + alliesPower / 5;
 
@@ -1702,7 +1702,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                         if (relation == 2)
                                             mod = 10;
                                         int powerSum = factionPowerMod + factionData.FactionDict[key].rulerPowerBonus;
-                                        if (mod + (powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, random.id) * 3) / 5 + 70 < UnityEngine.Random.Range(0, 100 + 1))
+                                        if (Dice100.FailedRoll(mod + (powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, random.id) * 3) / 5 + 70))
                                         {
                                             if (factionData.FactionDict[key].region != -1 && factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province)
                                                 GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, random.id, factionData.FactionDict[key].region, 27, 1482); // War started sign message
@@ -1731,7 +1731,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         if (!factionData.GetFlag(key, FactionFile.Flags.RulerImmune))
                         {
                             int mod = factionData.FactionDict[key].rulerPowerBonus / 3;
-                            if (UnityEngine.Random.Range(0, 100 + 1) > mod + 70)
+                            if (Dice100.FailedRoll(mod + 70))
                             {
                                 if (factionData.FactionDict[key].region != -1 && factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province)
                                     GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, -1, 12, 1480); // New ruler. Although unused, a regionID is defined for this rumor in classic.
@@ -1759,7 +1759,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 TurnOffConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.FamineEnding);
                             else if (regionData[factionData.FactionDict[key].region].Flags[(int)RegionDataFlags.FamineOngoing])
                             {
-                                if (UnityEngine.Random.Range(0, 100 + 1) < factionData.FactionDict[key].rulerPowerBonus / 5 + alliesPowerMod + factionData.FactionDict[key].power / 5)
+                                if (Dice100.SuccessRoll(factionData.FactionDict[key].rulerPowerBonus / 5 + alliesPowerMod + factionData.FactionDict[key].power / 5))
                                 {
                                     TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.FamineEnding);
                                     GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 7, 1477); // Famine sign message
@@ -1770,7 +1770,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.FamineOngoing);
                                 GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 7, 1477); // Famine sign message
                             }
-                            else if (UnityEngine.Random.Range(1, 100 + 1) <= 2 && UnityEngine.Random.Range(0, 100 + 1) > factionData.FactionDict[key].rulerPowerBonus + alliesPowerMod)
+                            else if (Dice100.SuccessRoll(2) && Dice100.FailedRoll(factionData.FactionDict[key].rulerPowerBonus + alliesPowerMod))
                             {
                                 TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.FamineBeginning);
                                 GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 7, 1477); // Famine sign message
@@ -1787,7 +1787,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 if (temple.id != 0)
                                     factionData.ChangePower(temple.id, -1);
                                 factionData.ChangePower(factionData.FactionDict[key].id, -1);
-                                if (UnityEngine.Random.Range(0, 100 + 1) < factionData.FactionDict[key].power / 5 + factionData.FactionDict[key].rulerPowerBonus / 5 + alliesPowerMod)
+                                if (Dice100.SuccessRoll(factionData.FactionDict[key].power / 5 + factionData.FactionDict[key].rulerPowerBonus / 5 + alliesPowerMod))
                                 {
                                     TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PlagueEnding);
                                     GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 4, 1478); // Plague sign message
@@ -1801,7 +1801,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 GameManager.Instance.TalkManager.AddNonQuestRumor(factionData.FactionDict[key].id, 0, factionData.FactionDict[key].region, 4, 1478); // Plague sign message
                                 TurnOnConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PlagueOngoing);
                             }
-                            else if (UnityEngine.Random.Range(1, 100 + 1) <= 2 && UnityEngine.Random.Range(0, 100 + 1) > factionData.FactionDict[key].rulerPowerBonus + alliesPowerMod)
+                            else if (Dice100.SuccessRoll(2) && Dice100.FailedRoll(factionData.FactionDict[key].rulerPowerBonus + alliesPowerMod))
                             {
                                 if (temple.id != 0)
                                     factionData.ChangePower(temple.id, -1);
@@ -1813,7 +1813,7 @@ namespace DaggerfallWorkshop.Game.Entity
                             // Persecuted temple
                             if (TemplesAssociatedWithRegions[factionData.FactionDict[key].region] != 0)
                             {
-                                if (UnityEngine.Random.Range(0, 100 + 1) >= (temple.power - factionData.FactionDict[key].power + 5) / 5)
+                                if (Dice100.FailedRoll((temple.power - factionData.FactionDict[key].power + 5) / 5))
                                     TurnOffConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PersecutedTemple);
                                 else if (temple.power >= 2 * factionData.FactionDict[key].power)
                                     TurnOffConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PersecutedTemple);
@@ -1836,7 +1836,7 @@ namespace DaggerfallWorkshop.Game.Entity
                             FactionFile.FactionData darkBrotherhood;
                             FactionData.GetFactionData((int)FactionFile.FactionIDs.The_Dark_Brotherhood, out darkBrotherhood);
 
-                            if (UnityEngine.Random.Range(0, 101) >= ((thievesGuild.power + darkBrotherhood.power) / 2 - factionData.FactionDict[key].power + 5) / 5)
+                            if (Dice100.FailedRoll(((thievesGuild.power + darkBrotherhood.power) / 2 - factionData.FactionDict[key].power + 5) / 5))
                                 TurnOffConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.CrimeWave);
                             else
                             {
@@ -1852,7 +1852,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 factionData.ChangePower(witches.id, -1);
                             if (witches.id != 0)
                             {
-                                if (UnityEngine.Random.Range(0, 101) >= (witches.power - factionData.FactionDict[key].power + 5) / 5)
+                                if (Dice100.FailedRoll((witches.power - factionData.FactionDict[key].power + 5) / 5))
                                     TurnOffConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.WitchBurnings);
                                 else
                                 {

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -269,8 +269,8 @@ namespace DaggerfallWorkshop.Game.Formulas
                 return del(player);
 
             int minRoll = player.Career.HitPointsPerLevel / 2;
-            int maxRoll = player.Career.HitPointsPerLevel + 1; // Adding +1 as Unity Random.Range(int,int) is exclusive of maximum value
-            int addHitPoints = UnityEngine.Random.Range(minRoll, maxRoll);
+            int maxRoll = player.Career.HitPointsPerLevel;
+            int addHitPoints = UnityEngine.Random.Range(minRoll, maxRoll + 1); // Adding +1 as Unity Random.Range(int,int) is exclusive of maximum value
             addHitPoints += HitPointsModifier(player.Stats.LiveEndurance);
             if (addHitPoints < 1)
                 addHitPoints = 1;
@@ -298,7 +298,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             }
             chance += GameManager.Instance.WeaponManager.Sheathed ? 10 : -25;
 
-            int roll = UnityEngine.Random.Range(0, 200);
+            int roll = UnityEngine.Random.Range(0, 200 + 1);
             bool success = (roll < chance);
             if (success)
                 player.TallySkill(languageSkill, 1);
@@ -1485,7 +1485,7 @@ namespace DaggerfallWorkshop.Game.Formulas
         public static void RandomizeInitialRegionalPrices(ref PlayerEntity.RegionDataRecord[] regionData)
         {
             for (int i = 0; i < regionData.Length; i++)
-                regionData[i].PriceAdjustment = (ushort)(UnityEngine.Random.Range(0, 501) + 750);
+                regionData[i].PriceAdjustment = (ushort)(UnityEngine.Random.Range(0, 500 + 1) + 750);
         }
 
         public static void UpdateRegionalPrices(ref PlayerEntity.RegionDataRecord[] regionData, int times)
@@ -1504,7 +1504,7 @@ namespace DaggerfallWorkshop.Game.Formulas
                     {
                         int chanceOfPriceRise = ((merchantsFaction.power) - (regionFaction.power)) / 5
                             + 50 - (regionData[i].PriceAdjustment - 1000) / 25;
-                        if (UnityEngine.Random.Range(0, 101) >= chanceOfPriceRise)
+                        if (UnityEngine.Random.Range(0, 100 + 1) >= chanceOfPriceRise)
                             regionData[i].PriceAdjustment = (ushort)(49 * regionData[i].PriceAdjustment / 50);
                         else
                             regionData[i].PriceAdjustment = (ushort)(51 * regionData[i].PriceAdjustment / 50);

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -22,6 +22,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Utility;
 using DaggerfallConnect.Save;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Formulas
 {
@@ -298,7 +299,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             }
             chance += GameManager.Instance.WeaponManager.Sheathed ? 10 : -25;
 
-            int roll = UnityEngine.Random.Range(0, 200 + 1);
+            int roll = UnityEngine.Random.Range(0, 200);
             bool success = (roll < chance);
             if (success)
                 player.TallySkill(languageSkill, 1);
@@ -670,7 +671,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             if (formula_2i.TryGetValue("CalculateBackstabDamage", out del))
                 return del(damage, backstabbingLevel);
 
-            if (backstabbingLevel > 1 && UnityEngine.Random.Range(1, 100 + 1) <= backstabbingLevel)
+            if (backstabbingLevel > 1 && Dice100.SuccessRoll(backstabbingLevel))
             {
                 damage *= 3;
                 string backstabMessage = UserInterfaceWindows.HardStrings.successfulBackstab;
@@ -760,12 +761,12 @@ namespace DaggerfallWorkshop.Game.Formulas
                 case (int)MonsterCareers.Rat:
                     // In classic rat can only give plague (diseaseListA), but DF Chronicles says plague, stomach rot and brain fever (diseaseListB).
                     // Don't know which was intended. Using B since it has more variety.
-                    if (UnityEngine.Random.Range(1, 100 + 1) <= 5)
+                    if (Dice100.SuccessRoll(5))
                         InflictDisease(target, diseaseListB);
                     break;
                 case (int)MonsterCareers.GiantBat:
                     // Classic uses 2% chance, but DF Chronicles says 5% chance. Not sure which was intended.
-                    if (UnityEngine.Random.Range(1, 100 + 1) <= 2)
+                    if (Dice100.SuccessRoll(2))
                         InflictDisease(target, diseaseListB);
                     break;
                 case (int)MonsterCareers.Spider:
@@ -808,11 +809,11 @@ namespace DaggerfallWorkshop.Game.Formulas
                 case (int)MonsterCareers.Zombie:
                     // Nothing in classic. DF Chronicles says 2% chance of disease, which seems like it was probably intended.
                     // Diseases listed in DF Chronicles match those of mummy (except missing cholera, probably a mistake)
-                    if (UnityEngine.Random.Range(1, 100 + 1) <= 2)
+                    if (Dice100.SuccessRoll(2))
                         InflictDisease(target, diseaseListC);
                     break;
                 case (int)MonsterCareers.Mummy:
-                    if (UnityEngine.Random.Range(1, 100 + 1) <= 5)
+                    if (Dice100.SuccessRoll(5))
                         InflictDisease(target, diseaseListC);
                     break;
                 case (int)MonsterCareers.Vampire:
@@ -895,7 +896,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             chanceToHit -= (target.Skills.GetLiveSkillValue(DFCareer.Skills.Dodging) / 4);
 
             // Apply critical strike modifier.
-            if (UnityEngine.Random.Range(0, 100 + 1) < attacker.Skills.GetLiveSkillValue(DFCareer.Skills.CriticalStrike))
+            if (Dice100.SuccessRoll(attacker.Skills.GetLiveSkillValue(DFCareer.Skills.CriticalStrike)))
             {
                 chanceToHit += (attacker.Skills.GetLiveSkillValue(DFCareer.Skills.CriticalStrike) / 10);
             }
@@ -911,9 +912,7 @@ namespace DaggerfallWorkshop.Game.Formulas
 
             Mathf.Clamp(chanceToHit, 3, 97);
 
-            int roll = UnityEngine.Random.Range(0, 100 + 1);
-
-            if (roll <= chanceToHit)
+            if (Dice100.SuccessRoll(chanceToHit))
                 return 1;
             else
                 return 0;
@@ -1020,7 +1019,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             if (target.HasResistanceFlag(elementType))
             {
                 int chance = target.GetResistanceChance(elementType);
-                if (UnityEngine.Random.Range(1, 100 + 1) <= chance)
+                if (Dice100.SuccessRoll(chance))
                     return 0;
             }
 
@@ -1087,7 +1086,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             savingThrow = Mathf.Clamp(savingThrow, 5, 95);
 
             int percentDamageOrDuration = 0;
-            int roll = UnityEngine.Random.Range(1, 100 + 1);
+            int roll = Dice100.Roll();
 
             if (roll <= savingThrow)
             {
@@ -1504,7 +1503,7 @@ namespace DaggerfallWorkshop.Game.Formulas
                     {
                         int chanceOfPriceRise = ((merchantsFaction.power) - (regionFaction.power)) / 5
                             + 50 - (regionData[i].PriceAdjustment - 1000) / 25;
-                        if (UnityEngine.Random.Range(0, 100 + 1) >= chanceOfPriceRise)
+                        if (Dice100.FailedRoll(chanceOfPriceRise))
                             regionData[i].PriceAdjustment = (ushort)(49 * regionData[i].PriceAdjustment / 50);
                         else
                             regionData[i].PriceAdjustment = (ushort)(51 * regionData[i].PriceAdjustment / 50);

--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -210,7 +210,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                 ArmorMaterialTypes material = ArmorMaterialTypes.Iron + rank;
                 for (int i = UnityEngine.Random.Range(3, 7); i >= 0; i--)
                 {
-                    Armor armor = (Armor)UnityEngine.Random.Range(102, 109);
+                    Armor armor = (Armor)UnityEngine.Random.Range(102, 108 + 1);
                     rewardArmor.AddItem(ItemBuilder.CreateArmor(playerEntity.Gender, playerEntity.Race, armor, material));
                 }
                 flags = flags | ArmorFlagMask;

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -499,7 +499,7 @@ namespace DaggerfallWorkshop.Game.Items
             unknown2 = 0;
             typeDependentData = 0;
             enchantmentPoints = itemTemplate.enchantmentPoints;
-            message = (itemGroup == ItemGroups.Paintings) ? UnityEngine.Random.Range(0, 65535) : 0;
+            message = (itemGroup == ItemGroups.Paintings) ? UnityEngine.Random.Range(0, 65536) : 0;
             stackCount = 1;
         }
 

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -17,6 +17,7 @@ using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Questing;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -1115,7 +1116,7 @@ namespace DaggerfallWorkshop.Game.Items
         public void DamageThroughPhysicalHit(int damage, DaggerfallEntity owner)
         {
             int amount = (10 * damage + 50) / 100;
-            if ((amount == 0) && UnityEngine.Random.Range(1, 100 + 1) < 20)
+            if ((amount == 0) && Dice100.SuccessRoll(20))
                 amount = 1;
             currentCondition -= amount;
             if (currentCondition <= 0)

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -18,6 +18,7 @@ using DaggerfallConnect.FallExe;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Utility.AssetInjection;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -131,11 +132,11 @@ namespace DaggerfallWorkshop.Game.Items
         public static ArmorMaterialTypes RandomArmorMaterial(int playerLevel)
         {
             // Random armor material
-            int random = UnityEngine.Random.Range(1, 100 + 1);
+            int roll = Dice100.Roll();
 
-            if (random >= 70)
+            if (roll >= 70)
             {
-                if (random >= 90)
+                if (roll >= 90)
                 {
                     WeaponMaterialTypes plateMaterial = RandomMaterial(playerLevel);
                     return (ArmorMaterialTypes)(0x0200 + plateMaterial);

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -131,7 +131,7 @@ namespace DaggerfallWorkshop.Game.Items
         public static ArmorMaterialTypes RandomArmorMaterial(int playerLevel)
         {
             // Random armor material
-            int random = UnityEngine.Random.Range(1, 101);
+            int random = UnityEngine.Random.Range(1, 100 + 1);
 
             if (random >= 70)
             {
@@ -338,7 +338,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             if (weapon == Weapons.Arrow)
             {   // Handle arrows
-                newItem.stackCount = UnityEngine.Random.Range(1, 21);
+                newItem.stackCount = UnityEngine.Random.Range(1, 20 + 1);
                 newItem.currentCondition = 0; // not sure if this is necessary, but classic does it
             }
             else
@@ -372,7 +372,7 @@ namespace DaggerfallWorkshop.Game.Items
             // Handle arrows
             if (groupIndex == 18)
             {
-                newItem.stackCount = UnityEngine.Random.Range(1, 21);
+                newItem.stackCount = UnityEngine.Random.Range(1, 20 + 1);
                 newItem.currentCondition = 0; // not sure if this is necessary, but classic does it
             }
 

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -442,7 +442,7 @@ namespace DaggerfallWorkshop.Game.Items
         {
             List<int> keys = new List<int>(bookIDNameMapping.Keys);
             int size = bookIDNameMapping.Count;
-            return keys[UnityEngine.Random.Range(0, size - 1)];
+            return keys[UnityEngine.Random.Range(0, size)];
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/LootTables.cs
+++ b/Assets/Scripts/Game/Items/LootTables.cs
@@ -166,7 +166,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random weapon
             chance = matrix.WP;
-            while (Random.Range(0, 100) < chance)
+            while (Random.Range(0, 100 + 1) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
                 chance *= 0.5f;
@@ -174,7 +174,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random armor
             chance = matrix.AM;
-            while (Random.Range(0, 100) < chance)
+            while (Random.Range(0, 100 + 1) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
@@ -191,7 +191,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random magic item
             chance = matrix.MI;
-            while (Random.Range(0, 100) < chance)
+            while (Random.Range(0, 100 + 1) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
@@ -199,7 +199,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random clothes
             chance = matrix.CL;
-            while (Random.Range(0, 100) < chance)
+            while (Random.Range(0, 100 + 1) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
@@ -207,7 +207,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random books
             chance = matrix.BK;
-            while (Random.Range(0, 100) < chance)
+            while (Random.Range(0, 100 + 1) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomBook());
                 chance *= 0.5f;
@@ -215,7 +215,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random religious item
             chance = matrix.RL;
-            while (Random.Range(0, 100) < chance)
+            while (Random.Range(0, 100 + 1) < chance)
             {
                 items.Add(ItemBuilder.CreateRandomReligiousItem());
                 chance *= 0.5f;
@@ -228,7 +228,7 @@ namespace DaggerfallWorkshop.Game.Items
 
         static void RandomIngredient(float chance, ItemGroups ingredientGroup, List<DaggerfallUnityItem> targetItems)
         {
-            while (Random.Range(0, 100) < chance)
+            while (Random.Range(0, 100 + 1) < chance)
             {
                 targetItems.Add(ItemBuilder.CreateRandomIngredient(ingredientGroup));
                 chance *= 0.5f;

--- a/Assets/Scripts/Game/Items/LootTables.cs
+++ b/Assets/Scripts/Game/Items/LootTables.cs
@@ -12,6 +12,7 @@
 using UnityEngine;
 using DaggerfallWorkshop.Game.Entity;
 using System.Collections.Generic;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -166,7 +167,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random weapon
             chance = matrix.WP;
-            while (Random.Range(0, 100 + 1) < chance)
+            while (Dice100.SuccessRoll((int)chance))
             {
                 items.Add(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
                 chance *= 0.5f;
@@ -174,7 +175,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random armor
             chance = matrix.AM;
-            while (Random.Range(0, 100 + 1) < chance)
+            while (Dice100.SuccessRoll((int)chance))
             {
                 items.Add(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
@@ -191,7 +192,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random magic item
             chance = matrix.MI;
-            while (Random.Range(0, 100 + 1) < chance)
+            while (Dice100.SuccessRoll((int)chance))
             {
                 items.Add(ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
@@ -199,7 +200,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random clothes
             chance = matrix.CL;
-            while (Random.Range(0, 100 + 1) < chance)
+            while (Dice100.SuccessRoll((int)chance))
             {
                 items.Add(ItemBuilder.CreateRandomClothing(playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
@@ -207,7 +208,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random books
             chance = matrix.BK;
-            while (Random.Range(0, 100 + 1) < chance)
+            while (Dice100.SuccessRoll((int)chance))
             {
                 items.Add(ItemBuilder.CreateRandomBook());
                 chance *= 0.5f;
@@ -215,7 +216,7 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Random religious item
             chance = matrix.RL;
-            while (Random.Range(0, 100 + 1) < chance)
+            while (Dice100.SuccessRoll((int)chance))
             {
                 items.Add(ItemBuilder.CreateRandomReligiousItem());
                 chance *= 0.5f;
@@ -228,7 +229,7 @@ namespace DaggerfallWorkshop.Game.Items
 
         static void RandomIngredient(float chance, ItemGroups ingredientGroup, List<DaggerfallUnityItem> targetItems)
         {
-            while (Random.Range(0, 100 + 1) < chance)
+            while (Dice100.SuccessRoll((int)chance))
             {
                 targetItems.Add(ItemBuilder.CreateRandomIngredient(ingredientGroup));
                 chance *= 0.5f;

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
@@ -14,6 +14,7 @@ using DaggerfallConnect;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Formulas;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.MagicAndEffects
 {
@@ -504,8 +505,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             if (!Properties.SupportChance)
                 return false;
 
-            int roll = Random.Range(1, 100 + 1);
-            bool outcome = (roll <= ChanceValue());
+            bool outcome = Dice100.SuccessRoll(ChanceValue());
 
             //Debug.LogFormat("Effect '{0}' has a {1}% chance of succeeding and rolled {2} for a {3}", Key, ChanceValue(), roll, (outcome) ? "success" : "fail");
 

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
@@ -504,7 +504,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             if (!Properties.SupportChance)
                 return false;
 
-            int roll = Random.Range(1, 100);
+            int roll = Random.Range(1, 100 + 1);
             bool outcome = (roll <= ChanceValue());
 
             //Debug.LogFormat("Effect '{0}' has a {1}% chance of succeeding and rolled {2} for a {3}", Key, ChanceValue(), roll, (outcome) ? "success" : "fail");

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1059,7 +1059,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         bool TryEffectBasedAbsorption(IEntityEffect effect, SpellAbsorption absorbEffect, DaggerfallEntity casterEntity)
         {
             int chance = absorbEffect.Settings.ChanceBase + absorbEffect.Settings.ChancePlus * (int)Mathf.Floor(casterEntity.Level / absorbEffect.Settings.ChancePerLevel);
-            int roll = UnityEngine.Random.Range(1, 100);
+            int roll = UnityEngine.Random.Range(1, 100 + 1);
 
             return (roll <= chance);
         }

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1059,9 +1059,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         bool TryEffectBasedAbsorption(IEntityEffect effect, SpellAbsorption absorbEffect, DaggerfallEntity casterEntity)
         {
             int chance = absorbEffect.Settings.ChanceBase + absorbEffect.Settings.ChancePlus * (int)Mathf.Floor(casterEntity.Level / absorbEffect.Settings.ChancePerLevel);
-            int roll = UnityEngine.Random.Range(1, 100 + 1);
 
-            return (roll <= chance);
+            return Dice100.SuccessRoll(chance);
         }
 
         bool TryCareerBasedAbsorption(IEntityEffect effect, DaggerfallEntity casterEntity)

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using System;
 using System.Collections;
 using DaggerfallConnect;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -585,9 +586,9 @@ namespace DaggerfallWorkshop.Game
             float luckFactor = Mathf.Lerp(0, 10, luck * 0.01f);
 
             // Skill Check
-            float percentRolled = Mathf.Lerp(basePercentSuccess, 100, skill * .01f) + luckFactor;
+            float percentSuccess = Mathf.Lerp(basePercentSuccess, 100, skill * .01f) + luckFactor;
 
-            if (percentRolled < UnityEngine.Random.Range(1, 100 + 1)) // Failed Check?
+            if (Dice100.FailedRoll((int)percentSuccess))
             {
                 // Don't allow skill check to break climbing while swimming
                 // Water makes it easier to climb

--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -587,7 +587,7 @@ namespace DaggerfallWorkshop.Game
             // Skill Check
             float percentRolled = Mathf.Lerp(basePercentSuccess, 100, skill * .01f) + luckFactor;
 
-            if (percentRolled < UnityEngine.Random.Range(1, 101)) // Failed Check?
+            if (percentRolled < UnityEngine.Random.Range(1, 100 + 1)) // Failed Check?
             {
                 // Don't allow skill check to break climbing while swimming
                 // Water makes it easier to climb

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -573,7 +573,7 @@ namespace DaggerfallWorkshop.Game
                 // Roll for chance to open
                 // TODO: Factor door lock value into chance to open
                 int chance = 20;
-                int roll = Random.Range(1, 101);
+                int roll = Random.Range(1, 100 + 1);
                 if (roll <= chance)
                 {
                     TransitionInterior(doorOwner, door, true);
@@ -1129,9 +1129,9 @@ namespace DaggerfallWorkshop.Game
 
             int chance = Formulas.FormulaHelper.CalculatePickpocketingChance(player, enemyEntity);
 
-            if (Random.Range(0, 101) <= chance)
+            if (Random.Range(0, 100 + 1) <= chance)
             {
-                if (Random.Range(0, 101) >= 33)
+                if (Random.Range(0, 100 + 1) >= 33)
                 {
                     int pinchedGoldPieces = Random.Range(0, 6) + 1;
                     player.GoldPieces += pinchedGoldPieces;

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -23,6 +23,7 @@ using DaggerfallWorkshop.Game.Guilds;
 using DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects;
 using System.Collections.Generic;
 using DaggerfallWorkshop.Utility.AssetInjection;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -573,8 +574,7 @@ namespace DaggerfallWorkshop.Game
                 // Roll for chance to open
                 // TODO: Factor door lock value into chance to open
                 int chance = 20;
-                int roll = Random.Range(1, 100 + 1);
-                if (roll <= chance)
+                if (Dice100.SuccessRoll(chance))
                 {
                     TransitionInterior(doorOwner, door, true);
                     return true;
@@ -1129,9 +1129,9 @@ namespace DaggerfallWorkshop.Game
 
             int chance = Formulas.FormulaHelper.CalculatePickpocketingChance(player, enemyEntity);
 
-            if (Random.Range(0, 100 + 1) <= chance)
+            if (Dice100.SuccessRoll(chance))
             {
-                if (Random.Range(0, 100 + 1) >= 33)
+                if (Dice100.FailedRoll(33))
                 {
                     int pinchedGoldPieces = Random.Range(0, 6) + 1;
                     player.GoldPieces += pinchedGoldPieces;

--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -12,6 +12,7 @@
 using UnityEngine;
 using System.Collections;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -296,7 +297,7 @@ namespace DaggerfallWorkshop.Game
         // Capture this message so we can play pain voice
         public void RemoveHealth(int amount)
         {
-            if (dfAudioSource && DaggerfallUnity.Settings.CombatVoices && Random.Range(1, 100 + 1) <= 40)
+            if (dfAudioSource && DaggerfallUnity.Settings.CombatVoices && Dice100.SuccessRoll(40))
             {
                 Entity.PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
                 bool heavyDamage = amount >= playerEntity.MaxHealth / 4;

--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -296,7 +296,7 @@ namespace DaggerfallWorkshop.Game
         // Capture this message so we can play pain voice
         public void RemoveHealth(int amount)
         {
-            if (dfAudioSource && DaggerfallUnity.Settings.CombatVoices && Random.Range(1, 101) <= 40)
+            if (dfAudioSource && DaggerfallUnity.Settings.CombatVoices && Random.Range(1, 100 + 1) <= 40)
             {
                 Entity.PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
                 bool heavyDamage = amount >= playerEntity.MaxHealth / 4;

--- a/Assets/Scripts/Game/Questing/Actions/CreateFoe.cs
+++ b/Assets/Scripts/Game/Questing/Actions/CreateFoe.cs
@@ -98,7 +98,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
             // Init spawn timer on first update
             if (lastSpawnTime == 0)
-                lastSpawnTime = gameSeconds + (uint)UnityEngine.Random.Range(0, spawnInterval);
+                lastSpawnTime = gameSeconds + (uint)UnityEngine.Random.Range(0, spawnInterval + 1);
 
             // Do nothing if max foes already spawned
             // This can be cleared on next set/rearm

--- a/Assets/Scripts/Game/Questing/Actions/Demo/JuggleAction.cs
+++ b/Assets/Scripts/Game/Questing/Actions/Demo/JuggleAction.cs
@@ -150,7 +150,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             DaggerfallUI.AddHUDText(string.Format("Juggling {0} {1}...", thingsRemaining, thingName));
 
             // We might drop something!
-            int roll = Random.Range(1, 101);
+            int roll = Random.Range(1, 100 + 1);
             if (roll < dropPercent)
             {
                 thingsRemaining--;

--- a/Assets/Scripts/Game/Questing/Actions/Demo/JuggleAction.cs
+++ b/Assets/Scripts/Game/Questing/Actions/Demo/JuggleAction.cs
@@ -12,6 +12,7 @@
 using UnityEngine;
 using System.Text.RegularExpressions;
 using FullSerializer;
+using DaggerfallWorkshop.Game.Utility;
 
 // Place actions in this namespace
 namespace DaggerfallWorkshop.Game.Questing.Actions
@@ -150,8 +151,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             DaggerfallUI.AddHUDText(string.Format("Juggling {0} {1}...", thingsRemaining, thingName));
 
             // We might drop something!
-            int roll = Random.Range(1, 100 + 1);
-            if (roll < dropPercent)
+            if (Dice100.SuccessRoll(dropPercent))
             {
                 thingsRemaining--;
                 DaggerfallUI.AddHUDText("Oops, I dropped one!");

--- a/Assets/Scripts/Game/Questing/Actions/GivePc.cs
+++ b/Assets/Scripts/Game/Questing/Actions/GivePc.cs
@@ -89,7 +89,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                 // If we were waiting then add a small random delay so messages don't all arrive at once
                 if (waitingForTown)
                 {
-                    ticksUntilFire = UnityEngine.Random.Range(minDelay, maxDelay);
+                    ticksUntilFire = UnityEngine.Random.Range(minDelay, maxDelay + 1);
                     waitingForTown = false;
                     RaiseOnOfferPendingEvent(this);
                 }

--- a/Assets/Scripts/Game/Questing/Clock.cs
+++ b/Assets/Scripts/Game/Questing/Clock.cs
@@ -237,7 +237,7 @@ namespace DaggerfallWorkshop.Game.Questing
                         clockTimeInSeconds = GetTravelTimeInSeconds();
 
                     // Add range
-                    int randomDays = UnityEngine.Random.Range(minRange, maxRange);
+                    int randomDays = UnityEngine.Random.Range(minRange, maxRange + 1);
                     clockTimeInSeconds += randomDays * DaggerfallDateTime.SecondsPerDay;
                 }
 
@@ -379,7 +379,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
         int FromRange(int minSeconds, int maxSeconds)
         {
-            return UnityEngine.Random.Range(minSeconds, maxSeconds);
+            return UnityEngine.Random.Range(minSeconds, maxSeconds + 1);
         }
 
         void InitialiseTimer(int clockTimeInSeconds)

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1087,7 +1087,7 @@ namespace DaggerfallWorkshop.Game
                         // Flag 1 being set makes faction's rumors less likely to appear in conversation.
                         if ((entry.faction1 != 0 && GameManager.Instance.PlayerEntity.FactionData.GetFactionData(entry.faction1, out factionData1) && (factionData1.flags & 1) == 1
                             || entry.faction2 != 0 && GameManager.Instance.PlayerEntity.FactionData.GetFactionData(entry.faction2, out factionData2) && (factionData2.flags & 1) == 1)
-                            && UnityEngine.Random.Range(1, 101) <= 75)
+                            && UnityEngine.Random.Range(1, 100 + 1) <= 75)
                             continue;
                     }
                 }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -25,6 +25,7 @@ using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Player;
 using DaggerfallWorkshop.Game.Guilds;
 using Wenzil.Console;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -1087,7 +1088,7 @@ namespace DaggerfallWorkshop.Game
                         // Flag 1 being set makes faction's rumors less likely to appear in conversation.
                         if ((entry.faction1 != 0 && GameManager.Instance.PlayerEntity.FactionData.GetFactionData(entry.faction1, out factionData1) && (factionData1.flags & 1) == 1
                             || entry.faction2 != 0 && GameManager.Instance.PlayerEntity.FactionData.GetFactionData(entry.faction2, out factionData2) && (factionData2.flags & 1) == 1)
-                            && UnityEngine.Random.Range(1, 100 + 1) <= 75)
+                            && Dice100.SuccessRoll(75))
                             continue;
                     }
                 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -118,8 +118,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (threshold2 > 75)
                         threshold2 = 75;
                 }
-                if (UnityEngine.Random.Range(1, 101) > threshold2 &&
-                    UnityEngine.Random.Range(1, 101) > threshold1)
+                if (UnityEngine.Random.Range(1, 100 + 1) > threshold2 &&
+                    UnityEngine.Random.Range(1, 100 + 1) > threshold1)
                     punishmentType = 2; // fine/prison
                 else
                     punishmentType = 0; // banishment or execution
@@ -375,7 +375,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             else if (chanceToGoFree < 5)
                 chanceToGoFree = 5;
 
-            if (UnityEngine.Random.Range(1, 101) > chanceToGoFree)
+            if (UnityEngine.Random.Range(1, 100 + 1) > chanceToGoFree)
             {
                 // Banishment
                 if (punishmentType == 0)
@@ -386,7 +386,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // Prison/Fine
                 else
                 {
-                    int roll = playerEntity.RegionData[regionIndex].LegalRep + UnityEngine.Random.Range(1, 101);
+                    int roll = playerEntity.RegionData[regionIndex].LegalRep + UnityEngine.Random.Range(1, 100 + 1);
                     if (roll < 25)
                         fine *= 2;
                     else if (roll > 75)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -17,7 +17,7 @@ using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
 using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
-
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -118,8 +118,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (threshold2 > 75)
                         threshold2 = 75;
                 }
-                if (UnityEngine.Random.Range(1, 100 + 1) > threshold2 &&
-                    UnityEngine.Random.Range(1, 100 + 1) > threshold1)
+                if (Dice100.FailedRoll(threshold2) &&
+                    Dice100.FailedRoll(threshold1))
                     punishmentType = 2; // fine/prison
                 else
                     punishmentType = 0; // banishment or execution
@@ -375,7 +375,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             else if (chanceToGoFree < 5)
                 chanceToGoFree = 5;
 
-            if (UnityEngine.Random.Range(1, 100 + 1) > chanceToGoFree)
+            if (Dice100.FailedRoll(chanceToGoFree))
             {
                 // Banishment
                 if (punishmentType == 0)
@@ -386,7 +386,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // Prison/Fine
                 else
                 {
-                    int roll = playerEntity.RegionData[regionIndex].LegalRep + UnityEngine.Random.Range(1, 100 + 1);
+                    int roll = playerEntity.RegionData[regionIndex].LegalRep + Dice100.Roll();
                     if (roll < 25)
                         fine *= 2;
                     else if (roll > 75)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -209,7 +209,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     DaggerfallUnityItem magicItem = ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Soul_trap);
                     magicItem.value = 5000;
 
-                    if (UnityEngine.Random.Range(1, 100 + 1) >= 25)
+                    if (Dice100.FailedRoll(25))
                         magicItem.TrappedSoulType = MobileTypes.None;
                     else
                     {
@@ -603,7 +603,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                     // Change reputation
                     int rep = Math.Abs(playerEntity.FactionData.GetReputation(factionId));
-                    if (UnityEngine.Random.Range(1, 100 + 1) <= (2 * amount / rep + 1))
+                    if (Dice100.SuccessRoll(2 * amount / rep + 1))
                         playerEntity.FactionData.ChangeReputation(factionId, 1); // Does not propagate in classic
 
                     // Show thanks message

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -21,6 +21,7 @@ using DaggerfallWorkshop.Game.Questing;
 using System;
 using DaggerfallWorkshop.Game.Guilds;
 using DaggerfallWorkshop.Game.Formulas;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -566,7 +567,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 playerEntity.DeductGoldAmount(guild.GetTrainingPrice());
                 playerEntity.DecreaseFatigue(PlayerEntity.DefaultFatigueLoss * 180);
                 int skillAdvancementMultiplier = DaggerfallSkills.GetAdvancementMultiplier(skillToTrain);
-                short tallyAmount = (short)(UnityEngine.Random.Range(10, 21) * skillAdvancementMultiplier);
+                short tallyAmount = (short)(UnityEngine.Random.Range(10, 20 + 1) * skillAdvancementMultiplier);
                 playerEntity.TallySkill(skillToTrain, tallyAmount);
                 DaggerfallUI.MessageBox(TrainSkillId);
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -209,7 +209,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     DaggerfallUnityItem magicItem = ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Soul_trap);
                     magicItem.value = 5000;
 
-                    if (UnityEngine.Random.Range(1, 101) >= 25)
+                    if (UnityEngine.Random.Range(1, 100 + 1) >= 25)
                         magicItem.TrappedSoulType = MobileTypes.None;
                     else
                     {
@@ -603,7 +603,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                     // Change reputation
                     int rep = Math.Abs(playerEntity.FactionData.GetReputation(factionId));
-                    if (UnityEngine.Random.Range(1, 101) <= (2 * amount / rep + 1))
+                    if (UnityEngine.Random.Range(1, 100 + 1) <= (2 * amount / rep + 1))
                         playerEntity.FactionData.ChangeReputation(factionId, 1); // Does not propagate in classic
 
                     // Show thanks message

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -237,7 +237,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     int sheoChance = (weatherManager.IsStorming) ? 15 : 5;
                     // Get summoning chance for selected daedra and roll.
                     int chance = FormulaHelper.CalculateDaedraSummoningChance(playerEntity.FactionData.GetReputation(daedraToSummon.factionId), bonus);
-                    int roll = Random.Range(1, 101);
+                    int roll = Random.Range(1, 100 + 1);
                     Debug.LogFormat("Summoning {0} with chance = {1}%, Sheogorath chance = {2}%, roll = {3}, summoner rep = {4}, cost: {5}",
                         daedraToSummon.vidFile.Substring(0, daedraToSummon.vidFile.Length-4), chance, sheoChance, roll, summonerFactionData.rep, summonCost);
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -16,6 +16,7 @@ using DaggerfallWorkshop.Game.Questing;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Formulas;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -237,7 +238,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     int sheoChance = (weatherManager.IsStorming) ? 15 : 5;
                     // Get summoning chance for selected daedra and roll.
                     int chance = FormulaHelper.CalculateDaedraSummoningChance(playerEntity.FactionData.GetReputation(daedraToSummon.factionId), bonus);
-                    int roll = Random.Range(1, 100 + 1);
+                    int roll = Dice100.Roll();
                     Debug.LogFormat("Summoning {0} with chance = {1}%, Sheogorath chance = {2}%, roll = {3}, summoner rep = {4}, cost: {5}",
                         daedraToSummon.vidFile.Substring(0, daedraToSummon.vidFile.Length-4), chance, sheoChance, roll, summonerFactionData.rep, summonCost);
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -21,6 +21,7 @@ using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.Banking;
 using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.Guilds;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -688,10 +689,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 // Calculate the weight of all items picked from shelves, then get chance of shoplifting success.
                 int weightAndNumItems = (int) basketItems.GetWeight() + basketItems.Count;
-                int chance = FormulaHelper.CalculateShopliftingChance(PlayerEntity, null, buildingDiscoveryData.quality, weightAndNumItems);
+                int chanceBeingDetected = FormulaHelper.CalculateShopliftingChance(PlayerEntity, null, buildingDiscoveryData.quality, weightAndNumItems);
                 PlayerEntity.TallySkill(DFCareer.Skills.Pickpocket, 1);
 
-                if (UnityEngine.Random.Range(0, 100 + 1) > chance)
+                if (Dice100.FailedRoll(chanceBeingDetected))
                 {
                     DaggerfallUI.AddHUDText(TextManager.Instance.GetText(textDatabase, "youAreSuccessful"), 2);
                     RaiseOnTradeHandler(basketItems.GetNumItems(), 0);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -691,7 +691,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 int chance = FormulaHelper.CalculateShopliftingChance(PlayerEntity, null, buildingDiscoveryData.quality, weightAndNumItems);
                 PlayerEntity.TallySkill(DFCareer.Skills.Pickpocket, 1);
 
-                if (UnityEngine.Random.Range(0, 101) > chance)
+                if (UnityEngine.Random.Range(0, 100 + 1) > chance)
                 {
                     DaggerfallUI.AddHUDText(TextManager.Instance.GetText(textDatabase, "youAreSuccessful"), 2);
                     RaiseOnTradeHandler(basketItems.GetNumItems(), 0);

--- a/Assets/Scripts/Game/Utility/CityNavigation.cs
+++ b/Assets/Scripts/Game/Utility/CityNavigation.cs
@@ -512,8 +512,8 @@ namespace DaggerfallWorkshop.Game.Utility
             DFPosition testPosition = new DFPosition();
             while (!found)
             {
-                testPosition.X = origin.X + UnityEngine.Random.Range(-radius, radius);
-                testPosition.Y = origin.Y + UnityEngine.Random.Range(-radius, radius);
+                testPosition.X = origin.X + UnityEngine.Random.Range(-radius, radius + 1);
+                testPosition.Y = origin.Y + UnityEngine.Random.Range(-radius, radius + 1);
 
                 if (GetNavGridWeightLocal(testPosition) > 0)
                 {

--- a/Assets/Scripts/Game/Utility/Dice100.cs
+++ b/Assets/Scripts/Game/Utility/Dice100.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+namespace DaggerfallWorkshop.Game.Utility
+{
+    public class Dice100
+    {
+        private Dice100()
+        {
+        }
+
+        public static int Roll()
+        {
+            return Random.Range(1, 101);
+        }
+
+        public static bool SuccessRoll(int chanceSuccess)
+        {
+            return Random.Range(0, 100) < chanceSuccess; // Same as Random.Range(1, 101) <= chanceSuccess
+        }
+
+        public static bool FailedRoll(int chanceSuccess)
+        {
+            return Random.Range(0, 100) >= chanceSuccess; // Same as Random.Range(1, 101) > chanceSuccess
+        }
+    }
+}

--- a/Assets/Scripts/Game/Utility/FoeSpawner.cs
+++ b/Assets/Scripts/Game/Utility/FoeSpawner.cs
@@ -147,7 +147,7 @@ namespace DaggerfallWorkshop.Game.Utility
             else
             {
                 // Don't care about player's field of view (e.g. at rest)
-                rotation = Quaternion.Euler(0, UnityEngine.Random.Range(0, 361), 0);
+                rotation = Quaternion.Euler(0, UnityEngine.Random.Range(0, 360), 0);
             }
 
             // Get direction vector and create a new ray

--- a/Assets/Scripts/Game/Utility/NameHelper.cs
+++ b/Assets/Scripts/Game/Utility/NameHelper.cs
@@ -289,7 +289,7 @@ namespace DaggerfallWorkshop.Game.Utility
         // Monster3: (if male, 25% +3 + " ")+0+1+2
         string GetRandomMonsterName(Genders gender)
         {
-            BankTypes type = (BankTypes)UnityEngine.Random.Range(8, 10); // Get random Monster1 or Monster2 for now.
+            BankTypes type = (BankTypes)UnityEngine.Random.Range(8, 9 + 1); // Get random Monster1 or Monster2 for now.
             NameBank nameBank = bankDict[type];
 
             // Get set parts

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -20,6 +20,7 @@ using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -333,7 +334,7 @@ namespace DaggerfallWorkshop.Game
             else if (!isDamageFinished && ScreenWeapon.GetCurrentFrame() == ScreenWeapon.GetHitFrame())
             {
                 // Chance to play attack voice
-                if (DaggerfallUnity.Settings.CombatVoices && ScreenWeapon.WeaponType != WeaponTypes.Bow && UnityEngine.Random.Range(1, 100 + 1) <= 20)
+                if (DaggerfallUnity.Settings.CombatVoices && ScreenWeapon.WeaponType != WeaponTypes.Bow && Dice100.SuccessRoll(20))
                     ScreenWeapon.PlayAttackVoice();
 
                 // Transfer damage.
@@ -528,7 +529,7 @@ namespace DaggerfallWorkshop.Game
                             }
                         }
 
-                        if (DaggerfallUnity.Settings.CombatVoices && entityBehaviour.EntityType == EntityTypes.EnemyClass && UnityEngine.Random.Range(1, 100 + 1) <= 40)
+                        if (DaggerfallUnity.Settings.CombatVoices && entityBehaviour.EntityType == EntityTypes.EnemyClass && Dice100.SuccessRoll(40))
                         {
                             Genders gender;
                             if (entityMobileUnit.Summary.Enemy.Gender == MobileGender.Male || enemyEntity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -333,7 +333,7 @@ namespace DaggerfallWorkshop.Game
             else if (!isDamageFinished && ScreenWeapon.GetCurrentFrame() == ScreenWeapon.GetHitFrame())
             {
                 // Chance to play attack voice
-                if (DaggerfallUnity.Settings.CombatVoices && ScreenWeapon.WeaponType != WeaponTypes.Bow && UnityEngine.Random.Range(1, 101) <= 20)
+                if (DaggerfallUnity.Settings.CombatVoices && ScreenWeapon.WeaponType != WeaponTypes.Bow && UnityEngine.Random.Range(1, 100 + 1) <= 20)
                     ScreenWeapon.PlayAttackVoice();
 
                 // Transfer damage.
@@ -528,7 +528,7 @@ namespace DaggerfallWorkshop.Game
                             }
                         }
 
-                        if (DaggerfallUnity.Settings.CombatVoices && entityBehaviour.EntityType == EntityTypes.EnemyClass && UnityEngine.Random.Range(1, 101) <= 40)
+                        if (DaggerfallUnity.Settings.CombatVoices && entityBehaviour.EntityType == EntityTypes.EnemyClass && UnityEngine.Random.Range(1, 100 + 1) <= 40)
                         {
                             Genders gender;
                             if (entityMobileUnit.Summary.Enemy.Gender == MobileGender.Male || enemyEntity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)

--- a/Assets/Scripts/Game/WeatherManager.cs
+++ b/Assets/Scripts/Game/WeatherManager.cs
@@ -220,7 +220,7 @@ namespace DaggerfallWorkshop.Game
         {
             if (DaggerfallSky)
             {
-                if (Random.Range(0, 1) > 0.5f)
+                if (Random.Range(0f, 1f) > 0.5f)
                     DaggerfallSky.WeatherStyle = WeatherStyle.Rain1;
                 else
                     DaggerfallSky.WeatherStyle = WeatherStyle.Rain2;
@@ -255,7 +255,7 @@ namespace DaggerfallWorkshop.Game
         {
             if (DaggerfallSky)
             {
-                if (Random.Range(0, 1) > 0.5f)
+                if (Random.Range(0f, 1f) > 0.5f)
                     DaggerfallSky.WeatherStyle = WeatherStyle.Snow1;
                 else
                     DaggerfallSky.WeatherStyle = WeatherStyle.Snow2;

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -176,7 +176,7 @@ namespace DaggerfallWorkshop
                 player.TallySkill(DFCareer.Skills.Lockpicking, 1);
                 chance = FormulaHelper.CalculateInteriorLockpickingChance(player.Level, CurrentLockValue, player.Skills.GetLiveSkillValue(DFCareer.Skills.Lockpicking));
 
-                if (Random.Range(0, 101) > chance)
+                if (Random.Range(0, 100 + 1) > chance)
                 {
                     Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickingFailure);
                     FailedSkillLevel = player.Skills.GetLiveSkillValue(DFCareer.Skills.Lockpicking);
@@ -218,7 +218,7 @@ namespace DaggerfallWorkshop
                 {
                     // Roll for chance to open
                     int chance = 20 - CurrentLockValue;
-                    int roll = UnityEngine.Random.Range(1, 101);
+                    int roll = UnityEngine.Random.Range(1, 100 + 1);
                     if (roll <= chance)
                     {
                         CurrentLockValue = 0;

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -15,6 +15,7 @@ using DaggerfallConnect;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Formulas;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop
 {
@@ -176,7 +177,7 @@ namespace DaggerfallWorkshop
                 player.TallySkill(DFCareer.Skills.Lockpicking, 1);
                 chance = FormulaHelper.CalculateInteriorLockpickingChance(player.Level, CurrentLockValue, player.Skills.GetLiveSkillValue(DFCareer.Skills.Lockpicking));
 
-                if (Random.Range(0, 100 + 1) > chance)
+                if (Dice100.FailedRoll(chance))
                 {
                     Game.DaggerfallUI.Instance.PopupMessage(HardStrings.lockpickingFailure);
                     FailedSkillLevel = player.Skills.GetLiveSkillValue(DFCareer.Skills.Lockpicking);
@@ -218,8 +219,7 @@ namespace DaggerfallWorkshop
                 {
                     // Roll for chance to open
                     int chance = 20 - CurrentLockValue;
-                    int roll = UnityEngine.Random.Range(1, 100 + 1);
-                    if (roll <= chance)
+                    if (Dice100.SuccessRoll(chance))
                     {
                         CurrentLockValue = 0;
                         ToggleDoor(true);

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -73,7 +73,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void RandomlyAddMap(int chance, ItemCollection collection)
         {
-            if (Random.Range(1, 101) <= chance)
+            if (Random.Range(1, 100 + 1) <= chance)
             {
                 DaggerfallUnityItem map = new DaggerfallUnityItem(ItemGroups.MiscItems, 8);
                 collection.AddItem(map);
@@ -85,7 +85,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void RandomlyAddPotion(int chance, ItemCollection collection)
         {
-            if (Random.Range(1, 101) < chance)
+            if (Random.Range(1, 100 + 1) < chance)
                 collection.AddItem(ItemBuilder.CreateRandomPotion());
         }
 
@@ -94,7 +94,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void RandomlyAddPotionRecipe(int chance, ItemCollection collection)
         {
-            if (Random.Range(1, 101) < chance)
+            if (Random.Range(1, 100 + 1) < chance)
             {
                 DaggerfallUnityItem potionRecipe = new DaggerfallUnityItem(ItemGroups.MiscItems, 4);
                 byte recipe = (byte)Random.Range(0, 20);
@@ -192,7 +192,7 @@ namespace DaggerfallWorkshop
                             if (itemTemplate.rarity <= shopQuality)
                             {
                                 int stockChance = chanceMod * 5 * (21 - itemTemplate.rarity) / 100;
-                                if (Random.Range(1, 101) <= stockChance)
+                                if (Random.Range(1, 100 + 1) <= stockChance)
                                 {
                                     DaggerfallUnityItem item = null;
                                     if (itemGroup == ItemGroups.Weapons)
@@ -213,7 +213,7 @@ namespace DaggerfallWorkshop
                                     {
                                         item = new DaggerfallUnityItem(itemGroup, j);
                                         if (DaggerfallUnity.Settings.PlayerTorchFromItems && item.IsOfTemplate(ItemGroups.UselessItems2, (int)UselessItems2.Oil))
-                                            item.stackCount = Random.Range(5, 21);  // Shops stock 5-20 bottles
+                                            item.stackCount = Random.Range(5, 20 + 1);  // Shops stock 5-20 bottles
                                     }
                                     items.AddItem(item);
                                 }

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -14,6 +14,7 @@ using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallConnect;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop
 {
@@ -73,7 +74,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void RandomlyAddMap(int chance, ItemCollection collection)
         {
-            if (Random.Range(1, 100 + 1) <= chance)
+            if (Dice100.SuccessRoll(chance))
             {
                 DaggerfallUnityItem map = new DaggerfallUnityItem(ItemGroups.MiscItems, 8);
                 collection.AddItem(map);
@@ -85,7 +86,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void RandomlyAddPotion(int chance, ItemCollection collection)
         {
-            if (Random.Range(1, 100 + 1) < chance)
+            if (Dice100.SuccessRoll(chance))
                 collection.AddItem(ItemBuilder.CreateRandomPotion());
         }
 
@@ -94,7 +95,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void RandomlyAddPotionRecipe(int chance, ItemCollection collection)
         {
-            if (Random.Range(1, 100 + 1) < chance)
+            if (Dice100.SuccessRoll(chance))
             {
                 DaggerfallUnityItem potionRecipe = new DaggerfallUnityItem(ItemGroups.MiscItems, 4);
                 byte recipe = (byte)Random.Range(0, 20);
@@ -192,7 +193,7 @@ namespace DaggerfallWorkshop
                             if (itemTemplate.rarity <= shopQuality)
                             {
                                 int stockChance = chanceMod * 5 * (21 - itemTemplate.rarity) / 100;
-                                if (Random.Range(1, 100 + 1) <= stockChance)
+                                if (Dice100.SuccessRoll(stockChance))
                                 {
                                     DaggerfallUnityItem item = null;
                                     if (itemGroup == ItemGroups.Weapons)

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -251,7 +251,7 @@ namespace DaggerfallWorkshop
             summary.StateAnims = GetStateAnims(summary.EnemyState);
             if (summary.EnemyState == MobileStates.PrimaryAttack)
             {
-                int random = UnityEngine.Random.Range(1, 101);
+                int random = UnityEngine.Random.Range(1, 100 + 1);
 
                 if (random <= summary.Enemy.ChanceForAttack2)
                     summary.StateAnimFrames = summary.Enemy.PrimaryAttackAnimFrames2;

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -22,6 +22,7 @@ using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Utility.AssetInjection;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop
 {
@@ -251,7 +252,7 @@ namespace DaggerfallWorkshop
             summary.StateAnims = GetStateAnims(summary.EnemyState);
             if (summary.EnemyState == MobileStates.PrimaryAttack)
             {
-                int random = UnityEngine.Random.Range(1, 100 + 1);
+                int random = Dice100.Roll();
 
                 if (random <= summary.Enemy.ChanceForAttack2)
                     summary.StateAnimFrames = summary.Enemy.PrimaryAttackAnimFrames2;

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -575,7 +575,7 @@ namespace DaggerfallWorkshop.Utility
             if (buildingDirectory && buildingDirectory.BuildingCount > 0)
             {
                 List<BuildingSummary> taverns = buildingDirectory.GetBuildingsOfType(DFLocation.BuildingTypes.Tavern);
-                int i = UnityEngine.Random.Range(0, taverns.Count - 1);
+                int i = UnityEngine.Random.Range(0, taverns.Count);
                 PlayerGPS.DiscoveredBuilding tavern;
                 if (GameManager.Instance.PlayerGPS.GetAnyBuilding(taverns[i].buildingKey, out tavern))
                     return tavern.displayName;

--- a/Assets/Scripts/Utility/RandomEncounters.cs
+++ b/Assets/Scripts/Utility/RandomEncounters.cs
@@ -1467,7 +1467,7 @@ namespace DaggerfallWorkshop.Utility
                 }
             }
 
-            int random = UnityEngine.Random.Range(1, 101);
+            int random = UnityEngine.Random.Range(1, 100 + 1);
             int playerLevel = Game.GameManager.Instance.PlayerEntity.Level;
             int min;
             int max;

--- a/Assets/Scripts/Utility/RandomEncounters.cs
+++ b/Assets/Scripts/Utility/RandomEncounters.cs
@@ -12,6 +12,7 @@
 using System;
 using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Utility
 {
@@ -1467,15 +1468,15 @@ namespace DaggerfallWorkshop.Utility
                 }
             }
 
-            int random = UnityEngine.Random.Range(1, 100 + 1);
+            int roll = Dice100.Roll();
             int playerLevel = Game.GameManager.Instance.PlayerEntity.Level;
             int min;
             int max;
 
             // Random/player level based adjustments from classic. These assume enemy lists of length 20.
-            if (random > 80)
+            if (roll > 80)
             {
-                if (random > 95)
+                if (roll > 95)
                 {
                     if (playerLevel <= 5)
                     {


### PR DESCRIPTION
Upper bound is exclusive for Random.Range(int, int), leading to a few off-by-one bugs.
Solution is often to increase upper bound by one, in a few place Random.Range(float, float) is used instead.
There's an obvious but mild risk of introducing or uncovering bugs, even if I tried to be careful and started testing those changes.

Also refacto (separate commit): as was the case in some places already, when the code really means to use an inclusive upper bound, rewrite as Random.random(lowerbound, upperbound + 1) even if upperbound + 1 is a constant.
Any compiler worth its salt will optimize that away, and it conveys programmers intent better.
