### PR TITLE
Show loading text before loading game

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
@@ -50,6 +50,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         TextLabel gameTimeLabel = new TextLabel();
         TextLabel saveVersionLabel = new TextLabel();
         TextLabel saveFolderLabel = new TextLabel();
+        TextLabel loadingLabel = new TextLabel();
         ListBox savesList = new ListBox();
         Button deleteSaveButton = new Button();
         Button goButton = new Button();
@@ -68,6 +69,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Modes mode = Modes.SaveGame;
         string currentPlayerName;
         bool displayMostRecentChar;
+        bool loading = false;
+        int loadingCountdown = 2;
 
         #endregion
 
@@ -235,6 +238,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             gameTimeLabel.Position = new Vector2(0, 9);
             infoPanel.Components.Add(gameTimeLabel);
 
+            // Loading label
+            loadingLabel.BackgroundColor = Color.gray;
+            loadingLabel.TextColor = Color.white;
+            loadingLabel.HorizontalAlignment = HorizontalAlignment.Center;
+            loadingLabel.VerticalAlignment = VerticalAlignment.Middle;
+            loadingLabel.Position = new Vector2(mainPanel.Size.x / 2f, mainPanel.Size.y / 2f);
+            mainPanel.Components.Add(loadingLabel);
+
             // Delete save button
             deleteSaveButton.Position = new Vector2(0, 132);
             deleteSaveButton.Size = new Vector2(98, 8);
@@ -280,6 +291,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (Input.GetKeyDown(KeyCode.Return))
                 SaveLoadEventHandler(null, Vector2.zero);
+            if (loading && --loadingCountdown == 0) // Allow loading text to draw before loading
+                LoadGame();
         }
 
         #endregion
@@ -474,7 +487,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     return;
                 }
 
-                LoadGame();
+                loadingLabel.Text = "Please wait...";
+                loading = true;
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
@@ -487,7 +487,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     return;
                 }
 
-                loadingLabel.Text = "Please wait...";
+                loadingLabel.Text = TextManager.Instance.GetText("DaggerfallUI", "loading");
                 loading = true;
             }
         }

--- a/Assets/StreamingAssets/Text/DaggerfallUI.txt
+++ b/Assets/StreamingAssets/Text/DaggerfallUI.txt
@@ -164,3 +164,6 @@ exteriorAutomapToolTipRotateRightButton,	"left click: rotate map to the right (h
 exteriorAutomapToolTipUpstairsButton,		"left click: zoom in (hotkey: {0})\rright click: apply maximum zoom)"
 exteriorAutomapToolTipDownstairsButton,		"left click: zoom out (hotkey: {0}\rright click: apply minimum zoom)"
 exteriorAutomapToolTipPanelCompass,			"left click: focus player position (hotkey: {0})\rright click: reset view (hotkey: {1})"
+
+- Save/Load window
+loading,                                    "Please wait..."


### PR DESCRIPTION
When playing on slower systems I've found myself wondering if the click registered after I selected "Load" in the Load Game window.  This gives the user simple visual feedback to assure them that the game is loading.