### PR TITLE
Fix micromap size

### DIFF
--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -1851,8 +1851,8 @@ namespace DaggerfallWorkshop.Game
             }
 
             int microMapBlockSizeInPixels = 2;
-            int width = 7 * microMapBlockSizeInPixels;
-            int height = 7 * microMapBlockSizeInPixels;
+            int width = 9 * microMapBlockSizeInPixels;
+            int height = 9 * microMapBlockSizeInPixels;
             textureMicroMap = new Texture2D(width, height, TextureFormat.ARGB32, false);
             textureMicroMap.filterMode = FilterMode.Point;
 


### PR DESCRIPTION
My previous PR fixed the micromap for some dungeons but not all.  This increases the size of the micromap so that dungeon blocks won't run off the end of the texture.