### PR TITLE
Don't display a message when entering a TG or DB

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -386,9 +386,14 @@ namespace DaggerfallWorkshop.Game
 
                         DaggerfallMessageBox mb;
 
+                        PlayerGPS.DiscoveredBuilding buildingData;
+                        GameManager.Instance.PlayerGPS.GetDiscoveredBuilding(building.buildingKey, out buildingData);
+
                         if (buildingUnlocked &&
                             buildingType >= DFLocation.BuildingTypes.House1 &&
                             buildingType <= DFLocation.BuildingTypes.House4 &&
+                            buildingData.factionID != (int)FactionFile.FactionIDs.The_Thieves_Guild &&
+                            buildingData.factionID != (int)FactionFile.FactionIDs.The_Dark_Brotherhood &&
                             !DaggerfallBankManager.IsHouseOwned(building.buildingKey))
                         {
                             string greetingText = DaggerfallUnity.Instance.TextProvider.GetRandomText(houseGreetingsTextId);


### PR DESCRIPTION
Actually don't display the message if player is a member of the guild, as classic does. I wasn't able to test the case where player is not a member as in DFU, it seems Thieves Guild and Dark Brotherhood hideouts are always locked in this case.

Edit. @ajrb confirmed that contrary to what classic does, DFU behavior is to always lock Thieves Guild and Dark Brotherhood hideouts when player is not a guild member, so I simplified the check.