### PR TITLE
Fix NPC talk reactions

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -95,7 +95,7 @@ namespace DaggerfallWorkshop.Game
         const int minVeryLikeReaction = 30;
 
         // Changed from classic (classis uses { 10, -5, 0, 0, 0, -10, -5, -5 } )
-        readonly short[] questionTypeReactionMods = { 10, -5, 0, 0, 10, -5, 0, 0 };
+        readonly short[] questionTypeReactionMods = { 5, 0, 0, 0, 5, 0, 0, 0 };
 
         /// Improvement over classic, add reaction modifiers when using Etiquette
         /// and Streetwise in relation to social groups.
@@ -594,6 +594,12 @@ namespace DaggerfallWorkshop.Game
             int reaction = player.Stats.LivePersonality / 5
                + questionTypeReactionMods[classicDataIndex]
                + toneModifier;
+
+            // Make roll result be the same every time for a given NPC
+            if (currentNPCType == NPCType.Mobile)
+                DFRandom.Seed = (uint)lastTargetMobileNPC.GetHashCode();
+            else if (currentNPCType == NPCType.Static)
+                DFRandom.Seed = (uint)lastTargetStaticNPC.GetHashCode();
 
             int rollToBeat = DFRandom.random_range_inclusive(0, 20);
             if (toneReactionForTalkSession[toneIndex] != 0)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -283,12 +283,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 SetTalkModeWhereIs();
                 talkCategoryLastUsed = TalkCategory.None; // enforce that function SetTalkCategoryLocation does not skip itself and updated its topic list
                 SetTalkCategoryLocation();
-                panelTone.Position = panelToneNormalPos;
             }
 
             selectedTalkOption = TalkOption.WhereIs;
             selectedTalkCategory = TalkCategory.Location;
-            selectedTalkTone = TalkTone.Normal;
             talkCategoryLastUsed = TalkCategory.None;
             talkOptionLastUsed = TalkOption.None;
             toneLastUsed = -1;


### PR DESCRIPTION
Fix NPC reactions issues mentioned on the forums, especially here: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2410&start=10#p29493

This restores random seed based on current NPC guid so each NPC in the same town will now react differently as this was already the case before PR #1370.

I also lowered the difficulty level required to get a successfull answer when asking for people location with low personality characters, balancing this change by also lowering the bonus given to find a location (+5 instead of +10). Still, it's much more difficult than classic to find people, where we nearly always get a successful answer even with a very low personality, because of an incorrectly applied modifier (classic seems to always apply +10, regardless of the kind of question).

As with my previous PR #1370, Streetwise and Etiquette are more useful than in classic where one would always use Normal tone since it almost always gives better results. As an example, in DFU, I managed to get a positive answer from the same NPC by switching from Normal to Blunt tone (NPC was a commoner, for a Noble I would have used Etiquette of course).

And as requested on the forums (https://forums.dfworkshop.net/viewtopic.php?f=5&t=2404), tone now remains checked as it was during the last talk session. Since this does not match classic, I let you decide (@Interkarma and others) if you prefer to keep it that way or not.