### PR TITLE
Minor cleanup

### DIFF
--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -64,7 +64,6 @@ namespace DaggerfallWorkshop.Game
         Vector3 direction;
         Light myLight;
         SphereCollider myCollider;
-        MeshCollider arrowCollider;
         DaggerfallAudioSource audioSource;
         Rigidbody myRigidbody;
         DaggerfallBillboard myBillboard;
@@ -207,7 +206,7 @@ namespace DaggerfallWorkshop.Game
             {
                 // Create and orient 3d arrow
                 goModel = GameObjectHelper.CreateDaggerfallMeshGameObject(99800, transform);
-                arrowCollider = GetComponent<MeshCollider>();
+                MeshCollider arrowCollider = GetComponent<MeshCollider>();
                 arrowCollider.sharedMesh = goModel.GetComponent<MeshFilter>().sharedMesh;
 
                 // Offset up so it comes from same place LOS check is done from
@@ -360,7 +359,8 @@ namespace DaggerfallWorkshop.Game
             if (isArrow)
             {
                 if (other != null)
-                AssignBowDamageToTarget(other);
+                    AssignBowDamageToTarget(other);
+
                 // Destroy 3d arrow
                 Destroy(goModel.gameObject);
                 impactDetected = true;


### PR DESCRIPTION
Very minor cleanup of 2 things in `DaggerfallMissile`. `arrowCollider` could be made a local variable, and the `AssignBowDamageToTarget(other)` line wasn't indented and made it look a little unclear what was intended to fall under the if statement.