### PR TITLE
Handle %kno macro for quests

### DIFF
--- a/Assets/Scripts/Game/Questing/QuestMCP.cs
+++ b/Assets/Scripts/Game/Questing/QuestMCP.cs
@@ -6,12 +6,12 @@
 // Original Author: Hazelnut
 
 using UnityEngine;
-using System;
 using DaggerfallConnect;
 using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
+using DaggerfallWorkshop.Game.Guilds;
 
 namespace DaggerfallWorkshop.Game.Questing
 {
@@ -31,6 +31,16 @@ namespace DaggerfallWorkshop.Game.Questing
             public QuestMacroDataSource(Quest parent)
             {
                 this.parent = parent;
+            }
+
+            public override string FactionOrderName()
+            {
+                // Only used for knightly order quests, %kno macro. (removing 'The ' prefix from name for readability)
+                FactionFile.FactionData factionData;
+                if (DaggerfallUnity.Instance.ContentReader.FactionFileReader.GetFactionData(parent.FactionId, out factionData))
+                    return factionData.name.StartsWith("The ") ? factionData.name.Substring(4) : factionData.name;
+                else
+                    return null;
             }
 
             // He/She

--- a/Assets/Scripts/Game/Questing/QuestMCP.cs
+++ b/Assets/Scripts/Game/Questing/QuestMCP.cs
@@ -11,7 +11,6 @@ using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
-using DaggerfallWorkshop.Game.Guilds;
 
 namespace DaggerfallWorkshop.Game.Questing
 {

--- a/Assets/Scripts/Utility/MacroDataSource.cs
+++ b/Assets/Scripts/Utility/MacroDataSource.cs
@@ -25,7 +25,7 @@ namespace DaggerfallWorkshop.Utility
         }
 
         public virtual string FactionOrderName()
-        {   // %fon
+        {   // %fon %kno
             throw new NotImplementedException();
         }
 

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -962,7 +962,7 @@ namespace DaggerfallWorkshop.Utility
         }
 
         private static string FactionOrderName(IMacroContextProvider mcp)
-        {   // %fon
+        {   // %fon %kno
             if (mcp == null) return null;
             return mcp.GetMacroDataSource().FactionOrderName();
         }


### PR DESCRIPTION
I'm not sure if classic does this, but I removed the "The " prefix from the order names so the quest messages doesn't come up displaying "The The " - anyone have an issue with that?