### PR TITLE
Enable texture override for paperdoll

### DIFF
--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -331,14 +331,16 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             // Get mask texture where alpha 0 is umasked areas of image and alpha 1 are masked areas of image
-            // Note: Texture replacement will need to support import of an optional mask texture for each replacement
-            ImageReader.UpdateMaskTexture(ref data);
+            Texture2D maskTexture;
+            if (TextureReplacement.TryImportTexture(archive, record, 0, item.dyeColor, TextureMap.Mask, out maskTexture))
+                data.maskTexture = maskTexture;
+            else
+                ImageReader.UpdateMaskTexture(ref data);
 
             Texture2D tex;
-            if (!forPaperDoll && TextureReplacement.TryImportTexture(archive, record, 0, item.dyeColor, out tex))
+            if (TextureReplacement.TryImportTexture(archive, record, 0, item.dyeColor, TextureMap.Albedo, out tex))
             {
                 // Assign imported texture
-                // Paperdoll is disabled for now
                 data.texture = tex;
             }
             else

--- a/Assets/Scripts/Game/UserInterface/PaperDoll.cs
+++ b/Assets/Scripts/Game/UserInterface/PaperDoll.cs
@@ -30,26 +30,23 @@ namespace DaggerfallWorkshop.Game.UserInterface
         const int paperDollHeight = 184;
         const int waistHeight = 40;
 
-        DFSize backgroundFullSize = new DFSize(125, 198);
-        Rect backgroundSubRect = new Rect(8, 7, paperDollWidth, paperDollHeight);
+        readonly DFSize backgroundFullSize = new DFSize(125, 198);
+        readonly Rect backgroundSubRect = new Rect(8, 7, paperDollWidth, paperDollHeight);
 
         #endregion
 
         #region Fields
 
-        static Color32 maskColor = new Color(255, 0, 200, 0);   // Special mask colour used on helmets, cloaks, etc.
-        DFPosition paperDollOrigin = new DFPosition(200, 8);    // Used to translate hard-coded IMG file offsets back to origin
+        static readonly Color32 maskColor = new Color(255, 0, 200, 0);   // Special mask colour used on helmets, cloaks, etc.
 
-        bool showBackgroundLayer = true;
-        bool showCharacterLayer = true;
+        const bool showBackgroundLayer = true;
+        const bool showCharacterLayer = true;
 
-        Texture2D paperDollTexture;
+        readonly Panel backgroundPanel = new Panel();
+        readonly Panel characterPanel = new Panel();
 
-        Panel backgroundPanel = new Panel();
-        Panel characterPanel = new Panel();
-
-        TextLabel[] armourLabels = new TextLabel[DaggerfallEntity.NumberBodyParts];
-        Vector2[] armourLabelPos = new Vector2[] { new Vector2(70, 12), new Vector2(20, 38), new Vector2(86, 38), new Vector2(12, 58), new Vector2(6, 90), new Vector2(18, 120), new Vector2(22, 168) };
+        readonly TextLabel[] armourLabels = new TextLabel[DaggerfallEntity.NumberBodyParts];
+        readonly Vector2[] armourLabelPos = new Vector2[] { new Vector2(70, 12), new Vector2(20, 38), new Vector2(86, 38), new Vector2(12, 58), new Vector2(6, 90), new Vector2(18, 120), new Vector2(22, 168) };
 
         string lastBackgroundName = string.Empty;
 
@@ -124,11 +121,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             // Update background
             RefreshBackground(playerEntity);
-
-            // Destroy old paper doll texture
-            characterPanel.BackgroundTexture = null;
-            GameObject.Destroy(paperDollTexture);
-            paperDollTexture = null;
 
             // Display paper doll render
             DaggerfallUI.Instance.PaperDollRenderer.Refresh(PaperDollRenderer.LayerFlags.All, playerEntity);

