### PR TITLE
remove LegacyDeferred setting

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -14,7 +14,6 @@ FieldOfView=65
 MainFilterMode=0
 QualityLevel=5
 ShadowResolutionMode=0
-UseLegacyDeferred=False
 DungeonLightShadows=False
 InteriorLightShadows=True
 ExteriorLightShadows=True

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -149,7 +149,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox dungeonLightShadows;
         Checkbox interiorLightShadows;
         Checkbox exteriorLightShadows;
-        Checkbox useLegacyDeferred;
 
         #endregion
 
@@ -335,7 +334,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             dungeonLightShadows = AddCheckbox(rightPanel, "dungeonLightShadows", DaggerfallUnity.Settings.DungeonLightShadows);
             interiorLightShadows = AddCheckbox(rightPanel, "interiorLightShadows", DaggerfallUnity.Settings.InteriorLightShadows);
             exteriorLightShadows = AddCheckbox(rightPanel, "exteriorLightShadows", DaggerfallUnity.Settings.ExteriorLightShadows);
-            useLegacyDeferred = AddCheckbox(rightPanel, "useLegacyDeferred", DaggerfallUnity.Settings.UseLegacyDeferred);
             string textureArrayLabel = "Texture Arrays: ";
             if (!SystemInfo.supports2DArrayTextures)
                 textureArrayLabel += "Unsupported";
@@ -450,7 +448,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.DungeonLightShadows = dungeonLightShadows.IsChecked;
             DaggerfallUnity.Settings.InteriorLightShadows = interiorLightShadows.IsChecked;
             DaggerfallUnity.Settings.ExteriorLightShadows = exteriorLightShadows.IsChecked;
-            DaggerfallUnity.Settings.UseLegacyDeferred = useLegacyDeferred.IsChecked;
             DaggerfallUnity.Settings.RetroRenderingMode = retroRenderingMode.ScrollIndex;
 
             DaggerfallUnity.Settings.SaveSettings();

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -201,10 +201,6 @@ namespace DaggerfallWorkshop.Game.Utility
                 // Set mouse look sensitivity
                 if (mouseLook)
                     mouseLook.sensitivityScale = DaggerfallUnity.Settings.MouseLookSensitivity;
-
-                // Set rendering path
-                if (DaggerfallUnity.Settings.UseLegacyDeferred)
-                    camera.renderingPath = RenderingPath.DeferredLighting;
             }
 
             // Set shadow resolution

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -76,7 +76,6 @@ namespace DaggerfallWorkshop
         public int ShadowResolutionMode { get; set; }
         public int MainFilterMode { get; set; }
         public int QualityLevel { get; set; }
-        public bool UseLegacyDeferred { get; set; }
         public bool DungeonLightShadows { get; set; }
         public bool InteriorLightShadows { get; set; }
         public bool ExteriorLightShadows { get; set; }
@@ -208,7 +207,6 @@ namespace DaggerfallWorkshop
             MainFilterMode = GetInt(sectionVideo, "MainFilterMode", 0, 2);
             ShadowResolutionMode = GetInt(sectionVideo, "ShadowResolutionMode", 0, 3);
             QualityLevel = GetInt(sectionVideo, "QualityLevel", 0, 5);
-            UseLegacyDeferred = GetBool(sectionVideo, "UseLegacyDeferred");
             DungeonLightShadows = GetBool(sectionVideo, "DungeonLightShadows");
             InteriorLightShadows = GetBool(sectionVideo, "InteriorLightShadows");
             ExteriorLightShadows = GetBool(sectionVideo, "ExteriorLightShadows");
@@ -324,7 +322,6 @@ namespace DaggerfallWorkshop
             SetInt(sectionVideo, "MainFilterMode", MainFilterMode);
             SetInt(sectionVideo, "ShadowResolutionMode", ShadowResolutionMode);
             SetInt(sectionVideo, "QualityLevel", QualityLevel);
-            SetBool(sectionVideo, "UseLegacyDeferred", UseLegacyDeferred);
             SetBool(sectionVideo, "DungeonLightShadows", DungeonLightShadows);
             SetBool(sectionVideo, "InteriorLightShadows", InteriorLightShadows);
             SetBool(sectionVideo, "ExteriorLightShadows", ExteriorLightShadows);

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -145,8 +145,6 @@ interiorLightShadows,                               Interior Light Shadows
 interiorLightShadowsInfo,                           Interior lights cast shadows
 exteriorLightShadows,                               Exterior Light Shadows
 exteriorLightShadowsInfo,                           Exterior sunlight casts shadows
-useLegacyDeferred,                                  Use Legacy Deferred
-useLegacyDeferredInfo,                              Legacy rendering path
 retroRenderingMode,                                 Retro Rendering Mode
 retroRenderingModeInfo,                             3D world rendered at low resolution while UI remains at set resolution
 


### PR DESCRIPTION
It seems to no longer work correctly with recent Unity, it's becoming a way for players to shoot themselves in the foot, so drop it altogether.

Are there anything to remove beside camera.renderingPath tweak?

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=2183