### PR TITLE
Assign flags from factions.txt with |=

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -1061,7 +1061,7 @@ namespace DaggerfallConnect.Arena2
                         faction.power = ParseInt(value);
                         break;
                     case "flags":
-                        faction.flags = ParseInt(value);
+                        faction.flags |= ParseInt(value);
                         break;
                     case "ruler":
                         faction.ruler = ParseInt(value);


### PR DESCRIPTION
A faction can have its flags value from `FACTION.TXT` be composed by multiple "flags" lines, and these should all be ORed together.

Fixes https://forums.dfworkshop.net/viewtopic.php?f=24&t=1887&p=22188#p22188. I wrote a description of the problem there.