### PR TITLE
Change nature 3d asset replacement to limit performance hit

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -10,7 +10,7 @@
 //
 
 #define SHOW_LAYOUT_TIMES
-#define SHOW_LAYOUT_TIMES_NATURE
+//#define SHOW_LAYOUT_TIMES_NATURE
 
 using UnityEngine;
 using System;
@@ -1235,8 +1235,8 @@ namespace DaggerfallWorkshop
                 // Get current climate and nature archive and terrain distance
                 int natureArchive = ClimateSwaps.GetNatureArchive(LocalPlayerGPS.ClimateSettings.NatureSet, dfUnity.WorldTime.Now.SeasonValue);
                 dfBillboardBatch.SetMaterial(natureArchive);
-                int tDist = GetTerrainDist(LocalPlayerGPS.CurrentMapPixel, dfTerrain.MapPixelX, dfTerrain.MapPixelY);
-                TerrainHelper.LayoutNatureBillboards(dfTerrain, dfBillboardBatch, TerrainScale, tDist);
+                int terrainDist = GetTerrainDist(LocalPlayerGPS.CurrentMapPixel, dfTerrain.MapPixelX, dfTerrain.MapPixelY);
+                TerrainHelper.LayoutNatureBillboards(dfTerrain, dfBillboardBatch, TerrainScale, terrainDist);
             }
 
             // Only set active again once complete

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -106,6 +106,7 @@ namespace DaggerfallWorkshop
 
         DaggerfallLocation currentPlayerLocationObject;
         int playerTilemapIndex = -1;
+        DFPosition prevMapPixel;
 
         private int? travelStartX = null;
         private int? travelStartZ = null;
