### PR TITLE
Inventory filter

### DIFF
--- a/Assets/Game/Addons/Healer.meta
+++ b/Assets/Game/Addons/Healer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6bb3dd4449ecd243b83fd3ab1e3e55e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Addons/Healer/modsettings.json
+++ b/Assets/Game/Addons/Healer/modsettings.json
@@ -1,0 +1,49 @@
+{
+    "Version": null,
+    "Sections": [
+        {
+            "Name": "TimeToWait",
+            "Description": null,
+            "IsAdvanced": false,
+            "Keys": [
+                {
+                    "Min": 1,
+                    "Max": 300,
+                    "Value": 1,
+                    "Name": "waitTimeMin",
+                    "Description": null,
+                    "$version": "v1",
+                    "$type": "DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.SliderIntKey"
+                },
+                {
+                    "Min": 2,
+                    "Max": 300,
+                    "Value": 2,
+                    "Name": "waitTimeMax",
+                    "Description": null,
+                    "$version": "v1",
+                    "$type": "DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.SliderIntKey"
+                },
+                {
+                    "Min": 1,
+                    "Max": 100,
+                    "Value": 1,
+                    "Name": "HealthRecoveryAmount",
+                    "Description": "As a percent of max health",
+                    "$version": "v1",
+                    "$type": "DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.SliderIntKey"
+                },
+                {
+                    "Min": 1,
+                    "Max": 100,
+                    "Value": 1,
+                    "Name": "MagickaRecoveryAmount",
+                    "Description": null,
+                    "$version": "v1",
+                    "$type": "DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.SliderIntKey"
+                }
+            ],
+            "$version": "v1"
+        }
+    ]
+}

--- a/Assets/Game/Addons/Healer/modsettings.json.meta
+++ b/Assets/Game/Addons/Healer/modsettings.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d1327b84a27088344919ce5f35d74687
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Items/LootTables.cs
+++ b/Assets/Scripts/Game/Items/LootTables.cs
@@ -48,31 +48,35 @@ namespace DaggerfallWorkshop.Game.Items
         /// T, 3, 1
         /// U, 3, 2
         /// </summary>
+
+        private readonly static int[] tiers = { 1, 4, 6, 10, 20, 40 };
+
+
         public static LootChanceMatrix[] DefaultLootTables = {
-            new LootChanceMatrix() {key = "-", MinGold = 0, MaxGold = 0, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = 0, CL = 0, BK = 0, M2 = 0, RL = 0 },
-            new LootChanceMatrix() {key = "A", MinGold = 1, MaxGold = 10, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 5, WP = 5, MI = 2, CL = 4, BK = 0, M2 = 2, RL = 0 },
+            new LootChanceMatrix() {key = "-", MinGold = 0, MaxGold = 0, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = tiers[0], CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "A", MinGold = 1, MaxGold = 10, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 5, WP = 5, MI = tiers[2], CL = 4, BK = 0, M2 = 2, RL = 0 },
             // Chronicles says B has 10 for Warm Plant and Misc. Monster, but in FALL.EXE it is Temperate Plant and Warm Plant.
-            new LootChanceMatrix() {key = "B", MinGold = 0, MaxGold = 0, P1 = 10, P2 = 10, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = 0, CL = 0, BK = 0, M2 = 0, RL = 0 },
-            new LootChanceMatrix() {key = "C", MinGold = 2, MaxGold = 20, P1 = 10, P2 = 10, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 25, MI = 3, CL = 0, BK = 2, M2 = 2, RL = 2 },
-            new LootChanceMatrix() {key = "D", MinGold = 1, MaxGold = 4, P1 = 6, P2 = 6, C1 = 6, C2 = 6, C3 = 6, M1 = 6, AM = 0, WP = 0, MI = 0, CL = 0, BK = 0, M2 = 0, RL = 4 },
-            new LootChanceMatrix() {key = "E", MinGold = 20, MaxGold = 80, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 10, WP = 10, MI = 3, CL = 4, BK = 2, M2 = 1, RL = 15 },
-            new LootChanceMatrix() {key = "F", MinGold = 4, MaxGold = 30, P1 = 2, P2 = 2, C1 = 5, C2 = 5, C3 = 5, M1 = 2, AM = 50, WP = 50, MI = 1, CL = 0, BK = 0, M2 = 3, RL = 0 },
-            new LootChanceMatrix() {key = "G", MinGold = 3, MaxGold = 15, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 50, WP = 50, MI = 1, CL = 5, BK = 0, M2 = 3, RL = 0 },
-            new LootChanceMatrix() {key = "H", MinGold = 2, MaxGold = 10, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 100, MI = 1, CL = 2, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "B", MinGold = 0, MaxGold = 0, P1 = 10, P2 = 10, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = tiers[0], CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "C", MinGold = 2, MaxGold = 20, P1 = 10, P2 = 10, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 25, MI = tiers[3], CL = 0, BK = 2, M2 = 2, RL = 2 },
+            new LootChanceMatrix() {key = "D", MinGold = 1, MaxGold = 4, P1 = 6, P2 = 6, C1 = 6, C2 = 6, C3 = 6, M1 = 6, AM = 0, WP = 0, MI = tiers[0], CL = 0, BK = 0, M2 = 0, RL = 4 },
+            new LootChanceMatrix() {key = "E", MinGold = 20, MaxGold = 80, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 10, WP = 10, MI = tiers[3], CL = 4, BK = 2, M2 = 1, RL = 15 },
+            new LootChanceMatrix() {key = "F", MinGold = 4, MaxGold = 30, P1 = 2, P2 = 2, C1 = 5, C2 = 5, C3 = 5, M1 = 2, AM = 50, WP = 50, MI = tiers[1], CL = 0, BK = 0, M2 = 3, RL = 0 },
+            new LootChanceMatrix() {key = "G", MinGold = 3, MaxGold = 15, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 50, WP = 50, MI = tiers[2], CL = 5, BK = 0, M2 = 3, RL = 0 },
+            new LootChanceMatrix() {key = "H", MinGold = 2, MaxGold = 10, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 100, MI = tiers[1], CL = 2, BK = 0, M2 = 0, RL = 0 },
             // Chronicles is missing "I" but lists its data in table "J." All the tables from here are off by one compared to Chronicles.
-            new LootChanceMatrix() {key = "I", MinGold = 0, MaxGold = 0, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = 2, CL = 0, BK = 0, M2 = 0, RL = 5 },
-            new LootChanceMatrix() {key = "J", MinGold = 50, MaxGold = 150, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 5, WP = 5, MI = 3, CL = 0, BK = 0, M2 = 0, RL = 0 },
-            new LootChanceMatrix() {key = "K", MinGold = 1, MaxGold = 10, P1 = 3, P2 = 3, C1 = 3, C2 = 3, C3 = 3, M1 = 3, AM = 5, WP = 5, MI = 3, CL = 0, BK = 5, M2 = 2, RL = 100 },
-            new LootChanceMatrix() {key = "L", MinGold = 1, MaxGold = 20, P1 = 0, P2 = 0, C1 = 3, C2 = 3, C3 = 3, M1 = 3, AM = 50, WP = 50, MI = 1, CL = 75, BK = 0, M2 = 5, RL = 3 },
-            new LootChanceMatrix() {key = "M", MinGold = 1, MaxGold = 15, P1 = 1, P2 = 1, C1 = 1, C2 = 1, C3 = 1, M1 = 2, AM = 10, WP = 10, MI = 1, CL = 15, BK = 2, M2 = 3, RL = 1 },
-            new LootChanceMatrix() {key = "N", MinGold = 1, MaxGold = 80, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 5, MI = 1, CL = 20, BK = 5, M2 = 2, RL = 5 },
-            new LootChanceMatrix() {key = "O", MinGold = 5, MaxGold = 20, P1 = 1, P2 = 1, C1 = 1, C2 = 1, C3 = 1, M1 = 1, AM = 10, WP = 15, MI = 2, CL = 0, BK = 0, M2 = 0, RL = 0 },
-            new LootChanceMatrix() {key = "P", MinGold = 5, MaxGold = 20, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 10, MI = 2, CL = 0, BK = 10, M2 = 5, RL = 0 },
-            new LootChanceMatrix() {key = "Q", MinGold = 20, MaxGold = 80, P1 = 2, P2 = 2, C1 = 8, C2 = 8, C3 = 8, M1 = 2, AM = 10, WP = 25, MI = 3, CL = 35, BK = 5, M2 = 3, RL = 0 },
-            new LootChanceMatrix() {key = "R", MinGold = 5, MaxGold = 20, P1 = 0, P2 = 0, C1 = 3, C2 = 3, C3 = 3, M1 = 5, AM = 5, WP = 15, MI = 2, CL = 0, BK = 0, M2 = 0, RL = 0 },
-            new LootChanceMatrix() {key = "S", MinGold = 50, MaxGold = 125, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 15, AM = 10, WP = 10, MI = 3, CL = 0, BK = 5, M2 = 5, RL = 0 },
-            new LootChanceMatrix() {key = "T", MinGold = 20, MaxGold = 80, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 100, WP = 100, MI = 1, CL = 0, BK = 0, M2 = 0, RL = 0},
-            new LootChanceMatrix() {key = "U", MinGold = 7, MaxGold = 30, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 10, AM = 10, WP = 10, MI = 2, CL = 0, BK = 2, M2 = 2, RL = 10 },
+            new LootChanceMatrix() {key = "I", MinGold = 0, MaxGold = 0, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 0, WP = 0, MI = tiers[4], CL = 0, BK = 0, M2 = 0, RL = 5 },
+            new LootChanceMatrix() {key = "J", MinGold = 50, MaxGold = 150, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 5, WP = 5, MI = tiers[5], CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "K", MinGold = 1, MaxGold = 10, P1 = 3, P2 = 3, C1 = 3, C2 = 3, C3 = 3, M1 = 3, AM = 5, WP = 5, MI = tiers[3], CL = 0, BK = 5, M2 = 2, RL = 100 },
+            new LootChanceMatrix() {key = "L", MinGold = 1, MaxGold = 20, P1 = 0, P2 = 0, C1 = 3, C2 = 3, C3 = 3, M1 = 3, AM = 50, WP = 50, MI = tiers[2], CL = 75, BK = 0, M2 = 5, RL = 3 },
+            new LootChanceMatrix() {key = "M", MinGold = 1, MaxGold = 15, P1 = 1, P2 = 1, C1 = 1, C2 = 1, C3 = 1, M1 = 2, AM = 10, WP = 10, MI = tiers[1], CL = 15, BK = 2, M2 = 3, RL = 1 },
+            new LootChanceMatrix() {key = "N", MinGold = 1, MaxGold = 80, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 5, MI = tiers[2], CL = 20, BK = 5, M2 = 2, RL = 5 },
+            new LootChanceMatrix() {key = "O", MinGold = 5, MaxGold = 20, P1 = 1, P2 = 1, C1 = 1, C2 = 1, C3 = 1, M1 = 1, AM = 10, WP = 15, MI = tiers[2], CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "P", MinGold = 5, MaxGold = 20, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 5, AM = 5, WP = 10, MI = tiers[3], CL = 0, BK = 10, M2 = 5, RL = 0 },
+            new LootChanceMatrix() {key = "Q", MinGold = 20, MaxGold = 80, P1 = 2, P2 = 2, C1 = 8, C2 = 8, C3 = 8, M1 = 2, AM = 10, WP = 25, MI = tiers[4], CL = 35, BK = 5, M2 = 3, RL = 0 },
+            new LootChanceMatrix() {key = "R", MinGold = 5, MaxGold = 20, P1 = 0, P2 = 0, C1 = 3, C2 = 3, C3 = 3, M1 = 5, AM = 5, WP = 15, MI = tiers[4], CL = 0, BK = 0, M2 = 0, RL = 0 },
+            new LootChanceMatrix() {key = "S", MinGold = 50, MaxGold = 125, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 15, AM = 10, WP = 10, MI = tiers[5], CL = 0, BK = 5, M2 = 5, RL = 0 },
+            new LootChanceMatrix() {key = "T", MinGold = 20, MaxGold = 80, P1 = 0, P2 = 0, C1 = 0, C2 = 0, C3 = 0, M1 = 0, AM = 100, WP = 100, MI = tiers[2], CL = 0, BK = 0, M2 = 0, RL = 0},
+            new LootChanceMatrix() {key = "U", MinGold = 7, MaxGold = 30, P1 = 5, P2 = 5, C1 = 5, C2 = 5, C3 = 5, M1 = 10, AM = 10, WP = 10, MI = tiers[2], CL = 0, BK = 2, M2 = 2, RL = 10 },
         };
 
         /// <summary>
