### PR TITLE
FindClosestDoorToPlayer() to return false if all doors are filtered out

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1058,13 +1058,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallStaticDoors[] allDoors = GameObject.FindObjectsOfType<DaggerfallStaticDoors>();
             if (allDoors != null && allDoors.Length > 0)
             {
+                Vector3 playerPos = GameManager.Instance.PlayerObject.transform.position;
                 // Find closest door to player
                 float closestDoorDistance = float.MaxValue;
                 foreach (DaggerfallStaticDoors doors in allDoors)
                 {
                     int doorIndex;
                     Vector3 doorPos;
-                    Vector3 playerPos = GameManager.Instance.PlayerObject.transform.position;
                     if (doors.FindClosestDoorToPlayer(playerPos, -1, out doorPos, out doorIndex, DoorTypes.DungeonExit))
                     {
                         float distance = Vector3.Distance(playerPos, doorPos);

--- a/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
+++ b/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
@@ -109,7 +109,7 @@ namespace DaggerfallWorkshop
         public bool FindClosestDoorToPlayer(Vector3 playerPos, int record, out Vector3 doorPosOut, out int doorIndexOut, DoorTypes requiredDoorType = DoorTypes.None)
         {
             // Init output
-            doorPosOut = playerPos;
+            doorPosOut = Vector3.zero;
             doorIndexOut = -1;
 
             // Must have door array
@@ -118,18 +118,19 @@ namespace DaggerfallWorkshop
 
             // Find closest door to player position
             float minDistance = float.MaxValue;
+            bool found = false;
             for (int i = 0; i < Doors.Length; i++)
             {
                 // Must be of door type if set
                 if (requiredDoorType != DoorTypes.None && Doors[i].doorType != requiredDoorType)
                     continue;
 
-                // Get this door centre in world space
-                Vector3 centre = transform.rotation * Doors[i].buildingMatrix.MultiplyPoint3x4(Doors[i].centre) + transform.position;
-
                 // Check if door belongs to same building record or accept any record
-                if (Doors[i].recordIndex == record || record == -1)
+                if (record == -1 || Doors[i].recordIndex == record)
                 {
+                    // Get this door centre in world space
+                    Vector3 centre = transform.rotation * Doors[i].buildingMatrix.MultiplyPoint3x4(Doors[i].centre) + transform.position;
+
                     // Check distance and save closest
                     float distance = Vector3.Distance(playerPos, centre);
                     if (distance < minDistance)
@@ -137,11 +138,12 @@ namespace DaggerfallWorkshop
                         doorPosOut = centre;
                         doorIndexOut = i;
                         minDistance = distance;
+                        found = true;
                     }
                 }
             }
 
-            return true;
+            return found;
         }
 
         /// <summary>


### PR DESCRIPTION
DaggerfallStaticDoors.FindClosestDoorToPlayer() was returning true if all doors were filtered out by requiredDoorType.
When this happened, doorPosOut would still have its default value of playerPos, making DaggerfallInventoryWindow believe that indeed a door was found close to the player.

This only happens in some dungeons. The issue was first seen in a stream, in the Citadel of Hawking, Daggerfall:

https://www.twitch.tv/videos/461269349?t=01h50m27s