### PR TITLE
MeshReplacement: Ensure DaggerfallBilboard is found on loot

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
@@ -117,9 +117,14 @@ namespace DaggerfallWorkshop.Game.Serialization
                     if (billboard) Destroy(billboard);
                     Destroy(GetComponent<MeshRenderer>());
                 }
-                else if (billboard)
+                else
                 {
-                    // Restore billboard appearance if present
+                    // Restore billboard if previously replaced by custom model
+                    // This happens when the record is changed and new model is not provided by mods
+                    if (!billboard)
+                        billboard = loot.transform.gameObject.AddComponent<DaggerfallBillboard>();
+
+                    // Restore billboard appearance
                     billboard.SetMaterial(data.textureArchive, data.textureRecord);
                 }
             }

--- a/Assets/Scripts/Game/Serialization/SerializableStateManager.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableStateManager.cs
@@ -431,7 +431,7 @@ namespace DaggerfallWorkshop.Game.Serialization
                     // Add custom drop containers back to scene (e.g. dropped loot, slain foes)
                     if (lootContainers[i].customDrop)
                     {
-                        DaggerfallLoot customLootContainer = GameObjectHelper.CreateDroppedLootContainer(GameManager.Instance.PlayerObject, key);
+                        DaggerfallLoot customLootContainer = GameObjectHelper.CreateDroppedLootContainer(GameManager.Instance.PlayerObject, key, lootContainers[i].textureArchive, lootContainers[i].textureRecord);
                         SerializableLootContainer serializableLootContainer = customLootContainer.GetComponent<SerializableLootContainer>();
                         if (serializableLootContainer)
                         {


### PR DESCRIPTION
Fix one the two issues raised [here](https://forums.dfworkshop.net/viewtopic.php?p=23300#p23234), specifically the invisible loot containers.

I've not yet been able to replicate issue with loot content.