### PR TITLE
Weaken shadows under scattered light

### DIFF
--- a/Assets/Scripts/Game/SunlightManager.cs
+++ b/Assets/Scripts/Game/SunlightManager.cs
@@ -22,10 +22,13 @@ namespace DaggerfallWorkshop.Game
     public class SunlightManager : MonoBehaviour
     {
         public const float defaultScaleFactor = 1;
+        public const float defaultShadowStrength = 1;
 
         public float Angle = -90f;                          // Sunlight direction throughout day
         [Range(0, 1)]
         public float ScaleFactor = defaultScaleFactor;      // Scale all lights by this amount
+        [Range(0, 1)]
+        public float ShadowStrength = defaultShadowStrength;
         public Light IndirectLight;                         // Point light that follows player to simulate indirect lighting
         public GameObject LocalPlayer;                      // Player for indirect light positioning
         public Light[] OtherLights;                         // Other lights to scale and enable/disable
@@ -120,6 +123,7 @@ namespace DaggerfallWorkshop.Game
                 daylightScale *= ScaleFactor;
 
                 SetLightIntensity(daylightScale);
+                SetShadows(ShadowStrength);
             }
         }
 
@@ -182,6 +186,26 @@ namespace DaggerfallWorkshop.Game
             if (IndirectLight != null)
             {
                 IndirectLight.intensity = indirectLightIntensity * scale;
+            }
+        }
+
+        void SetShadows(float strength)
+        {
+            if (myLight)
+                myLight.shadowStrength = strength;
+
+            if (OtherLights != null)
+            {
+                for (int i = 0; i < OtherLights.Length; i++)
+                {
+                    if (OtherLights[i] == null)
+                        continue;
+                    OtherLights[i].shadowStrength = strength;
+                }
+            }
+            if (IndirectLight != null)
+            {
+                IndirectLight.shadowStrength = strength;
             }
         }
 

--- a/Assets/Scripts/Game/SunlightManager.cs
+++ b/Assets/Scripts/Game/SunlightManager.cs
@@ -122,8 +122,7 @@ namespace DaggerfallWorkshop.Game
                 // Adjust for custom scale factor
                 daylightScale *= ScaleFactor;
 
-                SetLightIntensity(daylightScale);
-                SetShadows(ShadowStrength);
+                SetLightIntensity(daylightScale, ShadowStrength);
             }
         }
 
@@ -169,10 +168,13 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
-        void SetLightIntensity(float scale)
+        void SetLightIntensity(float scale, float shadowStrength)
         {
             if (myLight)
+            {
                 myLight.intensity = keyLightIntensity * scale;
+                myLight.shadowStrength = shadowStrength;
+            }
 
             if (OtherLights != null)
             {
@@ -181,31 +183,13 @@ namespace DaggerfallWorkshop.Game
                     if (OtherLights[i] == null)
                         continue;
                     OtherLights[i].intensity = otherLightsIntensity[i] * scale;
+                    OtherLights[i].shadowStrength = shadowStrength;
                 }
             }
             if (IndirectLight != null)
             {
                 IndirectLight.intensity = indirectLightIntensity * scale;
-            }
-        }
-
-        void SetShadows(float strength)
-        {
-            if (myLight)
-                myLight.shadowStrength = strength;
-
-            if (OtherLights != null)
-            {
-                for (int i = 0; i < OtherLights.Length; i++)
-                {
-                    if (OtherLights[i] == null)
-                        continue;
-                    OtherLights[i].shadowStrength = strength;
-                }
-            }
-            if (IndirectLight != null)
-            {
-                IndirectLight.shadowStrength = strength;
+                IndirectLight.shadowStrength = shadowStrength;
             }
         }
 

--- a/Assets/Scripts/Game/WeatherManager.cs
+++ b/Assets/Scripts/Game/WeatherManager.cs
@@ -34,6 +34,8 @@ namespace DaggerfallWorkshop.Game
         public AmbientEffectsPlayer WeatherEffects;
 
         [Range(0, 1)]
+        public float OvercastSunlightScale = 0.65f;
+        [Range(0, 1)]
         public float RainSunlightScale = 0.45f;
         [Range(0, 1)]
         public float StormSunlightScale = 0.25f;
@@ -41,6 +43,17 @@ namespace DaggerfallWorkshop.Game
         public float SnowSunlightScale = 0.45f;
         [Range(0, 1)]
         public float WinterSunlightScale = 0.65f;
+
+        [Range(0, 1)]
+        public float OvercastShadowStrength = 0.6f;
+        [Range(0, 1)]
+        public float RainShadowStrength = 0.4f;
+        [Range(0, 1)]
+        public float StormShadowStrength = 0.4f;
+        [Range(0, 1)]
+        public float SnowShadowStrength = 0.25f;
+        [Range(0, 1)]
+        public float WinterShadowStrength = 0.8f;
 
         [System.Serializable]
         public struct FogSettings
@@ -112,7 +125,7 @@ namespace DaggerfallWorkshop.Game
         {
             _dfUnity = DaggerfallUnity.Instance;
             _weatherTable = WeatherTable.ParseJsonTable();
-            
+
             postProcessingBehaviour = Camera.main.GetComponent<PostProcessingBehaviour>();
             if (postProcessingBehaviour != null)
             {
@@ -283,22 +296,45 @@ namespace DaggerfallWorkshop.Game
         {
             // Start with default scale
             float scale = SunlightManager.defaultScaleFactor;
+            float shadowStrength = SunlightManager.defaultShadowStrength;
 
             // Apply winter
             if (_dfUnity.WorldTime.Now.SeasonValue == DaggerfallDateTime.Seasons.Winter)
+            {
                 scale = WinterSunlightScale;
+                shadowStrength = WinterShadowStrength;
+            }
 
             // Apply rain, storm, snow light scale
             if (IsRaining && !IsStorming)
+            {
                 scale = RainSunlightScale;
+                shadowStrength = RainShadowStrength;
+            }
             else if (IsRaining && IsStorming)
+            {
                 scale = StormSunlightScale;
+                shadowStrength = StormShadowStrength;
+            }
             else if (IsSnowing)
+            {
                 scale = SnowSunlightScale;
+                shadowStrength = SnowShadowStrength;
+            }
+            else if (IsOvercast)
+            {
+                scale = OvercastSunlightScale;
+                shadowStrength = OvercastShadowStrength;
+            }
+
+            shadowStrength *= Mathf.Exp(-50f * currentOutdoorFogSettings.density);
 
             // Apply scale to sunlight manager
             if (SunlightManager)
+            {
                 SunlightManager.ScaleFactor = scale;
+                SunlightManager.ShadowStrength = shadowStrength;
+            }
         }
 
         void SetAmbientEffects()


### PR DESCRIPTION
When light is scattered, there should be less hard shadows (only ambient occlusion shadows); This is most obvious during heavy fog.

So I modified the shadows to be
- slightly lighter during overcast weathers;
- very light during snowing weather;
- almost inexistant during fog.