### PR TITLE
Override world data for locations and dungeons

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -191,8 +191,8 @@ namespace Wenzil.Console
         {
             public static readonly string name = "dumplocblocks";
             public static readonly string error = "Failed to dump locations";
-            public static readonly string usage = "dumplocblocks [blockName.RMB]*";
-            public static readonly string description = "Dump the names of blocks for each location, or locations for given block(s), to json file";
+            public static readonly string usage = "dumplocblocks [locindex|(blockName.RMB )*]\nExamples:\ndumplocblocks\ndumplocblocks locindex\ndumplocblocks RESIAM10.RMB GEMSAM02.RMB";
+            public static readonly string description = "Dump the names of blocks for each location, location index or locations for list of given block(s), to json file";
 
             public static string Execute(params string[] args)
             {
@@ -213,6 +213,22 @@ namespace Wenzil.Console
                     string fileName = Path.Combine(Application.persistentDataPath, "LocationBlockNames.json");
                     File.WriteAllText(fileName, locJson);
                     return "Location block names json written to " + fileName;
+                }
+                else if (args.Length == 1 && args[0] == "locindex")
+                {
+                    string locIndex = "";
+                    for (int region = 0; region < mapFileReader.RegionCount; region++)
+                    {
+                        DFRegion dfRegion = mapFileReader.GetRegion(region);
+                        for (int location = 0; location < dfRegion.LocationCount; location++)
+                        {
+                            DFLocation dfLoc = mapFileReader.GetLocation(region, location);
+                            locIndex += string.Format("{0}, {1}: {2}\n", region, dfLoc.LocationIndex, dfLoc.Name);
+                        }
+                    }
+                    string fileName = Path.Combine(Application.persistentDataPath, "LocationIndex.txt");
+                    File.WriteAllText(fileName, locIndex);
+                    return "Location index written to " + fileName;
                 }
                 else
                 {

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -147,14 +147,22 @@ namespace Wenzil.Console
         {
             public static readonly string name = "dumpblock";
             public static readonly string error = "Failed to dump block";
-            public static readonly string usage = "dumpblock blockName";
-            public static readonly string description = "Dump a block to json file";
+            public static readonly string usage = "dumpblock [blockName]";
+            public static readonly string description = "Dump a block to json file, or index if no block name specified";
 
             public static string Execute(params string[] args)
             {
                 if (args.Length == 0)
                 {
-                    return HelpCommand.Execute(DumpBlock.name);
+                    string blockIndex = "";
+                    BsaFile blockBsa = DaggerfallUnity.Instance.ContentReader.BlockFileReader.BsaFile;
+                    for (int b = 0; b < blockBsa.Count; b++)
+                    {
+                        blockIndex += string.Format("{0}: {1}\n", b, blockBsa.GetRecordName(b));
+                    }
+                    string fileName = Path.Combine(Application.persistentDataPath, "BlockIndex.txt");
+                    File.WriteAllText(fileName, blockIndex);
+                    return "Block index data written to " + Path.Combine(Application.persistentDataPath, fileName);
                 }
                 else
                 {
@@ -170,7 +178,7 @@ namespace Wenzil.Console
                     if (!string.IsNullOrEmpty(blockData.Name))
                     {
                         string blockJson = SaveLoadManager.Serialize(blockData.GetType(), blockData);
-                        string fileName = WorldDataReplacement.GetBlockReplacementFilename(blockData.Name);
+                        string fileName = WorldDataReplacement.GetDFBlockReplacementFilename(blockData.Name);
                         File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), blockJson);
                         return "Block data json written to " + Path.Combine(Application.persistentDataPath, fileName);
                     }

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -134,7 +134,7 @@ namespace Wenzil.Console
                         DFLocation location = playerGPS.CurrentLocation;
 
                         string locJson = SaveLoadManager.Serialize(location.GetType(), location);
-                        string fileName = WorldDataReplacement.GetLocationReplacementFilename(location.RegionIndex, location.LocationIndex);
+                        string fileName = WorldDataReplacement.GetDFLocationReplacementFilename(location.RegionIndex, location.LocationIndex);
                         File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), locJson);
                         return "Location data json written to " + Path.Combine(Application.persistentDataPath, fileName);
                     }

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -98,6 +98,7 @@ namespace Wenzil.Console
             ConsoleCommandsDatabase.RegisterCommand(DiseasePlayer.name, DiseasePlayer.usage, DiseasePlayer.description, DiseasePlayer.Execute);
             ConsoleCommandsDatabase.RegisterCommand(PoisonPlayer.name, PoisonPlayer.usage, PoisonPlayer.description, PoisonPlayer.Execute);
 
+            ConsoleCommandsDatabase.RegisterCommand(DumpRegion.name, DumpRegion.description, DumpRegion.usage, DumpRegion.Execute);
             ConsoleCommandsDatabase.RegisterCommand(DumpLocation.name, DumpLocation.description, DumpLocation.usage, DumpLocation.Execute);
             ConsoleCommandsDatabase.RegisterCommand(DumpBlock.name, DumpBlock.description, DumpBlock.usage, DumpBlock.Execute);
             ConsoleCommandsDatabase.RegisterCommand(DumpLocBlocks.name, DumpLocBlocks.description, DumpLocBlocks.usage, DumpLocBlocks.Execute);
@@ -111,6 +112,36 @@ namespace Wenzil.Console
 
             ConsoleCommandsDatabase.RegisterCommand(SummonDaedra.name, SummonDaedra.description, SummonDaedra.usage, SummonDaedra.Execute);
 
+        }
+
+        private static class DumpRegion
+        {
+            public static readonly string name = "dumpregion";
+            public static readonly string error = "Player not in a region, unable to dump";
+            public static readonly string usage = "dumpregion";
+            public static readonly string description = "Dump the current region (from MAPS.BSA) that the player is currently in to json file";
+
+            public static string Execute(params string[] args)
+            {
+                if (args.Length != 0)
+                {
+                    return HelpCommand.Execute(DumpRegion.name);
+                }
+                else
+                {
+                    PlayerGPS playerGPS = GameManager.Instance.PlayerGPS;
+                    if (playerGPS)
+                    {
+                        DFRegion region = playerGPS.CurrentRegion;
+
+                        string regionJson = SaveLoadManager.Serialize(region.GetType(), region);
+                        string fileName = WorldDataReplacement.GetDFRegionReplacementFilename(playerGPS.CurrentRegionIndex);
+                        File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), regionJson);
+                        return "Region data json written to " + Path.Combine(Application.persistentDataPath, fileName);
+                    }
+                    return error;
+                }
+            }
         }
 
         private static class DumpLocation

--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -211,12 +211,7 @@ namespace DaggerfallConnect.Arena2
         /// <returns>Name of the block.</returns>
         public string GetBlockName(int block)
         {
-            // Check for any new blocks added first
-            string replacementBlockName = WorldDataReplacement.GetNewDFBlockName(block);
-            if (replacementBlockName != null)
-                return replacementBlockName;
-
-            return bsaFile.GetRecordName(block);
+            return WorldDataReplacement.GetNewDFBlockName(block) ?? bsaFile.GetRecordName(block);
         }
 
         /// <summary>

--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -513,26 +513,26 @@ namespace DaggerfallConnect.Arena2
         /// <param name="block">Destination block index.</param>
         private void ReadBlock(BinaryReader reader, int block)
         {
-            // Step through file based on type
-            reader.BaseStream.Position = 0;
-            if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rmb)
+            // Check for replacement block data and use it if found
+            DFBlock dfBlock;
+            if (WorldDataReplacement.GetDFBlockReplacementData(block, GetBlockName(block), out dfBlock))
             {
-                // Read RMB data
-                ReadRmbFldHeader(reader, block);
-                ReadRmbBlockData(reader, block);
-                ReadRmbMisc3dObjects(reader, block);
-                ReadRmbMiscFlatObjectRecords(reader, block);
+                UnityEngine.Debug.LogFormat("Found DFBlock override: {0} - {1}", block, GetBlockName(block));
+                blocks[block].DFBlock = dfBlock;
             }
