### PR TITLE
Add all equippable items command

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -170,7 +170,7 @@ namespace Wenzil.Console
                     if (!string.IsNullOrEmpty(blockData.Name))
                     {
                         string blockJson = SaveLoadManager.Serialize(blockData.GetType(), blockData);
-                        string fileName = WorldDataReplacement.GetRMBBlockReplacementFilename(blockData.Name);
+                        string fileName = WorldDataReplacement.GetBlockReplacementFilename(blockData.Name);
                         File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), blockJson);
                         return "Block data json written to " + Path.Combine(Application.persistentDataPath, fileName);
                     }

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -85,6 +85,7 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(AddWeapon.name, AddWeapon.description, AddWeapon.usage, AddWeapon.Execute);
             ConsoleCommandsDatabase.RegisterCommand(AddArmor.name, AddArmor.description, AddArmor.usage, AddArmor.Execute);
             ConsoleCommandsDatabase.RegisterCommand(AddClothing.name, AddClothing.description, AddClothing.usage, AddClothing.Execute);
+            ConsoleCommandsDatabase.RegisterCommand(AddAllEquip.name, AddAllEquip.description, AddAllEquip.usage, AddAllEquip.Execute);
             ConsoleCommandsDatabase.RegisterCommand(AddBook.name, AddBook.description, AddBook.usage, AddBook.Execute);
             ConsoleCommandsDatabase.RegisterCommand(ShowBankWindow.name, ShowBankWindow.description, ShowBankWindow.usage, ShowBankWindow.Execute);
             ConsoleCommandsDatabase.RegisterCommand(ShowSpellmakerWindow.name, ShowSpellmakerWindow.description, ShowSpellmakerWindow.usage, ShowSpellmakerWindow.Execute);
@@ -126,11 +127,20 @@ namespace Wenzil.Console
                 else
                 {
                     DFBlock blockData;
-                    if (RMBLayout.GetBlockData(args[0], out blockData))
+                    if (!RMBLayout.GetBlockData(args[0], out blockData))
+                    {
+                        if (args[0].EndsWith(".RDB", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            blockData = DaggerfallUnity.Instance.ContentReader.BlockFileReader.GetBlock(args[0]);
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(blockData.Name))
                     {
                         string blockJson = SaveLoadManager.Serialize(blockData.GetType(), blockData);
-                        File.WriteAllText(Path.Combine(Application.persistentDataPath, args[0]), blockJson);
-                        return "Block data json written to " + Path.Combine(Application.persistentDataPath, args[0]);
+                        string fileName = WorldDataReplacement.GetRMBBlockReplacementFilename(blockData.Name);
+                        File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), blockJson);
+                        return "Block data json written to " + Path.Combine(Application.persistentDataPath, fileName);
                     }
                     return error;
                 }
@@ -1575,7 +1585,8 @@ namespace Wenzil.Console
 
             public static string Execute(params string[] args)
             {
-                if (args.Length < 1) return "see usage";
+                if (args.Length < 1)
+                    return usage;
 
                 GameObject player = GameObject.FindGameObjectWithTag("Player");
                 PlayerEntity playerEntity = player.GetComponent<DaggerfallEntityBehaviour>().Entity as PlayerEntity;
@@ -1589,11 +1600,11 @@ namespace Wenzil.Console
                 }
 
                 if (n < 1)
-                    return "Error - see usage";
+                    return usage;
 
                 if (args[0] == "gold")
                 {
-                    GameManager.Instance.PlayerEntity.GoldPieces += n;
+                    playerEntity.GoldPieces += n;
                     return string.Format("Added {0} gold pieces", n);
                 }
 
@@ -1821,6 +1832,96 @@ namespace Wenzil.Console
                     ItemBuilder.CreateMensClothing(x.Parse<MensClothing>(), x.Parse<Races>(), -1, x.Parse<DyeColors>()) :
                     ItemBuilder.CreateWomensClothing(x.Parse<WomensClothing>(), x.Parse<Races>(), -1, x.Parse<DyeColors>())
                 );
