### PR TITLE
Quest dispense lists

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -114,3 +114,4 @@ PlayerTorchFromItems=False
 CombatVoices=True
 EnemyInfighting=True
 EnhancedCombatAI=True
+GuildQuestListBox=False

--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -31,7 +31,7 @@ namespace DaggerfallWorkshop.Game.Questing
         Zenithar = 'Z',
     }
 
-    struct QuestData
+    public struct QuestData
     {
         public string name;
         public string path;
@@ -298,6 +298,15 @@ namespace DaggerfallWorkshop.Game.Questing
         /// </summary>
         public Quest GetGuildQuest(FactionFile.GuildGroups guildGroup, MembershipStatus status, int factionId, int rep, int rank)
         {
+            List<QuestData> pool = GetGuildQuestPool(guildGroup, status, factionId, rep, rank);
+            return SelectQuest(pool, factionId);
+        }
+
+        /// <summary>
+        /// Gets a pool of elligible quests for a guild to offer.
+        /// </summary>
+        public List<QuestData> GetGuildQuestPool(FactionFile.GuildGroups guildGroup, MembershipStatus status, int factionId, int rep, int rank)
+        {
 #if UNITY_EDITOR    // Reload every time when in editor
             LoadQuestLists();
 #endif
@@ -322,7 +331,7 @@ namespace DaggerfallWorkshop.Game.Questing
                             pool.Add(quest);
                     }
                 }
-                return SelectQuest(pool, factionId);
+                return pool;
             }
             return null;
         }
@@ -349,7 +358,7 @@ namespace DaggerfallWorkshop.Game.Questing
             return null;
         }
 
-        private Quest SelectQuest(List<QuestData> pool, int factionId)
+        public Quest SelectQuest(List<QuestData> pool, int factionId)
         {
             Debug.Log("Quest pool has " + pool.Count);
             // Choose random quest from pool and try to parse it
@@ -373,7 +382,7 @@ namespace DaggerfallWorkshop.Game.Questing
             return LoadQuest(new QuestData() { name = questName, path = questPath }, factionId);
         }
 
-        private Quest LoadQuest(QuestData questData, int factionId)
+        public Quest LoadQuest(QuestData questData, int factionId)
         {
             // Append extension if not present
             string questName = questData.name;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -129,6 +129,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox allowMagicRepairs;
         Checkbox instantRepairs;
         Checkbox playerTorchFromItems;
+        Checkbox guildQuestListBox;
         HorizontalSlider dungeonAmbientLightScale;
         HorizontalSlider nightAmbientLightScale;
         HorizontalSlider playerTorchLightScale;
@@ -300,7 +301,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             enhancedCombatAI = AddCheckbox(rightPanel, "enhancedCombatAI", DaggerfallUnity.Settings.EnhancedCombatAI);
             allowMagicRepairs = AddCheckbox(rightPanel, "allowMagicRepairs", DaggerfallUnity.Settings.AllowMagicRepairs);
             instantRepairs = AddCheckbox(rightPanel, "instantRepairs", DaggerfallUnity.Settings.InstantRepairs);
-
+            guildQuestListBox = AddCheckbox(rightPanel, "guildQuestListBox", DaggerfallUnity.Settings.GuildQuestListBox);
         }
 
         private void Video(Panel leftPanel, Panel rightPanel)
@@ -401,6 +402,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.EnhancedCombatAI = enhancedCombatAI.IsChecked;
             DaggerfallUnity.Settings.AllowMagicRepairs = allowMagicRepairs.IsChecked;
             DaggerfallUnity.Settings.InstantRepairs = instantRepairs.IsChecked;
+            DaggerfallUnity.Settings.GuildQuestListBox = guildQuestListBox.IsChecked;
 
             DaggerfallUnity.Settings.DungeonAmbientLightScale = dungeonAmbientLightScale.GetValue();
             DaggerfallUnity.Settings.NightAmbientLightScale = nightAmbientLightScale.GetValue();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -77,6 +77,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         PlayerGPS.DiscoveredBuilding buildingDiscoveryData;
         int curingCost = 0;
 