-            else if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rdb)
+            else
             {
-                // Check for replacement dungeon block data and use it if found
-                DFBlock rdbBlock;
-                if (WorldDataReplacement.GetRDBBlockReplacementData(block, GetBlockName(block), out rdbBlock))
+                // Step through file based on type
+                reader.BaseStream.Position = 0;
+                if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rmb)
                 {
-                    UnityEngine.Debug.LogFormat("Found RDB block override: {0} - {1}", block, GetBlockName(block));
-                    blocks[block].DFBlock = rdbBlock;
+                    // Read RMB data
+                    ReadRmbFldHeader(reader, block);
+                    ReadRmbBlockData(reader, block);
+                    ReadRmbMisc3dObjects(reader, block);
+                    ReadRmbMiscFlatObjectRecords(reader, block);
                 }
-                else
+                else if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rdb)
                 {
                     // Read RDB data
                     ReadRdbHeader(reader, block);
@@ -543,16 +543,16 @@ namespace DaggerfallConnect.Arena2
                     ReadRdbObjectSectionRootList(reader, block);
                     ReadRdbObjectLists(reader, block);
                 }
-            }
-            else if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rdi)
-            {
-                // Read RDI data
-                ReadRdiRecord(reader, block);
-            }
-            else
-            {
-                DiscardBlock(block);
-                return;
+                else if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rdi)
+                {
+                    // Read RDI data
+                    ReadRdiRecord(reader, block);
+                }
+                else
+                {
+                    DiscardBlock(block);
+                    return;
+                }
             }
         }
 

