### PR TITLE
Interior replacement core changes

### DIFF
--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -854,7 +854,9 @@ namespace DaggerfallConnect.Arena2
                 recordsOut[i].YPos = reader.ReadInt32();
                 recordsOut[i].ZPos = reader.ReadInt32();
                 recordsOut[i].NullValue2 = reader.ReadUInt32();
+                recordsOut[i].XRotation = 0;
                 recordsOut[i].YRotation = reader.ReadInt16();
+                recordsOut[i].ZRotation = 0;
                 recordsOut[i].Unknown4 = reader.ReadUInt16();
                 recordsOut[i].NullValue3 = reader.ReadUInt32();
                 recordsOut[i].Unknown5 = reader.ReadUInt32();

--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -411,8 +411,14 @@ namespace DaggerfallConnect
             /// <summary>Unknown.</summary>
             internal UInt32 NullValue2;
 
+            /// <summary>X rotation.</summary>
+            public Int16 XRotation;
+
             /// <summary>Y rotation.</summary>
             public Int16 YRotation;
+
+            /// <summary>Z rotation.</summary>
+            public Int16 ZRotation;
 
             /// <summary>Unknown.</summary>
             internal UInt16 Unknown4;

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -437,7 +437,7 @@ namespace DaggerfallWorkshop
                     stopCombine = true;
 
                 // Get model transform
-                Vector3 modelRotation = new Vector3(0, -obj.YRotation / BlocksFile.RotationDivisor, 0);
+                Vector3 modelRotation = new Vector3(-obj.XRotation / BlocksFile.RotationDivisor, -obj.YRotation / BlocksFile.RotationDivisor, -obj.ZRotation / BlocksFile.RotationDivisor);
                 Matrix4x4 modelMatrix = Matrix4x4.TRS(modelPosition, Quaternion.Euler(modelRotation), Vector3.one);
 
                 // Does this model have doors?
@@ -467,8 +467,8 @@ namespace DaggerfallWorkshop
                     }
                 }
 
-                // Make ladder collider convex
-                if (obj.ModelIdNum == ladderModelId)
+                // Make ladder collider convex and ladder functionality, if set up as propModelType
+                if (obj.ModelIdNum == ladderModelId && obj.ObjectType == propModelType)
                 {
                     var meshCollider = go.GetComponent<MeshCollider>();
                     if (meshCollider) meshCollider.convex = true;

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -528,36 +528,34 @@ namespace DaggerfallWorkshop.Utility
                     {
                         DFLocation.BuildingData building = block.RmbBlock.FldHeader.BuildingDataList[i];
                         if (IsNamedBuilding(building.BuildingType))
-                        {
+                        {                       
+                            // Try to find next building and merge data
+                            BuildingPoolItem item;
+                            if (!GetNextBuildingFromPool(namedBuildingPool, building.BuildingType, out item))
+                            {
+                                Debug.LogFormat("End of city building list reached without finding building type {0} in location {1}.{2}", building.BuildingType, location.RegionName, location.Name);
+                            }
+
+                            // Always copy nameSeed, LocationID and Sector found city building data to block level    
+                            building.NameSeed = item.buildingData.NameSeed;
+                            building.LocationId = item.buildingData.LocationId;
+                            building.Sector = item.buildingData.Sector;
+
                             // Check for replacement building data and use it if found
                             if (WorldDataReplacement.GetBuildingReplacementData(blockName, block.Index, i, out buildingReplacementData))
-                            {
-                                // Use custom building values from replacement data, don't use pool or maps file
-                                building.NameSeed = location.Exterior.Buildings[0].NameSeed;
+                            { 
+                                // Use custom building values from replacement data, don't use pool or maps file                                
                                 building.FactionId = buildingReplacementData.FactionId;
                                 building.BuildingType = (DFLocation.BuildingTypes) buildingReplacementData.BuildingType;
-                                building.LocationId = location.Exterior.Buildings[0].LocationId;
                                 building.Quality = buildingReplacementData.Quality;
                             }
                             else
                             {
-                                // Try to find next building and merge data
-                                BuildingPoolItem item;
-                                if (!GetNextBuildingFromPool(namedBuildingPool, building.BuildingType, out item))
-                                {
-                                    Debug.LogFormat("End of city building list reached without finding building type {0} in location {1}.{2}", building.BuildingType, location.RegionName, location.Name);
-                                }
-                                else
-                                {
-                                    // Copy found city building data to block level
-                                    building.NameSeed = item.buildingData.NameSeed;
-                                    building.FactionId = item.buildingData.FactionId;
-                                    building.Sector = item.buildingData.Sector;
-                                    building.LocationId = item.buildingData.LocationId;
-                                    building.Quality = item.buildingData.Quality;
-                                }
+                                // Copy remaining found city building data to block level                                   
+                                building.FactionId = item.buildingData.FactionId;
+                                building.Quality = item.buildingData.Quality;
                             }
-
+                            
                             // Matched to classic: special handling for some Order of the Raven buildings
                             if (block.RmbBlock.FldHeader.OtherNames[i] == "KRAVE01.HS2")
                             {
@@ -711,7 +709,7 @@ namespace DaggerfallWorkshop.Utility
                 {
                     // Get model transform
                     Vector3 modelPosition = new Vector3(obj.XPos, -obj.YPos, obj.ZPos) * MeshReader.GlobalScale;
-                    Vector3 modelRotation = new Vector3(0, -obj.YRotation / BlocksFile.RotationDivisor, 0);
+                    Vector3 modelRotation = new Vector3(-obj.XRotation / BlocksFile.RotationDivisor, -obj.YRotation / BlocksFile.RotationDivisor, -obj.ZRotation / BlocksFile.RotationDivisor);
                     Matrix4x4 modelMatrix = subRecordMatrix * Matrix4x4.TRS(modelPosition, Quaternion.Euler(modelRotation), Vector3.one);
 
                     // Get model data
@@ -782,7 +780,7 @@ namespace DaggerfallWorkshop.Utility
             {
                 // Get model transform
                 Vector3 modelPosition = new Vector3(obj.XPos, -obj.YPos + propsOffsetY, obj.ZPos + BlocksFile.RMBDimension) * MeshReader.GlobalScale;
-                Vector3 modelRotation = new Vector3(0, -obj.YRotation / BlocksFile.RotationDivisor, 0);
+                Vector3 modelRotation = new Vector3(-obj.XRotation / BlocksFile.RotationDivisor, -obj.YRotation / BlocksFile.RotationDivisor, -obj.ZRotation / BlocksFile.RotationDivisor);
                 Matrix4x4 modelMatrix = Matrix4x4.TRS(modelPosition, Quaternion.Euler(modelRotation), Vector3.one);
 
                 // Get model data


### PR DESCRIPTION
A clean commit with all changes to the existing core system

-3D props can now be rotated in X and Z. Default is set to 0 so it doesn't affect vanilla Assets
-Ladders will only be set to interactive if they are set uo as objectType 3 (propModel), all vanilla ladders are set up this way
-When replacing buildings, always use the original NameSeed, LocationID and Sector values