### PR TITLE
Enemies shooting point-blank

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -25,6 +25,8 @@ namespace DaggerfallWorkshop.Game
     [RequireComponent(typeof(EnemySenses))]
     public class EnemyAttack : MonoBehaviour
     {
+        public const float minRangedDistance = 240 * MeshReader.GlobalScale; // 6m
+        public const float maxRangedDistance = 2048 * MeshReader.GlobalScale; // 51.2m
         public float MeleeDistance = 2.25f;                // Maximum distance for melee attack
         public float ClassicMeleeDistanceVsAI = 1.5f;      // Maximum distance for melee attack vs other AI in classic AI mode
         public float MeleeTimer = 0;                       // Must be 0 for a melee attack or touch spell to be done

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -501,7 +501,8 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         bool DoRangedAttack(Vector3 direction, float moveSpeed, float distance, bool isPlayingOneShot)
         {
-            if ((CanShootBow() || CanCastRangedSpell()) && senses.TargetInSight && senses.DetectedTarget && 360 * MeshReader.GlobalScale > senses.DistanceToTarget && senses.DistanceToTarget < 2048 * MeshReader.GlobalScale)
+            bool inRange = senses.DistanceToTarget > EnemyAttack.minRangedDistance && senses.DistanceToTarget < EnemyAttack.maxRangedDistance;
+            if (inRange && senses.TargetInSight && senses.DetectedTarget && (CanShootBow() || CanCastRangedSpell()))
             {
                 if (DaggerfallUnity.Settings.EnhancedCombatAI && senses.TargetIsWithinYawAngle(22.5f, destination) && strafeTimer <= 0)
                 {
@@ -520,7 +521,7 @@ namespace DaggerfallWorkshop.Game
                         if (hasBowAttack)
                         {
                             // Random chance to shoot bow
-                            if (DFRandom.rand() < 1000)
+                            if (Random.value < 1/32f)
                             {
                                 if (mobile.Summary.Enemy.HasRangedAttack1 && !mobile.Summary.Enemy.HasRangedAttack2)
                                     mobile.ChangeEnemyState(MobileStates.RangedAttack1);
@@ -529,7 +530,7 @@ namespace DaggerfallWorkshop.Game
                             }
                         }
                         // Random chance to shoot spell
-                        else if (DFRandom.rand() % 40 == 0 && entityEffectManager.SetReadySpell(selectedSpell))
+                        else if (Random.value < 1/40f && entityEffectManager.SetReadySpell(selectedSpell))
                         {
                             mobile.ChangeEnemyState(MobileStates.Spell);
                         }


### PR DESCRIPTION
Restored point-blank range in which enemies don't use ranged attacks but made it 6m rather than the original 9m.

Also changed the random checks which were using classic random for non-deterministic purposes.