### PR TITLE
Import Texture Arrays as assets

### DIFF
--- a/Assets/Scripts/Editor/TextureArrayWizard.cs
+++ b/Assets/Scripts/Editor/TextureArrayWizard.cs
@@ -1,0 +1,120 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2019 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: TheLacus
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace DaggerfallWorkshop
+{
+    [Serializable]
+    public class TextureArrayWizardOptions
+    {
+        [Tooltip("Keep the texture readable.")]
+        public bool ReadWriteEnabled = false;
+
+        [Tooltip("Wrap mode for the texture array.")]
+        public TextureWrapMode WrapMode = TextureWrapMode.Clamp;
+
+        [Tooltip("Filtermode for the texture array.")]
+        public FilterMode FilterMode = FilterMode.Bilinear;
+
+        [Tooltip("Anisotropic filtering level for the texture array.")]
+        [Range(0, 16)]
+        public int AnisoLevel = 1;
+    }
+
+    /// <summary>
+    /// A basic wizard for texture array creation.
+    /// </summary>
+    public sealed class TextureArrayWizard : ScriptableWizard
+    {
+        [Tooltip("The directory where the texture array is created.")]
+        public string Directory;
+
+        [Tooltip("The name of the texture array asset.")]
+        public string Name = "Example-TexArray";
+
+        [Space]
+
+        public TextureArrayWizardOptions Advanced;
+
+        [Space]
+
+        [Tooltip("Textures to be included in the array in the given order.")]
+        public Texture2D[] Textures;
+
+        [MenuItem("Daggerfall Tools/Texture Array Creator")]
+        static void CreateWizard()
+        {
+            DisplayWizard<TextureArrayWizard>("Create Texture Array", "Create");
+        }
+
+        void OnWizardCreate()
+        {
+            if (!SystemInfo.supports2DArrayTextures)
+            {
+                Debug.LogError("Array textures are not supported!");
+                return;
+            }
+
+            Texture2D first = Textures[0];
+            Texture2DArray textureArray = new Texture2DArray(first.width, first.height, Textures.Length, first.format, first.mipmapCount > 1);
+
+            if (!Advanced.ReadWriteEnabled && (SystemInfo.copyTextureSupport & CopyTextureSupport.DifferentTypes) == CopyTextureSupport.DifferentTypes)
+            {
+                textureArray.Apply(false, true);
+
+                for (int i = 0; i < Textures.Length; i++)
+                    Graphics.CopyTexture(Textures[i], 0, textureArray, i);
+            }
+            else
+            {
+                for (int i = 0; i < Textures.Length; i++)
+                    textureArray.SetPixels32(Textures[i].GetPixels32(), i);
+
+                textureArray.Apply(true, !Advanced.ReadWriteEnabled);
+            }
+
+            textureArray.filterMode = Advanced.FilterMode;
+            textureArray.anisoLevel = Advanced.AnisoLevel;
+            textureArray.wrapMode = Advanced.WrapMode;
+
+            System.IO.Directory.CreateDirectory(Directory);
+            AssetDatabase.CreateAsset(textureArray, Path.Combine(Directory, Name + ".asset"));
+        }
+
+        void OnWizardUpdate()
+        {
+            isValid = !string.IsNullOrEmpty(Name) && Textures != null && Textures.Length > 0;
+
+            helpString = "Create a texture array from individual textures with the same size, format and mipmaps state.";
+            if (Textures != null && Textures.Length > 0)
+            {
+                Texture2D tex = Textures[0];
+                if (tex)
+                {
+                    helpString += string.Format("\n\nTarget: {0}x{1} (x{2}) {3} (mipmaps {4})",
+                        tex.width,
+                        tex.height,
+                        Textures.Length,
+                        tex.format,
+                        tex.mipmapCount > 0 ? "enabled" : "disabled");
+
+                    if (string.IsNullOrEmpty(Directory))
+                        Directory = Path.GetDirectoryName(AssetDatabase.GetAssetPath(tex));
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Editor/TextureArrayWizard.cs.meta
+++ b/Assets/Scripts/Editor/TextureArrayWizard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15c8a8d53a726a44da628618c48890aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -289,7 +289,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="archive">The requested texture archive.</param>
         /// <param name="depth">The expected number of layer.</param>
         /// <param name="textureMap">The texture type.</param>
-        /// <param name="fallbackColor">If provided is used silenty for missing layers.</param>
+        /// <param name="fallbackColor">If provided is used silenty for missing layers; texture format must be RGBA32 or ARGB32.</param>
         /// <param name="textureArray">Imported or created texture array or null.</param>
         /// <returns>True if the texture array has been imported or created.</returns>
         internal static bool TryImportTextureArray(int archive, int depth, TextureMap textureMap, Color32? fallbackColor, out Texture2DArray textureArray)
@@ -988,7 +988,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="archive">The requested texture archive.</param>
         /// <param name="depth">The expected number of layer.</param>
         /// <param name="textureMap">The texture type.</param>
-        /// <param name="fallbackColor">If provided is used silenty for missing layers.</param>
+        /// <param name="fallbackColor">If provided is used silenty for missing layers; texture format must be RGBA32 or ARGB32.</param>
         /// <param name="textureArray">The created texture array or null.</param>
         /// <returns>True if the texture array has been created.</returns>
         private static bool TryMakeTextureArrayCopyTexture(int archive, int depth, TextureMap textureMap, Color32? fallbackColor, out Texture2DArray textureArray)
@@ -1029,7 +1029,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 }
 
                 if (!textureArray)
+                {
+                    if (fallbackColor.HasValue && tex.format != TextureFormat.RGBA32 && tex.format != TextureFormat.ARGB32)
+                        return false;
+
                     textureArray = new Texture2DArray(tex.width, tex.height, depth, tex.format, mipMaps = tex.mipmapCount > 1);
+                }
 
                 if (tex.width == textureArray.width && tex.height == textureArray.height && tex.format == textureArray.format)
                     Graphics.CopyTexture(tex, 0, textureArray, record);


### PR DESCRIPTION
Terrain texture arrays can now also be created inside the Unity Editor and
provided via mods as assets. This brings the following benefits:

* Minor improvements for memory management and initialization times. The individual source
textures don't need to exist at runtime, only the final texture array.
* Failure due to resolution, format or mipmaps mismatches are not possible at
runtime. A texture array is only rejected if slice count is incorrect.
* Runtime creation of texture arrays requires CopyTexture support or Read/Write flag
(with increased memory usage). Texture arrays shipped as assets works on any platform
that support this feature alone.

The disadvantage is the introduction of an additional step in mod creation
workflow. For this reason is introduced as an optional feature.

This commit adds a simple texture array creator but there are also more advanced
free alternatives on the Unity Asset Store, like [Texture Array Inspector](https://assetstore.unity.com/packages/tools/utilities/texture-array-inspector-109547).