+        List<QuestData> questPool;
+
         #endregion
 
         #region Constructors
@@ -460,13 +462,42 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Get member status, including temple specific statuses
             MembershipStatus status = guild.IsMember() ? MembershipStatus.Member : MembershipStatus.Nonmember;
             if (guild.IsMember() && guildGroup == FactionFile.GuildGroups.HolyOrder)
-                status = (MembershipStatus) Enum.Parse(typeof(MembershipStatus), ((Temple)guild).Deity.ToString());
+                status = (MembershipStatus)Enum.Parse(typeof(MembershipStatus), ((Temple)guild).Deity.ToString());
 
             // Get the faction id for affecting reputation on success/failure
-            int factionId = (guildGroup == FactionFile.GuildGroups.HolyOrder || guildGroup == FactionFile.GuildGroups.KnightlyOrder) ? buildingFactionId : guildManager.GetGuildFactionId(guildGroup);
+            int factionId = GetFactionIdForGuild();
 
             // Select a quest at random from appropriate pool
-            offeredQuest = GameManager.Instance.QuestListsManager.GetGuildQuest(guildGroup, status, factionId, guild.GetReputation(playerEntity), guild.Rank);
+            QuestListsManager questListsManager = GameManager.Instance.QuestListsManager;
+            questPool = GameManager.Instance.QuestListsManager.GetGuildQuestPool(guildGroup, status, factionId, guild.GetReputation(playerEntity), guild.Rank);
+
+            if (DaggerfallUnity.Settings.GuildQuestListBox)
+            {
+                string[] message = {
+                        TextManager.Instance.GetText(textDatabase, "gettingQuests1"),
+                        TextManager.Instance.GetText(textDatabase, "gettingQuests2"),
+                        "", ""
+                    };
+                DaggerfallMessageBox gettingQuestsBox = new DaggerfallMessageBox(DaggerfallUI.UIManager, this);
+                gettingQuestsBox.SetText(message);
+                gettingQuestsBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.OK);
+                gettingQuestsBox.OnButtonClick += GettingQuestsBox_OnButtonClick;
+                gettingQuestsBox.Show();
+            }
+            else
+            {
+                offeredQuest = questListsManager.SelectQuest(questPool, factionId);
+                OfferQuest();
+            }
+        }
+
+        private int GetFactionIdForGuild()
+        {
+            return (guildGroup == FactionFile.GuildGroups.HolyOrder || guildGroup == FactionFile.GuildGroups.KnightlyOrder) ? buildingFactionId : guildManager.GetGuildFactionId(guildGroup);
+        }
+
+        protected void OfferQuest()
+        {
             if (offeredQuest != null)
             {
                 // Log offered quest
@@ -485,6 +516,42 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             else
             {
                 ShowFailGetQuestMessage();
+            }
+        }
+
+        public void GettingQuestsBox_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
+        {
+            sender.CloseWindow();
+            if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.OK)
+            {
+                DaggerfallListPickerWindow questPicker = new DaggerfallListPickerWindow(uiManager, uiManager.TopWindow);
+                questPicker.OnItemPicked += QuestPicker_OnItemPicked;
+                for (int i=0; i<questPool.Count; i++)
+                {
+                    try {
+                        Quest quest = GameManager.Instance.QuestListsManager.LoadQuest(questPool[i], GetFactionIdForGuild());
+                        if (quest != null)
+                            questPicker.ListBox.AddItem(quest.DisplayName == null ? quest.QuestName : quest.DisplayName);
+                        else
+                            questPool.RemoveAt(i);  // Remove any that fail compilation
+                    }
+                    catch (Exception)
+                    {
+                        questPool.RemoveAt(i);  // Remove any that throw exceptions
+                    }
+                }
+                uiManager.PushWindow(questPicker);
+            }
+        }
+
+        public void QuestPicker_OnItemPicked(int index, string name)
+        {
+            DaggerfallUI.UIManager.PopWindow();
+            if (index < questPool.Count)
+            {
+                QuestData questData = questPool[index];
+                offeredQuest = GameManager.Instance.QuestListsManager.LoadQuest(questData, GetFactionIdForGuild());
+                OfferQuest();
             }
         }
 

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -176,6 +176,7 @@ namespace DaggerfallWorkshop
         public bool CombatVoices { get; set; }
         public bool EnemyInfighting { get; set; }
         public bool EnhancedCombatAI { get; set; }
