### PR TITLE
Fix %qdt macro expansion

### DIFF
--- a/Assets/Scripts/Game/Questing/Message.cs
+++ b/Assets/Scripts/Game/Questing/Message.cs
@@ -164,8 +164,12 @@ namespace DaggerfallWorkshop.Game.Questing
             {
                 QuestMacroHelper macroHelper = new QuestMacroHelper();
 
-                // note Nystul: reveal dialog linked resources here on purpose (quest popups should reveal them: see this issue: https://forums.dfworkshop.net/viewtopic.php?f=24&t=1678&p=22069#p22069)                
+                ParentQuest.CurrentLogMessageId = this.id;
+
+                // note Nystul: reveal dialog linked resources here on purpose (quest popups should reveal them: see this issue: https://forums.dfworkshop.net/viewtopic.php?f=24&t=1678&p=22069#p22069)
                 macroHelper.ExpandQuestMessage(ParentQuest, ref tokens, true);
+
+                ParentQuest.CurrentLogMessageId = -1;
             }
 
             return tokens;

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -48,6 +48,7 @@ namespace DaggerfallWorkshop.Game.Questing
         bool questComplete = false;
         bool questSuccess = false;
         Dictionary<int, LogEntry> activeLogMessages = new Dictionary<int, LogEntry>();
+        int currentLogMessageId = -1;
 
         string questName;
         string displayName;
@@ -80,6 +81,7 @@ namespace DaggerfallWorkshop.Game.Questing
         {
             public int stepID;
             public int messageID;
+            public DaggerfallDateTime dateTime;
         }
 
         /// <summary>
@@ -230,6 +232,14 @@ namespace DaggerfallWorkshop.Game.Questing
         public DaggerfallDateTime QuestTombstoneTime
         {
             get { return questTombstoneTime; }
+        }
+
+        /// <summary>
+        /// Current log message ID, used only for expanding %qdt macro properly.
+        /// </summary>
+        public int CurrentLogMessageId
+        {
+            set { currentLogMessageId = value; }
         }
 
         #endregion
@@ -530,6 +540,7 @@ namespace DaggerfallWorkshop.Game.Questing
             LogEntry entry = new LogEntry();
             entry.stepID = stepID;
             entry.messageID = messageID;
+            entry.dateTime = new DaggerfallDateTime(DaggerfallUnity.Instance.WorldTime.Now);
             activeLogMessages.Add(stepID, entry);
         }
 
@@ -568,6 +579,21 @@ namespace DaggerfallWorkshop.Game.Questing
             }
 
             return logs;
+        }
+
+        /// <summary>
+        /// Get the current log entry date time when opening the active quests log.
+        /// </summary>
+        /// <returns>Return the current log entry time if any, otherwise the quest start time.</returns>
+        public DaggerfallDateTime GetCurrentLogMessageTime()
+        {
+            foreach (LogEntry log in activeLogMessages.Values)
+            {
+                if (log.messageID == currentLogMessageId && log.dateTime != null)
+                    return log.dateTime;
+            }
+
+            return questStartTime;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Questing/QuestMCP.cs
+++ b/Assets/Scripts/Game/Questing/QuestMCP.cs
@@ -140,7 +140,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
             public override string QuestDate()
             {
-                return parent.QuestStartTime.DateString();
+                return parent.GetCurrentLogMessageTime().DateString();
             }
 
             /// <summary>

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -200,7 +200,7 @@ namespace DaggerfallWorkshop.Utility
             { "%q11b", Q11b },
             { "%q12b", Q12b },
             { "%qdt", QuestDate }, // Quest date of log entry
-            { "%qdat", null },// Quest date of log entry [2]
+            { "%qdat", QuestDate },// Quest date of log entry [2]
             { "%qot", null }, // The log comment
             { "%qua", Condition }, // Condition
             { "%r1", CommonersRep },  // Commoners rep

--- a/Assets/StreamingAssets/Quests/K0C01Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C01Y00.txt
@@ -129,7 +129,7 @@ Message:  1015
 <ce>                                departs.
 
 Message:  1017
-%dat:
+%qdt:
  I received a
  letter from the Thieves Guild. It
  seems that the kidnappers are not


### PR DESCRIPTION
Correct macro %qdt expansion so each quest log entry now has its own time as in classic. Before that, it always resolved to quest start time.

Also fix quest K0C01Y00 message 1017 which always used the current time.

Note that this doesn't break current savegames as I added a check to ensure `LogEntry.dateTime` is not `null`. Else, it resolves to quest start time as before this fix.