### PR TITLE
Townsfolk names now match classic

### DIFF
--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -59,6 +59,18 @@ namespace DaggerfallConnect.Arena2
         };
 
         /// <summary>
+        /// All region races, primarily used to generate townsfolk names. In the array extracted from FALL.EXE:
+        /// 0 = Breton, 1 = Redguard.
+        /// </summary>
+        private static readonly byte[] regionRaces = {
+            1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0, 1,
+            0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0,
+            0, 1
+        };
+
+        /// <summary>
         /// Block file prefixes.
         /// </summary>
         private readonly string[] rmbBlockPrefixes = {
@@ -212,6 +224,14 @@ namespace DaggerfallConnect.Arena2
         public static string[] RegionNames
         {
             get { return regionNames; }
+        }
+
+        /// <summary>
+        /// Gets all region races as byte array.
+        /// </summary>
+        public static byte[] RegionRaces
+        {
+            get { return regionRaces; }
         }
 
         /// <summary>

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -428,7 +428,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_TemperateWoodland;
                     settings.SkyBase = 24;
                     settings.People = FactionFile.FactionRaces.Breton;
-                    settings.Names = FactionFile.FactionRaces.Breton;
                     break;
                 case (int)Climates.Desert:
                 case (int)Climates.Desert2:
@@ -437,7 +436,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_Desert;
                     settings.SkyBase = 8;
                     settings.People = FactionFile.FactionRaces.Redguard;
-                    settings.Names = FactionFile.FactionRaces.Redguard;
                     break;
                 case (int)Climates.Mountain:
                     settings.ClimateType = DFLocation.ClimateBaseType.Mountain;
@@ -445,7 +443,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_Mountains;
                     settings.SkyBase = 0;
                     settings.People = FactionFile.FactionRaces.Nord;
-                    settings.Names = FactionFile.FactionRaces.Nord;
                     break;
                 case (int)Climates.Rainforest:
                     settings.ClimateType = DFLocation.ClimateBaseType.Swamp;
@@ -453,7 +450,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_RainForest;
                     settings.SkyBase = 24;
                     settings.People = FactionFile.FactionRaces.Redguard;
-                    settings.Names = FactionFile.FactionRaces.Redguard;
                     break;
                 case (int)Climates.Swamp:
                     settings.ClimateType = DFLocation.ClimateBaseType.Swamp;
@@ -461,7 +457,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_Swamp;
                     settings.SkyBase = 24;
                     settings.People = FactionFile.FactionRaces.Breton;
-                    settings.Names = FactionFile.FactionRaces.Redguard;
                     break;
                 case (int)Climates.Subtropical:
                     settings.ClimateType = DFLocation.ClimateBaseType.Desert;
@@ -469,7 +464,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_SubTropical;
                     settings.SkyBase = 24;
                     settings.People = FactionFile.FactionRaces.Breton;
-                    settings.Names = FactionFile.FactionRaces.Redguard;
                     break;
                 case (int)Climates.MountainWoods:
                     settings.ClimateType = DFLocation.ClimateBaseType.Temperate;
@@ -477,7 +471,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_TemperateWoodland;
                     settings.SkyBase = 16;
                     settings.People = FactionFile.FactionRaces.Breton;
-                    settings.Names = FactionFile.FactionRaces.Breton;
                     break;
                 case (int)Climates.Woodlands:
                     settings.ClimateType = DFLocation.ClimateBaseType.Temperate;
@@ -485,7 +478,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_TemperateWoodland;
                     settings.SkyBase = 16;
                     settings.People = FactionFile.FactionRaces.Breton;
-                    settings.Names = FactionFile.FactionRaces.Breton;
                     break;
                 case (int)Climates.HauntedWoodlands:
                     settings.ClimateType = DFLocation.ClimateBaseType.Temperate;
@@ -493,7 +485,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_HauntedWoodlands;
                     settings.SkyBase = 16;
                     settings.People = FactionFile.FactionRaces.Breton;
-                    settings.Names = FactionFile.FactionRaces.Breton;
                     break;
                 default:
                     settings.ClimateType = DFLocation.ClimateBaseType.Temperate;
@@ -501,7 +492,6 @@ namespace DaggerfallConnect.Arena2
                     settings.NatureArchive = (int)DFLocation.ClimateTextureSet.Nature_TemperateWoodland;
                     settings.SkyBase = 16;
                     settings.People = FactionFile.FactionRaces.Breton;
-                    settings.Names = FactionFile.FactionRaces.Breton;
                     break;
             }
 