@@ -248,6 +249,7 @@ namespace DaggerfallWorkshop
                 init)
             {
                 Debug.Log(string.Format("Entering new map pixel X={0}, Y={1}", curMapPixel.X, curMapPixel.Y));
+                prevMapPixel = new DFPosition(MapPixelX, MapPixelY);
                 MapPixelX = curMapPixel.X;
                 MapPixelY = curMapPixel.Y;
                 UpdateWorld();
@@ -839,11 +841,9 @@ namespace DaggerfallWorkshop
             {
                 // Terrain exists, check if active
                 int index = terrainIndexDict[key];
-                terrainArray[index].updateNature = true;
                 if (terrainArray[index].active)
                 {
                     // Terrain already active in scene, nothing to do
-                    return;
                 }
                 else
                 {
@@ -851,6 +851,14 @@ namespace DaggerfallWorkshop
                     terrainArray[index].active = true;
                     terrainArray[index].terrainObject.SetActive(true);
                     terrainArray[index].billboardBatchObject.SetActive(true);
+                }
+                // If any nature model replacements are used then do extra nature updates for any terrains moving into or out of distance 1 or less.
+                if (TerrainHelper.NatureMeshUsed)
+                {
+                    int prevDist = GetTerrainDist(prevMapPixel, terrainArray[index].mapPixelX, terrainArray[index].mapPixelY);
+                    int currDist = GetTerrainDist(LocalPlayerGPS.CurrentMapPixel, terrainArray[index].mapPixelX, terrainArray[index].mapPixelY);
+                    if ((prevDist == 1 && currDist > 1) || (currDist == 1 && prevDist > 1))
+                        terrainArray[index].updateNature = true;
                 }
                 return;
             }
@@ -1224,15 +1232,10 @@ namespace DaggerfallWorkshop
             DaggerfallBillboardBatch dfBillboardBatch = terrainDesc.billboardBatchObject.GetComponent<DaggerfallBillboardBatch>();
             if (dfTerrain && dfBillboardBatch)
             {
-                // Calculate the terrain distance from player
-                DFPosition curMapPixel = LocalPlayerGPS.CurrentMapPixel;
-                int dx = Mathf.Abs(dfTerrain.MapPixelX - curMapPixel.X);
-                int dy = Mathf.Abs(dfTerrain.MapPixelY - curMapPixel.Y);
-                int tDist = Mathf.Max(dx, dy);
-
-                // Get current climate and nature archive
+                // Get current climate and nature archive and terrain distance
                 int natureArchive = ClimateSwaps.GetNatureArchive(LocalPlayerGPS.ClimateSettings.NatureSet, dfUnity.WorldTime.Now.SeasonValue);
                 dfBillboardBatch.SetMaterial(natureArchive);
+                int tDist = GetTerrainDist(LocalPlayerGPS.CurrentMapPixel, dfTerrain.MapPixelX, dfTerrain.MapPixelY);
                 TerrainHelper.LayoutNatureBillboards(dfTerrain, dfBillboardBatch, TerrainScale, tDist);
             }
 
@@ -1259,6 +1262,15 @@ namespace DaggerfallWorkshop
         #endregion
 
         #region Player Utility Methods
+
+        // Calculate the distance of terrain from given map position
+        private int GetTerrainDist(DFPosition mapPosition, int terrainMapPixelX, int terrainMapPixelY)
+        {
+            DFPosition curMapPixel = LocalPlayerGPS.CurrentMapPixel;
+            int dx = Mathf.Abs(terrainMapPixelX - mapPosition.X);
+            int dy = Mathf.Abs(terrainMapPixelY - mapPosition.Y);
+            return Mathf.Max(dx, dy);
+        }
 
         private DaggerfallTerrain GetPlayerTerrain()
         {

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -10,7 +10,7 @@
 //
 
 #define SHOW_LAYOUT_TIMES
-//#define SHOW_LAYOUT_TIMES_NATURE
+#define SHOW_LAYOUT_TIMES_NATURE
 
 using UnityEngine;
 using System;
@@ -839,6 +839,7 @@ namespace DaggerfallWorkshop
             {
                 // Terrain exists, check if active
                 int index = terrainIndexDict[key];
+                terrainArray[index].updateNature = true;
                 if (terrainArray[index].active)
                 {
                     // Terrain already active in scene, nothing to do
@@ -1223,10 +1224,16 @@ namespace DaggerfallWorkshop
             DaggerfallBillboardBatch dfBillboardBatch = terrainDesc.billboardBatchObject.GetComponent<DaggerfallBillboardBatch>();
             if (dfTerrain && dfBillboardBatch)
             {
+                // Calculate the terrain distance from player
+                DFPosition curMapPixel = LocalPlayerGPS.CurrentMapPixel;
+                int dx = Mathf.Abs(dfTerrain.MapPixelX - curMapPixel.X);
+                int dy = Mathf.Abs(dfTerrain.MapPixelY - curMapPixel.Y);
+                int tDist = Mathf.Max(dx, dy);
+
                 // Get current climate and nature archive
                 int natureArchive = ClimateSwaps.GetNatureArchive(LocalPlayerGPS.ClimateSettings.NatureSet, dfUnity.WorldTime.Now.SeasonValue);
                 dfBillboardBatch.SetMaterial(natureArchive);
-                TerrainHelper.LayoutNatureBillboards(dfTerrain, dfBillboardBatch, TerrainScale);
+                TerrainHelper.LayoutNatureBillboards(dfTerrain, dfBillboardBatch, TerrainScale, tDist);
             }
 
             // Only set active again once complete

--- a/Assets/Scripts/Terrain/TerrainHelper.cs
+++ b/Assets/Scripts/Terrain/TerrainHelper.cs
@@ -462,7 +462,7 @@ namespace DaggerfallWorkshop
         }
 
         // Drops nature flats based on random chance scaled by simple rules
-        public static void LayoutNatureBillboards(DaggerfallTerrain dfTerrain, DaggerfallBillboardBatch dfBillboardBatch, float terrainScale)
+        public static void LayoutNatureBillboards(DaggerfallTerrain dfTerrain, DaggerfallBillboardBatch dfBillboardBatch, float terrainScale, int tDist)
         {
             const float maxSteepness = 50f;         // 50
             const float baseChanceOnDirt = 0.2f;        // 0.2
@@ -576,7 +576,7 @@ namespace DaggerfallWorkshop
 
                     // Add to batch
                     int record = UnityEngine.Random.Range(1, 32);
-                    if (!MeshReplacement.ImportNatureGameObject(dfBillboardBatch.TextureArchive, record, terrain, x, y))
+                    if (tDist > 1 || !MeshReplacement.ImportNatureGameObject(dfBillboardBatch.TextureArchive, record, terrain, x, y))
                         dfBillboardBatch.AddItem(record, pos);
                 }
             }

--- a/Assets/Scripts/Terrain/TerrainHelper.cs
+++ b/Assets/Scripts/Terrain/TerrainHelper.cs
@@ -42,6 +42,8 @@ namespace DaggerfallWorkshop
         public const float maxTerrainScale = 10.0f;
         public const float defaultTerrainScale = 1.5f;
 
+        public static bool NatureMeshUsed { get; private set; }
+
         /// <summary>
         /// Gets the Terrain name for a given map pixel
         /// </summary>
@@ -543,17 +545,17 @@ namespace DaggerfallWorkshop
                     int tile = dfTerrain.MapData.tilemapSamples[x, y] & 0x3F;
                     if (tile == 1)
                     {   // Dirt
-                        if (UnityEngine.Random.Range(0f, 1f) > chanceOnDirt)
+                        if (Random.Range(0f, 1f) > chanceOnDirt)
                             continue;
                     }
                     else if (tile == 2)
                     {   // Grass
-                        if (UnityEngine.Random.Range(0f, 1f) > chanceOnGrass)
+                        if (Random.Range(0f, 1f) > chanceOnGrass)
                             continue;
                     }
                     else if (tile == 3)
                     {   // Stone
-                        if (UnityEngine.Random.Range(0f, 1f) > chanceOnStone)
+                        if (Random.Range(0f, 1f) > chanceOnStone)
                             continue;
                     }
                     else
@@ -574,10 +576,12 @@ namespace DaggerfallWorkshop
                     float height2 = terrain.SampleHeight(pos + terrain.transform.position);
                     pos.y = height2;
 
-                    // Add to batch
-                    int record = UnityEngine.Random.Range(1, 32);
+                    // Add to batch unless a mesh replacement is found
+                    int record = Random.Range(1, 32);
                     if (tDist > 1 || !MeshReplacement.ImportNatureGameObject(dfBillboardBatch.TextureArchive, record, terrain, x, y))
                         dfBillboardBatch.AddItem(record, pos);
+                    else if (!NatureMeshUsed)
+                        NatureMeshUsed = true;  // Signal that nature mesh has been used to initiate extra terrain updates
                 }
             }
 

