### PR TITLE
TextureReplacement: Emission maps for mobile billboards

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -429,7 +429,9 @@ namespace DaggerfallWorkshop
                     meshRenderer = GetComponent<MeshRenderer>();
 
                 // Assign imported texture
-                meshRenderer.material.mainTexture = summary.ImportedTextures.Textures[record][currentFrame];
+                meshRenderer.material.mainTexture = summary.ImportedTextures.Albedo[record][currentFrame];
+                if (summary.ImportedTextures.IsEmissive)
+                    meshRenderer.material.SetTexture(Uniforms.EmissionMap, summary.ImportedTextures.EmissionMaps[record][currentFrame]);
 
                 // Update UVs on mesh
                 Vector2[] uvs = new Vector2[4];
@@ -646,9 +648,6 @@ namespace DaggerfallWorkshop
             // Assign mesh
             meshFilter.sharedMesh = mesh;
 
-            // Seek textures from mods
-            TextureReplacement.SetMobileBillboardImportedTextures(archive, GetComponent<MeshFilter>(), ref summary.ImportedTextures);
-
             // Create material
             Material material;
             if (summary.ImportedTextures.HasImportedTextures)
@@ -670,6 +669,9 @@ namespace DaggerfallWorkshop
                 false,
                 true);
             }
+
+            // Seek textures from mods
+            TextureReplacement.SetMobileBillboardImportedTextures(archive, GetComponent<MeshFilter>(), material, ref summary.ImportedTextures);
 
             // Set new enemy material
             GetComponent<MeshRenderer>().sharedMaterial = material;

--- a/Assets/Scripts/Internal/MobilePersonBillboard.cs
+++ b/Assets/Scripts/Internal/MobilePersonBillboard.cs
@@ -338,9 +338,6 @@ namespace DaggerfallWorkshop
             // Assign mesh
             meshFilter.sharedMesh = mesh;
 
-            // Seek textures from mods
-            TextureReplacement.SetMobileBillboardImportedTextures(textureArchive, GetComponent<MeshFilter>(), ref importedTextures);
-
             // Create material
             Material material = importedTextures.HasImportedTextures ?
                 MaterialReader.CreateStandardMaterial(MaterialReader.CustomBlendMode.Cutout) :
@@ -356,6 +353,9 @@ namespace DaggerfallWorkshop
                 0,
                 false,
                 true);
+
+            // Seek textures from mods
+            TextureReplacement.SetMobileBillboardImportedTextures(textureArchive, GetComponent<MeshFilter>(), material, ref importedTextures);
 
             // Set new person material
             GetComponent<MeshRenderer>().sharedMaterial = material;
@@ -442,7 +442,9 @@ namespace DaggerfallWorkshop
                     meshRenderer = GetComponent<MeshRenderer>();
 
                 // Assign imported texture
-                meshRenderer.sharedMaterial.mainTexture = importedTextures.Textures[record][currentFrame];
+                meshRenderer.sharedMaterial.mainTexture = importedTextures.Albedo[record][currentFrame];
+                if (importedTextures.IsEmissive)
+                    meshRenderer.material.SetTexture(Uniforms.EmissionMap, importedTextures.EmissionMaps[record][currentFrame]);
 
                 // Update UVs on mesh
                 Vector2[] uvs = new Vector2[4];

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -50,6 +50,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         AllLocations
     }
 
+    /// <summary>
+    /// Textures for all frames of a billboard texture record.
+    /// </summary>
     public struct BillboardImportedTextures
     {
         public bool HasImportedTextures;            // Contains imported textures ?
@@ -59,10 +62,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         public List<Texture2D> Emission;            // EmissionMaps for all frames.
     }
 
+    /// <summary>
+    /// Imported textures for an archive used by a wandering npc or a foe.
+    /// </summary>
     public struct MobileBillboardImportedTextures
     {
-        public bool HasImportedTextures;            // Contains imported textures ?  
-        public List<List<Texture2D>> Textures;      // Textures for all records and frames.
+        public bool HasImportedTextures;            // Contains imported textures ?
+        public bool IsEmissive;                     // Is billboard emissive ?
+        public Texture2D[][] Albedo;                // Textures for all records and frames.
+        public Texture2D[][] EmissionMaps;          // Emission maps for all records and frames.
     }
 
     #endregion
@@ -386,6 +394,10 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <summary>
         /// Import textures and emission maps for all frames of this billboard. Also set other material properties from xml.
         /// </summary>
