### PR TITLE
Added support for cursor override

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -26,6 +26,7 @@ using DaggerfallWorkshop.Game.Player;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.Utility.ModSupport;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -151,6 +152,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
 
             moveNextStage = true;
+
+            // Override cursor
+            Texture2D tex;
+            if (TextureReplacement.TryImportTexture("Cursor", out tex))
+            {
+                Cursor.SetCursor(tex, Vector2.zero, CursorMode.Auto);
+                Debug.Log("Cursor texture overridden by mods.");
+            }
         }
 
         public override void Update()


### PR DESCRIPTION
Allows mods to provide a custom cursor texture. This must use the 'Cursor' texture type and have Read/Write flag enabled. Import from loose files is not supported.