### PR TITLE
building discovery rework

### DIFF
--- a/Assets/Scripts/Game/ExteriorAutomap.cs
+++ b/Assets/Scripts/Game/ExteriorAutomap.cs
@@ -693,7 +693,7 @@ namespace DaggerfallWorkshop.Game
                                             string overrideBuildingName = string.Empty;
                                             if (place.SiteDetails.buildingKey == discoveredBuilding.buildingKey && GameManager.Instance.TalkManager.IsBuildingQuestResource(buildingSummary.buildingKey, ref overrideBuildingName, ref pcLearnedAboutExistence, ref receivedDirectionalHints, ref locationWasMarkedOnMapByNPC))
                                             {
-                                                if (pcLearnedAboutExistence)
+                                                if (locationWasMarkedOnMapByNPC)
                                                     buildingQuestName = place.SiteDetails.buildingName; // get buildingName if involved in active quest (same as overrideBuildingName)
                                             }
                                         }

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -603,6 +603,14 @@ namespace DaggerfallWorkshop.Game.Questing
             // remove all quest topics for this quest from talk manager
             GameManager.Instance.TalkManager.RemoveQuestInfoTopicsForSpecificQuest(this.UID);
 
+            // undiscover all quest residences used by this quest
+            QuestResource[] allQuestResources = this.GetAllResources(typeof(Place)); // Get list of place quest resources
+            for (int i = 0; i < allQuestResources.Length; i++)
+            {
+                Place place = (Place)allQuestResources[i];
+                GameManager.Instance.PlayerGPS.UndiscoverBuilding(place.SiteDetails.buildingKey, true, place.SiteDetails.buildingName);
+            }
+
             // Remove all questors for this quest
             DropAllQuestors();
         }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1084,6 +1084,10 @@ namespace DaggerfallWorkshop.Game
                 if (dictQuestInfo.ContainsKey(currentQuestionListItem.questID) && dictQuestInfo[currentQuestionListItem.questID].resourceInfo.ContainsKey(currentQuestionListItem.key))
                     dictQuestInfo[currentQuestionListItem.questID].resourceInfo[currentQuestionListItem.key].questPlaceResourceHintTypeReceived = QuestResourceInfo.BuildingLocationHintTypeGiven.LocationWasMarkedOnMap;
                 GameManager.Instance.PlayerGPS.DiscoverBuilding(buildingInfo.buildingKey);
+                
+                // above line could also be done with these statements:
+                // Place place = (Place)dictQuestInfo[currentQuestionListItem.questID].resourceInfo[currentQuestionListItem.key].questResource;
+                // GameManager.Instance.PlayerGPS.DiscoverBuilding(buildingInfo.buildingKey, place.SiteDetails.buildingName);
             }
         }
 
@@ -2700,7 +2704,7 @@ namespace DaggerfallWorkshop.Game
                     if (symbolName != resourceName)
                         continue;
 
-                    GameManager.Instance.PlayerGPS.UndiscoverBuilding(buildingKey, true);
+                    GameManager.Instance.PlayerGPS.UndiscoverBuilding(buildingKey, true, place.SiteDetails.buildingName);
                 }
             }
         }

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -889,7 +889,7 @@ namespace DaggerfallWorkshop
 
             // Get building information
             DiscoveredBuilding db;
-            if (!GetBuildingDiscoveryData(buildingKey, out db))
+            if (!GetBaseBuildingDiscoveryData(buildingKey, out db))
                 return;
 
             // Get location discovery
@@ -1106,8 +1106,8 @@ namespace DaggerfallWorkshop
             if (GetDiscoveredBuilding(buildingKey, out discoveredBuildingOut))
                 return true;
 
-            // if not try to get it from GetBuildingDiscoveryData() function
-            if (GetBuildingDiscoveryData(buildingKey, out discoveredBuildingOut))
+            // if not try to get it from GetBaseBuildingDiscoveryData() function
+            if (GetBaseBuildingDiscoveryData(buildingKey, out discoveredBuildingOut))
                 return true;
 
             return false;
