### PR TITLE
Refine indoor guard spawns and private property theft

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -641,7 +641,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         }
                     }
 
-                    // If no guards spawned from nearby NPCs, handle special spawn cases
+                    // If no guards spawned from nearby NPCs, spawn randomly with a foeSpawner
                     if (guardsSpawnedFromNPCs == 0)
                     {
                         // If the player is inside an open shop then spawn guards at the ground-level door of the building

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -624,10 +624,28 @@ namespace DaggerfallWorkshop.Game.Entity
                         }
                     }
 
-                    // If no guards spawned from nearby NPCs, spawn randomly with a foeSpawner
+                    // If no guards spawned from nearby NPCs, handle special spawn cases
                     if (guardsSpawnedFromNPCs == 0)
                     {
-                        GameObjectHelper.CreateFoeSpawner(true, MobileTypes.Knight_CityWatch, UnityEngine.Random.Range(2, 5 + 1), 12.8f, 51.2f);
+                        // If the player is inside an open shop then spawn guards at the ground-level door of the building
+                        if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideOpenShop)
+                        {
+                            Vector3 lowestDoorPos;
+                            Vector3 lowestDoorNormal;
+                            if (GameManager.Instance.PlayerEnterExit.Interior.FindLowestInteriorDoor(out lowestDoorPos, out lowestDoorNormal))
+                            {
+                                lowestDoorPos += lowestDoorNormal * (GameManager.Instance.PlayerController.radius + 0.1f);
+                                int guardCount = UnityEngine.Random.Range(1, 3);
+                                for (int i = 0; i < guardCount; i++)
+                                {
+                                    SpawnCityGuard(lowestDoorPos, Vector3.forward);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            GameObjectHelper.CreateFoeSpawner(true, MobileTypes.Knight_CityWatch, UnityEngine.Random.Range(2, 5 + 1), 12.8f, 51.2f);
+                        }
                     }
                 }
                 else

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -584,6 +584,23 @@ namespace DaggerfallWorkshop.Game.Entity
             // Only spawn if player is not in a dungeon, and if there are 10 or fewer existing guards
             if (!GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && GameManager.Instance.HowManyEnemiesOfType(MobileTypes.Knight_CityWatch, false, true) <= 10)
             {
+                // Handle indoor guard spawning
+                if (GameManager.Instance.PlayerEnterExit.IsPlayerInside && GameManager.Instance.PlayerEnterExit.IsPlayerInsideOpenShop)
+                {
+                    Vector3 lowestDoorPos;
+                    Vector3 lowestDoorNormal;
+                    if (GameManager.Instance.PlayerEnterExit.Interior.FindLowestInteriorDoor(out lowestDoorPos, out lowestDoorNormal))
+                    {
+                        lowestDoorPos += lowestDoorNormal * (GameManager.Instance.PlayerController.radius + 0.1f);
+                        int guardCount = UnityEngine.Random.Range(2, 6);
+                        for (int i = 0; i < guardCount; i++)
+                        {
+                            SpawnCityGuard(lowestDoorPos, Vector3.forward);
+                        }
+                    }
+                    return;
+                }
+
                 DaggerfallLocation dfLocation = GameManager.Instance.StreamingWorld.CurrentPlayerLocationObject;
                 if (dfLocation == null)
                     return;
@@ -628,24 +645,7 @@ namespace DaggerfallWorkshop.Game.Entity
                     if (guardsSpawnedFromNPCs == 0)
                     {
                         // If the player is inside an open shop then spawn guards at the ground-level door of the building
-                        if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideOpenShop)
-                        {
-                            Vector3 lowestDoorPos;
-                            Vector3 lowestDoorNormal;
-                            if (GameManager.Instance.PlayerEnterExit.Interior.FindLowestInteriorDoor(out lowestDoorPos, out lowestDoorNormal))
-                            {
-                                lowestDoorPos += lowestDoorNormal * (GameManager.Instance.PlayerController.radius + 0.1f);
-                                int guardCount = UnityEngine.Random.Range(1, 3);
-                                for (int i = 0; i < guardCount; i++)
-                                {
-                                    SpawnCityGuard(lowestDoorPos, Vector3.forward);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            GameObjectHelper.CreateFoeSpawner(true, MobileTypes.Knight_CityWatch, UnityEngine.Random.Range(2, 5 + 1), 12.8f, 51.2f);
-                        }
+                        GameObjectHelper.CreateFoeSpawner(true, MobileTypes.Knight_CityWatch, UnityEngine.Random.Range(2, 5 + 1), 12.8f, 51.2f);
                     }
                 }
                 else

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -644,7 +644,6 @@ namespace DaggerfallWorkshop.Game.Entity
                     // If no guards spawned from nearby NPCs, spawn randomly with a foeSpawner
                     if (guardsSpawnedFromNPCs == 0)
                     {
-                        // If the player is inside an open shop then spawn guards at the ground-level door of the building
                         GameObjectHelper.CreateFoeSpawner(true, MobileTypes.Knight_CityWatch, UnityEngine.Random.Range(2, 5 + 1), 12.8f, 51.2f);
                     }
                 }

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -24,6 +24,7 @@ using DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects;
 using System.Collections.Generic;
 using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game.Utility;
