### PR TITLE
update region name from notebook fast travel

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -428,7 +428,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // If a goto location specified, find it and ask if player wants to travel.
             if (!string.IsNullOrEmpty(gotoLocation))
             {
-                OpenRegionPanel(gotoRegion);
+                mouseOverRegion = gotoRegion;
+                OpenRegionPanel(mouseOverRegion);
+                UpdateRegionLabel();
                 HandleLocationFindEvent(null, gotoLocation);
                 gotoLocation = null;
             }


### PR DESCRIPTION
When initiating fast travel from notebook, update travel map title so that region name shows up correctly.

Screenshot of the problem:
![missing region name](https://user-images.githubusercontent.com/1211431/62825653-c2992c80-bbaf-11e9-8649-88401d931e2b.jpg)
