### PR TITLE
prevent clicking on EXIT while banking amount input in progress

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
@@ -461,7 +461,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            CloseWindow();
+            if (!transactionInput.Enabled)
+                CloseWindow();
         }
 
         public void OnTransactionEventHandler(TransactionType type, TransactionResult result, int amount)


### PR DESCRIPTION
Seems to confuse some people, that input some amount, close the window and expect the transaction to have happened.

Another solution would be to open a dialog box to input transaction amounts; But it doesn't match classic screens.