### PR TITLE
Fix bug where no action mode selected first time inventory accessed

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -315,7 +315,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Setup initial state
             SelectTabPage(TabPages.WeaponsAndArmor);
-            SetupDefaultActionMode();
+            SelectActionMode((lootTarget != null) ? ActionModes.Remove : ActionModes.Equip);
 
             // Setup initial display
             FilterLocalItems();
@@ -541,35 +541,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        private void SetupDefaultActionMode()
-        {
-            bool dungeonExitPromptY = allowDungeonWagonAccess;
-            if (!allowDungeonWagonAccess &&
-                GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon &&
-                PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
-                allowDungeonWagonAccess = DungeonWagonAccessProximityCheck();
-
-            if (lootTarget != null)
-                SelectActionMode(ActionModes.Remove);
-            else if (DaggerfallUnity.Settings.DungeonExitWagonPrompt)
-            {
-                if (dungeonExitPromptY)
-                {
-                    SelectActionMode(ActionModes.Remove);
-                    ShowWagon(true);
-                }
-            }
-            else
-            { // !DaggerfallUnity.Settings.DungeonExitWagonPrompt
-                SelectActionMode(ActionModes.Equip);
-                if (allowDungeonWagonAccess)
-                {
-                    ShowWagon(true);
-                    // do not change default ActionMode, this can be confusing
-                }
-            }
-        }
-
         public override void OnPush()
         {
             // Racial override can suppress inventory
@@ -645,7 +616,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             if (IsSetup)
             {
-                SetupDefaultActionMode();
+                CheckWagonAccess();
                 // Reset item list scroll
                 localItemListScroller.ResetScroll();
                 remoteItemListScroller.ResetScroll();
@@ -1063,6 +1034,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             usingWagon = show;
             remoteItemListScroller.ResetScroll();
             Refresh(false);
+        }
+
+        private void CheckWagonAccess()
+        {
+            if (allowDungeonWagonAccess)
+            {
+                ShowWagon(true);
+                SelectActionMode(ActionModes.Remove);
+            }
+            else if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon &&
+                     PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart) &&
+                     DungeonWagonAccessProximityCheck())
+            {
+                allowDungeonWagonAccess = true;
+                ShowWagon(true);
+            }
         }
 
         bool DungeonWagonAccessProximityCheck()


### PR DESCRIPTION
Only occurred the first time inventory used if not in a dungeon.

I also simplified the code for wagon access because I simply could not follow it with my tired old brain. I literally spent over an hour getting confused so I had to change the logic for my own sanity. Sorry Pango, my brain gets confused easily sometimes. I think it behaves the same unless I missed something in testing. Could you check you're happy with it please?