### PR TITLE
Ambient sounds spatialization

### DIFF
--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -174,20 +174,26 @@ namespace DaggerfallWorkshop.Game
 
         private void AmbientPlayOneShot(SoundClips clip, float volumeScale)
         {
-            AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
-            ambientAudioSource.spatialBlend = 0;
-            ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
+            if (!ambientAudioSource.isPlaying)
+            {
+                AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
+                ambientAudioSource.spatialBlend = 0;
+                ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
+            }
         }
 
 
         private void SpatializedPlayOneShot(SoundClips clip, Vector3 position, float volumeScale, float minDistance = 8f)
         {
-            AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
-            ambientAudioSource.transform.position = position;
-            ambientAudioSource.spatialBlend = 1f;
-            ambientAudioSource.minDistance = minDistance;
-            ambientAudioSource.maxDistance = minDistance * 8;
-            ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
+            if (!ambientAudioSource.isPlaying)
+            {
+                AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
+                ambientAudioSource.transform.position = position;
+                ambientAudioSource.spatialBlend = 1f;
+                ambientAudioSource.minDistance = minDistance;
+                ambientAudioSource.maxDistance = minDistance * 8;
+                ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
+            }
         }
 
         private float sqr(float x) 

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -179,11 +179,11 @@ namespace DaggerfallWorkshop.Game
             ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
         }
 
-        private void SpatializedPlayOneShot(SoundClips clip, Vector3 position, float volumeScale, float spatialBlend = 1f)
+        private void SpatializedPlayOneShot(SoundClips clip, Vector3 position, float volumeScale)
         {
             AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
             ambientAudioSource.transform.position = position;
-            ambientAudioSource.spatialBlend = spatialBlend;
+            ambientAudioSource.spatialBlend = 1f;
             ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
         }
 
@@ -206,12 +206,11 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
-        private void PlaySomewhereAround(SoundClips clip, float volumeScale, float spatialBlend = 1f)
+        private void PlaySomewhereAround(SoundClips clip, float volumeScale)
         {
-            //Debug.LogFormat("Playing clip {0}", clip.ToString());
             Vector3 randomPos = playerBehaviour.transform.position +
                 Random.onUnitSphere * 5.2f;
-            SpatializedPlayOneShot(clip, randomPos, volumeScale, spatialBlend);
+            SpatializedPlayOneShot(clip, randomPos, volumeScale);
         }
 
         private void PlaySomewhereOnHorizon(SoundClips clip, float volumeScale)
@@ -263,7 +262,7 @@ namespace DaggerfallWorkshop.Game
 
                 // Play ambient sound as a one-shot 3D sound
                 SoundClips clip = ambientSounds[index];
-                PlaySomewhereAround(clip, 10f, 0.25f);
+                PlaySomewhereAround(clip, 5f);
                 RaiseOnPlayEffectEvent(clip);
             }
         }

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -190,10 +190,15 @@ namespace DaggerfallWorkshop.Game
             ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
         }
 
+        private float sqr(float x) 
+        {
+            return x * x;
+        }
+
         private void PlaySomewhereAround(SoundClips clip, float volumeScale)
         {
             Vector3 randomPos = playerBehaviour.transform.position +
-                Random.onUnitSphere * Random.Range(10f, 20f);
+                Random.onUnitSphere * Mathf.Sqrt(Random.Range(sqr(10f), sqr(20f)));
             SpatializedPlayOneShot(clip, randomPos, volumeScale, 13f);
         }
 
@@ -201,7 +206,7 @@ namespace DaggerfallWorkshop.Game
         {
             // Somewhere around, 20° above horizon
             Vector3 randomPos = playerBehaviour.transform.position + 
-                Quaternion.AngleAxis(Random.Range(0f, 10000f), Vector3.up) * new Vector3(0.94f, 0.34f, 0f);
+                Quaternion.AngleAxis(Mathf.Sqrt(Random.Range(0f, sqr(10000f))), Vector3.up) * new Vector3(0.94f, 0.34f, 0f);
             SpatializedPlayOneShot(clip, randomPos, volumeScale, 3000f);
         }
 

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -136,7 +136,7 @@ namespace DaggerfallWorkshop.Game
                         waterSoundPosition.y = playerEnterExit.blockWaterLevel * -1 * MeshReader.GlobalScale;
                         waterSoundPosition.x += Random.Range(-3f, 3f);
                         waterSoundPosition.z += Random.Range(-3f, 3f);
-                        SpatializedPlayOneShot(SoundClips.WaterGentle, waterSoundPosition, 3f);
+                        SpatializedPlayOneShot(SoundClips.WaterGentle, waterSoundPosition, 1f);
                     }
 
                     // Chance to play water bubbles sound if player is underwater
@@ -179,45 +179,30 @@ namespace DaggerfallWorkshop.Game
             ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
         }
 
