### PR TITLE
Optimize location loading

### DIFF
--- a/Assets/Scripts/API/DFLocation.cs
+++ b/Assets/Scripts/API/DFLocation.cs
@@ -481,6 +481,9 @@ namespace DaggerfallConnect
 
             /// <summary>Exterior map data including layout information.</summary>
             public ExteriorData ExteriorData;
+
+            /// <summary>List of RMB blocks.</summary>
+            public DFBlock[] Blocks;
         }
 
         /// <summary>

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -14,6 +14,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using DaggerfallConnect.Utility;
+using DaggerfallWorkshop.Utility;
 #endregion
 
 namespace DaggerfallConnect.Arena2
@@ -694,6 +695,9 @@ namespace DaggerfallConnect.Arena2
             DFLocation dfLocation = new DFLocation();
             if (!ReadLocation(region, location, ref dfLocation))
                 return new DFLocation();
+
+            // Get RMB blocks
+            RMBLayout.GetLocationBuildingData(ref dfLocation);
 
             // Store indices
             dfLocation.RegionIndex = region;

--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -367,7 +367,7 @@ namespace DaggerfallWorkshop
         public int mapRegionIndex;                  // Map region index (if location present)
         public int mapLocationIndex;                // Map location index (if location present)
         public int locationID;                      // Location ID (if location present)
-        public string locationName;                 // Location name (if location present)
+        public DFLocation location;                 // Location (if location present)
         public float averageHeight;                 // Average height of terrain for location placement
         public float maxHeight;                     // Max height of terrain for location placement
         public Rect locationRect;                   // Rect of location tiles in sample are

