### PR TITLE
Allow magic item subclass definition in quests

### DIFF
--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -565,6 +565,8 @@ namespace DaggerfallWorkshop.Game.Items
 
             // Reduce the list to only the regular magic items.
             MagicItemTemplate[] regularMagicItems = magicItems.Where(template => template.type == MagicItemTypes.RegularMagicItem).ToArray();
+            if (chosenItem > regularMagicItems.Length)
+                throw new Exception(string.Format("Magic item subclass {0} does not exist", chosenItem));
 
             // Pick a random one if needed.
             if (chosenItem == chooseAtRandom)

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Game.Items
 
         const int firstFemaleArchive = 245;
         const int firstMaleArchive = 249;
+        private const int chooseAtRandom = -1;
 
         // This array is used to pick random material values.
         // The array is traversed, subtracting each value from a sum until the sum is less than the next value.
@@ -539,6 +540,20 @@ namespace DaggerfallWorkshop.Game.Items
         /// <returns>DaggerfallUnityItem</returns>
         public static DaggerfallUnityItem CreateRandomMagicItem(int playerLevel, Genders gender, Races race)
         {
+            return CreateRegularMagicItem(chooseAtRandom, playerLevel, gender, race);
+        }
+
+        /// <summary>
+        /// Create a regular non-artifact magic item.
+        /// </summary>
+        /// <param name="chosenItem">An integer index of the item to create, or -1 for a random one.</param>
+        /// <param name="playerLevel">The player level to create an item for.</param>
+        /// <param name="gender">The gender to create an item for.</param>
+        /// <param name="race">The race to create an item for.</param>
+        /// <returns>DaggerfallUnityItem</returns>
+        /// <exception cref="Exception">When a base item cannot be created.</exception>
+        public static DaggerfallUnityItem CreateRegularMagicItem(int chosenItem, int playerLevel, Genders gender, Races race)
+        {
             byte[] itemGroups0 = { 2, 3, 6, 10, 12, 14, 25 };
             byte[] itemGroups1 = { 2, 3, 6, 12, 25 };
 
@@ -548,114 +563,100 @@ namespace DaggerfallWorkshop.Game.Items
             MagicItemsFile magicItemsFile = new MagicItemsFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, "MAGIC.DEF"));
             List<MagicItemTemplate> magicItems = magicItemsFile.MagicItemsList;
 
-            // Get the number of non-artifact magic item templates in MAGIC.DEF
-            int numberOfRegularMagicItems = 0;
-            foreach (MagicItemTemplate magicItem in magicItems)
+            // Reduce the list to only the regular magic items.
+            MagicItemTemplate[] regularMagicItems = magicItems.Where(template => template.type == MagicItemTypes.RegularMagicItem).ToArray();
+
+            // Pick a random one if needed.
+            if (chosenItem == chooseAtRandom)
             {
-                if (magicItem.type == MagicItemTypes.RegularMagicItem)
-                    numberOfRegularMagicItems++;
+                chosenItem = UnityEngine.Random.Range(0, regularMagicItems.Length);
             }
 
-            // Choose a random one of the non-artifact magic item templates
-            int chosenItem = UnityEngine.Random.Range(0, numberOfRegularMagicItems);
-
             // Get the chosen template
