### PR TITLE
Update enumerated saves when a new savegame is created

### DIFF
--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -346,18 +346,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             if (LoadInProgress)
                 return;
 
-            // Look for existing save with this character and name
-            int key = FindSaveFolderByNames(characterName, saveName);
-
-            // Get or create folder
-            string path;
-            if (key == -1)
-                path = CreateNewSavePath(enumeratedSaveFolders);
-            else
-                path = GetSaveFolder(key);
-
             // Save game
-            StartCoroutine(SaveGame(saveName, path, instantReload));
+            StartCoroutine(SaveGame(characterName, saveName, instantReload));
         }
 
         public void QuickSave(bool instantReload = false)
@@ -916,8 +906,18 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         #region Utility
 
-        IEnumerator SaveGame(string saveName, string path, bool instantReload = false)
+        IEnumerator SaveGame(string characterName, string saveName, bool instantReload = false)
         {
+            // Look for existing save with this character and name
+            int key = FindSaveFolderByNames(characterName, saveName);
+
+            // Get or create folder
+            string path;
+            if (key == -1)
+                path = CreateNewSavePath(enumeratedSaveFolders);
+            else
+                path = GetSaveFolder(key);
+
             // Build save data
             SaveData_v1 saveData = BuildSaveData();
 
@@ -1032,6 +1032,10 @@ namespace DaggerfallWorkshop.Game.Serialization
 
             // Raise OnSaveEvent
             RaiseOnSaveEvent(saveData);
+
+            // Update saves if needed
+            if (key == -1)
+                EnumerateSaves();
 
             // Notify
             DaggerfallUI.Instance.PopupMessage(HardStrings.gameSaved);


### PR DESCRIPTION
Enumerated saves were not updated when a new savegame was created. This made QuickLoad not working immediately after using QuickSave for the first time (QuickLoad worked, however, when restarting DFU).