### PR TITLE
Immediately adjust looping sounds volume

### DIFF
--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Game
         System.Random random;
         DaggerfallAudioSource dfAudioSource;
         AudioSource loopAudioSource;
+        float loopVolumeScale;
         AudioSource ambientAudioSource;
         //private Coroutine relativePositionCoroutine = null;
 
@@ -147,6 +148,10 @@ namespace DaggerfallWorkshop.Game
                 }
                 waterWaitCounter = 0;
             }
+
+            // Update sound volume
+            if (loopAudioSource.isPlaying)
+                loopAudioSource.volume = loopVolumeScale * DaggerfallUnity.Settings.SoundVolume;
         }
 
         #region Private Methods
@@ -166,6 +171,7 @@ namespace DaggerfallWorkshop.Game
         private AudioClip PlayLoop(SoundClips clip, float volumeScale)
         {
             AudioClip loopClip = dfAudioSource.GetAudioClip((int)clip);
+            loopVolumeScale = volumeScale;
             loopAudioSource.loop = true;
             loopAudioSource.spatialBlend = 0;
             loopAudioSource.PlayWhenReady(loopClip, volumeScale);


### PR DESCRIPTION
Without that patch, looping sounds (crickets, rain) stay at the same volume until they're stopped.
(Effect sounds are less problematic because they don't last as long).

This adjust looping sounds immediately; Volume is adjusted with each frame, just like music in DaggerfallSongPlayer. A more elegant solution could involve AudioMixers...

Forums: https://forums.dfworkshop.net/viewtopic.php?f=14&t=1333&p=28652#p28648