### PR TITLE
Everything using ClassicUpdate uses FixedUpdate

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -47,27 +47,10 @@ namespace DaggerfallWorkshop.Game
             entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
         }
 
-        void Update()
+        void FixedUpdate()
         {
             if (GameManager.Instance.DisableAI)
                 return;
-
-            // If a melee attack has reached the damage frame we can run a melee attempt
-            if (mobile.DoMeleeDamage)
-            {
-                MeleeDamage();
-                mobile.DoMeleeDamage = false;
-            }
-            // If a bow attack has reached the shoot frame we can shoot an arrow
-            else if (mobile.ShootArrow)
-            {
-                ShootBow();
-                mobile.ShootArrow = false;
-
-                DaggerfallAudioSource dfAudioSource = GetComponent<DaggerfallAudioSource>();
-                if (dfAudioSource)
-                    dfAudioSource.PlayOneShot((int)SoundClips.ArrowShoot, 1, 1.0f);
-            }
 
             // Countdown to next melee attack
             MeleeTimer -= Time.deltaTime;
@@ -86,6 +69,26 @@ namespace DaggerfallWorkshop.Game
                     return;
 
                 ResetMeleeTimer();
+            }
+        }
+
+        void Update()
+        {
+            // If a melee attack has reached the damage frame we can run a melee attempt
+            if (mobile.DoMeleeDamage)
+            {
+                MeleeDamage();
+                mobile.DoMeleeDamage = false;
+            }
+            // If a bow attack has reached the shoot frame we can shoot an arrow
+            else if (mobile.ShootArrow)
+            {
+                ShootBow();
+                mobile.ShootArrow = false;
+
+                DaggerfallAudioSource dfAudioSource = GetComponent<DaggerfallAudioSource>();
+                if (dfAudioSource)
+                    dfAudioSource.PlayOneShot((int)SoundClips.ArrowShoot, 1, 1.0f);
             }
         }
 

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -745,6 +745,13 @@ namespace DaggerfallWorkshop.Game.Entity
         #region Helpers
 
         /// <summary>
+        /// Called by DaggerfallEntityBehaviour at regular intervals.
+        /// </summary>
+        public virtual void FixedUpdate()
+        {
+        }
+
+        /// <summary>
         /// Called by DaggerfallEntityBehaviour each frame.
         /// </summary>
         /// <param name="sender">DaggerfallEntityBehaviour making call.</param>

--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -58,6 +58,11 @@ namespace DaggerfallWorkshop.Game.Entity
             SetEntityType(EntityType);
         }
 
+        void FixedUpdate()
+        {
+            Entity.FixedUpdate();
+        }
+
         void Update()
         {
             // Change entity type

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -448,7 +448,7 @@ namespace DaggerfallWorkshop.Game
             Debug.Log("Welcome to Daggerfall Unity " + VersionInfo.DaggerfallUnityVersion);
         }
 
-        void Update()
+        void FixedUpdate()
         {
             if (!IsPlayingGame())
             {
@@ -465,7 +465,10 @@ namespace DaggerfallWorkshop.Game
             }
             else
                 classicUpdate = false;
+        }
 
+        void Update()
+        {
             // Post message to open options dialog on escape during gameplay
             if (Input.GetKeyDown(KeyCode.Escape))
             {


### PR DESCRIPTION
Should fix https://www.reddit.com/r/daggerfallunity/comments/bb5yu4/enemies_seem_floaty/.

When I merged all the classicUpdateTimers into one, I put it into the GameManager, and stuck it in its `Update()` along with all the rest of its update work. However, since `FixedUpdate()` and `Update()` are not in sync with each other, accesses to this from `FixedUpdate()` functions were not reliable. Everything needs to be either in `FixedUpdate()` or in `Update()`. Since https://docs.unity3d.com/Manual/ExecutionOrder.html says "All physics calculations and updates occur immediately after FixedUpdate.", and enemy AI is closely related to movement, `FixedUpdate()` seems to be the right place. When frame rates are high `FixedUpdate()` runs quite a lot less than `Update()`. When frame rates are low, like when loading up a save in a city exterior, `FixedUpdate()` runs more frequently, but hopefully that won't be a problem.

~In addition to `EnemyMotor`, that poster on Reddit should have also been having problems with the melee timer in `EnemyAttack`, which should both be fixed by this.~