### PR TITLE
Experimental support for custom books

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -746,26 +746,34 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         public static void SeekModContributes(ModInfo modInfo)
         {
             List<string> spellIcons = null;
+            List<string> booksMapping = null;
 
             foreach (string file in modInfo.Files)
             {
                 string directory = Path.GetDirectoryName(file);
-                if (directory.EndsWith("SpellIcons"))
-                {
-                    if (spellIcons == null)
-                        spellIcons = new List<string>();
 
-                    string name = Path.GetFileNameWithoutExtension(file);
-                    if (!spellIcons.Contains(name))
-                        spellIcons.Add(name);
-                }
+                if (directory.EndsWith("SpellIcons"))
+                    AddNameToList(ref spellIcons, file);
+                else if (directory.EndsWith("Books/Mapping"))
+                    AddNameToList(ref booksMapping, file);
             }
 
-            if (spellIcons != null)
+            if (spellIcons != null || booksMapping != null)
             {
                 var contributes = modInfo.Contributes ?? (modInfo.Contributes = new ModContributes());
-                contributes.SpellIcons = spellIcons.ToArray();
+                contributes.SpellIcons = spellIcons != null ? spellIcons.ToArray() : null;
+                contributes.BooksMapping = booksMapping != null ? booksMapping.ToArray() : null;
             }
+        }
+
+        private static void AddNameToList(ref List<string> names, string path)
+        {
+            if (names == null)
+                names = new List<string>();
+
+            string name = Path.GetFileNameWithoutExtension(path);
+            if (!names.Contains(name))
+                names.Add(name);
         }
 #endif
 

