### PR TITLE
Enable guild modding

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1447,7 +1447,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return cost;
         }
 
-        public static int CalculateItemRepairCost(int baseItemValue, int shopQuality, int condition, int max, Guild guild)
+        public static int CalculateItemRepairCost(int baseItemValue, int shopQuality, int condition, int max, IGuild guild)
         {
             // Don't cost already repaired item
             if (condition == max)
@@ -1473,7 +1473,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return Mathf.Max(repairTime, DaggerfallDateTime.SecondsPerDay);
         }
 
-        public static int CalculateItemIdentifyCost(int baseItemValue, Guild guild)
+        public static int CalculateItemIdentifyCost(int baseItemValue, IGuild guild)
         {
             // Free on Witches Festival
             uint minutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();

--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -80,16 +80,6 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Guild Membership and Faction
 
-        public DarkBrotherhood()
-        {
-            RegisterEvents();
-        }
-
-        ~DarkBrotherhood()
-        {
-            UnregisterEvents();
-        }
-
         public static int FactionId { get { return factionId; } }
 
         public override int GetFactionId()

--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -241,7 +241,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Serialization
 
-        internal override void RestoreGuildData(GuildMembership_v1 data)
+        public override void RestoreGuildData(GuildMembership_v1 data)
         {
             base.RestoreGuildData(data);
             RegisterEvents();

--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -13,6 +13,7 @@ using DaggerfallWorkshop.Game.Entity;
 using System;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
@@ -79,6 +80,16 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Guild Membership and Faction
 
+        public DarkBrotherhood()
+        {
+            RegisterEvents();
+        }
+
+        ~DarkBrotherhood()
+        {
+            UnregisterEvents();
+        }
+
         public static int FactionId { get { return factionId; } }
 
         public override int GetFactionId()
@@ -128,8 +139,13 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         protected override int CalculateNewRank(PlayerEntity playerEntity)
         {
-            // Dark Brotherhood never expel members (I assume at some point they 'retire' you instead!)
             int newRank = base.CalculateNewRank(playerEntity);
+            return AllowGuildExpulsion(newRank);
+        }
+
+        protected virtual int AllowGuildExpulsion(int newRank)
+        {
+            // Dark Brotherhood never expel members (I assume at some point they 'retire' you instead!)
             return (newRank < 0) ? 0 : newRank;
         }
 
@@ -203,9 +219,13 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         private void RegisterEvents()
         {
-            // Register for location entry events so can auto discover guild houses
+            // Register events for location entry events so can auto discover guild houses.
             PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
             StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+
+            // Register events so as to know when to unregister events.
+            SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
         }
 
         private void UnregisterEvents()
@@ -213,6 +233,18 @@ namespace DaggerfallWorkshop.Game.Guilds
             // Unregister events
             PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
             StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
+        private void StartGameBehaviour_OnNewGame()
+        {
+            UnregisterEvents();
+        }
+
+        private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
+        {
+            UnregisterEvents();
         }
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)

--- a/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
+++ b/Assets/Scripts/Game/Guilds/DarkBrotherhood.cs
@@ -130,10 +130,10 @@ namespace DaggerfallWorkshop.Game.Guilds
         protected override int CalculateNewRank(PlayerEntity playerEntity)
         {
             int newRank = base.CalculateNewRank(playerEntity);
-            return AllowGuildExpulsion(newRank);
+            return AllowGuildExpulsion(playerEntity, newRank);
         }
 
-        protected virtual int AllowGuildExpulsion(int newRank)
+        protected virtual int AllowGuildExpulsion(PlayerEntity playerEntity, int newRank)
         {
             // Dark Brotherhood never expel members (I assume at some point they 'retire' you instead!)
             return (newRank < 0) ? 0 : newRank;

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -19,7 +19,7 @@ namespace DaggerfallWorkshop.Game.Guilds
     /// <summary>
     ///  Guild objects define player status and benefits with the guild.
     /// </summary>
-    public abstract class Guild : IMacroContextProvider  // TODO: Extract interface?
+    public abstract class Guild : IGuild
     {
         #region Constants
 
@@ -326,12 +326,12 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Serialization
 
-        internal virtual GuildMembership_v1 GetGuildData()
+        public virtual GuildMembership_v1 GetGuildData()
         {
             return new GuildMembership_v1() { rank = rank, lastRankChange = lastRankChange };
         }
 
-        internal virtual void RestoreGuildData(GuildMembership_v1 data)
+        public virtual void RestoreGuildData(GuildMembership_v1 data)
         {
             rank = data.rank;
             lastRankChange = data.lastRankChange;

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -47,10 +47,6 @@ namespace DaggerfallWorkshop.Game.Guilds
             // Listen for quest end events which trigger joining TG & DB.
             QuestMachine.OnQuestEnded += QuestMachine_OnQuestEnded;
 
-            // Clear all guilds affilations when loading or starting a new game
-            SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
-            StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
-
             // Register console commands
             GuildConsoleCommands.RegisterCommands();
         }
@@ -70,16 +66,6 @@ namespace DaggerfallWorkshop.Game.Guilds
                     AddMembership(FactionFile.GuildGroups.DarkBrotherHood, db);
                 }
             }
-        }
-
-        private void StartGameBehaviour_OnNewGame()
-        {
-            ClearMembershipData();
-        }
-
-        private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
-        {
-            ClearMembershipData();
         }
 
         /// <summary>