+            }
+        }
+
+        private static class AddAllEquip
+        {
+            public static readonly string name = "add_all_equip";
+            public static readonly string description = "Adds all equippable item types to inventory for the current characters gender & race. (for testing paperdoll images)";
+            public static readonly string usage = "add_all_equip (clothing|armor|weapons)";
+
+            public static ArmorMaterialTypes[] armorMaterials = {
+                ArmorMaterialTypes.Leather,
+                ArmorMaterialTypes.Chain,
+                ArmorMaterialTypes.Iron,
+                ArmorMaterialTypes.Steel,
+                ArmorMaterialTypes.Silver,
+                ArmorMaterialTypes.Elven,
+                ArmorMaterialTypes.Dwarven,
+                ArmorMaterialTypes.Mithril,
+                ArmorMaterialTypes.Adamantium,
+                ArmorMaterialTypes.Ebony,
+                ArmorMaterialTypes.Orcish,
+                ArmorMaterialTypes.Daedric
+            };
+            public static WeaponMaterialTypes[] weaponMaterials = {
+                WeaponMaterialTypes.Iron,
+                WeaponMaterialTypes.Steel,
+                WeaponMaterialTypes.Silver,
+                WeaponMaterialTypes.Elven,
+                WeaponMaterialTypes.Dwarven,
+                WeaponMaterialTypes.Mithril,
+                WeaponMaterialTypes.Adamantium,
+                WeaponMaterialTypes.Ebony,
+                WeaponMaterialTypes.Orcish,
+                WeaponMaterialTypes.Daedric
+            };
+
+            public static string Execute(params string[] args)
+            {
+                if (args.Length != 1)
+                    return usage;
+
+                PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+                ItemCollection items = playerEntity.Items;
+                DaggerfallUnityItem newItem = null;
+
+                switch (args[0])
+                {
+                    case "clothing":
+                        ItemGroups clothing = (playerEntity.Gender == Genders.Male) ? ItemGroups.MensClothing : ItemGroups.WomensClothing;
+                        foreach (DyeColors dye in ItemBuilder.clothingDyes)
+                        {
+                            Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(clothing);
+                            for (int i = 0; i < enumArray.Length; i++)
+                            {
+                                newItem = new DaggerfallUnityItem(clothing, i);
+                                ItemBuilder.SetRace(newItem, playerEntity.Race);
+                                newItem.dyeColor = dye;
+                                playerEntity.Items.AddItem(newItem);
+                            }
+                        }
+                        return string.Format("Added all clothing types for a {0} {1}", playerEntity.Gender, playerEntity.Race);
+
+                    case "armor":
+                        foreach (ArmorMaterialTypes material in armorMaterials)
+                        {
+                            Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(ItemGroups.Armor);
+                            for (int i = 0; i < enumArray.Length; i++)
+                            {
+                                newItem = ItemBuilder.CreateArmor(playerEntity.Gender, playerEntity.Race, (Armor)enumArray.GetValue(i), material);
+                                playerEntity.Items.AddItem(newItem);
+                            }
+                        }
+                        return string.Format("Added all armor types for a {0} {1}", playerEntity.Gender, playerEntity.Race);
+
+                    case "weapons":
+                        foreach (WeaponMaterialTypes material in weaponMaterials)
+                        {
+                            Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(ItemGroups.Weapons);
+                            for (int i = 0; i < enumArray.Length; i++)
+                            {
+                                newItem = ItemBuilder.CreateWeapon((Weapons)enumArray.GetValue(i), material);
+                                playerEntity.Items.AddItem(newItem);
+                            }
+                        }
+                        return string.Format("Added all weapon types for any gender/race.");
+
+                    default:
+                        return "No valid equippable item group specified.";
+                }
+
             }
         }
 

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -98,6 +98,7 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(DiseasePlayer.name, DiseasePlayer.usage, DiseasePlayer.description, DiseasePlayer.Execute);
             ConsoleCommandsDatabase.RegisterCommand(PoisonPlayer.name, PoisonPlayer.usage, PoisonPlayer.description, PoisonPlayer.Execute);
 
+            ConsoleCommandsDatabase.RegisterCommand(DumpLocation.name, DumpLocation.description, DumpLocation.usage, DumpLocation.Execute);
             ConsoleCommandsDatabase.RegisterCommand(DumpBlock.name, DumpBlock.description, DumpBlock.usage, DumpBlock.Execute);
             ConsoleCommandsDatabase.RegisterCommand(DumpLocBlocks.name, DumpLocBlocks.description, DumpLocBlocks.usage, DumpLocBlocks.Execute);
             ConsoleCommandsDatabase.RegisterCommand(DumpBuilding.name, DumpBuilding.description, DumpBuilding.usage, DumpBuilding.Execute);
@@ -110,6 +111,36 @@ namespace Wenzil.Console
 
             ConsoleCommandsDatabase.RegisterCommand(SummonDaedra.name, SummonDaedra.description, SummonDaedra.usage, SummonDaedra.Execute);
 
