### PR TITLE
Add Skull of Corruption effect and Tweak Sanguine Rose

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/SkullOfCorruptionEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/SkullOfCorruptionEffect.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Numidium
-// Contributors:    Gavin Clayton (interkarma@dfworkshop.net)
+// Contributors:    
 // 
 // Notes:
 //
@@ -17,12 +17,9 @@ using System.Linq;
 
 namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 {
-    /// <summary>
-    /// Used by the Sanguine Rose. Spawns a Daedroth ally.
-    /// </summary>
-    public class SanguineRoseEffect : BaseEntityEffect
+    class SkullOfCorruptionEffect : BaseEntityEffect
     {
-        public static readonly string EffectKey = ArtifactsSubTypes.Sanguine_Rose.ToString();
+        public static readonly string EffectKey = ArtifactsSubTypes.Skull_of_Corruption.ToString();
 
         const float enemyRange = 12;
 
@@ -43,17 +40,37 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             if (context != EnchantmentPayloadFlags.Used)
                 return null;
 
-            // Must have nearby enemies
+            // Must have nearby non-allied enemies
             List<PlayerGPS.NearbyObject> nearby = GameManager.Instance.PlayerGPS.GetNearbyObjects(PlayerGPS.NearbyObjectFlags.Enemy, enemyRange)
                 .Where(x => ((EnemyEntity)x.gameObject.GetComponent<DaggerfallEntityBehaviour>().Entity).Team != MobileTeams.PlayerAlly).ToList();
+            MobileTypes nearestType;
             if (nearby.Count == 0)
             {
-                DaggerfallUI.Instance.PopupMessage(TextManager.Instance.GetText(textDatabase, "noMonstersNearby"));
+                ShowSummonFailMessage();
                 return null;
             }
+            else
+            {
+                // Use nearest enemy for cloning
+                PlayerGPS.NearbyObject nearest = nearby[0];
+                foreach (PlayerGPS.NearbyObject nearbyObject in nearby.Skip(1))
+                {
+                    if (nearbyObject.distance < nearest.distance)
+                    {
+                        nearest = nearbyObject;
+                    }
+                }
+                EnemyEntity enemy = (EnemyEntity)nearest.gameObject.GetComponent<DaggerfallEntityBehaviour>().Entity;
+                if (enemy.Team == MobileTeams.PlayerAlly)
+                {
+                    ShowSummonFailMessage();
+                    return null;
+                }
+                nearestType = (MobileTypes)enemy.MobileEnemy.ID;
+            }
 
-            // Summon a Daedroth to fight for the player
-            GameObjectHelper.CreateFoeSpawner(foeType: MobileTypes.Daedroth, spawnCount: 1, alliedToPlayer: true);
+            // Spawn clone
+            GameObjectHelper.CreateFoeSpawner(foeType: nearestType, spawnCount: 1, alliedToPlayer: true);
 
             // Durability loss for this effect
             return new PayloadCallbackResults()
@@ -63,5 +80,10 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         }
 
         #endregion
+
+        private void ShowSummonFailMessage()
+        {
+            DaggerfallUI.Instance.PopupMessage(TextManager.Instance.GetText(textDatabase, "noMonstersNearby"));
+        }
     }
 }

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/SkullOfCorruptionEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/SkullOfCorruptionEffect.cs
@@ -17,6 +17,9 @@ using System.Linq;
 
 namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 {
+    /// <summary>
+    /// Used by the Skull of Corruption. Creates a clone of the nearest enemy as an ally to the player.
+    /// </summary>
     class SkullOfCorruptionEffect : BaseEntityEffect
     {
         public static readonly string EffectKey = ArtifactsSubTypes.Skull_of_Corruption.ToString();

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/SkullOfCorruptionEffect.cs.meta
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/SkullOfCorruptionEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d0715b4aa5a6ed4db80e347d20f9137
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I made it so both the Skull and Rose only spawn allies if the monsters nearby are not allied with the player.  I'm aware that the Skull in classic only clones non-human enemies in classic but I didn't feel the need to limit it in that way (I'm willing to change it if there are objections).  The behavior otherwise matches classic to the best of my knowledge.  Please let me know if I'm missing anything.

On a side note, I'm impressed at how simplified the process of adding new artifact effects is now.  Well done, Interkarma!