### PR TITLE
Start target search prediction iteration from 0

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -440,7 +440,7 @@ namespace DaggerfallWorkshop.Game
             // Otherwise, search for target
             else
             {
-                Vector3 searchPosition = senses.LastKnownTargetPos - (senses.LastPositionDiff.normalized * searchMult);
+                Vector3 searchPosition = senses.LastKnownTargetPos + (senses.LastPositionDiff.normalized * searchMult);
                 if (!searchedLastKnownPos && (searchPosition - transform.position).magnitude <= stopDistance)
                     searchedLastKnownPos = true;
 

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -69,7 +69,7 @@ namespace DaggerfallWorkshop.Game
         float strafeAngle;
         Vector3 strafeDest;
         bool searchedLastKnownPos;
-        int searchMult = 1;
+        int searchMult = 0;
 
         EnemySenses senses;
         Vector3 destination;
@@ -377,7 +377,7 @@ namespace DaggerfallWorkshop.Game
                 SetChangeStateTimer();
                 bashing = false;
                 searchedLastKnownPos = false;
-                searchMult = 1;
+                searchMult = 0;
 
                 return;
             }
@@ -430,7 +430,7 @@ namespace DaggerfallWorkshop.Game
 
                 clearPathToShootAtPredictedPos = true;
                 searchedLastKnownPos = false;
-                searchMult = 1;
+                searchMult = 0;
             }
             // If detouring, use the detour position
             else if (avoidObstaclesTimer > 0)

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -455,7 +455,7 @@ namespace DaggerfallWorkshop.Game
                     if (!blockedByIllusionEffect && (targetInSight || targetInEarshot))
                     {
                         if (awareOfTargetForLastPrediction)
-                            lastPositionDiff = oldLastKnownTargetPos - lastKnownTargetPos;
+                            lastPositionDiff = lastKnownTargetPos - oldLastKnownTargetPos;
 
                         // Store current last known target position for next prediction update
                         oldLastKnownTargetPos = lastKnownTargetPos;


### PR DESCRIPTION
Minor tweak. I noticed that with the recent change to AI search behavior I made, starting the search with 1 movement prediction threw them off a little and could cause them to walk into the wall when trying to pursue.

Ex)
`e` = enemy
`p` = player
`-` = wall
`|` = where enemy goes to in pursuit

Master branch:
Player went through doorway and enemy last saw him moving to the right ("right" as seen from top-down view). By starting at prediction iteration "1", enemy heads to first predicted spot (based on player movement rate/direction and last known position) and goes to "|", hitting wall.

```
     e
      
----  -|--
         p
```

This PR:
Iteration starts from "0", so enemy starts with no prediction, heading to the last known player position (doorway) first. If it still can't see the player after getting there, it will then start iterating through predicted spots.

I only tested this PR briefly, but the enemy did seem better able to pursue through the door in the above situation.