### PR TITLE
Spell merchant consistency

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Vector2 spellNameLabelPos = new Vector2(123, 2);
         Vector2 spellPointsLabelPos = new Vector2(214, 2);
         Vector2 spellCostLabelPos = new Vector2(76, 154);
+        Vector2 goldLabelPos = new Vector2(116, 154);
 
         Rect mainPanelRect = new Rect(0, 0, 259, 164);
         Rect spellsListBoxRect = new Rect(5, 13, 110, 130);
@@ -76,6 +77,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         TextLabel spellNameLabel;
         TextLabel spellPointsLabel;
         TextLabel spellCostLabel;
+        TextLabel goldLabel;
         TextLabel[] spellEffectLabels;
 
         SpellIconPickerWindow iconPicker;
@@ -434,6 +436,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 spellCostLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, spellCostLabelPos, string.Empty, mainPanel);
                 spellCostLabel.ShadowPosition = Vector2.zero;
+                goldLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, goldLabelPos, string.Empty, mainPanel);
+                goldLabel.ShadowPosition = Vector2.zero;
+                UpdateGold();
             }
 
             // Spell points
@@ -459,6 +464,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 spellEffectPanels[i / 2].Components.Add(spellEffectLabels[i]);
             }
+        }
+
+        void UpdateGold()
+        {
+            goldLabel.Text = GameManager.Instance.PlayerEntity.GetGoldAmount().ToString();
         }
 
         void UpdateSelection()
@@ -910,6 +920,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 // Add to player entity spellbook
                 GameManager.Instance.PlayerEntity.AddSpell(offeredSpells[spellsListBox.SelectedIndex]);
+                UpdateGold();
             }
             CloseWindow();
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -102,7 +102,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const SoundClips closeSpellBook = SoundClips.PageTurn;
 
         bool buyMode = false;
-        bool autoClose = false;
         EffectBundleSettings renamedSpellSettings;
         int deleteSpellIndex = -1;
         KeyCode toggleClosedBinding;
@@ -329,7 +328,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             spellsListBox.MaxCharacters = 22;
             spellsListBox.OnSelectItem += SpellsListBox_OnSelectItem;
             if (buyMode)
-                spellsListBox.OnMouseDoubleClick += SpellsListBox_OnMouseDoubleClick;
+                spellsListBox.OnMouseDoubleClick += BuyButton_OnMouseClick;
             else
                 spellsListBox.OnUseSelectedItem += SpellsListBox_OnUseSelectedItem;
             spellsListBox.OnMouseScrollDown += SpellsListBox_OnMouseScroll;
@@ -868,18 +867,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void BuyButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            autoClose = false;
-            BuySpellHandler();
-        }
-
-        private void SpellsListBox_OnMouseDoubleClick(BaseScreenComponent sender, Vector2 position)
-        {
-            autoClose = true;
-            BuySpellHandler();
-        }
-
-        private void BuySpellHandler()
-        {
             const int tradeMessageBaseId = 260;
             const int notEnoughGoldId = 454;
             int tradePrice = GetTradePrice();
@@ -924,13 +911,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // Add to player entity spellbook
                 GameManager.Instance.PlayerEntity.AddSpell(offeredSpells[spellsListBox.SelectedIndex]);
             }
-            if (autoClose)
-            {
-                // Drop back to HUD like classic
-                DaggerfallUI.Instance.PopToHUD();
-            }
-            else
-                CloseWindow();
+            CloseWindow();
         }
 
         #endregion


### PR DESCRIPTION
Thinking again about an old patch (#1063), I think it makes more sense to make spell merchant window behavior consistent with all others, and not close on double-click.
On the other hand, display available money since that's an important information for the player. It lands perfectly at the right of cost, just like in standard merchants interface.
