### PR TITLE
use .webm video format on Linux

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/VideoReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/VideoReplacement.cs
@@ -25,6 +25,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     {
         static readonly string moviePath = Path.Combine(Application.streamingAssetsPath, "Movies");
 
+// https://docs.unity3d.com/Manual/VideoSources-FileCompatibility.html
+#if !UNITY_STANDALONE_LINUX
+        static readonly string videoExtension = ".mp4";
+#else
+        static readonly string videoExtension = ".webm";
+#endif
+
         /// <summary>
         /// Path to custom movies on disk.
         /// </summary>
@@ -49,7 +56,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     name = name.Substring(0, index);
 
                 // Seek from loose files
-                string path = Path.Combine(moviePath, name + ".mp4");
+                string path = Path.Combine(moviePath, name + videoExtension);
                 if (File.Exists(path))
                 {
                     videoPlayerDrawer = new VideoPlayerDrawer(path);


### PR DESCRIPTION
.mp4 format is not supported by VideoPlayer on Linux:

https://docs.unity3d.com/Manual/VideoSources-FileCompatibility.html

Fix for #1550 