### PR TITLE
Add exclusive fullscreen checkbox to advanced video options

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -9,6 +9,7 @@ RetroRenderingMode=0
 UseMipMapsInRetroMode=False
 VSync=True
 Fullscreen=False
+ExclusiveFullscreen=False
 FieldOfView=65
 MainFilterMode=0
 QualityLevel=5

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -137,6 +137,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         // Video
         HorizontalSlider resolution;
         Checkbox fullscreen;
+        //Checkbox exclusiveFullscreen;
         HorizontalSlider qualityLevel;
         HorizontalSlider mainFilterMode;
         HorizontalSlider guiFilterMode;
@@ -313,7 +314,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 resolutions.Select(x => string.Format("{0}x{1}", x.width, x.height)).ToArray());
             resolution.OnScroll += Resolution_OnScroll;
             fullscreen = AddCheckbox(leftPanel, "fullscreen", DaggerfallUnity.Settings.Fullscreen);
+            //exclusiveFullscreen = AddCheckbox(leftPanel, "exclusiveFullscreen", DaggerfallUnity.Settings.ExclusiveFullscreen);
             fullscreen.OnToggleState += Fullscreen_OnToggleState;
+            //exclusiveFullscreen.OnToggleState += ExclusiveFullscreen_OnToggleState;
             qualityLevel = AddSlider(leftPanel, "qualityLevel", DaggerfallUnity.Settings.QualityLevel, QualitySettings.names);
             qualityLevel.OnScroll += QualityLevel_OnScroll;
             string[] filterModes = new string[] { "Point", "Bilinear", "Trilinear" };
@@ -417,7 +420,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 DaggerfallUnity.Settings.ResolutionWidth = selectedResolution.width;
                 DaggerfallUnity.Settings.ResolutionHeight = selectedResolution.height;
                 DaggerfallUnity.Settings.Fullscreen = fullscreen.IsChecked;
-                Screen.SetResolution(selectedResolution.width, selectedResolution.height, fullscreen.IsChecked);
+                //DaggerfallUnity.Settings.ExclusiveFullscreen = exclusiveFullscreen.IsChecked;
+
+                if (DaggerfallUnity.Settings.ExclusiveFullscreen && DaggerfallUnity.Settings.Fullscreen)
+                {
+                    Screen.SetResolution(
+                        selectedResolution.width,
+                        selectedResolution.height,
+                        FullScreenMode.ExclusiveFullScreen);
+                }
+                else
+                {
+                    Screen.SetResolution(
+                        selectedResolution.width,
+                        selectedResolution.height,
+                        fullscreen.IsChecked);
+                }
 
                 DaggerfallUnity.Settings.QualityLevel = qualityLevel.ScrollIndex;
                 QualitySettings.SetQualityLevel(qualityLevel.ScrollIndex);
@@ -706,6 +724,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             applyScreenChanges = true;
         }
+
+        /*
+        private void ExclusiveFullscreen_OnToggleState()
+        {
+            applyScreenChanges = true;
+        }
+        */
 
         private void Resolution_OnScroll()
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
@@ -293,6 +293,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void FullScreenButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             fullScreenTick.Enabled = DaggerfallUnity.Settings.Fullscreen = Screen.fullScreen = !Screen.fullScreen;
+
+            if (DaggerfallUnity.Settings.Fullscreen && DaggerfallUnity.Settings.ExclusiveFullscreen)
+            {
+                Screen.SetResolution(
+                    DaggerfallUnity.Settings.ResolutionWidth,
+                    DaggerfallUnity.Settings.ResolutionHeight,
+                    FullScreenMode.ExclusiveFullScreen);
+            }
+
             if (!saveSettings)
                 saveSettings = true;
         }