--- a/Assets/Scripts/Game/MobilePersonNPC.cs
+++ b/Assets/Scripts/Game/MobilePersonNPC.cs
@@ -178,11 +178,8 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         void SetPerson()
         {
-            // do several things in switch statement:
             // get person's face texture record index for this race and gender and outfit variant
-            // get correct nameBankType for this race
             int[] recordIndices = null;
-            NameHelper.BankTypes nameBankType;
             switch (race)
             {
                 case Races.Redguard:
@@ -197,14 +194,10 @@ namespace DaggerfallWorkshop.Game
                     break;
             }
 
-            // create name for npc
-            byte nameRace = 0;
+            // get correct nameBankType for this race and create name for npc
+            NameHelper.BankTypes nameBankType = NameHelper.BankTypes.Breton;
             if (GameManager.Instance.PlayerGPS.CurrentRegionIndex > -1)
-                nameRace = MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
-            if (nameRace == 0)
-                nameBankType = NameHelper.BankTypes.Breton;
-            else
-                nameBankType = NameHelper.BankTypes.Redguard;
+                nameBankType = (NameHelper.BankTypes) MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
 
             this.nameNPC = DaggerfallUnity.Instance.NameHelper.FullName(nameBankType, gender);
 

--- a/Assets/Scripts/Game/MobilePersonNPC.cs
+++ b/Assets/Scripts/Game/MobilePersonNPC.cs
@@ -187,34 +187,25 @@ namespace DaggerfallWorkshop.Game
             {
                 case Races.Redguard:
                     recordIndices = (gender == Genders.Male) ? maleRedguardFaceRecordIndex : femaleRedguardFaceRecordIndex;
-                    //nameBankType = NameHelper.BankTypes.Redguard;
                     break;
                 case Races.Nord:
                     recordIndices = (gender == Genders.Male) ? maleNordFaceRecordIndex : femaleNordFaceRecordIndex;
-                    //nameBankType = NameHelper.BankTypes.Nord;
                     break;
                 case Races.Breton:
                 default:
                     recordIndices = (gender == Genders.Male) ? maleBretonFaceRecordIndex : femaleBretonFaceRecordIndex;
-                    //nameBankType = NameHelper.BankTypes.Breton;
                     break;
             }
 
             // create name for npc
-            DFLocation.ClimateSettings climateSettings = MapsFile.GetWorldClimateSettings(GameManager.Instance.PlayerGPS.ClimateSettings.WorldClimate);
-            switch (climateSettings.Names)
-            {                
-                case FactionFile.FactionRaces.Breton:
-                default:
-                    nameBankType = NameHelper.BankTypes.Breton;
-                    break;
-                case FactionFile.FactionRaces.Nord:
-                    nameBankType = NameHelper.BankTypes.Nord;
-                    break;
-                case FactionFile.FactionRaces.Redguard:
-                    nameBankType = NameHelper.BankTypes.Redguard;
-                    break;
-            }
+            byte nameRace = 0;
+            if (GameManager.Instance.PlayerGPS.CurrentRegionIndex > -1)
+                nameRace = MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
+            if (nameRace == 0)
+                nameBankType = NameHelper.BankTypes.Breton;
+            else
+                nameBankType = NameHelper.BankTypes.Redguard;
+
             this.nameNPC = DaggerfallUnity.Instance.NameHelper.FullName(nameBankType, gender);
 
             // get face record id to use (randomize portrait for current person outfit variant)

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -356,34 +356,15 @@ namespace DaggerfallWorkshop
 
         /// <summary>
         /// Gets NameHelper.BankType in player's current region.
-        /// In practice this will always be Redguard/Breton/Nord.
-        /// Supporting a few other name banks for possible diversity later.
+        /// In practice this will always be Redguard/Breton.
+        /// Supporting other name banks for possible diversity later.
         /// </summary>
         public NameHelper.BankTypes GetNameBankOfCurrentRegion()
         {
-            DFLocation.ClimateSettings settings = MapsFile.GetWorldClimateSettings(climateSettings.WorldClimate);
-            NameHelper.BankTypes bankType;
-            switch (settings.Names)
-            {
-                case FactionFile.FactionRaces.Redguard:
-                    bankType = NameHelper.BankTypes.Redguard;
-                    break;
-                case FactionFile.FactionRaces.Nord:
-                    bankType = NameHelper.BankTypes.Nord;
-                    break;
-                case FactionFile.FactionRaces.DarkElf:
-                    bankType = NameHelper.BankTypes.DarkElf;
-                    break;
-                case FactionFile.FactionRaces.WoodElf:
-                    bankType = NameHelper.BankTypes.WoodElf;
-                    break;
-                default:
-                case FactionFile.FactionRaces.Breton:
-                    bankType = NameHelper.BankTypes.Breton;
-                    break;
-            }
+            if (GameManager.Instance.PlayerGPS.CurrentRegionIndex > -1)
+                return (NameHelper.BankTypes) MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
 
-            return bankType;
+            return NameHelper.BankTypes.Breton;
         }
 
         /// <summary>


### PR DESCRIPTION
Townsfolk names are not tied to climate settings in classic. Instead, they use an array of 62 byte values hardcoded in FALL.EXE with 0 for Breton and 1 for Redguard. Nord names are never used for town NPCs.

This makes DFU behave the same.