### PR TITLE
Quest person factions fix

### DIFF
--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -773,9 +773,12 @@ namespace DaggerfallWorkshop.Game.Questing
             {
                 FactionFile.FactionData factionData = GetFactionData(factionID);
 
-                // This must is an individual NPC
-                if (factionData.type != (int)FactionFile.FactionTypes.Individual)
-                    throw new Exception(string.Format("Named NPC {0} with FactionID {1} is not an individual NPC", individualNPCName, factionID));
+                // This must is an individual NPC or Daedra
+                if (factionData.type != (int) FactionFile.FactionTypes.Individual 
+                    && factionData.type != (int) FactionFile.FactionTypes.Daedra)
+                {
+                    throw new Exception(string.Format("Named NPC {0} with FactionID {1} is not an individual NPC or Daedra", individualNPCName, factionID));
+                }
 
                 // Setup Person resource
                 isIndividualNPC = true;

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -773,7 +773,7 @@ namespace DaggerfallWorkshop.Game.Questing
             {
                 FactionFile.FactionData factionData = GetFactionData(factionID);
 
-                // This must is an individual NPC or Daedra
+                // This must be an individual NPC or Daedra
                 if (factionData.type != (int) FactionFile.FactionTypes.Individual 
                     && factionData.type != (int) FactionFile.FactionTypes.Daedra)
                 {

--- a/Assets/StreamingAssets/Quests/R0C10Y21.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y21.txt
@@ -117,7 +117,7 @@ Item _reward_ gold
 
 Person _questgiver_ face 112 group Questor
 Person _qgfriend_ group Noble female anyInfo 1011
-Person _dummyorc_ named Orsinium
+Person _dummyorc_ faction Orsinium
 
 Place _mondung_ remote dungeon4
 

--- a/Assets/StreamingAssets/Quests/R0C20Y22.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y22.txt
@@ -161,7 +161,7 @@ Item _item_ trinket
 
 Person _questgiver_ group Questor male anyInfo 1015 rumors 1016
 Person _contact_ group Local_3.0 female
-Person _orsinium_ face 184 named Orsinium anyInfo 1012 rumors 1013
+Person _orsinium_ face 184 faction Orsinium anyInfo 1012 rumors 1013
 
 Place orcCastle permanent OrsiniumCastle3
 


### PR DESCRIPTION
Allow Daedra to be used as named NPC as per https://www.dfworkshop.net/static_files/questing-source-docs.html#permanentnpc

Also fix 2 broken quests that were using "named" to align an npc with a provice, which prevented them from loading.
