### PR TITLE
URGENT FOR ALPHA BUILD: Improve guttering effect on player torch

### DIFF
--- a/Assets/Scripts/Game/EnablePlayerTorch.cs
+++ b/Assets/Scripts/Game/EnablePlayerTorch.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Game
         float intensityMod = 1f;
         float lastTickTime;
         float tickTimeInterval = 20f;
+        float guttering = 0;
 
         void Start()
         {
@@ -54,7 +55,7 @@ namespace DaggerfallWorkshop.Game
 
         void Update()
         {
-            if (!dfUnity.IsReady || !playerEnterExit || !PlayerTorch || playerEntity == null)
+            if (!dfUnity.IsReady || !playerEnterExit || !PlayerTorch || playerEntity == null || GameManager.IsGamePaused)
                 return;
 
             bool enableTorch = false;
@@ -66,7 +67,7 @@ namespace DaggerfallWorkshop.Game
                     enableTorch = true;
                     torchLight.range = lightSource.ItemTemplate.capacityOrTarget;
                     // Consume durability / fuel
-                    if (Time.realtimeSinceStartup > lastTickTime + tickTimeInterval && !GameManager.IsGamePaused)
+                    if (Time.realtimeSinceStartup > lastTickTime + tickTimeInterval)
                     {
                         lastTickTime = Time.realtimeSinceStartup;
                         if (lightSource.currentCondition > 0)
@@ -81,10 +82,18 @@ namespace DaggerfallWorkshop.Game
                                 playerEntity.Items.RemoveItem(lightSource);
                         }
                     }
-                    // Give warning signs if running out of fuel
-                    intensityMod = 1f;
-                    if (lightSource.currentCondition < 2)
-                        intensityMod = Random.Range(0.45f, 0.75f);
+                    
+                    if (lightSource.currentCondition < 3)
+                    {
+                        // Give warning signs if running low of fuel
+                        intensityMod = 0.6f + (Mathf.Cos(guttering) * 0.2f);
+                        guttering += Random.Range(-0.02f, 0.06f);
+                    }
+                    else
+                    {
+                        intensityMod = 1;
+                        guttering = 0;
+                    }
                 }
             }
             else


### PR DESCRIPTION
It has been reported that my lazy flickering guttering effect used to warn players (using player based torches) that a light source is running low on fuel is a potentially very serious epilepsy trigger. We must not release an alpha with that code, I would be pretty mortified if someone had a seizure because of it.

I've been less lazy now (but still pretty lazy) and implemented a very simple cosine based effect. Looks pretty decent actually for 1 extra variable and 2 lines of code!

Hopefully this will be fine, I will await feedback from the reporter, it's definitely not a fast stobe like flickery effect anymore anyway!