### PR TITLE
Improve KeyBind data handling

### DIFF
--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -38,6 +38,7 @@ namespace DaggerfallWorkshop.Game
 
         KeyCode[] reservedKeys = new KeyCode[] { KeyCode.Escape, KeyCode.BackQuote };
         Dictionary<KeyCode, Actions> actionKeyDict = new Dictionary<KeyCode, Actions>();
+        Dictionary<KeyCode, string> unknownActions = new Dictionary<KeyCode, string>();
         List<Actions> currentActions = new List<Actions>();
         List<Actions> previousActions = new List<Actions>();
         bool isPaused;
@@ -64,7 +65,7 @@ namespace DaggerfallWorkshop.Game
         [fsObject("v1")]
         public class KeyBindData_v1
         {
-            public Dictionary<KeyCode, Actions> actionKeyBinds;
+            public Dictionary<KeyCode, string> actionKeyBinds;
         }
 
         #endregion
@@ -187,6 +188,10 @@ namespace DaggerfallWorkshop.Game
 
             QuickSave,
             QuickLoad,
+
+
+            MountHorse,
+            Unknown,
         }
 
         #endregion
@@ -452,7 +457,20 @@ namespace DaggerfallWorkshop.Game
             string path = GetKeyBindsSavePath();
 
             KeyBindData_v1 keyBindsData = new KeyBindData_v1();
-            keyBindsData.actionKeyBinds = actionKeyDict;
+            keyBindsData.actionKeyBinds = new Dictionary<KeyCode, string>();
+
+            foreach (var item in actionKeyDict)
+            {
+                keyBindsData.actionKeyBinds.Add(item.Key, item.Value.ToString());
+            }
+
+            // If unknown actions were detected in this run, make sure we append them back to the settings file, so we won't break
+            // the newer builds potentially using them.
+            foreach (var item in unknownActions)
+            {
+                keyBindsData.actionKeyBinds.Add(item.Key, item.Value);
+            }
+
             string json = SaveLoadManager.Serialize(keyBindsData.GetType(), keyBindsData);
             File.WriteAllText(path, json);
             RaiseSavedKeyBindsEvent();
@@ -518,6 +536,8 @@ namespace DaggerfallWorkshop.Game
 
             SetBinding(KeyCode.F9, Actions.QuickSave);
             SetBinding(KeyCode.F12, Actions.QuickLoad);
+
+            SetBinding(KeyCode.G, Actions.MountHorse);
         }
 
         #endregion
@@ -623,6 +643,8 @@ namespace DaggerfallWorkshop.Game
 
             TestSetBinding(KeyCode.F9, Actions.QuickSave);
             TestSetBinding(KeyCode.F12, Actions.QuickLoad);
+
+            TestSetBinding(KeyCode.G, Actions.MountHorse);
         }
 
         // Apply force to horizontal axis
@@ -754,10 +776,33 @@ namespace DaggerfallWorkshop.Game
             KeyBindData_v1 keyBindsData = SaveLoadManager.Deserialize(typeof(KeyBindData_v1), json) as KeyBindData_v1;
             foreach(var item in keyBindsData.actionKeyBinds)
             {
-                if (!actionKeyDict.ContainsKey(item.Key))
-                    actionKeyDict.Add(item.Key, item.Value);
+                var actionVal = ActionNameToEnum(item.Value);
+                if (!actionKeyDict.ContainsKey(item.Key) && actionVal != Actions.Unknown)
+                    actionKeyDict.Add(item.Key, actionVal);
+                else
+                {
+                    // This action is unknown in this game, make sure we still keep it so once we save the settings, we
+                    // won't discard them.
+                    unknownActions.Add(item.Key, item.Value);
+                }
             }
             RaiseLoadedKeyBindsEvent();
+        }
+
+        static Actions ActionNameToEnum(string value)
+        {
+            Actions action;
+
+            try
+            {
+                action = (Actions) Enum.Parse(typeof(Actions), value, true);
+                return action;
+            }
+            catch (ArgumentException)
+            {
+                DaggerfallUnity.LogMessage("Unknown key action detected: " + value, true);
+                return Actions.Unknown;
+            }
         }
 
         #endregion


### PR DESCRIPTION
This PR tries to tackle issues mentioned by https://github.com/Interkarma/daggerfall-unity/pull/1320#issuecomment-499596177 by adding simple error resolution measurements to ensure backward and forward compatibility of the game.

Unknown actions will now be ignored by the `InputManager`, but kept in memory, so we can store them back to the settings file once we rebuild it.