### PR TITLE
Mod System: Cleanup and improved documentation

### DIFF
--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -244,7 +244,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         }
 
         /// <summary>
-        /// Loads all assets from asset bundle immediatly.
+        /// Loads all assets from asset bundle immediately.
+        /// Invidual assets can then be retrieved with <see cref="GetAsset{T}(string, bool)"/>.
         /// </summary>
         /// <param name="unloadBundle">Unload asset bundle if true</param>
         /// <returns>True if assetbundle has been loaded succesfully.</returns>
@@ -295,8 +296,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         /// <summary>
         /// Load all assets from asset bundle asynchronously.
+        /// Invidual assets can then be retrieved with <see cref="GetAsset{T}(string, bool)"/>.
         /// </summary>
-        /// <param name="unloadBundle">Unload asset bundle if true</param>
+        /// <param name="unloadBundle">Unload asset bundle if true.</param>
         public IEnumerator LoadAllAssetsFromBundleAsync(bool unloadBundle = true)
         {
             if (AssetNames == null)
@@ -434,7 +436,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <typeparam name="T">Type of asset</typeparam>
         /// <param name="assetName">name of asset</param>
         /// <param name="loadedBundle">had to load asset bundle</param>
-        /// <returns></returns>
+        /// <returns>A reference to the loaded asset or null if not found.</returns>
         private T LoadAssetFromBundle<T>(string assetName, out bool loadedBundle) where T : UnityEngine.Object
         {
             LoadedAsset la = new LoadedAsset();
@@ -611,7 +613,6 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                 Debug.Log(ex);
                 return null;
             }
-
         }
 
         /// <summary>
@@ -674,11 +675,15 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             return modLoaders;
         }
 
+        /// <summary>
+        /// Checks if an asset has already been loaded and can be retrieved without loading it again.
+        /// </summary>
+        /// <param name="assetName">The name of the asset.</param>
+        /// <returns>True if the asset is already loaded.</returns>
         public bool IsAssetLoaded(string assetName)
         {
             return loadedAssets.ContainsKey(assetName);
         }
-
 
         private bool AddAsset(string assetName, UnityEngine.Object asset)
         {
@@ -712,6 +717,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         }
 
+        /// <summary>
+        /// Unloads the asset bundle associated to this mod. Loaded assets can still be retrieved from cache, 
+        /// unless they are also unloaded.
+        /// </summary>
+        /// <param name="unloadAllObjects">Remove all loaded assets from memory.</param>
         public void UnloadAssetBundle(bool unloadAllObjects)
         {
             if (assetBundle == null)
@@ -723,6 +733,10 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 #endif
         }
 
+        /// <summary>
+        /// Loads the asset bundle associated to this mod.
+        /// </summary>
+        /// <returns>The loaded asset bundle or null.</returns>
         public AssetBundle LoadAssetBundle()
         {
             string abPath = System.IO.Path.Combine(dirPath, FileName + ModManager.MODEXTENSION);
@@ -738,6 +752,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             return ab;
         }
 