@@ -172,7 +176,11 @@ namespace DaggerfallWorkshop.Game.Items
             chance = matrix.WP;
             while (Dice100.SuccessRoll((int)chance))
             {
-                items.Add(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
+                int bonusRoll = RollForBonus(playerEntity.Level, (int)chance);
+                if (bonusRoll > 0)
+                    items.Add(ItemBuilder.CreateRandomWeapon(bonusRoll));
+                else
+                    items.Add(ItemBuilder.CreateRandomWeapon(playerEntity.Level));
                 chance *= 0.5f;
             }
 
@@ -180,7 +188,11 @@ namespace DaggerfallWorkshop.Game.Items
             chance = matrix.AM;
             while (Dice100.SuccessRoll((int)chance))
             {
-                items.Add(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
+                int bonusRoll = RollForBonus(playerEntity.Level, (int)chance);
+                if (bonusRoll > 0)
+                    items.Add(ItemBuilder.CreateRandomArmor(bonusRoll, playerEntity.Gender, playerEntity.Race));
+                else
+                    items.Add(ItemBuilder.CreateRandomArmor(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
             }
 
@@ -197,7 +209,12 @@ namespace DaggerfallWorkshop.Game.Items
             chance = matrix.MI;
             while (Dice100.SuccessRoll((int)chance))
             {
-                items.Add(ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
+                int bonusRoll = RollForBonus(playerEntity.Level, (int)chance);
+                Debug.Log("checking bonusRoll = " + bonusRoll);
+                if (bonusRoll > 0)
+                    items.Add(ItemBuilder.CreateRandomMagicItem(bonusRoll, playerEntity.Gender, playerEntity.Race));
+                else
+                    items.Add(ItemBuilder.CreateRandomMagicItem(playerEntity.Level, playerEntity.Gender, playerEntity.Race));
                 chance *= 0.5f;
             }
 
@@ -238,6 +255,28 @@ namespace DaggerfallWorkshop.Game.Items
                 chance *= 0.5f;
             }
         }
+        static int RollForBonus(int playerlevel, int chanceSuccess)        {
+            float tier = 0;
+            int chanceMultiplier = Random.Range(1, 11) - 7;
+            if (chanceMultiplier < 1)
+                chanceMultiplier = 1;
+
+            chanceSuccess *= chanceMultiplier;
+            if (Dice100.SuccessRoll(chanceSuccess))
+            {
+                tier = (float)Random.Range(1, 101);
+                if (tier < 100)
+                    tier = tier % 4 + 1;
+            }
+            else
+                tier = 0f;
+
+            tier = Mathf.Round(tier + (float)playerlevel);
+            if (tier > 100f)
+                tier = 100f;
+            return (int)tier;
+        }
+
 
         #endregion
     }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -88,9 +88,40 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected MultiFormatTextLabel itemInfoPanelLabel;
 
         protected static string filterString = string.Empty;
-        protected static string[] itemGroupNames = new string[30];
+        protected static string[] itemGroupNames = new string[]
+        {
+            "drugs",
+            "uselessitems1",
+            "armor",
+            "weapons",
+            "magicitems",
+            "artifacts",
+            "mensclothing",
+            "books",
+            "furniture",
+            "uselessitems2",
+            "religiousitems",
+            "maps",
+            "womensclothing",
+            "paintings",
+            "gems",
+            "plantingredients1",
+            "plantingredients2",
+            "creatureingredients1",
+            "creatureingredients2",
+            "creatureingredients3",
+            "miscellaneousingredients1",
+            "metalingredients",
+            "miscellaneousingredients2",
+            "transportation",
+            "deeds",
+            "jewellery",
+            "questitems",
+            "miscitems",
+            "currency"
+        };
 
-        protected ItemListScroller localItemListScroller;
+    protected ItemListScroller localItemListScroller;
         protected ItemListScroller remoteItemListScroller;
 
         // Only used for setting equip delay
@@ -288,9 +319,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void Setup()
         {
-            //Populate ItemGroupNames
-            PopulateItemGroupNames();
-
             // Load all the textures used by inventory system
             LoadTextures();
 
@@ -503,10 +531,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             useButton = DaggerfallUI.AddButton(useButtonRect, NativePanel);
             useButton.OnMouseClick += UseButton_OnMouseClick;
-
-            goldButton = DaggerfallUI.AddButton(goldButtonRect, NativePanel);
-            goldButton.OnMouseClick += GoldButton_OnMouseClick;
-            goldButton.OnMouseEnter += GoldButton_OnMouseEnter;
         }
 
         protected void SetupAccessoryElements()
@@ -665,7 +689,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             chooseOne = false;
 
             // Clear the Filter
-            clearFilterFields();
+            ClearFilterFields();
 
             // Handle stealing and reset shop shelf stealing mode
             if (shopShelfStealing && remoteItems.Count < lootTargetStartCount)
@@ -791,7 +815,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // Select new tab page
             selectedTabPage = tabPage;
-            clearFilterFields();
+            ClearFilterFields();
 
             // Set all buttons to appropriate state
             weaponsAndArmorButton.BackgroundTexture = (tabPage == TabPages.WeaponsAndArmor) ? weaponsAndArmorSelected : weaponsAndArmorNotSelected;
@@ -966,8 +990,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         ///</summary>
         protected virtual bool ItemPassesFilter(DaggerfallUnityItem item)
         {
-            bool itemPasses = true;
-            bool iterationPass = false;
+             bool iterationPass = false;
 
             if (filterString.Length == 0)
                 return true;
@@ -978,39 +1001,28 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     if (word[0] == '-')
                     {
+                        string wordLessFirstChar = word.Remove(0, 1);
                         iterationPass = true;
-                        if (item.LongName.ToLower().Contains(word.Remove(0, 1)))
+                        if (item.LongName.IndexOf(wordLessFirstChar, StringComparison.OrdinalIgnoreCase) != -1)
                             iterationPass = false;
-                        else if (itemGroupNames[(int)item.ItemGroup].Contains(word.Remove(0, 1)))
+                        else if (itemGroupNames[(int)item.ItemGroup].IndexOf(wordLessFirstChar, StringComparison.OrdinalIgnoreCase) != -1)
                             iterationPass = false;
                     }
                     else
                     {
                         iterationPass = false;
-                        if (item.LongName.ToLower().Contains(word))
+                        if (item.LongName.IndexOf(word, StringComparison.OrdinalIgnoreCase) != -1)
                             iterationPass = true;
-                        else if (itemGroupNames[(int)item.ItemGroup].Contains(word))
+                        else if (itemGroupNames[(int)item.ItemGroup].IndexOf(word, StringComparison.OrdinalIgnoreCase) != -1)
                             iterationPass = true;
                     }
 
-                    if (iterationPass == true && itemPasses == true)
-                        itemPasses = true;
-                    else
-                    {
-                        itemPasses = false;
-                        break;
-                    }
+                    if (!iterationPass)
+                        return false;
                 }
-                else
-                {
-                    iterationPass = true;
-                    if (iterationPass == true && itemPasses == true)
-                        itemPasses = true;
-                }
-
             }
 
-            return itemPasses;
+            return true;
         }
 
 