--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -525,14 +525,24 @@ namespace DaggerfallConnect.Arena2
             }
             else if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rdb)
             {
-                // Read RDB data
-                ReadRdbHeader(reader, block);
-                ReadRdbModelReferenceList(reader, block);
-                ReadRdbModelDataList(reader, block);
-                ReadRdbObjectSectionHeader(reader, block);
-                ReadRdbUnknownLinkedList(reader, block);
-                ReadRdbObjectSectionRootList(reader, block);
-                ReadRdbObjectLists(reader, block);
+                // Check for replacement dungeon block data and use it if found
+                DFBlock rdbBlock;
+                if (WorldDataReplacement.GetRDBBlockReplacementData(block, GetBlockName(block), out rdbBlock))
+                {
+                    UnityEngine.Debug.LogFormat("Found RDB block override: {0} - {1}", block, GetBlockName(block));
+                    blocks[block].DFBlock = rdbBlock;
+                }
+                else
+                {
+                    // Read RDB data
+                    ReadRdbHeader(reader, block);
+                    ReadRdbModelReferenceList(reader, block);
+                    ReadRdbModelDataList(reader, block);
+                    ReadRdbObjectSectionHeader(reader, block);
+                    ReadRdbUnknownLinkedList(reader, block);
+                    ReadRdbObjectSectionRootList(reader, block);
+                    ReadRdbObjectLists(reader, block);
+                }
             }
             else if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rdi)
             {

--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -211,7 +211,11 @@ namespace DaggerfallConnect.Arena2
         /// <returns>Name of the block.</returns>
         public string GetBlockName(int block)
         {
-            // TODO: check added blocks first
+            // Check for any new blocks added first
+            string replacementBlockName = WorldDataReplacement.GetNewDFBlockName(block);
+            if (replacementBlockName != null)
+                return replacementBlockName;
+
             return bsaFile.GetRecordName(block);
         }
 
@@ -269,6 +273,11 @@ namespace DaggerfallConnect.Arena2
             // Return known value if already indexed
             if (blockNameLookup.ContainsKey(name))
                 return blockNameLookup[name];
+
+            // Check for any new blocks added next
+            int blockIndex = WorldDataReplacement.GetNewDFBlockIndex(name);
+            if (blockIndex != -1)
+                return blockIndex;
 
             // Otherwise find and store index by searching for name
             for (int i = 0; i < Count; i++)
@@ -379,7 +388,11 @@ namespace DaggerfallConnect.Arena2
             // Check for replacement block data and use it if found
             DFBlock dfBlock;
             if (WorldDataReplacement.GetDFBlockReplacementData(block, GetBlockName(block), out dfBlock))
-                blocks[block].DFBlock = dfBlock;
+            {
+                if (blocks.Length > block)
+                    blocks[block].DFBlock = dfBlock;
+                return dfBlock;
+            }
             else
             // Load the record
             if (!LoadBlock(block))

--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -10,6 +10,7 @@
 //
 
 #region Using Statements
+using DaggerfallWorkshop.Utility.AssetInjection;
 using FullSerializer;
 using System;
 #endregion
@@ -777,6 +778,7 @@ namespace DaggerfallConnect
         /// <summary>
         /// An RDB block has this general structure.
         /// </summary>
+        [fsObject(Processor = typeof(RdbBlockDescProcessor))]
         public struct RdbBlockDesc
         {
             /// <summary>Position in stream to find this data.</summary>
@@ -900,10 +902,11 @@ namespace DaggerfallConnect
         /// <summary>
         /// A single RDB object has this structure.
         /// </summary>
+        [fsObject(Processor = typeof(RdbObjectProcessor))]
         public struct RdbObject
         {
             /// <summary>Offset of this object from start of RDB record. Not required unless you are extending the block reader.</summary>
-            internal Int32 Position;
+            public Int32 Position;
 
             /// <summary>Offset to next object from start of RDB record. Not required unless you are extending the block reader.</summary>
             internal Int32 Next;

--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -800,7 +800,7 @@ namespace DaggerfallConnect
             public RdbObjectRoot[] ObjectRootList;
 
             /// <summary>List of unknown objects from RdbObjectHeader.</summary>
-            public RdbUnknownObject[] UnknownObjectList;
+            internal RdbUnknownObject[] UnknownObjectList;
         }
 
         /// <summary>

--- a/Assets/Scripts/API/DFLocation.cs
+++ b/Assets/Scripts/API/DFLocation.cs
@@ -80,6 +80,22 @@ namespace DaggerfallConnect
 
         #endregion
 
+        #region Methods
+
+        /// <summary>Some 1x1 locations (e.g. Privateer's Hold exterior) are positioned differently
+        /// Seems to be 1x1 blocks using CUST prefix, but possibly more research needed</summary>
+        public bool HasCustomLocationPosition()
+        {
+            const string custBlockPrefix = "CUST";
+            if (Exterior.ExteriorData.Width == 1 && Exterior.ExteriorData.Height == 1)
+            {
+                return Exterior.ExteriorData.BlockNames[0].StartsWith(custBlockPrefix);
+            }
+            return false;
+        }
+
+        #endregion
+
         #region Building Enumerations
 
         /// <summary>

--- a/Assets/Scripts/API/DFLocation.cs
+++ b/Assets/Scripts/API/DFLocation.cs
@@ -446,8 +446,11 @@ namespace DaggerfallConnect
             /// <summary>Unknown.</summary>
             internal UInt32 Unknown1;
 
-            /// <summary>Location index. (from data, should match top level index)</summary>
-            public UInt32 LocationIndex;
+            /// <summary>
+            /// Unknown value for LocationDungeon structure, used by SongManager to select songs.
+            /// Location index for Exterior structure. (should match top level index)
+            /// </summary>
+            public UInt32 Unknown2;
 
             /// <summary>Always 1.</summary>
             internal UInt16 AlwaysOne2;

--- a/Assets/Scripts/API/DFLocation.cs
+++ b/Assets/Scripts/API/DFLocation.cs
@@ -367,10 +367,10 @@ namespace DaggerfallConnect
         public struct LocationRecordElement
         {
             /// <summary>Number of doors in this location.</summary>
-            public UInt32 DoorCount;
+            internal UInt32 DoorCount;
 
             /// <summary>Door data array with DoorCount members.</summary>
-            public LocationDoorElement[] Doors;
+            internal LocationDoorElement[] Doors;
 
             /// <summary>Header for location data.</summary>
             public LocationRecordElementHeader Header;
@@ -404,19 +404,19 @@ namespace DaggerfallConnect
         public struct LocationRecordElementHeader
         {
             /// <summary>Always 1.</summary>
-            public UInt32 AlwaysOne1;
+            internal UInt32 AlwaysOne1;
 
             /// <summary>Always 0.</summary>
-            public UInt16 NullValue1;
+            internal UInt16 NullValue1;
 
             /// <summary>Always 0.</summary>
-            public Byte NullValue2;
+            internal Byte NullValue2;
 
             /// <summary>X coordinate for location in world units.</summary>
             public Int32 X;
 
             /// <summary>Always 0.</summary>
-            public UInt32 NullValue3;
+            internal UInt32 NullValue3;
 
             /// <summary>X coordinate for location in world units.</summary>
             public Int32 Y;
@@ -425,22 +425,22 @@ namespace DaggerfallConnect
             public UInt16 IsExterior;
 
             /// <summary>Always 0.</summary>
-            public UInt16 NullValue4;
+            internal UInt16 NullValue4;
 
             /// <summary>Unknown.</summary>
-            public UInt32 Unknown1;
+            internal UInt32 Unknown1;
 
-            /// <summary>Unknown.</summary>
-            public UInt32 Unknown2;
+            /// <summary>Location index. (from data, should match top level index)</summary>
+            public UInt32 LocationIndex;
 
             /// <summary>Always 1.</summary>
-            public UInt16 AlwaysOne2;
+            internal UInt16 AlwaysOne2;
 
             /// <summary>LocationID used by the quest subsystem.</summary>
             public UInt16 LocationId;
 
             /// <summary>Always 0.</summary>
-            public UInt32 NullValue5;
+            internal UInt32 NullValue5;
 
             /// <summary>Set to 0x0000 for exterior data, or 0x0001 for interior data.</summary>
             public UInt16 IsInterior;
@@ -449,13 +449,13 @@ namespace DaggerfallConnect
             public UInt32 ExteriorLocationId;
 
             /// <summary>Array of 26 0-value bytes.</summary>
-            public Byte[] NullValue6;
+            internal Byte[] NullValue6;
 
             /// <summary>Name of location used when entering it.</summary>
             public String LocationName;
 
             /// <summary>Array of 9 unknown bytes.</summary>
-            public Byte[] Unknown3;
+            internal Byte[] Unknown3;
         }
 
         #endregion
@@ -474,7 +474,7 @@ namespace DaggerfallConnect
             public UInt16 BuildingCount;
 
             /// <summary>Unknown.</summary>
-            public Byte[] Unknown1;
+            internal Byte[] Unknown1;
 
             /// <summary>Data associated with each building.</summary>
             public BuildingData[] Buildings;
@@ -492,19 +492,19 @@ namespace DaggerfallConnect
             public UInt16 NameSeed;
 
             /// <summary>For taverns this is the time in game minutes when room rental will end.</summary>
-            public UInt32 ServiceTimeLimit;
+            internal UInt32 ServiceTimeLimit;
 
             /// <summary>Unknown. Set to 1 after renting a tavern room</summary>
-            public UInt16 Unknown;
+            internal UInt16 Unknown;
 
             /// <summary>Unknown.</summary>
-            public UInt16 Unknown2;
+            internal UInt16 Unknown2;
 
             /// <summary>Unknown.</summary>
-            public UInt32 Unknown3;
+            internal UInt32 Unknown3;
 
             /// <summary>Unknown.</summary>
-            public UInt32 Unknown4;
+            internal UInt32 Unknown4;
 
             /// <summary>FactionId associated with building, or 0 if no faction.</summary>
             public UInt16 FactionId;
@@ -534,8 +534,8 @@ namespace DaggerfallConnect
             /// <summary>This (value and 0x000fffff) matches (MapTable.MapId and 0x000fffff).</summary>
             public Int32 MapId;
 
-            /// <summary>Location ID.</summary>
-            public UInt32 LocationId;
+            /// <summary>Location ID. (always seems to be 0)</summary>
+            internal UInt32 LocationId;
 
             /// <summary>Width of exterior map grid from 1-8.</summary>
             public Byte Width;
@@ -544,46 +544,46 @@ namespace DaggerfallConnect
             public Byte Height;
 
             /// <summary>Unknown.</summary>
-            public Byte[] Unknown2;
+            internal Byte[] Unknown2;
 
             /// <summary>Unknown.</summary>
-            public Byte Unknown3;
+            internal Byte Unknown3;
 
             /// <summary>ASCII value for first letter in .RMB file name.</summary>
-            public Byte Letter1ForRMBName;
+            internal Byte Letter1ForRMBName;
 
             /// <summary>If non-zero, ships can be purchased at banks here. Also has an unknown use.</summary>
             public Byte PortTownAndUnknown;
 
             /// <summary>Only first Width*Height elements will have any meaning.</summary>
-            public Byte[] BlockIndex;
+            internal Byte[] BlockIndex;
 
             /// <summary>Only first Width*Height elements will have any meaning.</summary>
-            public Byte[] BlockNumber;
+            internal Byte[] BlockNumber;
 
             /// <summary>Only first Width*Height elements will have any meaning.</summary>
-            public Byte[] BlockCharacter;
+            internal Byte[] BlockCharacter;
 
             /// <summary>Resolved block names.</summary>
             public string[] BlockNames;
 
             /// <summary>Unknown.</summary>
-            public Byte[] Unknown4;
+            internal Byte[] Unknown4;
 
             /// <summary>Always 0.</summary>
-            public UInt64 NullValue1;
+            internal UInt64 NullValue1;
 
             /// <summary>Always 0.</summary>
-            public Byte NullValue2;
+            internal Byte NullValue2;
 
             /// <summary>Unknown.</summary>
-            public UInt32[] Unknown5;
+            internal UInt32[] Unknown5;
 
             /// <summary>Always 0.</summary>
-            public Byte[] NullValue3;
+            internal Byte[] NullValue3;
 
             /// <summary>Unknown.</summary>
-            public UInt32 Unknown6;
+            internal UInt32 Unknown6;
         }
 
         #endregion
@@ -611,19 +611,19 @@ namespace DaggerfallConnect
         public struct DungeonHeader
         {
             /// <summary>Always 0.</summary>
-            public UInt16 NullValue1;
+            internal UInt16 NullValue1;
 
             /// <summary>Unknown.</summary>
-            public UInt32 Unknown1;
+            internal UInt32 Unknown1;
 
             /// <summary>Unknown.</summary>
-            public UInt32 Unknown2;
+            internal UInt32 Unknown2;
 
             /// <summary>Count of DungeonBlock elements.</summary>
             public UInt16 BlockCount;
 
             /// <summary>Unknown.</summary>
-            public Byte[] Unknown3;
+            internal Byte[] Unknown3;
         }
 
         /// <summary>
@@ -638,16 +638,16 @@ namespace DaggerfallConnect
             public SByte Z;
 
             /// <summary>Bitfield containing BlockNumber, start bit, and BlockIndex.</summary>
-            public UInt16 BlockNumberStartIndexBitfield;
+            internal UInt16 BlockNumberStartIndexBitfield;
 
             /// <summary>BlockNumber read from bitfield.</summary>
-            public UInt16 BlockNumber;
+            internal UInt16 BlockNumber;
 
             /// <summary>IsStartingBlock read from bitfield.</summary>
             public Boolean IsStartingBlock;
 
             /// <summary>BlockIndex read from bitfield.</summary>
-            public Byte BlockIndex;
+            internal Byte BlockIndex;
 
             /// <summary>Name of RDB block.</summary>
             public String BlockName;

--- a/Assets/Scripts/API/DFLocation.cs
+++ b/Assets/Scripts/API/DFLocation.cs
@@ -553,8 +553,8 @@ namespace DaggerfallConnect
             /// <summary>This (value and 0x000fffff) matches (MapTable.MapId and 0x000fffff).</summary>
             public Int32 MapId;
 
-            /// <summary>Location ID. (always seems to be 0)</summary>
-            internal UInt32 LocationId;
+            /// <summary>Location ID.</summary>
+            public UInt32 LocationId;
 
             /// <summary>Width of exterior map grid from 1-8.</summary>
             public Byte Width;

--- a/Assets/Scripts/API/DFRegion.cs
+++ b/Assets/Scripts/API/DFRegion.cs
@@ -244,7 +244,7 @@ namespace DaggerfallConnect
             /// <summary>A key for the contents of the location.</summary>
             public UInt32 Key;
 
-            /// <summary>The LocationId of the location for added locations. (not read from classic data)</summary>
+            /// <summary>The LocationId of the location for any added locations. (can't be read from classic data by ReadLocationIdFast)</summary>
             internal UInt16 LocationId;
         }
 

--- a/Assets/Scripts/API/DFRegion.cs
+++ b/Assets/Scripts/API/DFRegion.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2019 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -243,6 +243,9 @@ namespace DaggerfallConnect
 
             /// <summary>A key for the contents of the location.</summary>
             public UInt32 Key;
+
+            /// <summary>The LocationId of the location for added locations. (not read from classic data)</summary>
+            internal UInt16 LocationId;
         }
 
         #endregion

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -1017,7 +1017,7 @@ namespace DaggerfallConnect.Arena2
 
             // Position reader at location record by reading offset and adding to end of offset table
             reader.BaseStream.Position = location * 4;
