### PR TITLE
Bugfixes

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -736,12 +736,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // Open potion mixer window if player has some ingredients
             CloseWindow();
-            for (int i = 0; i < playerEntity.Items.Count; i++)
+            foreach (ItemCollection playerItems in new ItemCollection[] { GameManager.Instance.PlayerEntity.Items, GameManager.Instance.PlayerEntity.WagonItems })
             {
-                if (playerEntity.Items.GetItem(i).IsIngredient)
+                for (int i = 0; i < playerItems.Count; i++)
                 {
-                    uiManager.PushWindow(DaggerfallUI.Instance.DfPotionMakerWindow);
-                    return;
+                    if (playerItems.GetItem(i).IsIngredient)
+                    {
+                        uiManager.PushWindow(DaggerfallUI.Instance.DfPotionMakerWindow);
+                        return;
+                    }
                 }
             }
             DaggerfallUI.MessageBox(34);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -286,18 +286,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void AddRecipeToCauldron(int index, string recipeName)
         {
-            ItemCollection playerItems = GameManager.Instance.PlayerEntity.Items;
             PotionRecipe recipe = recipes[index];
             Dictionary<int, DaggerfallUnityItem> recipeIngreds = new Dictionary<int, DaggerfallUnityItem>();
             foreach (PotionRecipe.Ingredient ingred in recipe.Ingredients)
                 recipeIngreds.Add(ingred.id, null);
 
             // Find matching items for the recipe ingredients
-            for (int i = 0; i < playerItems.Count; i++)
+            foreach (ItemCollection playerItems in new ItemCollection[] { GameManager.Instance.PlayerEntity.Items, GameManager.Instance.PlayerEntity.WagonItems })
             {
-                DaggerfallUnityItem item = playerItems.GetItem(i);
-                if (item.IsIngredient && recipeIngreds.ContainsKey(item.TemplateIndex) && recipeIngreds[item.TemplateIndex] == null)
-                    recipeIngreds[item.TemplateIndex] = item;
+                for (int i = 0; i < playerItems.Count; i++)
+                {
+                    DaggerfallUnityItem item = playerItems.GetItem(i);
+                    if (item.IsIngredient && recipeIngreds.ContainsKey(item.TemplateIndex) && recipeIngreds[item.TemplateIndex] == null)
+                        recipeIngreds[item.TemplateIndex] = item;
+                }
             }
             // If player doesn't have all the required ingredients, display message else move ingredients into cauldron.
             if (recipeIngreds.ContainsValue(null))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -644,7 +644,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     DaggerfallUnityItem item = localItems.GetItem(i);
                     if (!item.IsEquipped && (
                             (windowMode != WindowModes.Sell && windowMode != WindowModes.SellMagic) ||
-                            (windowMode == WindowModes.Sell && itemTypesAccepted.Contains(item.ItemGroup)) ||
+                            (windowMode == WindowModes.Sell && !item.IsEnchanted && itemTypesAccepted.Contains(item.ItemGroup)) ||
                             (windowMode == WindowModes.SellMagic && item.IsEnchanted) ))
                     {
                         AddLocalItem(item);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUseMagicItemWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUseMagicItemWindow.cs
@@ -85,7 +85,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             for (int i = 0; i < playerItems.Count; i++)
             {
                 DaggerfallUnityItem item = playerItems.GetItem(i);
-                if (item.IsEnchanted)
+                if (item.IsEnchanted && item.LegacyEnchantments != null)
                 {
                     foreach (DaggerfallEnchantment enchantment in item.LegacyEnchantments)
                         if (enchantment.type == EnchantmentTypes.CastWhenUsed)


### PR DESCRIPTION
Add check to prevent errors with modded items. Not all magic items will use legacy enchantments. e.g. locators in Archs guild mod.
Allow wagon ingredient access consistently.
Stop magic items being sold at normal stores.