### PR TITLE
Set main quest NPCs as questors

### DIFF
--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -84,6 +84,7 @@ namespace DaggerfallWorkshop.Game.Questing
         public bool IsQuestor
         {
             get { return isQuestor; }
+            set { SetQuestorStatus(value); }
         }
 
         public bool IsIndividualNPC
@@ -484,6 +485,17 @@ namespace DaggerfallWorkshop.Game.Questing
             isDestroyed = true;
         }
 
+        /// <summary>
+        /// Set Person as questor and assign questor data if needed.
+        /// Uses last clicked NPC data so has to be called after talking to the actual questor.
+        /// </summary>
+        private void SetQuestorStatus(bool status)
+        {
+            isQuestor = status;
+            if (isQuestor)
+                questorData = QuestMachine.Instance.LastNPCClicked.Data;
+        }
+
         #endregion
 
         #region Private Methods
@@ -874,9 +886,8 @@ namespace DaggerfallWorkshop.Game.Questing
                 return false;
             }
 
-            // Set questor data
-            questorData = QuestMachine.Instance.LastNPCClicked.Data;
-            isQuestor = true;
+            // Set as questor
+            IsQuestor = true;
 
             // Setup Person resource
             FactionFile.FactionData factionData = GetFactionData(questorData.factionID);

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -442,7 +442,10 @@ namespace DaggerfallWorkshop.Game.Questing
                 return;
             }
 
-            // Create new questor
+            // Set person as questor
+            person.IsQuestor = true;
+
+            // Create new questor symbol
             string key = personSymbol.Name;
             QuestorData qd = new QuestorData();
             qd.symbol = personSymbol.Clone();
@@ -487,10 +490,14 @@ namespace DaggerfallWorkshop.Game.Questing
                 questors.Remove(key);
             }
 
+            // Unset questor flag
+            Person personResource = GetPerson(personSymbol);
+            if (personResource != null)
+                personResource.IsQuestor = false;
+
             // Destroy QuestResourceBehaviour from target object if present in scene and not an individual NPC
             // If target object not present in scene then QuestResourceBehaviour simply wont be added next time as Person is no longer a questor
             // Individual NPCs have a permanent QuestResourceBehaviour attached as they have special usage in long-running quests - it must not be removed
-            Person personResource = GetPerson(personSymbol);
             if (personResource != null && personResource.QuestResourceBehaviour != null && !personResource.IsIndividualNPC)
                 MonoBehaviour.Destroy(personResource.QuestResourceBehaviour);
         }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -799,7 +799,7 @@ namespace DaggerfallWorkshop.Game
                         continue;
                     foreach (Person person in quest.GetAllResources(typeof(Person)))
                     {
-                        if (person.IsQuestor && GameManager.Instance.QuestMachine.IsNPCDataEqual(person.QuestorData, lastTargetStaticNPC.Data))
+                        if (GameManager.Instance.QuestMachine.IsNPCDataEqual(person.QuestorData, lastTargetStaticNPC.Data))
                         {
                             TextFile.Token[] tokens = dictQuestorPostQuestMessage[questID];
 

--- a/Assets/StreamingAssets/Quests/S0000005.txt
+++ b/Assets/StreamingAssets/Quests/S0000005.txt
@@ -60,10 +60,10 @@ It is nice to see Queen Aubk-i happy at last. She has a very pretty smile.
 Queen Aubk-i seems more than happy lately. She seems almost ... relieved.
 
 QuestorPostsuccess:  [1008]
-Ah, %pcn. The %ra that refused visit my dead husband's grandmother.
+Thank you once again for taking that dangerous trip to Shedungent to look in on Nulfaga for me.
 
 QuestorPostfailure:  [1009]
-Thank you once again for taking that dangerous trip to Shedungent to look in on Nulfaga for me.
+Ah, %pcn. The %ra that refused to visit my husband's grandmother.
 
 QuestLogEntry:  [1010]
 %qdt:


### PR DESCRIPTION
Main quest questor NPCs were never flagged as questors, so they never said their post success or post failure greetings to the player.

Also fix quest S0000005 where Aubk-i post success and post failure greetings were inverted. And removed the word "dead" from post failure greeting as neither her husband nor her husband's grandmother are dead.

Edit: I'm not a native English speaker, but it seems to me that "The %ra that refused visit my husband's grandmother" should be changed to "The %ra who refused to visit my husband's grandmother". Could someone confirm?