### PR TITLE
Boost Jumping for lycanthrope characters

### DIFF
--- a/Assets/Scripts/API/Save/CharacterRecord.cs
+++ b/Assets/Scripts/API/Save/CharacterRecord.cs
@@ -152,6 +152,7 @@ namespace DaggerfallConnect.Save
                 parsedData.skills.SetPermanentSkillValue(DFCareer.Skills.CriticalStrike, (short)(parsedData.skills.GetPermanentSkillValue(DFCareer.Skills.CriticalStrike) - 30));
                 parsedData.skills.SetPermanentSkillValue(DFCareer.Skills.Climbing, (short)(parsedData.skills.GetPermanentSkillValue(DFCareer.Skills.Climbing) - 30));
                 parsedData.skills.SetPermanentSkillValue(DFCareer.Skills.HandToHand, (short)(parsedData.skills.GetPermanentSkillValue(DFCareer.Skills.HandToHand) - 30));
+                parsedData.skills.SetPermanentSkillValue(DFCareer.Skills.Jumping, (short)(parsedData.skills.GetPermanentSkillValue(DFCareer.Skills.Jumping) - 30));
             }
 
             return liveRace;

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/LycanthropyEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/LycanthropyEffect.cs
@@ -531,6 +531,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             SetSkillMod(DFCareer.Skills.CriticalStrike, skillModAmount);
             SetSkillMod(DFCareer.Skills.Climbing, skillModAmount);
             SetSkillMod(DFCareer.Skills.HandToHand, skillModAmount);
+            SetSkillMod(DFCareer.Skills.Jumping, skillModAmount);
         }
 
         void InitMoveSoundTimer(float minTime = 4, float maxTime = 20)


### PR DESCRIPTION
Add the missing bonus to Jumping skill for werewolf or wereboar characters. I also fixed the UESP page in the meantime, which lacked this information (https://en.uesp.net/wiki/Daggerfall:Lycanthropy#Advantages).