### PR TITLE
Unregister events for TG and DB guild instances

### DIFF
--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -189,6 +189,11 @@ namespace DaggerfallWorkshop.Game.Guilds
             RevealGuildHallOnMap();
         }
 
+        override public void Leave()
+        {
+            UnregisterEvents();
+        }
+
         public override TextFile.Token[] TokensIneligible(PlayerEntity playerEntity)
         {
             throw new NotImplementedException();

--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -12,6 +12,8 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Entity;
 using System;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
@@ -80,16 +82,12 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public DarkBrotherhood()
         {
-            // Register for location entry events so can auto discover guild houses.
-            PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
-            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+            RegisterEvents();
         }
 
         ~DarkBrotherhood()
         {
-            // Unregister events
-            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
-            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
+            UnregisterEvents();
         }
 
         public static int FactionId { get { return factionId; } }
@@ -207,6 +205,36 @@ namespace DaggerfallWorkshop.Game.Guilds
         #endregion
 
         #region Event handlers
+
+        private void RegisterEvents()
+        {
+            // Register events for location entry events so can auto discover guild houses.
+            PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+
+            // Register events so as to know when to unregister events.
+            SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
+        }
+
+        private void UnregisterEvents()
+        {
+            // Unregister events
+            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
+        private void StartGameBehaviour_OnNewGame()
+        {
+            UnregisterEvents();
+        }
+
+        private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
+        {
+            UnregisterEvents();
+        }
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)
         {

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -302,6 +302,8 @@ namespace DaggerfallWorkshop.Game.Guilds
             lastRankChange = CalculateDaySinceZero(DaggerfallUnity.Instance.WorldTime.Now);
         }
 
+        public virtual void Leave() {   }
+
         public virtual bool IsEligibleToJoin(PlayerEntity playerEntity)
         {
             // Check reputation & skills

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -130,7 +130,10 @@ namespace DaggerfallWorkshop.Game.Guilds
                 }
             }
             if (guildGroup != FactionFile.GuildGroups.None)
+            {
+                guild.Leave();
                 memberships.Remove(guildGroup);
+            }
         }
 
         public bool HasJoined(FactionFile.GuildGroups guildGroup)
@@ -266,6 +269,10 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public void ClearMembershipData()
         {
+            foreach (Guild guild in memberships.Values)
+            {
+                guild.Leave();
+            }
             memberships.Clear();
         }
 

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -12,6 +12,8 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Entity;
 using System;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
@@ -77,16 +79,12 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public ThievesGuild()
         {
-            // Register for location entry events so can auto discover guild houses.
-            PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
-            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+            RegisterEvents();
         }
 
         ~ThievesGuild()
         {
-            // Unregister events
-            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
-            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
+            UnregisterEvents();
         }
 
         public static int FactionId { get { return factionId; } }
@@ -198,6 +196,36 @@ namespace DaggerfallWorkshop.Game.Guilds
         #endregion
 
         #region Event handlers
+
+        private void RegisterEvents()
+        {
+            // Register events for location entry events so can auto discover guild houses.
+            PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+
+            // Register events so as to know when to unregister events.
+            SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
+        }
+
+        private void UnregisterEvents()
+        {
+            // Unregister events
+            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
+            StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
+        private void StartGameBehaviour_OnNewGame()
+        {
+            UnregisterEvents();
+        }
+
+        private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
+        {
+            UnregisterEvents();
+        }
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)
         {

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -180,6 +180,11 @@ namespace DaggerfallWorkshop.Game.Guilds
             RevealGuildHallOnMap();
         }
 
+        override public void Leave()
+        {
+            UnregisterEvents();
+        }
+
         public override TextFile.Token[] TokensIneligible(PlayerEntity playerEntity)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
So they are correctly garbage collected and guild halls are not erroneously revealed after load/new game.

Supercedes PR #1559.

-----
Previously, Thieves Guild or Dark Brotherhood instances were never garbage collected because PlayerGPS and StreamingWorld kept strong references to them through events OnEnterLocationRect and OnAvailableLocationGameObject. This, because unsubscribing to these events took place in both class destructors, so, to summarize, it never happened.

This resulted in the following behavior: if you loaded a savegame with a character who was a member of any of these guilds, then loaded another savegame from another character who wasn't, you would still discover the guild hideouts using the automap.

Unfortunately, any game saved prior to this fix may still have the guilds available on the automap, this because all discovered buildings are saved.