### PR TITLE
Fix issues when activating Sheogorath

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -485,6 +485,15 @@ namespace DaggerfallWorkshop.Game
 
         void ActivateStaticNPC(RaycastHit hit, StaticNPC npc)
         {
+            // Do not activate static NPCs carrying specific non-dialog actions as these usually have some bespoke task to perform
+            // Note: currently only ShowText and ShowTextWithInput NPCs are excluded
+            // Examples are guard at entrance of Daggerfall Castle and Benefactor and Sheogorath in Mantellan Crux
+            DaggerfallAction action = npc.GetComponent<DaggerfallAction>();
+            if (action &&
+                (action.ActionFlag == DFBlock.RdbActionFlags.ShowTextWithInput ||
+                 action.ActionFlag == DFBlock.RdbActionFlags.ShowText))
+                return;
+
             switch (currentMode)
             {
                 case PlayerActivateModes.Info:
@@ -1282,12 +1291,6 @@ namespace DaggerfallWorkshop.Game
             }
             else // if no special handling had to be done (all remaining npcs of the remaining social groups not handled explicitely above): default is talk to the static npc
             {
-                // with one exception: guards - detect if clicked guard (comment Nystul: didn't find a better mechanism than billboard texture check)
-                if (npc.Data.billboardArchiveIndex == 183 && npc.Data.billboardRecordIndex == 3 ||
-                    npc.Data.billboardArchiveIndex == 346 && npc.Data.billboardRecordIndex == 20)
-                    return; // if guard was clicked don't open talk window
-
-                // otherwise open talk window
                 talkManager.TalkToStaticNPC(npc, false);
             }
         }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -638,12 +638,6 @@ namespace DaggerfallWorkshop.Game
         // Player has clicked or static talk target or clicked the talk button inside a popup-window
         public void TalkToStaticNPC(StaticNPC targetNPC, bool menu = true, bool isSpyMaster = false)
         {
-            // Do not speak with static NPCs carrying specific non-dialog actions as these usually have some bespoke task to perform
-            // Note: Currently only ShowTextWithInput NPCs are excluded. Examples are guard at entrance of Daggerfall castle and Benefactor in Mantellan Crux
-            DaggerfallAction action = targetNPC.GetComponent<DaggerfallAction>();
-            if (action && action.ActionFlag == DFBlock.RdbActionFlags.ShowTextWithInput)
-                return;
-
             // Populate NPC faction data
             FactionFile.FactionData targetFactionData;
             GameManager.Instance.PlayerEntity.FactionData.GetFactionData(targetNPC.Data.factionID, out targetFactionData);


### PR DESCRIPTION
Sheogorath should not be activated like a normal NPC, neither in information nor any other mode. As this is also the case for all static NPCs attached to "ShowText" or "ShowTextWithInput" action, I just moved the already available check from TalkManager to PlayerActivate and included "ShowText" action flag into it.

In information mode, this matches classic behavior where we never get any display name for this kind of NPC.

In other modes (steal, grab and talk), this fixes an exception which popups for Sheogorath due to the fact both his instances have an invalid faction ID.

Fix #1456