### PR TITLE
make sure videos play under best conditions

### DIFF
--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -11,6 +11,7 @@
 
 using UnityEngine;
 using System.Collections;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -25,6 +26,7 @@ namespace DaggerfallWorkshop.Game
         public int MinWaitTime = 4;             // Min wait time in seconds before next sound
         public int MaxWaitTime = 35;            // Max wait time in seconds before next sound
         public AmbientSoundPresets Presets;     // Ambient sound preset
+        public bool IsMuted = false;
         public bool doNotPlayInCastle = true;   // Do not play ambient effects in castle blocks
         public bool PlayLightningEffect;        // Play a lightning effect where appropriate
         //public DaggerfallSky SkyForEffects;     // Sky to receive effects
@@ -68,6 +70,9 @@ namespace DaggerfallWorkshop.Game
             StartWaiting();
             playerBehaviour = GameManager.Instance.PlayerEntityBehaviour;
             playerEnterExit = GameManager.Instance.PlayerEnterExit;
+
+            DaggerfallVidPlayerWindow.OnVideoStart += AmbientEffectsPlayer_OnVideoStart;
+            DaggerfallVidPlayerWindow.OnVideoEnd += AmbientEffectsPlayer_OnVideoEnd;
         }
 
         void OnDisable()
@@ -84,6 +89,9 @@ namespace DaggerfallWorkshop.Game
 
         void Update()
         {
+            if (IsMuted)
+                return;
+
             // Change sound presets
             if (Presets != lastPresets)
             {
@@ -452,6 +460,27 @@ namespace DaggerfallWorkshop.Game
             AmbientEffectsEventArgs args = new AmbientEffectsEventArgs(clip);
             if (OnPlayEffect != null)
                 OnPlayEffect(args);
+        }
+
+
+        private void AmbientEffectsPlayer_OnVideoStart()
+        {
+            rainLoop = null;
+            cricketsLoop = null;
+
+            // Stop playing any loops
+            if (loopAudioSource.isPlaying)
+            {
+                loopAudioSource.Stop();
+                loopAudioSource.clip = null;
+                loopAudioSource.loop = false;
+            }
+            IsMuted = true;
+        }
+
+        private void AmbientEffectsPlayer_OnVideoEnd()
+        {
+            IsMuted = false;
         }
 
         #endregion

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Diseases/LycanthropyInfection.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Diseases/LycanthropyInfection.cs
@@ -133,6 +133,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             {
                 // Play infection warning dream video
                 DaggerfallVidPlayerWindow vidPlayerWindow = new DaggerfallVidPlayerWindow(DaggerfallUI.UIManager, dreamVideoName);
+                vidPlayerWindow.EndOnAnyKey = false;
                 DaggerfallUI.UIManager.PushWindow(vidPlayerWindow);
                 warningDreamVideoPlayed = true;
             }

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Diseases/VampirismInfection.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Diseases/VampirismInfection.cs
@@ -143,6 +143,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             {
                 // Play infection warning dream video
                 DaggerfallVidPlayerWindow vidPlayerWindow = new DaggerfallVidPlayerWindow(DaggerfallUI.UIManager, dreamVideoName);
+                vidPlayerWindow.EndOnAnyKey = false;
                 DaggerfallUI.UIManager.PushWindow(vidPlayerWindow);
                 warningDreamVideoPlayed = true;
             }
@@ -150,6 +151,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             {
                 // Play "death" video ahead of final stage of infection
                 DaggerfallVidPlayerWindow vidPlayerWindow = new DaggerfallVidPlayerWindow(DaggerfallUI.UIManager, deathVideoName);
+                vidPlayerWindow.EndOnAnyKey = false;
                 DaggerfallUI.UIManager.PushWindow(vidPlayerWindow);
                 vidPlayerWindow.OnClose += DeployFullBlownVampirism;
                 fakeDeathVideoPlayed = true;

--- a/Assets/Scripts/Game/PlayerMouseLook.cs
+++ b/Assets/Scripts/Game/PlayerMouseLook.cs
@@ -41,6 +41,7 @@ namespace DaggerfallWorkshop.Game
         public bool enableMouseLook = true;
         public bool enableSmoothing = true;
         public bool simpleCursorLock = false;
+        private bool forceHideCursor;
 
         // Assign this if there's a parent object controlling motion, such as a Character Controller.
         // Yaw rotation will affect this object instead of the camera if set.
@@ -91,6 +92,13 @@ namespace DaggerfallWorkshop.Game
 
         void Update()
         {
+            if (forceHideCursor)
+            {
+                Cursor.lockState = CursorLockMode.Locked;
+                Cursor.visible = false;
+                return;
+            }
+
             bool applyLook = true;
 
             // Cursor activation toggle while game is running
@@ -233,6 +241,11 @@ namespace DaggerfallWorkshop.Game
             Quaternion q = Quaternion.LookRotation(forward);
             Vector3 v = q.eulerAngles;
             SetFacing(v.y, 0f);
+        }
+
+        public void ForceHideCursor(bool hideCursor)
+        {
+            this.forceHideCursor = hideCursor;
         }
     }
 }

