### PR TITLE
Fix a bug when entering certain buildings riding a horse

### DIFF
--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -51,12 +51,12 @@ namespace DaggerfallWorkshop.Game
         private LevitateMotor levitateMotor;
         private ClimbingMotor climbingMotor;
         private Camera mainCamera;
-        private const float controllerStandingHeight = 1.8f;
-        private const float controllerCrouchHeight = 0.9f;
-        private const float controllerRideHeight = 2.6f;   // Height of a horse plus seated rider. (1.6m + 1m)
-        private const float controllerSwimHeight = 0.30f;
-        private const float controllerSwimHorseDisplacement = 0.30f; // amount added to swim height if on horse
-        private const float eyeHeight = 0.09f;         // Eye height is 9cm below top of capsule.
+        public const float controllerStandingHeight = 1.8f;
+        public const float controllerCrouchHeight = 0.9f;
+        public const float controllerRideHeight = 2.6f;   // Height of a horse plus seated rider. (1.6m + 1m)
+        public const float controllerSwimHeight = 0.30f;
+        public const float controllerSwimHorseDisplacement = 0.30f; // amount added to swim height if on horse
+        public const float eyeHeight = 0.09f;         // Eye height is 9cm below top of capsule.
         private float targetCamLevel;
         private float prevCamLevel;
         private float camCrouchLevel;

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -1160,7 +1160,7 @@ namespace DaggerfallWorkshop.Game
             // Snap player to ground
             RaycastHit hit;
             Ray ray = new Ray(transform.position, Vector3.down);
-            if (Physics.Raycast(ray, out hit, controller.height * 2f))
+            if (Physics.Raycast(ray, out hit, PlayerHeightChanger.controllerStandingHeight * 2f))
             {
                 // Clear falling damage so player doesn't take damage if they transitioned into a dungeon while jumping
                 GameManager.Instance.AcrobatMotor.ClearFallingDamage();


### PR DESCRIPTION
Some extry doors are raised and cause issues when entered while on a horse since the controller height is larger so the raycast finds the streaming terrain somehow (I think) and the player is then moved under the floor by PlayerEnterExit.SetStanding()

This fix changes that method to always use the standing controller height rather than the dynamic value.

Reproduce the bug by entering the palace at Issaqumbaa  in Abibon-Gora while riding. Before this fix you fall though the world.