### PR TITLE
Fix N0B00Y16 "open chest"

### DIFF
--- a/Assets/StreamingAssets/Quests/N0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y16.txt
@@ -217,7 +217,9 @@ _a6_ task:
 	say 1043 
 
 _S.07_ task:
-	have _crn_ set _S.08_ 
+	start task _S.08_
+--	have _crn_ set _S.08_ 
+--  quest failed to recognize "have crn," which was crucial
 
 _S.08_ task:
 	pick one of _a3_ _a4_ _a5_ _a6_ 

--- a/Assets/StreamingAssets/Quests/O0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y01.txt
@@ -192,7 +192,7 @@ variable _pchasitem1_
 variable _pchasitem2_
 _S.06_ task:
 	injured _F.01_ 
-	prompt 1020 yes _yes_ no _no_ 
+	prompt 1022 yes _yes_ no _no_ 
 
 _yes_ task:
 	take _weapons_ from pc saying 1023 
@@ -208,7 +208,7 @@ _S.09_ task:
 
 _greklith_ task:
 	injured _guards_ 
-	prompt 1022 yes _yes_ no _no_ 
+	prompt 1020 yes _yes_ no _no_ 
 
 _S.11_ task:
 	change repute with _questgiver_ by -10 


### PR DESCRIPTION
S.07 failed to fire, wasn't recognizing the condition. One-line fix. Quest has another problem regarding failure line: if you talk to the merchant without opening the chest, you'll never get a success message afterward. Have tried to fix that problem and can't.