@@ -1053,44 +1065,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         #endregion
 
         #region Private Methods
-        protected void PopulateItemGroupNames()
-        {
-            itemGroupNames[0] = "drugs";
-            itemGroupNames[1] = "uselessitems1";
-            itemGroupNames[2] = "armor";
-            itemGroupNames[3] = "weapons";
-            itemGroupNames[4] = "magicitems";
-            itemGroupNames[5] = "artifacts";
-            itemGroupNames[6] = "mensclothing";
-            itemGroupNames[7] = "books";
-            itemGroupNames[8] = "furniture";
-            itemGroupNames[9] = "uselessitems2";
-            itemGroupNames[10] = "religiousitems";
-            itemGroupNames[11] = "maps";
-            itemGroupNames[12] = "womensclothing";
-            itemGroupNames[13] = "paintings";
-            itemGroupNames[14] = "gems";
-            itemGroupNames[15] = "plantingredients1";
-            itemGroupNames[16] = "plantingredients2";
-            itemGroupNames[17] = "creatureingredients1";
-            itemGroupNames[18] = "creatureingredients2";
-            itemGroupNames[19] = "creatureingredients3";
-            itemGroupNames[20] = "miscellaneousingredients1";
-            itemGroupNames[21] = "metalingredients";
-            itemGroupNames[22] = "miscellaneousingredients2";
-            itemGroupNames[23] = "transportation";
-            itemGroupNames[24] = "deeds";
-            itemGroupNames[25] = "jewellery";
-            itemGroupNames[26] = "questitems";
-            itemGroupNames[27] = "miscitems";
-            itemGroupNames[28] = "currency";
-
-        }
-
-
-
-
-
         protected virtual void LoadTextures()
         {
             // Load source textures
@@ -1311,7 +1285,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SelectTabPage(TabPages.Ingredients);
         }
 
-        private void clearFilterFields()
+        private void ClearFilterFields()
         {
             filterString = string.Empty;
             localFilterTextBox.Text = string.Empty;
@@ -2165,14 +2139,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 lastMouseOverPaperDollEquipIndex = value;
             }
         }
