### PR TITLE
Spatialized spell missile hit sounds

### DIFF
--- a/Assets/Prefabs/Missiles/ColdMissile.prefab
+++ b/Assets/Prefabs/Missiles/ColdMissile.prefab
@@ -79,8 +79,8 @@ AudioSource:
   SpatializePostEffects: 0
   Priority: 128
   DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
+  MinDistance: 8
+  MaxDistance: 65
   Pan2D: 0
   rolloffMode: 0
   BypassEffects: 0
@@ -115,7 +115,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0

--- a/Assets/Prefabs/Missiles/FireMissile.prefab
+++ b/Assets/Prefabs/Missiles/FireMissile.prefab
@@ -79,8 +79,8 @@ AudioSource:
   SpatializePostEffects: 0
   Priority: 128
   DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
+  MinDistance: 8
+  MaxDistance: 65
   Pan2D: 0
   rolloffMode: 0
   BypassEffects: 0
@@ -115,7 +115,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0

--- a/Assets/Prefabs/Missiles/MagicMissile.prefab
+++ b/Assets/Prefabs/Missiles/MagicMissile.prefab
@@ -79,8 +79,8 @@ AudioSource:
   SpatializePostEffects: 0
   Priority: 128
   DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
+  MinDistance: 8
+  MaxDistance: 65
   Pan2D: 0
   rolloffMode: 0
   BypassEffects: 0
@@ -115,7 +115,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0

--- a/Assets/Prefabs/Missiles/PoisonMissile.prefab
+++ b/Assets/Prefabs/Missiles/PoisonMissile.prefab
@@ -79,8 +79,8 @@ AudioSource:
   SpatializePostEffects: 0
   Priority: 128
   DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
+  MinDistance: 8
+  MaxDistance: 65
   Pan2D: 0
   rolloffMode: 0
   BypassEffects: 0
@@ -115,7 +115,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0

--- a/Assets/Prefabs/Missiles/ShockMissile.prefab
+++ b/Assets/Prefabs/Missiles/ShockMissile.prefab
@@ -79,8 +79,8 @@ AudioSource:
   SpatializePostEffects: 0
   Priority: 128
   DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
+  MinDistance: 8
+  MaxDistance: 65
   Pan2D: 0
   rolloffMode: 0
   BypassEffects: 0
@@ -115,7 +115,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -585,9 +585,9 @@ namespace DaggerfallWorkshop.Game
         {
             if (audioSource && ImpactSound != SoundClips.None)
             {
-                // Using doppler of zero as classic does not appear to use 3D sound for spell impact
+                // Using weakened spatialBlend, classic does not appear to use 3D sound for spell impact at all
                 if (!isArrow)
-                    audioSource.PlayOneShot(ImpactSound, 0);
+                    audioSource.PlayOneShot(ImpactSound, 0.95f);
                 else
                     audioSource.PlayOneShot(ImpactSound);
             }

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -586,10 +586,8 @@ namespace DaggerfallWorkshop.Game
             if (audioSource && ImpactSound != SoundClips.None)
             {
                 // Using weakened spatialBlend, classic does not appear to use 3D sound for spell impact at all
-                if (!isArrow)
-                    audioSource.PlayOneShot(ImpactSound, 0.95f);
-                else
-                    audioSource.PlayOneShot(ImpactSound);
+                float spatialBlend = !isArrow ? 0.95f : 1f;
+                audioSource.PlayOneShot(ImpactSound, spatialBlend, 5f);
             }
         }
 

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -68,6 +68,7 @@ namespace DaggerfallWorkshop.Game
         Rigidbody myRigidbody;
         DaggerfallBillboard myBillboard;
         bool forceDisableSpellLighting;
+        bool noSpellsSpatialBlend = false;
         float lifespan = 0f;
         float postImpactLifespan = 0f;
         TargetTypes targetType = TargetTypes.None;
@@ -84,6 +85,7 @@ namespace DaggerfallWorkshop.Game
         EnemySenses enemySenses;
 
         List<DaggerfallEntityBehaviour> targetEntities = new List<DaggerfallEntityBehaviour>();
+
 
         #endregion
 
@@ -585,9 +587,9 @@ namespace DaggerfallWorkshop.Game
         {
             if (audioSource && ImpactSound != SoundClips.None)
             {
-                // Using weakened spatialBlend, classic does not appear to use 3D sound for spell impact at all
-                float spatialBlend = !isArrow ? 0.95f : 1f;
-                audioSource.PlayOneShot(ImpactSound, spatialBlend, 5f);
+                // Classic does not appear to use 3D sound for spell impact at all
+                float spatialBlend = !isArrow && noSpellsSpatialBlend ? 0f : 1f;
+                audioSource.PlayOneShot(ImpactSound, spatialBlend);
             }
         }
 


### PR DESCRIPTION
tweak minDistance and maxDistance instead of spatialBlend and volume

volume is never effectively amplified, so setting volume > 1f has no effect.
Instead, one can increase minDistance, so the the sounds stays at nominal volume at a larger range.
maxDistance sets at what distance the sound stops becoming quieter with distance. This is actually better than using spatialBlend, because the sound stays directional, which is important to know where are enemies fighting.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2089&p=24412#p24412