### PR TITLE
[SaveLoadManager] Delete Notebook File

### DIFF
--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -312,6 +312,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             File.Delete(Path.Combine(path, factionDataFilename));
             File.Delete(Path.Combine(path, questDataFilename));
             File.Delete(Path.Combine(path, bioFileName));
+            File.Delete(Path.Combine(path, notebookDataFilename));
             if (ModManager.Instance != null)
             {
                 foreach (Mod mod in ModManager.Instance.GetAllModsWithSaveData())


### PR DESCRIPTION
PR adds the notebook to deleted files.

Noticed in unity that save folders were not being deleted because they weren't empty. Found they all had one NotebookData.txt file. Adding this line removed the folders and logging errors.