### PR TITLE
Refactor TransportManager

### DIFF
--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -101,7 +101,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Mounts a horse or cart if available if on foot, otherwise gets on foot
         /// </summary>
-        public void ToggleMount()
+        public void ToggleHorse()
         {
             if (TransportMode == TransportModes.Horse || TransportMode == TransportModes.Cart)
             {
@@ -248,7 +248,7 @@ namespace DaggerfallWorkshop.Game
                 {
                     if (GameManager.Instance.PlayerController.isGrounded)
                     {
-                        ToggleMount();
+                        ToggleHorse();
                     }
                 }
             }

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -12,7 +12,6 @@ using DaggerfallConnect.Arena2;
 using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Game.Banking;
 using DaggerfallWorkshop.Game.Items;
-using DaggerfallWorkshop.Game.UserInterfaceWindows;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -36,6 +35,7 @@ namespace DaggerfallWorkshop.Game
         public float RidingVolumeScale = 1.0f;  // TODO: Should this be the same setting as PlayerFootsteps.FootstepVolumeScale?
 
         #endregion
+
         #region Properties
 
         public TransportModes TransportMode
@@ -57,8 +57,7 @@ namespace DaggerfallWorkshop.Game
         }
         
         #endregion
-
-
+        
         #region Public Methods
         /// <summary>True when there's a recorded position before boarding and player is on the ship</summary>
         public bool IsOnShip()
@@ -118,6 +117,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         #endregion
+
         #region Private Fields
 
         private TransportModes mode = TransportModes.Foot;
@@ -235,21 +235,6 @@ namespace DaggerfallWorkshop.Game
                 {
                     dfAudioSource.AudioSource.PlayOneShot(neighClip, RidingVolumeScale * DaggerfallUnity.Settings.SoundVolume);
                     neighTime = Time.time + Random.Range(2, 40);
-                }
-            }
-
-            if (InputManager.Instance.ActionComplete(InputManager.Actions.MountHorse))
-            {
-                if (GameManager.Instance.IsPlayerInside)
-                {
-                    DaggerfallUI.AddHUDText(HardStrings.cannotChangeTransportationIndoors);
-                }
-                else
-                {
-                    if (GameManager.Instance.PlayerController.isGrounded)
-                    {
-                        ToggleHorse();
-                    }
                 }
             }
         }

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -100,7 +100,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Mounts a horse or cart if available if on foot, otherwise gets on foot
         /// </summary>
-        public void ToggleHorse()
+        public void ToggleMount()
         {
             if (TransportMode == TransportModes.Horse || TransportMode == TransportModes.Cart)
             {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -77,9 +77,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // What transport options does the player have?
             ItemCollection inventory = GameManager.Instance.PlayerEntity.Items;
-            bool hasHorse = inventory.Contains(ItemGroups.Transportation, (int) Transportation.Horse);
-            bool hasCart = inventory.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart);
-            bool hasShip = DaggerfallBankManager.OwnsShip;
+            bool hasHorse = GameManager.Instance.TransportManager.HasHorse();
+            bool hasCart = GameManager.Instance.TransportManager.HasCart();
+            bool hasShip = GameManager.Instance.TransportManager.HasShip();
 
             // Load all textures
             LoadTextures();


### PR DESCRIPTION
Implementation of a horse mount (or dismount when already on a horse/cart) for G key. This required some changes to the `TransportManager` to make sure transportation change conditions are kept in sync via a public API. `ToggleMount()` can easily mount or dismount a horse if conditions are met.

I can optionally get rid of the G key shortcut, if wanted.

NOTE:
Call to `ToggleMount()` works even inside of buildings or dungeons. This behaviour was kept intentionally to allow mods to use mounts even inside interiors. Of course, the front-end logic defaults to classic behaviour and only allows you to toggle mount in the exterior.

Introduced an option in the Enhancements section called `HorseMountShortcut`.