### PR TITLE
Support providers of mobile person graphics

### DIFF
--- a/Assets/Scripts/Editor/SetupMobilePersonEditor.cs
+++ b/Assets/Scripts/Editor/SetupMobilePersonEditor.cs
@@ -42,10 +42,10 @@ namespace DaggerfallWorkshop
             }
             if (GUILayout.Button("Align To Ground"))
             {
-                MobilePersonBillboard mobilePerson = setupMobilePerson.GetComponentInChildren<MobilePersonBillboard>();
+                var mobilePerson = setupMobilePerson.GetComponentInChildren<MobilePersonAsset>();
                 if (mobilePerson)
                 {
-                    Vector3 billboardSize = mobilePerson.GetBillboardSize();
+                    Vector3 billboardSize = mobilePerson.GetSize();
                     GameObjectHelper.AlignBillboardToGround(setupMobilePerson.gameObject, billboardSize);
                 }
             }

--- a/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntityBehaviour.cs
@@ -216,7 +216,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         }
                         else
                         {
-                            if (!mobileNpc.Billboard.IsUsingGuardTexture)
+                            if (!mobileNpc.IsGuard)
                             {
                                 playerEntity.TallyCrimeGuildRequirements(false, 5);
                                 playerEntity.CrimeCommitted = PlayerEntity.Crimes.Murder;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -649,7 +649,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         if (directionToMobile.magnitude <= 77.5f)
                         {
                             // Spawn from guard mobile NPCs first
-                            if (populationManager.PopulationPool[i].npc.Billboard.IsUsingGuardTexture)
+                            if (populationManager.PopulationPool[i].npc.IsGuard)
                             {
                                 SpawnCityGuard(populationManager.PopulationPool[i].npc.transform.position, populationManager.PopulationPool[i].npc.transform.forward);
                                 populationManager.PopulationPool[i].npc.gameObject.SetActive(false);
@@ -705,7 +705,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                 DaggerfallEntityBehaviour entity = hit.transform.gameObject.GetComponent<DaggerfallEntityBehaviour>();
                                 if (entity == GameManager.Instance.PlayerEntityBehaviour)
                                     seen = true;
-                                if (populationManager.PopulationPool[i].npc.Billboard.IsUsingGuardTexture)
+                                if (populationManager.PopulationPool[i].npc.IsGuard)
                                     seenByGuard = true;
                             }
                         }
@@ -763,7 +763,7 @@ namespace DaggerfallWorkshop.Game.Entity
                         continue;
 
                     // Spawn from guard mobile NPCs
-                    if (populationManager.PopulationPool[i].npc.Billboard.IsUsingGuardTexture)
+                    if (populationManager.PopulationPool[i].npc.IsGuard)
                     {
                         SpawnCityGuard(populationManager.PopulationPool[i].npc.transform.position, populationManager.PopulationPool[i].npc.transform.forward);
                         populationManager.PopulationPool[i].npc.gameObject.SetActive(false);

--- a/Assets/Scripts/Game/MobilePersonNPC.cs
+++ b/Assets/Scripts/Game/MobilePersonNPC.cs
@@ -53,10 +53,7 @@ namespace DaggerfallWorkshop.Game
         private int personOutfitVariant;                        // which basic outfit does the person wear
         private int personFaceRecordId;                         // used for portrait in talk window
         private bool pickpocketByPlayerAttempted = false;       // player can only attempt pickpocket on a mobile NPC once
-        private bool isGuard = false;                           // is a city watch guard
-
-        private MobilePersonBillboard billboard;    // billboard for npc
-        private MobilePersonMotor motor;            // motor for npc
+        private MobilePersonMotor motor;                        // motor for npc
 
         // these public fields are used for setting person attributes through Unity Inspector Window with function ApplyPersonSettings
         // (properties not available) as fields are randomized (e.g. name and face variant)
@@ -105,10 +102,15 @@ namespace DaggerfallWorkshop.Game
             set { pickpocketByPlayerAttempted = value; }
         }
 
-        public MobilePersonBillboard Billboard
-        {
-            get { return (billboard); }
-        }
+        /// <summary>
+        /// True if this npc is a city watch guard.
+        /// </summary>
+        public bool IsGuard { get; private set; }
+
+        /// <summary>
+        /// Billboard or custom asset for npc.
+        /// </summary>
+        public MobilePersonAsset Asset { get; private set; }
 
         public MobilePersonMotor Motor
         {
@@ -131,7 +133,7 @@ namespace DaggerfallWorkshop.Game
             {
                 gender = Genders.Male;
                 personOutfitVariant = 0;
-                isGuard = true;
+                IsGuard = true;
             }
             else
             {
@@ -139,7 +141,7 @@ namespace DaggerfallWorkshop.Game
                 gender = (Random.Range(0, 2) == 1) ? Genders.Female : Genders.Male;
                 // Set outfit variant for npc
                 personOutfitVariant = Random.Range(0, numPersonOutfitVariants);
-                isGuard = false;
+                IsGuard = false;
             }
             // Set race (set current race before calling this function with property Race)
             SetRace(race);
@@ -206,8 +208,8 @@ namespace DaggerfallWorkshop.Game
             this.personFaceRecordId = recordIndices[personOutfitVariant] + personFaceVariant;
 
             // set billboard to correct race, gender and outfit variant
-            billboard = GetComponentInChildren<MobilePersonBillboard>();
-            billboard.SetPerson(race, gender, personOutfitVariant, isGuard);
+            Asset = GetComponentInChildren<MobilePersonAsset>();
+            Asset.SetPerson(race, gender, personOutfitVariant, IsGuard);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Utility/PopulationManager.cs
+++ b/Assets/Scripts/Game/Utility/PopulationManager.cs
@@ -196,9 +196,9 @@ namespace DaggerfallWorkshop.Game.Utility
                     poolItem.npc.Motor.InitMotor();
 
                     // Adjust billboard position for actual size
-                    Vector2 size = poolItem.npc.Billboard.GetBillboardSize();
+                    Vector2 size = poolItem.npc.Asset.GetSize();
                     if (Mathf.Abs(size.y - 2f) > 0.1f)
-                        poolItem.npc.Billboard.transform.Translate(0, (size.y - 2f) * 0.52f, 0);
+                        poolItem.npc.Asset.transform.Translate(0, (size.y - 2f) * 0.52f, 0);
                 }
 
                 // Mark for recycling
@@ -216,17 +216,17 @@ namespace DaggerfallWorkshop.Game.Utility
                     poolItem.active = false;
                     poolItem.scheduleEnable = false;
                     poolItem.scheduleRecycle = false;
-                    if (poolItem.npc.Billboard)
-                        poolItem.npc.Billboard.transform.localPosition = Vector3.zero;
+                    if (poolItem.npc.Asset)
+                        poolItem.npc.Asset.transform.localPosition = Vector3.zero;
                 }
 
                 populationPool[i] = poolItem;
 
                 // Do not render active mobile until it has made at least 1 full tile move
                 // This hides skating effect while unit aligning to navigation grid
-                if (poolItem.active && poolItem.npc.Billboard)
+                if (poolItem.active && poolItem.npc.Asset)
                 {
-                    MeshRenderer billboardRenderer = poolItem.npc.Billboard.GetComponent<MeshRenderer>();
+                    MeshRenderer billboardRenderer = poolItem.npc.Asset.GetComponent<MeshRenderer>();
                     if (billboardRenderer)
                         billboardRenderer.enabled = (poolItem.npc.Motor.MoveCount > 0) ? true : false;
                 }

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -458,7 +458,7 @@ namespace DaggerfallWorkshop.Game
             MobilePersonNPC mobileNpc = hitTransform.GetComponent<MobilePersonNPC>();
             if (mobileNpc)
             {
-                if (!mobileNpc.Billboard.IsUsingGuardTexture)
+                if (!mobileNpc.IsGuard)
                 {
                     EnemyBlood blood = hitTransform.GetComponent<EnemyBlood>();
                     if (blood)


### PR DESCRIPTION
Allows mods to provide a gameobject that replaces mobile person prefab. An abstract component class is used to interact with the game, specifically to handle actual npc assignment and animation state.

This is a work in progress born from #1520


A basic example that replaces billboards with cubes:

```cs
using UnityEngine;
using DaggerfallWorkshop;
using DaggerfallWorkshop.Game.Entity;
using DaggerfallWorkshop.Game.Utility.ModSupport;

namespace MobilePersonCubeMod
{
    [ImportedComponent]
    public class MobilePersonCube : MobilePersonAsset
    {
        MeshRenderer meshRenderer;

        private void Awake()
        {
            meshRenderer = GetComponent<MeshRenderer>();
        }

        public override bool IsIdle
        {
            get; set;
        }

        public override void SetPerson(Races race, Genders gender, int personVariant, bool isGuard)
        {
            Vector3 size = GetSize();
            Trigger.height = size.y * 1.2f;
            Trigger.radius = size.x * 1.2f;
        }

        public override Vector3 GetSize()
        {
            return meshRenderer.bounds.size;
        }
    }
}
```