### PR TITLE
make sure you're grounded after fast travel

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -1267,8 +1267,9 @@ namespace DaggerfallWorkshop
 
         // Repositions player in world after a teleport.
         // If position.y is less than terrain height then player will be raised to sit on terrain.
+        // If grounded is true, position.y will be unconditionally set to terrain height.
         // Terrain data must already be loaded and LocalGPS must be attached to your player game object.
-        private void RepositionPlayer(int mapPixelX, int mapPixelY, Vector3 position)
+        private void RepositionPlayer(int mapPixelX, int mapPixelY, Vector3 position, bool grounded = false)
         {
             // Get terrain key
             int key = TerrainHelper.MakeTerrainKey(mapPixelX, mapPixelY);
@@ -1289,7 +1290,7 @@ namespace DaggerfallWorkshop
                 targetPosition.y = height + controller.height / 2f + 0.15f;
 
                 // If desired position is higher then minimum position then we can safely use that
-                if (position.y > targetPosition.y)
+                if (!grounded && position.y > targetPosition.y)
                     targetPosition.y = position.y;
 
                 // Move player object to new position
@@ -1520,14 +1521,14 @@ namespace DaggerfallWorkshop
                 if (closestMarker != -1)
                 {
                     //PositionPlayerToTerrain(mapPixelX, mapPixelY, startMarkers[closestMarker].transform.position);
-                    RepositionPlayer(mapPixelX, mapPixelY, startMarkers[closestMarker].transform.position);
+                    RepositionPlayer(mapPixelX, mapPixelY, startMarkers[closestMarker].transform.position, grounded: true);
                     return;
                 }
             }
 
             // Just position to outside location
             //PositionPlayerToTerrain(mapPixelX, mapPixelY, newPlayerPosition);
-            RepositionPlayer(mapPixelX, mapPixelY, newPlayerPosition);
+            RepositionPlayer(mapPixelX, mapPixelY, newPlayerPosition, grounded: true);
         }
 
         // Align player to ground


### PR DESCRIPTION
Replacement for PR #1359 
It adds a "grounded" boolean parameter tto RepositionPlayer() to force new position to be on the ground; That parameter is used when the player is relocated to a StartMarker using a cardinal direction, which include fast travel case but should always be a safe thing to do.

I'll keep testing it, but I'm releasing the PR so that more people can test it.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2307