-            reader.BaseStream.Position = (locationCount * 4) + reader.ReadUInt32(); // TODO remove MapsFileLocationCount, read from file
+            reader.BaseStream.Position = (locationCount * 4) + reader.ReadUInt32();
 
             // Skip doors (+6 bytes per door)
             UInt32 doorCount = reader.ReadUInt32();

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -883,37 +883,37 @@ namespace DaggerfallConnect.Arena2
         private bool ReadLocation(int region, int location, ref DFLocation dfLocation)
         {
             // Check for replacement location data and use it if found
-            if (!WorldDataReplacement.GetDFLocationReplacementData(region, location, out dfLocation))
+            if (WorldDataReplacement.GetDFLocationReplacementData(region, location, out dfLocation))
+                return true;
+
+            try
             {
-                try
-                {
-                    // Store parent region name
-                    dfLocation.RegionName = RegionNames[region];
+                // Store parent region name
+                dfLocation.RegionName = RegionNames[region];
 
-                    // Read MapPItem for this location
-                    BinaryReader reader = regions[region].MapPItem.GetReader();
-                    ReadMapPItem(ref reader, region, location, ref dfLocation);
+                // Read MapPItem for this location
+                BinaryReader reader = regions[region].MapPItem.GetReader();
+                ReadMapPItem(ref reader, region, location, ref dfLocation);
 
-                    // Read MapDItem for this location
-                    reader = regions[region].MapDItem.GetReader();
-                    ReadMapDItem(ref reader, region, ref dfLocation);
+                // Read MapDItem for this location
+                reader = regions[region].MapDItem.GetReader();
+                ReadMapDItem(ref reader, region, ref dfLocation);
 
-                    // Copy RegionMapTable data to this location
-                    dfLocation.MapTableData = regions[region].DFRegion.MapTable[location];
+                // Copy RegionMapTable data to this location
+                dfLocation.MapTableData = regions[region].DFRegion.MapTable[location];
 
-                    // Read climate and politic data
-                    ReadClimatePoliticData(ref dfLocation);
+                // Read climate and politic data
+                ReadClimatePoliticData(ref dfLocation);
 
-                    // Set loaded flag
-                    dfLocation.Loaded = true;
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine(e.Message);
-                    return false;
-                }
+                // Set loaded flag
+                dfLocation.Loaded = true;
+                return true;
             }
-            return true;
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return false;
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -14,6 +14,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using DaggerfallConnect.Utility;
+using DaggerfallWorkshop.Utility.AssetInjection;
 #endregion
 
 namespace DaggerfallConnect.Arena2
@@ -878,34 +879,37 @@ namespace DaggerfallConnect.Arena2
         /// <returns>True if successful, otherwise false.</returns>
         private bool ReadLocation(int region, int location, ref DFLocation dfLocation)
         {
-            try
+            // Check for replacement location data and use it if found
+            if (!WorldDataReplacement.GetDFLocationReplacementData(region, location, out dfLocation))
             {
-                // Store parent region name
-                dfLocation.RegionName = RegionNames[region];
+                try
+                {
+                    // Store parent region name
+                    dfLocation.RegionName = RegionNames[region];
 
-                // Read MapPItem for this location
-                BinaryReader reader = regions[region].MapPItem.GetReader();
-                ReadMapPItem(ref reader, region, location, ref dfLocation);
+                    // Read MapPItem for this location
+                    BinaryReader reader = regions[region].MapPItem.GetReader();
+                    ReadMapPItem(ref reader, region, location, ref dfLocation);
 
-                // Read MapDItem for this location
-                reader = regions[region].MapDItem.GetReader();
-                ReadMapDItem(ref reader, region, ref dfLocation);
+                    // Read MapDItem for this location
+                    reader = regions[region].MapDItem.GetReader();
+                    ReadMapDItem(ref reader, region, ref dfLocation);
 
-                // Copy RegionMapTable data to this location
-                dfLocation.MapTableData = regions[region].DFRegion.MapTable[location];
+                    // Copy RegionMapTable data to this location
+                    dfLocation.MapTableData = regions[region].DFRegion.MapTable[location];
 
-                // Read climate and politic data
-                ReadClimatePoliticData(ref dfLocation);
+                    // Read climate and politic data
+                    ReadClimatePoliticData(ref dfLocation);
 
-                // Set loaded flag
-                dfLocation.Loaded = true;
+                    // Set loaded flag
+                    dfLocation.Loaded = true;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e.Message);
+                    return false;
+                }
             }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.Message);
-                return false;
-            }
-
             return true;
         }
 

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -1116,7 +1116,7 @@ namespace DaggerfallConnect.Arena2
             recordElement.Header.IsExterior = reader.ReadUInt16();
             recordElement.Header.NullValue4 = reader.ReadUInt16();
             recordElement.Header.Unknown1 = reader.ReadUInt32();
-            recordElement.Header.Unknown2 = reader.ReadUInt32();
+            recordElement.Header.LocationIndex = reader.ReadUInt32();
             recordElement.Header.AlwaysOne2 = reader.ReadUInt16();
             recordElement.Header.LocationId = reader.ReadUInt16();
             recordElement.Header.NullValue5 = reader.ReadUInt32();

--- a/Assets/Scripts/Game/ExteriorAutomap.cs
+++ b/Assets/Scripts/Game/ExteriorAutomap.cs
@@ -1385,17 +1385,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // test if it is a custom location (layouting is different there)
-            isCustomLocation = false;
-            // But some 1x1 locations (e.g. Privateer's Hold exterior) are positioned differently
-            // Seems to be 1x1 blocks using CUST prefix, but possibly more research needed
-            const int custPrefixIndex = 40;
-            if (locationWidth == 1 && locationHeight == 1)
-            {
-                if (location.Exterior.ExteriorData.BlockIndex[0] == custPrefixIndex)
-                {
-                    isCustomLocation = true;
-                }
-            }
+            isCustomLocation = location.HasCustomLocationPosition();
 
             // Create layout image (texture)
             exteriorLayoutTexture = new Texture2D(layoutWidth, layoutHeight, TextureFormat.ARGB32, false);