+        public bool GuildQuestListBox { get; set; }
 
         #endregion
 
@@ -294,6 +295,7 @@ namespace DaggerfallWorkshop
             CombatVoices = GetBool(sectionEnhancements, "CombatVoices");
             EnemyInfighting = GetBool(sectionEnhancements, "EnemyInfighting");
             EnhancedCombatAI = GetBool(sectionEnhancements, "EnhancedCombatAI");
+            GuildQuestListBox = GetBool(sectionEnhancements, "GuildQuestListBox");
         }
 
         /// <summary>
@@ -401,6 +403,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionEnhancements, "CombatVoices", CombatVoices);
             SetBool(sectionEnhancements, "EnemyInfighting", EnemyInfighting);
             SetBool(sectionEnhancements, "EnhancedCombatAI", EnhancedCombatAI);
+            SetBool(sectionEnhancements, "GuildQuestListBox", GuildQuestListBox);
 
             // Write settings to persistent file
             WriteSettingsFile();

--- a/Assets/StreamingAssets/Quests/00B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/00B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 32
 Quest: 00B00Y00
+DisplayName: The Price of Knowledge
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/B0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 16
 Quest: B0B00Y00
+DisplayName: The Princess
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/B0B00Y01.txt
@@ -6,6 +6,7 @@
 -- QuestId: 1
 Messages: 12
 Quest: B0B00Y01
+DisplayName: Retribution
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B10Y04.txt
+++ b/Assets/StreamingAssets/Quests/B0B10Y04.txt
@@ -6,6 +6,7 @@
 -- QuestId: 4
 Messages: 18
 Quest: B0B10Y04
+DisplayName: The Crazed Mercenary
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B20Y07.txt
+++ b/Assets/StreamingAssets/Quests/B0B20Y07.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0B20Y07
+DisplayName: More Trouble with Orcs
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B40Y08.txt
+++ b/Assets/StreamingAssets/Quests/B0B40Y08.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0B40Y08
+DisplayName: Still More Trouble with Orcs
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B40Y09.txt
+++ b/Assets/StreamingAssets/Quests/B0B40Y09.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0B40Y09
+DisplayName: Killing a Giant
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B50Y11.txt
+++ b/Assets/StreamingAssets/Quests/B0B50Y11.txt
@@ -6,6 +6,7 @@
 -- QuestId: 11
 Messages: 12
 Quest: B0B50Y11
+DisplayName: The Exorcism
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B60Y12.txt
+++ b/Assets/StreamingAssets/Quests/B0B60Y12.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0B60Y12
+DisplayName: Eternal Rest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B70Y14.txt
+++ b/Assets/StreamingAssets/Quests/B0B70Y14.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0B70Y14
+DisplayName: Invasion from Oblivion
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B70Y16.txt
+++ b/Assets/StreamingAssets/Quests/B0B70Y16.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0B70Y16
+DisplayName: The Dragonslayer
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B71Y03.txt
+++ b/Assets/StreamingAssets/Quests/B0B71Y03.txt
@@ -6,6 +6,7 @@
 -- QuestId: 3
 Messages: 53
 Quest: B0B71Y03
