### PR TITLE
workaround for "water everywhere" texture issue on low-end hardware

### DIFF
--- a/Assets/Shaders/DaggerfallTilemapTextureArray.shader
+++ b/Assets/Shaders/DaggerfallTilemapTextureArray.shader
@@ -85,7 +85,7 @@ Shader "Daggerfall/TilemapTextureArray" {
 		void surf (Input IN, inout SurfaceOutputStandard o)
 		{
 			// Get offset to tile in atlas
-			uint index = tex2D(_TilemapTex, IN.uv_MainTex).a * _MaxIndex;
+			uint index = tex2D(_TilemapTex, IN.uv_MainTex).a * _MaxIndex + 0.5;
 
 			// Offset to fragment position inside tile
 			float2 unwrappedUV = IN.uv_MainTex * _TilemapDim;


### PR DESCRIPTION
It does not fix shadows issues or anything else, but still that's a noticeable improvement for people that have to run DFU on that hardware.

That looks like a very inexpensive workaround (most likely lost in the noise), and it seems to work fine on my regular hardware (from mathematical standpoint it also feels right to use rounding instead of floor() to make sure int -> float -> int conversions are robust), so maybe it can be added directly into the standard shader?

Otherwise, say if the risk of regression is deemed too high, it could be added to a variant of the shader, so it could be enabled at runtime; But I don't know how to do such things...

Tested on Intel HD-3000 by Siva Machina on Discord;
Tested on nVidia GTX-960 by myself (for lack of regression)

Forums:
https://forums.dfworkshop.net/viewtopic.php?f=5&t=2519&p=30610#p30610