@@ -1405,7 +1395,7 @@ namespace DaggerfallWorkshop.Game
             foreach (var layout in exteriorLayout)
             {
                 DFBlock block = DaggerfallUnity.Instance.ContentReader.BlockFileReader.GetBlock(layout.name);
-                DaggerfallUnity.Instance.ContentReader.BlockFileReader.LoadBlock(block.Index);
+
                 // Get block automap image
                 DFBitmap dfBitmap = DaggerfallUnity.Instance.ContentReader.BlockFileReader.GetBlockAutoMap(layout.name, removeGroundFlats);
 

--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -298,7 +298,7 @@ namespace DaggerfallWorkshop.Game
                     int region = 0;
                     if (gps.HasCurrentLocation)
                     {
-                        unknown2 = (ushort)gps.CurrentLocation.Dungeon.RecordElement.Header.LocationIndex;
+                        unknown2 = (ushort)gps.CurrentLocation.Dungeon.RecordElement.Header.Unknown2;
                         region = gps.CurrentRegionIndex;
                     }
                     DFRandom.srand(unknown2 ^ ((byte)region << 8));

--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2019 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -298,7 +298,7 @@ namespace DaggerfallWorkshop.Game
                     int region = 0;
                     if (gps.HasCurrentLocation)
                     {
-                        unknown2 = (ushort)gps.CurrentLocation.Dungeon.RecordElement.Header.Unknown2;
+                        unknown2 = (ushort)gps.CurrentLocation.Dungeon.RecordElement.Header.LocationIndex;
                         region = gps.CurrentRegionIndex;
                     }
                     DFRandom.srand(unknown2 ^ ((byte)region << 8));

--- a/Assets/Scripts/Terrain/TerrainHelper.cs
+++ b/Assets/Scripts/Terrain/TerrainHelper.cs
@@ -109,18 +109,12 @@ namespace DaggerfallWorkshop
             result.X = (RMBLayout.RMBTilesPerTerrain - width * RMBLayout.RMBTilesPerBlock) / 2;
             result.Y = (RMBLayout.RMBTilesPerTerrain - height * RMBLayout.RMBTilesPerBlock) / 2;
 
-            // But some 1x1 locations (e.g. Privateer's Hold exterior) are positioned differently
-            // Seems to be 1x1 blocks using CUST prefix, but possibly more research needed
-            const int custPrefixIndex = 40;
-            if (width == 1 && height == 1)
+            // Handle custom 1x1 location position
+            if (location.HasCustomLocationPosition())
             {
-                if (location.Exterior.ExteriorData.BlockIndex[0] == custPrefixIndex)
-                {
-                    result.X = 72;
-                    result.Y = 55;
-                }
+                result.X = 72;
+                result.Y = 55;
             }
-
             return result;
         }
 

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -40,41 +40,28 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     /// </summary>
     public class WorldDataReplacement
     {
-        #region Singleton
+        #region Fields & Constants
 
-        private static readonly WorldDataReplacement instance = new WorldDataReplacement();
-
-        private WorldDataReplacement() { }
-
-        public static WorldDataReplacement Instance { get { return instance; } }
-
-        #endregion
-
-
-        #region Fields & Properties
-
-        static readonly DFRegion noReplacementRegion = new DFRegion() { LocationCount = 0 };
-        static readonly DFLocation noReplacementLocation = new DFLocation() { LocationIndex = -1 };
-        static readonly DFBlock noReplacementBlock = new DFBlock() { Index = -1 };
-
-        private static Dictionary<int, DFRegion> regions = new Dictionary<int, DFRegion>();
-
-        private static Dictionary<int, DFLocation> locations = new Dictionary<int, DFLocation>();
-
-        private static int nextBlockIndex;
-        private static Dictionary<int, string> newBlockNames = new Dictionary<int, string>();
-        private static Dictionary<string, int> newBlockIndices = new Dictionary<string, int>();
-        private static Dictionary<string, DFBlock> blocks = new Dictionary<string, DFBlock>();
-
-        const int noReplacementBT = -1;
-        static readonly BuildingReplacementData noReplacementData = new BuildingReplacementData() { BuildingType = noReplacementBT };
-
+        const int noReplacementIndicator = -1;
         const string worldData = "WorldData";
         static readonly string worldDataPath = Path.Combine(Application.streamingAssetsPath, worldData);
 
-        private Dictionary<BlockRecordId, BuildingReplacementData> buildings = new Dictionary<BlockRecordId, BuildingReplacementData>();
+        // No replacement found indicator structures.
+        static readonly DFRegion noReplacementRegion = new DFRegion() { LocationCount = 0 };    // Use 0 as it's a uint
+        static readonly DFLocation noReplacementLocation = new DFLocation() { LocationIndex = noReplacementIndicator };
+        static readonly DFBlock noReplacementBlock = new DFBlock() { Index = noReplacementIndicator };
+        static readonly BuildingReplacementData noReplacementBuilding = new BuildingReplacementData() { BuildingType = noReplacementIndicator };
 
-        private static Dictionary<BlockRecordId, BuildingReplacementData> Buildings { get { return Instance.buildings; } }
+        // Replacement world data caches.
+        private static Dictionary<int, DFRegion> regions = new Dictionary<int, DFRegion>();
+        private static Dictionary<int, DFLocation> locations = new Dictionary<int, DFLocation>();
+        private static Dictionary<string, DFBlock> blocks = new Dictionary<string, DFBlock>();
+        private static Dictionary<BlockRecordId, BuildingReplacementData> buildings = new Dictionary<BlockRecordId, BuildingReplacementData>();
+
+        // New block index/name mappings.
+        private static int nextBlockIndex;
+        private static Dictionary<int, string> newBlockNames = new Dictionary<int, string>();
+        private static Dictionary<string, int> newBlockIndices = new Dictionary<string, int>();
 
         /// <summary>
         /// Path to custom world data on disk.
@@ -103,6 +90,268 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         public static string GetBuildingReplacementFilename(string blockName, int blockIndex, int recordIndex)
         {
             return string.Format("{0}-{1}-building{2}.json", blockName, blockIndex, recordIndex);
+        }
+
+        #endregion
+
+        #region Public WorldData Replacement Methods
+
+        /// <summary>
+        /// Checks a region for added location data. (i.e. new locations)
+        /// </summary>
+        /// <param name="regionIndex">Region index</param>
+        /// <param name="locationIndex">Location index</param>
+        /// <param name="dfRegion">DFRegion data output updated with any added locations found</param>
+        /// <returns>True if added blocks had indices assigned, false otherwise</returns>
+        public static bool GetDFRegionAdditionalLocationData(int regionIndex, ref DFRegion dfRegion)
+        {
+            if (DaggerfallUnity.Settings.AssetInjection)
+            {
+                // If found, return a previously cached DFRegion
+                if (regions.ContainsKey(regionIndex))
+                {
+                    if (regions[regionIndex].LocationCount != noReplacementRegion.LocationCount)
+                    {
+                        dfRegion = regions[regionIndex];
+                        return true;
+                    }
+                    return false;
+                }
+                // Setup local lists for the region arrays and record the location count from data
+                uint dataLocationCount = dfRegion.LocationCount;
+                List<string> mapNames = new List<string>(dfRegion.MapNames);
+                List<DFRegion.RegionMapTable> mapTable = new List<DFRegion.RegionMapTable>(dfRegion.MapTable);
+                bool newBlocksAssigned = false;
+
+                // Seek from loose files
+                string locationPattern = string.Format("locationnew-*-{0}.json", regionIndex);
+                string[] fileNames = Directory.GetFiles(worldDataPath, locationPattern);
+                foreach (string fileName in fileNames)
+                {
+                    string locationReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
+                    DFLocation dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJson);
+                    newBlocksAssigned = AddLocationToRegion(regionIndex, ref dfRegion, ref mapNames, ref mapTable, dfLocation);
+                }
+                // Seek from mods
+                if (ModManager.Instance != null)
+                {
+                    string locationExtension = string.Format("-{0}.json", regionIndex);
+                    List<TextAsset> assets = ModManager.Instance.FindAssets<TextAsset>(worldData, locationExtension);
+                    if (assets != null)
+                    {
+                        foreach (TextAsset locationReplacementJsonAsset in assets)
+                        {
+                            DFLocation dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJsonAsset.text);
+                            newBlocksAssigned &= AddLocationToRegion(regionIndex, ref dfRegion, ref mapNames, ref mapTable, dfLocation);
+                        }
+                    }
+                }
+                // If found any new locations for this region,
+                if (dfRegion.LocationCount > dataLocationCount)
+                {
+                    // Update the region arrays from local lists
+                    dfRegion.MapNames = mapNames.ToArray();
+                    dfRegion.MapTable = mapTable.ToArray();
+
+#if !UNITY_EDITOR  // Cache region data for added locations if new blocks have been assigned indices (unless running in editor)
+                    if (newBlocksAssigned)
+                        regions.Add(regionIndex, dfRegion);
+#endif
+                    Debug.LogFormat("Added {0} new DFLocation's to region {1}, indexes: {2} - {3}",
+                        dfRegion.LocationCount - dataLocationCount, regionIndex, dataLocationCount, dfRegion.LocationCount-1);
+                    return true;
+                }
+
+#if !UNITY_EDITOR // Cache that there's no replacement region data, so only look for added locations once per region (unless running in editor)
+                regions.Add(regionIndex, noReplacementRegion);
+#endif
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Checks for replacement location data.
+        /// </summary>
+        /// <param name="regionIndex">Region index</param>
+        /// <param name="locationIndex">Location index</param>
+        /// <param name="dfLocation">DFLocation data output</param>
+        /// <returns>True if replacement data found, false otherwise</returns>
+        public static bool GetDFLocationReplacementData(int regionIndex, int locationIndex, out DFLocation dfLocation)
+        {
+            if (DaggerfallUnity.Settings.AssetInjection)
+            {
+                // If found, return a previously cached DFLocation
+                int locationKey = MakeLocationKey(regionIndex, locationIndex);
+                if (locations.ContainsKey(locationKey))
+                {
+                    dfLocation = locations[locationKey];
+                    return dfLocation.LocationIndex != noReplacementLocation.LocationIndex;
+                }
+
+                string fileName = GetDFLocationReplacementFilename(regionIndex, locationIndex);
+                TextAsset locationReplacementJsonAsset;
+
+                // Seek from loose files
+                if (File.Exists(Path.Combine(worldDataPath, fileName)))
+                {
+                    string locationReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
+                    dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJson);
+                }
+                // Seek from mods
+                else if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(fileName, false, out locationReplacementJsonAsset))
+                {
+                    dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJsonAsset.text);
+                }
+                else
+                {
+#if !UNITY_EDITOR // Cache that there's no replacement location data, so only look for replaced locations once (unless running in editor)
+                    locations[locationKey] = noReplacementLocation;
+#endif
+                    dfLocation = noReplacementLocation;
+                    return false;
+                }
+                // Assign any new blocks in this location a block index if they haven't already been assigned
+                if (AssignBlockIndices(dfLocation))
+                {
+#if !UNITY_EDITOR   // Cache location data for replaced locations if new blocks have been assigned indices (unless running in editor)
+                    locations[locationKey] = dfLocation;
+#endif
+                }
+                Debug.LogFormat("Found DFLocation override, region:{0}, index:{1}", regionIndex, locationIndex);
+                return true;
+            }
+            dfLocation = noReplacementLocation;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the index for a new added block
+        /// </summary>
+        /// <param name="blockName">Block name</param>
+        /// <returns>Block index, or -1 if not found</returns>
+        public static int GetNewDFBlockIndex(string blockName)
+        {
+            if (newBlockIndices.ContainsKey(blockName))
+                return newBlockIndices[blockName];
+            else
+                return -1;
+        }
+
+        /// <summary>
+        /// Gets the name for a new added block
+        /// </summary>
+        /// <param name="block">Block index</param>
+        /// <returns>Block name, or null if not found</returns>
+        public static string GetNewDFBlockName(int block)
+        {
+            if (newBlockNames.ContainsKey(block))
+                return newBlockNames[block];
+            else
+                return null;
+        }
+
+        /// <summary>
+        /// Checks for replacement block data. Only RDB block replacement is currently possible.
+        /// </summary>
+        /// Replacing entire RMB blocks is not currently possible as RmbFldGroundData contains
+        /// groundData as a 2D array and FullSerializer can't do 2D arrays out of the box.
+        /// <param name="block">Block index</param>
+        /// <param name="blockName">Block name</param>
+        /// <param name="dfBlock">DFBlock data output</param>
+        /// <returns>True if replacement data found, false otherwise</returns>
+        public static bool GetDFBlockReplacementData(int block, string blockName, out DFBlock dfBlock)
+        {
+            if (DaggerfallUnity.Settings.AssetInjection)
+            {
+                // Check the block cache
+                if (blocks.ContainsKey(blockName))
+                {
+                    dfBlock = blocks[blockName];
+                    return dfBlock.Index != noReplacementBlock.Index;
+                }
+
+                string fileName = GetDFBlockReplacementFilename(blockName);
+                TextAsset blockReplacementJsonAsset;
+
+                // Seek from loose files
+                if (File.Exists(Path.Combine(worldDataPath, fileName)))
+                {
+                    string blockReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
+                    dfBlock = (DFBlock)SaveLoadManager.Deserialize(typeof(DFBlock), blockReplacementJson);
+                }
+                // Seek from mods
+                else if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(fileName, false, out blockReplacementJsonAsset))
+                {
+                    dfBlock = (DFBlock)SaveLoadManager.Deserialize(typeof(DFBlock), blockReplacementJsonAsset.text);
+                }
+                else
+                {
+#if !UNITY_EDITOR // Cache that there's no replacement block data, so only look for replaced blocks once (unless running in editor)
+                    blocks[blockName] = noReplacementBlock;
+#endif
+                    dfBlock = noReplacementBlock;
+                    return false;
+                }
+                dfBlock.Index = block;
+#if !UNITY_EDITOR   // Cache block data for added/replaced blocks (unless running in editor)
+                blocks[blockName] = dfBlock;
+#endif
+                Debug.LogFormat("Found DFBlock override: {0} (index: {1})", blockName, block);
+                return true;
+            }
+            dfBlock = noReplacementBlock;
+            return false;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="blockName">Block name</param>
+        /// <param name="blockIndex">Block index</param>
+        /// <param name="recordIndex">Record index of building within block</param>
+        /// <param name="buildingData">BuildingReplacementData output</param>
+        /// <returns>True if replacement data found, false otherwise</returns>
+        public static bool GetBuildingReplacementData(string blockName, int blockIndex, int recordIndex, out BuildingReplacementData buildingData)
+        {
+            if (DaggerfallUnity.Settings.AssetInjection)
+            {
+                BlockRecordId blockRecordId = new BlockRecordId() { blockIndex = blockIndex, recordIndex = recordIndex };
+                if (buildings.ContainsKey(blockRecordId))
+                {
+                    buildingData = buildings[blockRecordId];
+                    return (buildingData.BuildingType != noReplacementIndicator);
+                }
+                else
+                {
+                    string fileName = GetBuildingReplacementFilename(blockName, blockIndex, recordIndex);
+
+                    // Seek from loose files
+                    if (File.Exists(Path.Combine(worldDataPath, fileName)))
+                    {
+                        string buildingReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
+                        buildingData = (BuildingReplacementData)SaveLoadManager.Deserialize(typeof(BuildingReplacementData), buildingReplacementJson);
+#if !UNITY_EDITOR       // Cache building replacement data, unless running in editor
+                        buildings.Add(blockRecordId, buildingData);
+#endif
+                        return true;
+                    }
+                    // Seek from mods
+                    TextAsset buildingReplacementJsonAsset;
+                    if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(fileName, false, out buildingReplacementJsonAsset))
+                    {
+                        buildingData = (BuildingReplacementData)SaveLoadManager.Deserialize(typeof(BuildingReplacementData), buildingReplacementJsonAsset.text);
+#if !UNITY_EDITOR       // Cache building replacement data, unless running in editor
+                        buildings.Add(blockRecordId, buildingData);
+#endif
+                        return true;
+                    }
+#if !UNITY_EDITOR   // Only look for replacement data once, unless running in editor
+                    buildings.Add(blockRecordId, noReplacementBuilding);
+#endif
+                }
+            }
+            buildingData = noReplacementBuilding;
+            return false;
         }
 
         #endregion