-        protected virtual void GoldButton_OnMouseEnter(BaseScreenComponent sender)
-        {
-            TextAsset textAsset;
-            string str = string.Format("Gold Amount: {0}", GameManager.Instance.PlayerEntity.GoldPieces);
-            textAsset = new TextAsset(str);
-            itemInfoPanelLabel.Clear();
-            itemInfoPanelLabel.SetText(textAsset);
-        }
+
+
         protected virtual void AccessoryItemsButton_OnMouseEnter(BaseScreenComponent sender)
         {
             // Get item

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -72,6 +72,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button removeButton;
         Button useButton;
         Button goldButton;
+        
 
         Button[] accessoryButtons = new Button[accessoryCount];
         Panel[] accessoryIconPanels = new Panel[accessoryCount];
@@ -86,7 +87,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected TextLabel remoteTargetIconLabel;
         protected Panel itemInfoPanel;
         protected MultiFormatTextLabel itemInfoPanelLabel;
-
         protected static string filterString = string.Empty;
         protected static string[] itemGroupNames = new string[]
         {
@@ -121,7 +121,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             "currency"
         };
 
-    protected ItemListScroller localItemListScroller;
+        protected ItemListScroller localItemListScroller;
         protected ItemListScroller remoteItemListScroller;
 
         // Only used for setting equip delay

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -80,15 +80,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected Panel localTargetIconPanel;
         protected TextLabel localTargetIconLabel;
-        protected Button localFilterButton;
-        protected TextBox localFilterTextBox;
         protected Panel remoteTargetIconPanel;
         protected TextLabel remoteTargetIconLabel;
         protected Panel itemInfoPanel;
         protected MultiFormatTextLabel itemInfoPanelLabel;
-
-        protected string filterString = string.Empty;
-        protected string[] itemGroupNames = new string[30];
 
         protected ItemListScroller localItemListScroller;
         protected ItemListScroller remoteItemListScroller;
@@ -288,9 +283,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void Setup()
         {
-            //Populate ItemGroupNames
-            PopulateItemGroupNames();
-
             // Load all the textures used by inventory system
             LoadTextures();
 
@@ -346,7 +338,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Toggle window closed with same hotkey used to open it
             if (Input.GetKeyUp(toggleClosedBinding))
                 CloseWindow();
-
 
             // Close window immediately if inventory suppressed
             if (suppressInventory)
@@ -420,17 +411,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             localTargetIconLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(1, 2), localTargetIconPanel);
             localTargetIconLabel.TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
 
-            localFilterTextBox = DaggerfallUI.AddTextBoxWithFocus(new Rect(new Vector2(1, 24), new Vector2(40, 8)), "filter pattern", localTargetIconPanel);
-            localFilterTextBox.VerticalAlignment = VerticalAlignment.Bottom;
-            localFilterButton = DaggerfallUI.AddButton(new Rect(40, 25, 15, 8), localTargetIconPanel);
-            localFilterButton.Label.Text = "Filter";
-            localFilterButton.Label.TextScale = 0.75f;
-            localFilterButton.Label.ShadowColor = Color.black;
-            localFilterButton.VerticalAlignment = VerticalAlignment.Bottom;
-            localFilterButton.HorizontalAlignment = HorizontalAlignment.Right;
-            localFilterButton.BackgroundColor = new Color(0.5f, 0.5f, 0.5f, 0.75f);
-            localFilterButton.OnMouseClick += localFilterButton_OnMouseClick;
-
             remoteTargetIconPanel = DaggerfallUI.AddPanel(remoteTargetIconRect, NativePanel);
             remoteTargetIconPanel.BackgroundTextureLayout = BackgroundLayout.ScaleToFit;
             remoteTargetIconLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(1, 2), remoteTargetIconPanel);
@@ -440,7 +420,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             remoteTargetIconPanel.OnRightMouseClick += RemoteTargetIconPanel_OnRightMouseClick;
             remoteTargetIconPanel.OnMiddleMouseClick += RemoteTargetIconPanel_OnMiddleMouseClick;
         }
-
 
         protected void SetupItemInfoPanel()
         {
@@ -506,7 +485,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             goldButton = DaggerfallUI.AddButton(goldButtonRect, NativePanel);
             goldButton.OnMouseClick += GoldButton_OnMouseClick;
-            goldButton.OnMouseEnter += GoldButton_OnMouseEnter;
         }
 
         protected void SetupAccessoryElements()
@@ -664,9 +642,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Reset choose one mode
             chooseOne = false;
 
-            // Clear the Filter
-            clearFilterFields();
-
             // Handle stealing and reset shop shelf stealing mode
             if (shopShelfStealing && remoteItems.Count < lootTargetStartCount)
             {
@@ -791,7 +766,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // Select new tab page
             selectedTabPage = tabPage;
-            clearFilterFields();
 
             // Set all buttons to appropriate state
             weaponsAndArmorButton.BackgroundTexture = (tabPage == TabPages.WeaponsAndArmor) ? weaponsAndArmorSelected : weaponsAndArmorNotSelected;
@@ -807,8 +781,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             localItemListScroller.ResetScroll();
             FilterLocalItems();
             localItemListScroller.Items = localItemsFiltered;
-            FilterRemoteItems();
-            remoteItemListScroller.Items = remoteItemsFiltered;
         }
 
         void SelectActionMode(ActionModes mode)
@@ -896,11 +868,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     DaggerfallUnityItem item = localItems.GetItem(i);
                     // Add if not equipped
                     if (!item.IsEquipped)
-                    {
-                        if (ItemPassesFilter(item))
-                            AddLocalItem(item);
-                    }
-
+                        AddLocalItem(item);
                 }
             }
         }
@@ -940,81 +908,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// Creates filtered list of remote items.
         /// For now this just creates a flat list, as that is Daggerfall's behaviour.
         /// </summary>
-        protected virtual void FilterRemoteItems(bool applyExtraFilter = true)
+        protected virtual void FilterRemoteItems()
         {
-            DaggerfallUnityItem item;
             // Clear current references
             remoteItemsFiltered.Clear();
 
             // Add items to list
             if (remoteItems != null)
                 for (int i = 0; i < remoteItems.Count; i++)
-                {
-                    if (applyExtraFilter)
-                    {
-                        item = remoteItems.GetItem(i);
-                        if (ItemPassesFilter(item))
-                            remoteItemsFiltered.Add(item);
-
-                    }
-                    else
-                        remoteItemsFiltered.Add(remoteItems.GetItem(i));
-
-                }
+                    remoteItemsFiltered.Add(remoteItems.GetItem(i));
         }
-        ///<summary>
-        ///Checks whether inventory item meets criteria of filter
-        ///</summary>
-        protected virtual bool ItemPassesFilter(DaggerfallUnityItem item)
-        {
-            bool itemPasses = true;
-            bool iterationPass = false;
-
-            if (filterString.Length == 0)
-                return true;
-
-            foreach (string word in filterString.Split(' '))
-            {
-                if (word.Trim().Length > 0)
-                {
-                    if (word[0] == '-')
-                    {
-                        iterationPass = true;
-                        if (item.LongName.ToLower().Contains(word.Remove(0, 1)))
-                            iterationPass = false;
-                        else if (itemGroupNames[(int)item.ItemGroup].Contains(word.Remove(0, 1)))
-                            iterationPass = false;
-                    }
-                    else
-                    {
-                        iterationPass = false;
-                        if (item.LongName.ToLower().Contains(word))
-                            iterationPass = true;
-                        else if (itemGroupNames[(int)item.ItemGroup].Contains(word))
-                            iterationPass = true;
-                    }
-
-                    if (iterationPass == true && itemPasses == true)
-                        itemPasses = true;
-                    else
-                    {
-                        itemPasses = false;
-                        break;
-                    }
-                }
-                else
-                {
-                    iterationPass = true;
-                    if (iterationPass == true && itemPasses == true)
-                        itemPasses = true;
-                }
-
-            }
-
-            return itemPasses;
-        }
-
-
 
         /// <summary>
         /// Updates accessory items display.
@@ -1054,43 +957,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         #endregion
 
         #region Private Methods
