### PR TITLE
Only succeed the quest when both priest and betrothed have been clicked.

### DIFF
--- a/Assets/StreamingAssets/Quests/A0C10Y05.txt
+++ b/Assets/StreamingAssets/Quests/A0C10Y05.txt
@@ -201,7 +201,10 @@ _dummy_ task:
 	injured _F.00_ saying 1013 
 
 _S.05_ task:
-	clicked npc _priest_ 
+	clicked npc _priest_
+
+_success_ task:
+    when _S.01_ and _S.05_
 	give pc _gold_ 
 	drop _qgiver_ face 
 	drop _betrothed_ face 

--- a/Assets/StreamingAssets/Quests/A0C10Y05.txt
+++ b/Assets/StreamingAssets/Quests/A0C10Y05.txt
@@ -217,6 +217,6 @@ _clearclick_ task:
 	clear _S.05_ _clearclick_ 
 
 _questdone_ task:
-	when _S.05_ and not _S.03_ 
+	when _success_ and not _S.03_
 	restore _qgiver_ 
 	end quest 


### PR DESCRIPTION
Fix for part of the issues reported at https://forums.dfworkshop.net/viewtopic.php?f=29&t=2134

It was another execution order issue in the template generated quest.
In classic the click on the priest would be cleared again unless the betrothed was also clicked, thus preventing the whole "give pc gold, etc" from executing.
