### PR TITLE
Support live changes to mod settings

### DIFF
--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Reflection;
 using DaggerfallWorkshop.Utility;
 using FullSerializer;
+using DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings;
 
 namespace DaggerfallWorkshop.Game.Utility.ModSupport
 {
@@ -142,6 +143,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// If this mod has settings, they can be retrieved with <see cref="GetSettings()"/>.
         /// </summary>
         public bool HasSettings { get; private set; }
+
+        /// <summary>
+        /// If not null, this callback is invoked when settings are changed or when raised with <see cref="LoadSettings()"/>.
+        /// </summary>
+        public Action<ModSettings.ModSettings, ModSettingsChange> LoadSettingsCallback { internal get; set; }
 
         /// <summary>
         /// Cached list of all asset names (not the relative paths).
@@ -472,10 +478,23 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         /// <summary>
         /// Imports settings for this mod and provides a sanitized read-only access.
+        /// Use <see cref="LoadSettings()"/> if you want to support live changes.
         /// </summary>
         public ModSettings.ModSettings GetSettings()
         {
             return new ModSettings.ModSettings(this);
+        }
+
+        /// <summary>
+        /// Loads mod settings using <see cref="LoadSettingsCallback"/> with an event where all settings are considered changed.
+        /// Use <see cref="GetSettings"/> if you don't want to support live changes.
+        /// </summary>
+        public void LoadSettings()
+        {
+            if (LoadSettingsCallback == null)
+                throw new InvalidOperationException("LoadSettingsCallback is not set.");
+
+            LoadSettingsCallback(GetSettings(), new ModSettingsChange());
         }
 
         /// <summary>

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettings.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettings.cs
@@ -45,6 +45,17 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             data.LoadLocalValues();
         }
 
+        /// <summary>
+        /// Makes an instance of mod settings from existing settings data.
+        /// </summary>
+        /// <param name="mod">Target mod.</param>
+        /// <param name="data">Settings data for target mod.</param>
+        internal ModSettings(Mod mod, ModSettingsData data)
+        {
+            this.mod = mod;
+            this.data = data;
+        }
+
         #endregion
 
         #region Public Methods

--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsTypes.cs
@@ -206,6 +206,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         /// </summary>
         public abstract void OnSaveWindow(BaseScreenComponent control);
 
+        /// <summary>
+        /// Save value from a control and checks if value has changed.
+        /// </summary>
+        public abstract void OnSaveWindow(BaseScreenComponent control, out bool hasChanged);
+
 #if UNITY_EDITOR
         /// <summary>
         /// Draws a control on editor window. Returns number of lines.
@@ -303,6 +308,15 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             return Value;
         }
 
+        public sealed override void OnSaveWindow(BaseScreenComponent control, out bool hasChanged)
+        {
+            T previousValue = Value;
+            OnSaveWindow(control);
+            hasChanged = !IsValueEqual(previousValue);
+        }
+
+        protected abstract bool IsValueEqual(T value);
+
         protected virtual string Serialize()
         {
             return Convert.ToString(Value, CultureInfo.InvariantCulture);
@@ -340,6 +354,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             return 1;
         }
 #endif
+
+        protected override bool IsValueEqual(bool value)
+        {
+            return Value == value;
+        }
 
         protected override void Deserialize(string textValue)
         {
@@ -411,6 +430,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         }
 #endif
 
+        protected override bool IsValueEqual(int value)
+        {
+            return Value == value;
+        }
+
         protected override void Deserialize(string textValue)
         {
             int value;
@@ -458,6 +482,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             return 2;
         }
 #endif
+
+        protected override bool IsValueEqual(int value)
+        {
+            return Value == value;
+        }
 
         protected override void Deserialize(string textValue)
         {
@@ -507,6 +536,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         }
 #endif
 
+        protected override bool IsValueEqual(float value)
+        {
+            return Value == value;
+        }
+
         protected override void Deserialize(string textValue)
         {
             float value;
@@ -547,6 +581,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             return 1;
         }
 #endif
