### PR TITLE
Fixes to AI spell casting/shooting

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -321,18 +321,6 @@ namespace DaggerfallWorkshop.Game
                 return;
             }
 
-            // Apply gravity
-            if (!flies && !swims && !isLevitating && !controller.isGrounded)
-            {
-                controller.SimpleMove(Vector3.zero);
-
-                // Only return if actually falling. Sometimes mobiles can get stuck where they are !isGrounded but SimpleMove(Vector3.zero) doesn't help.
-                // Allowing them to continue and attempt a Move() in the code below frees them, but we don't want to allow that if we can avoid it so they aren't moving
-                // while falling, which can also accelerate the fall due to anti-bounce downward movement in Move().
-                if (lastPosition != transform.position)
-                    return;
-            }
-
             // Monster speed of movement follows the same formula as for when the player walks
             float moveSpeed = (entity.Stats.LiveSpeed + PlayerSpeedChanger.dfWalkBase) * MeshReader.GlobalScale;
 
@@ -368,8 +356,20 @@ namespace DaggerfallWorkshop.Game
                     mobile.ChangeEnemyState(MobileStates.Idle);
                 else
                     mobile.ChangeEnemyState(MobileStates.Move);
+            }
 
-                lastPosition = transform.position;
+            lastPosition = transform.position;
+
+            // Apply gravity
+            if (!flies && !swims && !isLevitating && !controller.isGrounded)
+            {
+                controller.SimpleMove(Vector3.zero);
+
+                // Only return if actually falling. Sometimes mobiles can get stuck where they are !isGrounded but SimpleMove(Vector3.zero) doesn't help.
+                // Allowing them to continue and attempt a Move() in the code below frees them, but we don't want to allow that if we can avoid it so they aren't moving
+                // while falling, which can also accelerate the fall due to anti-bounce downward movement in Move().
+                if (lastPosition != transform.position)
+                    return;
             }
 
             // Do nothing if no target or after giving up finding the target or if target position hasn't been acquired yet

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -438,7 +438,7 @@ namespace DaggerfallWorkshop.Game
                 destination = searchPosition;
             }
 
-                if (avoidObstaclesTimer == 0 && !flies && !isLevitating && !swims && senses.Target)
+            if (avoidObstaclesTimer == 0 && !flies && !isLevitating && !swims && senses.Target)
             {
                 // Ground enemies target at their own height
                 // Otherwise, their target vector aims up towards the target, which could interfere with distance-to-target calculations
@@ -449,7 +449,7 @@ namespace DaggerfallWorkshop.Game
 
             // Get direction & distance.
             var direction = (destination - transform.position).normalized;
-            float distance = 0f;
+            float distance;
 
             // If enemy sees the target, use the distance value from EnemySenses, as this is also used for the melee attack decision and we need to be consistent with that.
             if (clearPathToShootAtPredictedPos)
@@ -464,6 +464,7 @@ namespace DaggerfallWorkshop.Game
                 {
                     StrafeDecision();
                 }
+
                 if (doStrafe && strafeTimer > 0)
                 {
                     AttemptMove(direction, moveSpeed / 4, false, true, distance);
@@ -485,8 +486,7 @@ namespace DaggerfallWorkshop.Game
                             }
                         }
                         // Random chance to shoot spell
-                        else if (DFRandom.rand() % 40 == 0
-                             && entityEffectManager.SetReadySpell(selectedSpell))
+                        else if (DFRandom.rand() % 40 == 0 && entityEffectManager.SetReadySpell(selectedSpell))
                         {
                             mobile.ChangeEnemyState(MobileStates.Spell);
                         }
@@ -497,7 +497,6 @@ namespace DaggerfallWorkshop.Game
 
                 return;
             }
-
 
             // Touch spells
             if (senses.TargetInSight && senses.DetectedTarget && attack.MeleeTimer == 0 && senses.DistanceToTarget <= attack.MeleeDistance
@@ -950,7 +949,6 @@ namespace DaggerfallWorkshop.Game
 
             angle = 0;
             int count = 0;
-            testMove = Vector3.zero;
 
             do
             {

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -67,7 +67,7 @@ namespace DaggerfallWorkshop.Game
         bool strafeLeft;
         float strafeAngle;
         int searchMult;
-        bool clearPathToShootAtPredictedPos;
+        int ignoreMaskForShooting;
 
         EnemySenses senses;
         Vector3 destination;
@@ -131,6 +131,9 @@ namespace DaggerfallWorkshop.Game
 
             // Only need to check for ability to shoot bow once.
             hasBowAttack = mobile.Summary.Enemy.HasRangedAttack1 && mobile.Summary.Enemy.ID > 129 && mobile.Summary.Enemy.ID != 132;
+
+            // Add things AI should ignore when checking for a clear path to shoot.
+            ignoreMaskForShooting = ~(1 << LayerMask.NameToLayer("SpellMissiles") | 1 << LayerMask.NameToLayer("Ignore Raycast"));
         }
 
         void FixedUpdate()
@@ -399,8 +402,6 @@ namespace DaggerfallWorkshop.Game
                     stopDistance = attack.ClassicMeleeDistanceVsAI;
             }
 
