### PR TITLE
make sure wagon button is fully reset by buy window

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -203,7 +203,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupTargetIconPanels();
             SetupTabPageButtons();
             SetupActionButtons();
-            ResetWagonButton();
             SetupAccessoryElements();
             SetupItemListScrollers();
 
@@ -238,6 +237,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             UpdateRemoteTargetIcon();
             // UpdateRepairTimes(false);
             UpdateCostAndGold();
+            ShowWagon(false);
         }
 
         Color RepairItemBackgroundColourHandler(DaggerfallUnityItem item)
@@ -323,7 +323,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Clear wagon button state
             if (wagonButton != null)
             {
-                ResetWagonButton();
+                ShowWagon(false);
             }
 
             // Refresh window
@@ -613,12 +613,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 base.FilterRemoteItems();
         }
 
-        protected void ResetWagonButton()
-        {
-            usingWagon = false;
-            wagonButton.BackgroundTexture = wagonNotSelected;
-        }
-
         protected void ShowWagon(bool show)
         {
             if (show)
@@ -633,7 +627,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             usingWagon = show;
             localItemListScroller.ResetScroll();
-            Refresh(false);
+            // Caller must now use Refresh
+            // Refresh(false);
         }
 
         protected override void LoadTextures()
@@ -762,7 +757,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void WagonButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart))
+            {
                 ShowWagon(!usingWagon);
+                Refresh(false);
+            }
         }
 
         private void InfoButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -237,7 +237,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             UpdateRemoteTargetIcon();
             // UpdateRepairTimes(false);
             UpdateCostAndGold();
-            ShowWagon(false);
+            SelectWagon(false);
         }
 
         Color RepairItemBackgroundColourHandler(DaggerfallUnityItem item)
@@ -323,7 +323,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Clear wagon button state
             if (wagonButton != null)
             {
-                ShowWagon(false);
+                SelectWagon(false);
             }
 
             // Refresh window
@@ -613,7 +613,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 base.FilterRemoteItems();
         }
 
-        protected void ShowWagon(bool show)
+        protected void SelectWagon(bool show)
         {
             if (show)
             {   // Switch to wagon
@@ -758,7 +758,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart))
             {
-                ShowWagon(!usingWagon);
+                SelectWagon(!usingWagon);
                 Refresh(false);
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -203,6 +203,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupTargetIconPanels();
             SetupTabPageButtons();
             SetupActionButtons();
+            ResetWagonButton();
             SetupAccessoryElements();
             SetupItemListScrollers();
 
@@ -322,8 +323,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Clear wagon button state
             if (wagonButton != null)
             {
-                usingWagon = false;
-                wagonButton.BackgroundTexture = wagonNotSelected;
+                ResetWagonButton();
             }
 
             // Refresh window
@@ -611,6 +611,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else
                 base.FilterRemoteItems();
+        }
+
+        protected void ResetWagonButton()
+        {
+            usingWagon = false;
+            wagonButton.BackgroundTexture = wagonNotSelected;
         }
 
         protected void ShowWagon(bool show)


### PR DESCRIPTION
DaggerfallTradeWindow.OnPush() can be called before Setup() so wagonButton can be null in OnPush(), and its texture not settable there. 
So to cover all the bases the button background texture must also be set in Setup().

Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2040