### PR TITLE
Make NPC greetings selection match classic

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -883,6 +883,30 @@ namespace DaggerfallConnect.Arena2
             }
         }
 
+        /// <summary>
+        /// Check if a faction is another faction ally.
+        /// </summary>
+        /// <param name="firstFaction">The faction to check the allies of.</param>
+        /// <param name="secondFaction">The potential allied faction.</param>
+        /// <returns>True if factions are allied, otherwise false.</returns>
+        public static bool IsAlly(ref FactionData firstFaction, ref FactionData secondFaction)
+        {
+            return firstFaction.ally1 == secondFaction.id || firstFaction.ally2 == secondFaction.id ||
+                   firstFaction.ally3 == secondFaction.id;
+        }
+
+        /// <summary>
+        /// Check if a faction is another faction enemy.
+        /// </summary>
+        /// <param name="firstFaction">The faction to check the enemies of.</param>
+        /// <param name="secondFaction">The potential enemy faction.</param>
+        /// <returns></returns>
+        public static bool IsEnemy(ref FactionData firstFaction, ref FactionData secondFaction)
+        {
+            return firstFaction.enemy1 == secondFaction.id || firstFaction.enemy2 == secondFaction.id ||
+                   firstFaction.enemy3 == secondFaction.id;
+        }
+
         #endregion
 
         #region Private Methods

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -1139,6 +1139,15 @@ namespace DaggerfallWorkshop.Game
             return messageBox;
         }
 
+        public static DaggerfallMessageBox MessageBox(TextFile.Token[] tokens, IMacroContextProvider mcp = null)
+        {
+            DaggerfallMessageBox messageBox = new DaggerfallMessageBox(Instance.uiManager, Instance.uiManager.TopWindow);
+            messageBox.SetTextTokens(tokens, mcp);
+            messageBox.ClickAnywhereToClose = true;
+            messageBox.Show();
+            return messageBox;
+        }
+
         public static Texture2D CreateSolidTexture(Color color, int dim)
         {
             Texture2D texture = null;

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -291,6 +291,19 @@ namespace DaggerfallWorkshop.Game.Player
         }
 
         /// <summary>
+        /// Gets faction name from id.
+        /// </summary>
+        /// <param name="id">ID of faction to get name of.</param>
+        /// <returns>Faction name if name found, otherwise an empty string.</returns>
+        public string GetFactionName(int id)
+        {
+            if (factionDict.ContainsKey(id))
+                return factionDict[id].name;
+
+            return string.Empty;
+        }
+
+        /// <summary>
         /// Resets faction state back to starting point from FACTION.TXT.
         /// </summary>
         public void Reset()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -634,7 +634,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 listboxConversation.ClearItems();
 
                 ListBox.ListItem textLabelNPCGreeting;
-                listboxConversation.AddItem(TalkManager.Instance.GetNPCGreetingText(), out textLabelNPCGreeting);
+                listboxConversation.AddItem(TalkManager.Instance.NPCGreetingText, out textLabelNPCGreeting);
                 textLabelNPCGreeting.selectedTextColor = textcolorHighlighted;
                 textLabelNPCGreeting.textLabel.HorizontalAlignment = HorizontalAlignment.Left;
                 textLabelNPCGreeting.textLabel.HorizontalTextAlignment = TextLabel.HorizontalTextAlignmentSetting.Left;

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -72,7 +72,7 @@ namespace DaggerfallWorkshop.Utility
             { "%crn", CurrentRegion }, // Current Region
             { "%ct", CityType }, // City type? e.g city, town, village?
             { "%dae", Daedra }, // A daedra
-            { "%dam", DmgMod }, // Damage modifyer
+            { "%dam", DmgMod }, // Damage modifier
             { "%dat", Date }, // Date
             { "%di", LocationDirection },  // Direction
             { "%dip", DaysInPrison }, // Days in prison
@@ -82,17 +82,19 @@ namespace DaggerfallWorkshop.Utility
             { "%ef", null },  // Local shop name
             { "%enc", EncumbranceMax }, // Encumbrance
             { "%end", End }, // Amount of Endurance
+            { "%fa", FactionAlly }, // faction which is both PC and NPC ally (used for greetings)
+            { "%fae", FactionAllyEnemy }, // faction which is PC ally and NPC enemy (used for greetings)
             { "%fcn", LocationOfRegionalBuilding }, // Location with regional building asked about
