### PR TITLE
Fix PC greeting text for the first question

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Michael Rauter (Nystul)
-// Contributors:    Numidium, Allofich, Interkarma
+// Contributors:    Numidium, Allofich, Interkarma, Ferital
 // 
 // Notes:
 //
@@ -219,7 +219,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         string nameNPC = "";
-        bool isGreeting = false;  // Indicates a greeting is being parsed, %n = nameNPC.
+        string greetingNameNPC = ""; // used only for PC first question
 
         string npcGreetingText = ""; // the last NPC greeting text
 
@@ -396,9 +396,9 @@ namespace DaggerfallWorkshop.Game
             get { return nameNPC; }
         }
 
-        public bool IsGreeting
+        public string GreetingNameNPC
         {
-            get { return isGreeting; }
+            get { return greetingNameNPC; }
         }
 
         public ListItem CurrentQuestionListItem
@@ -995,9 +995,12 @@ namespace DaggerfallWorkshop.Game
 
         public string GetPCGreetingText(DaggerfallTalkWindow.TalkTone talkTone)
         {
-            isGreeting = true;
+            if (reactionToPlayer <= 0)
+                greetingNameNPC = ExpandRandomTextRecord(7221 + DaggerfallTalkWindow.TalkToneToIndex(talkTone));
+            else
+                greetingNameNPC = nameNPC;
             string greetingText = ExpandRandomTextRecord(7215 + DaggerfallTalkWindow.TalkToneToIndex(talkTone));
-            isGreeting = false;
+            greetingNameNPC = string.Empty;
             return greetingText;
         }
 
@@ -1008,13 +1011,10 @@ namespace DaggerfallWorkshop.Game
 
         public string GetPCGreetingOrFollowUpText()
         {
-            if (questionOpeningText == "")
-            {
-                if (numQuestionsAsked == 0)
-                    questionOpeningText = GetPCGreetingText(currentTalkTone);
-                else
-                    questionOpeningText = GetPCFollowUpText(currentTalkTone);
-            }
+            if (numQuestionsAsked == 0)
+                questionOpeningText = GetPCGreetingText(currentTalkTone);
+            else
+                questionOpeningText = GetPCFollowUpText(currentTalkTone);
             return questionOpeningText;
         }
 

--- a/Assets/Scripts/Game/TalkManagerMCP.cs
+++ b/Assets/Scripts/Game/TalkManagerMCP.cs
@@ -64,8 +64,8 @@ namespace DaggerfallWorkshop.Game
             public override string Name()
             {
                 // Used for greeting messages only: 7215, 7216, 7217
-                if (GameManager.Instance.TalkManager.IsGreeting)
-                    return GameManager.Instance.TalkManager.NameNPC;
+                if (!string.IsNullOrEmpty(GameManager.Instance.TalkManager.GreetingNameNPC))
+                    return GameManager.Instance.TalkManager.GreetingNameNPC;
                 else
                     return null;
             }


### PR DESCRIPTION
Fix the the first question greeting which was not updated when changing talking tone and also match classic behavior in using specific greeting names for NPCs (friend, mate, bud...) when NPC reaction is negative, see below:

Before:
![before](https://user-images.githubusercontent.com/46795115/67089885-fcd30b80-f1a8-11e9-9826-0dc624c62eba.png)

After:
![after](https://user-images.githubusercontent.com/46795115/67089891-00669280-f1a9-11e9-8320-e5989f05be0d.png)
