### PR TITLE
Prevent vampire sun damage in prison.

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -177,6 +177,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public Crimes CrimeCommitted { get { return crimeCommitted; } set { SetCrimeCommitted(value); } }
         public bool HaveShownSurrenderToGuardsDialogue { get { return haveShownSurrenderToGuardsDialogue; } set { haveShownSurrenderToGuardsDialogue = value; } }
         public bool Arrested { get { return arrested; } set { arrested = value; } }
+        public bool InPrison { get ; set ; }
         public bool IsInBeastForm { get; set; }
         public List<string> BackStory { get; set; }
         public VampireClans PreviousVampireClan { get; set; }

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -372,7 +372,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Player in sunlight or darkness
-            isPlayerInSunlight = DaggerfallUnity.Instance.WorldTime.Now.IsDay && !IsPlayerInside;
+            isPlayerInSunlight = DaggerfallUnity.Instance.WorldTime.Now.IsDay && !IsPlayerInside && !GameManager.Instance.PlayerEntity.InPrison;
         }
 
         #region Public Methods

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -47,7 +47,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         int daysInPrison;
         int daysInPrisonLeft;
         int state;
-        bool inPrison;
         bool repositionPlayer;
 
         float prisonUpdateTimer = 0f;
@@ -248,7 +247,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else if (state == 3) // Serve prison sentence
             {
-                inPrison = true;
+                playerEntity.InPrison = true;
                 SwitchToPrisonScreen();
                 daysInPrisonLeft = daysInPrison;
                 playerEntity.RaiseReputationForDoingSentence();
@@ -288,7 +287,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else if (state == 100) // Done
             {
-                if (inPrison)
+                if (playerEntity.InPrison)
                 {
                     if (Input.GetKey(exitKey)) // Speed up prison day countdown. Not in classic.
                         prisonUpdateInterval = 0.001f;
@@ -427,7 +426,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             GameManager.Instance.PlayerEntity.Arrested = false;
             state = 0;
             prisonUpdateTimer = 0f;
-            inPrison = false;
+            GameManager.Instance.PlayerEntity.InPrison = false;
             repositionPlayer = false;
             daysUntilFreedomLabel.Text = string.Empty;
 
@@ -466,7 +465,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 playerEntity.PreventNormalizingReputations = true;
                 DaggerfallUnity.WorldTime.DaggerfallDateTime.RaiseTime(daysInPrison * 1440 * 60);
                 RaiseOnEndPrisonTimeEvent();
-                inPrison = false;
+                playerEntity.InPrison = false;
                 playerEntity.FillVitalSigns();
             }
         }


### PR DESCRIPTION
Minimal code changes approach to prevent vampires burning up in prison.

A larger change would be to tie make the court window count as IsPlayerInside, but since the court window explicitly transitions to exterior and the player inside/outside is tightly coupled with the transitions I decided to go another route.

Source: https://www.reddit.com/r/daggerfallunity/comments/cwcsrb/is_going_to_prison_supposed_to_kill_vampires/
https://forums.dfworkshop.net/viewtopic.php?f=24&t=2605