### PR TITLE
Allow access to hide billboards for mods.

### DIFF
--- a/Assets/Scripts/Game/Entities/EntityConcealmentBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/EntityConcealmentBehaviour.cs
@@ -26,6 +26,17 @@ namespace DaggerfallWorkshop.Game.Entity
         protected EntityEffectManager entityEffectManager;
         protected MeshRenderer meshRenderer;
 
+
+        private bool isConcealed = false;
+
+        public bool IsConcealed
+        {
+            get { return (isConcealed); }
+        }
+
+        // Override any concealment to force billboard to always be hidden
+        public bool forceConcealment { get; set; }
+        
         #region Unity
 
         void Awake()
@@ -38,8 +49,8 @@ namespace DaggerfallWorkshop.Game.Entity
             if (!entityBehaviour || entityBehaviour.Entity == null)
                 return;
 
-            bool isConcealed = (entityBehaviour && entityBehaviour.Entity.IsMagicallyConcealed);
-            MakeConcealed(isConcealed);
+            isConcealed = (entityBehaviour && entityBehaviour.Entity.IsMagicallyConcealed);
+            MakeConcealed(isConcealed || forceConcealment);
         }
 
         #endregion


### PR DESCRIPTION
Here is a solution I've found to give public access to force hide a billboard, specifically with the intention of implementing 3D models, without impacting the engine or other mods, while also being able to access the engines concealment for magic effects.