### PR TITLE
Implement bow drawback option

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -69,6 +69,7 @@ SoundVolume = 1.0
 MusicVolume = 1.0
 InstantRepairs = False
 AllowMagicRepairs = False
+BowDrawback = False
 
 [Map]
 AutomapNumberOfDungeons=5

--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -229,7 +229,7 @@ namespace DaggerfallWorkshop.Game
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
 
             // Calculate damage
-            damage = FormulaHelper.CalculateAttackDamage(entity, playerEntity, weapon, -1);
+            damage = FormulaHelper.CalculateAttackDamage(entity, playerEntity, -1, 0, weapon);
 
             // Break any "normal power" concealment effects on enemy
             if (entity.IsMagicallyConcealedNormalPower && damage > 0)
@@ -290,7 +290,7 @@ namespace DaggerfallWorkshop.Game
             EnemyMotor targetMotor = senses.Target.transform.GetComponent<EnemyMotor>();
 
             // Calculate damage
-            damage = FormulaHelper.CalculateAttackDamage(entity, targetEntity, weapon, -1);
+            damage = FormulaHelper.CalculateAttackDamage(entity, targetEntity, -1, 0, weapon);
 
             // Break any "normal power" concealment effects on enemy
             if (entity.IsMagicallyConcealedNormalPower && damage > 0)

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Hazelnut
 // 
 // Notes:
 //

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -146,8 +146,6 @@ namespace DaggerfallWorkshop.Game
             if (WeaponType != WeaponTypes.Bow || state == WeaponStates.Idle)
                 currentFrame = 0;
 
-            Debug.LogFormat("Frame {0} new state {1}", currentFrame, weaponState);
-
             UpdateWeapon();
         }
 
@@ -431,10 +429,8 @@ namespace DaggerfallWorkshop.Game
                     }
 
                     // Only update if the frame actually changed
-                    if (frameBeforeStepping != currentFrame) {
-                        Debug.Log("Frame " + currentFrame);
+                    if (frameBeforeStepping != currentFrame)
                         UpdateWeapon();
-                    }
                 }
 
                 yield return new WaitForSeconds(time);

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -134,7 +134,7 @@ namespace DaggerfallWorkshop.Game
                     return;
             }
 
-            // Do not change if already playing attack animation
+            // Do not change if already playing attack animation, unless releasing an arrow (bow & state=up->down)
             if (!IsPlayingOneShot() || (WeaponType == WeaponTypes.Bow && weaponState == WeaponStates.StrikeUp && state == WeaponStates.StrikeDown))
                 ChangeWeaponState(state);
         }
@@ -143,6 +143,7 @@ namespace DaggerfallWorkshop.Game
         {
             weaponState = state;
 
+            // Only reset frame to 0 for bows if idle state
             if (WeaponType != WeaponTypes.Bow || state == WeaponStates.Idle)
                 currentFrame = 0;
 

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -40,8 +40,7 @@ namespace DaggerfallWorkshop.Game.Formulas
         public delegate int Formula_2i(int a, int b);
         public delegate int Formula_3i(int a, int b, int c);
         public delegate int Formula_1i_1f(int a, float b);
-        public delegate int Formula_2de_2i(DaggerfallEntity de1, DaggerfallEntity de2 = null, int a = 0, int b = 0);
-        public delegate int Formula_2de_1dui_1i(DaggerfallEntity de1, DaggerfallEntity de2 = null, DaggerfallUnityItem a = null, int b = 0);
+        public delegate int Formula_2de_2i(DaggerfallEntity de1, DaggerfallEntity de2 = null, int a = 0, int b = 0, DaggerfallUnityItem item = null);
         public delegate bool Formula_1pe_1sk(PlayerEntity pe, DFCareer.Skills sk);
 
         // Registries for overridden formula
@@ -51,7 +50,6 @@ namespace DaggerfallWorkshop.Game.Formulas
         public static Dictionary<string, Formula_3i>        formula_3i = new Dictionary<string, Formula_3i>();
         public static Dictionary<string, Formula_1i_1f>     formula_1i_1f = new Dictionary<string, Formula_1i_1f>();
         public static Dictionary<string, Formula_2de_2i>    formula_2de_2i = new Dictionary<string, Formula_2de_2i>();
-        public static Dictionary<string, Formula_2de_1dui_1i> formula_2de_1dui_1i = new Dictionary<string, Formula_2de_1dui_1i>();
         public static Dictionary<string, Formula_1pe_1sk>   formula_1pe_1sk = new Dictionary<string, Formula_1pe_1sk>();
 
         #region Basic Formulas
@@ -402,14 +400,14 @@ namespace DaggerfallWorkshop.Game.Formulas
             return (handToHandSkill / 5) + 1;
         }
 
