### PR TITLE
AI improvements

### DIFF
--- a/Assets/Prefabs/Missiles/ArrowMissile.prefab
+++ b/Assets/Prefabs/Missiles/ArrowMissile.prefab
@@ -26,7 +26,7 @@ GameObject:
   - component: {fileID: 114624404217668130}
   - component: {fileID: 54102960107042576}
   - component: {fileID: 64298782196861766}
-  m_Layer: 0
+  m_Layer: 14
   m_Name: ArrowMissile
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -4,13 +4,12 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Allofich
 // 
 // Notes:
 //
 
 using UnityEngine;
-using System.Collections;
 using DaggerfallConnect;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Formulas;
@@ -167,11 +166,8 @@ namespace DaggerfallWorkshop.Game
 
                 // Switch to hand-to-hand if enemy is immune to weapon
                 Items.DaggerfallUnityItem weapon = entity.ItemEquipTable.GetItem(Items.EquipSlots.RightHand);
-                if (weapon != null)
-                {
-                    if (targetEntity != null && targetEntity.MobileEnemy.MinMetalToHit > (Items.WeaponMaterialTypes)weapon.NativeMaterialValue)
-                        weapon = null;
-                }
+                if (weapon != null && targetEntity != null && targetEntity.MobileEnemy.MinMetalToHit > (Items.WeaponMaterialTypes)weapon.NativeMaterialValue)
+                    weapon = null;
 
                 damage = 0;
 
@@ -305,25 +301,21 @@ namespace DaggerfallWorkshop.Game
                 }
 
                 // Knock back enemy based on damage and enemy weight
-                if (targetMotor)
+                if (targetMotor && (targetMotor.KnockBackSpeed <= (5 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10))
+                        && (entityBehaviour.EntityType == EntityTypes.EnemyClass || targetEntity.MobileEnemy.Weight > 0)))
                 {
-                    if (targetMotor.KnockBackSpeed <= (5 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)) &&
-                        entityBehaviour.EntityType == EntityTypes.EnemyClass ||
-                        targetEntity.MobileEnemy.Weight > 0)
-                    {
-                        float enemyWeight = targetEntity.GetWeightInClassicUnits();
-                        float tenTimesDamage = damage * 10;
-                        float twoTimesDamage = damage * 2;
+                    float enemyWeight = targetEntity.GetWeightInClassicUnits();
+                    float tenTimesDamage = damage * 10;
+                    float twoTimesDamage = damage * 2;
 
-                        float knockBackAmount = ((tenTimesDamage - enemyWeight) * 256) / (enemyWeight + tenTimesDamage) * twoTimesDamage;
-                        float knockBackSpeed = (tenTimesDamage / enemyWeight) * (twoTimesDamage - (knockBackAmount / 256));
-                        knockBackSpeed /= (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10);
+                    float knockBackAmount = ((tenTimesDamage - enemyWeight) * 256) / (enemyWeight + tenTimesDamage) * twoTimesDamage;
+                    float knockBackSpeed = (tenTimesDamage / enemyWeight) * (twoTimesDamage - (knockBackAmount / 256));
+                    knockBackSpeed /= (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10);
 
-                        if (knockBackSpeed < (15 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)))
-                            knockBackSpeed = (15 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10));
-                        targetMotor.KnockBackSpeed = knockBackSpeed;
-                        targetMotor.KnockBackDirection = direction;
-                    }
+                    if (knockBackSpeed < (15 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10)))
+                        knockBackSpeed = (15 / (PlayerSpeedChanger.classicToUnitySpeedUnitRatio / 10));
+                    targetMotor.KnockBackSpeed = knockBackSpeed;
+                    targetMotor.KnockBackDirection = direction;
                 }
 
                 if (DaggerfallUnity.Settings.CombatVoices && senses.Target.EntityType == EntityTypes.EnemyClass && Dice100.SuccessRoll(40))
@@ -335,8 +327,7 @@ namespace DaggerfallWorkshop.Game
                     else
                         gender = Genders.Female;
 
-                    bool heavyDamage = damage >= targetEntity.MaxHealth / 4;
-                    targetSounds.PlayCombatVoice(gender, false, heavyDamage);
+                    targetSounds.PlayCombatVoice(gender, false, damage >= targetEntity.MaxHealth / 4);
                 }
             }
             else

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -176,8 +176,8 @@ namespace DaggerfallWorkshop.Game
                 damage = 0;
 
                 // Melee hit detection, matched to classic