@@ -173,233 +422,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         #endregion
-
-        #region Public WorldData Replacement Methods
-
-        public static bool GetDFRegionAdditionalLocationData(int regionIndex, ref DFRegion dfRegion)
-        {
-            if (DaggerfallUnity.Settings.AssetInjection)
-            {
-                // If found, return a previously cached DFRegion
-                if (regions.ContainsKey(regionIndex))
-                {
-                    if (regions[regionIndex].LocationCount != noReplacementRegion.LocationCount)
-                    {
-                        dfRegion = regions[regionIndex];
-                        return true;
-                    }
-                    return false;
-                }
-                // Setup local lists for the region arrays and record the location count from data
-                uint dataLocationCount = dfRegion.LocationCount;
-                List<string> mapNames = new List<string>(dfRegion.MapNames);
-                List<DFRegion.RegionMapTable> mapTable = new List<DFRegion.RegionMapTable>(dfRegion.MapTable);
-                bool newBlocksAssigned = false;
-
-                // Seek from loose files
-                string locationPattern = string.Format("locationnew-*-{0}.json", regionIndex);
-                string[] fileNames = Directory.GetFiles(worldDataPath, locationPattern);
-                foreach (string fileName in fileNames)
-                {
-                    string locationReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
-                    DFLocation dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJson);
-                    newBlocksAssigned = AddLocationToRegion(regionIndex, ref dfRegion, ref mapNames, ref mapTable, dfLocation);
-                }
-                // Seek from mods
-                if (ModManager.Instance != null)
-                {
-                    string locationExtension = string.Format("-{0}.json", regionIndex);
-                    List<TextAsset> assets = ModManager.Instance.FindAssets<TextAsset>(worldData, locationExtension);
-                    if (assets != null)
-                    {
-                        foreach (TextAsset locationReplacementJsonAsset in assets)
-                        {
-                            DFLocation dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJsonAsset.text);
-                            newBlocksAssigned &= AddLocationToRegion(regionIndex, ref dfRegion, ref mapNames, ref mapTable, dfLocation);
-                        }
-                    }
-                }
-                // If found any new locations for this region,
-                if (dfRegion.LocationCount > dataLocationCount)
-                {
-                    // Update the region arrays from local lists
-                    dfRegion.MapNames = mapNames.ToArray();
-                    dfRegion.MapTable = mapTable.ToArray();
-
-#if !UNITY_EDITOR  // Cache region data for added locations if new blocks have been assigned indices (unless running in editor)
-                    if (newBlocksAssigned)
-                        regions.Add(regionIndex, dfRegion);
-#endif
-                    Debug.LogFormat("Added {0} new DFLocation's to region {1}, indexes: {2} - {3}",
-                        dfRegion.LocationCount - dataLocationCount, regionIndex, dataLocationCount, dfRegion.LocationCount-1);
-                    return true;
-                }
-
-#if !UNITY_EDITOR // Cache that there's no replacement region data, so only look for added locations once per region (unless running in editor)
-                regions.Add(regionIndex, noReplacementRegion);
-#endif
-            }
-            return false;
-        }
-
-        public static bool GetDFLocationReplacementData(int regionIndex, int locationIndex, out DFLocation dfLocation)
-        {
-            if (DaggerfallUnity.Settings.AssetInjection)
-            {
-                // If found, return a previously cached DFLocation
-                int locationKey = MakeLocationKey(regionIndex, locationIndex);
-                if (locations.ContainsKey(locationKey))
-                {
-                    dfLocation = locations[locationKey];
-                    return dfLocation.LocationIndex != noReplacementLocation.LocationIndex;
-                }
-
-                string fileName = GetDFLocationReplacementFilename(regionIndex, locationIndex);
-                TextAsset locationReplacementJsonAsset;
-
-                // Seek from loose files
-                if (File.Exists(Path.Combine(worldDataPath, fileName)))
-                {
-                    string locationReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
-                    dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJson);
-                }
-                // Seek from mods
-                else if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(fileName, false, out locationReplacementJsonAsset))
-                {
-                    dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJsonAsset.text);
-                }
-                else
-                {
-#if !UNITY_EDITOR // Cache that there's no replacement location data, so only look for replaced locations once (unless running in editor)
-                    locations[locationKey] = noReplacementLocation;
-#endif
-                    dfLocation = noReplacementLocation;
-                    return false;
-                }
-                // Assign any new blocks in this location a block index if they haven't already been assigned
-                if (AssignBlockIndices(dfLocation))
-                {
-#if !UNITY_EDITOR   // Cache location data for replaced locations if new blocks have been assigned indices (unless running in editor)
-                    locations[locationKey] = dfLocation;
-#endif
-                }
-                Debug.LogFormat("Found DFLocation override: {0}, {1}", regionIndex, locationIndex);
-                return true;
-            }
-            dfLocation = noReplacementLocation;
-            return false;
-        }
-
-        public static int GetNewDFBlockIndex(string blockName)
-        {
-            if (newBlockIndices.ContainsKey(blockName))
-                return newBlockIndices[blockName];
-            else
-                return -1;
-        }
-
-        public static string GetNewDFBlockName(int block)
-        {
-            if (newBlockNames.ContainsKey(block))
-                return newBlockNames[block];
-            else
-                return null;
-        }
-
-        // Currently only RDB block replacement is possible.
-        // Replacing entire RMB blocks is not currently possible as RmbFldGroundData contains
-        // groundData as a 2D array and FullSerializer can't do 2D arrays out of the box.
-        // TODO - add cache so that the replacement data check isn't seeking files constantly.
-        public static bool GetDFBlockReplacementData(int block, string blockName, out DFBlock dfBlock)
-        {
-            if (DaggerfallUnity.Settings.AssetInjection)
-            {
-                // Check the block cache
-                if (blocks.ContainsKey(blockName))
-                {
-                    dfBlock = blocks[blockName];
-                    return dfBlock.Index != noReplacementBlock.Index;
-                }
-
-                string fileName = GetDFBlockReplacementFilename(blockName);
-                TextAsset blockReplacementJsonAsset;
-
-                // Seek from loose files
-                if (File.Exists(Path.Combine(worldDataPath, fileName)))
-                {
-                    string blockReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
-                    dfBlock = (DFBlock)SaveLoadManager.Deserialize(typeof(DFBlock), blockReplacementJson);
-                }
-                // Seek from mods
-                else if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(fileName, false, out blockReplacementJsonAsset))
-                {
-                    dfBlock = (DFBlock)SaveLoadManager.Deserialize(typeof(DFBlock), blockReplacementJsonAsset.text);
-                }
-                else
-                {
-                    // Only look for replacement data once, unless running in editor
-//                    blocks[blockName] = noReplaceBlock;
-                    dfBlock = noReplacementBlock;
-                    return false;
-                }
-                dfBlock.Index = block;
-                // Cache block replacement data, unless running in editor
-                blocks[blockName] = dfBlock;
-                Debug.LogFormat("Found DFBlock override: {0} (index: {1})", blockName, block);
-                return true;
-            }
-            dfBlock = noReplacementBlock;
-            return false;
-        }
-
-        public static bool GetBuildingReplacementData(string blockName, int blockIndex, int recordIndex, out BuildingReplacementData buildingData)
-        {
-            if (DaggerfallUnity.Settings.AssetInjection)
-            {
-                BlockRecordId blockRecordId = new BlockRecordId() { blockIndex = blockIndex, recordIndex = recordIndex };
-                if (Buildings.ContainsKey(blockRecordId))
-                {
-                    buildingData = Buildings[blockRecordId];
-                    return (buildingData.BuildingType != noReplacementBT);
-                }
-                else
-                {
-                    string fileName = GetBuildingReplacementFilename(blockName, blockIndex, recordIndex);
-
-                    // Seek from loose files
-                    if (File.Exists(Path.Combine(worldDataPath, fileName)))
-                    {
-                        string buildingReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
-                        buildingData = (BuildingReplacementData)SaveLoadManager.Deserialize(typeof(BuildingReplacementData), buildingReplacementJson);
-#if !UNITY_EDITOR       // Cache building replacement data, unless running in editor
-                        Buildings.Add(blockRecordId, buildingData);
-#endif
-                        return true;
-                    }
-                    // Seek from mods
-                    TextAsset buildingReplacementJsonAsset;
-                    if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(fileName, false, out buildingReplacementJsonAsset))
-                    {
-                        buildingData = (BuildingReplacementData)SaveLoadManager.Deserialize(typeof(BuildingReplacementData), buildingReplacementJsonAsset.text);
-#if !UNITY_EDITOR       // Cache building replacement data, unless running in editor
-                        Buildings.Add(blockRecordId, buildingData);
-#endif
-                        return true;
-                    }
-#if !UNITY_EDITOR   // Only look for replacement data once, unless running in editor
-                    Buildings.Add(blockRecordId, noReplacementData);
-#endif
-                }
-            }
-            buildingData = noReplacementData;
-            return false;
-        }
-
-#endregion
-
     }
 
