### PR TITLE
Randomize book quest rewards

### DIFF
--- a/Assets/Scripts/API/Save/ItemRecord.cs
+++ b/Assets/Scripts/API/Save/ItemRecord.cs
@@ -61,7 +61,9 @@ namespace DaggerfallConnect.Save
             public Byte color;
             public UInt32 weight;
             public UInt16 enchantmentPoints;
-            public UInt32 message;
+            public UInt16 message;
+            public Byte variants;
+            public Byte drawOrderOrEffect;
             public DaggerfallEnchantment[] magic;
         }
 
@@ -143,7 +145,9 @@ namespace DaggerfallConnect.Save
             parsedData.color = reader.ReadByte();
             parsedData.weight = reader.ReadUInt32();
             parsedData.enchantmentPoints = reader.ReadUInt16();
-            parsedData.message = reader.ReadUInt32();
+            parsedData.message = reader.ReadUInt16();
+            parsedData.variants = reader.ReadByte();
+            parsedData.drawOrderOrEffect = reader.ReadByte();
 
             // Read magic effect array
             const int effectCount = 10;

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -260,8 +260,6 @@ namespace DaggerfallWorkshop.Game.Items
         {
             Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(ItemGroups.Books);
             DaggerfallUnityItem book = new DaggerfallUnityItem(ItemGroups.Books, Array.IndexOf(enumArray, Books.Book0));
-
-            // TODO: Change DaggerfallUnityItem.message from int to ushort
             book.message = DaggerfallUnity.Instance.ItemHelper.getRandomBookID();
             book.CurrentVariant = UnityEngine.Random.Range(0, book.TotalVariants);
             // Update item value for this book.

--- a/Assets/Scripts/Game/Questing/Item.cs
+++ b/Assets/Scripts/Game/Questing/Item.cs
@@ -282,6 +282,11 @@ namespace DaggerfallWorkshop.Game.Questing
                 Entity.PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
                 result = ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
             }
+            // Handle books
+            else if (itemClass == (int)ItemGroups.Books)
+            {
+                result = ItemBuilder.CreateRandomBook();
+            }
             else
             {
                 // Handle random subclass


### PR DESCRIPTION
Also read "message" from classic data as a ushort as that is what it is in classic


This should hopefully fix
https://forums.dfworkshop.net/viewtopic.php?f=24&t=1845&p=23954#p23954.

I can't reproduce the problem of getting "The First Scroll of Baan Dar" in random loot. Maybe it was fixed as Jay_H's comment suggests. But it does look like quest rewards were neglecting to randomize the book, so that is added in this PR.

I didn't have a save handy to test a book quest reward, but this is a pretty straightforward change so it should work.