### PR TITLE
allow to cancel Recall spell (QoL)

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Teleport.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Teleport.cs
@@ -114,6 +114,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 
             // Prompt for outcome
             DaggerfallMessageBox mb = new DaggerfallMessageBox(DaggerfallUI.Instance.UserInterfaceManager, DaggerfallMessageBox.CommonMessageBoxButtons.AnchorTeleport, teleportOrSetAnchor, DaggerfallUI.Instance.UserInterfaceManager.TopWindow);
+            // QoL, does not match classic. No magicka refund, though
+            mb.AllowCancel = true;
             mb.OnButtonClick += EffectActionPrompt_OnButtonClick;
             mb.Show();
         }


### PR DESCRIPTION
In classic Daggerfall, if you cast Recall by mistake you have no way to cancel it and have to choose between losing your anchor or teleporting right away. This usually ends up in a game reload.

I suggest to allow to cancel it, unless there's some drawback for allowing that.

Magicka refund would be even more generous, but being able to cancel Recall is what really matters...

Forums: https://forums.dfworkshop.net/viewtopic.php?f=23&t=2690