-#region FullSerializer custom processors
+    #region FullSerializer Custom Processors (used when serializing world data structures)
 
     public class RdbBlockDescProcessor : fsObjectProcessor
     {
@@ -438,5 +463,5 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
     }
 
-#endregion
+    #endregion
 }

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -76,10 +76,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return string.Format("location-{0}-{1}.json", regionIndex, locationIndex);
         }
 
-        // Currently only RDB block replacement is possible.
-        // Replacing entire RMB blocks is not currently possible as RmbFldGroundData contains
-        // groundData as a 2D array and FullSerializer can't do 2D arrays out of the box.
-        public static string GetBlockReplacementFilename(string blockName)
+        public static string GetDFBlockReplacementFilename(string blockName)
         {
             return string.Format("{0}.json", blockName);
         }
@@ -89,29 +86,32 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return string.Format("{0}-{1}-building{2}.json", blockName, blockIndex, recordIndex);
         }
 
-        // TODO - add cache, or change BlocksFile.AutoDiscard to false? Speak to Interkarma!
-        public static bool GetRDBBlockReplacementData(int block, string blockName, out DFBlock rdbBlock)
+        // Currently only RDB block replacement is possible.
+        // Replacing entire RMB blocks is not currently possible as RmbFldGroundData contains
+        // groundData as a 2D array and FullSerializer can't do 2D arrays out of the box.
+        // TODO - add cache so that the replacement data check isn't seeking files constantly.
+        public static bool GetDFBlockReplacementData(int block, string blockName, out DFBlock dfBlock)
         {
-            if (DaggerfallUnity.Settings.AssetInjection && blockName.EndsWith(".RDB"))
+            if (DaggerfallUnity.Settings.AssetInjection)
             {
-                string fileName = GetBlockReplacementFilename(blockName);
+                string fileName = GetDFBlockReplacementFilename(blockName);
 
                 // Seek from loose files
                 if (File.Exists(Path.Combine(worldDataPath, fileName)))
                 {
                     string blockReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
-                    rdbBlock = (DFBlock)SaveLoadManager.Deserialize(typeof(DFBlock), blockReplacementJson);
+                    dfBlock = (DFBlock)SaveLoadManager.Deserialize(typeof(DFBlock), blockReplacementJson);
                     return true;
                 }
                 // Seek from mods
                 TextAsset blockReplacementJsonAsset;
                 if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(fileName, false, out blockReplacementJsonAsset))
                 {
-                    rdbBlock = (DFBlock)SaveLoadManager.Deserialize(typeof(DFBlock), blockReplacementJsonAsset.text);
+                    dfBlock = (DFBlock)SaveLoadManager.Deserialize(typeof(DFBlock), blockReplacementJsonAsset.text);
                     return true;
                 }
             }
