### PR TITLE
player smoother movements

### DIFF
--- a/Assets/Scripts/Game/Player/FrictionMotor.cs
+++ b/Assets/Scripts/Game/Player/FrictionMotor.cs
@@ -129,7 +129,7 @@ namespace DaggerfallWorkshop.Game
             //  -Tolerances should prevent false positives, but it's still possible - might require tuning/reworking later
             //  -Works best when player is standing as spherecast test has more clearance
             //  -Enemies will still become stuck as their motor does not have this handling
-            const float stuckMovementThreshold = 0.25f;
+            const float stuckMovementThreshold = 0.07f;
             const float stuckSampleDistance = 0.5f;
             const int stuckFrameThreshold = 3;
             bool tryingToMoveForwards = InputManager.Instance.HasAction(InputManager.Actions.MoveForwards);

--- a/Assets/Scripts/Game/Player/FrictionMotor.cs
+++ b/Assets/Scripts/Game/Player/FrictionMotor.cs
@@ -139,9 +139,9 @@ namespace DaggerfallWorkshop.Game
                 // Use a sqrmagnitude movement threshold check to see if player is stuck
                 // This is fast and overcomes precision issues with a simple position check
                 // Player must be stuck for multiple frames before unstuck handler will attempt to resolve
-                float testMagnitude = Mathf.Abs(lastMovePosition.sqrMagnitude - myTransform.position.sqrMagnitude);
+                float testMagnitude = (lastMovePosition - myTransform.position).sqrMagnitude;
                 //Debug.LogFormat("Testing stuck with {0} test magnitude", testMagnitude);
-                if (testMagnitude < stuckMovementThreshold)
+                if (testMagnitude < Mathf.Pow(stuckMovementThreshold, 2))
                 {
                     stuckFrameCount++;
                     if (stuckFrameCount > stuckFrameThreshold)

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -415,8 +415,8 @@ namespace DaggerfallWorkshop.Game
             if (smoothFollower != null && controller != null)
             {
                 float distanceMoved = Vector3.Distance(smoothFollowerPrevWorldPos, smoothFollower.position);        // Assuming the follower is a child of this motor transform we can get the distance travelled.
-                float maxPossibleDistanceByMotorVelocity = controller.velocity.magnitude * 2.0f * Time.deltaTime;   // Theoretically the max distance the motor can carry the player with a generous margin.
-                float speedThreshold = speedChanger.GetRunSpeed(speed) * Time.deltaTime;                                         // Without question any distance travelled less than the running speed is legal.
+                float maxPossibleDistanceByMotorVelocity = controller.velocity.magnitude * 2.0f * Time.fixedDeltaTime;   // Theoretically the max distance the motor can carry the player with a generous margin.
+                float speedThreshold = speedChanger.GetRunSpeed(speed) * Time.fixedDeltaTime;                            // Without question any distance travelled less than the running speed is legal.
 
                 // NOTE: Maybe the min distance should also include the height different between crouching / standing.
                 if (distanceMoved > speedThreshold && distanceMoved > maxPossibleDistanceByMotorVelocity)
@@ -426,6 +426,7 @@ namespace DaggerfallWorkshop.Game
 
                 if (smoothFollowerReset)
                 {
+                    // Debug.Log("smooth follower reset");
                     smoothFollowerPrevWorldPos = transform.position;
                     smoothFollowerReset = false;
                 }

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -415,11 +415,12 @@ namespace DaggerfallWorkshop.Game
             if (smoothFollower != null && controller != null)
             {
                 float distanceMoved = Vector3.Distance(smoothFollowerPrevWorldPos, smoothFollower.position);        // Assuming the follower is a child of this motor transform we can get the distance travelled.
-                float maxPossibleDistanceByMotorVelocity = controller.velocity.magnitude * 2.0f * Time.fixedDeltaTime;   // Theoretically the max distance the motor can carry the player with a generous margin.
-                float speedThreshold = speedChanger.GetRunSpeed(speed) * Time.fixedDeltaTime;                            // Without question any distance travelled less than the running speed is legal.
+                float distanceThreshold = speedChanger.GetRunSpeed(speed) * Time.deltaTime;         // Without question any distance travelled less than the running speed is legal.
+                float motorVelocity = controller.velocity.magnitude / Time.fixedDeltaTime;
+                float maxPossibleDistanceByMotorVelocity = motorVelocity * Time.deltaTime * 2.0f;   // Theoretically the max distance the motor can carry the player with a generous margin.
 
                 // NOTE: Maybe the min distance should also include the height different between crouching / standing.
-                if (distanceMoved > speedThreshold && distanceMoved > maxPossibleDistanceByMotorVelocity)
+                if (distanceMoved > distanceThreshold && distanceMoved > maxPossibleDistanceByMotorVelocity)
                 {
                     smoothFollowerReset = true;
                 }


### PR DESCRIPTION
- smooth follower could be reset very often at high FPS because speed threshold was computed based on framerate instead of fixed updates

- unstick handling could trigger during movements tangential to the (world) origin

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=2435&p=31737#p31728