### PR TITLE
Don't end quest when not done with escorting villager.

### DIFF
--- a/Assets/StreamingAssets/Quests/M0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y16.txt
@@ -232,7 +232,7 @@ _S.15_ task:
 	when _success_ and _no_ 
 
 _S.16_ task:
-	when _success_ and _yes_ 
+	when _success_ and _S.09_
 
 _S.17_ task:
 	when _success_ and _S.13_ 
@@ -240,10 +240,6 @@ _S.17_ task:
 _S.18_ task:
 	when _qtime_ or _S.15_ or _S.16_ or _S.17_ 
 	end quest 
-
-_S.19_ task:
-	when not _victim_ and _success_
-	end quest
 
 _giantWaveWhileInDungeon_ task:
 	pc at _mondung_ set _spawnGiants_


### PR DESCRIPTION
\_S.09\_ = there is no villager to escort.
\_victim\_ = there is a villager to escort.
\_yes\_ = you agreed to escort the villager.
\_S.13\_ = you completed the villager escort.
\_success\_ indicates you killed the giant and returned to the questgiver.

So the quest was ending when you killed the giant, returned to the questgiver, agreed to escort the villager but did not complete the escort yet.

Source: https://forums.dfworkshop.net/viewtopic.php?f=25&t=2557