-        protected void PopulateItemGroupNames()
-        {
-            itemGroupNames[0] = "drugs";
-            itemGroupNames[1] = "uselessitems1";
-            itemGroupNames[2] = "armor";
-            itemGroupNames[3] = "weapons";
-            itemGroupNames[4] = "magicitems";
-            itemGroupNames[5] = "artifacts";
-            itemGroupNames[6] = "mensclothing";
-            itemGroupNames[7] = "books";
-            itemGroupNames[8] = "furniture";
-            itemGroupNames[9] = "uselessitems2";
-            itemGroupNames[10] = "religiousitems";
-            itemGroupNames[11] = "maps";
-            itemGroupNames[12] = "womensclothing";
-            itemGroupNames[13] = "paintings";
-            itemGroupNames[14] = "gems";
-            itemGroupNames[15] = "plantingredients1";
-            itemGroupNames[16] = "plantingredients2";
-            itemGroupNames[17] = "creatureingredients1";
-            itemGroupNames[18] = "creatureingredients2";
-            itemGroupNames[19] = "creatureingredients3";
-            itemGroupNames[20] = "miscellaneousingredients1";
-            itemGroupNames[21] = "metalingredients";
-            itemGroupNames[22] = "miscellaneousingredients2";
-            itemGroupNames[23] = "transportation";
-            itemGroupNames[24] = "deeds";
-            itemGroupNames[25] = "jewellery";
-            itemGroupNames[26] = "questitems";
-            itemGroupNames[27] = "miscitems";
-            itemGroupNames[28] = "currency";
-
-        }
-
-
-
-
 
         protected virtual void LoadTextures()
         {
@@ -1312,12 +1178,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SelectTabPage(TabPages.Ingredients);
         }
 
-        private void clearFilterFields()
-        {
-            filterString = string.Empty;
-            localFilterTextBox.Text = string.Empty;
-        }
-
         #endregion
 
         #region Action Button Event Handlers
@@ -1467,8 +1327,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             List<DaggerfallUnityItem> unequippedList = playerEntity.ItemEquipTable.EquipItem(item);
             if (unequippedList != null)
             {
-                foreach (DaggerfallUnityItem unequippedItem in unequippedList)
-                {
+                foreach (DaggerfallUnityItem unequippedItem in unequippedList) {
                     playerEntity.UpdateEquippedArmorValues(unequippedItem, false);
                 }
                 playerEntity.UpdateEquippedArmorValues(item, true);
@@ -1525,7 +1384,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             return canHold;
         }
 
-        protected void TransferItem(DaggerfallUnityItem item, ItemCollection from, ItemCollection to, int? maxAmount = null,
+        protected void TransferItem(DaggerfallUnityItem item, ItemCollection from, ItemCollection to, int? maxAmount = null, 
                                     bool blockTransport = false, bool equip = false, bool allowSplitting = true)
         {
             // Block transfer of horse or cart (don't allow putting either in wagon)
@@ -1872,8 +1731,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             const int mapTextId = 499;
             PlayerGPS playerGPS = GameManager.Instance.PlayerGPS;
 
-            try
-            {
+            try {
                 DFLocation revealedLocation = playerGPS.DiscoverRandomLocation();
 
                 if (string.IsNullOrEmpty(revealedLocation.Name))
@@ -2064,18 +1922,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Dropped items icon selection Event Handlers
 
-
-        private void localFilterButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
-        {
-            // If items are being dropped by player, iterate up through drop textures
-            filterString = localFilterTextBox.Text.ToLower();
-            Refresh(false);
-
-        }
-
-
-
-
         private void RemoteTargetIconPanel_OnMiddleMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             // If items are being dropped by player, iterate up through drop archives
@@ -2166,14 +2012,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 lastMouseOverPaperDollEquipIndex = value;
             }
         }
-        protected virtual void GoldButton_OnMouseEnter(BaseScreenComponent sender)
-        {
-            TextAsset textAsset;
-            string str = string.Format("Gold Amount: {0}", GameManager.Instance.PlayerEntity.GoldPieces);
-            textAsset = new TextAsset(str);
-            itemInfoPanelLabel.Clear();
-            itemInfoPanelLabel.SetText(textAsset);
-        }
+
         protected virtual void AccessoryItemsButton_OnMouseEnter(BaseScreenComponent sender)
         {
             // Get item

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -82,11 +82,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected TextLabel localTargetIconLabel;
         protected Button localFilterButton;
         protected TextBox localFilterTextBox;
+        protected Button localCloseFilterButton;
+        protected bool filterButtonNeedUpdate;
         protected Panel remoteTargetIconPanel;
         protected TextLabel remoteTargetIconLabel;
         protected Panel itemInfoPanel;
         protected MultiFormatTextLabel itemInfoPanelLabel;
-        protected static string filterString = string.Empty;
+        protected static string filterString = null;
         protected static string[] itemGroupNames = new string[]
         {
             "drugs",
@@ -370,6 +372,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
+            if (filterButtonNeedUpdate)
+            {
+                filterButtonNeedUpdate = false;
+                UpdateFilterButton();
+            }
+
             // Toggle window closed with same hotkey used to open it
             if (Input.GetKeyUp(toggleClosedBinding))
                 CloseWindow();
@@ -447,8 +455,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             localTargetIconLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(1, 2), localTargetIconPanel);
             localTargetIconLabel.TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
 
-            localFilterTextBox = DaggerfallUI.AddTextBoxWithFocus(new Rect(new Vector2(1, 24), new Vector2(40, 8)), "filter pattern", localTargetIconPanel);
+            localFilterTextBox = DaggerfallUI.AddTextBoxWithFocus(new Rect(new Vector2(1, 24), new Vector2(47, 8)), "filter pattern", localTargetIconPanel);
             localFilterTextBox.VerticalAlignment = VerticalAlignment.Bottom;
+            localFilterTextBox.OnType += LocalFilterTextBox_OnType;
+
+            localCloseFilterButton = DaggerfallUI.AddButton(new Rect(47, 25, 8, 8), localTargetIconPanel);
+            localCloseFilterButton.Label.Text = "x";
+            localCloseFilterButton.Label.TextScale = 0.75f;
+            localCloseFilterButton.Label.ShadowColor = Color.black;
+            localCloseFilterButton.VerticalAlignment = VerticalAlignment.Bottom;
+            localCloseFilterButton.HorizontalAlignment = HorizontalAlignment.Right;
+            localCloseFilterButton.BackgroundColor = new Color(0.5f, 0.5f, 0.5f, 0.75f);
+            localCloseFilterButton.OnMouseClick += localCloseFilterButton_OnMouseClick;
+
             localFilterButton = DaggerfallUI.AddButton(new Rect(40, 25, 15, 8), localTargetIconPanel);
             localFilterButton.Label.Text = "Filter";
             localFilterButton.Label.TextScale = 0.75f;
@@ -457,6 +476,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             localFilterButton.HorizontalAlignment = HorizontalAlignment.Right;
             localFilterButton.BackgroundColor = new Color(0.5f, 0.5f, 0.5f, 0.75f);
             localFilterButton.OnMouseClick += localFilterButton_OnMouseClick;
+            filterButtonNeedUpdate = true;
 
             remoteTargetIconPanel = DaggerfallUI.AddPanel(remoteTargetIconRect, NativePanel);
             remoteTargetIconPanel.BackgroundTextureLayout = BackgroundLayout.ScaleToFit;
@@ -468,6 +488,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             remoteTargetIconPanel.OnMiddleMouseClick += RemoteTargetIconPanel_OnMiddleMouseClick;
         }
 
+        private void UpdateFilterButton()
+        {
+            if (filterString != null && localFilterButton.Enabled)
+            {
+                localFilterButton.Enabled = false;
+                localFilterTextBox.Enabled = true;
+                localCloseFilterButton.Enabled = true;
+            }
+            else
+            {
+                localFilterButton.Enabled = true;
+                localFilterTextBox.Enabled = false;
+                localCloseFilterButton.Enabled = false;
+            }
+        }
 
         protected void SetupItemInfoPanel()
         {
@@ -994,7 +1029,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
              bool iterationPass = false;
 
-            if (filterString.Length == 0)
+            if (String.IsNullOrEmpty(filterString))
                 return true;
 
             foreach (string word in filterString.Split(' '))
@@ -1289,7 +1324,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void ClearFilterFields()
         {
-            filterString = string.Empty;
+            filterString = null;
             localFilterTextBox.Text = string.Empty;
         }
 
@@ -2042,12 +2077,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void localFilterButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            // If items are being dropped by player, iterate up through drop textures
-            filterString = localFilterTextBox.Text.ToLower();
-            Refresh(false);
-
+            filterString = "";
+            filterButtonNeedUpdate = true;
         }
 
+        private void localCloseFilterButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            filterString = null;
+            Refresh(false);
+            filterButtonNeedUpdate = true;
+        }
+
+
+        private void LocalFilterTextBox_OnType()
+        {
+            filterString = localFilterTextBox.Text.ToLower();
+            Refresh(false);
+        }
 
 
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -73,7 +73,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button useButton;
         Button goldButton;
         
-
         Button[] accessoryButtons = new Button[accessoryCount];
         Panel[] accessoryIconPanels = new Panel[accessoryCount];
 
@@ -531,6 +530,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             useButton = DaggerfallUI.AddButton(useButtonRect, NativePanel);
             useButton.OnMouseClick += UseButton_OnMouseClick;
+
+            goldButton = DaggerfallUI.AddButton(goldButtonRect, NativePanel);
+            goldButton.OnMouseClick += GoldButton_OnMouseClick;
         }
 
         protected void SetupAccessoryElements()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -87,8 +87,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected Panel itemInfoPanel;
         protected MultiFormatTextLabel itemInfoPanelLabel;
 
-        protected string filterString = string.Empty;
-        protected string[] itemGroupNames = new string[30];
+        protected static string filterString = string.Empty;
+        protected static string[] itemGroupNames = new string[30];
 
         protected ItemListScroller localItemListScroller;
         protected ItemListScroller remoteItemListScroller;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -80,10 +80,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected Panel localTargetIconPanel;
         protected TextLabel localTargetIconLabel;
+        protected Button localFilterButton;
+        protected TextBox localFilterTextBox;
         protected Panel remoteTargetIconPanel;
         protected TextLabel remoteTargetIconLabel;
         protected Panel itemInfoPanel;
         protected MultiFormatTextLabel itemInfoPanelLabel;
+
+        protected string filterString = string.Empty;
+        protected string[] itemGroupNames = new string[30];
 
         protected ItemListScroller localItemListScroller;
         protected ItemListScroller remoteItemListScroller;
@@ -283,6 +288,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void Setup()
         {
+            //Populate ItemGroupNames
+            PopulateItemGroupNames();
+
             // Load all the textures used by inventory system
             LoadTextures();
 
@@ -338,6 +346,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Toggle window closed with same hotkey used to open it
             if (Input.GetKeyUp(toggleClosedBinding))
                 CloseWindow();
+
 
             // Close window immediately if inventory suppressed
             if (suppressInventory)
@@ -411,6 +420,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             localTargetIconLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(1, 2), localTargetIconPanel);
             localTargetIconLabel.TextColor = DaggerfallUI.DaggerfallUnityDefaultToolTipTextColor;
 
+            localFilterTextBox = DaggerfallUI.AddTextBoxWithFocus(new Rect(new Vector2(1, 24), new Vector2(40, 8)), "filter pattern", localTargetIconPanel);
+            localFilterTextBox.VerticalAlignment = VerticalAlignment.Bottom;
+            localFilterButton = DaggerfallUI.AddButton(new Rect(40, 25, 15, 8), localTargetIconPanel);
+            localFilterButton.Label.Text = "Filter";
+            localFilterButton.Label.TextScale = 0.75f;
+            localFilterButton.Label.ShadowColor = Color.black;
+            localFilterButton.VerticalAlignment = VerticalAlignment.Bottom;
+            localFilterButton.HorizontalAlignment = HorizontalAlignment.Right;
+            localFilterButton.BackgroundColor = new Color(0.5f, 0.5f, 0.5f, 0.75f);
+            localFilterButton.OnMouseClick += localFilterButton_OnMouseClick;
+
             remoteTargetIconPanel = DaggerfallUI.AddPanel(remoteTargetIconRect, NativePanel);
             remoteTargetIconPanel.BackgroundTextureLayout = BackgroundLayout.ScaleToFit;
             remoteTargetIconLabel = DaggerfallUI.AddDefaultShadowedTextLabel(new Vector2(1, 2), remoteTargetIconPanel);
@@ -420,6 +440,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             remoteTargetIconPanel.OnRightMouseClick += RemoteTargetIconPanel_OnRightMouseClick;
             remoteTargetIconPanel.OnMiddleMouseClick += RemoteTargetIconPanel_OnMiddleMouseClick;
         }
