### PR TITLE
Dungeon wagon prompt setting

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -48,6 +48,7 @@ EnableArrowCounter=True
 AccelerateUICopyTexture=False
 SDFFontRendering=True
 EnableGeographicBackgrounds=False
+DungeonExitWagonPrompt=True
 
 [Spells]
 EnableSpellLighting=True

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -327,7 +327,7 @@ namespace DaggerfallWorkshop.Game
                             else if (door.doorType == DoorTypes.DungeonExit && playerEnterExit.IsPlayerInside)
                             {
                                 // Hit dungeon exit while inside, ask if access wagon or transition outside
-                                if (GameManager.Instance.PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))  // && DungeonExitWagonCheck setting == false
+                                if (GameManager.Instance.PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart) && DaggerfallUnity.Settings.DungeonExitWagonPrompt)
                                 {
                                     DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.UIManager, DaggerfallMessageBox.CommonMessageBoxButtons.YesNo, 38, DaggerfallUI.UIManager.TopWindow);
                                     messageBox.OnButtonClick += DungeonWagonAccess_OnButtonClick;

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -327,7 +327,7 @@ namespace DaggerfallWorkshop.Game
                             else if (door.doorType == DoorTypes.DungeonExit && playerEnterExit.IsPlayerInside)
                             {
                                 // Hit dungeon exit while inside, ask if access wagon or transition outside
-                                if (GameManager.Instance.PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
+                                if (GameManager.Instance.PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))  // && DungeonExitWagonCheck setting == false
                                 {
                                     DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.UIManager, DaggerfallMessageBox.CommonMessageBoxButtons.YesNo, 38, DaggerfallUI.UIManager.TopWindow);
                                     messageBox.OnButtonClick += DungeonWagonAccess_OnButtonClick;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -110,6 +110,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox enableModernConversationStyleInTalkWindow;
         HorizontalSlider helmAndShieldMaterialDisplay;
         Checkbox geographicBackgrounds;
+        Checkbox dungeonExitWagonPrompt;
 
         // Enhancements
         Checkbox modSystem;
@@ -259,6 +260,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             helmAndShieldMaterialDisplay = AddSlider(rightPanel, "helmAndShieldMaterialDisplay",
                 DaggerfallUnity.Settings.HelmAndShieldMaterialDisplay, "off", "noLeatChai", "noLeat", "on");
             geographicBackgrounds = AddCheckbox(rightPanel, "geographicBackgrounds", DaggerfallUnity.Settings.EnableGeographicBackgrounds);
+            dungeonExitWagonPrompt = AddCheckbox(rightPanel, "dungeonExitWagonPrompt", DaggerfallUnity.Settings.DungeonExitWagonPrompt);
         }
 
         private void Enhancements(Panel leftPanel, Panel rightPanel)
@@ -365,6 +367,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.EnableModernConversationStyleInTalkWindow = enableModernConversationStyleInTalkWindow.IsChecked;
             DaggerfallUnity.Settings.HelmAndShieldMaterialDisplay = helmAndShieldMaterialDisplay.ScrollIndex;
             DaggerfallUnity.Settings.EnableGeographicBackgrounds = geographicBackgrounds.IsChecked;
+            DaggerfallUnity.Settings.DungeonExitWagonPrompt = dungeonExitWagonPrompt.IsChecked;
 
             /* Enhancements */
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -625,6 +625,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Update tracked weapons for setting equip delay
             SetEquipDelayTime(false);
 
+            if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && !allowDungeonWagonAccess)
+                DungeonWagonAccessProximityCheck();
+
             // Refresh window
             Refresh();
         }
@@ -1018,6 +1021,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             usingWagon = show;
             remoteItemListScroller.ResetScroll();
             Refresh(false);
+        }
+
+        void DungeonWagonAccessProximityCheck()
+        {
+            // Set allow wagon access if close enough (10m) to exit.
+            GameObject playerAdvancedGO = GameObject.Find("PlayerAdvanced");
+            DaggerfallDungeon dungeon = GameManager.Instance.DungeonParent.GetComponentInChildren<DaggerfallDungeon>();
+            Vector3 exitVector = dungeon.StartMarker.transform.position - playerAdvancedGO.transform.position;
+            if (exitVector.magnitude < 10)
+                allowDungeonWagonAccess = true;
         }
 
         void UpdateItemInfoPanel(DaggerfallUnityItem item)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1134,8 +1134,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void WagonButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             if (!GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon || allowDungeonWagonAccess)
-                if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart))
+            {
+                if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
                     ShowWagon(!usingWagon);
+                else
+                    DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "noWagon"));
+            }
+            else
+                DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "exitTooFar"));
         }
 
         private void InfoButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -110,6 +110,7 @@ namespace DaggerfallWorkshop
         public bool SDFFontRendering { get; set; }
         public bool EnableGeographicBackgrounds { get; set; }
         public bool EnableArrowCounter { get; set; }
+        public bool DungeonExitWagonPrompt { get; set; }
 
         // [Spells]
         public bool EnableSpellLighting { get; set; }
@@ -221,6 +222,7 @@ namespace DaggerfallWorkshop
             SDFFontRendering = GetBool(sectionGUI, "SDFFontRendering");
             EnableGeographicBackgrounds = GetBool(sectionGUI, "EnableGeographicBackgrounds");
             EnableArrowCounter = GetBool(sectionGUI, "EnableArrowCounter");
+            DungeonExitWagonPrompt = GetBool(sectionGUI, "DungeonExitWagonPrompt");
 
             EnableSpellLighting = GetBool(sectionSpells, "EnableSpellLighting");
             EnableSpellShadows = GetBool(sectionSpells, "EnableSpellShadows");
@@ -320,6 +322,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionGUI, "SDFFontRendering", SDFFontRendering);
             SetBool(sectionGUI, "EnableGeographicBackgrounds", EnableGeographicBackgrounds);
             SetBool(sectionGUI, "EnableArrowCounter", EnableArrowCounter);
+            SetBool(sectionGUI, "DungeonExitWagonPrompt", DungeonExitWagonPrompt);
 
             SetBool(sectionSpells, "EnableSpellLighting", EnableSpellLighting);
             SetBool(sectionSpells, "EnableSpellShadows", EnableSpellShadows);

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -65,6 +65,8 @@ arSrc,              armor rating
 arRep,              armor
 northern,           (northern)
 southern,           (southern)
+noWagon,            You don't own a wagon.
+exitTooFar,         The exit is too far away for you to access your wagon.
 
 - Potion mixing window:
 

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -79,6 +79,8 @@ helmAndShieldMaterialDisplay,                       Helm and Shield Material Dis
 helmAndShieldMaterialDisplayInfo,                   Show material for helms and shields in info popups and tooltips
 geographicBackgrounds,                              Geographic backgrounds
 geographicBackgroundsInfo,                          Contextual character backgrounds based on geographic location
+dungeonExitWagonPrompt,                             Dungeon wagon access prompt
+dungeonExitWagonPromptInfo,                         Prompt for wagon access on dungeon exit. (Wagon is always accessible within 10m of exit)
 
 modSystem,                                          Mod System
 modSystemInfo,                                      Enable support for mods.


### PR DESCRIPTION
Wagons can now be accessed when player is within 10m of a dungeon exit.
The access wagon prompt can be disabled in settings.
Added messages informing player why the wagon button does nothing in inventory window.