### PR TITLE
Only allow wagon access on sight

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -554,6 +554,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else
                 SelectActionMode(ActionModes.Equip);
+                
+            if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && !allowDungeonWagonAccess)
+                DungeonWagonAccessProximityCheck();
         }
 
         public override void OnPush()
@@ -642,9 +645,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Update tracked weapons for setting equip delay
             SetEquipDelayTime(false);
-
-            if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && !allowDungeonWagonAccess)
-                DungeonWagonAccessProximityCheck();
 
             // Refresh window
             Refresh();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1046,9 +1046,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Set allow wagon access if close enough (10m) to exit.
             GameObject playerAdvancedGO = GameObject.Find("PlayerAdvanced");
             DaggerfallDungeon dungeon = GameManager.Instance.DungeonParent.GetComponentInChildren<DaggerfallDungeon>();
-            Vector3 exitVector = dungeon.StartMarker.transform.position - playerAdvancedGO.transform.position;
-            if (exitVector.magnitude < 10)
+            Vector3 exitVector = playerAdvancedGO.transform.position - dungeon.StartMarker.transform.position;
+            if (exitVector.magnitude < 2)
+                // fix bad case when you've just been spawned on StartMarker
                 allowDungeonWagonAccess = true;
+            else if (exitVector.magnitude < 10f)
+            {
+                RaycastHit hit;
+                Ray ray = new Ray(dungeon.StartMarker.transform.position, exitVector);
+                if (Physics.Raycast(ray, out hit))
+                {
+                    if (hit.transform.gameObject == playerAdvancedGO)
+                        allowDungeonWagonAccess = true;
+                }
+            }
         }
 
         void UpdateItemInfoPanel(DaggerfallUnityItem item)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -313,10 +313,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Setup initial state
             SelectTabPage(TabPages.WeaponsAndArmor);
-            if (lootTarget != null)
-                SelectActionMode(ActionModes.Remove);
-            else
-                SelectActionMode(ActionModes.Equip);
+            SetupDefaultActionMode();
 
             // Setup initial display
             FilterLocalItems();
@@ -545,6 +542,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
+        private void SetupDefaultActionMode()
+        {
+            if (lootTarget != null)
+                SelectActionMode(ActionModes.Remove);
+            // Start with wagon if accessing from dungeon
+            else if (allowDungeonWagonAccess)
+            {
+                ShowWagon(true);
+                SelectActionMode(ActionModes.Remove);
+            }
+            else
+                SelectActionMode(ActionModes.Equip);
+        }
+
         public override void OnPush()
         {
             // Racial override can suppress inventory
@@ -620,11 +631,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             if (IsSetup)
             {
-                // Start with wagon if accessing from dungeon
-                if (allowDungeonWagonAccess) {
-                    ShowWagon(true);
-                    SelectActionMode(ActionModes.Remove);
-                }
+                SetupDefaultActionMode();
                 // Reset item list scroll
                 localItemListScroller.ResetScroll();
                 remoteItemListScroller.ResetScroll();


### PR DESCRIPTION
Patch on top of #1341

There's probably still some bug, but I need to find a dungeon to test it:
Some dungeons have more than one exit door, but DungeonWagonAccessProximityCheck() checks the proximity to the StartMarker, not from a dungeon exit. If my hypothesis is correct, when DungeonExitWagonPrompt is disabled you cannot use those secondary exit doors to access your wagon.
