### PR TITLE
always select EQUIP when opening inventory explicitly

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -544,28 +544,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void SetupDefaultActionMode()
         {
-            bool proximityWagonAccess = false;
             if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && !allowDungeonWagonAccess)
-                proximityWagonAccess = DungeonWagonAccessProximityCheck();
+                allowDungeonWagonAccess |= DungeonWagonAccessProximityCheck();
 
             if (lootTarget != null)
                 SelectActionMode(ActionModes.Remove);
-            // Start with wagon if accessing from dungeon
             else
             {
-                // Fast access: autoselect wagon when nearby
-                if (!DaggerfallUnity.Settings.DungeonExitWagonPrompt)
-                    allowDungeonWagonAccess |= proximityWagonAccess;
-
-                if (allowDungeonWagonAccess)
+                SelectActionMode(ActionModes.Equip);
+                if (!DaggerfallUnity.Settings.DungeonExitWagonPrompt && allowDungeonWagonAccess)
                 {
                     ShowWagon(true);
-                    SelectActionMode(ActionModes.Remove);
+                    // do not change default ActionMode, this can be confusing
                 }
-                else
-                    SelectActionMode(ActionModes.Equip);
             }
-            allowDungeonWagonAccess |= proximityWagonAccess;
         }
 
         public override void OnPush()


### PR DESCRIPTION
However, keep selecting the WAGON (instead of nothing) when opening the inventory explicitly near a dungeon entrance when DungeonExitWagonPrompt is off.

This is a trade-off @ajrb and I want to try concerning proximity wagon access,
Forums: https://forums.dfworkshop.net/viewtopic.php?f=4&t=2490