### PR TITLE
skip climbing/rappel mode checks when not on foot

### DIFF
--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -273,12 +273,17 @@ namespace DaggerfallWorkshop.Game
 
             playerScanner.FindHeadHit(new Ray(controller.transform.position, Vector3.up));
             playerScanner.SetHitSomethingInFront();
-            // Check if should hang
-            //hangingMotor.HangingChecks();
-            // Handle Rappeling
-            rappelMotor.RappelChecks();
-            // Handle climbing
-            climbingMotor.ClimbingCheck();
+
+            // Can only engage climbing/rappel mode when on foot
+            if (GameManager.Instance.TransportManager.IsOnFoot)
+            {
+                // Check if should hang
+                //hangingMotor.HangingChecks();
+                // Handle Rappeling
+                rappelMotor.RappelChecks();
+                // Handle climbing
+                climbingMotor.ClimbingCheck();
+            }
 
             // Do nothing if player levitating/swimming or climbing - replacement motor will take over movement for levitating/swimming
             if (levitateMotor && (levitateMotor.IsLevitating || levitateMotor.IsSwimming) || climbingMotor.IsClimbing /*|| hangingMotor.IsHanging*/)


### PR DESCRIPTION
Prevents trying to rappel down on horse or cart, for example.
Instead you'll just fall as per Newton's law; Should horses be unwilling to fall instead?
It seems falling off walls on horse is the way of classic too https://www.youtube.com/watch?v=1qco1jJmKu0

Also, is it the right place to check for transport mode?

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=2997