### PR TITLE
Fix Skull of Corruption and Hircine Ring appearing on paper doll

### DIFF
--- a/Assets/Scripts/Game/UserInterface/PaperDoll.cs
+++ b/Assets/Scripts/Game/UserInterface/PaperDoll.cs
@@ -373,6 +373,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // Blit item images
             foreach(var item in orderedItems)
             {
+                if (item.ItemGroup == ItemGroups.MensClothing || item.ItemGroup == ItemGroups.WomensClothing
+                    || item.ItemGroup == ItemGroups.Armor || item.ItemGroup == ItemGroups.Weapons)
                 BlitItem(item);
             }
         }


### PR DESCRIPTION
Looks like the Skull of Corruption and Hircine Ring were appearing where they did because of their images' x and y offset values. Other items that don't show on the paper doll like rings, etc. were also drawn but just not where you could see them.

Classic only draws items on the paper doll if they are of the clothing, armor or weapon groups. Using this same check for DFU fixes the Skull of Corruption and Hircine Ring.

The Hircine Ring's x and y offsets, appearance and text description seem to indicate it was going to be a shield at some point, and the graphic still looks like one. 

Bug report: https://forums.dfworkshop.net/viewtopic.php?f=24&t=1870&p=22543#p22543