### PR TITLE
AI fixes

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -26,9 +26,9 @@ namespace DaggerfallWorkshop.Game
     [RequireComponent(typeof(EnemySenses))]
     public class EnemyAttack : MonoBehaviour
     {
-        public float MeleeAttackSpeed = 1.25f;      // Number of seconds between melee attacks
-        public float MeleeDistance = 2.25f;          // Maximum distance for melee attack
-        public float MeleeTimer = 0;                // Must be 0 for a melee attack or touch spell to be done
+        public float MeleeDistance = 2.25f;                // Maximum distance for melee attack
+        public float ClassicMeleeDistanceVsAI = 1.5f;      // Maximum distance for melee attack vs other AI in classic AI mode
+        public float MeleeTimer = 0;                       // Must be 0 for a melee attack or touch spell to be done
         public DaggerfallMissile ArrowMissilePrefab;
 
         EnemyMotor motor;
@@ -128,8 +128,13 @@ namespace DaggerfallWorkshop.Game
             // Are we in range and facing target? Then start attack.
             if (senses.DetectedTarget && senses.TargetIsWithinYawAngle(22.5f, senses.LastKnownTargetPos))
             {
+                float distance = MeleeDistance;
+                // Classic uses separate melee distance for targeting player and for targeting other AI
+                if (!DaggerfallUnity.Settings.EnhancedCombatAI && senses.Target != GameManager.Instance.PlayerEntityBehaviour)
+                    distance = ClassicMeleeDistanceVsAI;
+
                 // Take the rate of target approach into account when deciding if to attack
-                if (senses.DistanceToTarget >= MeleeDistance + senses.TargetRateOfApproach)
+                if (senses.DistanceToTarget > distance + senses.TargetRateOfApproach)
                     return false;
 
                 // Set melee animation state

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -126,7 +126,7 @@ namespace DaggerfallWorkshop.Game
         private bool MeleeAnimation()
         {
             // Are we in range and facing target? Then start attack.
-            if (senses.DetectedTarget && senses.TargetIsWithinYawAngle(22.5f, senses.LastKnownTargetPos))
+            if (senses.TargetInSight && senses.TargetIsWithinYawAngle(22.5f, senses.LastKnownTargetPos))
             {
                 float distance = MeleeDistance;
                 // Classic uses separate melee distance for targeting player and for targeting other AI

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -454,7 +454,7 @@ namespace DaggerfallWorkshop.Game
 
                 if (hasBowAttack || rangedMagicAvailable)
                 {
-                    if (senses.TargetIsWithinYawAngle(22.5f, senses.LastKnownTargetPos) && strafeTimer <= 0)
+                    if (DaggerfallUnity.Settings.EnhancedCombatAI && senses.TargetIsWithinYawAngle(22.5f, senses.LastKnownTargetPos) && strafeTimer <= 0)
                     {
                         StrafeDecision();
                     }
@@ -525,7 +525,7 @@ namespace DaggerfallWorkshop.Game
                 else if (!senses.TargetIsWithinYawAngle(22.5f, destination))
                     TurnToTarget(direction);
             }
-            else if (strafeTimer <= 0)
+            else if (DaggerfallUnity.Settings.EnhancedCombatAI && strafeTimer <= 0)
             {
                 StrafeDecision();
             }
@@ -544,7 +544,9 @@ namespace DaggerfallWorkshop.Game
             }
             // Not moving, just look at target
             else if (!senses.TargetIsWithinYawAngle(22.5f, destination))
+            {
                 TurnToTarget(direction);
+            }
             else // Not moving, and no need to turn
             {
                 SetChangeStateTimer();
@@ -555,9 +557,6 @@ namespace DaggerfallWorkshop.Game
 
         void StrafeDecision()
         {
-            if (!DaggerfallUnity.Settings.EnhancedCombatAI)
-                return;
-
             doStrafe = Random.Range(0, 4) == 0;
             strafeTimer = Random.Range(1f, 2f);
             if (doStrafe)

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -111,6 +111,12 @@ namespace DaggerfallWorkshop.Game
             get { return bashing; }
         }
 
+        public int GiveUpTimer
+        {
+            get { return giveUpTimer; }
+            set { giveUpTimer = value; }
+        }
+
         void Start()
         {
             senses = GetComponent<EnemySenses>();

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -51,10 +51,10 @@ namespace DaggerfallWorkshop.Game
         EnemySenses targetSenses;
         float lastDistanceToTarget;
         float targetRateOfApproach;
-        Vector3 lastKnownTargetPos;
-        Vector3 oldLastKnownTargetPos;
-        Vector3 predictedTargetPos;
-        Vector3 predictedTargetPosWithoutLead;
+        Vector3 lastKnownTargetPos = ResetPlayerPos;
+        Vector3 oldLastKnownTargetPos = ResetPlayerPos;
+        Vector3 predictedTargetPos = ResetPlayerPos;
+        Vector3 predictedTargetPosWithoutLead = ResetPlayerPos;
         Vector3 lastPositionDiff;
         bool awareOfTargetForLastPrediction;
         DaggerfallActionDoor actionDoor;
@@ -194,9 +194,6 @@ namespace DaggerfallWorkshop.Game
             enemyEntity = entityBehaviour.Entity as EnemyEntity;
             motor = GetComponent<EnemyMotor>();
             questBehaviour = GetComponent<QuestResourceBehaviour>();
-            lastKnownTargetPos = ResetPlayerPos;
-            oldLastKnownTargetPos = ResetPlayerPos;
-            predictedTargetPos = ResetPlayerPos;
 
             short[] classicSpawnXZDistArray = { 1024, 384, 640, 768, 768, 768, 768 };
             short[] classicSpawnYDistUpperArray = { 128, 128, 128, 384, 768, 128, 256 };

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -463,7 +463,7 @@ namespace DaggerfallWorkshop.Game
                     hasEncounteredPlayer = true;
 
                     // Check appropriate language skill to see if player can pacify enemy
-                    if (entityBehaviour && motor &&
+                    if (!questBehaviour && entityBehaviour && motor &&
                         (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass))
                     {
                         DFCareer.Skills languageSkill = enemyEntity.GetLanguageSkill();

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -842,7 +842,6 @@ namespace DaggerfallWorkshop.Game
 
         bool CanHearTarget(DaggerfallEntityBehaviour target)
         {
-            bool heard = false;
             float hearingScale = 1f;
 
             // If something is between enemy and target then return false (was reduce hearingScale by half), to minimize
@@ -853,17 +852,12 @@ namespace DaggerfallWorkshop.Game
             if (Physics.Raycast(ray, out hit))
             {
                 DaggerfallEntityBehaviour entity = hit.transform.gameObject.GetComponent<DaggerfallEntityBehaviour>();
-                if (entity != target && hit.transform.gameObject.isStatic)
+                if (hit.transform.gameObject.isStatic)
                     return false;
             }
 
             // TODO: Modify this by how much noise the target is making
-            if (distanceToTarget < (HearingRadius * hearingScale) + mobile.Summary.Enemy.HearingModifier)
-            {
-                heard = true;
-            }
-
-            return heard;
+            return distanceToTarget < (HearingRadius * hearingScale) + mobile.Summary.Enemy.HearingModifier;
         }
 
         #endregion

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -489,7 +489,7 @@ namespace DaggerfallWorkshop.Game
         public Vector3 PredictNextTargetPos(float interceptSpeed)
         {
             // Be sure to only take difference of movement if we've seen the target for two consecutive prediction updates
-            if (targetInSight || targetInEarshot)
+            if (!blockedByIllusionEffect && (targetInSight || targetInEarshot))
             {
                 if (awareOfTargetForLastPrediction)
                     lastPositionDiff = lastKnownTargetPos - oldLastKnownTargetPos;
@@ -505,7 +505,7 @@ namespace DaggerfallWorkshop.Game
             Vector3 assumedCurrentPosition;
 
             // If aware of target, use last known position as assumed current position
-            if (targetInSight || targetInEarshot)
+            if (!blockedByIllusionEffect && (targetInSight || targetInEarshot))
             {
                 assumedCurrentPosition = lastKnownTargetPos;
             }

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -705,7 +705,13 @@ namespace DaggerfallWorkshop.Game.Entity
                 cityWatch[0].transform.parent = GameManager.Instance.StreamingWorld.CurrentPlayerLocationObject.transform;
             cityWatch[0].transform.forward = direction;
             EnemyMotor enemyMotor = cityWatch[0].GetComponent<EnemyMotor>();
+
+            // Classic does not do anything special to make guards aware of the player, but since they're responding to a crime, standing around
+            // unaware of the player can be perceived as a bug.
             enemyMotor.MakeEnemyHostileToAttacker(GameManager.Instance.PlayerEntityBehaviour);
+
+            // Set a longer giveUpTimer than usual in case it takes more than the usual timer to get to the player position
+            enemyMotor.GiveUpTimer *= 3;
             cityWatch[0].SetActive(true);
 
             return cityWatch[0];


### PR DESCRIPTION
Distance used in decision for doing melee attack used the value
in EnemySenses, which could differ from the distance value used in
EnemyMotor. Noticeable when classic AI, which only moves as close
as necessary to attack, could stand motionless due to being close
enough to satisfy EnemyMotor to no longer advance on target, but not
satisfy EnemyAttack to due melee attack.

Also melee decision should have been to attack if <= melee range, to
match classic.

Also implemented classic's differing melee range for vs. player and vs.
AI. This was probably done because the range used against player wouldn't
look right for AI vs. AI, because the sprites wouldn't appear to be physically touching.
But I guess the longer range looked better when attacking the player (attacking the screen)

Fixes issue 2 in https://forums.dfworkshop.net/viewtopic.php?f=24&t=1859&sid=bed84458b14ebae4f57363cdf767816f.