### PR TITLE
Implement AI pathing to target position

### DIFF
--- a/Assets/Prefabs/Scene/DaggerfallActionDoor [Dungeon Serializable].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallActionDoor [Dungeon Serializable].prefab
@@ -3,9 +3,9 @@
 --- !u!1 &122440
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 435366}
   - component: {fileID: 8202058}
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 6522250}
   - component: {fileID: 11410228}
   - component: {fileID: 11484958}
-  m_Layer: 0
+  m_Layer: 15
   m_Name: DaggerfallActionDoor [Dungeon Serializable]
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -23,7 +23,7 @@ GameObject:
 --- !u!4 &435366
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -36,7 +36,7 @@ Transform:
 --- !u!65 &6522250
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_Material: {fileID: 0}
@@ -48,7 +48,7 @@ BoxCollider:
 --- !u!82 &8202058
 AudioSource:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_Enabled: 1
@@ -74,61 +74,76 @@ AudioSource:
   rolloffCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
-    - serializedVersion: 2
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
       time: 1
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   panLevelCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
   spreadCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
 --- !u!114 &11410228
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_Enabled: 1
@@ -141,7 +156,6 @@ MonoBehaviour:
   OpenAngle: -90
   OpenDuration: 1.5
   IsTriggerWhenOpen: 1
-  ChanceToBash: 0.25
   PlaySounds: 1
   FailedSkillLevel: 0
   OpenSound: 25
@@ -151,7 +165,7 @@ MonoBehaviour:
 --- !u!114 &11484958
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_Enabled: 1
@@ -162,7 +176,7 @@ MonoBehaviour:
 --- !u!114 &11485404
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_Enabled: 1
@@ -187,6 +201,6 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
+  m_SourcePrefab: {fileID: 0}
   m_RootGameObject: {fileID: 122440}
-  m_IsPrefabParent: 1
+  m_IsPrefabAsset: 1

--- a/Assets/Prefabs/Scene/DaggerfallActionDoor [Dungeon].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallActionDoor [Dungeon].prefab
@@ -3,16 +3,16 @@
 --- !u!1 &122440
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 6
   m_Component:
-  - 4: {fileID: 435366}
-  - 82: {fileID: 8202058}
-  - 114: {fileID: 11485404}
-  - 65: {fileID: 6522250}
-  - 114: {fileID: 11410228}
-  m_Layer: 0
+  - component: {fileID: 435366}
+  - component: {fileID: 8202058}
+  - component: {fileID: 11485404}
+  - component: {fileID: 6522250}
+  - component: {fileID: 11410228}
+  m_Layer: 15
   m_Name: DaggerfallActionDoor [Dungeon]
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22,20 +22,20 @@ GameObject:
 --- !u!4 &435366
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &6522250
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_Material: {fileID: 0}
@@ -47,7 +47,7 @@ BoxCollider:
 --- !u!82 &8202058
 AudioSource:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_Enabled: 1
@@ -60,6 +60,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 0
+  SpatializePostEffects: 0
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -72,56 +73,76 @@ AudioSource:
   rolloffCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - time: 0
+    - serializedVersion: 3
+      time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
-    - time: 1
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   panLevelCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - time: 0
+    - serializedVersion: 3
+      time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   spreadCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - time: 0
+    - serializedVersion: 3
+      time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - time: 0
+    - serializedVersion: 3
+      time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
 --- !u!114 &11410228
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_Enabled: 1
@@ -134,16 +155,16 @@ MonoBehaviour:
   OpenAngle: -90
   OpenDuration: 1.5
   IsTriggerWhenOpen: 1
-  ChanceToBash: 0.25
   PlaySounds: 1
+  FailedSkillLevel: 0
   OpenSound: 25
   CloseSound: 24
   BashSound: 7
-  LockedSound: 316
+  PickedLockSound: 316
 --- !u!114 &11485404
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 122440}
   m_Enabled: 1
@@ -168,6 +189,6 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
+  m_SourcePrefab: {fileID: 0}
   m_RootGameObject: {fileID: 122440}