+DisplayName: The Artifact
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B80Y17.txt
+++ b/Assets/StreamingAssets/Quests/B0B80Y17.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0B80Y17
+DisplayName: The Army of Undead
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B81Y02.txt
+++ b/Assets/StreamingAssets/Quests/B0B81Y02.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 43
 Quest: B0B81Y02
+DisplayName: The Lost Artifact
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0C00Y05.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y05.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 81
 Quest: B0C00Y05
+DisplayName: The Traitor
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y06.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0C00Y06
+DisplayName: The Hunter
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y10.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0C00Y10
+DisplayName: Trouble with Orcs
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y13.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: B0C00Y13
+DisplayName: The Infested House
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y00.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 13
 Quest: C0B00Y00
+DisplayName: The Haunted House
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y01.txt
@@ -6,6 +6,7 @@
 -- QuestId: 1
 Messages: 38
 Quest: C0B00Y01
+DisplayName: The Heretic
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B00Y02.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y02.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 27
 Quest: C0B00Y02
+DisplayName: The Obsessed Child
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B00Y02.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y02.txt
@@ -7,7 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 27
 Quest: C0B00Y02
-DisplayName: The Obsessed Child
+DisplayName: The Possessed Child
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B00Y03.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y03.txt
@@ -6,6 +6,7 @@
 -- QuestId: 3
 Messages: 13
 Quest: C0B00Y03
+DisplayName: The Missing Scholar
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B00Y04.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y04.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 13
 Quest: C0B00Y04
+DisplayName: The Insane Priest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B00Y14.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y14.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 62
 Quest: C0B00Y14
+DisplayName: Hunt for Undead
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B10Y05.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y05.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 13
 Quest: C0B10Y05
+DisplayName: The Cursed Weapon
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B10Y06.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y06.txt
@@ -6,6 +6,7 @@
 -- QuestId: 6
 Messages: 12
 Quest: C0B10Y06
+DisplayName: The Expiatory Sacrifice
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B10Y07.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y07.txt
@@ -6,6 +6,7 @@
 -- QuestId: 7
 Messages: 12
 Quest: C0B10Y07
+DisplayName: A Delivery
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B10Y15.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y15.txt
@@ -6,6 +6,7 @@
 -- QuestId: 15
 Messages: 41
 Quest: C0B10Y15
+DisplayName: The Relic
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B20Y08.txt
+++ b/Assets/StreamingAssets/Quests/C0B20Y08.txt
@@ -6,6 +6,7 @@
 -- QuestId: 8
 Messages: 12
 Quest: C0B20Y08
+DisplayName: The Rite of Atonement
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0B3XY09.txt
+++ b/Assets/StreamingAssets/Quests/C0B3XY09.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 13
 Quest: C0B3XY09
+DisplayName: The Great Evil
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y10.txt
@@ -6,6 +6,7 @@
 -- QuestId: 10
 Messages: 26
 Quest: C0C00Y10
+DisplayName: The Healing
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y11.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 81
 Quest: C0C00Y11
+DisplayName: The Spook
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y12.txt
@@ -6,6 +6,7 @@
 -- QuestId: 12
 Messages: 21
 Quest: C0C00Y12
+DisplayName: The Stolen Item
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/C0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y13.txt
@@ -6,6 +6,7 @@
 -- QuestId: 13
 Messages: 12
 Quest: C0C00Y13
+DisplayName: An Errand
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/D0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/D0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 31
 Quest: D0B00Y00
+DisplayName: Avenge the Dragons
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/E0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/E0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 21
 Quest: E0B00Y00
+DisplayName: The Desecrated Temple
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/F0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/F0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 31
 Quest: F0B00Y00
+DisplayName: Desired Artwork
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/G0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/G0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 21
 Quest: G0B00Y00
+DisplayName: The Arm of Fury
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/H0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/H0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 21
 Quest: H0B00Y00
+DisplayName: A Powerful Spirit
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/I0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/I0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 31
 Quest: I0B00Y00
