### PR TITLE
fix for building-to-building teleport ending in the Void

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Teleport.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Teleport.cs
@@ -211,7 +211,13 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             {
                 // Compare building key
                 if (anchorPosition.buildingDiscoveryData.buildingKey == playerEnterExit.BuildingDiscoveryData.buildingKey)
-                    return true;
+                {
+                    // Also compare map pixel, in case we're unlucky https://forums.dfworkshop.net/viewtopic.php?f=24&t=2018
+                    DaggerfallConnect.Utility.DFPosition anchorMapPixel = DaggerfallConnect.Arena2.MapsFile.WorldCoordToMapPixel(anchorPosition.worldPosX, anchorPosition.worldPosZ);
+                    DaggerfallConnect.Utility.DFPosition playerMapPixel = GameManager.Instance.PlayerGPS.CurrentMapPixel;
+                    if (anchorMapPixel.X == playerMapPixel.X && anchorMapPixel.Y == playerMapPixel.Y)
+                        return true;
+                }
             }
             else if (playerEnterExit.IsPlayerInsideDungeon && anchorPosition.insideDungeon)
             {


### PR DESCRIPTION
In case current and anchor buildings have the same buildingKey, map pixels must also be compared to be sure it's not the same building.

Discovered data doesn't look good, that may not be the best possible fix.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2018