### PR TITLE
Extend interior replacement for locations that share the same blockdata

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -212,7 +212,7 @@ namespace Wenzil.Console
                 DFBlock blockData = DaggerfallUnity.Instance.ContentReader.BlockFileReader.GetBlock(blockIndex);
                 if (blockData.Type == DFBlock.BlockTypes.Rmb)
                 {
-                    string fileName = WorldDataReplacement.GetBuildingReplacementFilename(blockData.Name, blockIndex, recordIndex);
+                    string fileName = WorldDataReplacement.GetBuildingInstanceReplacementFilename(blockData.Name, blockIndex, recordIndex);
                     BuildingReplacementData buildingData = new BuildingReplacementData()
                     {
                         RmbSubRecord = blockData.RmbBlock.SubRecords[recordIndex]

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Hazelnut
-// Contributors:
+// Contributors: Uncanny
 //
 
 using System.IO;
@@ -47,14 +47,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
         #endregion
 
-
         #region Fields & Properties
 
         const int noReplacementBT = -1;
         static readonly BuildingReplacementData noReplacementData = new BuildingReplacementData() { BuildingType = noReplacementBT };
-
         static readonly string worldDataPath = Path.Combine(Application.streamingAssetsPath, "WorldData");
-
         private Dictionary<BlockRecordId, BuildingReplacementData> buildings = new Dictionary<BlockRecordId, BuildingReplacementData>();
 
         private static Dictionary<BlockRecordId, BuildingReplacementData> Buildings { get { return Instance.buildings; } }
@@ -68,9 +65,14 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
         #region Public Methods
 
-        public static string GetBuildingReplacementFilename(string blockName, int blockIndex, int recordIndex)
+        public static string GetBuildingInstanceReplacementFilename(string blockName, int blockIndex, int recordIndex)
         {
             return string.Format("{0}-{1}-building{2}.json", blockName, blockIndex, recordIndex);
+        }
+
+        public static string GetBuildingBlockReplacementFilename(string blockName, int recordIndex)
+        {
+            return string.Format("{0}-building{1}.json", blockName,  recordIndex);
         }
 
         public static bool GetBuildingReplacementData(string blockName, int blockIndex, int recordIndex, out BuildingReplacementData buildingData)
@@ -85,9 +87,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 }
                 else
                 {
-                    string fileName = GetBuildingReplacementFilename(blockName, blockIndex, recordIndex);
+                    string fileName = GetBuildingInstanceReplacementFilename(blockName, blockIndex, recordIndex);
 
-                    // Seek from loose files
+                    // Seek from loose files for replacment for the specific instance of the location
                     if (File.Exists(Path.Combine(worldDataPath, fileName)))
                     {
                         string buildingReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
@@ -97,7 +99,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 #endif
                         return true;
                     }
-                    // Seek from mods
+                    // Seek from mods for replacment for the specific instance of the location
                     TextAsset buildingReplacementJsonAsset;
                     if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(fileName, false, out buildingReplacementJsonAsset))
                     {
@@ -107,6 +109,28 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 #endif
                         return true;
                     }
+
+                    fileName = GetBuildingBlockReplacementFilename(blockName, recordIndex);
+
+                    // Seek from loose files for replacment for the block shared location
+                    if (File.Exists(Path.Combine(worldDataPath, fileName))) {
+                        string buildingReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
+                        buildingData = (BuildingReplacementData)SaveLoadManager.Deserialize(typeof(BuildingReplacementData), buildingReplacementJson);
+#if !UNITY_EDITOR       // Cache building replacement data, unless running in editor
+                        Buildings.Add(blockRecordId, buildingData);
+#endif
+                        return true;
+                    }
+                    // Seek from mods for replacment for the block shared location
+                    if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(fileName, false, out buildingReplacementJsonAsset)) {
+                        buildingData = (BuildingReplacementData)SaveLoadManager.Deserialize(typeof(BuildingReplacementData), buildingReplacementJsonAsset.text);
+#if !UNITY_EDITOR       // Cache building replacement data, unless running in editor
+                        Buildings.Add(blockRecordId, buildingData);
+#endif
+                        return true;
+                    }
+
+
 #if !UNITY_EDITOR   // Only look for replacement data once, unless running in editor
                     Buildings.Add(blockRecordId, noReplacementData);
 #endif


### PR DESCRIPTION

Allow you to replace interior location based on the shared block data, as well as the specific instance of that blockdata. The specific instance replacement takes priority.