-        public static int CalculateAttackDamage(DaggerfallEntity attacker, DaggerfallEntity target, DaggerfallUnityItem weapon, int enemyAnimStateRecord)
+        public static int CalculateAttackDamage(DaggerfallEntity attacker, DaggerfallEntity target, int enemyAnimStateRecord, int animTime, DaggerfallUnityItem weapon)
         {
             if (attacker == null || target == null)
                 return 0;
 
-            Formula_2de_1dui_1i del;
-            if (formula_2de_1dui_1i.TryGetValue("CalculateAttackDamage", out del))
-                return del(attacker, target, weapon, enemyAnimStateRecord);
+            Formula_2de_2i del;
+            if (formula_2de_2i.TryGetValue("CalculateAttackDamage", out del))
+                return del(attacker, target, enemyAnimStateRecord, animTime, weapon);
 
             int minBaseDamage = 0;
             int maxBaseDamage = 0;
@@ -640,6 +638,7 @@ namespace DaggerfallWorkshop.Game.Formulas
                     }
                 }
             }
+            Debug.LogFormat("Damage {0} applied, animTime={1}  ({2})", damage, animTime, GameManager.Instance.WeaponManager.ScreenWeapon.WeaponState);
 
             return damage;
         }

--- a/Assets/Scripts/Game/PlayerMouseLook.cs
+++ b/Assets/Scripts/Game/PlayerMouseLook.cs
@@ -105,7 +105,7 @@ namespace DaggerfallWorkshop.Game
                 return;
 
             // Suppress mouse look if player is swinging weapon
-            if (InputManager.Instance.HasAction(InputManager.Actions.SwingWeapon) && !DaggerfallUnity.Settings.ClickToAttack)
+            if (InputManager.Instance.HasAction(InputManager.Actions.SwingWeapon) && !DaggerfallUnity.Settings.ClickToAttack && GameManager.Instance.WeaponManager.ScreenWeapon.WeaponType != WeaponTypes.Bow)
                 applyLook = false;
 
             Vector2 rawMouseDelta = new Vector2(InputManager.Instance.LookX, InputManager.Instance.LookY);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -93,6 +93,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox spellLighting;
         Checkbox spellShadows;
         Checkbox instantRepairs;
+        Checkbox bowDrawback;
 
         // Interface
         Checkbox toolTips;
@@ -213,6 +214,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             weaponSensitivity = AddSlider(leftPanel, "weaponSensitivity", 0.1f, 10.0f, DaggerfallUnity.Settings.WeaponSensitivity);
             movementAcceleration = AddSlider(leftPanel, "moveSpeedAcceleration", InputManager.minAcceleration, InputManager.maxAcceleration, DaggerfallUnity.Settings.MoveSpeedAcceleration);
             weaponAttackThreshold = AddTextbox(leftPanel, "weaponAttackThreshold", DaggerfallUnity.Settings.WeaponAttackThreshold.ToString());
+            bowDrawback = AddCheckbox(leftPanel, "bowDrawback", DaggerfallUnity.Settings.BowDrawback);
 
             y = 0;
 