-                if (senses.Target != null && (senses.TargetInSight && senses.DistanceToTarget <= 0.25f
-                    || senses.DistanceToTarget <= MeleeDistance && senses.TargetIsWithinYawAngle(35.156f, senses.Target.transform.position)))
+                if (senses.Target != null && senses.TargetInSight && (senses.DistanceToTarget <= 0.25f
+                    || (senses.DistanceToTarget <= MeleeDistance && senses.TargetIsWithinYawAngle(35.156f, senses.Target.transform.position))))
                 {
                     if (senses.Target == GameManager.Instance.PlayerEntityBehaviour)
                         damage = ApplyDamageToPlayer(weapon);

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -67,9 +67,7 @@ namespace DaggerfallWorkshop.Game
         float heightChangeTimer;
         bool strafeLeft;
         float strafeAngle;
-        Vector3 strafeDest;
-        bool searchedLastKnownPos;
-        int searchMult = 0;
+        int searchMult;
 
         EnemySenses senses;
         Vector3 destination;
@@ -379,7 +377,6 @@ namespace DaggerfallWorkshop.Game
             {
                 SetChangeStateTimer();
                 bashing = false;
-                searchedLastKnownPos = false;
                 searchMult = 0;
 
                 return;
@@ -439,27 +436,29 @@ namespace DaggerfallWorkshop.Game
                     destination.y += 0.9f;
 
                 clearPathToShootAtPredictedPos = true;
-                searchedLastKnownPos = false;
                 searchMult = 0;
             }
             // Otherwise, search for target based on its last known position and direction
             else
             {
                 Vector3 searchPosition = senses.LastKnownTargetPos + (senses.LastPositionDiff.normalized * searchMult);
-                if (!searchedLastKnownPos && (searchPosition - transform.position).magnitude <= stopDistance)
-                    searchedLastKnownPos = true;
+                if ((searchPosition - transform.position).magnitude <= stopDistance)
+                    searchMult++;
 
-                if (!searchedLastKnownPos)
-                    destination = searchPosition;
-                else
+                destination = searchPosition;
+            }
+
+            if (GameManager.ClassicUpdate)
+            {
+                EnemyBlood sparkles2 = entityBehaviour.GetComponent<EnemyBlood>();
+                if (sparkles2)
                 {
-                    if ((searchPosition - transform.position).magnitude <= stopDistance)
-                        searchMult++;
-                    destination = searchPosition;
+                    sparkles2.ShowMagicSparkles(destination);
+                    //Debug.Log("senses.LastKnownTargetPos " + senses.LastKnownTargetPos + " senses.LastPositionDiff " + senses.LastPositionDiff + " destination " + destination + " ");
                 }
             }
 
-            if (avoidObstaclesTimer == 0 && !flies && !isLevitating && !swims && senses.Target)
+                if (avoidObstaclesTimer == 0 && !flies && !isLevitating && !swims && senses.Target)
             {
                 // Ground enemies target at their own height
                 // Otherwise, their target vector aims up towards the target, which could interfere with distance-to-target calculations
@@ -819,7 +818,7 @@ namespace DaggerfallWorkshop.Game
 
             if (strafe)
             {
-                strafeDest = new Vector3(destination.x + (Mathf.Sin(strafeAngle) * strafeDist), transform.position.y, destination.z + (Mathf.Cos(strafeAngle) * strafeDist));
+                Vector3 strafeDest = new Vector3(destination.x + (Mathf.Sin(strafeAngle) * strafeDist), transform.position.y, destination.z + (Mathf.Cos(strafeAngle) * strafeDist));
                 direction = (strafeDest - transform.position).normalized;
 
                 if ((strafeDest - transform.position).magnitude <= 0.2f)

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -977,9 +977,9 @@ namespace DaggerfallWorkshop.Game
             do
             {
                 if (checkingClockwise)
-                    angle += 10;
+                    angle += 45;
                 else
-                    angle -= 10;
+                    angle -= 45;
 
                 testMove = Quaternion.AngleAxis(angle, Vector3.up) * motion2d;
                 RayCheckForObstacle(testMove);
@@ -987,7 +987,7 @@ namespace DaggerfallWorkshop.Game
 
                 // Break out of loop if can't find anywhere to go
                 count++;
-                if (count > 36)
+                if (count > 7)
                 {
                     break;
                 }

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -442,20 +442,10 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 Vector3 searchPosition = senses.LastKnownTargetPos + (senses.LastPositionDiff.normalized * searchMult);
-                if ((searchPosition - transform.position).magnitude <= stopDistance)
+                if (searchMult <= 10 && (searchPosition - transform.position).magnitude <= stopDistance)
                     searchMult++;
 
                 destination = searchPosition;
-            }
-
-            if (GameManager.ClassicUpdate)
-            {
-                EnemyBlood sparkles2 = entityBehaviour.GetComponent<EnemyBlood>();
-                if (sparkles2)
-                {
-                    sparkles2.ShowMagicSparkles(destination);
-                    //Debug.Log("senses.LastKnownTargetPos " + senses.LastKnownTargetPos + " senses.LastPositionDiff " + senses.LastPositionDiff + " destination " + destination + " ");
-                }
             }
 
                 if (avoidObstaclesTimer == 0 && !flies && !isLevitating && !swims && senses.Target)
@@ -1024,7 +1014,7 @@ namespace DaggerfallWorkshop.Game
             Vector3 p1 = transform.position + charContr.center + Vector3.up * -charContr.height * 0.5F;
             Vector3 p2 = p1 + Vector3.up * charContr.height;
 
-            if (Physics.CapsuleCast(p1, p2, charContr.radius, transform.forward, out hit, checkDistance))
+            if (Physics.CapsuleCast(p1, p2, charContr.radius, direction, out hit, checkDistance))
             {
                 obstacleDetected = true;
 

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -509,6 +509,11 @@ namespace DaggerfallWorkshop.Game
         {
             Vector3 assumedCurrentPosition;
 
+            if (predictedTargetPosWithoutLead == ResetPlayerPos)
+            {
+                predictedTargetPosWithoutLead = lastKnownTargetPos;
+            }
+
             // If aware of target, use last known position as assumed current position
             if (targetInSight || targetInEarshot)
             {

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -536,6 +536,8 @@ namespace DaggerfallWorkshop.Game
             {
                 divisor = targetPosPredictTimer;
                 targetPosPredictTimer = 0;
+                lastPositionDiff = lastKnownTargetPos - oldLastKnownTargetPos;
+                oldLastKnownTargetPos = lastKnownTargetPos;
             }
 
             Vector3 prediction = assumedCurrentPosition + (lastPositionDiff / divisor * secondsToPredictedPos);

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -455,7 +455,7 @@ namespace DaggerfallWorkshop.Game
                 if (targetPosPredict && lastKnownTargetPos != ResetPlayerPos)
                 {
                     // Be sure to only take difference of movement if we've seen the target for two consecutive prediction updates
-                    if (!blockedByIllusionEffect && (targetInSight || targetInEarshot))
+                    if (!blockedByIllusionEffect && targetInSight)
                     {
                         if (awareOfTargetForLastPrediction)
                             lastPositionDiff = lastKnownTargetPos - oldLastKnownTargetPos;
@@ -508,22 +508,18 @@ namespace DaggerfallWorkshop.Game
         public Vector3 PredictNextTargetPos(float interceptSpeed)
         {
             Vector3 assumedCurrentPosition;
+            RaycastHit tempHit;
 
             if (predictedTargetPosWithoutLead == ResetPlayerPos)
             {
                 predictedTargetPosWithoutLead = lastKnownTargetPos;
             }
 
-            // If aware of target, use last known position as assumed current position
-            if (targetInSight || targetInEarshot)
+            // If aware of target, if distance is too far or can see nothing is there, use last known position as assumed current position
+            if (targetInSight || targetInEarshot || (predictedTargetPos - transform.position).magnitude > SightRadius + mobile.Summary.Enemy.SightModifier
+                || !Physics.Raycast(transform.position, (predictedTargetPosWithoutLead - transform.position).normalized, out tempHit, SightRadius + mobile.Summary.Enemy.SightModifier))
             {
                 assumedCurrentPosition = lastKnownTargetPos;
-            }
-            // Stop predicting if distance is too far
-            else if ((predictedTargetPos - transform.position).magnitude > SightRadius + mobile.Summary.Enemy.SightModifier)
-            {
-                assumedCurrentPosition = predictedTargetPosWithoutLead;
-                lastPositionDiff = Vector3.zero;
             }
             // If not aware of target and predicted position may still be good, use predicted position
             else


### PR DESCRIPTION
Make sure enemies don't get stuck with "avoidObstaclesTimer" > 0 if they
are somehow unable to point at the detour destination.
Raise avoidObstaclesTimer a bit now since it counts down regardless of
direction enemy is pointing, but set to 0 if got close enough to target
spot. 0.3 seems like a good distance for this check.
Make enemies aim at their own height for target when searching for
target, not just when approaching seen target.
Improve RayCheckForObstacle:
- Use a CapsuleCast. This does better at detecting things in the way.
- Adjust height of rays casted for checking for slope. Should still
detect climbable stairs while not treating large, unclimbable
differences in height as climbable.