+        /// <summary>
+        /// Loads the asset bundle associated to this mod asynchronously.
+        /// </summary>
         public IEnumerator LoadAssetBundleAsync()
         {
             string abPath = System.IO.Path.Combine(dirPath, FileName + ModManager.MODEXTENSION);

--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -40,19 +40,27 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         #endregion
 
-        #region properties
+        #region Properties
 
         /// <summary>
         /// The name of the mod file on disk without extension.
         /// </summary>
         [SerializeField]
-        public string FileName { get { return fileName; } private set { fileName = value; } }
+        public string FileName
+        {
+            get { return fileName; }
+            private set { fileName = value; }
+        }
 
         /// <summary>
         /// The readable title of the mod, which may contain invalid path characters.
         /// </summary>
         [SerializeField]
-        public string Title { get { return ModInfo.ModTitle; } private set { ModInfo.ModTitle = value; } }
+        public string Title
+        {
+            get { return ModInfo.ModTitle; }
+            private set { ModInfo.ModTitle = value; }
+        }
 
         /// <summary>
         /// A value indicating whether this mod is ready; It should be set by the mod itself after initialization.
@@ -149,7 +157,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         #endregion
 
-        #region constructors
+        #region Constructors
 
         public Mod()
         {
@@ -174,7 +182,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             {
                 Debug.LogError("asset bundle is null for mod: " + name);
             }
-            if(!LoadModInfoFromBundle())
+            if (!LoadModInfoFromBundle())
             {
                 Debug.LogError("Couldn't locate modinfo for mod: " + name);
                 modInfo = new ModInfo();
@@ -185,62 +193,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             this.LoadSourceCodeFromModBundle();
             this.HasSettings = ModSettings.ModSettingsData.HasSettings(this);
 #if DEBUG
-            Debug.Log(string.Format("Finished Mod setup: {0}",this.Title));
+            Debug.Log(string.Format("Finished Mod setup: {0}", this.Title));
 #endif
         }
 
         #endregion
-
-        /// <summary>
-        /// Will retrieve asset either from LoadedAssets or asset bundle and return it. Will load
-        /// asset bundle if necessary.
-        /// </summary>
-        /// <typeparam name="T">Type of asset</typeparam>
-        /// <param name="assetName">name of asset</param>
-        /// <param name="loadedBundle">had to load asset bundle</param>
-        /// <returns></returns>
-        private T LoadAssetFromBundle<T>(string assetName, out bool loadedBundle) where T : UnityEngine.Object
-        {
-            LoadedAsset la = new LoadedAsset();
-            loadedBundle = false;
-
-            if (string.IsNullOrEmpty(assetName))
-            {
-                return null;
-            }
-            try
-            {
-                assetName = ModManager.GetAssetName(assetName);
-
-                if (IsAssetLoaded(assetName))
-                {
-                    la = loadedAssets[assetName];
-                    return la.Obj as T;
-                }
-                if (assetBundle == null)
-                    loadedBundle = LoadAssetBundle();
-
-                if (assetBundle.Contains(assetName))
-                {
-                    la.Obj = assetBundle.LoadAsset<T>(assetName);
-
-                    if(la.Obj != null)
-                    {
-                        la.T = la.Obj.GetType();
-                        AddAsset(assetName, la);
-                    }
-                    return la.Obj as T;
-                }
-                else
-                    return null;
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError(ex.Message);
-                return null;
-            }
-
-        }
 
         #region Public Methods
 
@@ -249,13 +206,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// If required, the assetbundle will be automatically loaded.
         /// </summary>
         /// <typeparam name="T">The asset type.</typeparam>
-        /// <param name="assetname">The name of the asset with or without extension.</param>
+        /// <param name="assetName">The name of the asset with or without extension.</param>
         /// <param name="clone">Instantiate a cloned instance if true.</param>
         /// <returns>A reference to the loaded asset or a cloned instance.</returns>
-        public T GetAsset<T>(string assetname, bool clone = false) where T : UnityEngine.Object
+        public T GetAsset<T>(string assetName, bool clone = false) where T : UnityEngine.Object
         {
             bool loadedBundle;
-            return GetAsset<T>(assetname, out loadedBundle, clone);
+            return GetAsset<T>(assetName, out loadedBundle, clone);
         }
 
         /// <summary>
@@ -273,12 +230,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
             T asset = LoadAssetFromBundle<T>(assetName, out loadedBundle);
 
-            if(asset == null)
+            if (asset == null)
             {
                 Debug.LogWarning(string.Format("Failed to load asset: {0}", assetName));
                 return null;
             }
-            else if(clone)
+            else if (clone)
             {
                 return UnityEngine.Object.Instantiate(asset) as T;
             }
@@ -289,12 +246,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Loads all assets from asset bundle immediatly.
         /// </summary>
-        /// <param name="UnloadBundle">Unload asset bundle if true</param>
+        /// <param name="unloadBundle">Unload asset bundle if true</param>
         /// <returns>True if assetbundle has been loaded succesfully.</returns>
-        public bool LoadAllAssetsFromBundle(bool UnloadBundle = true)
+        public bool LoadAllAssetsFromBundle(bool unloadBundle = true)
         {
             if (AssetNames == null)
                 return false;
+
             try
             {
                 for (int i = 0; i < AssetNames.Length; i++)
@@ -313,7 +271,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                     LoadedAsset la = new LoadedAsset();
                     la.Obj = assetBundle.LoadAsset(assetname);
 
-                    if(la.Obj == null)
+                    if (la.Obj == null)
                     {
                         Debug.LogWarning(string.Format("failed to load asset: {0} for mod: {1}", AssetNames[i], Title));
                         continue;
@@ -323,10 +281,10 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                     AddAsset(assetname, la);
                 }
 
-                if(UnloadBundle)
+                if (unloadBundle)
                     UnloadAssetBundle(false);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Debug.LogError(ex.Message);
                 return false;
@@ -344,7 +302,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             if (AssetNames == null)
                 yield return null;
 
-            for(int i = 0; i < AssetNames.Length; i++)
+            for (int i = 0; i < AssetNames.Length; i++)
             {
                 string assetname = ModManager.GetAssetName(AssetNames[i]);
 
@@ -369,7 +327,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
                 AddAsset(assetname, request.asset);
             }
-            if(unloadBundle)
+            if (unloadBundle)
                 UnloadAssetBundle(false);
 
             yield return null;
@@ -467,7 +425,61 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         #endregion
 
-        #region setup
+        #region Private Methods
+
+        /// <summary>
+        /// Will retrieve asset either from LoadedAssets or asset bundle and return it. Will load
+        /// asset bundle if necessary.
+        /// </summary>
+        /// <typeparam name="T">Type of asset</typeparam>
+        /// <param name="assetName">name of asset</param>
+        /// <param name="loadedBundle">had to load asset bundle</param>
+        /// <returns></returns>
+        private T LoadAssetFromBundle<T>(string assetName, out bool loadedBundle) where T : UnityEngine.Object
+        {
+            LoadedAsset la = new LoadedAsset();
+            loadedBundle = false;
+
+            if (string.IsNullOrEmpty(assetName))
+            {
+                return null;
+            }
+            try
+            {
+                assetName = ModManager.GetAssetName(assetName);
+
+                if (IsAssetLoaded(assetName))
+                {
+                    la = loadedAssets[assetName];
+                    return la.Obj as T;
+                }
+                if (assetBundle == null)
+                    loadedBundle = LoadAssetBundle();
+
+                if (assetBundle.Contains(assetName))
+                {
+                    la.Obj = assetBundle.LoadAsset<T>(assetName);
+
+                    if (la.Obj != null)
+                    {
+                        la.T = la.Obj.GetType();
+                        AddAsset(assetName, la);
+                    }
+                    return la.Obj as T;
+                }
+                else
+                    return null;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError(ex.Message);
+                return null;
+            }
+        }
+
+        #endregion
+
+        #region Setup
 
         // Returns array containing names of all assets in asset bundle
         private string[] GetAllAssetNames()
@@ -485,7 +497,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
                 return assetNames;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Debug.Log(ex.Message);
                 return null;
@@ -551,7 +563,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
                 return true;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Debug.LogError(ex.Message);
                 return false;
@@ -564,8 +576,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <returns></returns>
         public List<Assembly> CompileSourceToAssemblies()
         {
-            List<string> stringSource   = new List<string>(sources.Count);
-            Assembly assembly           = null;
+            List<string> stringSource = new List<string>(sources.Count);
+            Assembly assembly = null;
 
             try
             {
@@ -590,11 +602,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                         assemblies.Add(assembly);
                 }
 
-                stringSource    = null;
-                sources         = null;
+                stringSource = null;
+                sources = null;
                 return assemblies;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Debug.Log(ex);
                 return null;
@@ -614,18 +626,18 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
             List<SetupOptions> modLoaders = new List<SetupOptions>(1);
 
-            for(int i = 0; i < assemblies.Count; i++)
+            for (int i = 0; i < assemblies.Count; i++)
             {
                 try
                 {
                     Type[] types = assemblies[i].GetTypes();
 
-                    foreach(Type t in types)
+                    foreach (Type t in types)
                     {
                         if (!t.IsClass)
                             continue;
 
-                        foreach(MethodInfo mi in t.GetMethods())
+                        foreach (MethodInfo mi in t.GetMethods())
                         {
                             if (!mi.IsPublic || !mi.IsStatic)
                                 continue;
@@ -635,14 +647,14 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                             Invoke initAttribute = (Invoke)Attribute.GetCustomAttribute(mi, typeof(Invoke));
                             if (initAttribute == null)
                                 continue;
-                            else if (initAttribute.startState != state)
+                            else if (initAttribute.StartState != state)
                                 continue;
                             ParameterInfo[] pi = mi.GetParameters();
                             if (pi.Length != 1)
                                 continue;
                             else if (pi[0].ParameterType != typeof(InitParams))
                                 continue;
-                            SetupOptions options = new SetupOptions(initAttribute.priority, this, mi);
+                            SetupOptions options = new SetupOptions(initAttribute.Priority, this, mi);
 #if DEBUG
                             Debug.Log(string.Format("found new loader: {0} for mod: {1}", options.mi.Name, this.Title));
 #endif
@@ -651,7 +663,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                         }
                     }
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     Debug.LogError(ex.Message);
                     continue;
@@ -662,9 +674,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             return modLoaders;
         }
 
-        public bool IsAssetLoaded(string AssetName)
+        public bool IsAssetLoaded(string assetName)
         {
-            return loadedAssets.ContainsKey(AssetName);
+            return loadedAssets.ContainsKey(assetName);
         }
 
 

--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -90,7 +90,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         public int LoadPriority
         {
             get { return loadPriorty; }
-            set { loadPriorty = value; }
+            internal set { loadPriorty = value; }
         }
 
         /// <summary>

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -109,8 +109,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Get index for mod by title
         /// </summary>
-        /// <param name="modTitle"></param>
-        /// <returns></returns>
+        /// <param name="modTitle">The title of a mod.</param>
+        /// <returns>The index of the mod with the given title or -1 if not found.</returns>
         public int GetModIndex(string modTitle)
         {
             if (string.IsNullOrEmpty(modTitle))
@@ -127,8 +127,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Get mod using index
         /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
+        /// <param name="index">The index of a mod.</param>
+        /// <returns>The mod at the given index or null if the index is invalid.</returns>
         public Mod GetMod(int index)
         {
             if (index < 0 || index > Mods.Count)
@@ -140,8 +140,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Get mod using Mod Title
         /// </summary>
-        /// <param name="modTitle"></param>
-        /// <returns></returns>
+        /// <param name="modTitle">The title of a mod.</param>
+        /// <returns>The mod with the given title or null if not found.</returns>
         public Mod GetMod(string modTitle)
         {
             int index = GetModIndex(modTitle);
@@ -155,8 +155,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Get mod from GUID
         /// </summary>
-        /// <param name="modGUID"></param>
-        /// <returns></returns>
+        /// <param name="modGUID">The unique identifier of a mod.</param>
+        /// <returns>The mod with the given GUID or null if not found.</returns>
         public Mod GetModFromGUID(string modGUID)
         {
             if (string.IsNullOrEmpty(modGUID))
@@ -178,8 +178,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Get mod title from GUID
         /// </summary>
-        /// <param name="modGUID"></param>
-        /// <returns></returns>
+        /// <param name="modGUID">The unique identifier of a mod.</param>
+        /// <returns>The title of the mod with the given GUID or null if not found.</returns>
         public string GetModTitleFromGUID(string modGUID)
         {
             if (string.IsNullOrEmpty(modGUID))
@@ -201,7 +201,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// Returns all loaded mods in array
         /// </summary>
         /// <param name="loadOrder">ordered by load priority if true</param>
-        /// <returns></returns>
+        /// <returns>A collection with all the mods.</returns>
         public Mod[] GetAllMods(bool loadOrder = false)
         {
             var selection = from mod in Mods
@@ -215,7 +215,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Get modtitle string for each loaded mod
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A collection with all mod titles.</returns>
         public string[] GetAllModTitles()
         {
             var selection = from modInfo in GetAllModInfo()
@@ -226,7 +226,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Get mod file name string for each loaded mod
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A collection with all mod file names.</returns>
         public string[] GetAllModFileNames()
         {
             var selection = from mod in Mods
@@ -237,7 +237,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Get array of ModInfo objects for each loaded mod
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A collection with all mod informations.</returns>
         public ModInfo[] GetAllModInfo()
         {
             var selection = from mod in GetAllMods()
@@ -246,6 +246,10 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             return selection.ToArray();
         }
 
+        /// <summary>
+        /// Gets all the mod GUIDs which are defined and valid.
+        /// </summary>
+        /// <returns>A collection of valid mod GUIDs.</returns>
         public string[] GetAllModGUID()
         {
             var selection = from mod in Mods
@@ -254,6 +258,10 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             return selection.ToArray();
         }
 
+        /// <summary>
+        /// Gets all mods wich provide contributes to save data.
+        /// </summary>
+        /// <returns>An enumeration of mods with save data.</returns>
         public IEnumerable<Mod> GetAllModsWithSaveData()
         {
             return from mod in Mods
@@ -264,8 +272,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Get all asset names from mod
         /// </summary>
-        /// <param name="modTitle"></param>
-        /// <returns></returns>
+        /// <param name="modTitle">The title of a mod.</param>
+        /// <returns>A collection with the names of all assets from a mod or null if not found.</returns>
         public string[] GetModAssetNames(string modTitle)
         {
             int index = GetModIndex(modTitle);
@@ -283,7 +291,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <param name="modTitle">title of mod</param>
         /// <param name="clone">return copy of asset</param>
         ///<param name="check">true if loaded sucessfully</param>
-        /// <returns></returns>
+        /// <returns>The loaded asset or null if not found.</returns>
         public T GetAssetFromMod<T>(string assetName, string modTitle, bool clone, out bool check) where T : UnityEngine.Object
         {
             check = false;
@@ -345,8 +353,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// convert full relative path to just the asset name for example:
         /// /Assets/examples/myscript.cs to myscript.cs
         /// </summary>
-        /// <param name="assetPath"></param>
-        /// <returns></returns>
+        /// <param name="assetPath">The full path of an asset.</param>
+        /// <returns>The name of the file in the given path with the extension.</returns>
         public static string GetAssetName(string assetPath)
         {
             if (string.IsNullOrEmpty(assetPath))
@@ -374,7 +382,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         #region Mod Loading & setup
 
-        //look for changes in mod directory before the compiling / loading process has begun
+        /// <summary>
+        /// Look for changes in mod directory before the compiling / loading process has begun.
+        /// </summary>
         public void Refresh()
         {
             if (!alreadyAtStartMenuState)
@@ -384,7 +394,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Locates all the .dfmod files in the mod path
         /// </summary>
-        /// <param name="refresh"></param>
+        /// <param name="refresh">Checks for mods to unload.</param>
         private void FindModsFromDirectory(bool refresh = false)
         {
             if (!Directory.Exists(ModDirectory))
@@ -399,7 +409,6 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
             for (int i = 0; i < modFiles.Length; i++)
             {
-
                 string modFilePath = modFiles[i];
 
                 string DirPath = modFilePath.Substring(0, modFilePath.LastIndexOf(Path.DirectorySeparatorChar));
@@ -565,8 +574,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Compile source files in mod bundle to assembly
         /// </summary>
-        /// <param name="source"></param>
-        /// <returns></returns>
+        /// <param name="source">The content of source files.</param>
+        /// <returns>The compiled assembly or null.</returns>
         public static Assembly CompileFromSourceAssets(string[] source)
         {
             if (source == null || source.Length < 1)
@@ -596,7 +605,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// Writes mod settings (title, priority, enabled) to file
         /// </summary>
-        /// <returns></returns>
+        /// <returns>True if settings written successfully.</returns>
         public static bool WriteModSettings()
         {
             try
@@ -625,9 +634,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         }
 
         /// <summary>
-        /// Attempts to load saved mod settings from file & updates loaded mods
+        /// Attempts to load saved mod settings from file and updates loaded mods.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>True if settings loaded successfully.</returns>
         public static bool LoadModSettings()
         {
            fsResult result = new fsResult();
@@ -672,11 +681,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         }
 
         /// <summary>
-        /// helper function to assist w/ serializing & deserializing prefabs
+        /// Helper function to assist with serializing and deserializing prefabs.
         /// </summary>
-        /// <param name="trans">parent transform</param>
-        /// <param name="transforms"></param>
-        /// <returns></returns>
+        /// <param name="trans">Parent transform.</param>
+        /// <param name="transforms">A list already containing data or null to request a new list.</param>
+        /// <returns>The list of transforms.</returns>
         public static List<Transform> GetAllChildren(Transform trans, ref List<Transform> transforms)
         {
             if (transforms == null)
@@ -693,12 +702,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         }
 
         /// <summary>
-        /// Send data to a mod that has a valid DFModMessageReceiver delegate 
+        /// Send data to a mod that has a valid DFModMessageReceiver delegate.
         /// </summary>
-        /// <param name="modTitle"></param>
-        /// <param name="message"></param>
-        /// <param name="data"></param>
-        /// <param name="callback"></param>
+        /// <param name="modTitle">The title of the target mod.</param>
+        /// <param name="message">A string to be sent to the target mod.</param>
+        /// <param name="data">Data to send with the message.</param>
+        /// <param name="callback">An optional message callback.</param>
         public void SendModMessage(string modTitle, string message, object data = null, DFModMessageCallback callback = null)
         {
             if (Mods == null || Mods.Count < 1)

--- a/Assets/Game/Addons/ModSupport/ModTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModTypes.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2019 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -12,7 +12,6 @@
 using UnityEngine;
 using System;
 using System.Collections.Generic;
-
 
 namespace DaggerfallWorkshop.Game.Utility.ModSupport
 {
@@ -62,7 +61,6 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             this.mi = mi;
         }
 
-
         public int CompareTo(SetupOptions other)
         {
             if (other.priority == priority)
@@ -99,14 +97,21 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         public bool isPreCompiled;
     }
 
-    //Used to specify functions to be called automaticlly by modmanager during mod setup.
-    //To work, must be on a non-generic, public, static, class method that only takes 
-    //an InitParams struct for a parameter
+    /// <summary>
+    /// Specify a non-generic, public, static, class method that only takes an <see cref="InitParams"/>
+    /// struct for a parameter, to be called automatically by Mod Manager during mod setup.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple=false)]
-    public class Invoke : System.Attribute
+    public class Invoke : Attribute
     {
         public readonly int priority;
         public readonly StateManager.StateTypes startState;
+
+        /// <summary>
+        /// Request the mod manager to invoke this method at the specified state.
+        /// </summary>
+        /// <param name="startState">At which state the ModManager will invoke this method; typically this the Start or the Game state.</param>
+        /// <param name="priority">Defines a per-mod order if there are multiple invoked methods for the same state.</param>
         public Invoke(StateManager.StateTypes startState = StateManager.StateTypes.Start, int priority = 99)
         {
             this.priority = priority;
@@ -119,10 +124,26 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
     /// </summary>
     public interface IHasModSaveData
     {
-        Type SaveDataType { get; }                      // Type of save data object.
-        object NewSaveData();                           // Make empty/default save data.
-        object GetSaveData();                           // Gets data to be serialized or null.
-        void RestoreSaveData(object saveData);          // Apply deserialized data.
+        /// <summary>
+        /// The type of a custom class that holds save data and optionally use <see cref="FullSerializer.fsObjectAttribute"/> for versioning.
+        /// </summary>
+        Type SaveDataType { get; }
+
+        /// <summary>
+        /// Makes a new instance of <see cref="SaveDataType"/> with default values.
+        /// </summary>
+        object NewSaveData();
+
+        /// <summary>
+        /// Makes a new instance of <see cref="SaveDataType"/> for the current state or null if there is nothing to save.
+        /// </summary>
+        object GetSaveData();
+
+        /// <summary>
+        /// Restores retrieved data when a save is loaded.
+        /// </summary>
+        /// <param name="saveData">An instance of <see cref="SaveDataType"/>.</param>
+        void RestoreSaveData(object saveData);
     }
 
     //used by mod builder window

--- a/Assets/Game/Addons/ModSupport/ModTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModTypes.cs
@@ -28,9 +28,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         }
     }
 
-
     //created with mod builder window, seralized to json, bundled into mod
-    [System.Serializable]
+    [Serializable]
     public class ModInfo
     {
         public string ModTitle;         //displayed in game
@@ -101,11 +100,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
     /// Specify a non-generic, public, static, class method that only takes an <see cref="InitParams"/>
     /// struct for a parameter, to be called automatically by Mod Manager during mod setup.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple=false)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class Invoke : Attribute
     {
-        public readonly int priority;
-        public readonly StateManager.StateTypes startState;
+        public readonly int Priority;
+        public readonly StateManager.StateTypes StartState;
 
         /// <summary>
         /// Request the mod manager to invoke this method at the specified state.
@@ -114,8 +113,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <param name="priority">Defines a per-mod order if there are multiple invoked methods for the same state.</param>
         public Invoke(StateManager.StateTypes startState = StateManager.StateTypes.Start, int priority = 99)
         {
-            this.priority = priority;
-            this.startState = startState;
+            this.Priority = priority;
+            this.StartState = startState;
         }
     }
 
@@ -149,9 +148,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
     //used by mod builder window
     public enum ModCompressionOptions
     {
-        LZ4=0,
-        LZMA=1,
-        Uncompressed=2,
+        LZ4 = 0,
+        LZMA = 1,
+        Uncompressed = 2,
     }
 
     public delegate void DFModMessageReceiver(string message, object data, DFModMessageCallback callBack);


### PR DESCRIPTION
# Cleanup
* Moved private methods to `Private Methods` regions.
* Default spacing.
* Removed empty lines.
* Use PascalCase for regions and public members.
* Use camelCase for private fields.
* Use AutoProperties.
* Use the same formatting for all properties.
* Use readonly.

# Other Improvements
* Reviewed documentation for public members.
* Setter of `Mod.LoadPriority` is now internal.