### PR TITLE
1383 Add quest location reference from Person

### DIFF
--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -293,6 +293,9 @@ namespace DaggerfallWorkshop.Game.Questing
             // Store this person in quest as last Person encountered
             // This will be used for subsequent pronoun macros, etc.
             ParentQuest.LastResourceReferenced = this;
+            Place homePlace = GetHomePlace();
+            if (homePlace != null)
+                ParentQuest.LastPlaceReferenced = homePlace;
 
             textOut = string.Empty;
             bool result = true;


### PR DESCRIPTION
Fixes messages like `Some weird-acting =contact_ in __contact_, %di of here.`
__contact_ would be filled by Person but not added as Quest.LastPlaceReferenced, which %di uses.
