### PR TITLE
Fix issues with replacement buildings

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -326,7 +326,6 @@ namespace Wenzil.Console
                     {
                         RmbSubRecord = blockData.RmbBlock.SubRecords[recordIndex],
                         BuildingType = (int)blockData.RmbBlock.FldHeader.BuildingDataList[recordIndex].BuildingType,
-                        FactionId = blockData.RmbBlock.FldHeader.BuildingDataList[recordIndex].FactionId,
                         Quality = blockData.RmbBlock.FldHeader.BuildingDataList[recordIndex].Quality,
                     };
                     string buildingJson = SaveLoadManager.Serialize(buildingData.GetType(), buildingData);

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -40,7 +40,7 @@ namespace DaggerfallWorkshop.Utility
 
         #region Structures
 
-        struct BuildingPoolItem
+        class BuildingPoolItem
         {
             public DFLocation.BuildingData buildingData;
             public bool used;
@@ -529,33 +529,33 @@ namespace DaggerfallWorkshop.Utility
                         DFLocation.BuildingData building = block.RmbBlock.FldHeader.BuildingDataList[i];
                         if (IsNamedBuilding(building.BuildingType))
                         {
+                            // Try to find next building and merge data
+                            BuildingPoolItem item;
+                            if (!GetNextBuildingFromPool(namedBuildingPool, building.BuildingType, out item))
+                            {
+                                Debug.LogFormat("End of city building list reached without finding building type {0} in location {1}.{2}", building.BuildingType, location.RegionName, location.Name);
+                            }
+
+                            // Copy found city building data to block level
+                            building.NameSeed = item.buildingData.NameSeed;
+                            building.FactionId = item.buildingData.FactionId;
+                            building.Sector = item.buildingData.Sector;
+                            building.LocationId = item.buildingData.LocationId;
+                            building.Quality = item.buildingData.Quality;
+
                             // Check for replacement building data and use it if found
                             if (WorldDataReplacement.GetBuildingReplacementData(blockName, block.Index, i, out buildingReplacementData))
                             {
-                                // Use custom building values from replacement data, don't use pool or maps file
-                                building.NameSeed = location.Exterior.Buildings[0].NameSeed;
-                                building.FactionId = buildingReplacementData.FactionId;
+                                // Use custom building values from replacement data, but only use up pool item if factionId is zero
+                                if (buildingReplacementData.FactionId != 0)
+                                {
+                                    // Don't use up pool item and set factionId from replacement data
+                                    item.used = false;
+                                    building.FactionId = buildingReplacementData.FactionId;
+                                }
+                                // Always override type and quality
                                 building.BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.BuildingType;
-                                building.LocationId = location.Exterior.Buildings[0].LocationId;
                                 building.Quality = buildingReplacementData.Quality;
-                            }
-                            else
-                            {
-                                // Try to find next building and merge data
-                                BuildingPoolItem item;
-                                if (!GetNextBuildingFromPool(namedBuildingPool, building.BuildingType, out item))
-                                {
-                                    Debug.LogFormat("End of city building list reached without finding building type {0} in location {1}.{2}", building.BuildingType, location.RegionName, location.Name);
-                                }
-                                else
-                                {
-                                    // Copy found city building data to block level
-                                    building.NameSeed = item.buildingData.NameSeed;
-                                    building.FactionId = item.buildingData.FactionId;
-                                    building.Sector = item.buildingData.Sector;
-                                    building.LocationId = item.buildingData.LocationId;
-                                    building.Quality = item.buildingData.Quality;
-                                }
                             }
 
                             // Matched to classic: special handling for some Order of the Raven buildings
@@ -590,14 +590,11 @@ namespace DaggerfallWorkshop.Utility
             {
                 if (!namedBuildingPool[i].used && namedBuildingPool[i].buildingData.BuildingType == buildingType)
                 {
-                    BuildingPoolItem item = namedBuildingPool[i];
-                    item.used = true;
-                    namedBuildingPool[i] = item;
-                    itemOut = item;
+                    itemOut = namedBuildingPool[i];
+                    itemOut.used = true;
                     return true;
                 }
             }
-
             return false;
         }
 


### PR DESCRIPTION
When altering named buildings, set factionId to zero and the building data pool items (from location) will be used as normal. Set factionId to >0 and pool items will not be used as it will be assumed this is a new named building.

This was the best way I could think of to fix the issues raised here https://forums.dfworkshop.net/viewtopic.php?f=5&p=34619#p34608

While also retaining the fix made by reverting in #1591 

@Interkarma I changed the pool items from a struct to a class so a ref is passed back and the pool item usage can be marked as unused if the replacement data is a new named building with a non zero faction id. Can you confirm this wont screw something else up? I couldn't see any potential issues with it.