### PR TITLE
adjust TilemapTextureArray mipmap levels to remove most aliasing

### DIFF
--- a/Assets/Shaders/DaggerfallTilemapTextureArray.shader
+++ b/Assets/Shaders/DaggerfallTilemapTextureArray.shader
@@ -99,28 +99,11 @@ Shader "Daggerfall/TilemapTextureArray" {
 			//half4 c = UNITY_SAMPLE_TEX2DARRAY_GRAD(_TileTexArr, uv3, ddx(uv3), ddy(uv3)); // (see https://forum.unity3d.com/threads/texture2d-array-mipmap-troubles.416799/)
 			// since there is currently a bug with seams when using the UNITY_SAMPLE_TEX2DARRAY_GRAD function in unity, this is used as workaround
 			// mip map level is selected manually dependent on fragment's distance from camera
-			float scale = sqrt(_TileTexArr_TexelSize.x * 64.0f);
-			float scaledDist = distance(IN.worldPos.xyz, _WorldSpaceCameraPos.xyz) / scale;
+			float scale = sqrt(_TileTexArr_TexelSize.x * 64.0f) * 12.38;
+			float relativeHeight = max(_WorldSpaceCameraPos.y - IN.worldPos.y, 1.8);
+			float dist = distance(IN.worldPos.xyz, _WorldSpaceCameraPos.xyz);
 
-			float mipMapLevel;
-			if (scaledDist < 17.5f)
-				mipMapLevel = 0.0;
-			else if (scaledDist < 25.0f)
-				mipMapLevel = 1.0;
-			else if (scaledDist < 35.0f)
-				mipMapLevel = 2.0;
-			else if (scaledDist < 50.0f)
-				mipMapLevel = 3.0;
-			else if (scaledDist < 70.0f)
-				mipMapLevel = 4.0;
-			else if (scaledDist < 100.0f)
-				mipMapLevel = 5.0;
-			else if (scaledDist < 140.0f)
-				mipMapLevel = 6.0;
-			else if (scaledDist < 200.0f)
-				mipMapLevel = 7.0;
-			else
-				mipMapLevel = 8.0;
+			float mipMapLevel = clamp(2 * log2(dist / scale) - log2(relativeHeight / 1.8), 0, 8);
 			half4 c = UNITY_SAMPLE_TEX2DARRAY_LOD(_TileTexArr, uv3, mipMapLevel);
 
 			o.Albedo = c.rgb;

--- a/Assets/Shaders/DaggerfallTilemapTextureArray.shader
+++ b/Assets/Shaders/DaggerfallTilemapTextureArray.shader
@@ -47,6 +47,7 @@ Shader "Daggerfall/TilemapTextureArray" {
 		#endif
 
 		sampler2D _TilemapTex;
+		float4 _TileTexArr_TexelSize;
 		int _MaxIndex;
 		int _TilemapDim;
 
@@ -98,24 +99,25 @@ Shader "Daggerfall/TilemapTextureArray" {
 			//half4 c = UNITY_SAMPLE_TEX2DARRAY_GRAD(_TileTexArr, uv3, ddx(uv3), ddy(uv3)); // (see https://forum.unity3d.com/threads/texture2d-array-mipmap-troubles.416799/)
 			// since there is currently a bug with seams when using the UNITY_SAMPLE_TEX2DARRAY_GRAD function in unity, this is used as workaround
 			// mip map level is selected manually dependent on fragment's distance from camera
-			float dist = distance(IN.worldPos.xyz, _WorldSpaceCameraPos.xyz);
-			
+			float scale = sqrt(_TileTexArr_TexelSize.x * 64.0f);
+			float scaledDist = distance(IN.worldPos.xyz, _WorldSpaceCameraPos.xyz) / scale;
+
 			float mipMapLevel;
-			if (dist < 4.375f)
+			if (scaledDist < 17.5f)
 				mipMapLevel = 0.0;
-			else if (dist < 6.25f)
+			else if (scaledDist < 25.0f)
 				mipMapLevel = 1.0;
-			else if (dist < 8.75f)
+			else if (scaledDist < 35.0f)
 				mipMapLevel = 2.0;
-			else if (dist < 12.5f)
+			else if (scaledDist < 50.0f)
 				mipMapLevel = 3.0;
-			else if (dist < 17.5f)
+			else if (scaledDist < 70.0f)
 				mipMapLevel = 4.0;
-			else if (dist < 25.0f)
+			else if (scaledDist < 100.0f)
 				mipMapLevel = 5.0;
-			else if (dist < 35.0f)
+			else if (scaledDist < 140.0f)
 				mipMapLevel = 6.0;
-			else if (dist < 50.0f)
+			else if (scaledDist < 200.0f)
 				mipMapLevel = 7.0;
 			else
 				mipMapLevel = 8.0;

--- a/Assets/Shaders/DaggerfallTilemapTextureArray.shader
+++ b/Assets/Shaders/DaggerfallTilemapTextureArray.shader
@@ -101,21 +101,21 @@ Shader "Daggerfall/TilemapTextureArray" {
 			float dist = distance(IN.worldPos.xyz, _WorldSpaceCameraPos.xyz);
 			
 			float mipMapLevel;
-			if (dist < 10.0f)
+			if (dist < 4.375f)
 				mipMapLevel = 0.0;
-			else if (dist < 25.0f)
+			else if (dist < 6.25f)
 				mipMapLevel = 1.0;
-			else if (dist < 50.0f)
+			else if (dist < 8.75f)
 				mipMapLevel = 2.0;
-			else if (dist < 125.0f)
+			else if (dist < 12.5f)
 				mipMapLevel = 3.0;
-			else if (dist < 250.0f)
+			else if (dist < 17.5f)
 				mipMapLevel = 4.0;
-			else if (dist < 500.0f)
+			else if (dist < 25.0f)
 				mipMapLevel = 5.0;
-			else if (dist < 1000.0f)
+			else if (dist < 35.0f)
 				mipMapLevel = 6.0;
-			else if (dist < 10000.0f)
+			else if (dist < 50.0f)
 				mipMapLevel = 7.0;
 			else
 				mipMapLevel = 8.0;


### PR DESCRIPTION
I did perceptual tests on modded terrain textures, then some analysis, using DREAM RC4 and no post processing mod on my screen (1080p).

First I checked that a mipmap level of 8.0 looked smooth in the distance: that works.
Then I checked how far the transition between level 7.0 and 8.0 could be pushed away before aliasing appears. In my tests, 50.0 was about right.
Then I checked how far the transition between level 0.0 and 7.0 could be pushed away before aliasing appears. In my tests, 4.5 was close to the max.

But what's the scale between the two? I assume the goal is to keep the angular diameter of pixels about constant. Pixel widths varies according to 1/d, but their height decreases faster because the surface also appears more and more tilted (from camera point of view).
I spare you the details, but height seems to vary in 1/d².

Mipmap scale is logarithmic (vs pixel size), so you end up with level = const - 2*log2(d)

In other words, you should gain one mipmap level each time the distance increases by a sqrt(2) factor.
And it matches almost perfectly with the two bounds found perceptually!

However I don't know how my perceptual tests are portable to other systems...

Forums: https://forums.dfworkshop.net/viewtopic.php?f=27&t=1168&p=25573#p25573