### PR TITLE
Implement 2 new commands for testing AI

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -33,6 +33,7 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(LoadCommand.name, LoadCommand.description, LoadCommand.usage, LoadCommand.Execute);
             ConsoleCommandsDatabase.RegisterCommand(GodCommand.name, GodCommand.description, GodCommand.usage, GodCommand.Execute);
             ConsoleCommandsDatabase.RegisterCommand(NoTargetCommand.name, NoTargetCommand.description, NoTargetCommand.usage, NoTargetCommand.Execute);
+            ConsoleCommandsDatabase.RegisterCommand(ToggleAICommand.name, ToggleAICommand.description, ToggleAICommand.usage, ToggleAICommand.Execute);
             ConsoleCommandsDatabase.RegisterCommand(CreateMobileCommand.name, CreateMobileCommand.description, CreateMobileCommand.usage, CreateMobileCommand.Execute);
             ConsoleCommandsDatabase.RegisterCommand(Suicide.name, Suicide.description, Suicide.usage, Suicide.Execute);
             ConsoleCommandsDatabase.RegisterCommand(ShowDebugStrings.name, ShowDebugStrings.description, ShowDebugStrings.usage, ShowDebugStrings.Execute);
@@ -275,6 +276,26 @@ namespace Wenzil.Console
                 {
                     playerEntity.NoTargetMode = !playerEntity.NoTargetMode;
                     return string.Format("NoTarget enabled: {0}", playerEntity.NoTargetMode);
+                }
+                else
+                    return error;
+            }
+        }
+
+        private static class ToggleAICommand
+        {
+            public static readonly string name = "tai";
+            public static readonly string error = "Failed to toggle AI";
+            public static readonly string usage = "tai";
+            public static readonly string description = "Toggles AI on or off";
+
+            public static string Execute(params string[] args)
+            {
+                GameManager gameManager = GameManager.Instance;
+                if (gameManager != null)
+                {
+                    gameManager.DisableAI = !gameManager.DisableAI;
+                    return string.Format("AI disabled: {0}", gameManager.DisableAI);
                 }
                 else
                     return error;

--- a/Assets/Scripts/DaggerfallUnityEnums.cs
+++ b/Assets/Scripts/DaggerfallUnityEnums.cs
@@ -260,6 +260,7 @@ namespace DaggerfallWorkshop
     /// </summary>
     public enum MobileTeams
     {
+        PlayerEnemy,
         PlayerAlly,
         Vermin,
         Spriggans,

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -49,6 +49,9 @@ namespace DaggerfallWorkshop.Game
 
         void Update()
         {
+            if (GameManager.Instance.DisableAI)
+                return;
+
             // If a melee attack has reached the damage frame we can run a melee attempt
             if (mobile.DoMeleeDamage)
             {

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -138,6 +138,9 @@ namespace DaggerfallWorkshop.Game
 
         void FixedUpdate()
         {
+            if (GameManager.Instance.DisableAI)
+                return;
+
             Move();
             OpenDoors();
             HeightAdjust();

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -216,6 +216,9 @@ namespace DaggerfallWorkshop.Game
 
         void FixedUpdate()
         {
+            if (GameManager.Instance.DisableAI)
+                return;
+
             targetPosPredictTimer += Time.deltaTime;
             if (targetPosPredictTimer >= predictionInterval)
             {

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -710,12 +710,14 @@ namespace DaggerfallWorkshop.Game
                         continue;
 
                     // Can't target ally
-                    if (DaggerfallUnity.Settings.EnemyInfighting)
+                    if (targetBehaviour == Player && enemyEntity.Team == MobileTeams.PlayerAlly)
+                        continue;
+                    else if (DaggerfallUnity.Settings.EnemyInfighting)
                     {
-                        if (targetEntity != null && targetEntity.MobileEnemy.Team == enemyEntity.MobileEnemy.Team)
+                        if (targetEntity != null && targetEntity.Team == enemyEntity.Team)
                             continue;
                     }
-                    else // TODO: Support player-summoned allies, even without infighting option
+                    else
                     {
                         if (targetBehaviour != Player)
                             continue;

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -58,6 +58,7 @@ namespace DaggerfallWorkshop.Game.Entity
         protected int currentBreath;
         protected WeaponMaterialTypes minMetalToHit;
         protected sbyte[] armorValues = new sbyte[NumberBodyParts];
+        protected MobileTeams team;
 
         bool quiesce = false;
         bool isParalyzed = false;
@@ -266,6 +267,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public int ToHitModifier { get { return FormulaHelper.ToHitModifier(stats.LiveAgility); } }
         public int HitPointsModifier { get { return FormulaHelper.HitPointsModifier(stats.LiveEndurance); } }
         public int HealingRateModifier { get { return FormulaHelper.HealingRateModifier(stats.LiveEndurance); } }
+        public MobileTeams Team { get { return team; } set { team = value; } }
 
         #endregion
 

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -215,6 +215,7 @@ namespace DaggerfallWorkshop.Game.Entity
             this.entityType = entityType;
             name = career.Name;
             minMetalToHit = mobileEnemy.MinMetalToHit;
+            team = mobileEnemy.Team;
 
             short skillsLevel = (short)((level * 5) + 30);
             if (skillsLevel > 100)

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -103,6 +103,8 @@ namespace DaggerfallWorkshop.Game
             get { return Instance.classicUpdate; }
         }
 
+        public bool DisableAI { get; set; }
+
         public StateManager StateManager
         {
             get { return (stateManager != null) ? stateManager : stateManager = new StateManager(StateManager.StateTypes.None); }


### PR DESCRIPTION
2 console commands that will be useful for working on the AI, as well as for just messing around and having fun with AI battles. Also lays some groundwork for implementing the artifact effects that involve summoning an ally.

"CreateMobile" = type "cm" followed by the numerical ID of the enemy type, then the number of the mobile team to spawn it in front of you.

Ex.) cm 0 1
Creates a rat (id 0) on the "player ally" team (team 1, won't attack player)

All teams are hostile to all other teams. Created a new "player enemy" (team 0) for general use in making enemies that are all allied with each other against the player.

Issues)
1: When created, mobiles are rotated to look in the direction the player was looking, but for some reason this seems a little finicky and they will at first briefly be looking at the player, or flicker back and forth a little before they settle on looking in the correct direction. Don't know why, as it's just a one-time "transform.LookAt" call, but the end result is correct, so I'm okay with it since it's just a test command. Might need to figure this out for the artifact effects, though.

2: Teams are not restored when loading a saved game. They get overwritten with the default teams. Since this is just a console command for testing I think that's okay for now. Will need to be solved when implementing the artifact effects.

"ToggleAI" = type "tai" to toggle between disabling and enabling all mobileEnemy AI. Doesn't affect townspeople.

P.S.
On the subject of AI (not related to this PR), the pursuit AI, such as when guards are pursuing you in town, is messed up at the moment, with them tending to go wandering in the wrong direction. I'm aware of it and working on a fix.