### PR TITLE
Fast travel to ground level, always

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -1286,11 +1286,7 @@ namespace DaggerfallWorkshop
                 // This is our minimum height before player falls through world
                 Vector3 targetPosition = new Vector3(position.x, 0, position.z);
                 float height = terrain.SampleHeight(targetPosition + terrain.transform.position) + worldCompensation.y;
-                targetPosition.y = height + controller.height / 2f + 0.15f;
-
-                // If desired position is higher then minimum position then we can safely use that
-                if (position.y > targetPosition.y)
-                    targetPosition.y = position.y;
+                targetPosition.y = height + controller.height * 0.65f;
 
                 // Move player object to new position
                 LocalPlayerGPS.transform.position = targetPosition;


### PR DESCRIPTION
After some fast travel, player position could only be adjusted upward; When terrain was very steep downward it could result in fall damage (and death). 

(Maybe there's a use case I'm not aware of for this behavior?)

Make adjustment unconditional; Height formula adjusted to (slightly higher) PlayerMotor.FixStanding formula.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2307