+using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -633,6 +634,7 @@ namespace DaggerfallWorkshop.Game
                     // If no contents, do nothing
                     if (loot.Items.Count == 0)
                         return;
+                    loot.houseOwned = true;
                     DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, DaggerfallMessageBox.CommonMessageBoxButtons.YesNo, PrivatePropertyId, uiManager.TopWindow);
                     messageBox.OnButtonClick += PrivateProperty_OnButtonClick;
                     uiManager.PushWindow(messageBox);
@@ -690,15 +692,6 @@ namespace DaggerfallWorkshop.Game
             sender.CloseWindow();
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
             {
-                // Record player crime
-                GameManager.Instance.PlayerEntity.TallyCrimeGuildRequirements(true, 1);
-                Debug.Log("Player crime detected: rifling through private property!!");
-
-                // Send the guards
-                PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
-                playerEntity.CrimeCommitted = PlayerEntity.Crimes.Theft;
-                playerEntity.SpawnCityGuards(true);
-
                 // Open inventory window with activated private container as remote target (pre-set)
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
             }

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    Nystul, Hazelnut
+// Contributors:    Nystul, Hazelnut, Numidium
 // 
 // Notes:
 //
@@ -212,6 +212,29 @@ namespace DaggerfallWorkshop
             if (interiorDoors.FindClosestDoorToPlayer(playerPos, -1, out closestDoorPositionOut, out doorIndex))
             {
                 closestDoorNormalOut = interiorDoors.GetDoorNormal(doorIndex);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Finds the interior door that is closest to ground level.
+        /// </summary>
+        /// <param name="lowestDoorPositionOut">Position of lowest door in scene.</param>
+        /// <param name="lowestDoorNormalOut">Normal vector of lowest door in scene.</param>
+        /// <returns>True if successful.</returns>
+        public bool FindLowestInteriorDoor(out Vector3 lowestDoorPositionOut, out Vector3 lowestDoorNormalOut)
+        {
+            lowestDoorPositionOut = lowestDoorNormalOut = Vector3.zero;
+            DaggerfallStaticDoors interiorDoors = GetComponent<DaggerfallStaticDoors>();
+            if (!interiorDoors)
+                return false;
+
+            int doorIndex;
+            if (interiorDoors.FindLowestDoor(-1, out lowestDoorPositionOut, out doorIndex))
+            {
+                lowestDoorNormalOut = interiorDoors.GetDoorNormal(doorIndex);
                 return true;
             }
 

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -35,6 +35,7 @@ namespace DaggerfallWorkshop
         public int TextureArchive = 0;
         public int TextureRecord = 0;
         public bool playerOwned = false;
+        public bool houseOwned = false;
         public bool customDrop = false;         // Custom drop loot is not part of base scene and must be respawned on deserialization
         public bool isEnemyClass = false;
         public int stockedDate = 0;

--- a/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
+++ b/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Numidium
 // 
 // Notes:
 //
@@ -133,6 +133,44 @@ namespace DaggerfallWorkshop
                         doorPosOut = centre;
                         doorIndexOut = i;
                         minDistance = distance;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Find lowest door position in world space.
+        /// </summary>
+        /// <param name="record">Door record index.</param>
+        /// <param name="doorPosOut">Position of closest door in world space.</param>
+        /// <param name="doorIndexOut">Door index in Doors array of closest door.</param>
+        /// <returns>Whether or not we found a door</returns>
+        public bool FindLowestDoor(int record, out Vector3 doorPosOut, out int doorIndexOut)
+        {
+            doorPosOut = Vector3.zero;
+            doorIndexOut = -1;
+
+            if (Doors == null)
+                return false;
+
+            // Find lowest door in interior
+            float lowestY = float.MaxValue;
+            for (int i = 0; i < Doors.Length; i++)
+            {
+                // Get this door centre in world space
+                Vector3 centre = transform.rotation * Doors[i].buildingMatrix.MultiplyPoint3x4(Doors[i].centre) + transform.position;
+
+                // Check if door belongs to same building record or accept any record
+                if (Doors[i].recordIndex == record || record == -1)
+                {
+                    float y = centre.y;
+                    if (y < lowestY)
+                    {
+                        doorPosOut = centre;
+                        doorIndexOut = i;
+                        lowestY = y;
                     }
                 }
             }


### PR DESCRIPTION
1. When in a shop, guards will now spawn at the lowest entrance.
2. Stealing private property now tallies Pickpocket and does a check against it.  If the check fails, guards are spawned and PC is accused of stealing.