### PR TITLE
Use saving throws and implement Mehrunes Razor effect

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/MehrunesRazorEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/MehrunesRazorEffect.cs
@@ -1,0 +1,71 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2019 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Numidium
+// Contributors:    
+// 
+// Notes:
+//
+using UnityEngine;
+using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
+using System.Collections.Generic;
+using DaggerfallWorkshop.Game.Items;
+using DaggerfallConnect.FallExe;
+using System;
+
+namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
+{
+    /// <summary>
+    /// Used by Mehrunes Razor. Kills target instantly if it does not save vs. magic.
+    /// </summary>
+    public class MehrunesRazorEffect : BaseEntityEffect
+    {
+        public static readonly string EffectKey = "MehrunesRazorEffect";
+
+        public override void MagicRound()
+        {
+            base.MagicRound();
+            DaggerfallEntityBehaviour entityBehaviour = GetPeeredEntityBehaviour(manager);
+            if (!entityBehaviour)
+                return;
+            // Reduce weapon health by damage done to target.
+            bool foundRazor = false;
+            DaggerfallUnityItem item;
+            item = GameManager.Instance.PlayerEntity.ItemEquipTable.GetItem(EquipSlots.RightHand);
+            foundRazor = IsRazor(item);
+            if (!foundRazor)
+            {
+                item = GameManager.Instance.PlayerEntity.ItemEquipTable.GetItem(EquipSlots.LeftHand);
+                foundRazor = IsRazor(item);
+            }
+
+            if (foundRazor)
+                item.currentCondition -= entityBehaviour.Entity.CurrentHealth;
+            entityBehaviour.Entity.CurrentHealth = 0;
+        }
+
+        public override void SetProperties()
+        {
+            properties.Key = EffectKey;
+        }
+
+        private bool IsRazor(DaggerfallUnityItem item)
+        {
+            if (item != null && item.Enchantments != null)
+            {
+                foreach (DaggerfallEnchantment enchantment in item.Enchantments)
+                {
+                    if (enchantment.type == EnchantmentTypes.SpecialArtifactEffect && enchantment.param == (int)ArtifactsSubTypes.Mehrunes_Razor)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/MehrunesRazorEffect.cs.meta
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/MehrunesRazorEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34d543ca804a6144dbc52487eb35bfe8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/WabbajackEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/WabbajackEffect.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
+using DaggerfallWorkshop.Game.Questing;
 
 namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 {
@@ -59,6 +60,13 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                     enemyType = (MobileTypes)(((int)enemyType + 1) % careerIDs.Length);
                 }
                 Transform parentTransform = entityBehaviour.gameObject.transform.parent;
+                // Do not disable enemy if in use by the quest system
+                QuestResourceBehaviour questResourceBehaviour = entityBehaviour.GetComponent<QuestResourceBehaviour>();
+                if (questResourceBehaviour)
+                {
+                    if (!questResourceBehaviour.IsFoeDead)
+                        return;
+                }
                 entityBehaviour.gameObject.SetActive(false);
                 GameObject gameObject = GameObjectHelper.CreateEnemy(HardStrings.enemyNames[(int)enemyType], enemyType, entityBehaviour.transform.localPosition, parentTransform);
                 DaggerfallEntityBehaviour newEnemyBehaviour = gameObject.GetComponent<DaggerfallEntityBehaviour>();
@@ -71,6 +79,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         public override void SetProperties()
         {
             properties.Key = EffectKey;
+            bypassSavingThrows = true;
         }
     }
 }

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Numidium
 // 
 // Notes:
 //
@@ -115,6 +115,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         int CurrentVariant { get; set; }
 
         /// <summary>
+        /// True if spell effect always lands regardless of saving throws.
+        /// </summary>
+        bool BypassSavingThrows { get; }
+
+        /// <summary>
         /// Called by an EntityEffectManager when parent bundle is attached to host entity.
         /// Use this for setup or immediate work performed only once.
         /// </summary>
@@ -180,6 +185,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         protected EntityEffectManager manager = null;
         protected int variantCount = 1;
         protected int currentVariant = 0;
+        protected bool bypassSavingThrows = false;
 
         int roundsRemaining;
         bool chanceSuccess = false;
@@ -310,6 +316,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         {
             get { return currentVariant; }
             set { currentVariant = Mathf.Clamp(value, 0, variantCount - 1); }
+        }
+
+        public bool BypassSavingThrows
+        {
+            get { return bypassSavingThrows; }
         }
 
         #endregion

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Numidium
 // 
 // Notes:
 //
@@ -476,9 +476,14 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public bool GetArtifactBundleSettings(out EffectBundleSettings settings, int effectIndex)
         {
             string effectKey = string.Empty;
-            if (effectIndex == (int)ArtifactsSubTypes.Wabbajack)
+            switch (effectIndex)
             {
-                effectKey = "WabbajackEffect";
+                case (int)ArtifactsSubTypes.Wabbajack:
+                    effectKey = "WabbajackEffect";
+                    break;
+                case (int)ArtifactsSubTypes.Mehrunes_Razor:
+                    effectKey = "MehrunesRazorEffect";
+                    break;
             }
             settings = new EffectBundleSettings
             {

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -464,24 +464,25 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                     continue;
                 }
 
-                // Saving throws
-                if (!effect.BypassSavingThrows && FormulaHelper.SavingThrow(effect, entityBehaviour.Entity) == 0)
+                // Saving throws are performed if bundle is not self-cast or originate from another entity
+                // Self-cast spells such as a heals and buffs are not checked for saving throws
+                // But player can still catch themselves in their own AoE spells and receive a chance to save
+                if (sourceBundle.Settings.TargetType != TargetTypes.CasterOnly || effect.Caster != EntityBehaviour)
                 {
-                    if (IsPlayerEntity || showNonPlayerFailures)
+                    if (!effect.BypassSavingThrows && FormulaHelper.SavingThrow(effect, entityBehaviour.Entity) == 0)
                     {
-                        // Output "Save versus spell made." for external contact spells
-                        DaggerfallUI.AddHUDText(TextManager.Instance.GetText(textDatabase, "saveVersusSpellMade"));
+                        if (IsPlayerEntity || showNonPlayerFailures)
+                        {
+                            // Output "Save versus spell made." for external contact spells
+                            DaggerfallUI.AddHUDText(TextManager.Instance.GetText(textDatabase, "saveVersusSpellMade"));
+                        }
+                        continue;
                     }
-                    continue;
                 }
 
-                // Special handling for paralysis
-                if (effect is Paralyze)
-                {
-                    // Immune in god mode
-                    if (IsPlayerEntity && GameManager.Instance.PlayerEntity.GodMode)
-                        continue;
-                }
+                // Player is immune to paralysis in god mode
+                if (IsPlayerEntity && GameManager.Instance.PlayerEntity.GodMode && effect is Paralyze)
+                    continue;
 
                 // Add effect
                 instancedBundle.liveEffects.Add(effect);

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Numidium
 // 
 // Notes:
 //
@@ -464,20 +464,20 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                     continue;
                 }
 
+                // Saving throws
+                if (!effect.BypassSavingThrows && FormulaHelper.SavingThrow(effect, entityBehaviour.Entity) == 0)
+                {
+                    if (IsPlayerEntity || showNonPlayerFailures)
+                    {
+                        // Output "Save versus spell made." for external contact spells
+                        DaggerfallUI.AddHUDText(TextManager.Instance.GetText(textDatabase, "saveVersusSpellMade"));
+                    }
+                    continue;
+                }
+
                 // Special handling for paralysis
                 if (effect is Paralyze)
                 {
-                    // Immune if saving throw made
-                    if (FormulaHelper.SavingThrow(effect, entityBehaviour.Entity) == 0)
-                    {
-                        if (IsPlayerEntity || showNonPlayerFailures)
-                        {
-                            // Output "Save versus spell made." for external contact spells
-                            DaggerfallUI.AddHUDText(TextManager.Instance.GetText(textDatabase, "saveVersusSpellMade"));
-                        }
-                        continue;
-                    }
-
                     // Immune in god mode
                     if (IsPlayerEntity && GameManager.Instance.PlayerEntity.GodMode)
                         continue;


### PR DESCRIPTION
I noticed that saving throws weren't being used for most spells. If this is the desired behavior for now then I don't mind changing it back. Having saving throws active prevents MR from killing targets on the first hit every time.

I also altered the Wabbajack effect. It bypasses saving throws in classic so I added a flag for effects that ignore them. Added a check to prevent Wabbajack from disabling enemies that are in use by a current quest.