@@ -288,10 +274,6 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public void ClearMembershipData()
         {
-            foreach (IGuild guild in memberships.Values)
-            {
-                guild.Leave();
-            }
             memberships.Clear();
         }
 

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -28,7 +28,7 @@ namespace DaggerfallWorkshop.Game.Guilds
         // A base temple class defining non-membership.
         public static Guild templeNotMember = new NonMemberGuild(true);
 
-        // Custom guild registry.
+        // Custom guild registry. Can override vanilla guilds.
         private static Dictionary<FactionFile.GuildGroups, Type> customGuilds = new Dictionary<FactionFile.GuildGroups, Type>();
 
         public static bool RegisterCustomGuild(FactionFile.GuildGroups guildGroup, Type guildType)
@@ -174,32 +174,36 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         private IGuild CreateGuildObj(FactionFile.GuildGroups guildGroup, int variant = 0)
         {
-            switch (guildGroup)
+            Type guildType;
+            if (customGuilds.TryGetValue(guildGroup, out guildType))
             {
-                case FactionFile.GuildGroups.FightersGuild:
-                    return new FightersGuild();
+                return (IGuild)Activator.CreateInstance(guildType);
+            }
+            else
+            {
+                switch (guildGroup)
+                {
+                    case FactionFile.GuildGroups.FightersGuild:
+                        return new FightersGuild();
 
-                case FactionFile.GuildGroups.MagesGuild:
-                    return new MagesGuild();
+                    case FactionFile.GuildGroups.MagesGuild:
+                        return new MagesGuild();
 
-                case FactionFile.GuildGroups.HolyOrder:
-                    return new Temple(Temple.GetDivine(variant));
+                    case FactionFile.GuildGroups.HolyOrder:
+                        return new Temple(Temple.GetDivine(variant));
 
-                case FactionFile.GuildGroups.KnightlyOrder:
-                    return new KnightlyOrder(KnightlyOrder.GetOrder(variant));
+                    case FactionFile.GuildGroups.KnightlyOrder:
+                        return new KnightlyOrder(KnightlyOrder.GetOrder(variant));
 
-                case FactionFile.GuildGroups.GeneralPopulace:
-                    return new ThievesGuild();
+                    case FactionFile.GuildGroups.GeneralPopulace:
+                        return new ThievesGuild();
 
-                case FactionFile.GuildGroups.DarkBrotherHood:
-                    return new DarkBrotherhood();
+                    case FactionFile.GuildGroups.DarkBrotherHood:
+                        return new DarkBrotherhood();
 
-                default:
-                    Type guildType;
-                    if (customGuilds.TryGetValue(guildGroup, out guildType))
-                        return (IGuild)Activator.CreateInstance(guildType);
-                    else
+                    default:
                         return null;
+                }
             }
         }
 

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -17,7 +17,6 @@ using Wenzil.Console;
 using Wenzil.Console.Commands;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallConnect.Save;
