### PR TITLE
Rumor mill fixes

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1549,25 +1549,7 @@ namespace DaggerfallWorkshop.Game.Entity
             List<int> keys = new List<int>(factionData.FactionDict.Keys);
             foreach (int key in keys)
             {
-                // Classic does not do any check on factions included in rumor mill.
-                // Here we exclude all generic factions and those which should clearly not be
-                // included like Oblivion or The Septim Empire.
-                if ((factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Province ||
-                     factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Group ||
-                     factionData.FactionDict[key].type == (int)FactionFile.FactionTypes.Subgroup) &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Oblivion &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Children &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Generic_Knightly_Order &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Smiths &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Questers &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Healers &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Seneschal &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Temple_Missionaries &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Temple_Treasurers &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Temple_Healers &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Temple_Blessers &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.Random_Ruler &&
-                    factionData.FactionDict[key].id != (int)FactionFile.FactionIDs.The_Septim_Empire)
+                if (isFactionValidForRumorMill(factionData.FactionDict[key]))
                 {
                     // Get power mod from allies
                     int[] allies = { factionData.FactionDict[key].ally1, factionData.FactionDict[key].ally2, factionData.FactionDict[key].ally3 };
@@ -1679,20 +1661,17 @@ namespace DaggerfallWorkshop.Game.Entity
                                     keys2.Remove(keys[randomKeyIndex]);
                                     count--;
                                 }
-                                while (random.type != (int)FactionFile.FactionTypes.Province &&
-                                       random.type != (int)FactionFile.FactionTypes.Group &&
-                                       random.type != (int)FactionFile.FactionTypes.Subgroup &&
-                                       count > 0);
+                                while (!isFactionValidForRumorMill(random) && count > 0);
 
-                                if (!factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].id, random.id)
-                                      && !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].id, random.id)
-                                      && !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally1, random.id)
-                                      && !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally2, random.id)
-                                      && !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally3, random.id)
-                                      && !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy1, random.id)
-                                      && !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy2, random.id)
-                                      && !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy3, random.id)
-                                      && factionData.GetFaction2ARelationToFaction1(factionData.FactionDict[key].id, random.id) == 0)
+                                if (!factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].id, random.id) &&
+                                    !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].id, random.id) &&
+                                    !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally1, random.id) &&
+                                    !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally2, random.id) &&
+                                    !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally3, random.id) &&
+                                    !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy1, random.id) &&
+                                    !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy2, random.id) &&
+                                    !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy3, random.id) &&
+                                    factionData.GetFaction2ARelationToFaction1(factionData.FactionDict[key].id, random.id) == -1)
                                 {
                                     int powerSum = factionPowerMod + factionData.FactionDict[key].rulerPowerBonus;
                                     if (Dice100.SuccessRoll((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, random.id) * 3) / 5))
@@ -1815,22 +1794,19 @@ namespace DaggerfallWorkshop.Game.Entity
                                     keys2.Remove(keys[randomKeyIndex]);
                                     count--;
                                 }
-                                while (random.type != (int)FactionFile.FactionTypes.Province &&
-                                       random.type != (int)FactionFile.FactionTypes.Group &&
-                                       random.type != (int)FactionFile.FactionTypes.Subgroup &&
-                                       count > 0);
+                                while (!isFactionValidForRumorMill(random) && count > 0);
 
-                                if (!factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].id, random.id)
-                                    && !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].id, random.id)
-                                    && !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally1, random.id)
-                                    && !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally2, random.id)
-                                    && !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally3, random.id)
-                                    && !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy1, random.id)
-                                    && !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy2, random.id)
-                                    && !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy3, random.id))
+                                if (!factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].id, random.id) &&
+                                    !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].id, random.id) &&
+                                    !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally1, random.id) &&
+                                    !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally2, random.id) &&
+                                    !factionData.IsFaction2AnEnemyOfFaction1(factionData.FactionDict[key].ally3, random.id) &&
+                                    !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy1, random.id) &&
+                                    !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy2, random.id) &&
+                                    !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy3, random.id))
                                 {
                                     int relation = factionData.GetFaction2ARelationToFaction1(factionData.FactionDict[key].id, random.id);
-                                    if (relation != 1 && relation != 3)
+                                    if (relation == -1 || relation == 2)
                                     {
                                         int mod = 0;
                                         if (relation == 2)
@@ -2055,6 +2031,28 @@ namespace DaggerfallWorkshop.Game.Entity
             }
         }
 
