### PR TITLE
fix an ArgumentOutOfRangeException

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -335,7 +335,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {               
             if (listboxTopic != null)
             {
-                string oldTopic = listboxTopic.SelectedItem;
+                string oldTopic = listboxTopic.SelectedIndex >= 0 ? listboxTopic.SelectedItem : null;
                 if (selectedTalkOption == TalkOption.TellMeAbout)
                 {
                     SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicTellMeAbout);
@@ -348,8 +348,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicPerson);
                     else if (selectedTalkCategory == TalkCategory.Things)
                         SetListboxTopics(ref listboxTopic, TalkManager.Instance.ListTopicThings);
-                }                
-                listboxTopic.SelectedIndex = listboxTopic.FindIndex(oldTopic);
+                }
+                if (oldTopic != null)
+                    listboxTopic.SelectedIndex = listboxTopic.FindIndex(oldTopic);
                 UpdateQuestion(listboxTopic.SelectedIndex);
             }                
         }


### PR DESCRIPTION
Happened while opening quest log:

ArgumentOutOfRangeException: Argument is out of range.
Parameter name: index
  at System.Collections.Generic.List`1[DaggerfallWorkshop.Game.UserInterface.ListBox+ListItem].get_Item (Int32 index) [0x00000] in <filename unknown>:0 
  at DaggerfallWorkshop.Game.UserInterface.ListBox.get_SelectedItem () [0x00000] in <filename unknown>:0 
  at DaggerfallWorkshop.Game.UserInterface.DaggerfallTalkWindow.UpdateListboxTopic () [0x00000] in <filename unknown>:0 
  at DaggerfallWorkshop.Game.TalkManager.AssembleTopicLists (Boolean isInstantRebuild) [0x00000] in <filename unknown>:0 
  at DaggerfallWorkshop.Game.TalkManager.AddDialogForQuestInfoResource (UInt64 questID, System.String resourceName, QuestInfoResourceType resourceType, Boolean instantRebuildTopicLists) [0x00000] in <filename unknown>:0 
  at DaggerfallWorkshop.Utility.QuestMacroHelper.ExpandQuestMessage (DaggerfallWorkshop.Game.Questing.Quest parentQuest, .Token[]& tokens, Boolean revealDialogLinks) [0x00000] in <filename unknown>:0 
  at DaggerfallWorkshop.Game.Questing.Message.GetTextTokens (Int32 variant, Boolean expandMacros) [0x00000] in <filename unknown>:0 
  at DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallQuestJournalWindow.SetTextActiveQuests () [0x00000] in <filename unknown>:0 
  at DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallQuestJournalWindow.Update () [0x00000] in <filename unknown>:0 
  at DaggerfallWorkshop.Game.DaggerfallUI.Update () [0x00000] in <filename unknown>:0 
