### PR TITLE
Do not show the same resolution with multiple refresh rates

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -11,6 +11,7 @@
 
 using UnityEngine;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
@@ -1156,6 +1157,32 @@ namespace DaggerfallWorkshop.Game
             texture.filterMode = FilterMode.Point;
 
             return texture;
+        }
+
+        /// <summary>
+        /// Gets all resolutions without duplicates; when the same resolution support different refresh rates, the highest one is chosen.
+        /// </summary>
+        /// <returns>All supported distinct resolutions.</returns>
+        public static Resolution[] GetDistinctResolutions()
+        {
+            Resolution[] resolutions = Screen.resolutions;
+            var distinctResolutions = new List<Resolution>(resolutions.Length);
+
+            for (int i = 0; i < resolutions.Length; i++)
+            {
+                Resolution current = resolutions[i];
+
+                if (i + 1 < resolutions.Length)
+                {
+                    Resolution next = resolutions[i + 1];
+                    if (current.width == next.width && current.height == next.height)
+                        continue;
+                }
+
+                distinctResolutions.Add(current);
+            }
+
+            return distinctResolutions.ToArray();
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -71,6 +71,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         DaggerfallFont titleFont        = DaggerfallUI.Instance.Font2;
         DaggerfallFont pageButtonFont   = DaggerfallUI.Instance.Font3;
 
+        readonly Resolution[] resolutions = DaggerfallUI.GetDistinctResolutions();
+
         int currentPage = 0;
         float y = 0;
 
@@ -294,8 +296,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Basic settings
             AddSectionTitle(leftPanel, "basic");
             resolution = AddSlider(leftPanel, "resolution",
-                Array.FindIndex(Screen.resolutions, x => x.width == DaggerfallUnity.Settings.ResolutionWidth && x.height == DaggerfallUnity.Settings.ResolutionHeight),
-                Screen.resolutions.Select(x => string.Format("{0}x{1}", x.width, x.height)).ToArray());
+                Array.FindIndex(resolutions, x => x.width == DaggerfallUnity.Settings.ResolutionWidth && x.height == DaggerfallUnity.Settings.ResolutionHeight),
+                resolutions.Select(x => string.Format("{0}x{1}", x.width, x.height)).ToArray());
             resolution.OnScroll += Resolution_OnScroll;
             fullscreen = AddCheckbox(leftPanel, "fullscreen", DaggerfallUnity.Settings.Fullscreen);
             fullscreen.OnToggleState += Fullscreen_OnToggleState;
@@ -390,7 +392,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (applyScreenChanges)
             {
-                Resolution selectedResolution = Screen.resolutions[resolution.ScrollIndex];
+                Resolution selectedResolution = resolutions[resolution.ScrollIndex];
                 DaggerfallUnity.Settings.ResolutionWidth = selectedResolution.width;
                 DaggerfallUnity.Settings.ResolutionHeight = selectedResolution.height;
                 DaggerfallUnity.Settings.Fullscreen = fullscreen.IsChecked;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -258,7 +258,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Get resolutions
             initialResolution = Screen.currentResolution;
-            availableResolutions = Screen.resolutions;
+            availableResolutions = DaggerfallUI.GetDistinctResolutions();
 
             // Create backdrop
             if (!backdropCreated)


### PR DESCRIPTION
Fix issue reported [here](https://www.reddit.com/r/daggerfallunity/comments/bkb1hv/a_question_about_the_resolution_settings_from_the/):  Daggerfall Unity always uses the highest supported so there is no need to show multiple values on UI.