-using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -61,12 +61,12 @@ namespace DaggerfallWorkshop.Game.Guilds
             {
                 if (quest.QuestName == ThievesGuild.InitiationQuestName)
                 {
-                    Guild tg = CreateGuildObj(FactionFile.GuildGroups.GeneralPopulace);
+                    IGuild tg = CreateGuildObj(FactionFile.GuildGroups.GeneralPopulace);
                     AddMembership(FactionFile.GuildGroups.GeneralPopulace, tg);
                 }
                 if (quest.QuestName == DarkBrotherhood.InitiationQuestName)
                 {
-                    Guild db = CreateGuildObj(FactionFile.GuildGroups.DarkBrotherHood);
+                    IGuild db = CreateGuildObj(FactionFile.GuildGroups.DarkBrotherHood);
                     AddMembership(FactionFile.GuildGroups.DarkBrotherHood, db);
                 }
             }
@@ -117,23 +117,23 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Guild membership handling
 
-        private readonly Dictionary<FactionFile.GuildGroups, Guild> memberships = new Dictionary<FactionFile.GuildGroups, Guild>();
+        private readonly Dictionary<FactionFile.GuildGroups, IGuild> memberships = new Dictionary<FactionFile.GuildGroups, IGuild>();
 
-        public List<Guild> GetMemberships()
+        public List<IGuild> GetMemberships()
         {
-            List<Guild> guilds = new List<Guild>();
-            foreach (Guild guild in memberships.Values)
+            List<IGuild> guilds = new List<IGuild>();
+            foreach (IGuild guild in memberships.Values)
                 guilds.Add(guild);
             return guilds;
         }
 
-        public void AddMembership(FactionFile.GuildGroups guildGroup, Guild guild)
+        public void AddMembership(FactionFile.GuildGroups guildGroup, IGuild guild)
         {
             guild.Join();
             memberships[guildGroup] = guild;
         }
 
-        public void RemoveMembership(Guild guild)
+        public void RemoveMembership(IGuild guild)
         {
             FactionFile.GuildGroups guildGroup = FactionFile.GuildGroups.None;
             foreach (FactionFile.GuildGroups group in memberships.Keys)
@@ -156,7 +156,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             return memberships.ContainsKey(guildGroup);
         }
 
-        public bool GetJoinedGuildOfGuildGroup(FactionFile.GuildGroups guildGroup, out Guild value)
+        public bool GetJoinedGuildOfGuildGroup(FactionFile.GuildGroups guildGroup, out IGuild value)
         {
             if (memberships.TryGetValue(guildGroup, out value))
                 return true;
@@ -164,7 +164,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             return false;
         }
 
-        public Guild JoinGuild(FactionFile.GuildGroups guildGroup, int buildingFactionId = 0)
+        public IGuild JoinGuild(FactionFile.GuildGroups guildGroup, int buildingFactionId = 0)
         {
             if (memberships.ContainsKey(guildGroup))
                 return memberships[guildGroup];
@@ -172,7 +172,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             return CreateGuildObj(guildGroup, buildingFactionId);
         }
 
