### PR TITLE
Implement option to partially parse a quest

### DIFF
--- a/Assets/Scripts/Game/Questing/Parser.cs
+++ b/Assets/Scripts/Game/Questing/Parser.cs
@@ -51,7 +51,8 @@ namespace DaggerfallWorkshop.Game.Questing
         /// </summary>
         /// <param name="source">Array of text lines from quest source.</param>
         /// <param name="factionId">Faction id of quest giver for guilds.</param>
-        public Quest Parse(string[] source, int factionId)
+        /// <param name="partialParse">If true the QRC & QBN sections will not be parsed</param>
+        public Quest Parse(string[] source, int factionId, bool partialParse = false)
         {
             Quest quest = new Quest();
             quest.FactionId = factionId;
@@ -139,9 +140,12 @@ namespace DaggerfallWorkshop.Game.Questing
                 throw new Exception("Parse() error: Quest has no QBN section.");
             }
 
-            // Parse QRC and QBN
-            ParseQRC(quest, qrcLines);
-            ParseQBN(quest, qbnLines);
+            // Parse QRC and QBN, unless partial parse requested
+            if (!partialParse)
+            {
+                ParseQRC(quest, qrcLines);
+                ParseQBN(quest, qbnLines);
+            }
 
             // End timer
             long totalTime = stopwatch.ElapsedMilliseconds - startTime;

--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -386,7 +386,14 @@ namespace DaggerfallWorkshop.Game.Questing
             return LoadQuest(new QuestData() { name = questName, path = questPath }, factionId);
         }
 
-        public Quest LoadQuest(QuestData questData, int factionId)
+        /// <summary>
+        /// Loads a quest script from the quest data.
+        /// </summary>
+        /// <param name="questData">The quest data object of the quest to load.</param>
+        /// <param name="factionId">Faction id that should get the rep change for quest success/failure.</param>
+        /// <param name="partialParse">If true the quest will only be partially parsed and cannot be instantiated.</param>
+        /// <returns></returns>
+        public Quest LoadQuest(QuestData questData, int factionId, bool partialParse = false)
         {
             // Append extension if not present
             string questName = questData.name;
@@ -398,7 +405,7 @@ namespace DaggerfallWorkshop.Game.Questing
             string questFile = Path.Combine(questData.path, questName);
             if (File.Exists(questFile))
             {
-                quest = QuestMachine.Instance.ParseQuest(questName, File.ReadAllLines(questFile), factionId);
+                quest = QuestMachine.Instance.ParseQuest(questName, File.ReadAllLines(questFile), factionId, partialParse);
                 if (quest == null)
                     return null;
             }
@@ -409,7 +416,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(questName, false, out questAsset))
                 {
                     List<string> lines = ModManager.GetTextAssetLines(questAsset);
-                    quest = QuestMachine.Instance.ParseQuest(questName, lines.ToArray(), factionId);
+                    quest = QuestMachine.Instance.ParseQuest(questName, lines.ToArray(), factionId, partialParse);
                     if (quest == null)
                         return null;
                 }

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -617,8 +617,9 @@ namespace DaggerfallWorkshop.Game.Questing
         /// <param name="questName">Name of quest filename. Extensions .txt is optional.</param>
         /// <param name="questSource">Array of lines from quest source file.</param>
         /// <param name="factionId">Faction id of quest giver for guilds.</param>
+        /// <param name="partialParse">If true the QRC & QBN sections will not be parsed</param>
         /// <returns>Quest.</returns>
-        public Quest ParseQuest(string questName, string[] questSource, int factionId = 0)
+        public Quest ParseQuest(string questName, string[] questSource, int factionId = 0, bool partialParse = false)
         {
             LogFormat("\r\n\r\nParsing quest {0}", questName);
 
@@ -626,7 +627,7 @@ namespace DaggerfallWorkshop.Game.Questing
             {
                 // Parse quest
                 Parser parser = new Parser();
-                Quest quest = parser.Parse(questSource, factionId);
+                Quest quest = parser.Parse(questSource, factionId, partialParse);
 
                 return quest;
             }


### PR DESCRIPTION
This is what I considered doing when I originally implementing the quest lists option, but I was concerned about altering the quest parsing stuff so instead I decided to do full parse of every quest and have a 'please wait' message instead.

Since this is the root cause of the bugs we've seen with this feature, I've gone back to my original idea and added a boolean param that allows a partial quest parse to be requested. This doesn't parse the QRC or QBN sections, so the quest object returned is not startable.

This should fix #1536 and also speed up the list preparation. I've left the please wait message in there for now. It could be removed as it's quick enough with this change, but I would like to know that having this partial parse is acceptable by @Interkarma first. Also it's is nice flavor in a way, so I would be happy to keep it. Maybe just have a random delay as the quest giver goes to 'look' at availiable quests? :-)