### PR TITLE
Immediately get NatureSet and Season for location creation

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -770,7 +770,9 @@ namespace DaggerfallWorkshop
                                 lightsBillboardBatch,
                                 animalsBillboardBatch,
                                 null,
-                                null);
+                                null,
+                                dfLocation.Summary.Nature,
+                                dfUnity.WorldTime.Now.SeasonValue == DaggerfallDateTime.Seasons.Winter ? ClimateSeason.Winter : ClimateSeason.Summer);
 
                             // Set game object properties
                             go.hideFlags = defaultHideFlags;


### PR DESCRIPTION
Billboard trees can swap material at any time but imported 3d trees must be loaded with the correct variation during location setup.