-            foreach (MagicItemTemplate magicItem in magicItems)
+            MagicItemTemplate magicItem = regularMagicItems[chosenItem];
+
+            // Get the item group. The possible groups are determined by the 33rd byte (magicItem.group) of the MAGIC.DEF template being used.
+            ItemGroups group = 0;
+            if (magicItem.group == 0)
+                group = (ItemGroups)itemGroups0[UnityEngine.Random.Range(0, 7)];
+            else if (magicItem.group == 1)
+                group = (ItemGroups)itemGroups1[UnityEngine.Random.Range(0, 5)];
+            else if (magicItem.group == 2)
+                group = ItemGroups.Weapons;
+
+            // Create the base item
+            if (group == ItemGroups.Weapons)
             {
-                if (magicItem.type == MagicItemTypes.RegularMagicItem)
+                newItem = CreateRandomWeapon(playerLevel);
+
+                // No arrows as enchanted items
+                while (newItem.GroupIndex == 18)
+                    newItem = CreateRandomWeapon(playerLevel);
+            }
+            else if (group == ItemGroups.Armor)
+                newItem = CreateRandomArmor(playerLevel, gender, race);
+            else if (group == ItemGroups.MensClothing || group == ItemGroups.WomensClothing)
+                newItem = CreateRandomClothing(gender, race);
+            else if (group == ItemGroups.ReligiousItems)
+                newItem = CreateRandomReligiousItem();
+            else if (group == ItemGroups.Gems)
+                newItem = CreateRandomGem();
+            else // Only other possibility is jewellery
+                newItem = CreateRandomJewellery();
+
+            if (newItem == null)
+                throw new Exception("CreateRegularMagicItem() failed to create an item.");
+
+            // Replace the regular item name with the magic item name
+            newItem.shortName = magicItem.name;
+
+            // Add the enchantments
+            newItem.legacyMagic = new DaggerfallEnchantment[magicItem.enchantments.Length];
+            for (int i = 0; i < magicItem.enchantments.Length; ++i)
+                newItem.legacyMagic[i] = magicItem.enchantments[i];
+
+            // Set the condition/magic uses
+            newItem.maxCondition = magicItem.uses;
+            newItem.currentCondition = magicItem.uses;
+
+            // Set the value of the item. This is determined by the enchantment point cost/spell-casting cost
+            // of the enchantments on the item.
+            int value = 0;
+            for (int i = 0; i < magicItem.enchantments.Length; ++i)
+            {
+                if (magicItem.enchantments[i].type != EnchantmentTypes.None
+                    && magicItem.enchantments[i].type < EnchantmentTypes.ItemDeteriorates)
                 {
-                    // Proceed when the template is found
-                    if (chosenItem == 0)
+                    switch (magicItem.enchantments[i].type)
                     {
-                        // Get the item group. The possible groups are determined by the 33rd byte (magicItem.group) of the MAGIC.DEF template being used.
-                        ItemGroups group = 0;
-                        if (magicItem.group == 0)
-                            group = (ItemGroups)itemGroups0[UnityEngine.Random.Range(0, 7)];
-                        else if (magicItem.group == 1)
-                            group = (ItemGroups)itemGroups1[UnityEngine.Random.Range(0, 5)];
-                        else if (magicItem.group == 2)
-                            group = ItemGroups.Weapons;
-
-                        // Create the base item
-                        if (group == ItemGroups.Weapons)
-                        {
-                            newItem = CreateRandomWeapon(playerLevel);
-
-                            // No arrows as enchanted items
-                            while (newItem.GroupIndex == 18)
-                                newItem = CreateRandomWeapon(playerLevel);
-                        }
-                        else if (group == ItemGroups.Armor)
-                            newItem = CreateRandomArmor(playerLevel, gender, race);
-                        else if (group == ItemGroups.MensClothing || group == ItemGroups.WomensClothing)
-                            newItem = CreateRandomClothing(gender, race);
-                        else if (group == ItemGroups.ReligiousItems)
-                            newItem = CreateRandomReligiousItem();
-                        else if (group == ItemGroups.Gems)
-                            newItem = CreateRandomGem();
-                        else // Only other possibility is jewellery
-                            newItem = CreateRandomJewellery();
-
-                        // Replace the regular item name with the magic item name
-                        newItem.shortName = magicItem.name;
-
-                        // Add the enchantments
-                        newItem.legacyMagic = new DaggerfallEnchantment[magicItem.enchantments.Length];
-                        for (int i = 0; i < magicItem.enchantments.Length; ++i)
-                            newItem.legacyMagic[i] = magicItem.enchantments[i];
-
-                        // Set the condition/magic uses
-                        newItem.maxCondition = magicItem.uses;
-                        newItem.currentCondition = magicItem.uses;
-
-                        // Set the value of the item. This is determined by the enchantment point cost/spell-casting cost
-                        // of the enchantments on the item.
-                        int value = 0;
-                        for (int i = 0; i < magicItem.enchantments.Length; ++i)
-                        {
-                            if (magicItem.enchantments[i].type != EnchantmentTypes.None
-                                && magicItem.enchantments[i].type < EnchantmentTypes.ItemDeteriorates)
-                            {
-                                switch (magicItem.enchantments[i].type)
-                                {
-                                    case EnchantmentTypes.CastWhenUsed:
-                                    case EnchantmentTypes.CastWhenHeld:
-                                    case EnchantmentTypes.CastWhenStrikes:
-                                        // Enchantments that cast a spell. The parameter is the spell index in SPELLS.STD.
-                                        value += Formulas.FormulaHelper.GetSpellEnchantPtCost(magicItem.enchantments[i].param);
-                                        break;
-                                    case EnchantmentTypes.RepairsObjects:
-                                    case EnchantmentTypes.AbsorbsSpells:
-                                    case EnchantmentTypes.EnhancesSkill:
-                                    case EnchantmentTypes.FeatherWeight:
-                                    case EnchantmentTypes.StrengthensArmor:
-                                        // Enchantments that provide an effect that has no parameters
-                                        value += enchantmentPointCostsForNonParamTypes[(int)magicItem.enchantments[i].type];
-                                        break;
-                                    case EnchantmentTypes.SoulBound:
-                                        // Bound soul
-                                        MobileEnemy mobileEnemy = GameObjectHelper.EnemyDict[magicItem.enchantments[i].param];
-                                        value += mobileEnemy.SoulPts; // TODO: Not sure about this. Should be negative? Needs to be tested.
-                                        break;
-                                    default:
-                                        // Enchantments that provide a non-spell effect with a parameter (parameter = when effect applies, what enemies are affected, etc.)
-                                        value += enchantmentPtsForItemPowerArrays[(int)magicItem.enchantments[i].type][magicItem.enchantments[i].param];
-                                        break;
-                                }
-                            }
-                        }
-
-                        newItem.value = value;
-
-                        break;
+                        case EnchantmentTypes.CastWhenUsed:
+                        case EnchantmentTypes.CastWhenHeld:
+                        case EnchantmentTypes.CastWhenStrikes:
+                            // Enchantments that cast a spell. The parameter is the spell index in SPELLS.STD.
+                            value += Formulas.FormulaHelper.GetSpellEnchantPtCost(magicItem.enchantments[i].param);
+                            break;
+                        case EnchantmentTypes.RepairsObjects:
+                        case EnchantmentTypes.AbsorbsSpells:
+                        case EnchantmentTypes.EnhancesSkill:
+                        case EnchantmentTypes.FeatherWeight:
+                        case EnchantmentTypes.StrengthensArmor:
+                            // Enchantments that provide an effect that has no parameters
+                            value += enchantmentPointCostsForNonParamTypes[(int)magicItem.enchantments[i].type];
+                            break;
+                        case EnchantmentTypes.SoulBound:
+                            // Bound soul
+                            MobileEnemy mobileEnemy = GameObjectHelper.EnemyDict[magicItem.enchantments[i].param];
+                            value += mobileEnemy.SoulPts; // TODO: Not sure about this. Should be negative? Needs to be tested.
+                            break;
+                        default:
+                            // Enchantments that provide a non-spell effect with a parameter (parameter = when effect applies, what enemies are affected, etc.)
+                            value += enchantmentPtsForItemPowerArrays[(int)magicItem.enchantments[i].type][magicItem.enchantments[i].param];
+                            break;
                     }
-
-                    chosenItem--;
                 }
             }
 
