### PR TITLE
Spawn guards after rifling through private property

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -694,6 +694,11 @@ namespace DaggerfallWorkshop.Game
                 GameManager.Instance.PlayerEntity.TallyCrimeGuildRequirements(true, 1);
                 Debug.Log("Player crime detected: rifling through private property!!");
 
+                // Send the guards
+                PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+                playerEntity.CrimeCommitted = PlayerEntity.Crimes.Theft;
+                playerEntity.SpawnCityGuards(true);
+
                 // Open inventory window with activated private container as remote target (pre-set)
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
             }


### PR DESCRIPTION
This triggers the guard spawner after the player says "yes" to the "This looks like private property" dialog box.  Shop interiors are relatively small so the spawner doesn't always find a minimum distance, especially in one-room shops.

I'm thinking of doing an overhaul of interior guard spawns so they are handled in a more reliable way that also makes more gameplay sense.  I'll do that in a separate PR unless you would like to have that in this one.