### PR TITLE
Match enchantment reputation mods to classic

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/BadRepWith.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/BadRepWith.cs
@@ -19,18 +19,15 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
     /// <summary>
     /// Lower reaction with selected social groups while item held.
     /// Notes:
-    ///  * Classic reaction decrease amount currently unknown.
     ///  * Sources claim that effect persists even when item in wagon, but this is suspect and not consistent with other item effects.
     ///  * Classic allows unusual stacking of variants, e.g. all is exclusive to groups but each group not exclusive with itself.
     ///  * Changed this to work uniformly as per GoodRepWith, which does not allow self-stacking of groups.
-    /// TODO:
-    ///  * Find correct reaction adjustment value.
     /// </summary>
     public class BadRepWith : BaseEntityEffect
     {
         public static readonly string EffectKey = EnchantmentTypes.BadRepWith.ToString();
 
-        const int adjustmentAmount = -25;
+        const int adjustmentAmount = -10;
 
         public override void SetProperties()
         {

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/GoodRepWith.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/GoodRepWith.cs
@@ -18,16 +18,12 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 {
     /// <summary>
     /// Increase reaction with selected social groups while item held.
-    /// Notes:
-    ///  * Classic reaction increase amount currently unknown.
-    /// TODO:
-    ///  * Find correct reaction adjustment value.
     /// </summary>
     public class GoodRepWith : BaseEntityEffect
     {
         public static readonly string EffectKey = EnchantmentTypes.GoodRepWith.ToString();
 
-        const int adjustmentAmount = 25;
+        const int adjustmentAmount = 10;
 
         public override void SetProperties()
         {


### PR DESCRIPTION
BTW, Interkarma, I didn't completely understand a couple of comments in `BadRepWith.cs`.

> Sources claim that effect persists even when item in wagon, but this is suspect and not consistent with other item effects.

Not completely sure what you meant but I think it may be true that good rep and bad rep enchantments take effect for any item in inventory in classic even if not equipped. But if so that seems like it may be a mistake as I don't think anything else works like that.

> Classic allows unusual stacking of variants, e.g. all is exclusive to groups but each group not exclusive with itself.
Changed this to work uniformly as per GoodRepWith, which does not allow self-stacking of groups.

Do you mean stacking vs. being exclusive when selecting enchantments in the item maker? I'm not sure about that but as for the actual applying of the enchantments, classic allows stacking as it will apply them for each one it encounters while iterating over the 10 enchantment slots. So if you hacked in an item with 4 enchantments on it of:
1) Good rep with commoners (+10)
2) Good rep with all  (+10)
3) Good rep with commoners  (+10)
4) Bad rep with commoners  (-10)

These would all be summed together, and you'd end with +20 for commoners and +10 for the 4 other groups.