### PR TITLE
Add support for mod dependencies

### DIFF
--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -51,6 +51,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <summary>
         /// The name of the mod file on disk without extension.
         /// </summary>
+        /// <remarks>
+        /// While GUID can be used behind the scenes, a short, unique and readable name for the mod is needed
+        /// when it surface to users or other mod developers (for example for presets and dependencies).
+        /// Filename is the best candidate because it can't contain invalid path chars.
+        /// A good name should be lowercase and without spaces (i.e "example-mod").
+        /// A new "Name" property may be created to allow filename to be changed.
+        /// </remarks>
         [SerializeField]
         public string FileName { get; private set; }
 
@@ -235,7 +242,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             types = modInfo.Files.Where(x => x.EndsWith(".cs"))
                 .Select(x => AssetDatabase.LoadAssetAtPath<MonoScript>(x))
                 .Where(x => x != null).Select(x => x.GetClass()).Where(x => x != null).ToArray();
-            FileName = Path.GetFileName(manifestPath.Remove(manifestPath.IndexOf(ModManager.MODINFOEXTENSION)));
+            FileName = Path.GetFileName(manifestPath.Remove(manifestPath.IndexOf(ModManager.MODINFOEXTENSION))).ToLower();
             DirPath = ModManager.Instance.ModDirectory;
             HasSettings = ModSettings.ModSettingsData.HasSettings(this);
         }
@@ -754,9 +761,16 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                 if (modInfoAsset == null)
                     return false;
 
-                string modInfo = modInfoAsset.ToString();
-                this.ModInfo = (ModInfo)JsonUtility.FromJson(modInfo, typeof(ModInfo));
-                return ModInfo != null;
+
+                ModInfo modInfo = null;
+                if (ModManager._serializer.TryDeserialize(fsJsonParser.Parse(modInfoAsset.text), ref modInfo).Succeeded)
+                {
+                    this.ModInfo = modInfo;
+                    return true;
+                }
+
+                Debug.LogErrorFormat("Failed to deserialize manifest file for mod {0}", Title);
+                return false;
             }
             catch (Exception ex)
             {

--- a/Assets/Game/Addons/ModSupport/ModLoaderInterfaceWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModLoaderInterfaceWindow.cs
@@ -65,6 +65,7 @@ public class ModLoaderInterfaceWindow : DaggerfallPopupWindow
     int currentSelection = -1;
 
     ModSettings[] modSettings;
+    bool closeIfTopWindow;
 
     #endregion
 
@@ -286,6 +287,9 @@ public class ModLoaderInterfaceWindow : DaggerfallPopupWindow
         {
             modListScrollBar.ScrollIndex = modList.ScrollIndex;
         }
+
+        if (closeIfTopWindow && uiManager.TopWindow == this)
+            uiManager.PopWindow();
     }
 
     bool GetModSettings(ref ModSettings ms)
@@ -382,7 +386,7 @@ public class ModLoaderInterfaceWindow : DaggerfallPopupWindow
         }
     }
 
-    private void CleanConfigurationDirectory(Action onPerformed = null)
+    private void CleanConfigurationDirectory()
     {
         var unknownDirectories = Directory.GetDirectories(ModManager.Instance.ModDataDirectory)
             .Select(x => new DirectoryInfo(x))
@@ -405,16 +409,37 @@ public class ModLoaderInterfaceWindow : DaggerfallPopupWindow
                 }
 
                 messageBox.CancelWindow();
-
-                if (onPerformed != null)
-                    onPerformed();
             };
             uiManager.PushWindow(cleanConfigMessageBox);
         }
-        else
+    }
+
+    private void CheckDependencies()
+    {
+        foreach (Mod mod in ModManager.Instance.Mods.Where(x => x.Enabled))
         {
-            if (onPerformed != null)
-                onPerformed();
+            string errorMessage = ModManager.Instance.CheckModDependencies(mod);
+            if (errorMessage != null)
+            {
+                string message = string.Format(ModManager.GetText("dependencyErrorMessage"), mod.Title, errorMessage);
+                var messageBox = new DaggerfallMessageBox(uiManager, this, true);
+                messageBox.ClickAnywhereToClose = true;
+                messageBox.SetText(message);
+                messageBox.SetText(new[] { message, ModManager.GetText("sortModsQuestion") });
+                messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
+                messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No, true);
+                messageBox.OnButtonClick += (_, button) =>
+                {
+                    if (button == DaggerfallMessageBox.MessageBoxButtons.Yes)
+                    {
+                        ModManager.Instance.AutoSortMods();
+                        ModManager.WriteModSettings();
+                        Debug.Log("Mods have been sorted automatically");
+                    }
+                };
+                uiManager.PushWindow(messageBox);
+                Debug.LogError(message);
+            }
         }
     }
 