-            rdbBlock = nullBlock;
+            dfBlock = nullBlock;
             return false;
         }
 

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -304,7 +304,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// 
+        /// Checks for replacement building data within a block.
         /// </summary>
         /// <param name="blockName">Block name</param>
         /// <param name="blockIndex">Block index</param>

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -180,7 +180,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         {
             if (DaggerfallUnity.Settings.AssetInjection)
             {
-                // Return the previously cached DFRegion if found
+                // If found, return a previously cached DFRegion
                 if (regions.ContainsKey(regionIndex))
                 {
                     if (regions[regionIndex].LocationCount != noReplacementRegion.LocationCount)
@@ -226,7 +226,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     dfRegion.MapNames = mapNames.ToArray();
                     dfRegion.MapTable = mapTable.ToArray();
 
-#if !UNITY_EDITOR  // Cache region data for added locations if new blocks have been assigned indices, unless running in editor
+#if !UNITY_EDITOR  // Cache region data for added locations if new blocks have been assigned indices (unless running in editor)
                     if (newBlocksAssigned)
                         regions.Add(regionIndex, dfRegion);
 #endif
@@ -235,7 +235,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     return true;
                 }
 
-#if !UNITY_EDITOR  // Cache no region data so only look for added locations once per region, unless running in editor
+#if !UNITY_EDITOR // Cache that there's no replacement region data, so only look for added locations once per region (unless running in editor)
                 regions.Add(regionIndex, noReplacementRegion);
 #endif
             }
@@ -246,12 +246,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         {
             if (DaggerfallUnity.Settings.AssetInjection)
             {
-                // Check the location cache
+                // If found, return a previously cached DFLocation
                 int locationKey = MakeLocationKey(regionIndex, locationIndex);
                 if (locations.ContainsKey(locationKey))
                 {
                     dfLocation = locations[locationKey];
-                    return dfLocation.Name != noReplacementLocation.Name;
+                    return dfLocation.LocationIndex != noReplacementLocation.LocationIndex;
                 }
 
                 string fileName = GetDFLocationReplacementFilename(regionIndex, locationIndex);
@@ -270,16 +270,19 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 }
                 else
                 {
-                    // Only look for replacement data once, unless running in editor
-                    //                  locations[locationKey] = noReplaceLocation;
+#if !UNITY_EDITOR // Cache that there's no replacement location data, so only look for replaced locations once (unless running in editor)
+                    locations[locationKey] = noReplacementLocation;
+#endif
                     dfLocation = noReplacementLocation;
                     return false;
                 }
-                // Assign any new blocks in this location a block index if they haven't already ben assigned
-                AssignBlockIndices(dfLocation);
-
-                // Cache location replacement data, unless running in editor 
-                //              locations[locationKey] = dfLocation;
+                // Assign any new blocks in this location a block index if they haven't already been assigned
+                if (AssignBlockIndices(dfLocation))
+                {
+#if !UNITY_EDITOR   // Cache location data for replaced locations if new blocks have been assigned indices (unless running in editor)
+                    locations[locationKey] = dfLocation;
+#endif
+                }
                 Debug.LogFormat("Found DFLocation override: {0}, {1}", regionIndex, locationIndex);
                 return true;
             }
@@ -392,11 +395,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return false;
         }
 
-        #endregion
+#endregion
 
     }
 
-    #region FullSerializer custom processors
+#region FullSerializer custom processors
 
     public class RdbBlockDescProcessor : fsObjectProcessor
     {
@@ -435,5 +438,5 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
     }
 
-    #endregion
+#endregion
 }

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -423,45 +423,4 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
         #endregion
     }
-
-    #region FullSerializer Custom Processors (used when serializing world data structures)
-
-    public class RdbBlockDescProcessor : fsObjectProcessor
-    {
-        // Invoked after serialization has finished. Update any state inside of instance, modify the output data, etc.
-        public override void OnAfterSerialize(Type storageType, object instance, ref fsData data)
-        {
-            // Truncate ModelReferenceList at the first null entry in array[750].
-            List<fsData> modelRefs = data.AsDictionary["ModelReferenceList"].AsList;
-            for (int i = 0; i < modelRefs.Count; i++)
-            {
-                if (modelRefs[i].AsDictionary["ModelIdNum"].AsInt64 == 0)
-                {
-                    modelRefs.RemoveRange(i, modelRefs.Count - i);
-                    break;
-                }
-            }
-        }
-    }
-
-    public class RdbObjectProcessor : fsObjectProcessor
-    {
-        // Invoked after serialization has finished. Update any state inside of instance, modify the output data, etc.
-        public override void OnAfterSerialize(Type storageType, object instance, ref fsData data)
-        {
-            // Only write relevant type resource data for Rdb Objects.
-            Dictionary<string, fsData> rdbObject = data.AsDictionary;
-            DFBlock.RdbResourceTypes type = (DFBlock.RdbResourceTypes) Enum.Parse(typeof(DFBlock.RdbResourceTypes), rdbObject["Type"].AsString);
-            Dictionary<string, fsData> resources = rdbObject["Resources"].AsDictionary;
-
-            if (type == DFBlock.RdbResourceTypes.Flat || type == DFBlock.RdbResourceTypes.Light)
-                resources.Remove("ModelResource");
-            if (type == DFBlock.RdbResourceTypes.Flat || type == DFBlock.RdbResourceTypes.Model)
-                resources.Remove("LightResource");
-            if (type == DFBlock.RdbResourceTypes.Model || type == DFBlock.RdbResourceTypes.Light)
-                resources.Remove("FlatResource");
-        }
-    }
-
-    #endregion
 }

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -100,7 +100,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             if (DaggerfallUnity.Settings.AssetInjection)
             {
                 // Seek from loose files
-                string locationPattern = string.Format("location-{0}-add-*.json", regionIndex);
+                string locationPattern = string.Format("location-new-{0}-*.json", regionIndex);
                 string[] fileNames = Directory.GetFiles(worldDataPath, locationPattern);
                 if (fileNames.Length > 0)
                 {
@@ -199,6 +199,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 {
                     string blockReplacementJson = File.ReadAllText(Path.Combine(worldDataPath, fileName));
                     dfBlock = (DFBlock)SaveLoadManager.Deserialize(typeof(DFBlock), blockReplacementJson);
+                    Debug.LogFormat("Found DFBlock override: {0} - {1}", block, blockName);
                     return true;
                 }
                 // Seek from mods

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -636,10 +636,11 @@ namespace DaggerfallWorkshop.Utility
 
                         // Get model data
                         ModelData modelData;
-                        dfUnity.MeshReader.GetModelData(modelId, out modelData);
-
-                        // Add to static doors
-                        exitDoorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, 0, modelMatrix));
+                        if (dfUnity.MeshReader.GetModelData(modelId, out modelData))
+                        {
+                            // Add to static doors
+                            exitDoorsOut.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, 0, modelMatrix));
+                        }
 
                         // Check if model has an action record
                         bool hasAction = HasAction(obj);


### PR DESCRIPTION
This extends the world data replacement system to handle:

- Adding new locations
- Changing existing locations
- Adding new dungeon blocks
- Changing existing dungeon blocks
- Updates to world data dump commands

Indexes are automatically assigned to any new locations or blocks added, and the system hooks into the content file readers to seamlessly layer new or altered world data into the DFU engine. New locations and blocks are fully integrated with all the Daggerfall game systems and should be able to be targets for quests, which I need to be able to exclude somehow in the future, and locations appear on the travel map and can be fast travelled to.

I will be documenting how to use this system on the forums over the coming days.