-            clearPathToShootAtPredictedPos = false;
-
             // Set avoidObstaclesTimer to 0 if got close enough to detourDestination
             if (avoidObstaclesTimer > 0)
             {
@@ -419,7 +420,7 @@ namespace DaggerfallWorkshop.Game
                 destination = detourDestination;
             }
             // Otherwise, try to get to the combat target if there is a clear path to it
-            else if (ClearPathToPosition(senses.PredictedTargetPos, (destination - transform.position).magnitude) || (clearPathToShootAtPredictedPos && (hasBowAttack || entity.CurrentMagicka > 0)))
+            else if (ClearPathToPosition(senses.PredictedTargetPos, (destination - transform.position).magnitude) || (senses.TargetInSight && (hasBowAttack || entity.CurrentMagicka > 0)))
             {
                 destination = senses.PredictedTargetPos;
                 // Flying enemies and slaughterfish aim for target face
@@ -452,13 +453,13 @@ namespace DaggerfallWorkshop.Game
             float distance;
 
             // If enemy sees the target, use the distance value from EnemySenses, as this is also used for the melee attack decision and we need to be consistent with that.
-            if (clearPathToShootAtPredictedPos)
+            if (avoidObstaclesTimer == 0 && senses.TargetInSight)
                 distance = senses.DistanceToTarget;
             else
                 distance = (destination - transform.position).magnitude;
 
             // Ranged attacks
-            if ((hasBowAttack || CanCastRangedSpell()) && clearPathToShootAtPredictedPos && senses.TargetInSight && senses.DetectedTarget && 360 * MeshReader.GlobalScale < senses.DistanceToTarget && senses.DistanceToTarget < 2048 * MeshReader.GlobalScale)
+            if ((CanShootBow() || CanCastRangedSpell()) && senses.TargetInSight && senses.DetectedTarget && 360 * MeshReader.GlobalScale < senses.DistanceToTarget && senses.DistanceToTarget < 2048 * MeshReader.GlobalScale)
             {
                 if (DaggerfallUnity.Settings.EnhancedCombatAI && senses.TargetIsWithinYawAngle(22.5f, destination) && strafeTimer <= 0)
                 {
@@ -595,29 +596,69 @@ namespace DaggerfallWorkshop.Game
             sphereCastDir2d.y = 0;
             RayCheckForObstacle(sphereCastDir2d);
             RayCheckForFall(sphereCastDir2d);
-            bool result = true;
 
             if (obstacleDetected || fallDetected)
-                result = false;
+                return false;
 
             RaycastHit hit;
-            int layerSpellMissiles = LayerMask.NameToLayer("SpellMissiles");
-            if (Physics.SphereCast(transform.position, controller.radius / 2, sphereCastDir, out hit, dist, layerSpellMissiles))
+            if (Physics.SphereCast(transform.position, controller.radius / 2, sphereCastDir, out hit, dist, ignoreMaskForShooting))
             {
                 DaggerfallEntityBehaviour hitTarget = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
                 if (hitTarget == senses.Target)
                 {
-                    clearPathToShootAtPredictedPos = true;
+                    return true;
                 }
                 else
                 {
-                    result = false;
+                    return false;
                 }
             }
-            else
-                clearPathToShootAtPredictedPos = true;
 
-            return result;
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if can shoot projectile at target.
+        /// </summary>
+        bool HasClearPathToShootProjectile(float speed, float radius)
+        {
+            // Check that there is a clear path to shoot projectile
+            Vector3 sphereCastDir = senses.PredictNextTargetPos(speed);
+            if (sphereCastDir == EnemySenses.ResetPlayerPos)
+                return false;
+
+            float sphereCastDist = (sphereCastDir - transform.position).magnitude;
+            sphereCastDir = (sphereCastDir - transform.position).normalized;
+
+            RaycastHit hit;
+            if (Physics.SphereCast(transform.position, radius, sphereCastDir, out hit, sphereCastDist, ignoreMaskForShooting))
+            {
+                DaggerfallEntityBehaviour hitTarget = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
+
+                // Clear path to target
+                if (hitTarget == senses.Target)
+                    return true;
+
+                // Something in the way
+                return false;
+            }
+
+            // Clear path to predicted target position
+            return true;
+        }
+
+
+        /// <summary>
+        /// Returns true if can shoot bow at target.
+        /// </summary>
+        bool CanShootBow()
+        {
+            if (!hasBowAttack)
+                return false;
+
+            // Check that there is a clear path to shoot a spell
+            // All arrows are currently 35 speed.
+            return HasClearPathToShootProjectile(35f, 0.45f);
         }
 
         /// <summary>
@@ -651,29 +692,8 @@ namespace DaggerfallWorkshop.Game
                 return false;
 
             // Check that there is a clear path to shoot a spell
-            float spellMovementSpeed = 25; // All range spells are currently 25 speed
-            Vector3 sphereCastDir = senses.PredictNextTargetPos(spellMovementSpeed);
-            if (sphereCastDir == EnemySenses.ResetPlayerPos)
-                return false;
-
-            float sphereCastDist = (sphereCastDir - transform.position).magnitude;
-            sphereCastDir = (sphereCastDir - transform.position).normalized;
-
-            RaycastHit hit;
-            if (Physics.SphereCast(transform.position, 0.45f, sphereCastDir, out hit, sphereCastDist))
-            {
-                DaggerfallEntityBehaviour hitTarget = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
-
-                // Clear path to target
-                if (hitTarget == senses.Target)
-                    return true;
-
-                // Something in the way
-                return false;
-            }
-
-            // Clear path to predicted target position
-            return true;
+            // All range spells are currently 25 speed and 0.45f radius
+            return HasClearPathToShootProjectile(25f, 0.45f);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -231,7 +231,7 @@ namespace DaggerfallWorkshop.Game
             {
                 if (distanceToPlayer < 1094 * MeshReader.GlobalScale)
                 {
-                    float upperXZ = 0;
+                    float upperXZ;
                     float upperY = 0;
                     float lowerY = 0;
                     bool playerInside = GameManager.Instance.PlayerGPS.GetComponent<PlayerEnterExit>().IsPlayerInside;
@@ -392,14 +392,9 @@ namespace DaggerfallWorkshop.Game
                 }
                 else
                 {
-                    Vector3 toTarget = ResetPlayerPos;
-                    toTarget = target.transform.position - transform.position;
-
-                    if (toTarget != ResetPlayerPos)
-                    {
-                        distanceToTarget = toTarget.magnitude;
-                        directionToTarget = toTarget.normalized;
-                    }
+                    Vector3 toTarget = target.transform.position - transform.position;
+                    distanceToTarget = toTarget.magnitude;
+                    directionToTarget = toTarget.normalized;
                     targetInSight = CanSeeTarget(target);
                 }
 

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -532,9 +532,7 @@ namespace DaggerfallWorkshop.Game
             if (targetPosPredictTimer != 0)
             {
                 divisor = targetPosPredictTimer;
-                targetPosPredictTimer = 0;
                 lastPositionDiff = lastKnownTargetPos - oldLastKnownTargetPos;
-                oldLastKnownTargetPos = lastKnownTargetPos;
             }
 
             Vector3 prediction = assumedCurrentPosition + (lastPositionDiff / divisor * secondsToPredictedPos);

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -300,11 +300,12 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             bool godModeCast = (IsPlayerEntity && GameManager.Instance.PlayerEntity.GodMode);
 
             // Enforce spell point costs - Daggerfall does this when setting ready spell
-            if (entityBehaviour.Entity.CurrentMagicka < readySpellCastingCost && !godModeCast && !noSpellPointCost)
+            // Classic does not enforce this for enemies, they can cast any spell as long as they still have at least 1 spell point.
+            // Doing the same here. This also matters for classic AI combat logic, as it uses the existence of any remaining spell points
+            // to determine whether or not it can still cast spells.
+            if (IsPlayerEntity && entityBehaviour.Entity.CurrentMagicka < readySpellCastingCost && !godModeCast && !noSpellPointCost)
             {
-                // Output message only for player
-                if (IsPlayerEntity)
-                    DaggerfallUI.AddHUDText(TextManager.Instance.GetText(textDatabase, youDontHaveTheSpellPointsMessageKey));
+                DaggerfallUI.AddHUDText(TextManager.Instance.GetText(textDatabase, youDontHaveTheSpellPointsMessageKey));
 
                 readySpell = null;
                 readySpellCastingCost = 0;


### PR DESCRIPTION
1. Main fix here is that the prediction counter is no longer reset whenever the AI checks for whether it can shoot a spell. This was causing the imp and others with ranged spells to get stuck. (In master branch create an imp with "cm 1" and they should get stuck almost immediately. With this PR they are fixed. This problem surfaced after one of my recent PRs)

2. Enemies can now cast any spell as long as they have at least 1 spell point left. This matches classic and should allow them to cast the same number of times. It's also relevant to the classic AI's spell decision, as it checks for whether it has any spell points left when deciding if it can still cast. (Otherwise, we'd need to check whether it has at least the spell points of its cheapest ranged spell or something like that)

3. Cleaned up logic and treasure loot/other spells are ignored when the AI checks if they can shoot. They can now shoot projectile spells more often. (Tested with the mage on the pedestal in the entrance room of Woodborne Hall. In master they just wander around trying to find a way to you without a fall, without shooting)

4. Minor cleanups

5. Added a fix for when an AI gets stuck falling. I've only had this happen once so I think it's pretty rare, but the AI could get stuck while falling if the `controller.SimpleMove(Vector3.zero);` that applies gravity failed to move it downward, as it would return without updating `lastPosition`. Changed the order of code so that `lastPosition` will update and it won't get stuck.