### PR TITLE
Faster noprompt wagon access

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1046,9 +1046,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Set allow wagon access if close enough (10m) to exit.
             GameObject playerAdvancedGO = GameObject.Find("PlayerAdvanced");
             DaggerfallDungeon dungeon = GameManager.Instance.DungeonParent.GetComponentInChildren<DaggerfallDungeon>();
-            Vector3 exitVector = dungeon.StartMarker.transform.position - playerAdvancedGO.transform.position;
-            if (exitVector.magnitude < 10)
+            Vector3 exitVector = playerAdvancedGO.transform.position - dungeon.StartMarker.transform.position;
+            if (exitVector.magnitude < 2)
+                // fix bad case when you've just been spawned on StartMarker
                 allowDungeonWagonAccess = true;
+            else if (exitVector.magnitude < 10f)
+            {
+                RaycastHit hit;
+                Ray ray = new Ray(dungeon.StartMarker.transform.position, exitVector);
+                if (Physics.Raycast(ray, out hit))
+                {
+                    if (hit.transform.gameObject == playerAdvancedGO)
+                        allowDungeonWagonAccess = true;
+                }
+            }
         }
 
         void UpdateItemInfoPanel(DaggerfallUnityItem item)


### PR DESCRIPTION
Patch on top of #1341 and #1342 

When opening the inventory by keypress near dungeon exit in no DungeonExitWagonPrompt mode, do not only allow access to the wagon but also auto-select it.
This makes this mode actually more convenient than prompt mode.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=12&t=2098&start=10#p26151