-        private Guild CreateGuildObj(FactionFile.GuildGroups guildGroup, int variant = 0)
+        private IGuild CreateGuildObj(FactionFile.GuildGroups guildGroup, int variant = 0)
         {
             switch (guildGroup)
             {
@@ -197,7 +197,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                 default:
                     Type guildType;
                     if (customGuilds.TryGetValue(guildGroup, out guildType))
-                        return (Guild)Activator.CreateInstance(guildType);
+                        return (IGuild)Activator.CreateInstance(guildType);
                     else
                         return null;
             }
@@ -208,10 +208,10 @@ namespace DaggerfallWorkshop.Game.Guilds
         /// </summary>
         /// <param name="guildGroup"></param>
         /// <param name="buildingFactionId">Specify this to ensure only the temple of matching Divine is returned</param>
-        /// <returns>Guild object</returns>
-        public Guild GetGuild(FactionFile.GuildGroups guildGroup, int buildingFactionId = 0)
+        /// <returns>IGuild object</returns>
+        public IGuild GetGuild(FactionFile.GuildGroups guildGroup, int buildingFactionId = 0)
         {
-            Guild guild;
+            IGuild guild;
             memberships.TryGetValue(guildGroup, out guild);
 
             if (guildGroup == FactionFile.GuildGroups.HolyOrder && buildingFactionId > 0)
@@ -242,7 +242,7 @@ namespace DaggerfallWorkshop.Game.Guilds
         /// <summary>
         /// Retrieve the guild object for the given faction id.
         /// </summary>
-        public Guild GetGuild(int factionId)
+        public IGuild GetGuild(int factionId)
         {
             try {
                 FactionFile.GuildGroups guildGroup = GetGuildGroup(factionId);
@@ -284,7 +284,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public void ClearMembershipData()
         {
-            foreach (Guild guild in memberships.Values)
+            foreach (IGuild guild in memberships.Values)
             {
                 guild.Leave();
             }
@@ -307,7 +307,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                 foreach (FactionFile.GuildGroups guildGroup in data.Keys)
                 {
                     GuildMembership_v1 guildMembershipData = data[(int)guildGroup];
-                    Guild guild = CreateGuildObj(guildGroup, guildMembershipData.variant);
+                    IGuild guild = CreateGuildObj(guildGroup, guildMembershipData.variant);
                     if (guild != null)
                     {
                         guild.RestoreGuildData(guildMembershipData);
@@ -326,7 +326,7 @@ namespace DaggerfallWorkshop.Game.Guilds
             foreach (GuildMembershipRecord record in guildMembershipRecords)
             {
                 FactionFile.GuildGroups guildGroup = GetGuildGroup(record.ParsedData.factionID);
-                Guild guild = CreateGuildObj(guildGroup, record.ParsedData.factionID);
+                IGuild guild = CreateGuildObj(guildGroup, record.ParsedData.factionID);
                 AddMembership(guildGroup, guild);
 
                 // Set rank and time from parsed data.
@@ -341,7 +341,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public bool FreeShipTravel()
         {
-            foreach (Guild guild in memberships.Values)
+            foreach (IGuild guild in memberships.Values)
                 if (guild.FreeShipTravel())
                     return true;
 
@@ -351,7 +351,7 @@ namespace DaggerfallWorkshop.Game.Guilds
         public int FastTravel(int duration)
         {
             int newDuration = duration;
-            foreach (Guild guild in memberships.Values)
+            foreach (IGuild guild in memberships.Values)
                 newDuration = guild.FastTravel(newDuration);
             return newDuration;
         }
@@ -359,14 +359,14 @@ namespace DaggerfallWorkshop.Game.Guilds
         public int DeepBreath(int duration)
         {
             int newDuration = duration;
-            foreach (Guild guild in memberships.Values)
+            foreach (IGuild guild in memberships.Values)
                 newDuration = guild.DeepBreath(newDuration);
             return newDuration;
         }
 
         public bool AvoidDeath()
         {
-            foreach (Guild guild in memberships.Values)
+            foreach (IGuild guild in memberships.Values)
                 if (guild.AvoidDeath())
                     return true;
             return false;
@@ -421,7 +421,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                             if (args.Length > 1)
                             {
                                 int factionId = int.Parse(args[1]);
-                                Guild guild = guildManager.JoinGuild(guildGroup, factionId);
+                                IGuild guild = guildManager.JoinGuild(guildGroup, factionId);
                                 guildManager.AddMembership(guildGroup, guild);
                                 return "Guild joined.";
                             }
@@ -432,7 +432,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                         }
                         else
                         {
-                            Guild guild = guildManager.JoinGuild(guildGroup);
+                            IGuild guild = guildManager.JoinGuild(guildGroup);
                             guildManager.AddMembership(guildGroup, guild);
                             return "Guild " + guildGroup.ToString() + " joined.";
                         }
@@ -472,7 +472,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                             int newRank = int.Parse(args[1]);
                             if (newRank > 0 && newRank < 10)
                             {
-                                Guild guild = guildManager.GetGuild(guildGroup);
+                                IGuild guild = guildManager.GetGuild(guildGroup);
                                 int rep = guild.GetReputation(playerEntity);
                                 int newRep = Guild.rankReqReputation[newRank];
                                 playerEntity.FactionData.ChangeReputation(guild.GetFactionId(), newRep - rep, true);

--- a/Assets/Scripts/Game/Guilds/IGuild.cs
+++ b/Assets/Scripts/Game/Guilds/IGuild.cs
@@ -1,0 +1,140 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2019 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Hazelnut
+// Contributors:    
+
+using System.Collections.Generic;
+using DaggerfallConnect;
+using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Serialization;
+
+namespace DaggerfallWorkshop.Game.Guilds
+{
+    /// <summary>
+    ///  Guild objects define player rank progression and benefits with the guild.
+    ///  For vanilla style guilds, extend abstract class Guild.cs which defines most
+    ///  of the vanilla base behaviour.
+    /// </summary>
+    public interface IGuild : IMacroContextProvider
+    {
+        #region Properties
+
+        string[] RankTitles { get; }
+
+        List<DFCareer.Skills> GuildSkills { get; }
+
+        List<DFCareer.Skills> TrainingSkills { get; }
+
+        #endregion
+
+        #region Guild Ranks
+
+        int Rank { get; set; }
+
+        void ImportLastRankChange(uint timeOfLastRankChange);
+
+        TextFile.Token[] UpdateRank(PlayerEntity playerEntity);
+
+        TextFile.Token[] TokensPromotion(int newRank);
+
+        TextFile.Token[] TokensDemotion();
+
+        TextFile.Token[] TokensExpulsion();
+
+        #endregion
+
+        #region Guild Membership and Faction Data
+
+        bool IsMember();
+
+        int GetFactionId();
+
+        int GetReputation(PlayerEntity playerEntity);
+
+        string GetGuildName();
+
+        string GetAffiliation();
+
+        string GetTitle();
+
+        #endregion
+
+        #region Common Benefits
+
+        bool CanRest();
+
+        bool HallAccessAnytime();
+
+        bool FreeHealing();
+
+        bool FreeMagickaRecharge();
+
+        int ReducedRepairCost(int price);
+
+        int ReducedIdentifyCost(int price);
+
+        int ReducedCureCost(int price);
+
+        #endregion
+
+        #region Special benefits:
+
+        bool FreeTavernRooms();
+
+        bool FreeShipTravel();
+
+        int FastTravel(int duration);
+
+        int DeepBreath(int duration);
+
+        bool AvoidDeath();
+
+        #endregion
+
+        #region Service Access:
+
+        bool CanAccessLibrary();
+
+        bool CanAccessService(GuildServices service);
+
+        #endregion
+
+        #region Service: Training
+
+        int GetTrainingMax(DFCareer.Skills skill);
+
+        int GetTrainingPrice();
+
+        #endregion
+
+        #region Joining
+
+        void Join();
+
+        void Leave();
+
+        bool IsEligibleToJoin(PlayerEntity playerEntity);
+
+        TextFile.Token[] TokensIneligible(PlayerEntity playerEntity);
+
+        TextFile.Token[] TokensEligible(PlayerEntity playerEntity);
+
+        TextFile.Token[] TokensWelcome();
+
+        #endregion
+
+
+        #region Serialization
+
+        GuildMembership_v1 GetGuildData();
+
+        void RestoreGuildData(GuildMembership_v1 data);
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Game/Guilds/IGuild.cs.meta
+++ b/Assets/Scripts/Game/Guilds/IGuild.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f7c18200cf1bb545ac8f594ec20a7f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -280,12 +280,12 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Serialization
 
-        internal override GuildMembership_v1 GetGuildData()
+        public override GuildMembership_v1 GetGuildData()
         {
             return new GuildMembership_v1() { rank = rank, lastRankChange = lastRankChange, variant = (int)order, flags = flags };
         }
 
-        internal override void RestoreGuildData(GuildMembership_v1 data)
+        public override void RestoreGuildData(GuildMembership_v1 data)
         {
             base.RestoreGuildData(data);
             order = (Orders)data.variant;

--- a/Assets/Scripts/Game/Guilds/Temple.cs
+++ b/Assets/Scripts/Game/Guilds/Temple.cs
@@ -519,12 +519,12 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Serialization
 
-        internal override GuildMembership_v1 GetGuildData()
+        public override GuildMembership_v1 GetGuildData()
         {
             return new GuildMembership_v1() { rank = rank, lastRankChange = lastRankChange, variant = (int)deity };
         }
 
-        internal override void RestoreGuildData(GuildMembership_v1 data)
+        public override void RestoreGuildData(GuildMembership_v1 data)
         {
             base.RestoreGuildData(data);
             deity = (Divines)data.variant;

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -136,7 +136,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #endregion
 
-            #region Benefits
+        #region Benefits
 
         public override bool HallAccessAnytime()
         {

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -125,10 +125,10 @@ namespace DaggerfallWorkshop.Game.Guilds
         protected override int CalculateNewRank(PlayerEntity playerEntity)
         {
             int newRank = base.CalculateNewRank(playerEntity);
-            return AllowGuildExpulsion(newRank);
+            return AllowGuildExpulsion(playerEntity, newRank);
         }
 
-        protected virtual int AllowGuildExpulsion(int newRank)
+        protected virtual int AllowGuildExpulsion(PlayerEntity playerEntity, int newRank)
         {
             // Thieves guild never expel members (I assume at some point they 'retire' you instead!)
             return (newRank < 0) ? 0 : newRank;

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -232,7 +232,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Serialization
 
-        internal override void RestoreGuildData(GuildMembership_v1 data)
+        public override void RestoreGuildData(GuildMembership_v1 data)
         {
             base.RestoreGuildData(data);
             RegisterEvents();

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -134,14 +134,19 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         protected override int CalculateNewRank(PlayerEntity playerEntity)
         {
-            // Thieves guild never expel members (I assume at some point they 'retire' you instead!)
             int newRank = base.CalculateNewRank(playerEntity);
+            return AllowGuildExpulsion(newRank);
+        }
+
+        protected virtual int AllowGuildExpulsion(int newRank)
+        {
+            // Thieves guild never expel members (I assume at some point they 'retire' you instead!)
             return (newRank < 0) ? 0 : newRank;
         }
 
         #endregion
 
-        #region Benefits
+            #region Benefits
 
         public override bool HallAccessAnytime()
         {

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -13,6 +13,7 @@ using DaggerfallWorkshop.Game.Entity;
 using System;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Serialization;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Guilds
 {
@@ -75,6 +76,16 @@ namespace DaggerfallWorkshop.Game.Guilds
         #endregion
 
         #region Guild Membership and Faction
+
+        public ThievesGuild()
+        {
+            RegisterEvents();
+        }
+
+        ~ThievesGuild()
+        {
+            UnregisterEvents();
+        }
 
         public static int FactionId { get { return factionId; } }
 
@@ -194,9 +205,13 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         private void RegisterEvents()
         {
-            // Register for location entry events so can auto discover guild houses
+            // Register events for location entry events so can auto discover guild houses.
             PlayerGPS.OnEnterLocationRect += PlayerGPS_OnEnterLocationRect;
             StreamingWorld.OnAvailableLocationGameObject += StreamingWorld_OnAvailableLocationGameObject;
+
+            // Register events so as to know when to unregister events.
+            SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
         }
 
         private void UnregisterEvents()
@@ -204,6 +219,18 @@ namespace DaggerfallWorkshop.Game.Guilds
             // Unregister events
             PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
             StreamingWorld.OnAvailableLocationGameObject -= StreamingWorld_OnAvailableLocationGameObject;
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
+        private void StartGameBehaviour_OnNewGame()
+        {
+            UnregisterEvents();
+        }
+
+        private void SaveLoadManager_OnStartLoad(SaveData_v1 saveData)
+        {
+            UnregisterEvents();
         }
 
         private void PlayerGPS_OnEnterLocationRect(DFLocation location)

--- a/Assets/Scripts/Game/Guilds/ThievesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/ThievesGuild.cs
@@ -77,16 +77,6 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         #region Guild Membership and Faction
 
-        public ThievesGuild()
-        {
-            RegisterEvents();
-        }
-
-        ~ThievesGuild()
-        {
-            UnregisterEvents();
-        }
-
         public static int FactionId { get { return factionId; } }
 
         public override int GetFactionId()

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -1019,13 +1019,13 @@ namespace DaggerfallWorkshop.Game
             // Handle guild halls
             if (type == DFLocation.BuildingTypes.GuildHall)
             {
-                Guild guild = GameManager.Instance.GuildManager.GetGuild(buildingSummary.FactionId);
+                IGuild guild = GameManager.Instance.GuildManager.GetGuild(buildingSummary.FactionId);
                 unlocked = guild.HallAccessAnytime() ? true : IsBuildingOpen(type);
             }
             // Handle TG/DB houses
             else if (type == DFLocation.BuildingTypes.House2 && buildingSummary.FactionId != 0)
             {
-                Guild guild = GameManager.Instance.GuildManager.GetGuild(buildingSummary.FactionId);
+                IGuild guild = GameManager.Instance.GuildManager.GetGuild(buildingSummary.FactionId);
                 unlocked = guild.IsMember();
             }
             // Handle House1 through House4

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -786,7 +786,7 @@ namespace DaggerfallWorkshop.Game
 
         private string GetNPCQuestGreeting()
         {
-            Guild guild = GameManager.Instance.GuildManager.GetGuild((int)GameManager.Instance.PlayerEnterExit.FactionID);
+            IGuild guild = GameManager.Instance.GuildManager.GetGuild((int)GameManager.Instance.PlayerEnterExit.FactionID);
 
             if (currentNPCType == NPCType.Static)
             {
@@ -876,8 +876,8 @@ namespace DaggerfallWorkshop.Game
             PersistentFactionData persistentFactionData = GameManager.Instance.PlayerEntity.FactionData;
 
             int greetingIndex = 8;
-            List<Guild> guildMemberships = GameManager.Instance.GuildManager.GetMemberships();
-            foreach (Guild guild in guildMemberships)
+            List<IGuild> guildMemberships = GameManager.Instance.GuildManager.GetMemberships();
+            foreach (IGuild guild in guildMemberships)
             {
                 FactionFile.FactionData guildFactionData;
                 persistentFactionData.GetFactionData(guild.GetFactionId(), out guildFactionData);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -357,7 +357,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         void ShowAffiliationsDialog()
         {
             List<TextFile.Token> tokens = new List<TextFile.Token>();
-            List<Guild> guildMemberships = GameManager.Instance.GuildManager.GetMemberships();
+            List<IGuild> guildMemberships = GameManager.Instance.GuildManager.GetMemberships();
 
             if (guildMemberships.Count == 0)
                 DaggerfallUI.MessageBox(noAffiliationsMsgId);
@@ -377,7 +377,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 });
                 tokens.Add(TextFile.NewLineToken);
 
-                foreach (Guild guild in guildMemberships)
+                foreach (IGuild guild in guildMemberships)
                 {
                     tokens.Add(TextFile.CreateTextToken(guild.GetAffiliation()));
                     tokens.Add(tab);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -171,7 +171,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (crimeType == 4 || crimeType == 3) // Assault or murder
                 {
                     // If player is a member of the Dark Brotherhood, they may be rescued for a violent crime
-                    Guilds.Guild guild = GameManager.Instance.GuildManager.GetGuild((int)FactionFile.FactionIDs.The_Dark_Brotherhood);
+                    Guilds.IGuild guild = GameManager.Instance.GuildManager.GetGuild((int)FactionFile.FactionIDs.The_Dark_Brotherhood);
                     if (guild.IsMember())
                     {
                         if (guild.Rank >= UnityEngine.Random.Range(0, 20))
@@ -192,7 +192,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (crimeType <= 2 || crimeType == 11) // Attempted breaking and entering, trespassing, breaking and entering, pickpocketing
                 {
                     // If player is a member of the Thieves Guild, they may be rescued for a thieving crime
-                    Guilds.Guild guild = GameManager.Instance.GuildManager.GetGuild((int)FactionFile.FactionIDs.The_Thieves_Guild);
+                    Guilds.IGuild guild = GameManager.Instance.GuildManager.GetGuild((int)FactionFile.FactionIDs.The_Thieves_Guild);
                     if (guild.IsMember())
                     {
                         if (guild.Rank >= UnityEngine.Random.Range(0, 20))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -73,7 +73,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         GuildServices service;
         int buildingFactionId;  // Needed for temples & orders
 
-        Guild guild;
+        IGuild guild;
         PlayerGPS.DiscoveredBuilding buildingDiscoveryData;
         int curingCost = 0;
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -88,7 +88,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Color repairItemBackgroundColor = new Color(0.17f, 0.32f, 0.7f, 0.6f);
 
         WindowModes windowMode = WindowModes.Inventory;
-        Guild guild;
+        IGuild guild;
 
         PlayerGPS.DiscoveredBuilding buildingDiscoveryData;
         List<ItemGroups> itemTypesAccepted = storeBuysItemType[DFLocation.BuildingTypes.GeneralStore];
@@ -158,7 +158,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Constructors
 
-        public DaggerfallTradeWindow(IUserInterfaceManager uiManager, WindowModes windowMode, DaggerfallBaseWindow previous = null, Guild guild = null)
+        public DaggerfallTradeWindow(IUserInterfaceManager uiManager, WindowModes windowMode, DaggerfallBaseWindow previous = null, IGuild guild = null)
             : base(uiManager, previous)
         {
             this.windowMode = windowMode;

--- a/Assets/Scripts/Internal/DaggerfallBookshelf.cs
+++ b/Assets/Scripts/Internal/DaggerfallBookshelf.cs
@@ -44,7 +44,7 @@ namespace DaggerfallWorkshop
             PlayerGPS.DiscoveredBuilding buildingData = GameManager.Instance.PlayerEnterExit.BuildingDiscoveryData;
             int factionID = buildingData.factionID;
             Debug.Log("Bookshelf access, Faction ID = " + factionID);
-            Guild guild = GameManager.Instance.GuildManager.GetGuild(factionID);
+            IGuild guild = GameManager.Instance.GuildManager.GetGuild(factionID);
             if ((buildingData.buildingType == DFLocation.BuildingTypes.GuildHall ||
                  buildingData.buildingType == DFLocation.BuildingTypes.Temple) &&
                  !guild.CanAccessLibrary())


### PR DESCRIPTION
* **Extract IGuild interface and use it instead of Guild abstract class** - This will allow mods to be more easily created with guild implementations that deviate from default vanilla guild behaviour. Note there are still some constraints, like 9 rank based etc.

* **Allow vanilla guilds to be overridden** - by registering a new implementation extended from core or completely new implementations.

* **Move save/new event unregistering into guild classes** - This is so that GuildManager.ClearMembershipData() does not call Leave() to unregister the guild events. This is because the clear method is for clearing memberships while loading etc (happens twice) and is not for when the player is actually leaving the guild. If mods add behaviour for leaving, it should not be initiated when just saving/loading/new game etc. Now only RemoveMembership calls Leave() so this is the case. 