### PR TITLE
Prevent game load from restoring players breath underwater

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -317,7 +317,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
         public override void Update(DaggerfallEntityBehaviour sender)
         {
-            if (SaveLoadManager.Instance.LoadInProgress)
+            if (!GameManager.Instance.IsPlayingGame())
                 return;
 
             if (CurrentHealth <= 0)

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -813,8 +813,8 @@ namespace DaggerfallWorkshop.Game
             if (isGamePaused)
                 return false;
 
-            // Game not active when SaveLoadManager not present
-            if (SaveLoadManager.Instance == null)
+            // Game not active when SaveLoadManager not present or when loading
+            if (SaveLoadManager.Instance == null || SaveLoadManager.Instance.LoadInProgress)
                 return false;
 
             // Game not active when top window is neither null or HUD

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -282,6 +282,9 @@ namespace DaggerfallWorkshop.Game
 
         void Update()
         {
+            if (!GameManager.Instance.IsPlayingGame())
+                return;
+
             // Track which dungeon block player is inside of
             if (dungeon && isPlayerInsideDungeon)
             {


### PR DESCRIPTION
Forum topic: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2681

This is one approach to fixing the reported issue.
It seems to work fine on the saves I have, but this definitely needs thorough testing for side-effects.