### PR TITLE
Fix arrow blood splash position

### DIFF
--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -5,7 +5,7 @@
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
 // Contributors:    Numidium, Hazelnut
-// 
+//
 // Notes:
 //
 
@@ -447,25 +447,23 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Set up for use below
-            Transform transform = arrowHit ? arrowHitCollider.gameObject.transform : hit.transform;
-            DaggerfallEntityBehaviour entityBehaviour = transform.GetComponent<DaggerfallEntityBehaviour>();
-            DaggerfallMobileUnit entityMobileUnit = transform.GetComponentInChildren<DaggerfallMobileUnit>();
-            EnemyMotor enemyMotor = transform.GetComponent<EnemyMotor>();
-            EnemySounds enemySounds = transform.GetComponent<EnemySounds>();
+            Transform hitTransform = arrowHit ? arrowHitCollider.gameObject.transform : hit.transform;
+            Vector3 impactPosition = arrowHit ? hitTransform.position : hit.point;
+            DaggerfallEntityBehaviour entityBehaviour = hitTransform.GetComponent<DaggerfallEntityBehaviour>();
+            DaggerfallMobileUnit entityMobileUnit = hitTransform.GetComponentInChildren<DaggerfallMobileUnit>();
+            EnemyMotor enemyMotor = hitTransform.GetComponent<EnemyMotor>();
+            EnemySounds enemySounds = hitTransform.GetComponent<EnemySounds>();
 
             // Check if hit a mobile NPC
-            MobilePersonNPC mobileNpc = transform.GetComponent<MobilePersonNPC>();
+            MobilePersonNPC mobileNpc = hitTransform.GetComponent<MobilePersonNPC>();
             if (mobileNpc)
             {
                 if (!mobileNpc.Billboard.IsUsingGuardTexture)
                 {
-                    EnemyBlood blood = transform.GetComponent<EnemyBlood>();
+                    EnemyBlood blood = hitTransform.GetComponent<EnemyBlood>();
                     if (blood)
                     {
-                        if (!arrowHit)
-                            blood.ShowBloodSplash(0, hit.point);
-                        else
-                            blood.ShowBloodSplash(0, arrowHitCollider.gameObject.transform.position);
+                        blood.ShowBloodSplash(0, impactPosition);
                     }
                     mobileNpc.Motor.gameObject.SetActive(false);
                     playerEntity.TallyCrimeGuildRequirements(false, 5);
@@ -501,7 +499,7 @@ namespace DaggerfallWorkshop.Game
                     EnemyEntity enemyEntity = entityBehaviour.Entity as EnemyEntity;
 
                     // Calculate damage
-                    int animTime = (int)(ScreenWeapon.GetAnimTime() * 1000);    // Get animation time, converted to ms. 
+                    int animTime = (int)(ScreenWeapon.GetAnimTime() * 1000);    // Get animation time, converted to ms.
                     int damage = FormulaHelper.CalculateAttackDamage(playerEntity, enemyEntity, entityMobileUnit.Summary.AnimStateRecord, animTime, strikingWeapon);
 
                     // Break any "normal power" concealment effects on player
@@ -523,10 +521,10 @@ namespace DaggerfallWorkshop.Game
                         else
                             enemySounds.PlayHitSound(currentLeftHandWeapon);
 
-                        EnemyBlood blood = transform.GetComponent<EnemyBlood>();
+                        EnemyBlood blood = hitTransform.GetComponent<EnemyBlood>();
                         if (blood)
                         {
-                            blood.ShowBloodSplash(enemyEntity.MobileEnemy.BloodIndex, hit.point);
+                            blood.ShowBloodSplash(enemyEntity.MobileEnemy.BloodIndex, impactPosition);
                         }
 
                         // Knock back enemy based on damage and enemy weight
@@ -799,7 +797,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         void ExecuteAttacks(MouseDirections direction)
-        { 
+        {
             if (ScreenWeapon)
             {
                 // Fire screen weapon animation


### PR DESCRIPTION
Fix for bug https://forums.dfworkshop.net/viewtopic.php?f=24&t=2219

I stepped through it with a debugger and the splash for arrows against enemies was being spawned at 0,0,0.
So I copied the NPC arrow hitting logic and now it works again.