### PR TITLE
Remove redundant parent assignments

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -344,10 +344,6 @@ namespace Wenzil.Console
                     else
                         team = (int)entity.Team;
 
-                    if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideBuilding)
-                        mobile[0].transform.parent = GameManager.Instance.PlayerEnterExit.Interior.transform;
-                    else if (GameManager.Instance.PlayerGPS.IsPlayerInLocationRect)
-                        mobile[0].transform.parent = GameManager.Instance.StreamingWorld.CurrentPlayerLocationObject.transform;
                     mobile[0].transform.LookAt(mobile[0].transform.position + (mobile[0].transform.position - player.transform.position));
                     mobile[0].SetActive(true);
 

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -701,10 +701,6 @@ namespace DaggerfallWorkshop.Game.Entity
         public GameObject SpawnCityGuard(Vector3 position, Vector3 direction)
         {
             GameObject[] cityWatch = GameObjectHelper.CreateFoeGameObjects(position, MobileTypes.Knight_CityWatch, 1);
-            if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideBuilding)
-                cityWatch[0].transform.parent = GameManager.Instance.PlayerEnterExit.Interior.transform;
-            else if (GameManager.Instance.PlayerGPS.IsPlayerInLocationRect)
-                cityWatch[0].transform.parent = GameManager.Instance.StreamingWorld.CurrentPlayerLocationObject.transform;
             cityWatch[0].transform.forward = direction;
             EnemyMotor enemyMotor = cityWatch[0].GetComponent<EnemyMotor>();
 


### PR DESCRIPTION
Removed parent assignments when creating city guards or using the "CreateMobile" command, as they are now redundant because of
https://github.com/Interkarma/daggerfall-unity/commit/88644c22c1063079d811b148c26b4628b3297600