### PR TITLE
Prevent non-guard spawns while in water

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -413,8 +413,8 @@ namespace DaggerfallWorkshop.Game.Entity
 
                 for (uint l = 0; l < (gameMinutes - lastGameMinutes); ++l)
                 {
-                    // Catch up time and break if something spawns
-                    if (IntermittentEnemySpawn(l + lastGameMinutes + 1))
+                    // Catch up time and break if something spawns. Don't spawn encounters while player is swimming in water (same as classic).
+                    if (!GameManager.Instance.PlayerEnterExit.IsPlayerSwimming && IntermittentEnemySpawn(l + lastGameMinutes + 1))
                         break;
 
                     // Confirm regionData is available


### PR DESCRIPTION
Prevent random encounter spawns as mentioned here https://forums.dfworkshop.net/viewtopic.php?f=24&t=1918&sid=b161443d647dd3d6ddfe6e86d3b194ed.

They are also prevented in this case in classic.