-  m_IsPrefabParent: 1
+  m_IsPrefabAsset: 1

--- a/Assets/Prefabs/Scene/DaggerfallActionDoor [Interior Serializable].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallActionDoor [Interior Serializable].prefab
@@ -3,9 +3,9 @@
 --- !u!1 &118732
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 411640}
   - component: {fileID: 8261896}
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 6536966}
   - component: {fileID: 11420022}
   - component: {fileID: 11411846}
-  m_Layer: 0
+  m_Layer: 15
   m_Name: DaggerfallActionDoor [Interior Serializable]
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -23,7 +23,7 @@ GameObject:
 --- !u!4 &411640
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -36,7 +36,7 @@ Transform:
 --- !u!65 &6536966
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_Material: {fileID: 0}
@@ -48,7 +48,7 @@ BoxCollider:
 --- !u!82 &8261896
 AudioSource:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_Enabled: 1
@@ -74,61 +74,76 @@ AudioSource:
   rolloffCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
-    - serializedVersion: 2
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
       time: 1
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   panLevelCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
   spreadCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
 --- !u!114 &11411846
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_Enabled: 1
@@ -139,7 +154,7 @@ MonoBehaviour:
 --- !u!114 &11420022
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_Enabled: 1
@@ -152,7 +167,6 @@ MonoBehaviour:
   OpenAngle: -90
   OpenDuration: 1.5
   IsTriggerWhenOpen: 1
-  ChanceToBash: 0.25
   PlaySounds: 1
   FailedSkillLevel: 0
   OpenSound: 94
@@ -162,7 +176,7 @@ MonoBehaviour:
 --- !u!114 &11425152
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_Enabled: 1
@@ -187,6 +201,6 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
+  m_SourcePrefab: {fileID: 0}
   m_RootGameObject: {fileID: 118732}
-  m_IsPrefabParent: 1
+  m_IsPrefabAsset: 1

--- a/Assets/Prefabs/Scene/DaggerfallActionDoor [Interior].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallActionDoor [Interior].prefab
@@ -3,16 +3,16 @@
 --- !u!1 &118732
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 411640}
   - component: {fileID: 8261896}
   - component: {fileID: 11425152}
   - component: {fileID: 6536966}
   - component: {fileID: 11420022}
-  m_Layer: 0
+  m_Layer: 15
   m_Name: DaggerfallActionDoor [Interior]
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22,7 +22,7 @@ GameObject:
 --- !u!4 &411640
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -35,7 +35,7 @@ Transform:
 --- !u!65 &6536966
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_Material: {fileID: 0}
@@ -47,7 +47,7 @@ BoxCollider:
 --- !u!82 &8261896
 AudioSource:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_Enabled: 1
@@ -73,61 +73,76 @@ AudioSource:
   rolloffCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
-    - serializedVersion: 2
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
       time: 1
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   panLevelCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
   spreadCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
 --- !u!114 &11420022
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_Enabled: 1
@@ -149,7 +164,7 @@ MonoBehaviour:
 --- !u!114 &11425152
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 118732}
   m_Enabled: 1
@@ -174,6 +189,6 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
+  m_SourcePrefab: {fileID: 0}
   m_RootGameObject: {fileID: 118732}
-  m_IsPrefabParent: 1
+  m_IsPrefabAsset: 1

--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Game Serializable].prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 3367684}
   - component: {fileID: 2302536}
   - component: {fileID: 11478892}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: MobileUnitBillboard
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -41,7 +41,7 @@ GameObject:
   - component: {fileID: 11449422}
   - component: {fileID: 114919659270182526}
   - component: {fileID: 114564829754804976}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: DaggerfallEnemy [Game Serializable]
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -226,6 +226,7 @@ MonoBehaviour:
   EnemyType: 15
   EnemyReaction: 0
   EnemyGender: 0
+  AlliedToPlayer: 0
   ClassicSpawnDistanceType: 0
 --- !u!114 &11424130
 MonoBehaviour:
