### PR TITLE
Quest item dropping fixes

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1425,16 +1425,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 Item questItem = GetQuestItem(item);
 
                 // Player cannot drop most quest items
-                if (questItem == null | (!questItem.AllowDrop && from == localItems))
+                if (questItem == null || (!questItem.AllowDrop && from == localItems))
                 {
                     DaggerfallUI.MessageBox(TextManager.Instance.GetText(textDatabase, "cannotRemoveItem"));
                     return;
                 }
 
                 // Dropping or picking up quest item
-                if (questItem.AllowDrop && from == localItems && remoteTargetType == RemoteTargetTypes.Dropped)
+                if (questItem.AllowDrop && from == localItems && remoteTargetType != RemoteTargetTypes.Wagon)
                     questItem.PlayerDropped = true;
-                else if (questItem.AllowDrop && from == remoteItems && remoteTargetType == RemoteTargetTypes.Dropped)
+                else if (from == remoteItems)
                     questItem.PlayerDropped = false;
             }
             // Extinguish light sources when transferring out of player inventory


### PR DESCRIPTION
- Picking up previously dropped quest items would not unset the dropped state because they come from Loot, not Dropped.
- Moving quest Items to Loot piles or Merchants would not set the dropped state.
- Picking up quest items without AllowDrop would not unset the dropped state.
- Bitwise or in stead of logical or could cause null reference.

Test quest:
```
- Test quest for dropping and picking up quest items
Quest: __TEST001
QRC:
QBN:
Place _house_ local house2
Item _treasure_ portrait

	place item _treasure_ at _house_

_pickedup_ task:
	clicked item _treasure_
	clear _dropped_

_dropped_ task:
	dropped _treasure_ at _house_
	clear _pickedup_
```
