### PR TITLE
Fix inv behaviour near exit

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -316,6 +316,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Setup initial state
             SelectTabPage(TabPages.WeaponsAndArmor);
             SelectActionMode((lootTarget != null) ? ActionModes.Remove : ActionModes.Equip);
+            CheckWagonAccess();
 
             // Setup initial display
             FilterLocalItems();
@@ -1048,7 +1049,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                      DungeonWagonAccessProximityCheck())
             {
                 allowDungeonWagonAccess = true;
-                ShowWagon(true);
+                if (lootTarget == null)
+                    ShowWagon(true);
             }
         }
 


### PR DESCRIPTION
Fix for first time inventory opens (again, in dungeons near exits thsi time)
Fix for clicking on loot containers near an exit