-        private void SpatializedPlayOneShot(SoundClips clip, Vector3 position, float volumeScale)
+
+        private void SpatializedPlayOneShot(SoundClips clip, Vector3 position, float volumeScale, float minDistance = 8f)
         {
             AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
             ambientAudioSource.transform.position = position;
             ambientAudioSource.spatialBlend = 1f;
+            ambientAudioSource.minDistance = minDistance;
+            ambientAudioSource.maxDistance = minDistance * 8;
             ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
-        }
-
-        private void RelativePlayOneShot(SoundClips clip, Vector3 relativePosition, float volumeScale)
-        {
-            AudioClip audioClip = dfAudioSource.GetAudioClip((int)clip);
-            ambientAudioSource.spatialBlend = 1f;
-            ambientAudioSource.PlayOneShotWhenReady(audioClip, volumeScale);
-            if (relativePositionCoroutine != null)
-                StopCoroutine(relativePositionCoroutine);
-            relativePositionCoroutine = StartCoroutine(UpdateAmbientSoundRelativePosition(relativePosition));
-        }
-
-        private IEnumerator UpdateAmbientSoundRelativePosition(Vector3 relativePosition)
-        {
-            while (ambientAudioSource.isPlaying)
-            {
-                ambientAudioSource.transform.position = playerBehaviour.transform.position + relativePosition;
-                yield return new WaitForEndOfFrame();
-            }
         }
 
         private void PlaySomewhereAround(SoundClips clip, float volumeScale)
         {
             Vector3 randomPos = playerBehaviour.transform.position +
-                Random.onUnitSphere * 5.2f;
-            SpatializedPlayOneShot(clip, randomPos, volumeScale);
+                Random.onUnitSphere * Random.Range(10f, 20f);
+            SpatializedPlayOneShot(clip, randomPos, volumeScale, 13f);
         }
 
         private void PlaySomewhereOnHorizon(SoundClips clip, float volumeScale)
         {
             // Somewhere around, 20° above horizon
-            Vector3 randomPos = Quaternion.AngleAxis(Random.Range(0f, 360f), Vector3.up) * new Vector3(0.94f, 0.34f, 0f);
-            RelativePlayOneShot(clip, randomPos, volumeScale);
+            Vector3 randomPos = playerBehaviour.transform.position + 
+                Quaternion.AngleAxis(Random.Range(0f, 10000f), Vector3.up) * new Vector3(0.94f, 0.34f, 0f);
+            SpatializedPlayOneShot(clip, randomPos, volumeScale, 3000f);
         }
 
         private void PlayEffects()
@@ -241,7 +226,7 @@ namespace DaggerfallWorkshop.Game
                 {
                     // Play ambient sound as a one-shot 3D sound
                     SoundClips clip = ambientSounds[index];
-                    PlaySomewhereOnHorizon(clip, 5f);
+                    PlaySomewhereOnHorizon(clip, 1f);
 
                     // AmbientPlayOneShot(clip, 5f);
                     RaiseOnPlayEffectEvent(clip);
@@ -262,7 +247,7 @@ namespace DaggerfallWorkshop.Game
 
                 // Play ambient sound as a one-shot 3D sound
                 SoundClips clip = ambientSounds[index];
-                PlaySomewhereAround(clip, 5f);
+                PlaySomewhereAround(clip, 1f);
                 RaiseOnPlayEffectEvent(clip);
             }
         }
@@ -338,7 +323,7 @@ namespace DaggerfallWorkshop.Game
                 yield return new WaitForSeconds(soundDelay);
 
             // Play sound effect
-            PlaySomewhereOnHorizon(clip, 5f);
+            PlaySomewhereOnHorizon(clip, 1f);
 
             // Raise event
             RaiseOnPlayEffectEvent(clip);
@@ -372,6 +357,7 @@ namespace DaggerfallWorkshop.Game
                     SoundClips.AmbientBirdCall,
                     SoundClips.AmbientDoorClose,
                 };
+                AmbientInteriorPresets();
             }
             else if (Presets == AmbientSoundPresets.Storm)
             {
@@ -381,6 +367,7 @@ namespace DaggerfallWorkshop.Game
                     SoundClips.StormLightningThunder,
                     SoundClips.StormThunderRoll,
                 };
+                AmbientExteriorPresets();
             }
             else if (Presets == AmbientSoundPresets.SunnyDay)
             {
@@ -389,6 +376,7 @@ namespace DaggerfallWorkshop.Game
                     SoundClips.BirdCall1,
                     SoundClips.BirdCall2,
                 };
+                AmbientExteriorPresets();
             }
             else
             {
@@ -396,6 +384,18 @@ namespace DaggerfallWorkshop.Game
             }
 
             lastPresets = Presets;
+        }
+
+        private void AmbientInteriorPresets()
+        {
+            // Wider spread angle because of environment reverberation
+            ambientAudioSource.spread = 45f;
+        }
+
+        private void AmbientExteriorPresets()
+        {
+            // Narroer spread angle because of lesser environment reverberation
+            ambientAudioSource.spread = 15f;
         }
 
         #endregion


### PR DESCRIPTION
use AudioSource's minDistance to play distant ambient sounds at correct volume

- Simplified thunder sound: instead of enforcing source direction using a coroutine, put the sound source much further and compensate with high minDistance.
- Sounds are not always located within minDistance, so there's some volume randomization that wasn't there before; That can be adjusted if you feel that volume so too often too low;
- Increase ambient AudioSource's 3D spread, so that the hear opposite to the sound source gets more input; Specially in dungeons, to simulate environment reverberation and increase perceived volume.

This is a minimal patch, for example only one ambient sound can be played at any moment (not that PlayOneShot cannot be used several times simultaneously on an AudioSource, but all sounds will share some parameters, like the 3D location). 
Unity has lots of untapped sound features, AudioMixerGroups, ReverbZones,...