### PR TITLE
Paying spellmaker and spellbook check

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -311,11 +311,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 case GuildServices.BuySpellsMages:
                     CloseWindow();
                     uiManager.PushWindow(new DaggerfallSpellBookWindow(uiManager, this, true));
+                    NoSpellbookWarning();
                     break;
 
                 case GuildServices.MakeSpells:
                     CloseWindow();
                     uiManager.PushWindow(DaggerfallUI.Instance.DfSpellMakerWindow);
+                    NoSpellbookWarning();
                     break;
 
                 case GuildServices.BuyMagicItems:   // TODO: switch items depending on npcService?
@@ -370,6 +372,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     else
                         DaggerfallUI.MessageBox("Guild service not yet implemented.");
                     break;
+            }
+        }
+
+        private void NoSpellbookWarning()
+        {
+            if (!GameManager.Instance.PlayerEntity.Items.Contains(Items.ItemGroups.MiscItems, (int)Items.MiscItems.Spellbook))
+            {
+                DaggerfallUI.MessageBox(TextManager.Instance.GetText("ClassicEffects", "noSpellbook"));
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -311,13 +311,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 case GuildServices.BuySpellsMages:
                     CloseWindow();
                     uiManager.PushWindow(new DaggerfallSpellBookWindow(uiManager, this, true));
-                    NoSpellbookWarning();
                     break;
 
                 case GuildServices.MakeSpells:
                     CloseWindow();
-                    uiManager.PushWindow(DaggerfallUI.Instance.DfSpellMakerWindow);
-                    NoSpellbookWarning();
+                    if (GameManager.Instance.PlayerEntity.Items.Contains(Items.ItemGroups.MiscItems, (int)Items.MiscItems.Spellbook))
+                        uiManager.PushWindow(DaggerfallUI.Instance.DfSpellMakerWindow);
+                    else
+                        DaggerfallUI.MessageBox(TextManager.Instance.GetText("ClassicEffects", "noSpellbook"));
                     break;
 
                 case GuildServices.BuyMagicItems:   // TODO: switch items depending on npcService?
@@ -372,14 +373,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     else
                         DaggerfallUI.MessageBox("Guild service not yet implemented.");
                     break;
-            }
-        }
-
-        private void NoSpellbookWarning()
-        {
-            if (!GameManager.Instance.PlayerEntity.Items.Contains(Items.ItemGroups.MiscItems, (int)Items.MiscItems.Spellbook))
-            {
-                DaggerfallUI.MessageBox(TextManager.Instance.GetText("ClassicEffects", "noSpellbook"));
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -95,6 +95,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const string spellBookBuyModeTextureFilename = "SPBK01I0.IMG";
         const string spellsFilename = "SPELLS.STD";
 
+        const int noSpellBook = 1703;
+
         const SoundClips openSpellBook = SoundClips.OpenBook;
         const SoundClips openSpellBookBuyMode = SoundClips.ButtonClick;
         const SoundClips closeSpellBook = SoundClips.PageTurn;
@@ -885,7 +887,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             int tradePrice = GetTradePrice();
             int msgOffset = 0;
 
-            if (GameManager.Instance.PlayerEntity.GetGoldAmount() < tradePrice)
+            if (!GameManager.Instance.PlayerEntity.Items.Contains(Items.ItemGroups.MiscItems, (int)Items.MiscItems.Spellbook))
+            {
+                DaggerfallUI.MessageBox(noSpellBook);
+            }
+            else if (GameManager.Instance.PlayerEntity.GetGoldAmount() < tradePrice)
             {
                 DaggerfallUI.MessageBox(notEnoughGoldId);
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
@@ -743,10 +743,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             //   Implement costs and remove gold from player and block if user does not have enough gold (message 1702)
             //   Spells will be free (both gold and spell points) during build-out of effect system.
 
-            var moneyAvailable = GameManager.Instance.PlayerEntity.GoldPieces;
-            var cost = totalGoldCost;
+            var moneyAvailable = GameManager.Instance.PlayerEntity.GetGoldAmount();
 
-            if (moneyAvailable < cost)
+            if (moneyAvailable < totalGoldCost)
             {
                 DaggerfallMessageBox mbNoMoney = DaggerfallUI.MessageBox(notEnoughGold);
                 mbNoMoney.ClickAnywhereToClose = true;
@@ -756,7 +755,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else
             {
-                GameManager.Instance.PlayerEntity.DeductGoldAmount(cost);
+                GameManager.Instance.PlayerEntity.DeductGoldAmount(totalGoldCost);
             }
 
             // NOTES:

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
@@ -196,7 +196,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public override void OnPush()
         {
             InitEffectSlots();
-            
+
             SetDefaults();
         }
 
@@ -732,7 +732,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void BuyButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            //const int notEnoughGold = 1702;
+            const int notEnoughGold = 1702;
             //const int noSpellBook = 1703;
             const int youMustChooseAName = 1704;
             const int spellHasBeenInscribed = 1705;
@@ -742,6 +742,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // TODO:
             //   Implement costs and remove gold from player and block if user does not have enough gold (message 1702)
             //   Spells will be free (both gold and spell points) during build-out of effect system.
+
+            var moneyAvailable = GameManager.Instance.PlayerEntity.GoldPieces;
+            var cost = totalGoldCost;
+
+            if (moneyAvailable < cost)
+            {
+                DaggerfallMessageBox mbNoMoney = DaggerfallUI.MessageBox(notEnoughGold);
+                mbNoMoney.ClickAnywhereToClose = true;
+                mbNoMoney.PreviousWindow = this;
+                mbNoMoney.Show();
+                return;
+            }
+            else
+            {
+                GameManager.Instance.PlayerEntity.DeductGoldAmount(cost);
+            }
 
             // NOTES:
             //  In classic, player must have a spellbook item in their inventory (message 1703).
@@ -933,7 +949,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             enumeratedEffectTemplates.Sort((s1, s2) => s1.Properties.SubGroupName.CompareTo(s2.Properties.SubGroupName));
 
             // Populate subgroup names in list box
-            foreach(IEntityEffect effect in enumeratedEffectTemplates)
+            foreach (IEntityEffect effect in enumeratedEffectTemplates)
             {
                 effectSubGroupPicker.ListBox.AddItem(effect.Properties.SubGroupName);
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
@@ -12,12 +12,12 @@
 using UnityEngine;
 using System;
 using System.Collections.Generic;
-using DaggerfallConnect;
 using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using DaggerfallWorkshop.Game.Formulas;
+using DaggerfallWorkshop.Game.Items;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -196,7 +196,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public override void OnPush()
         {
             InitEffectSlots();
-
+            
             SetDefaults();
         }
 
@@ -733,57 +733,43 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void BuyButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             const int notEnoughGold = 1702;
-            //const int noSpellBook = 1703;
+            const int noSpellBook = 1703;
             const int youMustChooseAName = 1704;
             const int spellHasBeenInscribed = 1705;
 
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
 
-            // TODO:
-            //   Implement costs and remove gold from player and block if user does not have enough gold (message 1702)
-            //   Spells will be free (both gold and spell points) during build-out of effect system.
-
-            var moneyAvailable = GameManager.Instance.PlayerEntity.GetGoldAmount();
-
-            if (moneyAvailable < totalGoldCost)
+            // Presence of spellbook is also checked earlier
+            if (!GameManager.Instance.PlayerEntity.Items.Contains(Items.ItemGroups.MiscItems, (int)Items.MiscItems.Spellbook))
             {
-                DaggerfallMessageBox mbNoMoney = DaggerfallUI.MessageBox(notEnoughGold);
-                mbNoMoney.ClickAnywhereToClose = true;
-                mbNoMoney.PreviousWindow = this;
-                mbNoMoney.Show();
+                DaggerfallUI.MessageBox(noSpellBook);
                 return;
             }
-            else
-            {
-                GameManager.Instance.PlayerEntity.DeductGoldAmount(totalGoldCost);
-            }
-
-            // NOTES:
-            //  In classic, player must have a spellbook item in their inventory (message 1703).
-            //  In Daggerfall Unity, the spellbook is a permanent item that all players own and cannot be removed.
-            //  This is to prevent player accidentally dropping or selling their spellbook.
-            //  So not performing spellbook check at this time and 1703 is never shown.
 
             // Spell must have at least one effect - adding custom message
             List<EffectEntry> effects = GetEffectEntries();
             if (effects.Count == 0)
             {
-                DaggerfallMessageBox mbNoEffects = DaggerfallUI.MessageBox(TextManager.Instance.GetText("SpellmakerUI", "noEffectsError"));
-                mbNoEffects.ClickAnywhereToClose = true;
-                mbNoEffects.PreviousWindow = this;
-                mbNoEffects.Show();
+                DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "noEffectsError"));
                 return;
             }
 
-            // Spell must have a name
-            if (string.IsNullOrEmpty(spellNameLabel.Text))
+            // Enough money?
+            var moneyAvailable = GameManager.Instance.PlayerEntity.GetGoldAmount();
+            if (moneyAvailable < totalGoldCost)
             {
-                DaggerfallMessageBox mbNoName = DaggerfallUI.MessageBox(youMustChooseAName);
-                mbNoName.ClickAnywhereToClose = true;
-                mbNoName.PreviousWindow = this;
-                mbNoName.Show();
+                DaggerfallUI.MessageBox(notEnoughGold);
                 return;
             }
+
+            // Spell must have a name; Only bother the player if everything else is correct
+            if (string.IsNullOrEmpty(spellNameLabel.Text))
+            {
+                DaggerfallUI.MessageBox(youMustChooseAName);
+                return;
+            }
+
+            GameManager.Instance.PlayerEntity.DeductGoldAmount(totalGoldCost);
 
             // Create effect bundle settings
             EffectBundleSettings spell = new EffectBundleSettings();

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 2800000, guid: 887ec86cd12e1624d8458c8d7950402a, type: 3}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 2800000, guid: 887ec86cd12e1624d8458c8d7950402a, type: 3}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1


### PR DESCRIPTION
Supersedes #1252 (Deducts gold when buying spells from spellmaker)

Also, check for spellbook presence. In classic, when you have no spellbook:
 

- spell merchant does nothing, not explaining why;
- spell maker fails at the last minute ("you have no spellbook to inscribe this spell")

I think that in both cases the player, even without a spellbook, could want to peruse available spells, so I implemented a preliminary warning that does not block the access to the spell merchant and the spell maker.
A second check is done if you try to buy a spell though.
    
Maybe that's overkill and confusing, and access could simply be denied with an error message?
The simplification I'm considering:

- remove spell merchant warning. The player can peruse the spells, but will be denied to buy any. There's not much effort investment from the player so that should be ok;
- display a blocking error message when trying to access the spell maker