+        }
+
+        private static class DumpLocation
+        {
+            public static readonly string name = "dumplocation";
+            public static readonly string error = "Player not at a location, unable to dump";
+            public static readonly string usage = "dumplocation";
+            public static readonly string description = "Dump the current location (from MAPS.BSA) that the player is currently in to json file";
+
+            public static string Execute(params string[] args)
+            {
+                if (args.Length != 0)
+                {
+                    return HelpCommand.Execute(DumpLocation.name);
+                }
+                else
+                {
+                    PlayerGPS playerGPS = GameManager.Instance.PlayerGPS;
+                    if (playerGPS.HasCurrentLocation)
+                    {
+                        DFLocation location = playerGPS.CurrentLocation;
+
+                        string locJson = SaveLoadManager.Serialize(location.GetType(), location);
+                        string fileName = WorldDataReplacement.GetLocationReplacementFilename(location.RegionIndex, location.LocationIndex);
+                        File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), locJson);
+                        return "Location data json written to " + Path.Combine(Application.persistentDataPath, fileName);
+                    }
+                    return error;
+                }
+            }
         }
 
         private static class DumpBlock

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -31,8 +31,8 @@ namespace DaggerfallWorkshop.Game.Items
     {
         #region Data
 
-        const int firstFemaleArchive = 245;
-        const int firstMaleArchive = 249;
+        public const int firstFemaleArchive = 245;
+        public const int firstMaleArchive = 249;
         private const int chooseAtRandom = -1;
 
         // This array is used to pick random material values.
@@ -73,7 +73,7 @@ namespace DaggerfallWorkshop.Game.Items
             Khajiit = 3,
         }
 
-        static DyeColors[] clothingDyes = {
+        public static DyeColors[] clothingDyes = {
             DyeColors.Blue,
             DyeColors.Grey,
             DyeColors.Red,
@@ -868,15 +868,15 @@ namespace DaggerfallWorkshop.Game.Items
 
         #endregion
 
-        #region Private Methods
+        #region Static Utility Methods
 
-        static void SetRace(DaggerfallUnityItem item, Races race)
+        public static void SetRace(DaggerfallUnityItem item, Races race)
         {
             int offset = (int)GetBodyMorphology(race);
             item.PlayerTextureArchive += offset;
         }
 
-        static void SetVariant(DaggerfallUnityItem item, int variant)
+        public static void SetVariant(DaggerfallUnityItem item, int variant)
         {
             // Range check
             int totalVariants = item.ItemTemplate.variants;

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -68,7 +68,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
         #region Public Methods
 
-        // Replacing entire blocks is not currently possible as RmbFldGroundData contains
+        public static string GetLocationReplacementFilename(int regionIndex, int locationIndex)
+        {
+            return string.Format("location-{0}-{1}.json", regionIndex, locationIndex);
+        }
+
+        // Replacing entire RMB blocks is not currently possible as RmbFldGroundData contains
         // groundData as a 2d array and FullSerializer can't do 2D arrays out of the box.
         public static string GetRMBBlockReplacementFilename(string blockName)
         {

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -68,6 +68,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
         #region Public Methods
 
+        // Replacing entire blocks is not currently possible as RmbFldGroundData contains
+        // groundData as a 2d array and FullSerializer can't do 2D arrays out of the box.
         public static string GetRMBBlockReplacementFilename(string blockName)
         {
             return string.Format("{0}.json", blockName);

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -73,9 +73,10 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return string.Format("location-{0}-{1}.json", regionIndex, locationIndex);
         }
 
+        // Currently only RDB block replacement is possible.
         // Replacing entire RMB blocks is not currently possible as RmbFldGroundData contains
-        // groundData as a 2d array and FullSerializer can't do 2D arrays out of the box.
-        public static string GetRMBBlockReplacementFilename(string blockName)
+        // groundData as a 2D array and FullSerializer can't do 2D arrays out of the box.
+        public static string GetBlockReplacementFilename(string blockName)
         {
             return string.Format("{0}.json", blockName);
         }

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -68,6 +68,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
         #region Public Methods
 
+        public static string GetRMBBlockReplacementFilename(string blockName)
+        {
+            return string.Format("{0}.json", blockName);
+        }
+
         public static string GetBuildingReplacementFilename(string blockName, int blockIndex, int recordIndex)
         {
             return string.Format("{0}-{1}-building{2}.json", blockName, blockIndex, recordIndex);


### PR DESCRIPTION
Enable testing of paperdoll images as requested by #1543.

Adds all types of equippable items for the current character gender/race, but doesn't add variants.

Also extended dumpblock command to be able to dump dungeon blocks, and added a dumplocation command to dump location records.