### PR TITLE
Adjust direct stat, skill and reaction mod mechanism

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1494,15 +1494,15 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// </summary>
         void DoMagicRound()
         {
-            // Do nothing further if no bundles, entity has perished, or object disabled
-            if (instancedBundles.Count == 0 || entityBehaviour.Entity.CurrentHealth <= 0 || !entityBehaviour.enabled)
-                return;
-
             // Clear direct mods
             Array.Clear(directStatMods, 0, DaggerfallStats.Count);
             Array.Clear(directSkillMods, 0, DaggerfallSkills.Count);
             if (IsPlayerEntity)
                 (entityBehaviour.Entity as PlayerEntity).ClearReactionMods();
+
+            // Do nothing further if no bundles, entity has perished, or object disabled
+            if (instancedBundles.Count == 0 || entityBehaviour.Entity.CurrentHealth <= 0 || !entityBehaviour.enabled)
+                return;
 
             // Run all bundles
             foreach (LiveEffectBundle bundle in instancedBundles)


### PR DESCRIPTION
Allows the direct stat mods to be able to be used outside the effect bundle system. Without this fix any application of direct stat mod value will accumulate until the player has at least 1 effect bundle applied.

I looked at the prototype vampire class VampiricFortifyEffect and copied it's way of adjusting stats. Unfortunately it didn't work without this fix since the direct stat array is not cleared unless the entity has a bundle associated.

See https://github.com/ajrb/dfunity-mods/blob/encumbrance/RoleplayRealism/Scripts/_startupMod.cs and look at the EncumbranceEffects_OnNewMagicRound() method at the bottom. 

@Interkarma I separated this from the other mod support changes in case this is problematic. I can't see any issues. I did consider creating an effect bundle but since the effect was calculated and permanent I decided that the dynamic effect system was not right. This is not based on a spell or item, just whether that module of the mod is active.