+
+        protected override bool IsValueEqual(Tuple<int, int> value)
+        {
+            return Value.First == value.First && Value.Second == value.Second;
+        }
 
         protected override string Serialize()
         {
@@ -594,6 +633,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         }
 #endif
 
+        protected override bool IsValueEqual(Tuple<float, float> value)
+        {
+            return Value.First == value.First && Value.Second == value.Second;
+        }
+
         protected override string Serialize()
         {
             return Join(Value.First, Value.Second);
@@ -638,6 +682,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         }
 #endif
 
+        protected override bool IsValueEqual(string value)
+        {
+            return Value.Equals(value, StringComparison.Ordinal);
+        }
+
         protected override void Deserialize(string textValue)
         {
             Value = textValue;
@@ -673,6 +722,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             return 1;
         }
 #endif
+
+        protected override bool IsValueEqual(Color32 value)
+        {
+            return Value.r == value.r || Value.g == value.g || Value.b == value.b || Value.a == value.a;
+        }
 
         protected override string Serialize()
         {
@@ -789,6 +843,44 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         }
 
 #endif
+    }
+
+    /// <summary>
+    /// Results of a mod settings change event.
+    /// </summary>
+    public struct ModSettingsChange
+    {
+        readonly HashSet<string> changedSettings;
+
+        /// <summary>
+        /// Makes an holder for a mod settings change event.
+        /// </summary>
+        /// <param name="changedSettings">A set containing names of changed settings or null to define all settings as changed.</param>
+        internal ModSettingsChange(HashSet<string> changedSettings = null)
+        {
+            this.changedSettings = changedSettings;
+        }
+
+        /// <summary>
+        /// Checks if any mod setting value in a section has changed during current change event.
+        /// </summary>
+        /// <param name="section">The name of the section.</param>
+        /// <returns>True if section has changed.</returns>
+        public bool HasChanged(string section)
+        {
+            return changedSettings == null || changedSettings.Contains(section);
+        }
+
+        /// <summary>
+        /// Checks if a mod setting value has changed during current change event.
+        /// </summary>
+        /// <param name="section">The name of the section.</param>
+        /// <param name="key">The name of the key.</param>
+        /// <returns>True if value has changed.</returns>
+        public bool HasChanged(string section, string key)
+        {
+            return changedSettings == null || changedSettings.Contains(string.Format("{0}.{1}", section, key));
+        }
     }
 
     #endregion


### PR DESCRIPTION
Adds support for live changes to mod settings. Mods that whish to implement this feature need to set property `Mod.LoadSettingsCallback` when they are started.

The value is a callback that receives an instance of `ModSettings` and `ModSettingsChange`, the latter being an holder for informations on the change event. Specifically, mods can use `bool ModSettingsChange.HasChanged(string section, string key)` to retrieve if a specific setting has changed.

For the time being, this feature is provided experimentally with a console command that opens a UI window.

Here's a simple example where the callback is assigned and immediately used for first time init where all settings are "changed". From now on, this method is also called automatically when settings are changed by player in game.

```cs
public class Test : MonoBehaviour
{
    Mod mod;

    [Invoke(StateManager.StateTypes.Game)]
    public static void Init(InitParams initParams)
    {
        var test = new GameObject("Test").AddComponent<Test>();
        test.mod = initParams.Mod;
    }

    private void Awake()
    {
        mod.LoadSettingsCallback = LoadSettings;
        mod.LoadSettings();
        mod.IsReady = true;
    }

    private void LoadSettings(ModSettings settings, ModSettingsChange change)
    {
        if (change.HasChanged("Foo"))
        {
            var number = settings.GetValue<int>("Foo", "Number");
            var color = settings.GetValue<Color32>("Foo", "Color");
        }

        if (change.HasChanged("Bar", "Text"))
        {
            var text = settings.GetValue<string>("Bar", "Text");
        }
    }
}
```