--- a/Assets/Game/Addons/ModSupport/ModTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModTypes.cs
@@ -67,6 +67,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
     internal sealed class ModContributes
     {
         /// <summary>
+        /// Look-up maps that announce additional books to be imported.
+        /// </summary>
+        [SerializeField]
+        internal string[] BooksMapping;
+
+        /// <summary>
         /// Names of spell icon packs; each name corresponds to a <see cref="Texture2D"/>
         /// asset and a <see cref="TextAsset"/> with `.json` extension.
         /// </summary>

--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -96,6 +96,7 @@ StartInDungeon=True
 TerrainDistance=3
 TerrainHeightmapPixelError=5
 SmallerDungeons=False
+CustomBooksImport=False
 
 [Enhancements]
 LypyL_GameConsole=True

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -12,6 +12,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallConnect.FallExe;
@@ -250,6 +251,41 @@ namespace DaggerfallWorkshop.Game.Items
             SetVariant(newItem, UnityEngine.Random.Range(0, newItem.TotalVariants));
 
             return newItem;
+        }
+
+        /// <summary>
+        /// Creates a new book from resource provided by mods.
+        /// Use <see cref="CreateBook(int)"/> for classic books.
+        /// </summary>
+        /// <param name="fileName">The name of the books resource.</param>
+        /// <returns>An instance of the book item or null.</returns>
+        public static DaggerfallUnityItem CreateBook(string fileName)
+        {
+            if (!Path.HasExtension(fileName))
+                fileName += ".TXT";
+
+            var entry = BookReplacement.FileNames.FirstOrDefault(x => x.Value == fileName);
+            return !entry.Equals(default(KeyValuePair<int, string>)) ? CreateBook(entry.Key) : null;
+        }
+
+        /// <summary>
+        /// Creates a new book from resource provided by classic game data or mods.
+        /// </summary>
+        /// <param name="id">The numeric id of book resource.</param>
+        /// <returns>An instance of the book item or null.</returns>
+        public static DaggerfallUnityItem CreateBook(int id)
+        {
+            var bookFile = new BookFile();
+            string name = DaggerfallUnity.Instance.ItemHelper.GetBookFileNameByMessage(id);
+            if (!BookReplacement.TryImportBook(name, bookFile) &&
+                !bookFile.OpenBook(DaggerfallUnity.Instance.Arena2Path, name))
+                return null;
+
+            return new DaggerfallUnityItem(ItemGroups.Books, 0)
+            {
+                message = id,
+                value = bookFile.Price
+            };
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -465,12 +465,20 @@ namespace DaggerfallWorkshop.Game.Items
         /// Gets the filename for a book (classic or imported).
         /// </summary>
         /// <param name="message">The message field for the book Item, containing the book ID.</param>
-        /// <returns>The filename of the book.</returns>
+        /// <returns>The filename of the book or null.</returns>
         internal string GetBookFileNameByMessage(int message)
         {
             BookReplacement.AssertCustomBooksImportEnabled();
 
-            return message <= 111 || message == 10000 ? BookFile.messageToBookFilename(message) : BookReplacement.FileNames[message];
+            if (message <= 111 || message == 10000)
+                return BookFile.messageToBookFilename(message);
+
+            string name;
+            if (BookReplacement.FileNames.TryGetValue(message, out name))
+                return name;
+
+            Debug.LogErrorFormat("ID {0} is not assigned to any known book; a mod that provides books was probably removed.", id);
+            return null;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -55,6 +55,23 @@ namespace DaggerfallWorkshop.Game.Items
 
         #endregion
 
+        #region Properties
+
+        /// <summary>
+        /// The total number of books available.
+        /// These are 1-111, plus custom books (112+), plus 10000.
+        /// </summary>
+        public int BooksCount
+        {
+            get
+            {
+                BookReplacement.AssertCustomBooksImportEnabled();
+                return bookIDNameMapping.Count;
+            }
+        }
+
+        #endregion
+
         #region Constructors
 
         public ItemHelper()
@@ -442,6 +459,18 @@ namespace DaggerfallWorkshop.Game.Items
         public String getBookNameByMessage(int message, string defaultBookName)
         {
             return getBookNameByID(message & 0xFF, defaultBookName);
+        }
+
+        /// <summary>
+        /// Gets the filename for a book (classic or imported).
+        /// </summary>
+        /// <param name="message">The message field for the book Item, containing the book ID.</param>
+        /// <returns>The filename of the book.</returns>
+        internal string GetBookFileNameByMessage(int message)
+        {
+            BookReplacement.AssertCustomBooksImportEnabled();
+
+            return message <= 111 || message == 10000 ? BookFile.messageToBookFilename(message) : BookReplacement.FileNames[message];
         }
 
         /// <summary>
@@ -1205,6 +1234,9 @@ namespace DaggerfallWorkshop.Game.Items
             {
                 Debug.Log("Could not load the BookIDName mapping from Resources. Check file exists and is in correct format.");
             }
+
+            if (DaggerfallUnity.Settings.CustomBooksImport)
+                BookReplacement.FindAdditionalBooks(bookIDNameMapping);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBookReaderWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBookReaderWindow.cs
@@ -41,9 +41,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             set
             {
                 bookTarget = value;
-                DaggerfallUnity.Instance.TextProvider.OpenBook(bookTarget.message);
+                IsBookOpen = DaggerfallUnity.Instance.TextProvider.OpenBook(bookTarget.message);
             }
         }
+
+        public bool IsBookOpen { get; private set; }
 
         protected override void Setup()
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBookReaderWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBookReaderWindow.cs
@@ -121,6 +121,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void LayoutPage()
         {
+            if (!dfUnity.TextProvider.IsBookOpen)
+                return;
+
             ClearPage();
             TextFile.Token[] tokens = dfUnity.TextProvider.PageTokens;
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1580,7 +1580,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (item.ItemGroup == ItemGroups.Books && !item.IsArtifact)
             {
                 DaggerfallUI.Instance.BookReaderWindow.BookTarget = item;
-                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenBookReaderWindow);
+                if (DaggerfallUI.Instance.BookReaderWindow.IsBookOpen)
+                {
+                    DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenBookReaderWindow);
+                }
+                else
+                {
+                    var messageBox = new DaggerfallMessageBox(uiManager, this);
+                    messageBox.SetText(TextManager.Instance.GetText(textDatabase, "bookUnavailable"));
+                    messageBox.ClickAnywhereToClose = true;
+                    uiManager.PushWindow(messageBox);
+                }
             }
             else if (item.IsPotion)
             {   // Handle drinking magic potions

--- a/Assets/Scripts/Internal/DaggerfallBookshelf.cs
+++ b/Assets/Scripts/Internal/DaggerfallBookshelf.cs
@@ -30,7 +30,7 @@ namespace DaggerfallWorkshop
                 books = new List<int>();
                 for (int i=0; i<10; i++)
                 {
-                    int bookNum = Random.Range(0, 111);
+                    int bookNum = Random.Range(0, DaggerfallUnity.Settings.CustomBooksImport ? DaggerfallUnity.Instance.ItemHelper.BooksCount - 1 : 111);
                     string bookName = DaggerfallUnity.Instance.ItemHelper.getBookNameByID(bookNum, string.Empty);
                     if (bookName != string.Empty)
                         books.Add(bookNum);

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -158,6 +158,7 @@ namespace DaggerfallWorkshop
 
         public float TerrainHeightmapPixelError { get; set; }
         public bool SmallerDungeons { get; set; }
+        public bool CustomBooksImport { get; set; }
 
         // [Enhancements]
         public bool LypyL_GameConsole { get; set; }
@@ -275,6 +276,7 @@ namespace DaggerfallWorkshop
             TerrainDistance = GetInt(sectionExperimental, "TerrainDistance", 1, 4);
             TerrainHeightmapPixelError = GetFloat(sectionExperimental, "TerrainHeightmapPixelError", 1, 10);
             SmallerDungeons = GetBool(sectionExperimental, "SmallerDungeons");
+            CustomBooksImport = GetBool(sectionExperimental, "CustomBooksImport");
 
             LypyL_GameConsole = GetBool(sectionEnhancements, "LypyL_GameConsole");
             LypyL_ModSystem = GetBool(sectionEnhancements, "LypyL_ModSystem");
@@ -379,6 +381,7 @@ namespace DaggerfallWorkshop
             SetInt(sectionExperimental, "TerrainDistance", TerrainDistance);
             SetFloat(sectionExperimental, "TerrainHeightmapPixelError", TerrainHeightmapPixelError);
             SetBool(sectionExperimental, "SmallerDungeons", SmallerDungeons);
+            SetBool(sectionExperimental, "CustomBooksImport", CustomBooksImport);
 
             SetBool(sectionEnhancements, "LypyL_GameConsole", LypyL_GameConsole);
             SetBool(sectionEnhancements, "LypyL_ModSystem", LypyL_ModSystem);

--- a/Assets/Scripts/Utility/TextProvider.cs
+++ b/Assets/Scripts/Utility/TextProvider.cs
@@ -203,6 +203,9 @@ namespace DaggerfallWorkshop.Utility
 
         public virtual bool OpenBook(string name)
         {
+            if (string.IsNullOrEmpty(name))
+                return false;
+
             if (!BookReplacement.TryImportBook(name, bookFile) &&
                 !bookFile.OpenBook(DaggerfallUnity.Instance.Arena2Path, name))
                 return false;

--- a/Assets/Scripts/Utility/TextProvider.cs
+++ b/Assets/Scripts/Utility/TextProvider.cs
@@ -195,6 +195,9 @@ namespace DaggerfallWorkshop.Utility
 
         public virtual bool OpenBook(int message)
         {
+            if (DaggerfallUnity.Settings.CustomBooksImport)
+                return OpenBook(DaggerfallUnity.Instance.ItemHelper.GetBookFileNameByMessage(message));
+
             return OpenBook(BookFile.messageToBookFilename(message));
         }
 

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -71,6 +71,7 @@ northern,           (northern)
 southern,           (southern)
 noWagon,            You don't own a wagon.
 exitTooFar,         The exit is too far away for you to access your wagon.
+bookUnavailable,    The book is ruined and is now unreadable.
 
 - Potion mixing window:
 


### PR DESCRIPTION
Preliminary support for import of custom books for bookshelves. 

## How it works
1. A book file is positioned inside _StreamingAssets\Books_. For example `StreamingAssets\Books\example-book.TXT`.
2. A map table is positioned inside _StreamingAssets\Books\Mapping_. For example:

```json
[
    {
        "Name": "example-book",
        "Title": "An Example Book"
    }
]
```

This table has two purposes: distinguish classic books replacements from additional custom books (could also have done this with a separate folder) and announces book titles before importing the actual resources. Custom subfolders can potentially be supported in the future.

3.  Each book is associated to a numeric id (only valid for the session) starting from 112 and added to **bookIDNameMapping** in ItemHelper.

## How to test

1. Add files as explained above.
2. Edit DaggerfallBookshelf to skew chances of selecting custom books (or add a lot of custom books...).
3. Find a book shelf (or add component to any test prop). The title should be visible and book resource readable.

This feature is disabled by default for the moment, and should not affect core in any way if disabled.