+DisplayName: A Special Plant
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/J0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/J0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 31
 Quest: J0B00Y00
+DisplayName: The Bounty
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0A01L00.txt
+++ b/Assets/StreamingAssets/Quests/L0A01L00.txt
@@ -8,6 +8,7 @@
 -- Temp changes to allow joining DB made by Hazelnut
 Messages: 21
 Quest: L0A01L00
+DisplayName: The Acceptance Test
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 22
 Quest: L0B00Y00
+DisplayName: A Renegade Member
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y01.txt
@@ -6,6 +6,7 @@
 -- QuestId: 1
 Messages: 14
 Quest: L0B00Y01
+DisplayName: No Escape
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B00Y02.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y02.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 16
 Quest: L0B00Y02
+DisplayName: Disagreeable Competition
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B00Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y03.txt
@@ -6,6 +6,7 @@
 -- QuestId: 3
 Messages: 12
 Quest: L0B00Y03
+DisplayName: A Renegade Mage
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B10Y01.txt
+++ b/Assets/StreamingAssets/Quests/L0B10Y01.txt
@@ -6,6 +6,7 @@
 -- QuestId: 1
 Messages: 21
 Quest: L0B10Y01
+DisplayName: A Fateful Song
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B10Y03.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 15
 Quest: L0B10Y03
+DisplayName: Unauthorized Absence
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/L0B20Y02.txt
@@ -6,6 +6,7 @@
 -- QuestId: 2
 Messages: 22
 Quest: L0B20Y02
+DisplayName: A Knight Without Honor
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B30Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B30Y03.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 21
 Quest: L0B30Y03
+DisplayName: Contract on a Mage
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B30Y09.txt
+++ b/Assets/StreamingAssets/Quests/L0B30Y09.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 22
 Quest: L0B30Y09
+DisplayName: An Anonymous Job
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B40Y04.txt
+++ b/Assets/StreamingAssets/Quests/L0B40Y04.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 22
 Quest: L0B40Y04
+DisplayName: Concerns of a Noble
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B50Y11.txt
+++ b/Assets/StreamingAssets/Quests/L0B50Y11.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 32
 Quest: L0B50Y11
+DisplayName: Taking on the Thieves Guild
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/L0B60Y10.txt
+++ b/Assets/StreamingAssets/Quests/L0B60Y10.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 24
 Quest: L0B60Y10
+DisplayName: The Veteran
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 81
 Quest: M0B00Y00
+DisplayName: Hunt for a Lycanthrope
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B00Y06.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y06.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 81
 Quest: M0B00Y06
+DisplayName: Wild Animal
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B00Y07.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y07.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 81
 Quest: M0B00Y07
+DisplayName: Unwanted Houseguest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B00Y15.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y15.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 21
 Quest: M0B00Y15
+DisplayName: Hunt for Giant Rodents
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y16.txt
@@ -6,6 +6,7 @@
 -- QuestId: 16
 Messages: 81
 Quest: M0B00Y16
+DisplayName: Giant Killing
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B00Y17.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y17.txt
@@ -6,6 +6,7 @@
 -- QuestId: 17
 Messages: 62
 Quest: M0B00Y17
+DisplayName: Runaway Pet
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B11Y18.txt
+++ b/Assets/StreamingAssets/Quests/M0B11Y18.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 74
 Quest: M0B11Y18
+DisplayName: Lord K'avar Quest Part I
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B1XY01.txt
+++ b/Assets/StreamingAssets/Quests/M0B1XY01.txt
@@ -6,6 +6,7 @@
 -- QuestId: 1
 Messages: 81
 Quest: M0B1XY01
+DisplayName: Hunt for Harpies
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/M0B20Y02.txt
@@ -6,6 +6,7 @@
 -- QuestId: 2
 Messages: 81
 Quest: M0B20Y02
