### PR TITLE
Mod support for item usage and ship availiablity

### DIFF
--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -35,12 +35,12 @@ namespace DaggerfallWorkshop.Game.Items
 
         private static Dictionary<string, Type> customItems = new Dictionary<string, Type>();
 
-        public static bool RegisterCustomItem(string className, Type guildType)
+        public static bool RegisterCustomItem(string itemClassName, Type itemClassType)
         {
-            DaggerfallUnity.LogMessage("RegisterCustomItem: " + className, true);
-            if (!customItems.ContainsKey(className))
+            DaggerfallUnity.LogMessage("RegisterCustomItem: " + itemClassName, true);
+            if (!customItems.ContainsKey(itemClassName))
             {
-                customItems.Add(className, guildType);
+                customItems.Add(itemClassName, itemClassType);
                 return true;
             }
             return false;

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -122,6 +122,11 @@ namespace DaggerfallWorkshop.Game.Items
             return itemTemplates[templateIndex];
         }
 
+        public void SetItemTemplate(ItemTemplate template)
+        {
+            itemTemplates[template.index] = template;
+        }
+
         /// <summary>
         /// Gets artifact template from magic item template data.
         /// </summary>

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -54,6 +54,9 @@ namespace DaggerfallWorkshop.Game.Items
         readonly Dictionary<InventoryContainerImages, ImageData> containerImages = new Dictionary<InventoryContainerImages, ImageData>();
         readonly Dictionary<int, String> bookIDNameMapping = new Dictionary<int, String>();
 
+        public delegate bool ItemUseHander(DaggerfallUnityItem item, ItemCollection collection);
+        Dictionary<int, ItemUseHander> itemUseHandlers = new Dictionary<int, ItemUseHander>();
+
         #endregion
 
         #region Constructors
@@ -68,6 +71,23 @@ namespace DaggerfallWorkshop.Game.Items
         #endregion
 
         #region Public Methods
+
+        public bool RegisterItemUseHander(int templateIndex, ItemUseHander itemUseHander)
+        {
+            DaggerfallUnity.LogMessage("RegisterItemUseHander: TemplateIndex={1}" + templateIndex);
+            if (!itemUseHandlers.ContainsKey(templateIndex))
+            {
+                itemUseHandlers.Add(templateIndex, itemUseHander);
+                return true;
+            }
+            return false;
+        }
+
+        public bool GetItemUseHander(int templateIndex, out ItemUseHander itemUseHander)
+        {
+            return itemUseHandlers.TryGetValue(templateIndex, out itemUseHander);
+        }
+
 
         /// <summary>
         /// Gets item template data using group and index.

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -122,11 +122,6 @@ namespace DaggerfallWorkshop.Game.Items
             return itemTemplates[templateIndex];
         }
 
-        public void SetItemTemplate(ItemTemplate template)
-        {
-            itemTemplates[template.index] = template;
-        }
-
         /// <summary>
         /// Gets artifact template from magic item template data.
         /// </summary>

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -70,15 +70,7 @@ namespace DaggerfallWorkshop.Game
         {
             StreamingWorld world = GameManager.Instance.StreamingWorld;
             DFPosition shipCoords = DaggerfallBankManager.GetShipCoords();
-            return boardShipPosition != null && world.MapPixelX == shipCoords.X && world.MapPixelY == shipCoords.Y;
-        }
-
-        /// <summary>
-        /// True when player has bought a ship
-        /// </summary>
-        public bool HasShip()
-        {
-            return DaggerfallBankManager.OwnsShip;
+            return boardShipPosition != null && shipCoords != null && world.MapPixelX == shipCoords.X && world.MapPixelY == shipCoords.Y;
         }
 
         /// <summary>
@@ -122,6 +114,17 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
+        public delegate bool PlayerShipAvailiable();
+        public PlayerShipAvailiable ShipAvailiable { get; set; }
+
+        /// <summary>
+        /// True when player has bought a ship
+        /// </summary>
+        private bool HasShip()
+        {
+            return DaggerfallBankManager.OwnsShip;
+        }
+
         #endregion
 
         #region Private Fields
@@ -158,6 +161,12 @@ namespace DaggerfallWorkshop.Game
         #endregion
 
         #region Unity
+
+        void Awake()
+        {
+            ShipAvailiable = HasShip;
+        }
+
         // Use this for initialization
         void Start()
         {
@@ -272,6 +281,7 @@ namespace DaggerfallWorkshop.Game
         #endregion
 
         #region Private Methods
+
         private void UpdateMode(TransportModes transportMode)
         {
             // Update the transport mode and stop any riding sounds playing.

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1618,6 +1618,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
             }
 
+            // Try to handle use with a registered delegate
+            ItemHelper.ItemUseHander itemUseHander;
+            if (DaggerfallUnity.Instance.ItemHelper.GetItemUseHander(item.TemplateIndex, out itemUseHander))
+            {
+                if (itemUseHander(item, collection))
+                    return;
+            }
+
             // Handle normal items
             if (item.ItemGroup == ItemGroups.Books && !item.IsArtifact)
             {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -79,7 +79,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             ItemCollection inventory = GameManager.Instance.PlayerEntity.Items;
             bool hasHorse = GameManager.Instance.TransportManager.HasHorse();
             bool hasCart = GameManager.Instance.TransportManager.HasCart();
-            bool hasShip = GameManager.Instance.TransportManager.HasShip();
+            bool hasShip = GameManager.Instance.TransportManager.ShipAvailiable();
 
             // Load all textures
             LoadTextures();


### PR DESCRIPTION
Add ability to register custom item usage handlers for vanilla items.
Allow ship availiability to be defined by mods.

Will be used by next version of R&R modpack for bandage usage and only allowing ships to be boarded in port towns.