### PR TITLE
Fix most remaining texture alignment problems

### DIFF
--- a/Assets/Scripts/API/Arch3dFile.cs
+++ b/Assets/Scripts/API/Arch3dFile.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2018 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -765,14 +765,16 @@ namespace DaggerfallConnect.Arena2
         /// <param name="u">The U or V coordinate</param>
         private static void UVunpack(ref int u)
         {
-            // A packed coordinate has to be a multiple of 1024
             const int n = 1024;
-            if (u % n != 0)
+            const int delta = n * 8;
+
+            // A packed coordinate has to be a multiple of 1024
+            // Also avoid unpacking 8192 or -8192
+            if (u % n != 0 || u == delta || u == -delta)
                 return;
 
-            // Values below or above those ones produce incorrect results
-            const int threshold = 7167;
-            const int delta = 8192;
+            // Values below or above this one produce incorrect results
+            const int threshold = delta - n - 1;
             if (u > threshold)
                 u = n - (u + n) % delta;
             else if (u < -threshold)

--- a/Assets/Scripts/API/Arch3dFile.cs
+++ b/Assets/Scripts/API/Arch3dFile.cs
@@ -763,8 +763,6 @@ namespace DaggerfallConnect.Arena2
         /// Unpack special texture coordinates.
         /// </summary>
         /// <param name="u">The U or V coordinate</param>
-        /// <param name="flag"></param>
-        /// <returns></returns>
         private static void UVunpack(ref int u)
         {
             // A packed coordinate has to be a multiple of 1024
@@ -776,13 +774,9 @@ namespace DaggerfallConnect.Arena2
             const int threshold = 7167;
             const int delta = 8192;
             if (u > threshold)
-            {
                 u = n - (u + n) % delta;
-            }
             else if (u < -threshold)
-            {
                 u = n + (u - n) % delta;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
I spent hours (if not days) on this one...
This fixes most of the texture UV coordinates problems uncovered on the forums:

https://forums.dfworkshop.net/viewtopic.php?f=24&t=328: I removed the special case @Interkarma put several years ago for the building window since it is not needed anymore. The weapon store used for The Count's Arsenal in Newtale (@petchema) is also fixed.
https://forums.dfworkshop.net/viewtopic.php?f=28&t=1588: the dungeon room is fixed but not the tavern pillars. @petchema, could you check that the dungeon corridor streched textures you saw are corrected?

To fix this, I used in particular a previously unused and unknown field from the mesh header. It is read as an integer but from my tests, the only values it can take are 0 and 65536, so I think it should actually be an unsigned int. But as it does not really matter since I do the check against 0, I didn't change the type.

The only known remaining issues are textures coordinates for tavern pillars like the ones in The King's Fairy, Daggerfall.