+DisplayName: Pack of Giants
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B21Y19.txt
+++ b/Assets/StreamingAssets/Quests/M0B21Y19.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 72
 Quest: M0B21Y19
+DisplayName: Standard Protection
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B30Y03.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y03.txt
@@ -6,6 +6,7 @@
 -- QuestId: 3
 Messages: 81
 Quest: M0B30Y03
+DisplayName: Hunt for a Daedroth
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B30Y04.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y04.txt
@@ -6,6 +6,7 @@
 -- QuestId: 4
 Messages: 81
 Quest: M0B30Y04
+DisplayName: Fighters Lich
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B30Y08.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y08.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 81
 Quest: M0B30Y08
+DisplayName: Domestic Squabble
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B40Y05.txt
+++ b/Assets/StreamingAssets/Quests/M0B40Y05.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 81
 Quest: M0B40Y05
+DisplayName: Hunt for a Spriggan
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B50Y09.txt
+++ b/Assets/StreamingAssets/Quests/M0B50Y09.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 81
 Quest: M0B50Y09
+DisplayName: Hunt for a Gargoyle
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0B60Y10.txt
+++ b/Assets/StreamingAssets/Quests/M0B60Y10.txt
@@ -6,6 +6,7 @@
 -- QuestId: 10
 Messages: 81
 Quest: M0B60Y10
+DisplayName: Hunt for an Atronach
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y11.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: M0C00Y11
+DisplayName: Hunt for a Giant Scorpion
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y12.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: M0C00Y12
+DisplayName: Hunt for a Giant Spider
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y13.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: M0C00Y13
+DisplayName: Hunt for Barbarians
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/M0C00Y14.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y14.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 21
 Quest: M0C00Y14
+DisplayName: A Rat Infestation
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B00Y04.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y04.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 46
 Quest: N0B00Y04
+DisplayName: Retrieve an Ingredient
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B00Y06.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y06.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 12
 Quest: N0B00Y06
+DisplayName: Mummy Wrappings
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B00Y08.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y08.txt
@@ -6,6 +6,7 @@
 -- QuestId: 8
 Messages: 12
 Quest: N0B00Y08
+DisplayName: Cast the Sleep spell
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B00Y09.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y09.txt
@@ -6,6 +6,7 @@
 -- QuestId: 9
 Messages: 23
 Quest: N0B00Y09
+DisplayName: Research Notes
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y16.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 52
 Quest: N0B00Y16
+DisplayName: Open a chest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B00Y17.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y17.txt
@@ -6,6 +6,7 @@
 -- QuestId: 17
 Messages: 61
 Quest: N0B00Y17
+DisplayName: Azimuthal Vectors
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B10Y01.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y01.txt
@@ -6,6 +6,7 @@
 -- QuestId: 1
 Messages: 21
 Quest: N0B10Y01
+DisplayName: Atronach Hunting
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y03.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 14
 Quest: N0B10Y03
+DisplayName: Guard the Guild
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B11Y18.txt
+++ b/Assets/StreamingAssets/Quests/N0B11Y18.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 64
 Quest: N0B11Y18
+DisplayName: Former Student Part I
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/N0B20Y02.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 31
 Quest: N0B20Y02
+DisplayName: Protect an Honored Mage
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B20Y05.txt
+++ b/Assets/StreamingAssets/Quests/N0B20Y05.txt
@@ -6,6 +6,7 @@
 -- QuestId: 5
 Messages: 41
 Quest: N0B20Y05
+DisplayName: A Dangerous Wizard
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B21Y14.txt
+++ b/Assets/StreamingAssets/Quests/N0B21Y14.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 25
 Quest: N0B21Y14
+DisplayName: Oracle
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B30Y15.txt
+++ b/Assets/StreamingAssets/Quests/N0B30Y15.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 11
 Quest: N0B30Y15
+DisplayName: Rogue Imp
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0B40Y07.txt
+++ b/Assets/StreamingAssets/Quests/N0B40Y07.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 61
 Quest: N0B40Y07