--- a/Assets/Scripts/Game/Questing/Actions/PlayVideo.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlayVideo.cs
@@ -74,6 +74,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             base.Update(caller);
 
             DaggerfallVidPlayerWindow vidPlayerWindow = new DaggerfallVidPlayerWindow(DaggerfallUI.UIManager, videoName);
+            vidPlayerWindow.EndOnAnyKey = false;
             DaggerfallUI.UIManager.PushWindow(vidPlayerWindow);
 
             SetComplete();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallVidPlayerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallVidPlayerWindow.cs
@@ -10,11 +10,6 @@
 //
 
 using UnityEngine;
-using UnityEngine.Video;
-using System;
-using System.IO;
-using System.Collections;
-using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Utility.AssetInjection;
 
@@ -25,6 +20,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     /// </summary>
     public class DaggerfallVidPlayerWindow : DaggerfallBaseWindow
     {
+
         DaggerfallVideo video;
         VideoPlayerDrawer customVideo;
         bool useCustomVideo = false;
@@ -84,7 +80,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // Play custom video
                 customVideo.Size = new Vector2(Screen.width, Screen.height);
                 NativePanel.Components.Add(customVideo);
+                DoHideCursor(hideCursor);
+
                 customVideo.Play();
+                RaiseOnVideoStartGlobalEvent();
             }
             else
             {
@@ -96,13 +95,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 video.HorizontalAlignment = HorizontalAlignment.Center;
                 video.Size = new Vector2(nativeScreenWidth, nativeScreenHeight);
                 NativePanel.Components.Add(video);
+                DoHideCursor(hideCursor);
 
                 // Start playing
                 if (!string.IsNullOrEmpty(PlayOnStart))
                 {
                     video.Open(PlayOnStart);
                     video.Playing = true;
-                    Cursor.visible = false;
                     RaiseOnVideoStartGlobalEvent();
                 }
             }
@@ -122,6 +121,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     customVideo.Stop();
                     customVideo.Dispose();
                     customVideo = null;
+
+                    DoHideCursor(false);
                     RaiseOnVideoFinishedHandler();
                     RaiseOnVideoEndGlobalEvent();
                     CloseWindow();
@@ -135,11 +136,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     video.Playing = false;
                     video.Dispose();
+                    DoHideCursor(false);
                     RaiseOnVideoFinishedHandler();
                     RaiseOnVideoEndGlobalEvent();
                     CloseWindow();
                 }
             }
+        }
+
+        private void DoHideCursor(bool hide)
+        {
+            PlayerMouseLook mLook = GameManager.Instance.PlayerMouseLook;
+            if (mLook != null)
+                mLook.ForceHideCursor(hide && hideCursor);
         }
 
         #region Event Handlers

--- a/Assets/Scripts/Internal/DaggerfallSongPlayer.cs
+++ b/Assets/Scripts/Internal/DaggerfallSongPlayer.cs
@@ -42,6 +42,7 @@ namespace DaggerfallWorkshop
 
         [Range(0.0f, 10.0f)]
         public float Gain = 5.0f;
+        private bool IsMuted = false;
         public string SongFolder = "Songs/";
         public SongFiles Song = SongFiles.song_none;
 
@@ -102,7 +103,7 @@ namespace DaggerfallWorkshop
                 CurrentTime = audioSource.timeSamples;
                 EndTime = audioSource.clip.samples;
             }
-            audioSource.volume = DaggerfallUnity.Settings.MusicVolume;
+            audioSource.volume = IsMuted ? 0f : DaggerfallUnity.Settings.MusicVolume;
         }
 
         void LateUpdate()
@@ -357,12 +358,14 @@ namespace DaggerfallWorkshop
             // Mute music while video is playing
             oldGain = Gain;
             Gain = 0;
+            IsMuted = true;
         }
 
         private void DaggerfallVidPlayerWindow_OnVideoEnd()
         {
             // Restore music to previous level
             Gain = oldGain;
+            IsMuted = false;
         }
 
         #endregion


### PR DESCRIPTION
- stop digitalized music (only MIDI synthesis was muted);
- stop ambient loop sounds
- videos played by quests can only be interrupted by Escape key. This should prevent mouse clicks from accidentally closing the video.
- implement HideCursor. This requires some cooperation with PlayerMouseLook that constantly updates mouse cursor visibility. I'm not sure how to best interact with it though