### PR TITLE
fix a NullReferenceException in DaggerfallVidPlayerWindow.IsPlaying

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallVidPlayerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallVidPlayerWindow.cs
@@ -53,7 +53,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public bool IsPlaying
         {
-            get { return useCustomVideo ? customVideo.IsPlaying : video.Playing; }
+            get { return useCustomVideo ? (customVideo != null && customVideo.IsPlaying) : (video != null && video.Playing); }
         }
 
         public bool EndOnAnyKey
@@ -136,6 +136,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     video.Playing = false;
                     video.Dispose();
+                    video = null;
+
                     DoHideCursor(false);
                     RaiseOnVideoFinishedHandler();
                     RaiseOnVideoEndGlobalEvent();


### PR DESCRIPTION
LoadingScreen uses player.IsPlaying to poll when a video is finished
playing, but the video may have been cleared

NullReferenceException: Object reference not set to an instance of an
object
  at
DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallVidPlayerWindow.get_IsPlaying
() [0x00000] in <filename unknown>:0
  at LoadingScreen.LoadingScreen+<DoDeathScreen>c__Iterator1.MoveNext ()
[0x00000] in <filename unknown>:0
  at UnityEngine.SetupCoroutine.InvokeMoveNext (IEnumerator enumerator,
IntPtr returnValueAddress) [0x00000] in <filename unknown>:0