### PR TITLE
Handle %bn (biography name) macro expansion

### DIFF
--- a/Assets/Scripts/API/BiogFileMCP.cs
+++ b/Assets/Scripts/API/BiogFileMCP.cs
@@ -13,6 +13,7 @@ using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop;
 using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallConnect.Arena2
 {
@@ -136,6 +137,14 @@ namespace DaggerfallConnect.Arena2
                     default:
                         return null;
                 }
+            }
+
+            public override string Name()
+            {   // %bn
+                System.Random random = new System.Random();
+                DFRandom.Seed = (uint)random.Next();
+                NameHelper.BankTypes race = MacroHelper.GetNameBank((Races)parent.characterDocument.raceTemplate.ID);
+                return DaggerfallUnity.Instance.NameHelper.FullName(race, Genders.Male);
             }
 
             public override string Q1()

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -59,7 +59,7 @@ namespace DaggerfallWorkshop.Utility
             { "%ba", BookAuthor },  // Book Author
             { "%bch", ChanceBase }, // Base chance
             { "%bdr", DurationBase }, // Base Duration
-            { "%bn", null },  // ?
+            { "%bn", Name }, // Random name in biography text
             { "%bt", ItemName },  // Book title
             { "%cbl", null }, // Cash balance in current region
             { "%clc", ChancePerLevel }, // Per level (Chance)
@@ -294,21 +294,23 @@ namespace DaggerfallWorkshop.Utility
         {
             switch (race)
             {
-                case Races.Argonian:
                 case Races.Breton:
-                case Races.Khajiit:
                 default:
                     return NameHelper.BankTypes.Breton;
+                case Races.Redguard:
+                    return NameHelper.BankTypes.Redguard;
+                case Races.Nord:
+                    return NameHelper.BankTypes.Nord;
                 case Races.DarkElf:
                     return NameHelper.BankTypes.DarkElf;
                 case Races.HighElf:
                     return NameHelper.BankTypes.HighElf;
                 case Races.WoodElf:
                     return NameHelper.BankTypes.WoodElf;
-                case Races.Nord:
-                    return NameHelper.BankTypes.Nord;
-                case Races.Redguard:
-                    return NameHelper.BankTypes.Redguard;
+                case Races.Khajiit:
+                    return NameHelper.BankTypes.Khajiit;
+                case Races.Argonian:
+                    return NameHelper.BankTypes.Imperial;
             }
         }
 


### PR DESCRIPTION
Macro %bn is used only for Nightblade biography history. It expands to a random name using player character race and a random gender.

But as the occupation of the corresponding individual is given by the %q8 macro which expands to a neutral or (mostly) masculine noun (priest, wizard, sorceror, revolutionary, anarchist, warlord, robber baron, assassin), I chose to differ from classic and force the gender to male.

I also fixed MacroHelper.GetNameBank to match classic so it now returns a Khajiit name for Khajiits and an Imperial name for Argonians.