@@ -1159,13 +1159,13 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
-        /// Gets initial building information from current location (no building name expansion).
+        /// Gets base building information from current location (no building name expansion). This is used as intermediate result by other functions like DiscoverBuilding and GetAnyBuilding
         /// Does not change discovery state for building.
         /// </summary>
         /// <param name="buildingKey">Key of building to query.</param>
         /// <param name="buildingDiscoveryData">[out] building discovery data of queried building</param>
         /// <returns>True if building information was found.</returns>
-        bool GetBuildingDiscoveryData(int buildingKey, out DiscoveredBuilding buildingDiscoveryData)
+        bool GetBaseBuildingDiscoveryData(int buildingKey, out DiscoveredBuilding buildingDiscoveryData)
         {
             buildingDiscoveryData = new DiscoveredBuilding();
 

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -1125,21 +1125,21 @@ namespace DaggerfallWorkshop
         {
             buildingDiscoveryData = new DiscoveredBuilding();
 
-            // Must have discovered building
-            if (!HasDiscoveredBuilding(buildingKey))
-                return false;
+            // if discovered building data is available for building key
+            if (HasDiscoveredBuilding(buildingKey))
+            {
+                // Get the location discovery for this mapID
+                int mapPixelID = MapsFile.GetMapPixelIDFromLongitudeLatitude((int)CurrentLocation.MapTableData.Longitude, CurrentLocation.MapTableData.Latitude);
+                DiscoveredLocation dl = discoveredLocations[mapPixelID];
+                if (dl.discoveredBuildings == null)
+                    return false;
 
-            // Get the location discovery for this mapID
-            int mapPixelID = MapsFile.GetMapPixelIDFromLongitudeLatitude((int)CurrentLocation.MapTableData.Longitude, CurrentLocation.MapTableData.Latitude);
-            DiscoveredLocation dl = discoveredLocations[mapPixelID];
-            if (dl.discoveredBuildings == null)
-                return false;
+                buildingDiscoveryData = dl.discoveredBuildings[buildingKey];
 
-            buildingDiscoveryData = dl.discoveredBuildings[buildingKey];
-
-            // if override name - use this name and don't do any further name resolving
-            if (buildingDiscoveryData.isOverrideName)
-                return true;
+                // if override name - use this name and don't do any further name resolving
+                if (buildingDiscoveryData.isOverrideName)
+                    return true;
+            }
 
             // Get building directory for location
             BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();
@@ -1174,7 +1174,7 @@ namespace DaggerfallWorkshop
                 string overrideBuildingName = string.Empty;
                 if (GameManager.Instance.TalkManager.IsBuildingQuestResource(buildingSummary.buildingKey, ref overrideBuildingName, ref pcLearnedAboutExistence, ref receivedDirectionalHints, ref locationWasMarkedOnMapByNPC))
                 {
-                    if (pcLearnedAboutExistence)
+                    if (locationWasMarkedOnMapByNPC)
                         buildingName = overrideBuildingName;
                 }
             }
@@ -1187,6 +1187,9 @@ namespace DaggerfallWorkshop
                     buildingSummary.FactionId,
                     buildingDirectory.LocationData.Name,
                     buildingDirectory.LocationData.RegionName);
+
+                if (!HasDiscoveredBuilding(buildingKey))
+                    return false;
             }
 
             // Add to data

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -997,22 +997,8 @@ namespace DaggerfallWorkshop
         /// <returns>True if building discovered, false if building not discovered.</returns>
         public bool GetDiscoveredBuilding(int buildingKey, out DiscoveredBuilding discoveredBuildingOut)
         {
-            discoveredBuildingOut = new DiscoveredBuilding();
-
-            // Must have discovered building
-            if (!HasDiscoveredBuilding(buildingKey))
-                return false;
-
-            // Get the location discovery for this mapID
-            int mapPixelID = MapsFile.GetMapPixelIDFromLongitudeLatitude((int)CurrentLocation.MapTableData.Longitude, CurrentLocation.MapTableData.Latitude);
-            DiscoveredLocation dl = discoveredLocations[mapPixelID];
-            if (dl.discoveredBuildings == null)
-                return false;
-
             // Get discovery data for building
-            bool discovered = GetBuildingDiscoveryData(buildingKey, out discoveredBuildingOut);
-
-            return discovered;
+            return GetBuildingDiscoveryData(buildingKey, out discoveredBuildingOut);
         }
 
         /// <summary>
