### PR TITLE
fix: localized floating numbers handling

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsTypes.cs
@@ -264,7 +264,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
                 string[] args = input.Split(new char[] { ',' }, count);
                 items = new T[args.Length];
                 for (int i = 0; i < args.Length; i++)
-                    items[i] = (T)Convert.ChangeType(args[i], typeof(T));
+                    items[i] = (T)Convert.ChangeType(args[i], typeof(T), CultureInfo.InvariantCulture);
                 return true;
             }
             catch (Exception e)
@@ -544,7 +544,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         protected override void Deserialize(string textValue)
         {
             float value;
-            if (float.TryParse(textValue, out value))
+            if (float.TryParse(textValue, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out value))
                 Value = Mathf.Clamp(value, Min, Max);
         }
     }

--- a/Assets/Scripts/Game/UserInterface/TextBox.cs
+++ b/Assets/Scripts/Game/UserInterface/TextBox.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.IO;
+using System.Globalization;
 
 namespace DaggerfallWorkshop.Game.UserInterface
 {
@@ -42,6 +43,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
         bool upperOnly = false;
         bool fixedSize = false;
         bool previousSDFState;
+
+        // Are those guaranteed to be strings of one character?
+        readonly static char minus = CultureInfo.CurrentCulture.NumberFormat.NegativeSign[0];
+        readonly static char dot = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator[0];
 
         public int MaxCharacters
         {
@@ -225,9 +230,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 if (numeric)
                 {
-                    const char minus = '-';
-                    const char dot = '.';
-
                     int value = (int)character;
                     if (value < 0x30 || value > 0x39)
                     {


### PR DESCRIPTION
Fixes two issues that only happen in some locales (like french) that do not use the dot as floating point separator:

- Join correctly writes lists of values with InvariantCulture, but TrySplit does not, leading to parse errors:

Failed to split values from 0.65,1.05
System.FormatException: Unknown char: .
  at System.Double.Parse (System.String s, NumberStyles style,
IFormatProvider provider) [0x00000] in <filename unknown>:0
  at System.Single.Parse (System.String s, IFormatProvider provider)
[0x00000] in <filename unknown>:0
  at System.Convert.ToSingle (System.String value, IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.String.System.IConvertible.ToSingle (IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.Convert.ToType (System.Object value, System.Type
conversionType, IFormatProvider provider, Boolean try_target_to_type)
[0x00000] in <filename unknown>:0
  at System.Convert.ChangeType (System.Object value, System.Type
conversionType) [0x00000] in <filename unknown>:0
  at
DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.Key.TrySplit[Single]
(System.String input, Int32 count, System.Single[]& items) [0x00000] in
<filename unknown>:0

(Filename: ./Runtime/Export/Debug.bindings.h Line: 43)

Failed to split values from 0.8,1
System.FormatException: Unknown char: .
  at System.Double.Parse (System.String s, NumberStyles style,
IFormatProvider provider) [0x00000] in <filename unknown>:0
  at System.Single.Parse (System.String s, IFormatProvider provider)
[0x00000] in <filename unknown>:0
  at System.Convert.ToSingle (System.String value, IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.String.System.IConvertible.ToSingle (IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.Convert.ToType (System.Object value, System.Type
conversionType, IFormatProvider provider, Boolean try_target_to_type)
[0x00000] in <filename unknown>:0
  at System.Convert.ChangeType (System.Object value, System.Type
conversionType) [0x00000] in <filename unknown>:0
  at
DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.Key.TrySplit[Single]
(System.String input, Int32 count, System.Single[]& items) [0x00000] in
<filename unknown>:0

(Filename: ./Runtime/Export/Debug.bindings.h Line: 43)

Failed to split values from 0.1,0.9
System.FormatException: Unknown char: .
  at System.Double.Parse (System.String s, NumberStyles style,
IFormatProvider provider) [0x00000] in <filename unknown>:0
  at System.Single.Parse (System.String s, IFormatProvider provider)
[0x00000] in <filename unknown>:0
  at System.Convert.ToSingle (System.String value, IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.String.System.IConvertible.ToSingle (IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.Convert.ToType (System.Object value, System.Type
conversionType, IFormatProvider provider, Boolean try_target_to_type)
[0x00000] in <filename unknown>:0
  at System.Convert.ChangeType (System.Object value, System.Type
conversionType) [0x00000] in <filename unknown>:0
  at
DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.Key.TrySplit[Single]
(System.String input, Int32 count, System.Single[]& items) [0x00000] in
<filename unknown>:0

(Filename: ./Runtime/Export/Debug.bindings.h Line: 43)

Failed to split values from 0.2,0.6
System.FormatException: Unknown char: .
  at System.Double.Parse (System.String s, NumberStyles style,
IFormatProvider provider) [0x00000] in <filename unknown>:0
  at System.Single.Parse (System.String s, IFormatProvider provider)
[0x00000] in <filename unknown>:0
  at System.Convert.ToSingle (System.String value, IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.String.System.IConvertible.ToSingle (IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.Convert.ToType (System.Object value, System.Type
conversionType, IFormatProvider provider, Boolean try_target_to_type)
[0x00000] in <filename unknown>:0
  at System.Convert.ChangeType (System.Object value, System.Type
conversionType) [0x00000] in <filename unknown>:0
  at
DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.Key.TrySplit[Single]
(System.String input, Int32 count, System.Single[]& items) [0x00000] in
<filename unknown>:0

(Filename: ./Runtime/Export/Debug.bindings.h Line: 43)

Failed to split values from 0.1,0.8
System.FormatException: Unknown char: .
  at System.Double.Parse (System.String s, NumberStyles style,
IFormatProvider provider) [0x00000] in <filename unknown>:0
  at System.Single.Parse (System.String s, IFormatProvider provider)
[0x00000] in <filename unknown>:0
  at System.Convert.ToSingle (System.String value, IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.String.System.IConvertible.ToSingle (IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.Convert.ToType (System.Object value, System.Type
conversionType, IFormatProvider provider, Boolean try_target_to_type)
[0x00000] in <filename unknown>:0
  at System.Convert.ChangeType (System.Object value, System.Type
conversionType) [0x00000] in <filename unknown>:0
  at
DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.Key.TrySplit[Single]
(System.String input, Int32 count, System.Single[]& items) [0x00000] in
<filename unknown>:0

(Filename: ./Runtime/Export/Debug.bindings.h Line: 43)

Failed to split values from 0,1.1
System.FormatException: Unknown char: .
  at System.Double.Parse (System.String s, NumberStyles style,
IFormatProvider provider) [0x00000] in <filename unknown>:0
  at System.Single.Parse (System.String s, IFormatProvider provider)
[0x00000] in <filename unknown>:0
  at System.Convert.ToSingle (System.String value, IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.String.System.IConvertible.ToSingle (IFormatProvider
provider) [0x00000] in <filename unknown>:0
  at System.Convert.ToType (System.Object value, System.Type
conversionType, IFormatProvider provider, Boolean try_target_to_type)
[0x00000] in <filename unknown>:0
  at System.Convert.ChangeType (System.Object value, System.Type
conversionType) [0x00000] in <filename unknown>:0
  at
DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings.Key.TrySplit[Single]
(System.String input, Int32 count, System.Single[]& items) [0x00000] in
<filename unknown>:0

- Other issue is related to float tuples deserialization; For example ConvenientClock allows to set clock scale, correctly write this setting in InvariantCulture format, but is not restored in game (clock stays at its nominal size).