### PR TITLE
prevent f5 from closing level up screen

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -203,7 +203,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Toggle window closed with same hotkey used to open it
             if (Input.GetKeyUp(toggleClosedBinding))
-                CloseWindow();
+                if (CheckIfDoneLeveling())
+                    CloseWindow();
         }
 
         public override void OnPush()
@@ -218,20 +219,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public override void CancelWindow()
         {
-            if (leveling)
-            {
-                if (!CheckIfDoneLeveling())
-                    return;
-            }
-            base.CancelWindow();
-        }
-
-        public override void OnPop()
-        {
-            base.OnPop();
-            if (!leveling)
-                playerEntity.ResetSkillsRecentlyRaised();
-            leveling = false;
+            if (CheckIfDoneLeveling())
+                base.CancelWindow();
         }
 
         #endregion
@@ -458,20 +447,28 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         bool CheckIfDoneLeveling()
         {
-            if (statsRollout.BonusPool > 0 && !statsRollout.WorkingStats.IsAllMax())
+            if (leveling)
             {
-                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
-                messageBox.SetText(HardStrings.mustDistributeBonusPoints);
-                messageBox.ClickAnywhereToClose = true;
-                messageBox.Show();
-                return false;
+                if (statsRollout.BonusPool > 0 && !statsRollout.WorkingStats.IsAllMax())
+                {
+                    DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
+                    messageBox.SetText(HardStrings.mustDistributeBonusPoints);
+                    messageBox.ClickAnywhereToClose = true;
+                    messageBox.Show();
+                    return false;
+                }
+                else
+                {
+                    leveling = false;
+                    PlayerEntity.Stats = statsRollout.WorkingStats;
+                    NativePanel.Components.Remove(statsRollout);
+                }
             }
             else
             {
-                PlayerEntity.Stats = statsRollout.WorkingStats;
-                NativePanel.Components.Remove(statsRollout);
-                return true;
+                playerEntity.ResetSkillsRecentlyRaised();
             }
+            return true;
         }
 
         string[] GetClassSpecials()
@@ -874,12 +871,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            if (leveling)
-            {
-                if (!CheckIfDoneLeveling())
-                    return;
-            }
-            CloseWindow();
+            if (CheckIfDoneLeveling())
+                CloseWindow();
         }
 
         private void StatsRollout_OnStatChanged()


### PR DESCRIPTION
In classic Daggerfall, one cannot exit the level up screen until all
ability bonus points have been distributed.

In Daggerfall Unity, this is true when trying to use the EXIT button or
the Escape key, but it was possible to exit the character sheet window
and distribute remaining bonus points later by pressing the character
sheet keyboard shortcut (f5 by default).

This patch closes this loophole, and factorizes some code between the
different ways to close the character sheet.

Bug tracker:
https://github.com/Interkarma/daggerfall-unity/commit/b0f6f52bd3c7d99ff7e6873e18807f6c3f29be11