--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -1936,7 +1936,8 @@ namespace DaggerfallWorkshop.Game
         /// <param name="args"> the static door for loading the correct interior </param>
         private void CreateIndoorGeometryForAutomap(StaticDoor door)
         {
-            String newGeometryName = DaggerfallInterior.GetSceneName(GameManager.Instance.PlayerGPS.CurrentLocation, door);
+            DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
+            String newGeometryName = DaggerfallInterior.GetSceneName(ref location, door);
 
             //SetupMicroMapTexture(null); // setup micro map texture for interior geometry
 
@@ -1990,7 +1991,7 @@ namespace DaggerfallWorkshop.Game
         private void CreateDungeonGeometryForAutomap()
         {
             DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
-            String newGeometryName = DaggerfallDungeon.GetSceneName(location);
+            String newGeometryName = DaggerfallDungeon.GetSceneName(ref location);
 
             //SetupMicroMapTexture(location); // setup micro map texture for dungeon
 

--- a/Assets/Scripts/Game/BuildingDirectory.cs
+++ b/Assets/Scripts/Game/BuildingDirectory.cs
@@ -81,14 +81,10 @@ namespace DaggerfallWorkshop.Game
         /// Setup building directory from specified location.
         /// </summary>
         /// <param name="location">Source location data.</param>
-        public void SetLocation(DFLocation location)
+        public void SetLocation(ref DFLocation location)
         {
             // Clear existing buildings
             buildingDict.Clear();
-
-            // Get block data pre-populated with map building data.
-            DFBlock[] blocks;
-            RMBLayout.GetLocationBuildingData(location, out blocks);
 
             // Construct building directory
             int width = location.Exterior.ExteriorData.Width;
@@ -100,7 +96,7 @@ namespace DaggerfallWorkshop.Game
                     // Get all buildings for this block
                     // Some blocks have zero buildings
                     int index = y * width + x;
-                    BuildingSummary[] buildings = RMBLayout.GetBuildingData(blocks[index], x, y);
+                    BuildingSummary[] buildings = RMBLayout.GetBuildingData(ref location.Exterior.Blocks[index], x, y);
                     if (buildings == null || buildings.Length == 0)
                         continue;
 

--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -237,7 +237,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             UnregisterEvents();
         }
 
-        private void PlayerGPS_OnEnterLocationRect(DFLocation location)
+        private void PlayerGPS_OnEnterLocationRect(ref DFLocation location)
         {
             RevealGuildHallOnMap();
         }

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -228,7 +228,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             UnregisterEvents();
         }
 
-        private void PlayerGPS_OnEnterLocationRect(DFLocation location)
+        private void PlayerGPS_OnEnterLocationRect(ref DFLocation location)
         {
             RevealGuildHallOnMap();
         }

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -486,19 +486,17 @@ namespace DaggerfallWorkshop.Game
             else if (hasLocation && insideDungeon)
             {
                 // Start in dungeon
-                DFLocation location;
                 world.TeleportToCoordinates(pos.X, pos.Y, StreamingWorld.RepositionMethods.None);
-                dfUnity.ContentReader.GetLocation(summary.RegionIndex, summary.MapIndex, out location);
-                StartDungeonInterior(location, true, importEnemies);
+                DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
+                StartDungeonInterior(ref location, true, importEnemies);
                 world.suppressWorld = true;
             }
             else if (hasLocation && insideBuilding && exteriorDoors != null)
             {
                 // Start in building
-                DFLocation location;
                 world.TeleportToCoordinates(pos.X, pos.Y, StreamingWorld.RepositionMethods.None);
-                dfUnity.ContentReader.GetLocation(summary.RegionIndex, summary.MapIndex, out location);
-                StartBuildingInterior(location, exteriorDoors[0], start);
+                DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
+                StartBuildingInterior(ref location, exteriorDoors[0], start);
                 world.suppressWorld = true;
             }
             else
@@ -660,7 +658,8 @@ namespace DaggerfallWorkshop.Game
 
             // Layout interior
             // This needs to be done first so we know where the enter markers are
-            GameObject newInterior = new GameObject(DaggerfallInterior.GetSceneName(playerGPS.CurrentLocation, door));
+            DFLocation location = playerGPS.CurrentLocation;
+            GameObject newInterior = new GameObject(DaggerfallInterior.GetSceneName(ref location, door));
             newInterior.hideFlags = defaultHideFlags;
             interior = newInterior.AddComponent<DaggerfallInterior>();
 
@@ -857,7 +856,7 @@ namespace DaggerfallWorkshop.Game
             RaiseOnPreTransitionEvent(TransitionType.ToDungeonInterior, door);
 
             // Layout dungeon
-            GameObject newDungeon = GameObjectHelper.CreateDaggerfallDungeonGameObject(location, DungeonParent.transform);
+            GameObject newDungeon = GameObjectHelper.CreateDaggerfallDungeonGameObject(ref location, DungeonParent.transform);
             newDungeon.hideFlags = defaultHideFlags;
             dungeon = newDungeon.GetComponent<DaggerfallDungeon>();
 
@@ -906,7 +905,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Starts player inside dungeon with no exterior world.
         /// </summary>
-        public void StartDungeonInterior(DFLocation location, bool preferEnterMarker = true, bool importEnemies = true)
+        public void StartDungeonInterior(ref DFLocation location, bool preferEnterMarker = true, bool importEnemies = true)
         {
             // Ensure we have component references
             if (!ReferenceComponents())
@@ -916,7 +915,7 @@ namespace DaggerfallWorkshop.Game
             RaiseOnPreTransitionEvent(TransitionType.ToDungeonInterior);
 
             // Layout dungeon
-            GameObject newDungeon = GameObjectHelper.CreateDaggerfallDungeonGameObject(location, DungeonParent.transform, importEnemies);
+            GameObject newDungeon = GameObjectHelper.CreateDaggerfallDungeonGameObject(ref location, DungeonParent.transform, importEnemies);
             newDungeon.hideFlags = defaultHideFlags;
             dungeon = newDungeon.GetComponent<DaggerfallDungeon>();
 
@@ -955,7 +954,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Starts player inside building with no exterior world.
         /// </summary>
-        public void StartBuildingInterior(DFLocation location, StaticDoor exteriorDoor, bool start = true)
+        public void StartBuildingInterior(ref DFLocation location, StaticDoor exteriorDoor, bool start = true)
         {
             // Store start flag
             lastInteriorStartFlag = start;
@@ -1262,7 +1261,7 @@ namespace DaggerfallWorkshop.Game
         // Notify player when they enter location rect
         // For exterior towns, print out "You are entering %s".
         // For exterior dungeons, print out flavour text.
-        private void PlayerGPS_OnEnterLocationRect(DFLocation location)
+        private void PlayerGPS_OnEnterLocationRect(ref DFLocation location)
         {
             const int set1StartID = 500;
             const int set2StartID = 520;

--- a/Assets/Scripts/Game/Questing/Actions/WhenPcEntersExits.cs
+++ b/Assets/Scripts/Game/Questing/Actions/WhenPcEntersExits.cs
@@ -124,7 +124,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
 
         #region Events Handlers
 
-        private void PlayerGPS_OnEnterLocationRect(DFLocation location)
+        private void PlayerGPS_OnEnterLocationRect(ref DFLocation location)
         {
             previousLocationType = currentLocationType;
             if (location.Loaded)

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -564,11 +564,11 @@ namespace DaggerfallWorkshop.Game.Questing
             // Get list of valid sites
             SiteDetails[] foundSites = null;
             if (p2 == -1 && p3 == 0)
-                foundSites = CollectQuestSitesOfBuildingType(location, DFLocation.BuildingTypes.AllValid, p3);
+                foundSites = CollectQuestSitesOfBuildingType(ref location, DFLocation.BuildingTypes.AllValid, p3);
             else if (p2 == -1 && p3 == 1)
-                foundSites = CollectQuestSitesOfBuildingType(location, DFLocation.BuildingTypes.AnyHouse, p3);
+                foundSites = CollectQuestSitesOfBuildingType(ref location, DFLocation.BuildingTypes.AnyHouse, p3);
             else
-                foundSites = CollectQuestSitesOfBuildingType(location, (DFLocation.BuildingTypes)p2, p3);
+                foundSites = CollectQuestSitesOfBuildingType(ref location, (DFLocation.BuildingTypes)p2, p3);
 
             // Do some fallback for house types if nothing found locally
             // There should almost always be a suitable local house available
@@ -578,7 +578,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 requiredBuildingType <= DFLocation.BuildingTypes.House6)
             {
                 p2 = -1;
-                foundSites = CollectQuestSitesOfBuildingType(location, DFLocation.BuildingTypes.AnyHouse, p3);
+                foundSites = CollectQuestSitesOfBuildingType(ref location, DFLocation.BuildingTypes.AnyHouse, p3);
             }
 
             // Must have found at least one site
@@ -679,18 +679,18 @@ namespace DaggerfallWorkshop.Game.Questing
                 // Get list of valid sites
                 SiteDetails[] foundSites = null;
                 if (p2 == -1 && p3 == 0)
-                    foundSites = CollectQuestSitesOfBuildingType(location, DFLocation.BuildingTypes.AllValid, p3);
+                    foundSites = CollectQuestSitesOfBuildingType(ref location, DFLocation.BuildingTypes.AllValid, p3);
                 else if (p2 == -1 && p3 == 1)
-                    foundSites = CollectQuestSitesOfBuildingType(location, DFLocation.BuildingTypes.AnyHouse, p3);
+                    foundSites = CollectQuestSitesOfBuildingType(ref location, DFLocation.BuildingTypes.AnyHouse, p3);
                 else
                 {
                     // Check if town contains specified building type in MAPS.BSA directory
-                    if (!HasBuildingType(location, requiredBuildingType))
+                    if (!HasBuildingType(ref location, requiredBuildingType))
                         continue;
 
                     // Get an array of potential quest sites with specified building type
                     // This ensures building site actually exists inside town, as MAPS.BSA directory can be incorrect
-                    foundSites = CollectQuestSitesOfBuildingType(location, (DFLocation.BuildingTypes)p2, p3);
+                    foundSites = CollectQuestSitesOfBuildingType(ref location, (DFLocation.BuildingTypes)p2, p3);
                 }
 
                 // Must have found at least one site
@@ -751,7 +751,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
             // Dungeon must have at least one marker available
             QuestMarker[] questSpawnMarkers, questItemMarkers;
-            EnumerateDungeonQuestMarkers(location, out questSpawnMarkers, out questItemMarkers);
+            EnumerateDungeonQuestMarkers(ref location, out questSpawnMarkers, out questItemMarkers);
             if (!ValidateQuestMarkers(questSpawnMarkers, questItemMarkers))
             {
                 Debug.LogFormat("Could not find any quest markers in random dungeon {0}", location.Name);
@@ -864,7 +864,7 @@ namespace DaggerfallWorkshop.Game.Questing
             if (siteType == SiteTypes.Dungeon)
             {
                 // Enumerate markers
-                EnumerateDungeonQuestMarkers(location, out questSpawnMarkers, out questItemMarkers);
+                EnumerateDungeonQuestMarkers(ref location, out questSpawnMarkers, out questItemMarkers);
                 if (p1 == 50000)
                 {
                     // Hardcode for MantellanCrux as it only has a quest spawn marker
@@ -949,7 +949,7 @@ namespace DaggerfallWorkshop.Game.Questing
         /// This uses actual map layout and block data rather than the (often inaccurate) list of building in map data.
         /// Specify BuildingTypes.AllValid to find all valid building types
         /// </summary>
-        SiteDetails[] CollectQuestSitesOfBuildingType(DFLocation location, DFLocation.BuildingTypes buildingType, int guildHallFaction)
+        SiteDetails[] CollectQuestSitesOfBuildingType(ref DFLocation location, DFLocation.BuildingTypes buildingType, int guildHallFaction)
         {
             // Valid building types for valid search
             int[] validBuildingTypes = { 0, 2, 3, 5, 6, 8, 9, 11, 12, 13, 14, 15, 17, 18, 19, 20 };
@@ -963,8 +963,6 @@ namespace DaggerfallWorkshop.Game.Questing
             QuestResource[] parentQuestPlaceResources = ParentQuest.GetAllResources(typeof(Place));
 
             // Iterate through all blocks
-            DFBlock[] blocks;
-            RMBLayout.GetLocationBuildingData(location, out blocks);
             int width = location.Exterior.ExteriorData.Width;
             int height = location.Exterior.ExteriorData.Height;
             for (int y = 0; y < height; y++)
@@ -973,7 +971,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 {
                     // Iterate through all buildings in this block
                     int index = y * width + x;
-                    BuildingSummary[] buildingSummary = RMBLayout.GetBuildingData(blocks[index], x, y);
+                    BuildingSummary[] buildingSummary = RMBLayout.GetBuildingData(ref location.Exterior.Blocks[index], x, y);
                     for (int i = 0; i < buildingSummary.Length; i++)
                     {
                         bool wildcardFound = false;
@@ -1026,7 +1024,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
                             // Building must have at least one marker available
                             QuestMarker[] questSpawnMarkers, questItemMarkers;
-                            EnumerateBuildingQuestMarkers(blocks[index], i, out questSpawnMarkers, out questItemMarkers);
+                            EnumerateBuildingQuestMarkers(ref location.Exterior.Blocks[index], i, out questSpawnMarkers, out questItemMarkers);
                             if (!ValidateQuestMarkers(questSpawnMarkers, questItemMarkers))
                                 continue;
 
@@ -1127,7 +1125,7 @@ namespace DaggerfallWorkshop.Game.Questing
         /// Quick check to see if map data lists a specific building type in header.
         /// This can be inaccurate so should always followed up with a full check.
         /// </summary>
-        bool HasBuildingType(DFLocation location, DFLocation.BuildingTypes buildingType)
+        bool HasBuildingType(ref DFLocation location, DFLocation.BuildingTypes buildingType)
         {
             foreach (var building in location.Exterior.Buildings)
             {
@@ -1319,7 +1317,7 @@ namespace DaggerfallWorkshop.Game.Questing
         /// <summary>
         /// Collect all quest markers inside a building.
         /// </summary>
-        void EnumerateBuildingQuestMarkers(DFBlock blockData, int recordIndex, out QuestMarker[] questSpawnMarkers, out QuestMarker[] questItemMarkers)
+        void EnumerateBuildingQuestMarkers(ref DFBlock blockData, int recordIndex, out QuestMarker[] questSpawnMarkers, out QuestMarker[] questItemMarkers)
         {
             questSpawnMarkers = null;
             questItemMarkers = null;
@@ -1355,7 +1353,7 @@ namespace DaggerfallWorkshop.Game.Questing
         /// <summary>
         /// Collect all quest markers from inside a dungeon.
         /// </summary>
-        void EnumerateDungeonQuestMarkers(DFLocation location, out QuestMarker[] questSpawnMarkers, out QuestMarker[] questItemMarkers)
+        void EnumerateDungeonQuestMarkers(ref DFLocation location, out QuestMarker[] questSpawnMarkers, out QuestMarker[] questItemMarkers)
         {
             questSpawnMarkers = null;
             questItemMarkers = null;

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2581,25 +2581,9 @@ namespace DaggerfallWorkshop.Game
         {
             listBuildings = new List<BuildingInfo>();
 
-            ContentReader.MapSummary mapSummary;
-            DFPosition mapPixel = GameManager.Instance.PlayerGPS.CurrentMapPixel;
-            if (!DaggerfallUnity.Instance.ContentReader.HasLocation(mapPixel.X, mapPixel.Y, out mapSummary))
-            {
-                // No location found
-                return; // Do nothing
-            }
-
-            DFLocation location = DaggerfallUnity.Instance.ContentReader.MapFileReader.GetLocation(mapSummary.RegionIndex, mapSummary.MapIndex);
-            if (!location.Loaded)
-            {
-                // Location not loaded, something went wrong
-                DaggerfallUnity.LogMessage("Error when loading location in TalkManager.GetBuildingList", true);
-            }
-
+            DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
             ExteriorAutomap.BlockLayout[] blockLayout = GameManager.Instance.ExteriorAutomap.ExteriorLayout;
 
-            DFBlock[] blocks;
-            RMBLayout.GetLocationBuildingData(location, out blocks);
             int width = location.Exterior.ExteriorData.Width;
             int height = location.Exterior.ExteriorData.Height;
             bool populateQuestors = false;
@@ -2615,7 +2599,7 @@ namespace DaggerfallWorkshop.Game
                 for (int x = 0; x < width; x++)
                 {
                     int index = y * width + x;
-                    BuildingSummary[] buildingsInBlock = RMBLayout.GetBuildingData(blocks[index], x, y);
+                    BuildingSummary[] buildingsInBlock = RMBLayout.GetBuildingData(ref location.Exterior.Blocks[index], x, y);
 
                     for (int i = 0; i < buildingsInBlock.Length; i++)
                     {
@@ -2645,7 +2629,7 @@ namespace DaggerfallWorkshop.Game
                         if (populateQuestors)
                         {
                             PersistentFactionData factions = GameManager.Instance.PlayerEntity.FactionData;
-                            DFBlock.RmbBlockPeopleRecord[] buildingNpcs = blocks[index].RmbBlock.SubRecords[i].Interior.BlockPeopleRecords;
+                            DFBlock.RmbBlockPeopleRecord[] buildingNpcs = location.Exterior.Blocks[index].RmbBlock.SubRecords[i].Interior.BlockPeopleRecords;
                             for (int p = 0; p < buildingNpcs.Length; p++)
                             {
                                 FactionFile.FactionData factionData;

--- a/Assets/Scripts/Game/UserInterface/HUDPlaceMarker.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDPlaceMarker.cs
@@ -178,7 +178,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #region Event Handlers
 
-        private void PlayerGPS_OnEnterLocationRect(DaggerfallConnect.DFLocation location)
+        private void PlayerGPS_OnEnterLocationRect(ref DFLocation location)
         {
             // Refresh when entering a location rect
             RefreshSiteTargets();

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -358,7 +358,7 @@ namespace DaggerfallWorkshop.Game.Utility
                         streamingWorld.suppressWorld = true;
                     }
                     playerEnterExit.EnableDungeonParent();
-                    playerEnterExit.StartDungeonInterior(location);
+                    playerEnterExit.StartDungeonInterior(ref location);
                 }
                 else
                 {

--- a/Assets/Scripts/Internal/DaggerfallDungeon.cs
+++ b/Assets/Scripts/Internal/DaggerfallDungeon.cs
@@ -45,7 +45,7 @@ namespace DaggerfallWorkshop
         /// <summary>
         /// Gets the scene name for the dungeon at the given location.
         /// </summary>
-        public static string GetSceneName(DFLocation location)
+        public static string GetSceneName(ref DFLocation location)
         {
             return string.Format("DaggerfallDungeon [Region={0}, Name={1}]", location.RegionName, location.Name);
         }
@@ -82,7 +82,7 @@ namespace DaggerfallWorkshop
             public DFRegion.DungeonTypes DungeonType;
         }
 
-        public void SetDungeon(DFLocation location, bool importEnemies = true)
+        public void SetDungeon(ref DFLocation location, bool importEnemies = true)
         {
             if (!ReadyCheck())
                 return;

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -71,7 +71,7 @@ namespace DaggerfallWorkshop
         /// <summary>
         /// Gets the scene name for the interior behind the given door.
         /// </summary>
-        public static string GetSceneName(DFLocation location, StaticDoor door)
+        public static string GetSceneName(ref DFLocation location, StaticDoor door)
         {
             return GetSceneName(location.MapTableData.MapId, door.buildingKey);
         }
@@ -369,14 +369,12 @@ namespace DaggerfallWorkshop
         {
             // Get block data
             DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
-            DFBlock[] blocks;
-            RMBLayout.GetLocationBuildingData(location, out blocks);
             bool foundBlock = false;
-            for (int index = 0; index < blocks.Length && !foundBlock; ++index)
+            for (int index = 0; index < location.Exterior.Blocks.Length && !foundBlock; ++index)
             {
-                if (blocks[index].Index == door.blockIndex)
+                if (location.Exterior.Blocks[index].Index == door.blockIndex)
                 {
-                    this.blockData = blocks[index];
+                    this.blockData = location.Exterior.Blocks[index];
                     foundBlock = true;
                 }
             }

--- a/Assets/Scripts/Internal/DaggerfallLocation.cs
+++ b/Assets/Scripts/Internal/DaggerfallLocation.cs
@@ -148,7 +148,7 @@ namespace DaggerfallWorkshop
             ApplyClimateSettings();
         }
 
-        public void SetLocation(DFLocation location, bool performLayout = true)
+        public void SetLocation(ref DFLocation location, bool performLayout = true)
         {
             if (!ReadyCheck())
                 return;
@@ -301,14 +301,14 @@ namespace DaggerfallWorkshop
         /// </summary>
         /// <param name="location">Target location.</param>
         /// <returns>Location rect in world space. xMin,yMin is SW corner. xMax,yMax is NE corner.</returns>
-        public static Rect GetLocationRect(DFLocation location)
+        public static Rect GetLocationRect(ref DFLocation location)
         {
             // This finds the absolute SW origin of map pixel in world coords
             DFPosition mapPixel = MapsFile.LongitudeLatitudeToMapPixel(location.MapTableData.Longitude, location.MapTableData.Latitude);
             DFPosition worldOrigin = MapsFile.MapPixelToWorldCoord(mapPixel.X, mapPixel.Y);
 
             // Find tile offset point using same logic as terrain helper
-            DFPosition tileOrigin = TerrainHelper.GetLocationTerrainTileOrigin(location);
+            DFPosition tileOrigin = TerrainHelper.GetLocationTerrainTileOrigin(ref location);
 
             // Adjust world origin by tileorigin*2 in world units
             worldOrigin.X += (tileOrigin.X * 2) * MapsFile.WorldMapTileDim;
@@ -338,7 +338,7 @@ namespace DaggerfallWorkshop
 
             // Find tile offset point using same logic as terrain helper
             DFLocation currentLocation = Summary.LegacyLocation;
-            DFPosition tileOrigin = TerrainHelper.GetLocationTerrainTileOrigin(currentLocation);
+            DFPosition tileOrigin = TerrainHelper.GetLocationTerrainTileOrigin(ref currentLocation);
 
             // Adjust world origin by tileorigin*2 in world units
             worldOrigin.X += (tileOrigin.X * 2) * MapsFile.WorldMapTileDim;
@@ -423,9 +423,9 @@ namespace DaggerfallWorkshop
                         //miscBillboardBatch.BlockOrigin = blockOrigin;
                     }
 
-                    string blockName = dfUnity.ContentReader.BlockFileReader.CheckName(dfUnity.ContentReader.MapFileReader.GetRmbBlockName(ref location, x, y));
+                    int index = y * width + x;
                     GameObject go = GameObjectHelper.CreateRMBBlockGameObject(
-                        blockName,
+                        location.Exterior.Blocks[index].Name,
                         x,
                         y,
                         dfUnity.Option_RMBGroundPlane,

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -699,7 +699,7 @@ namespace DaggerfallWorkshop
                 {
                     // Add building directory to location game object
                     BuildingDirectory buildingDirectory = locationObject.AddComponent<BuildingDirectory>();
-                    buildingDirectory.SetLocation(location);
+                    buildingDirectory.SetLocation(ref location);
 
                     // Add location to loose object list
                     LooseObjectDesc looseObject = new LooseObjectDesc();
@@ -727,7 +727,7 @@ namespace DaggerfallWorkshop
                     // Position RMB blocks inside terrain area
                     int width = location.Exterior.ExteriorData.Width;
                     int height = location.Exterior.ExteriorData.Height;
-                    DFPosition tilePos = TerrainHelper.GetLocationTerrainTileOrigin(location);
+                    DFPosition tilePos = TerrainHelper.GetLocationTerrainTileOrigin(ref location);
                     Vector3 origin = new Vector3(tilePos.X * RMBLayout.RMBTileSide, 2.0f * MeshReader.GlobalScale, tilePos.Y * RMBLayout.RMBTileSide);
 
                     // Get location component
@@ -1139,7 +1139,7 @@ namespace DaggerfallWorkshop
                 return null;
 
             // Get location data
-            locationOut = dfUnity.ContentReader.MapFileReader.GetLocation(dfTerrain.MapData.mapRegionIndex, dfTerrain.MapData.mapLocationIndex);
+            locationOut = dfTerrain.MapData.location;
             if (!locationOut.Loaded)
                 return null;
 
@@ -1160,7 +1160,7 @@ namespace DaggerfallWorkshop
             locationObject.hideFlags = defaultHideFlags;
             locationObject.transform.position = terrainArray[terrain].terrainObject.transform.position + new Vector3(0, height, 0);
             DaggerfallLocation dfLocation = locationObject.AddComponent<DaggerfallLocation>() as DaggerfallLocation;
-            dfLocation.SetLocation(locationOut, false);
+            dfLocation.SetLocation(ref locationOut, false);
 
             // Raise event
             RaiseOnCreateLocationGameObjectEvent(dfLocation);
@@ -1414,7 +1414,8 @@ namespace DaggerfallWorkshop
             // Get location dimensions for positioning
             int width = currentLocation.Summary.BlockWidth;
             int height = currentLocation.Summary.BlockHeight;
-            DFPosition tilePos = TerrainHelper.GetLocationTerrainTileOrigin(currentLocation.Summary.LegacyLocation);
+            DFLocation legacyLocation = currentLocation.Summary.LegacyLocation;
+            DFPosition tilePos = TerrainHelper.GetLocationTerrainTileOrigin(ref legacyLocation);
             Vector3 origin = new Vector3(tilePos.X * RMBLayout.RMBTileSide, 2.0f * MeshReader.GlobalScale, tilePos.Y * RMBLayout.RMBTileSide);
 
             // Position player to random side of location

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -1298,7 +1298,7 @@ namespace DaggerfallWorkshop.Utility
             GameObject go = new GameObject(string.Format("DaggerfallLocation [Region={0}, Name={1}]", location.RegionName, location.Name));
             if (parent) go.transform.parent = parent;
             DaggerfallLocation c = go.AddComponent<DaggerfallLocation>() as DaggerfallLocation;
-            c.SetLocation(location);
+            c.SetLocation(ref location);
 
             return go;
         }
@@ -1310,10 +1310,10 @@ namespace DaggerfallWorkshop.Utility
             if (!FindMultiNameLocation(multiName, out location))
                 return null;
 
-            return CreateDaggerfallDungeonGameObject(location, parent);
+            return CreateDaggerfallDungeonGameObject(ref location, parent);
         }
 
-        public static GameObject CreateDaggerfallDungeonGameObject(DFLocation location, Transform parent, bool importEnemies = true)
+        public static GameObject CreateDaggerfallDungeonGameObject(ref DFLocation location, Transform parent, bool importEnemies = true)
         {
             if (!location.HasDungeon)
             {
@@ -1322,10 +1322,10 @@ namespace DaggerfallWorkshop.Utility
                 return null;
             }
 
-            GameObject go = new GameObject(DaggerfallDungeon.GetSceneName(location));
+            GameObject go = new GameObject(DaggerfallDungeon.GetSceneName(ref location));
             if (parent) go.transform.parent = parent;
             DaggerfallDungeon c = go.AddComponent<DaggerfallDungeon>();
-            c.SetDungeon(location, importEnemies);
+            c.SetDungeon(ref location, importEnemies);
 
             return go;
         }

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -438,10 +438,10 @@ namespace DaggerfallWorkshop.Utility
         /// Otherwise not all building data will be present.
         /// </summary>
         /// <param name="blockData">DFBlock data.</param>
-        /// <param name="layoutX">X coordindate in map layout used to generate building key.</param>
-        /// <param name="layoutY">Y coordindate in map layout used to generate building key.</param>
+        /// <param name="layoutX">X coordinate in map layout used to generate building key.</param>
+        /// <param name="layoutY">Y coordinate in map layout used to generate building key.</param>
         /// <returns>BuildingSummary.</returns>
-        public static BuildingSummary[] GetBuildingData(DFBlock blockData, int layoutX = -1, int layoutY = -1)
+        public static BuildingSummary[] GetBuildingData(ref DFBlock blockData, int layoutX = -1, int layoutY = -1)
         {
             // Store building information
             int buildingCount = blockData.RmbBlock.SubRecords.Length;
@@ -484,7 +484,7 @@ namespace DaggerfallWorkshop.Utility
         /// </summary>
         /// <param name="location">Location to use.</param>
         /// <param name="blocksOut">Array of blocks populated with data from MAPS.BSA.</param>
-        public static void GetLocationBuildingData(DFLocation location, out DFBlock[] blocksOut)
+        public static void GetLocationBuildingData(ref DFLocation location)
         {
             List<BuildingPoolItem> namedBuildingPool = new List<BuildingPoolItem>();
             List<DFBlock> blocks = new List<DFBlock>();
@@ -574,7 +574,7 @@ namespace DaggerfallWorkshop.Utility
             }
 
             // Send blocks array back to caller
-            blocksOut = blocks.ToArray();
+            location.Exterior.Blocks = blocks.ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
Improve location loading by keeping the list of blocks related to a location inside `DFLocation`. I made this after I noticed `RMBLayout.GetLocationBuildingData` was called several times: when entering a town, when entering a building, when talking to a NPC, etc. Unfortunately, calling this method can be relatively heavy in large cities (around 0.150s on my computer). Furthermore, when loading a savegame or when travelling to a new location, the method can be called 4 or 5 times.

So, this PR improves performance while making a location buildings list accessible immediately, reducing code bloat and improving overall clarity. The only drawback comes from `Clock.GetTravelTimeInSeconds` which may become a little slower, since it does not require location buildings list, only location coordinates. However, this isn't really noticeable in game.