+
 
         protected void SetupItemInfoPanel()
         {
@@ -485,6 +506,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             goldButton = DaggerfallUI.AddButton(goldButtonRect, NativePanel);
             goldButton.OnMouseClick += GoldButton_OnMouseClick;
+            goldButton.OnMouseEnter += GoldButton_OnMouseEnter;
         }
 
         protected void SetupAccessoryElements()
@@ -642,6 +664,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Reset choose one mode
             chooseOne = false;
 
+            // Clear the Filter
+            clearFilterFields();
+
             // Handle stealing and reset shop shelf stealing mode
             if (shopShelfStealing && remoteItems.Count < lootTargetStartCount)
             {
@@ -766,6 +791,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // Select new tab page
             selectedTabPage = tabPage;
+            clearFilterFields();
 
             // Set all buttons to appropriate state
             weaponsAndArmorButton.BackgroundTexture = (tabPage == TabPages.WeaponsAndArmor) ? weaponsAndArmorSelected : weaponsAndArmorNotSelected;
@@ -781,6 +807,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             localItemListScroller.ResetScroll();
             FilterLocalItems();
             localItemListScroller.Items = localItemsFiltered;
+            FilterRemoteItems();
+            remoteItemListScroller.Items = remoteItemsFiltered;
         }
 
         void SelectActionMode(ActionModes mode)
@@ -868,7 +896,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     DaggerfallUnityItem item = localItems.GetItem(i);
                     // Add if not equipped
                     if (!item.IsEquipped)
-                        AddLocalItem(item);
+                    {
+                        if (ItemPassesFilter(item))
+                            AddLocalItem(item);
+                    }
+
                 }
             }
         }
@@ -908,16 +940,80 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// Creates filtered list of remote items.
         /// For now this just creates a flat list, as that is Daggerfall's behaviour.
         /// </summary>
-        protected virtual void FilterRemoteItems()
+        protected virtual void FilterRemoteItems(bool applyExtraFilter = true)
         {
+            DaggerfallUnityItem item;
             // Clear current references
             remoteItemsFiltered.Clear();
 
             // Add items to list
             if (remoteItems != null)
                 for (int i = 0; i < remoteItems.Count; i++)
-                    remoteItemsFiltered.Add(remoteItems.GetItem(i));
+                {
+                    if (applyExtraFilter)
+                    {
+                        item = remoteItems.GetItem(i);
+                        if (ItemPassesFilter(item))
+                            remoteItemsFiltered.Add(item);
+
+                    }
+                    else
+                        remoteItemsFiltered.Add(remoteItems.GetItem(i));
+                }
         }
