### PR TITLE
Holiday effect implementation

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -883,7 +883,17 @@ namespace DaggerfallWorkshop.Game
             {
                 unlocked = true;
             }
-            // Handle other structures (stores, temples, taverns, palaces)
+            // Handle stores
+            else if (RMBLayout.IsShop(type))
+            {
+                uint minutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+                int holidayId = Formulas.FormulaHelper.GetHolidayId(minutes, GameManager.Instance.PlayerGPS.CurrentRegionIndex);
+                if (holidayId == (int)DFLocation.Holidays.Suns_Rest)
+                    unlocked = false;   // Shops are closed on Suns Rest holiday
+                else
+                    unlocked = IsBuildingOpen(type);
+            }
+            // Handle other structures (temples, taverns, palaces)
             else if (type <= DFLocation.BuildingTypes.Palace)
             {
                 unlocked = IsBuildingOpen(type);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -644,7 +644,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             uint minutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
             int holidayId = FormulaHelper.GetHolidayId(minutes, GameManager.Instance.PlayerGPS.CurrentRegionIndex);
 
-
             if (numberOfDiseases > 0 &&
                 (holidayId == (int)DFLocation.Holidays.South_Winds_Prayer ||
                  holidayId == (int)DFLocation.Holidays.First_Harvest ||

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -265,7 +265,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
                 else
                 {
-                    DaggerfallUI.MessageBox(HardStrings.serviceMembersOnly);
+                    DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "serviceMembersOnly"));
                 }
                 return;
             }
@@ -586,7 +586,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             CloseWindow();
             DaggerfallInputMessageBox donationMsgBox = new DaggerfallInputMessageBox(uiManager, this);
-            donationMsgBox.SetTextBoxLabel(HardStrings.serviceDonateHowMuch);
+            donationMsgBox.SetTextBoxLabel(TextManager.Instance.GetText(textDatabase, "serviceDonateHowMuch"));
             donationMsgBox.TextPanelDistanceX = 6;
             donationMsgBox.TextPanelDistanceY = 6;
             donationMsgBox.TextBox.Numeric = true;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -357,10 +357,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (windowMode == WindowModes.Buy && basketItems != null)
             {
-                // Check holidays for half price sales
-                // - Merchants Festival, suns height 10th for normal shops.
-                // - Tales and Tallows hearth fire 3rd for mages guild.
-                // - weapons on Warriors Festival suns dusk 20th
+                // Check holidays for half price sales:
+                // - Merchants Festival, suns height 10th for normal shops
+                // - Tales and Tallows hearth fire 3rd for mages guild
+                // - Weapons on Warriors Festival suns dusk 20th
                 uint minutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
                 int holidayId = FormulaHelper.GetHolidayId(minutes, GameManager.Instance.PlayerGPS.CurrentRegionIndex);
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -357,11 +357,25 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (windowMode == WindowModes.Buy && basketItems != null)
             {
+                // Check holidays for half price sales
+                // - Merchants Festival, suns height 10th for normal shops.
+                // - Tales and Tallows hearth fire 3rd for mages guild.
+                // - weapons on Warriors Festival suns dusk 20th
+                uint minutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+                int holidayId = FormulaHelper.GetHolidayId(minutes, GameManager.Instance.PlayerGPS.CurrentRegionIndex);
+
                 for (int i = 0; i < basketItems.Count; i++)
                 {
                     DaggerfallUnityItem item = basketItems.GetItem(i);
                     modeActionEnabled = true;
-                    cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality) * item.stackCount;
+                    int itemPrice = FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality) * item.stackCount;
+                    if ((holidayId == (int)DFLocation.Holidays.Merchants_Festival && guild == null) ||
+                        (holidayId == (int)DFLocation.Holidays.Tales_and_Tallow && guild != null && guild.GetFactionId() == (int)FactionFile.FactionIDs.The_Mages_Guild) ||
+                        (holidayId == (int)DFLocation.Holidays.Warriors_Festival && guild == null && item.ItemGroup == ItemGroups.Weapons))
+                    {
+                        itemPrice /= 2;
+                    }
+                    cost += itemPrice;
                 }
             }
             else if (remoteItems != null)

--- a/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/HardStrings.cs
@@ -153,9 +153,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public const string serviceReceiveArmor = "Receive Armor";
         public const string serviceReceiveHouse = "Receive House";
         public const string serviceReceiveHouseAlready = "You have already received your house.";
-        public const string serviceMembersOnly = "My services are reserved for members only.";
         public const string accessMembersOnly = "You need to be a member of sufficient rank to access this.";
-        public const string serviceDonateHowMuch = "Donate how much money : ";
         public const string serviceCured = "You are cured.";
         public const string serviceSummonCost1 = "%pcn, the cost for me to attempt a";
         public const string serviceSummonCost2 = "summoning of %dae is ";

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -77,3 +77,8 @@ reqIngredients,     You do not have the ingredients required.
 
 classicIcons,       Classic
 suggestedIcons,     Suggested
+
+- Guild service window:
+
+curedDisease,       You are cured.
+freeHolidayCuring,  You are cured free from cost due to todays' holiday.

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -80,5 +80,7 @@ suggestedIcons,     Suggested
 
 - Guild service window:
 
+serviceMembersOnly, My services are reserved for members only.
+serviceDonateHowMuch, Donate how much money : 
 curedDisease,       You are cured.
 freeHolidayCuring,  You are cured free from cost due to todays' holiday.


### PR DESCRIPTION
- Enable holiday effect for closed shops on Suns Rest 

- Enable holiday effects for free & half price curing
** Free on: South_Winds_Prayer, First_Harvest, Second_Harvest
** Half price on: North_Winds_Festival (needs testing)

- Enable holiday effects for half price sales
** Merchants Festival, suns height 10th for normal shops
** Tales and Tallows hearth fire 3rd for mages guild (needs testing)
** Weapons on Warriors Festival suns dusk 20th (needs testing)