-            if (newItem == null)
-                throw new Exception("CreateRandomMagicItem() failed to create an item.");
+            newItem.value = value;
 
             return newItem;
         }

--- a/Assets/Scripts/Game/Questing/Item.cs
+++ b/Assets/Scripts/Game/Questing/Item.cs
@@ -304,7 +304,17 @@ namespace DaggerfallWorkshop.Game.Questing
             // Link item to quest
             result.LinkQuestItem(ParentQuest.UID, Symbol.Clone());
 
-            return result;
+            string name = result.shortName.Replace("%it", result.ItemTemplate.name);
+            QuestMachine.LogFormat(
+                ParentQuest,
+                "Generated \"{0}\" from Class {1} and Subclass {2} for item {3}",
+                name,
+                itemClass,
+                itemSubClass,
+                Symbol.Original
+            );
+
+             return result;
         }
 
         // Create stack of gold pieces

--- a/Assets/Scripts/Game/Questing/Item.cs
+++ b/Assets/Scripts/Game/Questing/Item.cs
@@ -278,10 +278,10 @@ namespace DaggerfallWorkshop.Game.Questing
             DaggerfallUnityItem result;
 
             // Handle random magic items
-            if (itemClass == (int)ItemGroups.MagicItems && itemSubClass == -1)
+            if (itemClass == (int)ItemGroups.MagicItems)
             {
                 Entity.PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
-                result = ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race);
+                result = ItemBuilder.CreateRegularMagicItem(itemSubClass, playerEntity.Level, playerEntity.Gender, playerEntity.Race);
             }
             // Handle books
             else if (itemClass == (int)ItemGroups.Books)


### PR DESCRIPTION
Fix for https://forums.dfworkshop.net/viewtopic.php?f=25&t=1098&start=30#p28634

Implements subclasses for magic items (class 4) in quests.

Testcase:
`startquest S0000501`
That quest uses 
`Item _reward1_ item class 4 subclass 26`
which should generate a random "Unrestrainable" item as \_reward1\_
