### PR TITLE
NPC reactions enhancement

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -283,6 +283,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 SetTalkModeWhereIs();
                 talkCategoryLastUsed = TalkCategory.None; // enforce that function SetTalkCategoryLocation does not skip itself and updated its topic list
                 SetTalkCategoryLocation();
+                panelTone.Position = panelToneNormalPos;
             }
 
             selectedTalkOption = TalkOption.WhereIs;


### PR DESCRIPTION
Improve the way NPCs react to player questions.

I decided to give Streetwise and Etiquette more weight by setting reaction modifiers related to NPC social groups. For example, talking bluntly to a Noble or Scholar will now give a penalty, while doing the same with a Commoner or a member of the Underworld (Thieves Guild or Assassin) will give a bonus. Of course, using Etiquette through a polite tone will trigger the exact opposite. Merchants, as a sort of middle class, will be unaffected by this change. I gave them a default modifier of +5 when using both skills which makes them behave the same as before as I also changed skill check result: failing will give a penalty of -10 while succeeding will give +5.

I also lowered the required value to get the best NPC reaction, though it's still difficult to get, especially with a low personality and low Etiquette and Streetwise skills.

Finally, I also set default modifiers for "Tell me about" kind of questions the same as there "Where is" counterparts.

In my opinion, this is quite an improvement over classic.

While doing so, I also noticed and fixed a problem with the Talk Window: tone checkbox was not reset to Normal after modifying the tone, then closing the window and reopening it.