@@ -339,6 +341,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             float weaponAttackThresholdValue;
             if (float.TryParse(weaponAttackThreshold.Text, out weaponAttackThresholdValue))
                 DaggerfallUnity.Settings.WeaponAttackThreshold = Mathf.Clamp(weaponAttackThresholdValue, 0.001f, 1.0f);
+            DaggerfallUnity.Settings.BowDrawback = bowDrawback.IsChecked;
 
             DaggerfallUnity.Settings.SoundVolume = soundVolume.GetValue();
             DaggerfallUnity.Settings.MusicVolume = musicVolume.GetValue();

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -36,6 +36,9 @@ namespace DaggerfallWorkshop.Game
         // Max time-length of a trail of mouse positions for attack gestures
         private const float MaxGestureSeconds = 1.0f;
 
+        // Max time bow can be held drawn
+        private const int MaxBowHeldDrawnSeconds = 10;
+
         public FPSWeapon ScreenWeapon;              // Weapon displayed in FPS view
         public bool Sheathed;                       // Weapon is sheathed
         public float SphereCastRadius = 0.3f;       // Radius of SphereCast used to target attacks
@@ -311,7 +314,7 @@ namespace DaggerfallWorkshop.Game
             }
             if (isAttacking && bowEquipped && DaggerfallUnity.Settings.BowDrawback && ScreenWeapon.GetCurrentFrame() == 3)
             {
-                if (InputManager.Instance.HasAction(InputManager.Actions.ActivateCenterObject))
+                if (InputManager.Instance.HasAction(InputManager.Actions.ActivateCenterObject) || ScreenWeapon.GetAnimTime() > MaxBowHeldDrawnSeconds)
                 {   // Un-draw the bow without releasing an arrow.
                     ScreenWeapon.ChangeWeaponState(WeaponStates.Idle);
                 }

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -297,7 +297,7 @@ namespace DaggerfallWorkshop.Game
                 {
                     // Ensure attack button was released before starting the next attack
                     if (lastAttackHand == Hand.None)
-                        attackDirection = MouseDirections.Down; // Force attack without tracking a swing for Bow
+                        attackDirection = DaggerfallUnity.Settings.BowDrawback ? MouseDirections.Up : MouseDirections.Down; // Force attack without tracking a swing for Bow
                 }
                 else if (isClickAttack)
                 {
@@ -308,6 +308,12 @@ namespace DaggerfallWorkshop.Game
                 {
                     attackDirection = TrackMouseAttack(); // Track swing direction for other weapons
                 }
+            }
+            if (isAttacking && bowEquipped && DaggerfallUnity.Settings.BowDrawback &&
+                !InputManager.Instance.HasAction(InputManager.Actions.SwingWeapon) && ScreenWeapon.GetCurrentFrame() == 3)
+            {
+                Debug.Log("Release arrow!");
+                attackDirection = MouseDirections.Down;
             }
 
             // Start attack if one has been initiated
@@ -321,7 +327,7 @@ namespace DaggerfallWorkshop.Game
             if (!isAttacking)
                 return;
 
-            if (!isBowSoundFinished && ScreenWeapon.WeaponType == WeaponTypes.Bow && ScreenWeapon.GetCurrentFrame() == 3)
+            if (!isBowSoundFinished && ScreenWeapon.WeaponType == WeaponTypes.Bow && ScreenWeapon.GetCurrentFrame() == 4)
             {
                 ScreenWeapon.PlaySwingSound();
                 isBowSoundFinished = true;
@@ -333,6 +339,7 @@ namespace DaggerfallWorkshop.Game
             }
             else if (!isDamageFinished && ScreenWeapon.GetCurrentFrame() == ScreenWeapon.GetHitFrame())
             {
+                Debug.Log("HitFrame");
                 // Racial override can suppress optional attack voice
                 RacialOverrideEffect racialOverride = GameManager.Instance.PlayerEffectManager.GetRacialOverrideEffect();
                 bool suppressCombatVoices = racialOverride != null && racialOverride.SuppressOptionalCombatVoices;

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -312,7 +312,7 @@ namespace DaggerfallWorkshop.Game
             if (isAttacking && bowEquipped && DaggerfallUnity.Settings.BowDrawback &&
                 !InputManager.Instance.HasAction(InputManager.Actions.SwingWeapon) && ScreenWeapon.GetCurrentFrame() == 3)
             {
-                Debug.Log("Release arrow!");
+                // Release arrow. Debug.Log("Release arrow!");
                 attackDirection = MouseDirections.Down;
             }
 
@@ -339,7 +339,6 @@ namespace DaggerfallWorkshop.Game
             }
             else if (!isDamageFinished && ScreenWeapon.GetCurrentFrame() == ScreenWeapon.GetHitFrame())
             {
-                Debug.Log("HitFrame");
                 // Racial override can suppress optional attack voice
                 RacialOverrideEffect racialOverride = GameManager.Instance.PlayerEffectManager.GetRacialOverrideEffect();
                 bool suppressCombatVoices = racialOverride != null && racialOverride.SuppressOptionalCombatVoices;

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -309,11 +309,16 @@ namespace DaggerfallWorkshop.Game
                     attackDirection = TrackMouseAttack(); // Track swing direction for other weapons
                 }
             }