+DisplayName: Banish Daedra
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y10.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 41
 Quest: N0C00Y10
+DisplayName: Missing Book
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y11.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 81
 Quest: N0C00Y11
+DisplayName: Grab an Ingredient
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y12.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 21
 Quest: N0C00Y12
+DisplayName: The Loose Pet Imp
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/N0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y13.txt
@@ -6,6 +6,7 @@
 -- QuestId: 13
 Messages: 46
 Quest: N0C00Y13
+DisplayName: An Ancient Scroll
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0A0AL00.txt
+++ b/Assets/StreamingAssets/Quests/O0A0AL00.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 31
 Quest: O0A0AL00
+DisplayName: The Qualifying Examination
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 21
 Quest: O0B00Y00
+DisplayName: A Hot Stone
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y01.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 31
 Quest: O0B00Y01
+DisplayName: Arms Supply
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B00Y11.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y11.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 64
 Quest: O0B00Y11
+DisplayName: Antique Ivory
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B00Y12.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y12.txt
@@ -6,6 +6,7 @@
 -- QuestId: 12
 Messages: 36
 Quest: O0B00Y12
+DisplayName: Drugs Delivery
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B10Y00.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 21
 Quest: O0B10Y00
+DisplayName: A Stolen Gem
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y03.txt
@@ -6,6 +6,7 @@
 -- QuestId: 3
 Messages: 11
 Quest: O0B10Y03
+DisplayName: A Temple Visit
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B10Y05.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y05.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 11
 Quest: O0B10Y05
+DisplayName: Valuable Artwork
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B10Y06.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y06.txt
@@ -6,6 +6,7 @@
 -- QuestId: 6
 Messages: 11
 Quest: O0B10Y06
+DisplayName: The Jewel Heist
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B10Y07.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y07.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 21
 Quest: O0B10Y07
+DisplayName: The Noble's Jewelry
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/O0B20Y02.txt
@@ -6,6 +6,7 @@
 -- QuestId: 2
 Messages: 11
 Quest: O0B20Y02
+DisplayName: A Prized Item
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B2XY04.txt
+++ b/Assets/StreamingAssets/Quests/O0B2XY04.txt
@@ -6,6 +6,7 @@
 -- QuestId: 4
 Messages: 11
 Quest: O0B2XY04
+DisplayName: Valuable Pages
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B2XY08.txt
+++ b/Assets/StreamingAssets/Quests/O0B2XY08.txt
@@ -6,6 +6,7 @@
 -- QuestId: 8
 Messages: 11
 Quest: O0B2XY08
+DisplayName: A Prized Herb
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B2XY09.txt
+++ b/Assets/StreamingAssets/Quests/O0B2XY09.txt
@@ -6,6 +6,7 @@
 -- QuestId: 9
 Messages: 11
 Quest: O0B2XY09
+DisplayName: The Rich Merchant
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/O0B2XY10.txt
+++ b/Assets/StreamingAssets/Quests/O0B2XY10.txt
@@ -6,6 +6,7 @@
 -- QuestId: 10
 Messages: 11
 Quest: O0B2XY10
+DisplayName: A Treasured Potion
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y01.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y01.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 14
 Quest: Q0C00Y01
+DisplayName: The Libel
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y03.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y03.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 14
 Quest: Q0C00Y03
+DisplayName: Public Relation
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y04.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y04.txt
@@ -6,6 +6,7 @@
 -- QuestId: 4
 Messages: 18
 Quest: Q0C00Y04
+DisplayName: A Special Mixture
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y06.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 21
 Quest: Q0C00Y06
+DisplayName: Problems with Vampires
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y07.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y07.txt
@@ -6,6 +6,7 @@
 -- QuestId: 7
 Messages: 14
 Quest: Q0C00Y07
