### PR TITLE
Make random spymaster NPCs act like non-guild

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -1075,9 +1075,11 @@ namespace DaggerfallWorkshop.Game
                     {   // Use NPC guild group if building has none (e.g. Temple buildings of divine faction)
                         guildGroup = (FactionFile.GuildGroups)factionData.ggroup;
                         // Don't popup guild service menu when holy order NPC isn't in a divine faction building. (bug t=1238)
-                        if (guildGroup == FactionFile.GuildGroups.HolyOrder && !Temple.IsDivine(buildingFactionData.id))
+                        // Don't popup guild service menu when TG spymaster NPC isn't in a faction building. (bug t=2037)
+                        if (guildGroup == FactionFile.GuildGroups.HolyOrder && !Temple.IsDivine(buildingFactionData.id) ||
+                            factionData.id == (int)GuildNpcServices.TG_Spymaster && buildingFactionData.id == 0)
                         {
-                            talkManager.TalkToStaticNPC(npc, false);
+                            talkManager.TalkToStaticNPC(npc, false, factionData.id == (int)GuildNpcServices.TG_Spymaster);
                             return;
                         }
                     }

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -864,12 +864,6 @@ namespace DaggerfallWorkshop
                 {
                     go.SetActive(false);
                 }
-                // Disable people if they are TG spymaster, but not in a legit TG house (TODO: spot any other instances for TG/DB)
-                else if (buildingData.buildingType == DFLocation.BuildingTypes.House2 && buildingData.factionID == 0 &&
-                         npc.Data.factionID == (int)GuildNpcServices.TG_Spymaster)
-                {
-                    go.SetActive(false);
-                }
             }
         }
 


### PR DESCRIPTION
There are some NPCs marked as TG spymasters in various houses, I had suppressed ones in House2 buildings already. I've changed this so all misplaced spymaster NPCs now have special case handling so they act just like regular NPCs instead of just making them disappear. Basically the same as I did for holy order NPCs that are not in a temple. (viewtopic.php?f=28&t=1238)

I also fixed it so the responses are now general ones for spymasters, left it alone for the priests since they already use a parent faction with no guild group.

Additionally the guild responses were getting random messages using strings when the msgs being used have formatting tags, so I fixed that too.