+        private static bool isFactionValidForRumorMill(FactionFile.FactionData factionData)
+        {
+            // Classic does not do any check on factions included in rumor mill.
+            // Here we exclude all generic factions and those which should clearly not be
+            // included like Oblivion or The Septim Empire.
+            return ((factionData.type == (int) FactionFile.FactionTypes.Province ||
+                     factionData.type == (int) FactionFile.FactionTypes.Group ||
+                     factionData.type == (int) FactionFile.FactionTypes.Subgroup) &&
+                    factionData.id != (int) FactionFile.FactionIDs.Oblivion &&
+                    factionData.id != (int) FactionFile.FactionIDs.Children &&
+                    factionData.id != (int) FactionFile.FactionIDs.Generic_Knightly_Order &&
+                    factionData.id != (int) FactionFile.FactionIDs.Smiths &&
+                    factionData.id != (int) FactionFile.FactionIDs.Questers &&
+                    factionData.id != (int) FactionFile.FactionIDs.Healers &&
+                    factionData.id != (int) FactionFile.FactionIDs.Seneschal &&
+                    factionData.id != (int) FactionFile.FactionIDs.Temple_Missionaries &&
+                    factionData.id != (int) FactionFile.FactionIDs.Temple_Treasurers &&
+                    factionData.id != (int) FactionFile.FactionIDs.Temple_Healers &&
+                    factionData.id != (int) FactionFile.FactionIDs.Temple_Blessers &&
+                    factionData.id != (int) FactionFile.FactionIDs.Random_Ruler &&
+                    factionData.id != (int) FactionFile.FactionIDs.The_Septim_Empire);
+        }
 
         public void TurnOnConditionFlag(int regionID, RegionDataFlags flagID)
         {
@@ -2083,7 +2081,7 @@ namespace DaggerfallWorkshop.Game.Entity
             regionData[regionID].Flags2[flagsToFlags2Map[(int)flagID]] = false;
         }
 
-        public void ResetWarDataForRegion(int factionID)
+        private void ResetWarDataForRegion(int factionID)
         {
             FactionFile.FactionData faction;
             if (FactionData.GetFactionData(factionID, out faction))

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -595,13 +595,20 @@ namespace DaggerfallWorkshop.Game.Player
         }
 
         /// <summary>
-        /// Get faction2 relation to faction1. Returns 1 if faction2 is the parent of faction1, 2 if faction1 and faction2 share the same parent
-        /// 3 if faction2 is a child of faction1, and 0 if none of the above.
+        /// Get faction2 relation to faction1. Returns:
+        ///    -1 if factions are unrelated
+        ///     0 if factions are the same
+        ///     1 if faction2 is the parent of faction1
+        ///     2 if faction1 and faction2 share the same parent
+        ///     3 if faction2 is a child of faction1
         /// </summary>
         public int GetFaction2ARelationToFaction1(int factionID1, int factionID2)
         {
             if (factionDict.ContainsKey(factionID1) && factionDict.ContainsKey(factionID2))
             {
+                if (factionID1 == factionID2)
+                    return 0;
+
                 FactionFile.FactionData factionData1 = factionDict[factionID1];
 
                 if (factionData1.parent == factionID2)
@@ -618,7 +625,7 @@ namespace DaggerfallWorkshop.Game.Player
                     return 3;
             }
 
-            return 0;
+            return -1;
         }
 
 


### PR DESCRIPTION
In the case a rumor involves two factions, previous exclusions of generic factions made in PR #1479 were valid only for the first one. Now, same filters also applies to the second faction.

Also added a check to ensure both factions are not the same, so a faction cannot be its own enemy anymore: https://forums.dfworkshop.net/viewtopic.php?f=5&t=2676#p31098