### PR TITLE
fix for bug: "opening quest log can clear marked residences from map"

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2074,10 +2074,6 @@ namespace DaggerfallWorkshop.Game
                 if (questResourceInfo.resourceType == QuestInfoResourceType.Location)
                 {
                     instantRebuildTopicListLocation = true;
-
-                    // Undiscover residences when they are a quest resource (named residence) when "add dialog" is done for this quest resource
-                    // Otherwise previously discovered residences will automatically show up on the automap when used in a quest
-                    UndiscoverQuestResidence(questID, resourceName, questResourceInfo);
                 }
                 else if (questResourceInfo.resourceType == QuestInfoResourceType.Person)
                 {


### PR DESCRIPTION
fix for bug described here: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2994

info:
the line removed was the culprit causing the bug described, it was necessary before the discovery rework but is no longer needed (since named residences get correctly undiscovered once quest is handed in (I checked this) and when I reworked discovery system last time I changed it so that it deletes the discovery list of orphaned entries on load and save (function PlayerGPS.RemoveUnnamedResidencesFromDiscoveryData) - so no need to handle orphaned entries here