### PR TITLE
Implement classic tweak regarding some Order of the Raven buildings

### DIFF
--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -557,6 +557,14 @@ namespace DaggerfallWorkshop.Utility
                                     building.Quality = item.buildingData.Quality;
                                 }
                             }
+
+                            // Matched to classic: special handling for some Order of the Raven buildings
+                            if (block.RmbBlock.FldHeader.OtherNames[i] == "KRAVE01.HS2")
+                            {
+                                building.BuildingType = DFLocation.BuildingTypes.GuildHall;
+                                building.FactionId = 414;
+                            }
+
                             // Set whatever building data we could find
                             block.RmbBlock.FldHeader.BuildingDataList[i] = building;
                         }


### PR DESCRIPTION
Found while reverse engineering FALL.EXE to understand map buildings to blocks building mapping process.

Classic uses this exact same runtime patch for some Order of the Raven buildings. These can be found  in Dwynnen or Whitewold for example, and aren't colored in blue on the map.

This is really hacky stuff but it works!