### PR TITLE
hide icons in empty spellbooks

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -285,6 +285,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 else
                     spellsListBox.SelectedIndex = oldSelectedIndex;
             }
+
+            // Hide icons when there's nothing to select
+            ShowIcons(spellsListBox.Count > 0);
         }
 
         #endregion
@@ -401,6 +404,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             spellElementIconPanel.BackgroundColor = Color.black;
             spellElementIconPanel.BackgroundTextureLayout = BackgroundLayout.StretchToFill;
             spellElementIconPanel.ToolTip = defaultToolTip;
+        }
+
+        void ShowIcons(bool show)
+        {
+            spellIconPanel.Enabled = show;
+            spellTargetIconPanel.Enabled = show;
+            spellElementIconPanel.Enabled = show;
         }
 
         void SetupLabels()


### PR DESCRIPTION
Cosmetic fix: currently when you open an empty spellbook, the different icons appear as black empty spaces, which does not look good (specially on a nicely modded spellbook background).

Simply remove the icons altogether in this case.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&p=21577#p21577