-            if (isAttacking && bowEquipped && DaggerfallUnity.Settings.BowDrawback &&
-                !InputManager.Instance.HasAction(InputManager.Actions.SwingWeapon) && ScreenWeapon.GetCurrentFrame() == 3)
+            if (isAttacking && bowEquipped && DaggerfallUnity.Settings.BowDrawback && ScreenWeapon.GetCurrentFrame() == 3)
             {
-                // Release arrow. Debug.Log("Release arrow!");
-                attackDirection = MouseDirections.Down;
+                if (InputManager.Instance.HasAction(InputManager.Actions.ActivateCenterObject))
+                {   // Un-draw the bow without releasing an arrow.
+                    ScreenWeapon.ChangeWeaponState(WeaponStates.Idle);
+                }
+                else if (!InputManager.Instance.HasAction(InputManager.Actions.SwingWeapon))
+                {   // Release arrow. Debug.Log("Release arrow!");
+                    attackDirection = MouseDirections.Down;
+                }
             }
 
             // Start attack if one has been initiated
@@ -832,7 +837,7 @@ namespace DaggerfallWorkshop.Game
 
         void ExecuteAttacks(MouseDirections direction)
         { 
-            if(ScreenWeapon)
+            if (ScreenWeapon)
             {
                 // Fire screen weapon animation
                 ScreenWeapon.OnAttackDirection(direction);

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors: Numidium   
+// Contributors:    Numidium, Hazelnut
 // 
 // Notes:
 //

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -131,6 +131,7 @@ namespace DaggerfallWorkshop
         public float SoundVolume { get; set; }
         public bool InstantRepairs { get; set; }
         public bool AllowMagicRepairs { get; set; }
+        public bool BowDrawback { get; set; }
 
         // [Map]
         public int AutomapNumberOfDungeons { get; set; }
@@ -241,6 +242,7 @@ namespace DaggerfallWorkshop
             MusicVolume = GetFloat(sectionControls, "MusicVolume", 0f, 1.0f);
             InstantRepairs = GetBool(sectionControls, "InstantRepairs");
             AllowMagicRepairs = GetBool(sectionControls, "AllowMagicRepairs");
+            BowDrawback = GetBool(sectionControls, "BowDrawback");
 
             AutomapNumberOfDungeons = GetInt(sectionMap, "AutomapNumberOfDungeons", 0, 100);
             ExteriorMapDefaultZoomLevel = GetFloat(sectionMap, "ExteriorMapDefaultZoomLevel", 4, 31);
@@ -341,6 +343,7 @@ namespace DaggerfallWorkshop
             SetFloat(sectionControls, "MusicVolume", MusicVolume);
             SetBool(sectionControls, "InstantRepairs", InstantRepairs);
             SetBool(sectionControls, "AllowMagicRepairs", AllowMagicRepairs);
+            SetBool(sectionControls, "BowDrawback", BowDrawback);
 
             SetInt(sectionStartup, "StartCellX", StartCellX);
             SetInt(sectionStartup, "StartCellY", StartCellY);

--- a/Assets/Scripts/Utility/WeaponBasics.cs
+++ b/Assets/Scripts/Utility/WeaponBasics.cs
@@ -85,13 +85,13 @@ namespace DaggerfallWorkshop.Utility
         // Animations for bow
         public static WeaponAnimation[] BowWeaponAnims = new WeaponAnimation[]
         {
-            new WeaponAnimation() {Record = 0, NumFrames = 4, FramePerSecond = IdleAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
+            new WeaponAnimation() {Record = 0, NumFrames = 1, FramePerSecond = IdleAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
             new WeaponAnimation() {Record = 0, NumFrames = 7, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
             new WeaponAnimation() {Record = 0, NumFrames = 7, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
             new WeaponAnimation() {Record = 0, NumFrames = 7, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
             new WeaponAnimation() {Record = 0, NumFrames = 7, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
             new WeaponAnimation() {Record = 0, NumFrames = 7, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
-            new WeaponAnimation() {Record = 0, NumFrames = 7, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
+            new WeaponAnimation() {Record = 0, NumFrames = 4, FramePerSecond = BowAnimSpeed, Alignment = WeaponAlignment.Right, Offset = 0f},
         };
 
         // Animations for werecreature - alignment changes

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -48,7 +48,7 @@ spellShadows,                                       Spell shadows
 spellShadowsInfo,                                   Enable spell shadows
 instantRepairs,                                     Instant repair services
 instantRepairsInfo,                                 Disables waiting for repairs and makes them instantaneous
-bowDrawback,                                        Enable bow drawing
+bowDrawback,                                        Bows - draw and release
 bowDrawbackInfo,                                    Enables bow drawback while holding RH mouse; release to fire
 
 toolTips,                                           Tool Tips

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -48,6 +48,8 @@ spellShadows,                                       Spell shadows
 spellShadowsInfo,                                   Enable spell shadows
 instantRepairs,                                     Instant repair services
 instantRepairsInfo,                                 Disables waiting for repairs and makes them instantaneous
+bowDrawback,                                        Enable bow drawing
+bowDrawbackInfo,                                    Enables bow drawback while holding RH mouse; release to fire
 
 toolTips,                                           Tool Tips
 toolTipsInfo,                                       Shows informations about GUI items


### PR DESCRIPTION
Adds a 2 stage process for shooting arrows with a bow. Hold down right mouse to draw and release to fire. Uses 3 frames of animation which were previously unused due to single stage attack animation process.

1) Draw the bow. frames 0-3
2) Release the arrow. frames 4-6

Set BowDrawback true to enable. Left click releases without firing arrow, this will automatically happen after 10s anyway.

This came out of the discussion here https://forums.dfworkshop.net/viewtopic.php?f=12&t=1748. I had intended the whole thing to be in a mod, but after looking at the weapon handling and animation code, it feels like it would need a massive amount of re-factoring to achieve this. So, I've put this into the core DFU codebase as an option. 

I think it has as much value as click to attack, and is a nice updating of archery interaction for DFU. In fact I would quite like it to be the default, but that's up to the dev community to decide. I do intend to add some mod hooks / formulas so that this 2 stage process can be integrated with damage and hold limits in a mod. Would like to be sure you're okay with these changes first though @Interkarma .