@@ -1138,6 +1124,22 @@ namespace DaggerfallWorkshop
         bool GetBuildingDiscoveryData(int buildingKey, out DiscoveredBuilding buildingDiscoveryData)
         {
             buildingDiscoveryData = new DiscoveredBuilding();
+
+            // Must have discovered building
+            if (!HasDiscoveredBuilding(buildingKey))
+                return false;
+
+            // Get the location discovery for this mapID
+            int mapPixelID = MapsFile.GetMapPixelIDFromLongitudeLatitude((int)CurrentLocation.MapTableData.Longitude, CurrentLocation.MapTableData.Latitude);
+            DiscoveredLocation dl = discoveredLocations[mapPixelID];
+            if (dl.discoveredBuildings == null)
+                return false;
+
+            buildingDiscoveryData = dl.discoveredBuildings[buildingKey];
+
+            // if override name - use this name and don't do any further name resolving
+            if (buildingDiscoveryData.isOverrideName)
+                return true;
 
             // Get building directory for location
             BuildingDirectory buildingDirectory = GameManager.Instance.StreamingWorld.GetCurrentBuildingDirectory();

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -1159,7 +1159,7 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
-        /// Gets initial building information from current location (no building).
+        /// Gets initial building information from current location (no building name expansion).
         /// Does not change discovery state for building.
         /// </summary>
         /// <param name="buildingKey">Key of building to query.</param>


### PR DESCRIPTION
First of all: PLEASE help me to test this out before merging - I tested quite a bit and it seems to work ok, but the devil does not sleep ;)

now regarding the changes:
reworked the building discovery system a bit - no fear - nothing too heavy.
just tried to split stuff a bit better between functions:
- DiscoverBuilding is now the only function that really changes discovery state (except one small exception about player house name which I plan to fix as well)
- GetDiscoveredBuilding only uses this data and does not compute any building names on its own (except player house name)
- GetBuildingDiscoveryData gets initial building information from current location (no building name expansion like quest-named residences, no thieves guild name, etc.) - this function is not used directly by other systems but used by DiscoverBuilding and GetAnyBuilding - so no code duplication anymore and thus less bugs hopefully
- GetAnyBuilding now uses the other two functions (GetDiscoveredBuilding and GetBuildingDiscoveryData) to get any building discovery data (undiscovered and discovered) - this is much cleaner now and fixes some incorrect answers to the "Where am I?" question, I tested to make sure this does not break dialog linked topics in quests (and my hardcore testing quest (the non-member mages guild quest with the missing book passed my tests)).

I would like to rename GetBuildingDiscoveryData into something that better reflects the fact that this function computes intermediate results without expanding quest named residences, special guildhalls etc. Would like to hear your suggestions, something like GetInitialBuildingDiscoveryData or GetRawBuildingDiscoveryData were my best ideas but they don't seem too good to me

some of the bugs that should be fixed now are:
- special guild halls should show up again
- named residence showing up on map but not telling the right name on info click should be fixed
- named residences not showing up on map in some cases should be fixed
- potential problem with the same residence used by 2 quests simultaneously should behave like this: info click when undiscovered will give one of the two, otherwise the name first marked on map (update: we can change this so it shows the last name that was marked by npcs on map - what do you think how it should behave?) 
- talk question "Where am I?" should now always give resolved names of residences etc.

