### PR TITLE
Fix for closing windows when using magic items

### DIFF
--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -52,15 +52,18 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public void QuestMachine_OnQuestEnded(Quest quest)
         {
-            if (quest.QuestName == ThievesGuild.InitiationQuestName)
+            if (quest.QuestSuccess)
             {
-                Guild tg = CreateGuildObj(FactionFile.GuildGroups.GeneralPopulace);
-                AddMembership(FactionFile.GuildGroups.GeneralPopulace, tg);
-            }
-            if (quest.QuestName == DarkBrotherhood.InitiationQuestName)
-            {
-                Guild db = CreateGuildObj(FactionFile.GuildGroups.DarkBrotherHood);
-                AddMembership(FactionFile.GuildGroups.DarkBrotherHood, db);
+                if (quest.QuestName == ThievesGuild.InitiationQuestName)
+                {
+                    Guild tg = CreateGuildObj(FactionFile.GuildGroups.GeneralPopulace);
+                    AddMembership(FactionFile.GuildGroups.GeneralPopulace, tg);
+                }
+                if (quest.QuestName == DarkBrotherhood.InitiationQuestName)
+                {
+                    Guild db = CreateGuildObj(FactionFile.GuildGroups.DarkBrotherHood);
+                    AddMembership(FactionFile.GuildGroups.DarkBrotherHood, db);
+                }
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1667,11 +1667,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Will see what feedback is like and revert to classic behaviour if widely preferred
             if (item.IsEnchanted)
             {
+                // Close the inventory window first. Some artifacts (Azura's Star, the Oghma Infinium) create windows on use and we don't want to close those.
+                CloseWindow();
                 GameManager.Instance.PlayerEffectManager.DoItemEnchantmentPayloads(MagicAndEffects.EnchantmentPayloadFlags.Used, item, collection);
-
-                // Only pop the inventory window. Some artifacts (Azura's Star, the Oghma Infinium) create windows on use and we don't want to pop those.
-                if (DaggerfallUI.Instance.UserInterfaceManager.TopWindow.GetType() == typeof(DaggerfallInventoryWindow))
-                  DaggerfallUI.Instance.UserInterfaceManager.PopWindow();
                 return;
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUseMagicItemWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUseMagicItemWindow.cs
@@ -113,8 +113,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public void MagicItemPicker_OnItemPicked(int index, string itemName)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
-            // Use item
             DaggerfallUnityItem itemToUse = magicUseItems[index];
+            CloseWindow();
+            // Use item
             if (itemToUse.IsPotion)
             {
                 GameManager.Instance.PlayerEffectManager.DrinkPotion(itemToUse);
@@ -122,8 +123,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else if (itemToUse.IsEnchanted)
                 GameManager.Instance.PlayerEffectManager.DoItemEnchantmentPayloads(MagicAndEffects.EnchantmentPayloadFlags.Used, itemToUse, GameManager.Instance.PlayerEntity.Items);
-
-            CloseWindow();
         }
 
         #endregion


### PR DESCRIPTION
Much easier to pop off the stack before pushing any subsequent windows. This fixes the issues I had with teleport item for archaeologists mod.
Also includes a fix so TG & BD membership to only occur if the joining quest is successful.