@@ -238,8 +239,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 148778fc11ccec74aa9f538dab0d07d9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MeleeAttackSpeed: 1.25
   MeleeDistance: 2.25
+  ClassicMeleeDistanceVsAI: 1.5
   MeleeTimer: 0
   ArrowMissilePrefab: {fileID: 114624404217668130, guid: 0fdc5fb41ee669e49b44322b7db26e9e,
     type: 2}

--- a/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
+++ b/Assets/Prefabs/Scene/DaggerfallEnemy [Standalone].prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 3367684}
   - component: {fileID: 2302536}
   - component: {fileID: 11478892}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: MobileUnitBillboard
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 11439840}
   - component: {fileID: 11452974}
   - component: {fileID: 11435454}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: DaggerfallEnemy [Standalone]
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -223,6 +223,7 @@ MonoBehaviour:
   EnemyType: 15
   EnemyReaction: 0
   EnemyGender: 0
+  AlliedToPlayer: 0
   ClassicSpawnDistanceType: 0
 --- !u!114 &11424130
 MonoBehaviour:
@@ -235,9 +236,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 148778fc11ccec74aa9f538dab0d07d9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MeleeAttackSpeed: 1.25
   MeleeDistance: 2.25
+  ClassicMeleeDistanceVsAI: 1.5
   MeleeTimer: 0
+  ArrowMissilePrefab: {fileID: 0}
 --- !u!114 &11435454
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -965,7 +965,7 @@ namespace DaggerfallWorkshop.Game
 
             // Check that there is a clear path to shoot a spell
             float spellMovementSpeed = 25; // All range spells are currently 25 speed
-            Vector3 sphereCastDir = senses.PredictNextTargetPos(spellMovementSpeed);
+            Vector3 sphereCastDir = senses.PredictedTargetPos;
             if (sphereCastDir == EnemySenses.ResetPlayerPos)
                 return false;
 

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -392,14 +392,9 @@ namespace DaggerfallWorkshop.Game
                 }
                 else
                 {
-                    Vector3 toTarget = ResetPlayerPos;
-                    toTarget = target.transform.position - transform.position;
-
-                    if (toTarget != ResetPlayerPos)
-                    {
-                        distanceToTarget = toTarget.magnitude;
-                        directionToTarget = toTarget.normalized;
-                    }
+                    Vector3 toTarget = target.transform.position - transform.position;
+                    distanceToTarget = toTarget.magnitude;
+                    directionToTarget = toTarget.normalized;
                     targetInSight = CanSeeTarget(target);
                 }
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -23,7 +23,7 @@ TagManager:
   - BankPurchase
   - Player
   - SpellMissiles
-  - 
+  - Doors
   - 
   - 
   - 


### PR DESCRIPTION
Implements actual AI pathing to targets. With this, enemies are quite a bit better (still far from perfect) at navigating complex areas like building interiors or moving up or down land bridges or chasing the player from room to room.

In master branch the AI basically takes a "blindly feeling along the wall" approach, but this only works for simple obstacles and is pretty useless when up and down is involved. With this PR a grid of 1-unit spaced points is created and searched, using 8-directions and aiming for the direction of the target's predicted position. Attempts are made to recognize climbable slopes and falls. The AI then follows the path it created, whether it successfully reached the target position within the allowed number of tries or not. It follows the path point to point, short-cutting a point ahead if it has a clear path to it and the y-difference is small. 

I've been working on this for a while now and I finally got it to where my test cases seem to all be working OK, but I'm sure problem situations still exist.

Also includes a fix for magic users caused by my last AI PR. I noticed imps could get easily stuck vibrating back and forth. This fixes that.

If you want to test, turn on the "Gizmos" in the upper right corner of the Unity editor to see the pathing. The red lines are the grid of searched points, the blue line is the path result, and the green lines point to the position the enemy is currently trying to get to.

There's a lot of sphere-casting going on, but I haven't really noticed a performance drop in my testing. If it does cause performance drops, we could limit the searching or make it less frequent, randomly space them out a little so AI's created at the same time don't all search at the same time, etc.