### PR TITLE
scrolling speed adjustments

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -64,6 +64,7 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(SetWalkSpeed.name, SetWalkSpeed.description, SetWalkSpeed.usage, SetWalkSpeed.Execute);
             ConsoleCommandsDatabase.RegisterCommand(SetMouseSensitivity.name, SetMouseSensitivity.description, SetMouseSensitivity.usage, SetMouseSensitivity.Execute);
             ConsoleCommandsDatabase.RegisterCommand(ToggleMouseSmoothing.name, ToggleMouseSmoothing.description, ToggleMouseSmoothing.usage, ToggleMouseSmoothing.Execute);
+            ConsoleCommandsDatabase.RegisterCommand(AddPopupText.name, AddPopupText.description, AddPopupText.usage, AddPopupText.Execute);
 
             //ConsoleCommandsDatabase.RegisterCommand(SetMouseSmoothing.name, SetMouseSmoothing.description, SetMouseSmoothing.usage, SetMouseSmoothing.Execute);
             ConsoleCommandsDatabase.RegisterCommand(SetVSync.name, SetVSync.description, SetVSync.usage, SetVSync.Execute);
@@ -2097,5 +2098,27 @@ namespace Wenzil.Console
             }
         }
 
+        private static class AddPopupText
+        {
+            public static readonly string name = "addpopuptext";
+            public static readonly string description = "Fill HUD buffer with messages";
+            public static readonly string usage = "addpopuptext count";
+
+            public static string Execute(params string[] args)
+            {
+                if (args.Length < 1) return "see usage";
+
+                int n = 1;
+                Int32.TryParse(args[0], out n);
+
+                if (n < 1)
+                    return "Error - see usage";
+
+                for (int i = 1; i <= n; i++)
+                    DaggerfallUI.Instance.PopupMessage("message " + i);
+                return "Finished";
+            }
+        }
     }
+
 }

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -2111,7 +2111,7 @@ namespace Wenzil.Console
                 int n = 1;
                 Int32.TryParse(args[0], out n);
 
-                if (n < 1)
+                if (n < 1 || n > 100000)
                     return "Error - see usage";
 
                 for (int i = 1; i <= n; i++)

--- a/Assets/Scripts/Game/UserInterface/PopupText.cs
+++ b/Assets/Scripts/Game/UserInterface/PopupText.cs
@@ -26,9 +26,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         const float popDelay = 1.0f;
         const int maxRows = 7;
-        const float maxUnseenDelay = 1.5f;
 
-        const float speedupPerExtraLine = 1f + 1f / maxUnseenDelay;
+        const float rubberbandFactor = 0.8f;
 
         LinkedList<TextLabel> textRows = new LinkedList<TextLabel>();
         // Text scrolls away when timer becomes negative
@@ -48,18 +47,17 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             if (textRows.Count > 0)
             {
-                if (textRows.Count > maxRows)
+                int rowsLate = textRows.Count - maxRows;
+                if (rowsLate > 0)
                 {
                     // Accelerate to keep up
-                    float speedup = Mathf.Pow(speedupPerExtraLine, textRows.Count - maxRows);
-                    // Smoother, but no time guarantees:
-                    // float speedup = 1f + 0.5f * (textRows.Count - maxRows);
+                    float speedup = 1f + rubberbandFactor * rowsLate;
                     timer -= Time.deltaTime * speedup;
                 }
                 else
                     timer -= Time.deltaTime;
 
-                if (timer < -popDelay)
+                while (timer < -popDelay)
                 {
                     timer += nextPopDelay;
                     // Remove item from front of list


### PR DESCRIPTION
Exponential speedups did not work as well as the math suggested, with large lags the acceleration made all lines disappear from screen in a blink, including the most recent ones; Or get stuck because speedup overflows floats capacity!
Replaced with simple rubberbanding (proportional speedup) for now. I don't like that acceleration profile as much, but it fixes those issues. That may be improved later.
Added a "addpopuptext" console command to push n lines in the buffer for testing.