### PR TITLE
Fix old ruler name being identical to new one

### DIFF
--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -278,7 +278,7 @@ namespace DaggerfallWorkshop.Utility
             return GetNameBank(race);
         }
 
-        public static string GetLordNameForFaction(int factionId)
+        public static string GetLordNameForFaction(int factionId, bool oldRuler = false)
         {
             PersistentFactionData factions = GameManager.Instance.PlayerEntity.FactionData;
             FactionFile.FactionData fd;
@@ -295,7 +295,8 @@ namespace DaggerfallWorkshop.Utility
 
             Genders gender = (Genders) ((fd.ruler + 1) % 2); // even entries are female titles/genders, odd entries are male ones
             Races race = RaceTemplate.GetRaceFromFactionRace((FactionFile.FactionRaces)fd.race);
-            DFRandom.Seed = fd.rulerNameSeed & 0xffff; // Matched to classic: used to retain the same ruler name for each region
+            // Matched to classic: used to retain the same old and new ruler name for each region
+            DFRandom.Seed = oldRuler ? fd.rulerNameSeed >> 16 : fd.rulerNameSeed & 0xffff;
 
             return DaggerfallUnity.Instance.NameHelper.FullName(GetNameBank(race), gender);
         }
@@ -899,7 +900,7 @@ namespace DaggerfallWorkshop.Utility
 
         public static string OldLordOfFaction1(IMacroContextProvider mcp)
         {   // %ol1
-            return GetLordNameForFaction(idFaction1);
+            return GetLordNameForFaction(idFaction1, true);
         }
 
         public static string LordOfFaction1(IMacroContextProvider mcp)

--- a/Assets/StreamingAssets/Factions/FACTION.TXT
+++ b/Assets/StreamingAssets/Factions/FACTION.TXT
@@ -3228,7 +3228,7 @@ rep: 0
 summon: -1
 region: 22
 power: 60
-flags: 0
+flags: 16
 ruler: 12
 face: -1
 race: 3
@@ -3364,7 +3364,7 @@ rep: 0
 summon: -1
 region: 23
 power: 72
-flags: 0
+flags: 16
 ruler: 9
 face: -1
 race: 2
@@ -5507,6 +5507,7 @@ summon: -1
 region: 27
 power: 65
 flags: 1
+flags: 16
 ruler: 1
 race: 17
 flat: 182 3
@@ -6231,6 +6232,7 @@ rep: 0
 summon: -1
 region: 10
 power: 5
+flags: 16
 flags: 128
 face: -1
 race: 0


### PR DESCRIPTION
In rumors involving a new ruler, when the old one was mentioned, he used the same name. Fixed this by matching classic: random old name uses the HIWORD part of the ruler name seed while new name uses the LOWORD.

FACTION.TXT was tweaked so the following factions always have the same ruler (as intended) and are therefore excluded from "new ruler chance":
Anticlere: Lady Doryanna Flyte
Isle of Balfiera: Medora
Lainlyn: Baron Shrike
Orsinium: Gortwog
