### PR TITLE
Revert change from PR#1557 to building matching

### DIFF
--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -528,34 +528,36 @@ namespace DaggerfallWorkshop.Utility
                     {
                         DFLocation.BuildingData building = block.RmbBlock.FldHeader.BuildingDataList[i];
                         if (IsNamedBuilding(building.BuildingType))
-                        {                       
-                            // Try to find next building and merge data
-                            BuildingPoolItem item;
-                            if (!GetNextBuildingFromPool(namedBuildingPool, building.BuildingType, out item))
-                            {
-                                Debug.LogFormat("End of city building list reached without finding building type {0} in location {1}.{2}", building.BuildingType, location.RegionName, location.Name);
-                            }
-
-                            // Always copy nameSeed, LocationID and Sector found city building data to block level    
-                            building.NameSeed = item.buildingData.NameSeed;
-                            building.LocationId = item.buildingData.LocationId;
-                            building.Sector = item.buildingData.Sector;
-
+                        {
                             // Check for replacement building data and use it if found
                             if (WorldDataReplacement.GetBuildingReplacementData(blockName, block.Index, i, out buildingReplacementData))
-                            { 
-                                // Use custom building values from replacement data, don't use pool or maps file                                
+                            {
+                                // Use custom building values from replacement data, don't use pool or maps file
+                                building.NameSeed = location.Exterior.Buildings[0].NameSeed;
                                 building.FactionId = buildingReplacementData.FactionId;
-                                building.BuildingType = (DFLocation.BuildingTypes) buildingReplacementData.BuildingType;
+                                building.BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.BuildingType;
+                                building.LocationId = location.Exterior.Buildings[0].LocationId;
                                 building.Quality = buildingReplacementData.Quality;
                             }
                             else
                             {
-                                // Copy remaining found city building data to block level                                   
-                                building.FactionId = item.buildingData.FactionId;
-                                building.Quality = item.buildingData.Quality;
+                                // Try to find next building and merge data
+                                BuildingPoolItem item;
+                                if (!GetNextBuildingFromPool(namedBuildingPool, building.BuildingType, out item))
+                                {
+                                    Debug.LogFormat("End of city building list reached without finding building type {0} in location {1}.{2}", building.BuildingType, location.RegionName, location.Name);
+                                }
+                                else
+                                {
+                                    // Copy found city building data to block level
+                                    building.NameSeed = item.buildingData.NameSeed;
+                                    building.FactionId = item.buildingData.FactionId;
+                                    building.Sector = item.buildingData.Sector;
+                                    building.LocationId = item.buildingData.LocationId;
+                                    building.Quality = item.buildingData.Quality;
+                                }
                             }
-                            
+
                             // Matched to classic: special handling for some Order of the Raven buildings
                             if (block.RmbBlock.FldHeader.OtherNames[i] == "KRAVE01.HS2")
                             {


### PR DESCRIPTION
This change meant that replacement buildings e.g. new guilds could take a guild hall entry out of the pool, messing up the matching algorithm.
This does mean that replacement classic guild buildings probably won't work without futher changes, but this fixes an issue where classic guilds are broken with the Archaeologists mod in DFU 0.10.8 - 0.10.10