+        /// <remarks>
+        /// Seek the texture for the first frame of the given record. If found, it imports all other frames.
+        /// Always creates an emission map for textures marked as emissive by TextureReader, import emission maps for others only if available.
+        /// </remarks>
         public static void SetBillboardImportedTextures(GameObject go, ref DaggerfallBillboard.BillboardSummary summary)
         {
             if (!DaggerfallUnity.Settings.AssetInjection)
@@ -396,28 +408,28 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             int archive = summary.Archive;
             int record = summary.Record;
             int frame = 0;
-            bool isEmissive = DaggerfallUnity.Instance.MaterialReader.TextureReader.IsEmissive(archive, record);
 
             // Check first frame
             Texture2D albedo, emission;
-            bool hasImportedTextures = LoadFromCacheOrImport(archive, record, frame, isEmissive, true, out albedo, out emission);
+            bool hasImportedTextures = LoadFromCacheOrImport(archive, record, frame, true, true, out albedo, out emission);
+            bool isEmissive = emission || DaggerfallUnity.Instance.MaterialReader.TextureReader.IsEmissive(archive, record);
 
             if (summary.ImportedTextures.HasImportedTextures = hasImportedTextures)
             {
                 // Set textures on material; emission is always overriden, with actual texture or null.
                 meshRenderer.material.SetTexture(Uniforms.MainTex, albedo);
-                meshRenderer.material.SetTexture(Uniforms.EmissionMap, emission);
+                meshRenderer.material.SetTexture(Uniforms.EmissionMap, isEmissive ? emission ?? albedo : null);
                 if (!isEmissive)
                     meshRenderer.material.DisableKeyword(KeyWords.Emission);
 
                 // Import animation frames
                 var albedoTextures = new List<Texture2D>();
-                var emissionTextures = new List<Texture2D>();
+                var emissionTextures = isEmissive ? new List<Texture2D>() : null;
                 do
                 {
                     albedoTextures.Add(albedo);
                     if (isEmissive)
-                        emissionTextures.Add(emission);
+                        emissionTextures.Add(emission ?? albedo);
                 }
                 while (LoadFromCacheOrImport(archive, record, ++frame, isEmissive, true, out albedo, out emission));
 
@@ -442,49 +454,61 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 summary.ImportedTextures.IsEmissive = isEmissive;
                 summary.ImportedTextures.Albedo = albedoTextures;
                 summary.ImportedTextures.Emission = emissionTextures;
-            }        
+            }
         }
 
         /// <summary>
         /// Import textures for all records and frames of a mobile billboard.
         /// </summary>
-        public static void SetMobileBillboardImportedTextures(int archive, MeshFilter meshFilter, ref MobileBillboardImportedTextures importedTextures)
+        /// <remarks>
+        /// Seek the texture for the first frame of the first record. If found, it imports the entire archive.
+        /// If this texture has an emission map the material is considered emissive and all emission maps are imported.
+        /// </remarks>
+        public static void SetMobileBillboardImportedTextures(int archive, MeshFilter meshFilter, Material material, ref MobileBillboardImportedTextures importedTextures)
         {
             if (!DaggerfallUnity.Settings.AssetInjection)
                 return;
 
-            // Check first texture.
-            Texture2D tex;
-            bool hasImportedTextures = LoadFromCacheOrImport(archive, 0, 0, true, out tex);
-
-            if (importedTextures.HasImportedTextures = hasImportedTextures)
+            Texture2D tex, emission;
+            if (importedTextures.HasImportedTextures = LoadFromCacheOrImport(archive, 0, 0, true, true, out tex, out emission))
             {
+                // Enable emission
+                if (importedTextures.IsEmissive = emission != null)
+                {
+                    material.EnableKeyword(KeyWords.Emission);
+                    material.SetColor(Uniforms.EmissionColor, Color.white);
+                }
+
+                // Load texture file to get record and frame count
                 string fileName = TextureFile.IndexToFileName(archive);
                 var textureFile = new TextureFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, fileName), FileUsage.UseMemory, true);
 
                 // Import all textures in this archive
