### PR TITLE
1369 have item should not clear target

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/HaveItem.cs
+++ b/Assets/Scripts/Game/Questing/Actions/HaveItem.cs
@@ -17,7 +17,7 @@ namespace DaggerfallWorkshop.Game.Questing
 {
     /// <summary>
     /// Starts a task when player has a particular item resource in their inventory.
-    /// This task continues to run and will start/clear task when item present/not present
+    /// This task continues to run and will start task when item present
     /// </summary>
     public class HaveItem : ActionTemplate
     {
@@ -59,11 +59,9 @@ namespace DaggerfallWorkshop.Game.Questing
                 throw new Exception(string.Format("Could not find Item resource symbol {0}", targetItem));
             }
 
-            // Start/Clear target task based on player carrying item
+            // Start target task based on player carrying item
             if (GameManager.Instance.PlayerEntity.Items.Contains(item.DaggerfallUnityItem))
                 ParentQuest.StartTask(targetTask);
-            else
-                ParentQuest.ClearTask(targetTask);
         }
 
         #region Serialization

--- a/Assets/StreamingAssets/Quests/N0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y16.txt
@@ -217,9 +217,7 @@ _a6_ task:
 	say 1043 
 
 _S.07_ task:
-	start task _S.08_
---	have _crn_ set _S.08_ 
---  quest failed to recognize "have crn," which was crucial
+	have _crn_ set _S.08_
 
 _S.08_ task:
 	pick one of _a3_ _a4_ _a5_ _a6_ 


### PR DESCRIPTION
Fix for (among others probably) #1369 
`have _item_ set _state_` is only supposed to _enable_ `_state_`, not disable it.

As per 
https://en.uesp.net/wiki/Daggerfall:Quest_pseudo-codes#Pseudo-code_Type_0x46_.2F_70_.28PC_has_Items.29_.5B5_sub-records.5D
and 
https://www.dfworkshop.net/static_files/questing-source-docs.html#usingitems
