### PR TITLE
apply a -0.5 mipmap bias to DaggerfallTilemapTextureArray shader

### DIFF
--- a/Assets/Shaders/DaggerfallTilemapTextureArray.shader
+++ b/Assets/Shaders/DaggerfallTilemapTextureArray.shader
@@ -65,13 +65,15 @@ Shader "Daggerfall/TilemapTextureArray" {
 			//float2 uv_BumpMap;
 		};
 
-	float GetMipLevel(float2 iUV, float4 iTextureSize)
-	{
-		float2 dx = ddx(iUV * iTextureSize.z);
-		float2 dy = ddy(iUV * iTextureSize.w);
-		float d = max(dot(dx, dx), dot(dy,dy));
-		return 0.5 * log2(d);
-	}
+		#define MIPMAP_BIAS (-0.5)
+
+		float GetMipLevel(float2 iUV, float4 iTextureSize)
+		{
+			float2 dx = ddx(iUV * iTextureSize.z);
+			float2 dy = ddy(iUV * iTextureSize.w);
+			float d = max(dot(dx, dx), dot(dy,dy));
+			return 0.5 * log2(d) + MIPMAP_BIAS;
+		}
 
 		void surf (Input IN, inout SurfaceOutputStandard o)
 		{


### PR DESCRIPTION
Seems still almost aliasing free according to visual tests.

Implementing mipmap bias by hand, does standard Texture.mipmapBias apply to custom surface shaders? And if so, where should it be set?

Forums: https://forums.dfworkshop.net/viewtopic.php?f=4&t=37&p=26322#p26322