-                var textures = new List<List<Texture2D>>();
+                importedTextures.Albedo = new Texture2D[textureFile.RecordCount][];
+                importedTextures.EmissionMaps = importedTextures.IsEmissive ? new Texture2D[textureFile.RecordCount][] : null;
                 for (int record = 0; record < textureFile.RecordCount; record++)
                 {
                     int frames = textureFile.GetFrameCount(record);
-                    var frameTextures = new List<Texture2D>();
+                    var frameTextures = new Texture2D[frames];
+                    var frameEmissionMaps = importedTextures.IsEmissive ? new Texture2D[frames] : null;
+
                     for (int frame = 0; frame < frames; frame++)
                     {
-                        if ((record != 0 || frame != 0) && !LoadFromCacheOrImport(archive, record, frame, true, out tex))
-                        {
-                            Debug.LogErrorFormat("Imported archive {0} does not contain texture for record {1}, frame {2}!", archive, record, frame);
-                            tex = ImageReader.GetTexture(fileName, record, frame, true);
-                        }
-                        frameTextures.Add(tex);
+                        if (record != 0 || frame != 0)
+                            LoadFromCacheOrImport(archive, record, frame, importedTextures.IsEmissive, true, out tex, out emission);
+
+                        frameTextures[frame] = tex ?? ImageReader.GetTexture(fileName, record, frame, true);
+                        if (frameEmissionMaps != null)
+                            frameEmissionMaps[frame] = emission ?? frameTextures[frame];
                     }
-                    textures.Add(frameTextures);
+
+                    importedTextures.Albedo[record] = frameTextures;
+                    if (importedTextures.EmissionMaps != null)
+                        importedTextures.EmissionMaps[record] = frameEmissionMaps;
                 }
 
                 // Update UV map
                 SetUv(meshFilter);
-
-                // Save results
-                importedTextures.Textures = textures;
             }
         }
 
@@ -883,36 +907,21 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Seek albedo from cache, loose files and mods.
-        /// </summary>
-        /// <param name="archive">Texture archive.</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Animation frame index.</param>
-        /// <param name="readOnly">Release copy on system memory after uploading to gpu.</param>
-        /// <param name="albedo">Imported texture.</param>
-        /// <returns>True if textures found and loaded.</returns>
-        private static bool LoadFromCacheOrImport(int archive, int record, int frame, bool readOnly, out Texture2D albedo)
-        {
-            Texture2D emission;
-            return LoadFromCacheOrImport(archive, record, frame, false, readOnly, out albedo, out emission);
-        }
-
-        /// <summary>
         /// Seek albedo and, if requested, emission map from cache, loose files and mods.
         /// </summary>
-        /// <param name="archive">Texture archive.</param>
+        /// <param name="archive">Archive index.</param>
         /// <param name="record">Record index.</param>
-        /// <param name="frame">Animation frame index.</param>
-        /// <param name="isEmissive">Request emission map. If missing, albedo is used as a fully emissive surface.</param>
+        /// <param name="frame">Texture frame.</param>
+        /// <param name="allowEmissionMap">Should the emission map be seeked?</param>
         /// <param name="readOnly">Release copy on system memory after uploading to gpu.</param>
-        /// <param name="albedo">Imported albedo texture.</param>
-        /// <param name="emission">Imported emission map.</param>
+        /// <param name="albedo">Imported albedo or null.</param>
+        /// <param name="emission">Imported emission map or null.</param>
         /// <returns>True if textures found and loaded.</returns>
         private static bool LoadFromCacheOrImport(
             int archive,
             int record,
             int frame,
-            bool isEmissive,
+            bool allowEmissionMap,
             bool readOnly,
             out Texture2D albedo,
             out Texture2D emission)
@@ -932,17 +941,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             }
 
             // Try to import and save in cache
-            if (TryImportTexture(archive, record, frame, out albedo))
+            if (TryImportTexture(archive, record, frame, TextureMap.Albedo, readOnly, out albedo))
             {
                 var filterMode = MainFilterMode;
 
                 albedo.filterMode = filterMode;
                 cachedMaterial.albedoMap = albedo;
 
-                if (isEmissive)
+                if (allowEmissionMap && TryImportTexture(archive, record, frame, TextureMap.Emission, readOnly, out emission))
                 {
-                    if (!TryImportTexture(archive, record, frame, TextureMap.Emission, readOnly, out emission))
-                        emission = albedo;
                     emission.filterMode = filterMode;
                     cachedMaterial.emissionMap = emission;
                 }

--- a/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
+++ b/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
@@ -59,6 +59,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return false;
         }
 
+        public bool GetBool(string key, bool defaultValue = false)
+        {
+            XElement element;
+            return TryGetElement(key, out element) ? bool.Parse((string)element) : defaultValue;
+        }
+
         public bool TryGetFloat(string key, out float value)
         {
             XElement element;


### PR DESCRIPTION
Added support for emission for mobile billboards. This can be used to provide emission maps for enemies such as Fire Atronach.