--- a/Assets/Scripts/Game/Utility/SceneControl.cs
+++ b/Assets/Scripts/Game/Utility/SceneControl.cs
@@ -27,10 +27,20 @@ namespace DaggerfallWorkshop.Game.Utility
         void Start()
         {
             // Resolution
-            Screen.SetResolution(
-                DaggerfallUnity.Settings.ResolutionWidth,
-                DaggerfallUnity.Settings.ResolutionHeight,
-                DaggerfallUnity.Settings.Fullscreen);
+            if (DaggerfallUnity.Settings.ExclusiveFullscreen && DaggerfallUnity.Settings.Fullscreen)
+            {
+                Screen.SetResolution(
+                    DaggerfallUnity.Settings.ResolutionWidth,
+                    DaggerfallUnity.Settings.ResolutionHeight,
+                    FullScreenMode.ExclusiveFullScreen);
+            }
+            else
+            {
+                Screen.SetResolution(
+                    DaggerfallUnity.Settings.ResolutionWidth,
+                    DaggerfallUnity.Settings.ResolutionHeight,
+                    DaggerfallUnity.Settings.Fullscreen);
+            }
 
             // Check arena2 path is validated OK, otherwise start game setup
             if (!DaggerfallUnity.Instance.IsPathValidated || DaggerfallUnity.Settings.ShowOptionsAtStart)

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -165,10 +165,20 @@ namespace DaggerfallWorkshop.Game.Utility
         void ApplyStartSettings()
         {
             // Resolution
-            Screen.SetResolution(
-                DaggerfallUnity.Settings.ResolutionWidth,
-                DaggerfallUnity.Settings.ResolutionHeight,
-                DaggerfallUnity.Settings.Fullscreen);
+            if (DaggerfallUnity.Settings.ExclusiveFullscreen && DaggerfallUnity.Settings.Fullscreen)
+            {
+                Screen.SetResolution(
+                    DaggerfallUnity.Settings.ResolutionWidth,
+                    DaggerfallUnity.Settings.ResolutionHeight,
+                    FullScreenMode.ExclusiveFullScreen);
+            }
+            else
+            {
+                Screen.SetResolution(
+                    DaggerfallUnity.Settings.ResolutionWidth,
+                    DaggerfallUnity.Settings.ResolutionHeight,
+                    DaggerfallUnity.Settings.Fullscreen);
+            }
 
             // Camera settings
             GameObject cameraObject = GameObject.FindGameObjectWithTag("MainCamera");

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -71,6 +71,7 @@ namespace DaggerfallWorkshop
         public bool UseMipMapsInRetroMode { get; set; }
         public bool VSync { get; set; }
         public bool Fullscreen { get; set; }
+        public bool ExclusiveFullscreen { get; set; }
         public int FieldOfView { get; set; }
         public int ShadowResolutionMode { get; set; }
         public int MainFilterMode { get; set; }
@@ -200,6 +201,7 @@ namespace DaggerfallWorkshop
             UseMipMapsInRetroMode = GetBool(sectionVideo, "UseMipMapsInRetroMode");
             VSync = GetBool(sectionVideo, "VSync");
             Fullscreen = GetBool(sectionVideo, "Fullscreen");
+            ExclusiveFullscreen = GetBool(sectionVideo, "ExclusiveFullscreen");
             FieldOfView = GetInt(sectionVideo, "FieldOfView", 60, 80);
             MainFilterMode = GetInt(sectionVideo, "MainFilterMode", 0, 2);
             ShadowResolutionMode = GetInt(sectionVideo, "ShadowResolutionMode", 0, 3);
@@ -313,6 +315,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionVideo, "UseMipMapsInRetroMode", UseMipMapsInRetroMode);
             SetBool(sectionVideo, "VSync", VSync);
             SetBool(sectionVideo, "Fullscreen", Fullscreen);
+            SetBool(sectionVideo, "ExclusiveFullscreen", ExclusiveFullscreen);
             SetInt(sectionVideo, "FieldOfView", FieldOfView);
             SetInt(sectionVideo, "MainFilterMode", MainFilterMode);
             SetInt(sectionVideo, "ShadowResolutionMode", ShadowResolutionMode);

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -123,6 +123,8 @@ resolution,                                         Resolution
 resolutionInfo,                                     Screen resolution
 fullscreen,                                         Fullscreen
 fullscreenInfo,                                     Enable fullscreen
+exclusiveFullscreen,                                Exclusive Fullscreen
+exclusiveFullscreenInfo,                            Enable exclusive fullscreen
 qualityLevel,                                       Quality Level
 qualityLevelInfo,                                   General graphic quality
 mainFilterMode,                                     Main Filter


### PR DESCRIPTION
`-window-mode exclusive` arg wasn't working, so I added it as a proper option.

![exclusive](https://user-images.githubusercontent.com/12547453/63651649-9eca0f00-c789-11e9-9e77-1a536016edaa.png)