### PR TITLE
Restrict building interior loot piles to TG, DB and pubs

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -568,7 +568,6 @@ namespace DaggerfallWorkshop
                          buildingData.factionID == ThievesGuild.FactionId ||
                          buildingData.factionID == DarkBrotherhood.FactionId))
                     {
-                        Debug.Log("Treasure pile!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
                         // Create unique LoadID for save system, using 9 lsb and the sign bit from each coord pos int
                         ulong loadID = ((ulong) buildingData.buildingKey) << 30 |
                                         (uint)(obj.XPos << 1 & posMask) << 20 |

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -562,9 +562,13 @@ namespace DaggerfallWorkshop
                     marker.gameObject = go;
                     markers.Add(marker);
 
-                    // Add loot containers for treasure markers (always use pile of clothes icon)
-                    if (marker.type == InteriorMarkerTypes.Treasure)
+                    // Add loot containers for treasure markers for TG, DB & taverns (uses pile of clothes icon)
+                    if (marker.type == InteriorMarkerTypes.Treasure &&
+                        (buildingData.buildingType == DFLocation.BuildingTypes.Tavern ||
+                         buildingData.factionID == ThievesGuild.FactionId ||
+                         buildingData.factionID == DarkBrotherhood.FactionId))
                     {
+                        Debug.Log("Treasure pile!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
                         // Create unique LoadID for save system, using 9 lsb and the sign bit from each coord pos int
                         ulong loadID = ((ulong) buildingData.buildingKey) << 30 |
                                         (uint)(obj.XPos << 1 & posMask) << 20 |


### PR DESCRIPTION
This is not exactly as classic but as close as I can get without reverse engineering why they appear is desert FGs but no where else.

I think this is close enough now having spent a few hours testing various buildings in classic.