--- a/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
+++ b/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
@@ -37,13 +37,13 @@ namespace DaggerfallWorkshop.Game.Utility
 
         const string paperDollMaterialName = "Daggerfall/PaperDoll";
 
-        Material paperDollMaterial = null;
+        readonly Material paperDollMaterial;
         RenderTexture target = null;
         Texture2D paperDollTexture = null;
-        DFPosition paperDollOrigin = new DFPosition(200, 8);    // Used to translate hard-coded IMG file offsets back to origin
+        readonly DFPosition paperDollOrigin = new DFPosition(200, 8);    // Used to translate hard-coded IMG file offsets back to origin
 
         float scale;
-        List<ItemElement> itemLayout = new List<ItemElement>();
+        readonly List<ItemElement> itemLayout = new List<ItemElement>();
 
         #endregion
 

--- a/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
+++ b/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
@@ -18,6 +18,7 @@ using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop.Game.Utility
 {
@@ -44,6 +45,7 @@ namespace DaggerfallWorkshop.Game.Utility
         Texture2D paperDollTexture = null;
         DFPosition paperDollOrigin = new DFPosition(200, 8);    // Used to translate hard-coded IMG file offsets back to origin
 
+        float scale;
         List<ItemElement> itemLayout = new List<ItemElement>();
 
         #endregion
@@ -123,6 +125,8 @@ namespace DaggerfallWorkshop.Game.Utility
             // Scale cannot be lower than 1.0
             if (scale < 1)
                 scale = 1;
+
+            this.scale = scale;
 
             // Create scaled render texture
             target = new RenderTexture((int)(paperDollWidth * scale), (int)(paperDollHeight * scale), 16);
@@ -259,6 +263,9 @@ namespace DaggerfallWorkshop.Game.Utility
                 posY * scaleY,
                 targetRect.width * scaleX,
                 targetRect.height * scaleY);
+
+            // Allow for some adjustment so artist can finetune how their new item images should be positioned.
+            TextureReplacement.OverridePaperdollItemRect(item, srcImage, scale, ref screenRect);
 
             // Draw with custom shader for paper doll item masking
             if (item != null)

--- a/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
+++ b/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
@@ -26,9 +26,6 @@ namespace DaggerfallWorkshop.Game.Utility
     /// Render paper doll at higher pixel densities using custom layer flags.
     /// Maintains layout data to sample equip index of item texture under mouse.
     /// Replacement paper doll textures must be readable.
-    /// TODO:
-    ///  - Read a mask texture with replacement (similar to reading emission texture) for masking out hair around helmets.
-    ///  - Allow for some adjustment by body morphology in XML so artist can finetune how their new item images should be positioned over paper doll based on race and gender.
     /// </summary>
     public class PaperDollRenderer
     {

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -11,7 +11,6 @@
 
 /*
  * TODO:
- * - Support for Paperdoll (BODY00I0.IMG)
  * - Support for Sky (SKYxx.DAT)
  */
 

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -40,7 +40,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         Normal,
         Height,
         Emission,
-        MetallicGloss
+        MetallicGloss,
+        Mask
     }
 
     public enum TextureImport
@@ -218,11 +219,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="record">Record index.</param>
         /// <param name="frame">Animation frame index</param>
         /// <param name="dye">Dye colour for armour, weapons, and clothing.</param>
+        /// <param name="textureMap">Texture type.</param>
         /// <param name="tex">Imported texture.</param>
         /// <returns>True if texture imported.</returns>
-        public static bool TryImportTexture(int archive, int record, int frame, DyeColors dye, out Texture2D tex)
+        public static bool TryImportTexture(int archive, int record, int frame, DyeColors dye, TextureMap textureMap, out Texture2D tex)
         {
-            return TryImportTexture(texturesPath, GetName(archive, record, frame, dye), false, out tex);
+            return TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap, dye), false, out tex);
         }
 
         /// <summary>
@@ -600,40 +602,20 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="archive">Archive index from TEXTURE.XXX</param>
         /// <param name="record">Record index.</param>
         /// <param name="frame">Frame index. It's different than zero only for animations.</param>
