### PR TITLE
Apply screen weapon dye overrides for artifacts

### DIFF
--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -739,14 +739,12 @@ namespace DaggerfallWorkshop.Game.Items
                         {
                             switch (enchantment.param)
                             {
-                                case (int)ArtifactsSubTypes.Mehrunes_Razor: // Uses Mithril in classic but Elven matches its paper doll image
+                                case (int)ArtifactsSubTypes.Mehrunes_Razor: // Different from classic but Elven matches the paper doll more closely
                                     return MetalTypes.Elven;
                                 case (int)ArtifactsSubTypes.Mace_of_Molag_Bal:
                                     return MetalTypes.Ebony;
                                 case (int)ArtifactsSubTypes.Wabbajack:
                                     return MetalTypes.Steel;
-                                case (int)ArtifactsSubTypes.Volendrung: // Uses Steel in classic but Dwarven matches its paper doll image
-                                    return MetalTypes.Dwarven;
                                 default:
                                     break;
                             }

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:
+// Contributors: Numidium
 //
 // Notes:
 //
@@ -730,6 +730,34 @@ namespace DaggerfallWorkshop.Game.Items
             // Determine metal type
             if (item.ItemGroup == ItemGroups.Weapons)
             {
+                // Overrides for artifacts whose dyes do not match their materials
+                if (item.IsArtifact)
+                {
+                    foreach (DaggerfallEnchantment enchantment in item.Enchantments)
+                    {
+                        if (enchantment.type == EnchantmentTypes.SpecialArtifactEffect)
+                        {
+                            switch (enchantment.param)
+                            {
+                                case (int)ArtifactsSubTypes.Mehrunes_Razor: // Uses Mithril in classic but Elven matches its paper doll image
+                                    return MetalTypes.Elven;
+                                case (int)ArtifactsSubTypes.Mace_of_Molag_Bal:
+                                    return MetalTypes.Ebony;
+                                case (int)ArtifactsSubTypes.Wabbajack:
+                                    return MetalTypes.Steel;
+                                case (int)ArtifactsSubTypes.Volendrung: // Uses Steel in classic but Dwarven matches its paper doll image
+                                    return MetalTypes.Dwarven;
+                                default:
+                                    break;
+                            }
+                        }
+                    }
+                    // Artifact weapons with no unique effects
+                    if (item.ItemName == "Chrysamere")
+                        return MetalTypes.Elven;
+                    if (item.ItemName == "Staff of Magnus")
+                        return MetalTypes.Mithril;
+                }
                 WeaponMaterialTypes weaponMaterial = (WeaponMaterialTypes)item.nativeMaterialValue;
                 switch (weaponMaterial)
                 {

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Powers.meta
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Powers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1e53b73e58038c468392fc0376d0f50
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I altered a couple of them from classic so that they match their respective paper doll images better.  Let me know if I'm out of line in doing this.