+        ///<summary>
+        ///Checks whether inventory item meets criteria of filter
+        ///</summary>
+        protected virtual bool ItemPassesFilter(DaggerfallUnityItem item)
+        {
+            bool itemPasses = true;
+            bool iterationPass = false;
+
+            if (filterString.Length == 0)
+                return true;
+
+            foreach (string word in filterString.Split(' '))
+            {
+                if (word.Trim().Length > 0)
+                {
+                    if (word[0] == '-')
+                    {
+                        iterationPass = true;
+                        if (item.LongName.ToLower().Contains(word.Remove(0, 1)))
+                            iterationPass = false;
+                        else if (itemGroupNames[(int)item.ItemGroup].Contains(word.Remove(0, 1)))
+                            iterationPass = false;
+                    }
+                    else
+                    {
+                        iterationPass = false;
+                        if (item.LongName.ToLower().Contains(word))
+                            iterationPass = true;
+                        else if (itemGroupNames[(int)item.ItemGroup].Contains(word))
+                            iterationPass = true;
+                    }
+
+                    if (iterationPass == true && itemPasses == true)
+                        itemPasses = true;
+                    else
+                    {
+                        itemPasses = false;
+                        break;
+                    }
+                }
+                else
+                {
+                    iterationPass = true;
+                    if (iterationPass == true && itemPasses == true)
+                        itemPasses = true;
+                }
+
+            }
+
+            return itemPasses;
+        }
+
+
 
         /// <summary>
         /// Updates accessory items display.
@@ -957,6 +1053,43 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         #endregion
 
         #region Private Methods
+        protected void PopulateItemGroupNames()
+        {
+            itemGroupNames[0] = "drugs";
+            itemGroupNames[1] = "uselessitems1";
+            itemGroupNames[2] = "armor";
+            itemGroupNames[3] = "weapons";
+            itemGroupNames[4] = "magicitems";
+            itemGroupNames[5] = "artifacts";
+            itemGroupNames[6] = "mensclothing";
+            itemGroupNames[7] = "books";
+            itemGroupNames[8] = "furniture";
+            itemGroupNames[9] = "uselessitems2";
+            itemGroupNames[10] = "religiousitems";
+            itemGroupNames[11] = "maps";
+            itemGroupNames[12] = "womensclothing";
+            itemGroupNames[13] = "paintings";
+            itemGroupNames[14] = "gems";
+            itemGroupNames[15] = "plantingredients1";
+            itemGroupNames[16] = "plantingredients2";
+            itemGroupNames[17] = "creatureingredients1";
+            itemGroupNames[18] = "creatureingredients2";
+            itemGroupNames[19] = "creatureingredients3";
+            itemGroupNames[20] = "miscellaneousingredients1";
+            itemGroupNames[21] = "metalingredients";
+            itemGroupNames[22] = "miscellaneousingredients2";
+            itemGroupNames[23] = "transportation";
+            itemGroupNames[24] = "deeds";
+            itemGroupNames[25] = "jewellery";
+            itemGroupNames[26] = "questitems";
+            itemGroupNames[27] = "miscitems";
+            itemGroupNames[28] = "currency";
+
+        }
+
+
+
+
 
         protected virtual void LoadTextures()
         {
@@ -1178,6 +1311,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SelectTabPage(TabPages.Ingredients);
         }
 
+        private void clearFilterFields()
+        {
+            filterString = string.Empty;
+            localFilterTextBox.Text = string.Empty;
+        }
+
         #endregion
 
         #region Action Button Event Handlers
@@ -1327,7 +1466,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             List<DaggerfallUnityItem> unequippedList = playerEntity.ItemEquipTable.EquipItem(item);
             if (unequippedList != null)
             {
-                foreach (DaggerfallUnityItem unequippedItem in unequippedList) {
+                foreach (DaggerfallUnityItem unequippedItem in unequippedList)
+                {
                     playerEntity.UpdateEquippedArmorValues(unequippedItem, false);
                 }
                 playerEntity.UpdateEquippedArmorValues(item, true);
@@ -1384,7 +1524,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             return canHold;
         }
 
-        protected void TransferItem(DaggerfallUnityItem item, ItemCollection from, ItemCollection to, int? maxAmount = null, 
+        protected void TransferItem(DaggerfallUnityItem item, ItemCollection from, ItemCollection to, int? maxAmount = null,
                                     bool blockTransport = false, bool equip = false, bool allowSplitting = true)
         {
             // Block transfer of horse or cart (don't allow putting either in wagon)
@@ -1731,7 +1871,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             const int mapTextId = 499;
             PlayerGPS playerGPS = GameManager.Instance.PlayerGPS;
 
-            try {
+            try
+            {
                 DFLocation revealedLocation = playerGPS.DiscoverRandomLocation();
 
                 if (string.IsNullOrEmpty(revealedLocation.Name))
@@ -1922,6 +2063,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Dropped items icon selection Event Handlers
 
+
+        private void localFilterButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            // If items are being dropped by player, iterate up through drop textures
+            filterString = localFilterTextBox.Text.ToLower();
+            Refresh(false);
+
+        }
+
+
+
+
         private void RemoteTargetIconPanel_OnMiddleMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             // If items are being dropped by player, iterate up through drop archives
@@ -2012,7 +2165,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 lastMouseOverPaperDollEquipIndex = value;
             }
         }
-
+        protected virtual void GoldButton_OnMouseEnter(BaseScreenComponent sender)
+        {
+            TextAsset textAsset;
+            string str = string.Format("Gold Amount: {0}", GameManager.Instance.PlayerEntity.GoldPieces);
+            textAsset = new TextAsset(str);
+            itemInfoPanelLabel.Clear();
+            itemInfoPanelLabel.SetText(textAsset);
+        }
         protected virtual void AccessoryItemsButton_OnMouseEnter(BaseScreenComponent sender)
         {
             // Get item

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -171,6 +171,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void Setup()
         {
+            //Populate ItemGroupNames
+            PopulateItemGroupNames();
+
             // Load all the textures used by inventory system
             LoadTextures();
 
@@ -218,7 +221,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 remoteItemListScroller.BackgroundAnimationDelay = coinsAnimationDelay;
             }
             // Setup special behaviour for remote items when repairing
-            if (windowMode == WindowModes.Repair) {
+            if (windowMode == WindowModes.Repair)
+            {
                 remoteItemListScroller.BackgroundColourHandler = RepairItemBackgroundColourHandler;
                 remoteItemListScroller.LabelTextHandler = RepairItemLabelTextHandler;
             }
@@ -259,8 +263,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         string RepairItemLabelTextHandler(DaggerfallUnityItem item)
         {
             bool repairDone = item.RepairData.IsBeingRepaired() ? item.RepairData.IsRepairFinished() : item.currentCondition == item.maxCondition;
-            return repairDone ? 
-                    TextManager.Instance.GetText(textDatabase, "repairDone") : 
+            return repairDone ?
+                    TextManager.Instance.GetText(textDatabase, "repairDone") :
                     TextManager.Instance.GetText(textDatabase, "repairDays").Replace("%d", item.RepairData.EstimatedDaysUntilRepaired().ToString());
         }
 
@@ -632,7 +636,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     DaggerfallUnityItem item = basketItems.GetItem(i);
                     // Add if not equipped
                     if (!item.IsEquipped)
+                    {
                         AddLocalItem(item);
+                    }
+
                 }
             }
             // Add local items to filtered list
@@ -645,15 +652,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (!item.IsEquipped && (
                             (windowMode != WindowModes.Sell && windowMode != WindowModes.SellMagic) ||
                             (windowMode == WindowModes.Sell && itemTypesAccepted.Contains(item.ItemGroup)) ||
-                            (windowMode == WindowModes.SellMagic && item.IsEnchanted) ))
+                            (windowMode == WindowModes.SellMagic && item.IsEnchanted)))
                     {
-                        AddLocalItem(item);
+
+                        if (ItemPassesFilter(item))
+                            AddLocalItem(item);
+
+
                     }
                 }
             }
         }
 
-        protected override void FilterRemoteItems()
+        protected override void FilterRemoteItems(bool applyExtraFilter = true)
         {
             if (windowMode == WindowModes.Repair)
             {
@@ -675,7 +686,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 UpdateRepairTimes(false);
             }
             else
-                base.FilterRemoteItems();
+                base.FilterRemoteItems(false);
         }
 
         protected void SelectWagon(bool show)
