### PR TITLE
Don't attempt to create textures for non existant images with zero width/height

### DIFF
--- a/Assets/Scripts/Utility/ImageReader.cs
+++ b/Assets/Scripts/Utility/ImageReader.cs
@@ -378,7 +378,7 @@ namespace DaggerfallWorkshop.Utility
             imageData.height = dfBitmap.Height;
 
             // Create Texture2D
-            if (createTexture)
+            if (createTexture && imageData.width > 0 && imageData.height > 0)
             {
                 // Get colors array
                 Color32[] colors = GetColors(imageData);


### PR DESCRIPTION
This allows virtual assets (i.e. don't exist in vanilla files) to be replaced by mods. I am using it to allow extra images for the horses neck to be contributed by other mods and used by R&R mod, even though none exist in vanilla DF.