### PR TITLE
raise event on teleporting out of dungeons

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Teleport.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Teleport.cs
@@ -157,6 +157,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                     SaveLoadManager.CacheScene(GameManager.Instance.StreamingWorld.SceneName);      // Player is outside
                 else if (playerEnterExit.IsPlayerInsideBuilding)
                     SaveLoadManager.CacheScene(playerEnterExit.Interior.name);                      // Player inside a building
+                else // Player inside a dungeon
+                    playerEnterExit.TransitionDungeonExteriorImmediate();
 
                 // Need to load some other part of the world again - player could be anywhere
                 PlayerEnterExit.OnRespawnerComplete += PlayerEnterExit_OnRespawnerComplete;

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -1119,6 +1119,14 @@ namespace DaggerfallWorkshop.Game
             RaiseOnTransitionDungeonExteriorEvent();
         }
 
+        public void TransitionDungeonExteriorImmediate()
+        {
+            if (!ReferenceComponents() || !dungeon || !isPlayerInsideDungeon)
+                return;
+
+            RaiseOnPreTransitionEvent(PlayerEnterExit.TransitionType.ToDungeonExterior);
+        }
+
         #endregion
 
         #region Private Methods


### PR DESCRIPTION

raise transition event on teleporting out of dungeons so it can be handled by Persistent Dungeons mod.

/!\ It seems to work, but I won't pretend I understand all what's going  on.

Forums:
https://forums.dfworkshop.net/viewtopic.php?f=27&t=1667&p=29398#p29398