-            { "%fe", null },  // ?
-            { "%fea", null }, // ?
+            { "%fe", FactionEnemy }, // faction which is both PC and NPC enemy (used for greetings)
+            { "%fea", FactionEnemyAlly }, // faction which is PC enemy and NPC ally (used for greetings)
             { "%fl1", LordOfFaction1 }, // Lord of _fx1
             { "%fl2", LordOfFaction2 }, // Lord of _fx2
             { "%fn", FemaleName },  // Random first name (Female)
             { "%fn2", FemaleFullname }, // Random full name (Female)
-            { "%fnpc", GuildNPC }, // faction of npc that is dialog partner
+            { "%fnpc", FactionNPC }, // faction of npc that is dialog partner
             { "%fon", FactionOrderName }, // Faction order name
             { "%fpa", FactionName }, // faction name? of dialog partner - should return "Kynareth" for npc that are members of "Temple of Kynareth"
-            { "%fpc", FactionPC }, // faction of pc that is from importance to dialog partner (same as his faction)
+            { "%fpc", FactionPC }, // PC faction used for guild related greetings
             { "%fx1", AFactionInNews }, // A faction in news
             { "%fx2", AnotherFactionInNews }, // Another faction in news
             { "%g", Pronoun },   // He/She etc...
@@ -826,14 +828,34 @@ namespace DaggerfallWorkshop.Utility
             return ""; // return empty string for now - not known if it does something else in classic
         }
 
+        private static string FactionAlly(IMacroContextProvider mcp)
+        {   // %fa
+            return GameManager.Instance.TalkManager.GetFactionNPCAlly();
+        }
+
+        private static string FactionEnemy(IMacroContextProvider mcp)
+        {   // %fe
+            return GameManager.Instance.TalkManager.GetFactionNPCEnemy();
+        }
+
+        private static string FactionAllyEnemy(IMacroContextProvider mcp)
+        {   // %fae
+            return GameManager.Instance.TalkManager.GetFactionNPCEnemy();
+        }
+
+        private static string FactionEnemyAlly(IMacroContextProvider mcp)
+        {   // %fea
+            return GameManager.Instance.TalkManager.GetFactionNPCAlly();
+        }
+
         private static string FactionPC(IMacroContextProvider mcp)
         {   // %fpc
             return GameManager.Instance.TalkManager.GetFactionPC();
         }
 
-        private static string GuildNPC(IMacroContextProvider mcp)
+        private static string FactionNPC(IMacroContextProvider mcp)
         {   // %fnpc
-            return GameManager.Instance.TalkManager.GetGuildNPC();
+            return GameManager.Instance.TalkManager.GetFactionNPC();
         }
 
         private static string FactionName(IMacroContextProvider mcp)


### PR DESCRIPTION
Make the greeting text selection process the same as in classic, with some improvements and a few bug fixes. To do this, I reverse engineered the 3 classic functions used to get the greeting text.

Now to explain the changes I made: in classic, a faction related (mostly guild related in fact) greeting is selected each time the player talks to an NPC which is not a member of a faction of type 14 or 15, i.e. "Court of" or "People of" current region. Then, the correct greeting text is given by checking all player guild affiliations, especially guild enemies and allies. I did the same in DFU, fixing two bugs of the original function.

I also improved the overall selection process in two ways:
- I decided to exclude unique NPCs whose first parent is a province, as this gave weird greetings in classic. Because these unique NPCs are not members of a guild or guild-like faction, in classic, they could greet the player with sentences beginning with "As a member of Sentinel..." and other inadequate text. Now in DFU, all NPCs belonging to province children factions (this includes children of children), apart from Knightly Orders, will greet the player like all common people would do.
- One other improvement over classic is also to filter the usual "Well met, stranger" greeting (record 8570), which is always fired when the faction of an NPC is unrelated to all player current guilds. This, even if player current reputation with the NPC faction (e.g. The Merchants or The Bards) is very good. So, I restricted this boring greeting to NPCs for which player reputation with their respective faction is below or equal to 5. So, when the player can really be considered a stranger to the NPC he is talking to. In other cases, NPCs of such factions will use common people greetings. I tested it in game and this is much better in my opinion.