@@ -484,7 +509,11 @@ public class ModLoaderInterfaceWindow : DaggerfallPopupWindow
         //save current mod settings to file
         ModManager.WriteModSettings();
         ModManager.Instance.SortMods();
-        CleanConfigurationDirectory(() => DaggerfallUI.UIManager.PopWindow());
+
+        // Show info popups and close
+        closeIfTopWindow = true;
+        CleanConfigurationDirectory();
+        CheckDependencies();
     }
 
     void ExtractFilesButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -580,7 +580,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             {
                 foreach (string manifestPath in Directory.GetFiles(EditorModsDirectory, "*" + MODINFOEXTENSION, SearchOption.AllDirectories))
                 {
-                    var modInfo = JsonUtility.FromJson<ModInfo>(File.ReadAllText(manifestPath));
+                    ModInfo modInfo = null;
+                    if (ModManager._serializer.TryDeserialize(fsJsonParser.Parse(File.ReadAllText(manifestPath)), ref modInfo).Failed)
+                    {
+                        Debug.LogErrorFormat("Failed to deserialize manifest file {0}", manifestPath);
+                        continue;
+                    }
+
                     if (mods.Any(x => x.ModInfo.GUID == modInfo.GUID))
                     {
                         Debug.LogWarningFormat("Ignoring virtual mod {0} because release mod is already loaded.", modInfo.ModTitle);
@@ -946,6 +952,81 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         }
 
         /// <summary>
+        /// Automatically assigns load priority from relationships defined by <see cref="ModInfo.Dependencies"/>.
+        /// </summary>
+        internal void AutoSortMods()
+        {
+            try
+            {
+                mods = TopologicalSort(mods, mod =>
+                {
+                    if (mod.ModInfo.Dependencies == null)
+                        return Enumerable.Empty<Mod>();
+
+                    var query = from dependency in mod.ModInfo.Dependencies
+                                where !dependency.IsPeer
+                                select GetModFromName(dependency.Name);
+
+                    return query.Where(x => x != null);
+                });
+
+                for (int i = 0; i < mods.Count; i++)
+                    mods[i].LoadPriority = i;
+            }
+            catch (Exception e)
+            {
+                Debug.LogErrorFormat("Failed to auto sort mods: {0}", e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Checks if all conditions defined in Dependency section of a mod are satisfied.
+        /// </summary>
+        /// <param name="mod">A mod that should be validated.</param>
+        /// <returns>A readable error message or null.</returns>
+        internal string CheckModDependencies(Mod mod)
+        {
+            if (mod.ModInfo.Dependencies != null)
+            {
+                foreach (ModDependency dependency in mod.ModInfo.Dependencies)
+                {
+                    // Check if dependency is available
+                    Mod target = GetModFromName(dependency.Name);
+                    if (target == null)
+                    {
+                        if (dependency.IsOptional)
+                            continue;
+
+                        return string.Format(ModManager.GetText("dependencyIsMissing"), dependency.Name);
+                    }
+
+                    // Check load order priority
+                    if (!dependency.IsPeer && mod.LoadPriority < target.LoadPriority)
+                        return string.Format(ModManager.GetText("dependencyWithIncorrectPosition"), target.Title);
+
+                    // Check minimum version (ignore pre-release identifiers after hyphen).
+                    if (dependency.Version != null)
+                    {
+                        if (target.ModInfo.ModVersion == null)
+                            return string.Format(ModManager.GetText("dependencyWithIncompatibleVersion"), target.Title, "<undefined>", dependency.Version);
+
+                        int index = target.ModInfo.ModVersion.IndexOf('-');
+                        string referenceVersion = index != -1 ? target.ModInfo.ModVersion.Remove(index) : target.ModInfo.ModVersion;
+                        if (IsVersionLowerOrEqual(dependency.Version, referenceVersion) != true)
+                            return string.Format(ModManager.GetText("dependencyWithIncompatibleVersion"), target.Title, target.ModInfo.ModVersion, dependency.Version);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        internal Mod GetModFromName(string name)
+        {
+            return mods.FirstOrDefault(x => x.FileName.Equals(name, StringComparison.Ordinal));
+        }
+
+        /// <summary>
         /// Gets a localized string for a mod system text.
         /// </summary>
         internal static string GetText(string key)
@@ -1036,6 +1117,36 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                     DaggerfallUnity.LogMessage("Multiple ModManager instances detected in scene!", true);
                     Destroy(this);
                 }
+            }
+        }
+
+        // Adapted from https://stackoverflow.com/questions/4106862/how-to-sort-depended-objects-by-dependency
+        private static List<T> TopologicalSort<T>(IEnumerable<T> source, Func<T, IEnumerable<T>> dependencies)
+        {
+            var sorted = new List<T>();
+            var visited = new HashSet<T>();
+
+            foreach (var item in source)
+                Visit(item, visited, sorted, dependencies);
+
+            return sorted;
+        }
+
+        private static void Visit<T>(T item, HashSet<T> visited, List<T> sorted, Func<T, IEnumerable<T>> dependencies)
+        {
+            if (!visited.Contains(item))
+            {
+                visited.Add(item);
+
+                foreach (var dependency in dependencies(item))
+                    Visit(dependency, visited, sorted, dependencies);
+
+                sorted.Add(item);
+            }
+            else
+            {
+                if (!sorted.Contains(item))
+                    throw new Exception("Cyclic dependency found");
             }
         }
 

--- a/Assets/Game/Addons/ModSupport/ModTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModTypes.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Lypyl (lypyl@dfworkshop.net)
-// Contributors:    
+// Contributors:    TheLacus
 // 
 // Notes:
 //
@@ -50,6 +50,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         [SerializeField]
         internal ModContributes Contributes;
 
+        /// <summary>
+        /// A list of mods that this mod depends on or is otherwise compatible with only if certain conditions are met.
+        /// </summary>
+        [SerializeField]
+        internal ModDependency[] Dependencies;
+
         public ModInfo()
         {
             Files = new List<string>();
@@ -80,6 +86,46 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// </summary>
         [SerializeField]
         internal string[] SpellIcons;
+    }
+
+    /// <summary>
+    /// A set of rules that defines the limits within which a mod is required or otherwise compatible with another one.
+    /// </summary>
+    /// <remarks>
+    /// These are all the possible combinations:
+    /// - Dependency: must be available, have higher priority and follow specified criteria.
+    /// - Optional dependency: if is available it must have higher priority and follow specified criteria.
+    /// - Peer dependency: must be available and follow specified criteria but higher priority is not required.
+    /// - Optional peer dependency: if is available it must follow specified criteria but higher priority is not required.
+    /// </summary>
+    [Serializable]
+    internal struct ModDependency
+    {
+        /// <summary>
+        /// Name of target mod.
+        /// </summary>
+        [SerializeField]
+        internal string Name;
+
+        /// <summary>
+        /// If true, target mod doesn't need to be available, but must validate these criteria if it is.
+        /// </summary>
+        [SerializeField]
+        internal bool IsOptional;
+
+        /// <summary>
+        /// If true, target mod can be positioned anywhere in the load order, otherwise must be positioned above.
+        /// </summary>
+        [SerializeField]
+        internal bool IsPeer;
+
+        /// <summary>
+        /// If not null this string is the minimum accepted version with format X.Y.Z.
+        /// Pre-release identifiers following an hyphen are ignored in target version so they must be omitted here.
+        /// For example "1.1.0" is higher than "1.0.12" and equal to "1.0.0-rc.1".
+        /// </summary>
+        [SerializeField]
+        internal string Version;
     }
 
     /// <summary>

--- a/Assets/StreamingAssets/Text/ModSystem.txt
+++ b/Assets/StreamingAssets/Text/ModSystem.txt
@@ -60,3 +60,9 @@ presetSaveInfo,             Save current settings to selected preset.
 presetDeleteInfo,           Delete selected presets.
 presetExportInfo,           Export selected preset to a file that can be shared.
 titleOrDescriptionMissing,  Title and Description are mandatory fields.
+
+dependencyErrorMessage,                 {0} has dependencies that are not satisfied: {1}. Please check the ReadMe provided by mod author for details.
+dependencyIsMissing,                    Failed to retrieve mod with GUID {0}
+dependencyWithIncorrectPosition,        {0} must be positioned above in the load order
+dependencyWithIncompatibleVersion,      {0} has version {1} but {2} or higher is requested
+sortModsQuestion,                       Do you want to sort mods automatically?


### PR DESCRIPTION
Allows mods to define other mods as dependencies to enforce a minimum version to be installed and/or to be positioned above in the load order. Dependencies are also used for the creation of an automatic load order.

```json
"Dependencies": [
    {
        "Name": "dungeonexit",
        "IsOptional": false,
        "IsPeer": false,
        "Version": "1.0.2"
    }
]
```

![mods_dependencies](https://user-images.githubusercontent.com/24359151/68252696-76cb1780-0026-11ea-968f-0aa15f568820.png)
