### PR TITLE
Fixes for the upcoming build

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -111,15 +111,15 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         {
             if (string.IsNullOrEmpty(ModDirectory))
                 ModDirectory = Path.Combine(Application.streamingAssetsPath, "Mods");
-
-            SetupSingleton();
-
-            if (Instance == this)
-                StateManager.OnStateChange += StateManager_OnStateChange;
         }
 
         void Start()
         {
+            SetupSingleton();
+
+            if (Instance == this)
+                StateManager.OnStateChange += StateManager_OnStateChange;
+
             if (!DaggerfallUnity.Settings.LypyL_ModSystem)
             {
                 Debug.Log("Mod System disabled");

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -82,6 +82,7 @@ namespace DaggerfallWorkshop.Game
         char lastCharacterTyped;
         KeyCode lastKeyCode;
         FadeBehaviour fadeBehaviour = null;
+        bool instantiatePersistentWindowInstances = true;
 
         bool hudSetup = false;
         DaggerfallHUD dfHUD;
@@ -129,6 +130,11 @@ namespace DaggerfallWorkshop.Game
         public Material SDFFontMaterial { get { return sdfFontMaterial; } set { sdfFontMaterial = value; } }
 
         PaperDollRenderer paperDollRenderer;
+
+        public void ReinstantiatePersistentWindowInstances()
+        {
+            instantiatePersistentWindowInstances = true;
+        }
 
         public UserInterfaceRenderTarget CustomRenderTarget
         {
@@ -287,26 +293,6 @@ namespace DaggerfallWorkshop.Game
             dfSongPlayer = GetComponent<DaggerfallSongPlayer>();
             fadeBehaviour = GetComponent<FadeBehaviour>();
 
-            dfPauseOptionsWindow = (DaggerfallPauseOptionsWindow)UIWindowFactory.GetInstance(UIWindowType.PauseOptions, uiManager, null);
-            dfCharacterSheetWindow = (DaggerfallCharacterSheetWindow)UIWindowFactory.GetInstance(UIWindowType.CharacterSheet, uiManager);
-            dfInventoryWindow = (DaggerfallInventoryWindow)UIWindowFactory.GetInstance(UIWindowType.Inventory, uiManager, null);
-            dfControlsWindow = (DaggerfallControlsWindow)UIWindowFactory.GetInstance(UIWindowType.Controls, uiManager, null);
-            dfJoystickControlsWindow = (DaggerfallJoystickControlsWindow)UIWindowFactory.GetInstance(UIWindowType.JoystickControls, uiManager, null);
-            dfUnityMouseControlsWindow = (DaggerfallUnityMouseControlsWindow)UIWindowFactory.GetInstance(UIWindowType.UnityMouseControls, uiManager, null);
-            dfTravelMapWindow = (DaggerfallTravelMapWindow)UIWindowFactory.GetInstance(UIWindowType.TravelMap, uiManager);
-            dfAutomapWindow = (DaggerfallAutomapWindow)UIWindowFactory.GetInstance(UIWindowType.Automap, uiManager);
-            dfBookReaderWindow = (DaggerfallBookReaderWindow)UIWindowFactory.GetInstance(UIWindowType.BookReader, uiManager);
-            dfQuestJournalWindow = (DaggerfallQuestJournalWindow)UIWindowFactory.GetInstance(UIWindowType.QuestJournal, uiManager);
-            dfPlayerHistoryWindow = (DaggerfallPlayerHistoryWindow)UIWindowFactory.GetInstance(UIWindowType.PlayerHistory, uiManager);
-            dfTalkWindow = (DaggerfallTalkWindow)UIWindowFactory.GetInstance(UIWindowType.Talk, uiManager, null);
-            dfSpellBookWindow = (DaggerfallSpellBookWindow)UIWindowFactory.GetInstanceWithArgs(UIWindowType.SpellBook, new object[] { uiManager, null, false });
-            dfUseMagicItemWindow = (DaggerfallUseMagicItemWindow)UIWindowFactory.GetInstance(UIWindowType.UseMagicItem, uiManager, null);
-            dfSpellMakerWindow = (DaggerfallSpellMakerWindow)UIWindowFactory.GetInstance(UIWindowType.SpellMaker, uiManager, null);
-            dfItemMakerWindow = (DaggerfallItemMakerWindow)UIWindowFactory.GetInstance(UIWindowType.ItemMaker, uiManager, null);
-            dfPotionMakerWindow = (DaggerfallPotionMakerWindow)UIWindowFactory.GetInstance(UIWindowType.PotionMaker, uiManager, null);
-            dfCourtWindow = (DaggerfallCourtWindow)UIWindowFactory.GetInstance(UIWindowType.Court, uiManager, null);
-            dfExteriorAutomapWindow = (DaggerfallExteriorAutomapWindow)UIWindowFactory.GetInstance(UIWindowType.ExteriorAutomap, uiManager);
-
             Questing.Actions.GivePc.OnOfferPending += GivePc_OnOfferPending;
 
             // Create 8x scale paper doll renderer
@@ -347,6 +333,9 @@ namespace DaggerfallWorkshop.Game
             // Route messages to top window or handle locally
             if (uiManager.MessageCount > 0)
             {
+                if (instantiatePersistentWindowInstances)
+                    InstantiatePersistentWindowInstances();
+
                 // Top window has first chance at message
                 if (uiManager.TopWindow != null)
                     uiManager.TopWindow.ProcessMessages();
@@ -408,6 +397,31 @@ namespace DaggerfallWorkshop.Game
                     RenderTexture.active = oldRT;
                 }
             }
+        }
+
+        private void InstantiatePersistentWindowInstances()
+        {
+            dfPauseOptionsWindow = (DaggerfallPauseOptionsWindow)UIWindowFactory.GetInstance(UIWindowType.PauseOptions, uiManager, null);
+            dfCharacterSheetWindow = (DaggerfallCharacterSheetWindow)UIWindowFactory.GetInstance(UIWindowType.CharacterSheet, uiManager);
+            dfInventoryWindow = (DaggerfallInventoryWindow)UIWindowFactory.GetInstance(UIWindowType.Inventory, uiManager, null);
+            dfControlsWindow = (DaggerfallControlsWindow)UIWindowFactory.GetInstance(UIWindowType.Controls, uiManager, null);
+            dfJoystickControlsWindow = (DaggerfallJoystickControlsWindow)UIWindowFactory.GetInstance(UIWindowType.JoystickControls, uiManager, null);
+            dfUnityMouseControlsWindow = (DaggerfallUnityMouseControlsWindow)UIWindowFactory.GetInstance(UIWindowType.UnityMouseControls, uiManager, null);
+            dfTravelMapWindow = (DaggerfallTravelMapWindow)UIWindowFactory.GetInstance(UIWindowType.TravelMap, uiManager);
+            dfAutomapWindow = (DaggerfallAutomapWindow)UIWindowFactory.GetInstance(UIWindowType.Automap, uiManager);
+            dfBookReaderWindow = (DaggerfallBookReaderWindow)UIWindowFactory.GetInstance(UIWindowType.BookReader, uiManager);
+            dfQuestJournalWindow = (DaggerfallQuestJournalWindow)UIWindowFactory.GetInstance(UIWindowType.QuestJournal, uiManager);
+            dfPlayerHistoryWindow = (DaggerfallPlayerHistoryWindow)UIWindowFactory.GetInstance(UIWindowType.PlayerHistory, uiManager);
+            dfTalkWindow = (DaggerfallTalkWindow)UIWindowFactory.GetInstance(UIWindowType.Talk, uiManager, null);
+            dfSpellBookWindow = (DaggerfallSpellBookWindow)UIWindowFactory.GetInstanceWithArgs(UIWindowType.SpellBook, new object[] { uiManager, null, false });
+            dfUseMagicItemWindow = (DaggerfallUseMagicItemWindow)UIWindowFactory.GetInstance(UIWindowType.UseMagicItem, uiManager, null);
+            dfSpellMakerWindow = (DaggerfallSpellMakerWindow)UIWindowFactory.GetInstance(UIWindowType.SpellMaker, uiManager, null);
+            dfItemMakerWindow = (DaggerfallItemMakerWindow)UIWindowFactory.GetInstance(UIWindowType.ItemMaker, uiManager, null);
+            dfPotionMakerWindow = (DaggerfallPotionMakerWindow)UIWindowFactory.GetInstance(UIWindowType.PotionMaker, uiManager, null);
+            dfCourtWindow = (DaggerfallCourtWindow)UIWindowFactory.GetInstance(UIWindowType.Court, uiManager, null);
+            dfExteriorAutomapWindow = (DaggerfallExteriorAutomapWindow)UIWindowFactory.GetInstance(UIWindowType.ExteriorAutomap, uiManager);
+
+            instantiatePersistentWindowInstances = false;
         }
 
         void ProcessMessages()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
@@ -23,24 +23,24 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     {
         #region Fields
 
-        const string nativeImgName = "OPTN00I0.IMG";
-        const int strAreYouSure = 1069;
-        const float barMaxLength = 109.1f;
+        protected const string nativeImgName = "OPTN00I0.IMG";
+        protected const int strAreYouSure = 1069;
+        protected const float barMaxLength = 109.1f;
 
-        Texture2D nativeTexture;
-        Panel optionsPanel = new Panel();
-        Panel fullScreenTick;
-        Panel headBobbingTick;
-        Panel musicBar;
-        Panel soundBar;
-        Panel detailBar;
-        DaggerfallHUD hud;
-        TextLabel versionTextLabel;
+        protected Texture2D nativeTexture;
+        protected Panel optionsPanel = new Panel();
+        protected Panel fullScreenTick;
+        protected Panel headBobbingTick;
+        protected Panel musicBar;
+        protected Panel soundBar;
+        protected Panel detailBar;
+        protected DaggerfallHUD hud;
+        protected TextLabel versionTextLabel;
 
-        readonly Color versionTextColor = new Color(0.75f, 0.75f, 0.75f, 1);
-        readonly Color versionShadowColor = new Color(0.15f, 0.15f, 0.15f, 1);
+        protected readonly Color versionTextColor = new Color(0.75f, 0.75f, 0.75f, 1);
+        protected readonly Color versionShadowColor = new Color(0.15f, 0.15f, 0.15f, 1);
 
-        bool saveSettings = false;
+        protected bool saveSettings = false;
 
         #endregion
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -36,58 +36,58 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region UI Controls
 
-        Button whileButton;
-        Button healedButton;
-        Button loiterButton;
-        Button stopButton;
+        protected Button whileButton;
+        protected Button healedButton;
+        protected Button loiterButton;
+        protected Button stopButton;
 
-        Panel mainPanel = new Panel();
-        Panel counterPanel = new Panel();
+        protected Panel mainPanel = new Panel();
+        protected Panel counterPanel = new Panel();
 
-        TextLabel counterLabel = new TextLabel();
+        protected TextLabel counterLabel = new TextLabel();
 
         #endregion
 
         #region UI Textures
 
-        Texture2D baseTexture;
-        Texture2D hoursPastTexture;
-        Texture2D hoursRemainingTexture;
+        protected Texture2D baseTexture;
+        protected Texture2D hoursPastTexture;
+        protected Texture2D hoursRemainingTexture;
 
         #endregion
 
         #region Fields
 
-        const string baseTextureName = "REST00I0.IMG";              // Rest type
-        const string hoursPastTextureName = "REST01I0.IMG";         // "Hours past"
-        const string hoursRemainingTextureName = "REST02I0.IMG";    // "Hours remaining"
+        protected const string baseTextureName = "REST00I0.IMG";              // Rest type
+        protected const string hoursPastTextureName = "REST01I0.IMG";         // "Hours past"
+        protected const string hoursRemainingTextureName = "REST02I0.IMG";    // "Hours remaining"
 
-        const int minutesPerTick = 10;
-        const float restWaitTimePerHour = 0.75f;
-        const float loiterWaitTimePerHour = 1.25f;
-        const int cityCampingIllegal = 17;
+        protected const int minutesPerTick = 10;
+        protected const float restWaitTimePerHour = 0.75f;
+        protected const float loiterWaitTimePerHour = 1.25f;
+        protected const int cityCampingIllegal = 17;
 
-        RestModes currentRestMode = RestModes.Selection;
-        int minutesOfHour = 0;
-        int hoursRemaining = 0;
-        int totalHours = 0;
-        float waitTimer = 0;
-        bool enemyBrokeRest = false;
-        int remainingHoursRented = -1;
-        Vector3 allocatedBed;
-        bool ignoreAllocatedBed = false;
-        bool abortRestForEnemySpawn = false;
+        protected RestModes currentRestMode = RestModes.Selection;
+        protected int minutesOfHour = 0;
+        protected int hoursRemaining = 0;
+        protected int totalHours = 0;
+        protected float waitTimer = 0;
+        protected bool enemyBrokeRest = false;
+        protected int remainingHoursRented = -1;
+        protected Vector3 allocatedBed;
+        protected bool ignoreAllocatedBed = false;
+        protected bool abortRestForEnemySpawn = false;
 
-        PlayerEntity playerEntity;
-        DaggerfallHUD hud;
+        protected PlayerEntity playerEntity;
+        protected DaggerfallHUD hud;
 
-        KeyCode toggleClosedBinding;
+        protected KeyCode toggleClosedBinding;
 
         #endregion
 
         #region Enums
 
-        enum RestModes
+        protected enum RestModes
         {
             Selection,
             TimedRest,

--- a/Assets/Scripts/Game/UserInterfaceWindows/UIWindowFactory.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/UIWindowFactory.cs
@@ -111,6 +111,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallUnity.LogMessage("RegisterCustomUIWindow: " + windowType, true);
             uiWindowImplementations[windowType] = windowClassType;
+            DaggerfallUI.Instance.ReinstantiatePersistentWindowInstances();
         }
 
         public static IUserInterfaceWindow GetInstance(UIWindowType windowType, IUserInterfaceManager uiManager)


### PR DESCRIPTION
Instantiate persistent windows only when needed and allow re-instantiation. Allows persistent windows to be replaced.

Made members protected on rest and pause windows during testing. All windows will require protections to be modified, but I suggest we do them as required. I certainly don't want to do them all en masse.

Fix loading new locations from dfmod's. Have to wait until mod manager is initialised before checking for new locations and filling cache

Move mod manager singleton creation.