### PR TITLE
Harden received armor

### DIFF
--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -213,10 +213,15 @@ namespace DaggerfallWorkshop.Game.Guilds
                     Armor armor = (Armor)UnityEngine.Random.Range(102, 108 + 1);
                     rewardArmor.AddItem(ItemBuilder.CreateArmor(playerEntity.Gender, playerEntity.Race, armor, material));
                 }
-                DaggerfallUI.MessageBox(ArmorId);
+                DaggerfallMessageBox mb = DaggerfallUI.MessageBox(ArmorId);
                 DaggerfallUI.Instance.InventoryWindow.SetChooseOne(rewardArmor, item => flags = flags | ArmorFlagMask);
-                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
+                mb.OnClose += ReceiveArmorPopup_OnClose;
             }
+        }
+
+        private void ReceiveArmorPopup_OnClose()
+        {
+            DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
         }
 
         public void ReceiveHouse()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1518,6 +1518,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (chooseOne && remoteItems == from && !usingWagon)
             {
+                while (uiManager.TopWindow != this)
+                    uiManager.PopWindow();
                 CloseWindow();
                 chooseOneCallback(item);
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1516,7 +1516,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Refresh(false);
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
 
-            if (chooseOne)
+            if (chooseOne && remoteItems == from && !usingWagon)
             {
                 CloseWindow();
                 chooseOneCallback(item);


### PR DESCRIPTION
3 modifications:
- wait for the weapon smith MessageBox to be closed before opening the inventory;
- make sure an item is picked from the list of proposed items (and, say, not from the wagon) before closing the inventory;
- close all transient windows before closing the inventory.

Use case for the latter: the player selects to EQUIP some item he cannot equip (forbidden material, for example). EquipItem() opens a MessageBox to tell it's not possible, chooseOne closes to top window which is the MessageBox, and the inventory stays open.

Another implementation would be to set a flag, and close the inventory in Update() when all transients have been closed by the player. The benefit is that the player would see that the item couldn't be equipped.
