### PR TITLE
Fix some circular dependencies so TG and DB are proplerly GC'ed

### DIFF
--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -12,6 +12,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Entity;
 using System;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Serialization;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
@@ -77,20 +78,6 @@ namespace DaggerfallWorkshop.Game.Guilds
         #endregion
 
         #region Guild Membership and Faction
-
-        public DarkBrotherhood()
-        {
-            // Register for location entry events so can auto discover guild houses.
-            PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
-            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
-        }
-
-        ~DarkBrotherhood()
-        {
-            // Unregister events
-            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
-            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
-        }
 
         public static int FactionId { get { return factionId; } }
 
@@ -188,7 +175,13 @@ namespace DaggerfallWorkshop.Game.Guilds
         override public void Join()
         {
             base.Join();
+            RegisterEvents();
             RevealGuildHallOnMap();
+        }
+
+        override public void Leave()
+        {
+            UnregisterEvents();
         }
 
         public override TextFile.Token[] TokensIneligible(PlayerEntity playerEntity)
@@ -207,6 +200,20 @@ namespace DaggerfallWorkshop.Game.Guilds
         #endregion
 
         #region Event handlers
+
+        private void RegisterEvents()
+        {
+            // Register for location entry events so can auto discover guild houses
+            PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+        }
+
+        private void UnregisterEvents()
+        {
+            // Unregister events
+            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
+        }
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)
         {
@@ -228,6 +235,16 @@ namespace DaggerfallWorkshop.Game.Guilds
             if (buildingDirectory)
                 foreach (BuildingSummary building in buildingDirectory.GetBuildingsOfFaction(factionId))
                     GameManager.Instance.PlayerGPS.DiscoverBuilding(building.buildingKey, GetGuildName());
+        }
+
+        #endregion
+
+        #region Serialization
+
+        internal override void RestoreGuildData(GuildMembership_v1 data)
+        {
+            base.RestoreGuildData(data);
+            RegisterEvents();
         }
 
         #endregion

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -302,6 +302,10 @@ namespace DaggerfallWorkshop.Game.Guilds
             lastRankChange = CalculateDaySinceZero(DaggerfallUnity.Instance.WorldTime.Now);
         }
 
+        public virtual void Leave()
+        {
+        }
+
         public virtual bool IsEligibleToJoin(PlayerEntity playerEntity)
         {
             // Check reputation & skills

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -130,7 +130,10 @@ namespace DaggerfallWorkshop.Game.Guilds
                 }
             }
             if (guildGroup != FactionFile.GuildGroups.None)
+            {
+                guild.Leave();
                 memberships.Remove(guildGroup);
+            }
         }
 
         public bool HasJoined(FactionFile.GuildGroups guildGroup)
@@ -266,6 +269,10 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public void ClearMembershipData()
         {
+            foreach (Guild guild in memberships.Values)
+            {
+                guild.Leave();
+            }
             memberships.Clear();
         }
 

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -17,6 +17,7 @@ using Wenzil.Console;
 using Wenzil.Console.Commands;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallConnect.Save;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
@@ -46,6 +47,10 @@ namespace DaggerfallWorkshop.Game.Guilds
             // Listen for quest end events which trigger joining TG & DB.
             QuestMachine.OnQuestEnded += QuestMachine_OnQuestEnded;
 
+            // Clear all guilds affilations when loading or starting a new game
+            SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
+
             // Register console commands
             GuildConsoleCommands.RegisterCommands();
         }
@@ -65,6 +70,16 @@ namespace DaggerfallWorkshop.Game.Guilds
                     AddMembership(FactionFile.GuildGroups.DarkBrotherHood, db);
                 }
             }
+        }
+
+        private void StartGameBehaviour_OnNewGame()
+        {
+            ClearMembershipData();
+        }
+
+        private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
+        {
+            ClearMembershipData();
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -12,6 +12,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Entity;
 using System;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Serialization;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
@@ -74,20 +75,6 @@ namespace DaggerfallWorkshop.Game.Guilds
         #endregion
 
         #region Guild Membership and Faction
-
-        public ThievesGuild()
-        {
-            // Register for location entry events so can auto discover guild houses.
-            PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
-            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
-        }
-
-        ~ThievesGuild()
-        {
-            // Unregister events
-            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
-            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
-        }
 
         public static int FactionId { get { return factionId; } }
 
@@ -179,7 +166,13 @@ namespace DaggerfallWorkshop.Game.Guilds
         override public void Join()
         {
             base.Join();
+            RegisterEvents();
             RevealGuildHallOnMap();
+        }
+
+        override public void Leave() 
+        {
+            UnregisterEvents();
         }
 
         public override TextFile.Token[] TokensIneligible(PlayerEntity playerEntity)
@@ -198,6 +191,20 @@ namespace DaggerfallWorkshop.Game.Guilds
         #endregion
 
         #region Event handlers
+
+        private void RegisterEvents()
+        {
+            // Register for location entry events so can auto discover guild houses
+            PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+        }
+
+        private void UnregisterEvents()
+        {
+            // Unregister events
+            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
+        }
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)
         {
@@ -219,6 +226,16 @@ namespace DaggerfallWorkshop.Game.Guilds
             if (buildingDirectory)
                 foreach (BuildingSummary building in buildingDirectory.GetBuildingsOfFaction(factionId))
                     GameManager.Instance.PlayerGPS.DiscoverBuilding(building.buildingKey, GetGuildName());
+        }
+
+        #endregion
+
+        #region Serialization
+
+        internal override void RestoreGuildData(GuildMembership_v1 data)
+        {
+            base.RestoreGuildData(data);
+            RegisterEvents();
         }
 
         #endregion


### PR DESCRIPTION
Previously, Thieves Guild or Dark Brotherhood instances were never garbage collected because `PlayerGPS` and `StreamingWorld` kept strong references to them through events `OnEnterLocationRect` and `OnAvailableLocationGameObject`. This, because unsubscribing to these events took place in both class destructors, so, to summarize, it never happened.

This resulted in the following behavior: if you loaded a savegame with a character who was a member of any of these guilds, then loaded another savegame from another character who wasn't, you would still discover the guild hideouts using the automap.

Unfortunately, any game saved prior to this fix may still have the guilds available on the automap, this because all discovered buildings are saved.