--- a/Assets/Scripts/Terrain/TerrainHelper.cs
+++ b/Assets/Scripts/Terrain/TerrainHelper.cs
@@ -464,7 +464,7 @@ namespace DaggerfallWorkshop
         }
 
         // Drops nature flats based on random chance scaled by simple rules
-        public static void LayoutNatureBillboards(DaggerfallTerrain dfTerrain, DaggerfallBillboardBatch dfBillboardBatch, float terrainScale, int tDist)
+        public static void LayoutNatureBillboards(DaggerfallTerrain dfTerrain, DaggerfallBillboardBatch dfBillboardBatch, float terrainScale, int terrainDist)
         {
             const float maxSteepness = 50f;         // 50
             const float baseChanceOnDirt = 0.2f;        // 0.2
@@ -578,7 +578,7 @@ namespace DaggerfallWorkshop
 
                     // Add to batch unless a mesh replacement is found
                     int record = Random.Range(1, 32);
-                    if (tDist > 1 || !MeshReplacement.ImportNatureGameObject(dfBillboardBatch.TextureArchive, record, terrain, x, y))
+                    if (terrainDist > 1 || !MeshReplacement.ImportNatureGameObject(dfBillboardBatch.TextureArchive, record, terrain, x, y))
                         dfBillboardBatch.AddItem(record, pos);
                     else if (!NatureMeshUsed)
                         NatureMeshUsed = true;  // Signal that nature mesh has been used to initiate extra terrain updates

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -178,6 +178,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             if (!TryImportGameObject(archive, record, false, out prefab))
                 return false;
 
+            // Store state of random sequence
+            Random.State prevState = Random.state;
+
             // Get instance properties
             Vector3 position = new Vector3(x / (float)tilemapDim, 0.0f, y / (float)tilemapDim);
             float scale = getTreeScaleCallback();
@@ -198,6 +201,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             };
             terrain.AddTreeInstance(treeInstance);
 
+            Random.state = prevState;   // Restore random state
             return true;
         }
 


### PR DESCRIPTION
Change 3d asset replacement for nature flats to only replace when terrain distance is <=1 for performance. At larger terrain distances, the standard DFU billboard system is still used since it's highly efficient and billboards are more than sufficient at this distance.

The nature flats used with standard DFU billboarding can still be replaced with high-res/different images.

- Update natures on terrains moving in/out of dist 1.
- Only do extra updates once any nature mesh replacement has been found.
- Ensure nature mesh replacement doesn't change nature placement. (bugfix)