### PR TITLE
New ruler namegen fix

### DIFF
--- a/Assets/Scripts/Game/Entities/RaceTemplate.cs
+++ b/Assets/Scripts/Game/Entities/RaceTemplate.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using DaggerfallConnect;
+using DaggerfallConnect.Arena2;
 
 namespace DaggerfallWorkshop.Game.Entity
 {
@@ -100,6 +101,33 @@ namespace DaggerfallWorkshop.Game.Entity
             raceDict.Add(argonian.ID, argonian);
 
             return raceDict;
+        }
+
+        /// <summary>
+        /// Get the entity race corresponding to that read from FACTION.TXT.
+        /// Only Breton, Redguard, Nord, Dark Elf and Wood Elf are supported.
+        /// Any other faction race will default to Breton.
+        /// </summary>
+        /// <param name="factionRace">The faction race</param>
+        /// <returns>The corresponding entity race.</returns>
+        public static Races GetRaceFromFactionRace(FactionFile.FactionRaces factionRace)
+        {
+            switch (factionRace)
+            {
+                case FactionFile.FactionRaces.None:
+                    return Races.None;
+                case FactionFile.FactionRaces.Redguard:
+                    return Races.Redguard;
+                case FactionFile.FactionRaces.Nord:
+                    return Races.Nord;
+                case FactionFile.FactionRaces.DarkElf:
+                    return Races.DarkElf;
+                case FactionFile.FactionRaces.WoodElf:
+                    return Races.WoodElf;
+                case FactionFile.FactionRaces.Breton:
+                default:
+                    return Races.Breton;
+            }
         }
     }
 

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -493,28 +493,10 @@ namespace DaggerfallWorkshop.Game.Questing
             // Use faction race only for individuals
             if (isIndividualNPC)
             {
-                FactionFile.FactionRaces factionRace = (FactionFile.FactionRaces)factionData.race;
-                if (factionRace != FactionFile.FactionRaces.None)
+                race = RaceTemplate.GetRaceFromFactionRace((FactionFile.FactionRaces)factionData.race);
+                if (race != Races.None)
                 {
-                    switch (factionRace)
-                    {
-                        case FactionFile.FactionRaces.Redguard:
-                            race = Races.Redguard;
-                            return;
-                        case FactionFile.FactionRaces.Nord:
-                            race = Races.Nord;
-                            return;
-                        case FactionFile.FactionRaces.DarkElf:
-                            race = Races.DarkElf;
-                            return;
-                        case FactionFile.FactionRaces.WoodElf:
-                            race = Races.WoodElf;
-                            return;
-                        case FactionFile.FactionRaces.Breton:
-                        default:
-                            race = Races.Breton;
-                            return;
-                    }
+                    return;
                 }
             }
 

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -272,7 +272,7 @@ namespace DaggerfallWorkshop.Utility
         {
             // TODO: How should bank type be randomised? This line results in blank names sometimes, so using race instead.
             //return (NameHelper.BankTypes) DFRandom.random_range_inclusive(0, 8);
-            Races race = (Races) DFRandom.random_range_inclusive(0, 8);
+            Races race = (Races) DFRandom.random_range_inclusive(1, 8);
             return GetNameBank(race);
         }
 
@@ -283,7 +283,7 @@ namespace DaggerfallWorkshop.Utility
             factions.GetFactionData(factionId, out fd);
 
             Genders gender = (Genders) ((fd.ruler + 1) % 2); // even entries are female titles/genders, odd entries are male ones
-            Races race = (Races) fd.race;
+            Races race = RaceTemplate.GetRaceFromFactionRace((FactionFile.FactionRaces)fd.race);
 
             return DaggerfallUnity.Instance.NameHelper.FullName(GetNameBank(race), gender);
         }


### PR DESCRIPTION
This fixes the mapping between race numbers from FACTION.TXT and races used in game, when generating a random ruler name when asking a NPC for any news.