-        public static string GetName(int archive, int record, int frame = 0)
+        /// <param name="textureMap">Texture type.</param>
+        /// <param name="dye">Color Dye.</param>
+        /// <returns>The name for the texture with requested options.</returns>
+        public static string GetName(int archive, int record, int frame = 0, TextureMap textureMap = TextureMap.Albedo, DyeColors dye = DyeColors.Unchanged)
         {
-            return string.Format("{0:000}_{1}-{2}", archive, record, frame);
-        }
+            string name = string.Format("{0:000}_{1}-{2}", archive, record, frame);
 
-        /// <summary>
-        /// Get name for a texture with a dye.
-        /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index. It's different than zero only for animations.</param>
-        /// <param name="dye">Color Dye</param>
-        public static string GetName(int archive, int record, int frame, DyeColors dye)
-        {
-            if (dye == DyeColors.Unchanged)
-                return GetName(archive, record, frame);
+            if (dye != DyeColors.Unchanged)
+                name = string.Format("{0}_{1}", name, dye);
 
-            return string.Format("{0}_{1}", GetName(archive, record, frame), dye);
-        }
+            if (textureMap != TextureMap.Albedo)
+                name = string.Format("{0}_{1}", name, textureMap);
 
-        /// <summary>
-        /// Get name for a specific texture map.
-        /// </summary>
-        /// <param name="archive">Archive index from TEXTURE.XXX</param>
-        /// <param name="record">Record index.</param>
-        /// <param name="frame">Frame index. It's different than zero only for animations.</param>
-        /// <param name="textureMap">Shader texture type.</param>
-        /// <returns></returns>
-        public static string GetName(int archive, int record, int frame, TextureMap textureMap)
-        {
-            if (textureMap == TextureMap.Albedo)
-                return GetName(archive, record, frame);
-
-            return string.Format("{0}_{1}", GetName(archive, record, frame), textureMap);
+            return name;
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
+++ b/Assets/Scripts/Utility/AssetInjection/XMLManager.cs
@@ -137,6 +137,29 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 );
         }
 
+        /// <summary>
+        /// Gets a rect and scale all its value to the requested <paramref name="requestedScale"/>.
+        /// The xml element can provide an attribute with a specified scale different than one.
+        /// </summary>
+        /// <param name="name">The name of the rect element.</param>
+        /// <param name="baseRect">Default values for the rect.</param>
+        /// <param name="requestedScale">A value to scale the rect.</param>
+        /// <returns>Rect read from xml file.</returns>
+        public Rect GetRect(string name, Rect baseRect, float requestedScale = 1)
+        {
+            XElement element;
+            if (!TryGetElement(name, out element))
+                return baseRect;
+
+            float scale = requestedScale / ParseFloat((string)element.Attribute("scale")) ?? 1;
+            return new Rect(
+                ParseFloat((string)element.Element("x"), scale) ?? baseRect.x,
+                ParseFloat((string)element.Element("y"), scale) ?? baseRect.y,
+                ParseFloat((string)element.Element("width"), scale) ?? baseRect.width,
+                ParseFloat((string)element.Element("height"), scale) ?? baseRect.height
+                );
+        }
+
         #endregion
 
         #region Private Methods
@@ -200,6 +223,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         {
             if (!path.EndsWith(extension))
                 path += extension;
+        }
+
+        private static float? ParseFloat(string element = null, float scale = 1)
+        {
+            float value;
+            if (element != null && float.TryParse(element, NumberStyles.Float, CultureInfo.InvariantCulture, out value))
+                return value * scale;
+
+            return null;
         }
 
         #endregion


### PR DESCRIPTION
Enabled injection of custom textures to new paperdoll renderer. Additional textures named `textureName_Mask` can provide masking defined on alpha channel. Maks provided via assetbundles should use texture type _Single Channel_ to automatically pick format with minimum amount of memory used.