+DisplayName: The Imprisoned Witch
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y08.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y08.txt
@@ -6,6 +6,7 @@
 -- QuestId: 8
 Messages: 14
 Quest: Q0C00Y08
+DisplayName: A Rare Tome
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C0XY02.txt
+++ b/Assets/StreamingAssets/Quests/Q0C0XY02.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 21
 Quest: Q0C0XY02
+DisplayName: A Treacherous Gift
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C10Y00.txt
+++ b/Assets/StreamingAssets/Quests/Q0C10Y00.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 24
 Quest: Q0C10Y00
+DisplayName: A Great Errand
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C20Y02.txt
+++ b/Assets/StreamingAssets/Quests/Q0C20Y02.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 26
 Quest: Q0C20Y02
+DisplayName: An Expensive Purchase
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Q0C4XY04.txt
+++ b/Assets/StreamingAssets/Quests/Q0C4XY04.txt
@@ -6,6 +6,7 @@
 -- QuestId: 4
 Messages: 41
 Quest: Q0C4XY04
+DisplayName: The Daedra's Heart
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -101,8 +101,8 @@ serviceMembersOnly, "My services are reserved for members only."
 serviceDonateHowMuch, "Donate how much money : "
 curedDisease,       "You are cured."
 freeHolidayCuring,  "You are cured free from cost due to todays' holiday."
-gettingQuests1,     "Hmm, let me see what tasks we have availiable. Please have"
-gettingQuests2,     "patence and wait here a moment, %pcf. I'll be right back."
+gettingQuests1,     "Hmm, let me see what tasks we have availiable."
+gettingQuests2,     "Please have patience and wait here a moment, %pcf."
 
 - Rest window
 

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -101,6 +101,8 @@ serviceMembersOnly, "My services are reserved for members only."
 serviceDonateHowMuch, "Donate how much money : "
 curedDisease,       "You are cured."
 freeHolidayCuring,  "You are cured free from cost due to todays' holiday."
+gettingQuests1,     "Hmm, let me see what tasks we have availiable. Please have"
+gettingQuests2,     "patence and wait here a moment, %pcf. I'll be right back."
 
 - Rest window
 

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -85,8 +85,8 @@ dungeonExitWagonPrompt,                             Dungeon wagon access prompt
 dungeonExitWagonPromptInfo,                         Prompt for wagon access on dungeon exit. (Wagon is always accessible within 5m of exit)
 loiterLimitInHours,                                 Maximum loiter time in hours
 loiterLimitInHoursInfo,                             Change default loiter time limit in hours
-guildQuestListBox,                                  Select guild quests from a list box
-guildQuestListBoxInfo,                              Presents all elligible guild quests in a list box allowing selection
+guildQuestListBox,                                  Guild quest player selection
+guildQuestListBoxInfo,                              Presents elligible guild quests in a list box
 
 modSystem,                                          Mod System
 modSystemInfo,                                      Enable support for mods.

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -85,6 +85,8 @@ dungeonExitWagonPrompt,                             Dungeon wagon access prompt
 dungeonExitWagonPromptInfo,                         Prompt for wagon access on dungeon exit. (Wagon is always accessible within 5m of exit)
 loiterLimitInHours,                                 Maximum loiter time in hours
 loiterLimitInHoursInfo,                             Change default loiter time limit in hours
+guildQuestListBox,                                  Select guild quests from a list box
+guildQuestListBoxInfo,                              Presents all elligible guild quests in a list box allowing selection
 
 modSystem,                                          Mod System
 modSystemInfo,                                      Enable support for mods.


### PR DESCRIPTION
See thread: https://forums.dfworkshop.net/viewtopic.php?f=22&p=28902
Thanks to Firebrand for doing the quest names!

The message box with OK button is to prepare player for a potentially long wait while all the availiable quests are parsed. This is to get the names and ensure no broken quests get offered. Seems like a lot of space below the button. This is the best I could get it to look, but happy if someone can improve it.