### PR TITLE
fall damage adjustments

### DIFF
--- a/Assets/Prefabs/Player/PlayerAdvanced.prefab
+++ b/Assets/Prefabs/Player/PlayerAdvanced.prefab
@@ -1099,7 +1099,7 @@ MonoBehaviour:
   jumpSpeed: 8
   gravity: 20
   crouchingJumpDelta: 0.8
-  fallingDamageThreshold: 10
+  fallingDamageThreshold: 5
   airControl: 0
 --- !u!114 &114121517922970790
 MonoBehaviour:

--- a/Assets/Prefabs/Player/PlayerStandalone.prefab
+++ b/Assets/Prefabs/Player/PlayerStandalone.prefab
@@ -542,7 +542,7 @@ MonoBehaviour:
   toggleRun: 0
   jumpSpeed: 8
   gravity: 20
-  fallingDamageThreshold: 10
+  fallingDamageThreshold: 5
   slideWhenOverSlopeLimit: 0
   slideOnTaggedObjects: 0
   slideSpeed: 12

--- a/Assets/Scripts/Game/Player/AcrobatMotor.cs
+++ b/Assets/Scripts/Game/Player/AcrobatMotor.cs
@@ -11,7 +11,7 @@ namespace DaggerfallWorkshop.Game
         public float jumpSpeed = 8.0f;
         public float gravity = 20.0f;
         public float crouchingJumpDelta = 0.8f;
-        public float fallingDamageThreshold = 10.0f;
+        public float fallingDamageThreshold = 5.0f;
         public bool airControl = false;
 
         PlayerMotor playerMotor;

--- a/Assets/Scripts/Game/PlayerHealth.cs
+++ b/Assets/Scripts/Game/PlayerHealth.cs
@@ -48,15 +48,12 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         void ApplyPlayerFallDamage(float fallDistance)
         {
-            const float threshold = 10f;
-            const float percentPerMetre = 50.0f / 100f;
+            const float threshold = 5f;
+            const float HPPerMetre = 5f;
 
             if (entityBehaviour)
             {
-                // Remove percent of max health for every metre over threshold
-                PlayerEntity entity = entityBehaviour.Entity as PlayerEntity;
-                int unit = (int)(entity.MaxHealth * percentPerMetre);
-                int damage = unit * (int)(fallDistance - threshold);
+                int damage = (int)(HPPerMetre * (fallDistance - threshold));
                 RemoveHealth(damage);
             }
         }


### PR DESCRIPTION
Tested using classic Daggerfall, falling from different platforms of Scourg Barrow and Daggerfall Castle.

I repeated some of the measures with a different encumbrance, with a totally different character (68 HP instead of 400 HP) and saw no difference in damage, so I assume the formula is only based on height. 
I got the exact same results with DOSBox's CPU cycles at 50k or 60k, but slightly less at 30k, so it's probably somewhat framerate dependant. Results below and patch match 50k and 60k cpu cycles measures, mainly because I tested the 30k cpu cycles at the last moment.

Threshold seems to be about 5 height units (no fall damage from the falling off the bottom of a crenel above Daggerfall Castle main entrance to the platform in front of the entrance, but small damage is falling slightly further away on the stairs. The difference in height in the first case being about 4.41 units, theshold is somewhere in the 4.5~5 units range.

By doing several falls (repeated 5 times at first, then only 3 times because the results were very consistent), including some from one of the high towers in Castle Daggerfall, damage seems to vary linearly with height above the threshold, and the slope nicely matches 5 HP/height unit.

location;height(unit);damage(HP)
Scourg Barrow external pillars;6.48;8
Scourg Barrow main, bottom of crenels;14.14;40
Scourg Barrow main, top of crenels;14.74;50
Daggerfall Castle, entrance tower bottom of crenels;10.91;24
Daggerfall Castle, entrance tower top of crenels;11.51;32
Daggerfall Castle, front gangway bottom of crenels;7.69;8
Daggerfall Castle, high tower bottom of crenels;17.36;60