### PR TITLE
Import spell icon packs from mods

### DIFF
--- a/Assets/Game/Addons/ModSupport/Editor/CreateModEditorWindow.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/CreateModEditorWindow.cs
@@ -14,6 +14,7 @@ using UnityEditor;
 using System;
 using System.IO;
 using System.Collections.Generic;
+using FullSerializer;
 
 
 /*
@@ -109,7 +110,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                     return new ModInfo();
 
                 string inPut = File.ReadAllText(currentFilePath);
-                info = (ModInfo)JsonUtility.FromJson(inPut, typeof(ModInfo));
+                ModManager._serializer.TryDeserialize(fsJsonParser.Parse(inPut), ref info).AssertSuccessWithoutWarnings();
                 if (string.IsNullOrEmpty(info.GUID) || info.GUID == "invalid")
                     info.GUID = System.Guid.NewGuid().ToString();
             }
@@ -379,7 +380,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             ModManager.SeekModContributes(modInfo);
 
             string path = currentFilePath;
-            string outPut = JsonUtility.ToJson(modInfo, true);
+            fsData fsData;
+            ModManager._serializer.TrySerialize(modInfo, out fsData).AssertSuccessWithoutWarnings();
+            string outPut = fsJsonPrinter.PrettyJson(fsData);
             string directory = "";
 
             if (!supressWindow)

--- a/Assets/Game/Addons/ModSupport/Editor/CreateModEditorWindow.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/CreateModEditorWindow.cs
@@ -376,6 +376,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         bool SaveModFile(bool supressWindow = false)
         {
+            ModManager.SeekModContributes(modInfo);
+
             string path = currentFilePath;
             string outPut = JsonUtility.ToJson(modInfo, true);
             string directory = "";

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -732,6 +732,43 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                 mod.MessageReceiver(message, data, callback);
         }
 
+#if UNITY_EDITOR
+        /// <summary>
+        /// Seeks asset contributes for the target mod, reading the folder name of each asset.
+        /// </summary>
+        /// <param name="modInfo">Manifest data for a mod, which will be filled with retrieved contributes.</param>
+        /// <remarks>
+        /// Assets are imported from loose files according to folder name,
+        /// for example all textures inside `SpellIcons` are considered icon atlases.
+        /// This method replicates the same behaviour for mods, doing all the hard work at build time.
+        /// Results are stored to json manifest file for performant queries at runtime.
+        /// </remarks>
+        public static void SeekModContributes(ModInfo modInfo)
+        {
+            List<string> spellIcons = null;
+
+            foreach (string file in modInfo.Files)
+            {
+                string directory = Path.GetDirectoryName(file);
+                if (directory.EndsWith("SpellIcons"))
+                {
+                    if (spellIcons == null)
+                        spellIcons = new List<string>();
+
+                    string name = Path.GetFileNameWithoutExtension(file);
+                    if (!spellIcons.Contains(name))
+                        spellIcons.Add(name);
+                }
+            }
+
+            if (spellIcons != null)
+            {
+                var contributes = modInfo.Contributes ?? (modInfo.Contributes = new ModContributes());
+                contributes.SpellIcons = spellIcons.ToArray();
+            }
+        }
+#endif
+
         #endregion
 
         #region Internal methods

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -270,6 +270,19 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         }
 
         /// <summary>
+        /// Gets all mods, in reverse order, that provide contributes that match the given filter.
+        /// </summary>
+        /// <param name="filter">A filter that accepts or rejects a mod; can be used to check if a contribute is present.</param>
+        /// <returns>An enumeration of mods with contributes.</returns>
+        internal IOrderedEnumerable<Mod> GetAllModsWithContributes(Predicate<ModContributes> filter = null)
+        {
+            return from mod in Mods
+                   where mod.ModInfo.Contributes != null && (filter == null || filter(mod.ModInfo.Contributes))
+                   orderby mod.LoadPriority descending
+                   select mod;
+        }
+
+        /// <summary>
         /// Get all asset names from mod
         /// </summary>
         /// <param name="modTitle">The title of a mod.</param>

--- a/Assets/Game/Addons/ModSupport/ModTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModTypes.cs
@@ -41,10 +41,37 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         public string GUID = "invalid";
         public List<string> Files;      //list of assets to add to mod (only used during creation)
 
+        /// <summary>
+        /// Automatic asset injections defined by manifest .json file.
+        /// These values are not available for edits from mods at runtime.
+        /// </summary>
+        [SerializeField]
+        internal ModContributes Contributes;
+
         public ModInfo()
         {
             Files = new List<string>();
         }
+    }
+
+    /// <summary>
+    /// Contributes provided by a mod to be injected in game.
+    /// </summary>
+    /// <remarks>
+    /// The purpose of this section of the manifest file is to signal the presence of additional
+    /// assets for the core game, which are imported automatically without the need of one-time
+    /// scripts for every mod, or even scripting knowledge on the modder side.
+    /// This class can be expanded over time as necessary but breaking changes should be avoided.
+    /// <remarks/>
+    [Serializable]
+    internal sealed class ModContributes
+    {
+        /// <summary>
+        /// Names of spell icon packs; each name corresponds to a <see cref="Texture2D"/>
+        /// asset and a <see cref="TextAsset"/> with `.json` extension.
+        /// </summary>
+        [SerializeField]
+        internal string[] SpellIcons;
     }
 
     public struct SetupOptions : IComparable<SetupOptions>

--- a/Assets/Scripts/Game/UserInterface/SpellIconCollection.cs
+++ b/Assets/Scripts/Game/UserInterface/SpellIconCollection.cs
@@ -12,11 +12,13 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Game.Utility.ModSupport;
 
 namespace DaggerfallWorkshop.Game.UserInterface
 {
@@ -228,42 +230,67 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // Start with all the atlases in the spell icons streaming assets path
             string sourcePath = Path.Combine(Application.streamingAssetsPath, sourceFolderName);
             string[] atlasPaths = Directory.GetFiles(sourcePath, "*.png");
-            if (atlasPaths == null || atlasPaths.Length == 0)
-                return;
-
-            // Read each atlas found and its metadata
-            foreach (string path in atlasPaths)
+            if (atlasPaths != null && atlasPaths.Length != 0)
             {
-                // Get source atlas
-                Texture2D atlasTexture = LoadAtlasTextureFromPNG(path);
-                if (atlasTexture == null)
+                // Read each atlas found and its metadata
+                foreach (string path in atlasPaths)
                 {
-                    Debug.LogWarningFormat("LoadSpellIconPacks(): Could not load spell icons atlas texture '{0}'", path);
-                    continue;
-                }
+                    // Get source atlas
+                    Texture2D atlasTexture = LoadAtlasTextureFromPNG(path);
+                    if (atlasTexture == null)
+                    {
+                        Debug.LogWarningFormat("LoadSpellIconPacks(): Could not load spell icons atlas texture '{0}'", path);
+                        continue;
+                    }
 
-                // Attempt to load metadata JSON file
-                SpellIconPack pack = null;
-                string packKey = Path.GetFileNameWithoutExtension(path);
-                string metadataFilename = packKey + ".txt";
-                string metadataPath = Path.Combine(sourcePath, metadataFilename);
-                if (File.Exists(metadataPath))
-                {
-                    // Try to load existing metadata and icons
-                    pack = ReadMetadata(metadataPath);
-                    LoadPackIcons(pack, atlasTexture, metadataPath);
-                }
-                else
-                {
-                    // Create empty metadata file if none found
-                    pack = CreateIconPackEmptyMetadata(atlasTexture, metadataPath);
-                    return;
-                }
+                    // Attempt to load metadata JSON file
+                    SpellIconPack pack = null;
+                    string packKey = Path.GetFileNameWithoutExtension(path);
+                    string metadataFilename = packKey + ".txt";
+                    string metadataPath = Path.Combine(sourcePath, metadataFilename);
+                    if (File.Exists(metadataPath))
+                    {
+                        // Try to load existing metadata and icons
+                        pack = ReadMetadata(metadataPath);
+                        if (!LoadPackIcons(pack, atlasTexture, metadataPath))
+                            continue;
+                    }
+                    else
+                    {
+                        // Create empty metadata file if none found
+                        pack = CreateIconPackEmptyMetadata(atlasTexture, metadataPath);
+                        return;
+                    }
 
-                // If pack is populated then add to dictionary
-                if (pack != null && pack.rowCount > 0 && pack.iconCount > 0 && pack.icons != null)
+                    // If pack is populated then add to dictionary
+                    if (pack != null && pack.rowCount > 0 && pack.iconCount > 0 && pack.icons != null)
+                    {
+                        spellIconPacks.Add(packKey, pack);
+                    }
+                }
+            }    
+
+            // Import icon packs from mods with load order
+            if (ModManager.Instance)
+            {
+                foreach (Mod mod in ModManager.Instance.GetAllModsWithContributes(x => x.SpellIcons != null))
                 {
-                    spellIconPacks.Add(packKey, pack);
+                    foreach (string packName in mod.ModInfo.Contributes.SpellIcons.Where(x => !spellIconPacks.ContainsKey(x)))
+                    {
+                        // Both atlas and metadata must be provided
+                        var atlas = mod.GetAsset<Texture2D>(packName);
+                        var metaData = mod.GetAsset<TextAsset>(packName + ".json");
+                        if (!atlas || !metaData)
+                        {
+                            Debug.LogWarningFormat("Failed to retrieve assets for icon pack {0} from {1}.", packName, mod.Title);
+                            continue;
+                        }
+
+                        // Add pack to dictionary
+                        var pack = SaveLoadManager.Deserialize(typeof(SpellIconPack), metaData.ToString()) as SpellIconPack;
+                        if (LoadPackIcons(pack, atlas) && pack.iconCount > 0)
+                            spellIconPacks.Add(packName, pack);
+                    }
                 }
             }
         }
@@ -295,7 +322,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             return pack;
         }
 
-        void CreateEmptyIconSettings(SpellIconPack pack, string path)
+        void CreateEmptyIconSettings(SpellIconPack pack, string path = null)
         {
             pack.icons = new SpellIconSettings[pack.iconCount];
             for (int i = 0; i < pack.iconCount; i++)
@@ -305,13 +332,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     index = i,
                 };
             }
-            WriteMetadata(pack, path);
+
+            if (path != null)
+                WriteMetadata(pack, path);
         }
 
-        void LoadPackIcons(SpellIconPack pack, Texture2D atlas, string path)
+        bool LoadPackIcons(SpellIconPack pack, Texture2D atlas, string path = null)
         {
             if (pack == null)
-                return;
+                return false;
 
             // Might need to generate empty icon settings for first time
             if (pack.icons == null)
@@ -319,6 +348,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             // Derive dimension of each icon from atlas width
             int dim = atlas.width / pack.rowCount;
+
+            // Check icons size
+            if (atlas.width % dim != 0 || atlas.height % dim != 0)
+            {
+                Debug.LogErrorFormat("Failed to extract icons from {0} because atlas size is not multiple of icons size.", pack.displayName);
+                return false;
+            }
 
             // Read icons to their own texture (remembering Unity textures are flipped vertically)
             int srcX = 0, srcY = atlas.height - dim;
@@ -338,6 +374,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     srcY -= dim;
                 }
             }
+
+            return true;
         }
 
         void WriteMetadata(SpellIconPack pack, string path)


### PR DESCRIPTION
Spell icon packs can be imported from mods when files are added to a folder name **SpellIcons**. During mod building, directory of selected files are matched and results, if any, are automatically added to `SpellIcons` array of `Contributes` property inside mod manifest file.

This process allows to provide icon packs (and possibly other assets in the future) in the same way for both mods and loose files, doing all the work at build-time rather than run-time where it could affect performance.

This is an example of a result manifest file.

```json
{
    "ModTitle": "Example Spell Icons pack",
    "ModVersion": "",
    "ModAuthor": "",
    "ContactInfo": "",
    "DFUnity_Version": "0.8",
    "ModDescription": "Adds a spell icons pack.",
    "GUID": "2f923d7b-b8e5-4db6-a535-6655896b87fc",
    "Files": [
        "Assets/Game/Addons/TestMod/SpellIcons/vmblast-test.png",
        "Assets/Game/Addons/TestMod/SpellIcons/vmblast-test.json"
    ],
    "Contributes": {
        "SpellIcons": [
            "vmblast-test"
        ]
    }
}
```