### PR TITLE
MeshReplacement: Fixes for loot containers

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
@@ -111,7 +111,7 @@ namespace DaggerfallWorkshop.Game.Serialization
                 }
 
                 // Restore appearance
-                if (MeshReplacement.ImportCustomFlatGameobject(data.textureArchive, data.textureRecord, Vector3.zero, loot.transform))
+                if (MeshReplacement.SwapCustomFlatGameobject(data.textureArchive, data.textureRecord, loot.transform, Vector3.zero, lootContext == WorldContext.Dungeon))
                 {
                     // Use imported model instead of billboard
                     if (billboard) Destroy(billboard);

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -111,13 +111,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             go.transform.parent = parent;
 
             // Assign position
-            if (inDungeon)
-            {
-                // Fix origin position for dungeon flats
-                int height = ImageReader.GetImageData(TextureFile.IndexToFileName(archive), record, createTexture: false).height;
-                position.y -= height / 2 * MeshReader.GlobalScale;
-            }
-            go.transform.localPosition = position;
+            AlignToBase(go.transform, position, archive, record, inDungeon);
 
             // Assign a random rotation
             if (go.GetComponent<FaceWall>() == null)
@@ -136,6 +130,34 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             // Finalise gameobject materials
             FinaliseMaterials(go);
             return go;
+        }
+
+        /// <summary>
+        /// Ensures that the requested imported model is assigned to the given transform and is positioned correctly.
+        /// If archive and record mismatch, the requested prefab is imported while currently loaded gameobject is destroyed.
+        /// This has a similar purpose to <see cref="DaggerfallBillboard.SetMaterial()"/>.
+        /// </summary>
+        /// <param name="archive">Texture archive for original billboard.</param>
+        /// <param name="record">Texture record for original billboard.</param>
+        /// <param name="parent">Parent to assign to GameObject.</param>
+        /// <param name="position">Position to assign to GameObject.</param>
+        /// <param name="inDungeon">Fix position for dungeon models.</param>
+        /// <returns>Returns the imported model or null if not found.</returns>
+        public static GameObject SwapCustomFlatGameobject(int archive, int record, Transform parent, Vector3 position, bool inDungeon = false)
+        {
+            GameObject go = null;
+
+            string name = string.Format("DaggerfallBillboard [Replacement] [TEXTURE.{0:000}, Index={1}]", archive, record);
+            for (int i = 0; i < parent.childCount; i++)
+            {
+                Transform transform = parent.GetChild(i);
+                if (transform.name == name)
+                    AlignToBase((go = transform.gameObject).transform, position, archive, record, inDungeon);
+                else if (transform.name.StartsWith("DaggerfallBillboard [Replacement]"))
+                    GameObject.Destroy(transform.gameObject);
+            }
+
+            return go ?? ImportCustomFlatGameobject(archive, record, position, parent, inDungeon);
         }
 
         /// <summary>
@@ -276,6 +298,22 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         private static string GetName(int archive, int record)
         {
             return string.Format("{0:000}_{1}", archive, record);
+        }
+
+        /// <summary>
+        /// Sets position for a gameobject that replaces a billboard, with the assumption that the origin is at the base of the model.
+        /// </summary>
+        private static void AlignToBase(Transform transform, Vector3 position, int archive, int record, bool inDungeon)
+        {
+            // Fix origin position for dungeon flats
+            if (inDungeon)
+            {
+                int height = ImageReader.GetImageData(TextureFile.IndexToFileName(archive), record, createTexture: false).height;
+                position.y -= height / 2 * MeshReader.GlobalScale;
+            }
+
+            // Assign position
+            transform.localPosition = position;
         }
 
         /// <summary>


### PR DESCRIPTION
* Fixed positioning issue with dungeon containers.
* Fixed issue which caused custom loot gameobjects to be instantiated twice at the same position.