### PR TITLE
Swap wagon access tests

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -544,22 +544,34 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void SetupDefaultActionMode()
         {
-            if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon &&
-                PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart) && 
-                !allowDungeonWagonAccess)
-                allowDungeonWagonAccess |= DungeonWagonAccessProximityCheck();
+            bool proximityAccess = false;
+            if (!allowDungeonWagonAccess &&
+                GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon &&
+                PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
+                proximityAccess = DungeonWagonAccessProximityCheck();
 
             if (lootTarget != null)
                 SelectActionMode(ActionModes.Remove);
-            else
+            else if (DaggerfallUnity.Settings.DungeonExitWagonPrompt)
             {
+                if (allowDungeonWagonAccess)
+                {
+                    // Dungeon exit wagon prompt
+                    SelectActionMode(ActionModes.Remove);
+                    ShowWagon(true);
+                }
+            }
+            else
+            { // !DaggerfallUnity.Settings.DungeonExitWagonPrompt
+                allowDungeonWagonAccess |= proximityAccess;
                 SelectActionMode(ActionModes.Equip);
-                if (!DaggerfallUnity.Settings.DungeonExitWagonPrompt && allowDungeonWagonAccess)
+                if (allowDungeonWagonAccess)
                 {
                     ShowWagon(true);
                     // do not change default ActionMode, this can be confusing
                 }
             }
+            allowDungeonWagonAccess |= proximityAccess;
         }
 
         public override void OnPush()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1172,15 +1172,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void WagonButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
-            {
-                if (!GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon || allowDungeonWagonAccess)
-                    ShowWagon(!usingWagon);
-                else
-                    DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "exitTooFar"));
-            }
-            else
+            if (!PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
                 DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "noWagon"));
+            else if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && !allowDungeonWagonAccess)
+                DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "exitTooFar"));
+            else
+                ShowWagon(!usingWagon);
         }
 
         private void InfoButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1172,15 +1172,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void WagonButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            if (!GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon || allowDungeonWagonAccess)
+            if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
             {
-                if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
+                if (!GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon || allowDungeonWagonAccess)
                     ShowWagon(!usingWagon);
                 else
-                    DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "noWagon"));
+                    DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "exitTooFar"));
             }
             else
-                DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "exitTooFar"));
+                DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "noWagon"));
         }
 
         private void InfoButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -544,7 +544,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void SetupDefaultActionMode()
         {
-            if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && !allowDungeonWagonAccess)
+            if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon &&
+                PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart) && 
+                !allowDungeonWagonAccess)
                 allowDungeonWagonAccess |= DungeonWagonAccessProximityCheck();
 
             if (lootTarget != null)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -544,26 +544,24 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void SetupDefaultActionMode()
         {
-            bool proximityAccess = false;
+            bool dungeonExitPromptY = allowDungeonWagonAccess;
             if (!allowDungeonWagonAccess &&
                 GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon &&
                 PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
-                proximityAccess = DungeonWagonAccessProximityCheck();
+                allowDungeonWagonAccess = DungeonWagonAccessProximityCheck();
 
             if (lootTarget != null)
                 SelectActionMode(ActionModes.Remove);
             else if (DaggerfallUnity.Settings.DungeonExitWagonPrompt)
             {
-                if (allowDungeonWagonAccess)
+                if (dungeonExitPromptY)
                 {
-                    // Dungeon exit wagon prompt
                     SelectActionMode(ActionModes.Remove);
                     ShowWagon(true);
                 }
             }
             else
             { // !DaggerfallUnity.Settings.DungeonExitWagonPrompt
-                allowDungeonWagonAccess |= proximityAccess;
                 SelectActionMode(ActionModes.Equip);
                 if (allowDungeonWagonAccess)
                 {
@@ -571,7 +569,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     // do not change default ActionMode, this can be confusing
                 }
             }
-            allowDungeonWagonAccess |= proximityAccess;
         }
 
         public override void OnPush()


### PR DESCRIPTION
When clicking on WAGON button from inside a dungeon when you had no wagon it was not logical to display a message you couldn't access it because you were to far from an entrance.
So, check if you have a wagon first, whether it's reachable second.

Also, add a wagon ownership test that was missing in proximity access since #1343 or even earlier


ownership | in dungeon | proximity |  
-- | -- | -- | --
F | F |   | wagon button not selected, « You don’t own a wagon »
F | F |   | --
F | T | F | wagon button not selected, « You don’t own a wagon »
F | T | T | wagon button not selected, « You don’t own a wagon »
T | F |   | wagon button not selected, but selectable
T | F |   | --
T | T | F | wagon button not selected, « The exit is too far away »
T | T | T | wagon button autoselected (#1416)

