### PR TITLE
Update crosshair on travelmap

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -945,6 +945,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mapIndex = newIndex;
             SetupArrowButtons();
             UpdateMapTextures();
+            UpdateCrosshair();
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for #1505 

Crosshair would stay at same position when moving the map below it with the on-screen arrows.