@@ -704,13 +715,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             base.LoadTextures();
 
             // Load special button texture.
-            if (windowMode == WindowModes.Sell || windowMode == WindowModes.SellMagic) {
+            if (windowMode == WindowModes.Sell || windowMode == WindowModes.SellMagic)
+            {
                 actionButtonsTexture = ImageReader.GetTexture(sellButtonsTextureName);
-            } else if (windowMode == WindowModes.Buy) {
+            }
+            else if (windowMode == WindowModes.Buy)
+            {
                 actionButtonsTexture = ImageReader.GetTexture(buyButtonsTextureName);
-            } else if (windowMode == WindowModes.Repair) {
+            }
+            else if (windowMode == WindowModes.Repair)
+            {
                 actionButtonsTexture = ImageReader.GetTexture(repairButtonsTextureName);
-            } else if (windowMode == WindowModes.Identify) {
+            }
+            else if (windowMode == WindowModes.Identify)
+            {
                 actionButtonsTexture = ImageReader.GetTexture(identifyButtonsTextureName);
             }
             actionButtonsGoldTexture = ImageReader.GetTexture(sellButtonsGoldTextureName);
@@ -833,7 +851,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void WagonButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart))
+            if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
             {
                 SelectWagon(!usingWagon);
                 Refresh(false);
@@ -855,7 +873,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (windowMode == WindowModes.Buy && cost > 0)
             {
                 // Calculate the weight of all items picked from shelves, then get chance of shoplifting success.
-                int weightAndNumItems = (int) basketItems.GetWeight() + basketItems.Count;
+                int weightAndNumItems = (int)basketItems.GetWeight() + basketItems.Count;
                 int chanceBeingDetected = FormulaHelper.CalculateShopliftingChance(PlayerEntity, null, buildingDiscoveryData.quality, weightAndNumItems);
                 PlayerEntity.TallySkill(DFCareer.Skills.Pickpocket, 1);
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -171,9 +171,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void Setup()
         {
-            //Populate ItemGroupNames
-            PopulateItemGroupNames();
-
             // Load all the textures used by inventory system
             LoadTextures();
 
@@ -221,8 +218,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 remoteItemListScroller.BackgroundAnimationDelay = coinsAnimationDelay;
             }
             // Setup special behaviour for remote items when repairing
-            if (windowMode == WindowModes.Repair)
-            {
+            if (windowMode == WindowModes.Repair) {
                 remoteItemListScroller.BackgroundColourHandler = RepairItemBackgroundColourHandler;
                 remoteItemListScroller.LabelTextHandler = RepairItemLabelTextHandler;
             }
@@ -263,8 +259,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         string RepairItemLabelTextHandler(DaggerfallUnityItem item)
         {
             bool repairDone = item.RepairData.IsBeingRepaired() ? item.RepairData.IsRepairFinished() : item.currentCondition == item.maxCondition;
-            return repairDone ?
-                    TextManager.Instance.GetText(textDatabase, "repairDone") :
+            return repairDone ? 
+                    TextManager.Instance.GetText(textDatabase, "repairDone") : 
                     TextManager.Instance.GetText(textDatabase, "repairDays").Replace("%d", item.RepairData.EstimatedDaysUntilRepaired().ToString());
         }
 
@@ -636,10 +632,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     DaggerfallUnityItem item = basketItems.GetItem(i);
                     // Add if not equipped
                     if (!item.IsEquipped)
-                    {
                         AddLocalItem(item);
-                    }
-
                 }
             }
             // Add local items to filtered list
@@ -652,19 +645,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (!item.IsEquipped && (
                             (windowMode != WindowModes.Sell && windowMode != WindowModes.SellMagic) ||
                             (windowMode == WindowModes.Sell && itemTypesAccepted.Contains(item.ItemGroup)) ||
-                            (windowMode == WindowModes.SellMagic && item.IsEnchanted)))
+                            (windowMode == WindowModes.SellMagic && item.IsEnchanted) ))
                     {
-
-                        if (ItemPassesFilter(item))
-                            AddLocalItem(item);
-
-
+                        AddLocalItem(item);
                     }
                 }
             }
         }
 
-        protected override void FilterRemoteItems(bool applyExtraFilter = true)
+        protected override void FilterRemoteItems()
         {
             if (windowMode == WindowModes.Repair)
             {
@@ -686,7 +675,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 UpdateRepairTimes(false);
             }
             else
-                base.FilterRemoteItems(false);
+                base.FilterRemoteItems();
         }
 
         protected void SelectWagon(bool show)
@@ -715,20 +704,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             base.LoadTextures();
 
             // Load special button texture.
-            if (windowMode == WindowModes.Sell || windowMode == WindowModes.SellMagic)
-            {
+            if (windowMode == WindowModes.Sell || windowMode == WindowModes.SellMagic) {
                 actionButtonsTexture = ImageReader.GetTexture(sellButtonsTextureName);
-            }
-            else if (windowMode == WindowModes.Buy)
-            {
+            } else if (windowMode == WindowModes.Buy) {
                 actionButtonsTexture = ImageReader.GetTexture(buyButtonsTextureName);
-            }
-            else if (windowMode == WindowModes.Repair)
-            {
+            } else if (windowMode == WindowModes.Repair) {
                 actionButtonsTexture = ImageReader.GetTexture(repairButtonsTextureName);
-            }
-            else if (windowMode == WindowModes.Identify)
-            {
+            } else if (windowMode == WindowModes.Identify) {
                 actionButtonsTexture = ImageReader.GetTexture(identifyButtonsTextureName);
             }
             actionButtonsGoldTexture = ImageReader.GetTexture(sellButtonsGoldTextureName);
@@ -851,7 +833,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void WagonButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int)Transportation.Small_cart))
+            if (PlayerEntity.Items.Contains(ItemGroups.Transportation, (int) Transportation.Small_cart))
             {
                 SelectWagon(!usingWagon);
                 Refresh(false);
@@ -873,7 +855,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (windowMode == WindowModes.Buy && cost > 0)
             {
                 // Calculate the weight of all items picked from shelves, then get chance of shoplifting success.
-                int weightAndNumItems = (int)basketItems.GetWeight() + basketItems.Count;
+                int weightAndNumItems = (int) basketItems.GetWeight() + basketItems.Count;
                 int chanceBeingDetected = FormulaHelper.CalculateShopliftingChance(PlayerEntity, null, buildingDiscoveryData.quality, weightAndNumItems);
                 PlayerEntity.TallySkill(DFCareer.Skills.Pickpocket, 1);
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -171,9 +171,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected override void Setup()
         {
-            //Populate ItemGroupNames
-            PopulateItemGroupNames();
-
             // Load all the textures used by inventory system
             LoadTextures();
 
@@ -654,11 +651,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                             (windowMode == WindowModes.Sell && itemTypesAccepted.Contains(item.ItemGroup)) ||
                             (windowMode == WindowModes.SellMagic && item.IsEnchanted)))
                     {
-
                         if (ItemPassesFilter(item))
                             AddLocalItem(item);
-
-
                     }
                 }
             }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 2800000, guid: 887ec86cd12e1624d8458c8d7950402a, type: 3}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 2800000, guid: 887ec86cd12e1624d8458c8d7950402a, type: 3}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1


### PR DESCRIPTION
Hi all, I created this pull request so that you can review my code changes regarding a filter on the inventory window.  When you enter a filter, and click on filter, it will perform a case-insensitve comparison of the filter against the long name and the item group name.  It also accepts "-" if you want to negate a filter.  For example, if you type "-steel armor", it will find all armor not made of steel.
This filter applies to both local and remote.
The filter is cleared when you switch tabs or close the inventory window.

Thanks all
a