### PR TITLE
quest popups now reveal dialog linked talk options

### DIFF
--- a/Assets/Scripts/Game/Questing/Message.cs
+++ b/Assets/Scripts/Game/Questing/Message.cs
@@ -163,7 +163,9 @@ namespace DaggerfallWorkshop.Game.Questing
             if (expandMacros)
             {
                 QuestMacroHelper macroHelper = new QuestMacroHelper();
-                macroHelper.ExpandQuestMessage(ParentQuest, ref tokens);
+
+                // note Nystul: reveal dialog linked resources here on purpose (quest popups should reveal them: see this issue: https://forums.dfworkshop.net/viewtopic.php?f=24&t=1678&p=22069#p22069)                
+                macroHelper.ExpandQuestMessage(ParentQuest, ref tokens, true);
             }
 
             return tokens;

--- a/Assets/Scripts/Utility/QuestMacroHelper.cs
+++ b/Assets/Scripts/Utility/QuestMacroHelper.cs
@@ -92,7 +92,7 @@ namespace DaggerfallWorkshop.Utility
                             }
 
                             // reveal dialog linked resources in talk window
-                            if (revealDialogLinks)
+                            if (revealDialogLinks && macro.type == MacroTypes.NameMacro1) // only resolve if their true name was expanded (given) which is MacroTypes.NameMacro1
                             {
                                 System.Type t = resource.GetType();
                                 if (t.Equals(typeof(DaggerfallWorkshop.Game.Questing.Place)))

--- a/Assets/Scripts/Utility/QuestMacroHelper.cs
+++ b/Assets/Scripts/Utility/QuestMacroHelper.cs
@@ -56,7 +56,7 @@ namespace DaggerfallWorkshop.Utility
         /// </summary>
         /// <param name="parentQuest">Parent quest of message.</param>
         /// <param name="tokens">Array of message tokens to expand macros inside of.</param>
-        /// <param name="resolveDialogLinks">will reveal dialog linked resources in talk window (this must be false for all calls to this function except if caller is talk manager when expanding answers).</param>
+        /// <param name="resolveDialogLinks">will reveal dialog linked resources in talk window (this must be false for all calls to this function except if caller is talk manager when expanding answers or for quest popups).</param>
         public void ExpandQuestMessage(Quest parentQuest, ref TextFile.Token[] tokens, bool revealDialogLinks = false)
         {
             // Iterate message tokens


### PR DESCRIPTION
fix for bug reported by forum user Ferital in this thread: https://forums.dfworkshop.net/viewtopic.php?f=24&t=1678&p=22074#p22074

dialog linked resources are now only resolved if their macro type is NameMacro1 - 
only if their true name (_person) is resolved (not other types like __person)