### PR TITLE
Show warning for incompatible mods when game is launched

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -978,10 +978,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             if (secondParts.Length < 1 || secondParts.Length > 3)
                 return null;
 
-            for (int i = 0; i < firstParts.Length && i < secondParts.Length; i++)
+            for (int i = 0; i < firstParts.Length || i < secondParts.Length; i++)
             {
-                int firstPart, secondPart;
-                if (!int.TryParse(firstParts[i], out firstPart) || !int.TryParse(secondParts[i], out secondPart))
+                int firstPart = 0;
+                int secondPart = 0;
+
+                if ((i < firstParts.Length && !int.TryParse(firstParts[i], out firstPart)) ||
+                    (i < secondParts.Length && !int.TryParse(secondParts[i], out secondPart)))
                     return null;
 
                 if (firstPart > secondPart)

--- a/Assets/StreamingAssets/Text/MainMenu.txt
+++ b/Assets/StreamingAssets/Text/MainMenu.txt
@@ -46,3 +46,4 @@ pathValidated,              Great! This looks like a valid Daggerfall folder :)
 testText,                   Test
 okText,                     OK
 keepSetting,                Keep this setting? Changes will revert in 8 seconds.
+incompatibleMods,           One or more mods are incompatible with current version of the game. Please check mods window for details. Do you wish to continue anyway?


### PR DESCRIPTION
A warning popup is shown if a mod is enabled and specifies a required game version that is higher than running build. It is possible to dismiss popup and launch the game anyway.