### PR TITLE
Fix fast travel for characters with Damage from Sunlight disadvantage

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -304,9 +304,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Halt random enemy spawns for next playerEntity update so player isn't bombarded by spawned enemies at the end of a long trip
             GameManager.Instance.PlayerEntity.PreventEnemySpawns = true;
 
-            // Vampires always arrive just after 6pm regardless of travel type
+            // Vampires and characters with Damage from Sunlight disadvantage always arrive just after 6pm regardless of travel type
             // Otherwise raise arrival time to just after 7am if cautious travel would arrive at night
-            if (GameManager.Instance.PlayerEffectManager.HasVampirism())
+            if (GameManager.Instance.PlayerEffectManager.HasVampirism() || GameManager.Instance.PlayerEntity.Career.DamageFromSunlight)
             {
                 DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.RaiseTime((DaggerfallDateTime.DuskHour - DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.Hour) * 3600);
             }


### PR DESCRIPTION
I tested the behaviour in classic and it seems that fast travel for characters with `Damage from Sunlight` disadvantage behave just like fast travel for vampires (in terms of arrival).  