### PR TITLE
add console command to open the potion maker

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -82,6 +82,7 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(ShowBankWindow.name, ShowBankWindow.description, ShowBankWindow.usage, ShowBankWindow.Execute);
             ConsoleCommandsDatabase.RegisterCommand(ShowSpellmakerWindow.name, ShowSpellmakerWindow.description, ShowSpellmakerWindow.usage, ShowSpellmakerWindow.Execute);
             ConsoleCommandsDatabase.RegisterCommand(ShowItemMakerWindow.name, ShowItemMakerWindow.description, ShowItemMakerWindow.usage, ShowItemMakerWindow.Execute);
+            ConsoleCommandsDatabase.RegisterCommand(ShowPotionMakerWindow.name, ShowPotionMakerWindow.description, ShowPotionMakerWindow.usage, ShowPotionMakerWindow.Execute);
             ConsoleCommandsDatabase.RegisterCommand(AddSpellBook.name, AddSpellBook.description, AddSpellBook.usage, AddSpellBook.Execute);
             ConsoleCommandsDatabase.RegisterCommand(StartQuest.name, StartQuest.usage, StartQuest.description, StartQuest.Execute);
 
@@ -1763,6 +1764,19 @@ namespace Wenzil.Console
             public static string Execute(params string[] args)
             {
                 DaggerfallUI.UIManager.PostMessage(DaggerfallUIMessages.dfuiOpenItemMakerWindow);
+                return "Finished";
+            }
+        }
+
+        private static class ShowPotionMakerWindow
+        {
+            public static readonly string name = "showpotionmaker";
+            public static readonly string description = "Opens a potion maker window to brew potions";
+            public static readonly string usage = "showpotionmaker";
+
+            public static string Execute(params string[] args)
+            {
+                DaggerfallUI.UIManager.PostMessage(DaggerfallUIMessages.dfuiOpenPotionMakerWindow);
                 return "Finished";
             }
         }

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -477,6 +477,9 @@ namespace DaggerfallWorkshop.Game
                 case DaggerfallUIMessages.dfuiOpenItemMakerWindow:
                     uiManager.PushWindow(dfItemMakerWindow);
                     break;
+                case DaggerfallUIMessages.dfuiOpenPotionMakerWindow:
+                    uiManager.PushWindow(dfPotionMakerWindow);
+                    break;
                 case DaggerfallUIMessages.dfuiOpenTravelMapWindow:
                     if (GameManager.Instance.IsPlayerInside)
                     {

--- a/Assets/Scripts/Game/DaggerfallUIMessages.cs
+++ b/Assets/Scripts/Game/DaggerfallUIMessages.cs
@@ -57,6 +57,7 @@ namespace DaggerfallWorkshop.Game
         public const string dfuiOpenSpellBookWindow = "dfuiOpenSpellBookWindow";
         public const string dfuiOpenSpellMakerWindow = "dfuiOpenSpellMakerWindow";
         public const string dfuiOpenItemMakerWindow = "dfuiOpenItemMakerWindow";
+        public const string dfuiOpenPotionMakerWindow = "dfuiOpenPotionMakerWindow";
         public const string dfuiOpenUseMagicItemWindow = "dfuiOpenUseMagicItemWindow";
 
         // Status info messages


### PR DESCRIPTION
Having to go see a potion maker makes potions brewing very cumbersome, if not useless.
Players that don't mind bending classic rules can use that command to brew potions from any place.

(Requested by Shinino on Discord)