### PR TITLE
Refactor quest system dependencies

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -2213,7 +2213,7 @@ namespace Wenzil.Console
                 UnityEngine.Random.InitState(Time.frameCount);
                 Quest quest = GameManager.Instance.QuestListsManager.GetQuest(args[0]);
                 if (quest != null)
-                    QuestMachine.Instance.InstantiateQuest(quest);
+                    QuestMachine.Instance.StartQuest(quest);
 
                 return "Finished";
             }

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1464,7 +1464,7 @@ namespace DaggerfallWorkshop.Game.Entity
             {
                 thievesGuildRequirementTally = InviteSent;
                 timeForThievesGuildLetter = 0;
-                Questing.QuestMachine.Instance.InstantiateQuest(ThievesGuild.InitiationQuestName, ThievesGuild.FactionId);
+                Questing.QuestMachine.Instance.StartQuest(ThievesGuild.InitiationQuestName, ThievesGuild.FactionId);
             }
             if (darkBrotherhoodRequirementTally != InviteSent
                 && timeForDarkBrotherhoodLetter > 0
@@ -1473,7 +1473,7 @@ namespace DaggerfallWorkshop.Game.Entity
             {
                 darkBrotherhoodRequirementTally = InviteSent;
                 timeForDarkBrotherhoodLetter = 0;
-                Questing.QuestMachine.Instance.InstantiateQuest(DarkBrotherhood.InitiationQuestName, DarkBrotherhood.FactionId);
+                Questing.QuestMachine.Instance.StartQuest(DarkBrotherhood.InitiationQuestName, DarkBrotherhood.FactionId);
             }
         }
 

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/LycanthropyEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/LycanthropyEffect.cs
@@ -401,7 +401,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                     return;
 
                 // Start the cure quest
-                QuestMachine.Instance.InstantiateQuest(cureQuestName);
+                QuestMachine.Instance.StartQuest(cureQuestName);
             }
         }
 

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/VampirismEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/VampirismEffect.cs
@@ -218,7 +218,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             if (isCureQuest)
             {
                 if (DFRandom.random_range_inclusive(10, 100) < 30)
-                    QuestMachine.Instance.InstantiateQuest("$CUREVAM");
+                    QuestMachine.Instance.StartQuest("$CUREVAM");
             }
             else if (hasStartedInitialVampireQuest)
             {
@@ -237,12 +237,12 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                         reputation,
                         GameManager.Instance.PlayerEntity.Level);
                     if (offeredQuest != null)
-                        QuestMachine.Instance.InstantiateQuest(offeredQuest);
+                        QuestMachine.Instance.StartQuest(offeredQuest);
                 }
             }
             else if (DFRandom.random_range_inclusive(1, 100) < 50)
             {
-                QuestMachine.Instance.InstantiateQuest("P0A01L00");
+                QuestMachine.Instance.StartQuest("P0A01L00");
                 hasStartedInitialVampireQuest = true;
             }
         }

--- a/Assets/Scripts/Game/Questing/Item.cs
+++ b/Assets/Scripts/Game/Questing/Item.cs
@@ -124,6 +124,7 @@ namespace DaggerfallWorkshop.Game.Questing
         public Item(Quest parentQuest, string line)
             : base(parentQuest)
         {
+            talkManagerType = TalkManager.QuestInfoResourceType.Thing;
             SetResource(line);
         }
 
@@ -203,8 +204,6 @@ namespace DaggerfallWorkshop.Game.Questing
                 else
                     throw new Exception(string.Format("Could not create Item from line {0}", line));
 
-                // add conversation topics from anyInfo command tag
-                AddConversationTopics();
             }
         }
 
@@ -372,40 +371,6 @@ namespace DaggerfallWorkshop.Game.Questing
             result.LinkQuestItem(ParentQuest.UID, Symbol.Clone());
 
             return result;
-        }
-
-
-        void AddConversationTopics()
-        {
-            List<TextFile.Token[]> anyInfoAnswers = null;
-            List<TextFile.Token[]> anyRumorsAnswers = null;
-            if (this.InfoMessageID != -1)
-            {
-                Message message = this.ParentQuest.GetMessage(this.InfoMessageID);
-                anyInfoAnswers = new List<TextFile.Token[]>();
-                if (message != null)
-                {
-                    for (int i = 0; i < message.VariantCount; i++)
-                    {
-                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
-                        anyInfoAnswers.Add(tokens);
-                    }
-                }
-
-                message = this.ParentQuest.GetMessage(this.RumorsMessageID);
-                anyRumorsAnswers = new List<TextFile.Token[]>();
-                if (message != null)
-                {
-                    for (int i = 0; i < message.VariantCount; i++)
-                    {
-                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
-                        anyRumorsAnswers.Add(tokens);
-                    }
-                }                
-            }
-
-            string key = this.Symbol.Name;
-            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, key, TalkManager.QuestInfoResourceType.Thing, anyInfoAnswers, anyRumorsAnswers);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Questing/Item.cs
+++ b/Assets/Scripts/Game/Questing/Item.cs
@@ -124,7 +124,6 @@ namespace DaggerfallWorkshop.Game.Questing
         public Item(Quest parentQuest, string line)
             : base(parentQuest)
         {
-            talkManagerType = TalkManager.QuestInfoResourceType.Thing;
             SetResource(line);
         }
 

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -165,6 +165,7 @@ namespace DaggerfallWorkshop.Game.Questing
         public Person(Quest parentQuest, string line)
             : base (parentQuest)
         {
+            talkManagerType = TalkManager.QuestInfoResourceType.Person;
             SetResource(line);
         }
 
@@ -272,9 +273,6 @@ namespace DaggerfallWorkshop.Game.Questing
 
                 // Is NPC at home?
                 isIndividualAtHome = atHome;
-
-                // add conversation topics from anyInfo command tag
-                AddConversationTopics();
 
                 // Done
                 Debug.LogFormat("Created NPC {0} with FactionID #{1}.", displayName, factionData.id);
@@ -703,39 +701,6 @@ namespace DaggerfallWorkshop.Game.Questing
         void AssignGod()
         {
             godName = GetRandomGodName();
-        }
-
-        void AddConversationTopics()
-        {
-            List<TextFile.Token[]> anyInfoAnswers = null;
-            List<TextFile.Token[]> anyRumorsAnswers = null;
-            if (this.InfoMessageID != -1)
-            {
-                anyInfoAnswers = new List<TextFile.Token[]>();                
-                Message message = this.ParentQuest.GetMessage(this.InfoMessageID);
-                if (message != null)
-                {
-                    for (int i = 0; i < message.VariantCount; i++)
-                    {
-                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
-                        anyInfoAnswers.Add(tokens);
-                    }
-                }
-
-                message = this.ParentQuest.GetMessage(this.RumorsMessageID);
-                anyRumorsAnswers = new List<TextFile.Token[]>();
-                if (message != null)
-                {
-                    for (int i = 0; i < message.VariantCount; i++)
-                    {
-                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
-                        anyRumorsAnswers.Add(tokens);
-                    }
-                }                
-            }
-
-            string key = this.Symbol.Name;
-            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, key, TalkManager.QuestInfoResourceType.Person, anyInfoAnswers, anyRumorsAnswers);
         }
 
         Genders GetGender(string genderName)

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -165,7 +165,6 @@ namespace DaggerfallWorkshop.Game.Questing
         public Person(Quest parentQuest, string line)
             : base (parentQuest)
         {
-            talkManagerType = TalkManager.QuestInfoResourceType.Person;
             SetResource(line);
         }
 

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -122,7 +122,6 @@ namespace DaggerfallWorkshop.Game.Questing
         public Place(Quest parentQuest)
             : base(parentQuest)
         {
-            talkManagerType = TalkManager.QuestInfoResourceType.Location;
         }
 
         /// <summary>
@@ -133,7 +132,6 @@ namespace DaggerfallWorkshop.Game.Questing
         public Place(Quest parentQuest, string line)
             : base(parentQuest)
         {
-            talkManagerType = TalkManager.QuestInfoResourceType.Location;
             SetResource(line);
         }
 

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -122,6 +122,7 @@ namespace DaggerfallWorkshop.Game.Questing
         public Place(Quest parentQuest)
             : base(parentQuest)
         {
+            talkManagerType = TalkManager.QuestInfoResourceType.Location;
         }
 
         /// <summary>
@@ -132,6 +133,7 @@ namespace DaggerfallWorkshop.Game.Questing
         public Place(Quest parentQuest, string line)
             : base(parentQuest)
         {
+            talkManagerType = TalkManager.QuestInfoResourceType.Location;
             SetResource(line);
         }
 
@@ -217,8 +219,6 @@ namespace DaggerfallWorkshop.Game.Questing
                     throw new Exception("Invalid placeType in line: " + line);
                 }
 
-                // add conversation topics from anyInfo command tag
-                AddConversationTopics();
             }
         }
 
@@ -1276,43 +1276,6 @@ namespace DaggerfallWorkshop.Game.Questing
             }
 
             return foundLocationIndices.ToArray();
-        }
-
-        void AddConversationTopics()
-        {
-            List<TextFile.Token[]> anyInfoAnswers = null;
-            List<TextFile.Token[]> anyRumorsAnswers = null;
-            if (this.InfoMessageID != -1)
-            {
-                Message message = this.ParentQuest.GetMessage(this.InfoMessageID);
-                anyInfoAnswers = new List<TextFile.Token[]>();                
-                if (message != null)
-                {
-                    for (int i = 0; i < message.VariantCount; i++)
-                    {
-                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
-                        anyInfoAnswers.Add(tokens);
-                    }
-                }
-
-                message = this.ParentQuest.GetMessage(this.RumorsMessageID);
-                anyRumorsAnswers = new List<TextFile.Token[]>();
-                if (message != null)
-                {                    
-                    for (int i = 0; i < message.VariantCount; i++)
-                    {
-                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
-                        anyRumorsAnswers.Add(tokens);
-                    }
-                }
-            }
-
-            string captionString;
-            this.ExpandMacro(MacroTypes.NameMacro1, out captionString); // first try to resolve building name (if this fails it is a dungeon...)
-            if (captionString == null) // if building name resolving failed
-                this.ExpandMacro(MacroTypes.NameMacro3, out captionString); // resolve dungeon name
-            string key = this.Symbol.Name;
-            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(this.ParentQuest.UID, this, key, TalkManager.QuestInfoResourceType.Location, anyInfoAnswers, anyRumorsAnswers);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -853,6 +853,18 @@ namespace DaggerfallWorkshop.Game.Questing
                 existingTask.CopyQuestActions(task);
             }
         }
+        
+        /// <summary>
+        /// Add topics from items, persons and places to a talkmanager. 
+        /// </summary>
+        /// <param name="talkManager"></param>
+        public void AddResourceTopics(TalkManager talkManager)
+        {
+            foreach (QuestResource resource in resources.Values)
+            {
+                resource.AddConversationTopics(talkManager);
+            }
+        }
 
         #endregion
 

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -52,7 +52,6 @@ namespace DaggerfallWorkshop.Game.Questing
 
         string questName;
         string displayName;
-        DaggerfallDateTime questStartTime;
         int factionId = 0;
         IMacroContextProvider mcp = null;
 
@@ -66,6 +65,7 @@ namespace DaggerfallWorkshop.Game.Questing
         List<QuestResource> pendingClickRearms = new List<QuestResource>();
 
         int ticksToEnd = 0;
+        public bool ReadyToStart { get; set; }
 
         #endregion
 
@@ -178,10 +178,7 @@ namespace DaggerfallWorkshop.Game.Questing
         /// <summary>
         /// Gets world time of quest when started.
         /// </summary>
-        public DaggerfallDateTime QuestStartTime
-        {
-            get { return questStartTime; }
-        }
+        public DaggerfallDateTime QuestStartTime { get ; set ; }
 
         /// <summary>
         /// Gets or sets last Place resource encountered during macro expand.
@@ -252,7 +249,6 @@ namespace DaggerfallWorkshop.Game.Questing
         public Quest()
         {
             uid = DaggerfallUnity.NextUID;
-            questStartTime = new DaggerfallDateTime(DaggerfallUnity.Instance.WorldTime.Now);
         }
 
         #endregion
@@ -599,7 +595,7 @@ namespace DaggerfallWorkshop.Game.Questing
                     return log.dateTime;
             }
 
-            return questStartTime;
+            return QuestStartTime;
         }
 
         /// <summary>
@@ -899,7 +895,7 @@ namespace DaggerfallWorkshop.Game.Questing
             data.questName = questName;
             data.displayName = displayName;
             data.factionId = factionId;
-            data.questStartTime = questStartTime;
+            data.questStartTime = QuestStartTime;
             data.questTombstoned = questTombstoned;
             data.questTombstoneTime = questTombstoneTime;
 
@@ -951,7 +947,7 @@ namespace DaggerfallWorkshop.Game.Questing
             questName = data.questName;
             displayName = data.displayName;
             factionId = data.factionId;
-            questStartTime = data.questStartTime;
+            QuestStartTime = data.questStartTime;
             questTombstoned = data.questTombstoned;
             questTombstoneTime = data.questTombstoneTime;
 

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -52,6 +52,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
         string questName;
         string displayName;
+        DaggerfallDateTime questStartTime;
         int factionId = 0;
         IMacroContextProvider mcp = null;
 
@@ -65,7 +66,6 @@ namespace DaggerfallWorkshop.Game.Questing
         List<QuestResource> pendingClickRearms = new List<QuestResource>();
 
         int ticksToEnd = 0;
-        private DaggerfallDateTime questStartTime;
 
         #endregion
 
@@ -592,7 +592,7 @@ namespace DaggerfallWorkshop.Game.Questing
                     return log.dateTime;
             }
 
-            return QuestStartTime;
+            return questStartTime;
         }
 
         /// <summary>
@@ -885,7 +885,7 @@ namespace DaggerfallWorkshop.Game.Questing
             data.questName = questName;
             data.displayName = displayName;
             data.factionId = factionId;
-            data.questStartTime = QuestStartTime;
+            data.questStartTime = questStartTime;
             data.questTombstoned = questTombstoned;
             data.questTombstoneTime = questTombstoneTime;
 

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -11,8 +11,8 @@
 
 using UnityEngine;
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using DaggerfallWorkshop.Utility;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
@@ -65,7 +65,7 @@ namespace DaggerfallWorkshop.Game.Questing
         List<QuestResource> pendingClickRearms = new List<QuestResource>();
 
         int ticksToEnd = 0;
-        public bool ReadyToStart { get; set; }
+        private DaggerfallDateTime questStartTime;
 
         #endregion
 
@@ -178,7 +178,10 @@ namespace DaggerfallWorkshop.Game.Questing
         /// <summary>
         /// Gets world time of quest when started.
         /// </summary>
-        public DaggerfallDateTime QuestStartTime { get ; set ; }
+        public DaggerfallDateTime QuestStartTime
+        {
+            get { return questStartTime; }
+        }
 
         /// <summary>
         /// Gets or sets last Place resource encountered during macro expand.
@@ -254,6 +257,15 @@ namespace DaggerfallWorkshop.Game.Questing
         #endregion
 
         #region Public Methods
+        
+        
+        /// <summary>
+        /// Start the quest.
+        /// </summary>
+        public void Start()
+        {
+            questStartTime = new DaggerfallDateTime(DaggerfallUnity.Instance.WorldTime.Now);
+        }
 
         /// <summary>
         /// Update quest.
@@ -333,21 +345,6 @@ namespace DaggerfallWorkshop.Game.Questing
                 resource.RearmPlayerClick();
             }
             pendingClickRearms.Clear();
-        }
-
-        /// <summary>
-        /// initializes quest rumors
-        /// dictionary must contain the quest's messages (call after messages was initialized correctly)
-        /// </summary>
-        public void initQuestRumors()
-        {
-            // Add RumorsDuringQuest rumor to rumor mill
-            Message message;
-            message = GetMessage((int)QuestMachine.QuestMessages.RumorsDuringQuest);
-            if (message != null)
-            {
-                GameManager.Instance.TalkManager.AddOrReplaceQuestProgressRumor(this.UID, message);
-            }
         }
 
         public void EndQuest()
@@ -704,6 +701,11 @@ namespace DaggerfallWorkshop.Game.Questing
                 return null;
         }
 
+        public QuestResource[] GetAllResources()
+        {
+            return resources.Values.ToArray();
+        }
+        
         public QuestResource[] GetAllResources(Type resourceType)
         {
             List<QuestResource> foundResources = new List<QuestResource>();
@@ -849,18 +851,6 @@ namespace DaggerfallWorkshop.Game.Questing
                 existingTask.CopyQuestActions(task);
             }
         }
-        
-        /// <summary>
-        /// Add topics from items, persons and places to a talkmanager. 
-        /// </summary>
-        /// <param name="talkManager"></param>
-        public void AddResourceTopics(TalkManager talkManager)
-        {
-            foreach (QuestResource resource in resources.Values)
-            {
-                resource.AddConversationTopics(talkManager);
-            }
-        }
 
         #endregion
 
@@ -947,7 +937,7 @@ namespace DaggerfallWorkshop.Game.Questing
             questName = data.questName;
             displayName = data.displayName;
             factionId = data.factionId;
-            QuestStartTime = data.questStartTime;
+            questStartTime = data.questStartTime;
             questTombstoned = data.questTombstoned;
             questTombstoneTime = data.questTombstoneTime;
 

--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -252,7 +252,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 if (quest == null)
                     continue;
 
-                QuestMachine.Instance.InstantiateQuest(quest);
+                QuestMachine.Instance.StartQuest(quest);
             }
         }
 

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -633,7 +633,6 @@ namespace DaggerfallWorkshop.Game.Questing
                 // Parse quest
                 Parser parser = new Parser();
                 Quest quest = parser.Parse(questSource, factionId);
-                quest.ReadyToStart = true;
 
                 return quest;
             }
@@ -667,15 +666,10 @@ namespace DaggerfallWorkshop.Game.Questing
         /// <param name="quest">Quest.</param>
         public void StartQuest(Quest quest)
         {
-            if (!quest.ReadyToStart)
-                throw new Exception("Cannot start quest that is not ready");
+            quest.Start();
             
-            quest.QuestStartTime = new DaggerfallDateTime(DaggerfallUnity.Instance.WorldTime.Now);
+            GameManager.Instance.TalkManager.AddQuestTopicWithInfoAndRumors(quest);
             
-            quest.AddResourceTopics(GameManager.Instance.TalkManager);
-            // init quest rumors (note Nystul: did not find a better place to do this since it must happen after quest parsing and should be called exactly one time for each quest)
-            quest.initQuestRumors();
-
             quests.Add(quest.UID, quest);            
 
             RaiseOnQuestStartedEvent(quest);

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -416,7 +416,7 @@ namespace DaggerfallWorkshop.Game.Questing
             {
                 if (quest != null)
                 {
-                    InstantiateQuest(quest);
+                    StartQuest(quest);
                     RaiseOnQuestStartedEvent(quest);
                 }
             }
@@ -645,26 +645,26 @@ namespace DaggerfallWorkshop.Game.Questing
         }
 
         /// <summary>
-        /// Parse and instantiate a quest from quest name.
+        /// Parse and start a quest from quest name.
         /// </summary>
         /// <param name="questName">Quest name.</param>
         /// <param name="factionId">Faction id. (optional)</param>
         /// <returns>Quest.</returns>
-        public void InstantiateQuest(string questName, int factionId = 0)
+        public void StartQuest(string questName, int factionId = 0)
         {
             Quest quest = ParseQuest(questName);
             if (quest != null)
             {
                 quest.FactionId = factionId;
-                InstantiateQuest(quest);
+                StartQuest(quest);
             }
         }
 
         /// <summary>
-        /// Instantiate quest from a parsed quest object.
+        /// Start a parsed quest.
         /// </summary>
         /// <param name="quest">Quest.</param>
-        public void InstantiateQuest(Quest quest)
+        public void StartQuest(Quest quest)
         {
             quest.AddResourceTopics(GameManager.Instance.TalkManager);
             // init quest rumors (note Nystul: did not find a better place to do this since it must happen after quest parsing and should be called exactly one time for each quest)

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -633,6 +633,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 // Parse quest
                 Parser parser = new Parser();
                 Quest quest = parser.Parse(questSource, factionId);
+                quest.ReadyToStart = true;
 
                 return quest;
             }
@@ -666,6 +667,11 @@ namespace DaggerfallWorkshop.Game.Questing
         /// <param name="quest">Quest.</param>
         public void StartQuest(Quest quest)
         {
+            if (!quest.ReadyToStart)
+                throw new Exception("Cannot start quest that is not ready");
+            
+            quest.QuestStartTime = new DaggerfallDateTime(DaggerfallUnity.Instance.WorldTime.Now);
+            
             quest.AddResourceTopics(GameManager.Instance.TalkManager);
             // init quest rumors (note Nystul: did not find a better place to do this since it must happen after quest parsing and should be called exactly one time for each quest)
             quest.initQuestRumors();

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -666,6 +666,7 @@ namespace DaggerfallWorkshop.Game.Questing
         /// <param name="quest">Quest.</param>
         public void InstantiateQuest(Quest quest)
         {
+            quest.AddResourceTopics(GameManager.Instance.TalkManager);
             // init quest rumors (note Nystul: did not find a better place to do this since it must happen after quest parsing and should be called exactly one time for each quest)
             quest.initQuestRumors();
 

--- a/Assets/Scripts/Game/Questing/QuestResource.cs
+++ b/Assets/Scripts/Game/Questing/QuestResource.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Entity;
 using System.Text.RegularExpressions;
+using DaggerfallConnect.Arena2;
 using FullSerializer;
 
 namespace DaggerfallWorkshop.Game.Questing
@@ -24,6 +26,8 @@ namespace DaggerfallWorkshop.Game.Questing
 
         [NonSerialized]
         QuestResourceBehaviour questResourceBehaviour = null;
+
+        protected TalkManager.QuestInfoResourceType talkManagerType = TalkManager.QuestInfoResourceType.NotSet;
 
         /// <summary>
         /// Symbol of this quest resource (if any).
@@ -276,6 +280,39 @@ namespace DaggerfallWorkshop.Game.Questing
         public void RearmPlayerClick()
         {
             hasPlayerClicked = false;
+        }
+        
+        public void AddConversationTopics(TalkManager talkManager)
+        {
+            List<TextFile.Token[]> anyInfoAnswers = null;
+            List<TextFile.Token[]> anyRumorsAnswers = null;
+            if (InfoMessageID != -1)
+            {
+                Message message = ParentQuest.GetMessage(InfoMessageID);
+                anyInfoAnswers = new List<TextFile.Token[]>();
+                if (message != null)
+                {
+                    for (int i = 0; i < message.VariantCount; i++)
+                    {
+                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
+                        anyInfoAnswers.Add(tokens);
+                    }
+                }
+
+                message = ParentQuest.GetMessage(RumorsMessageID);
+                anyRumorsAnswers = new List<TextFile.Token[]>();
+                if (message != null)
+                {
+                    for (int i = 0; i < message.VariantCount; i++)
+                    {
+                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
+                        anyRumorsAnswers.Add(tokens);
+                    }
+                }                
+            }
+
+            string key = Symbol.Name;
+            talkManager.AddQuestTopicWithInfoAndRumors(ParentQuest.UID, this, key, talkManagerType, anyInfoAnswers, anyRumorsAnswers);
         }
 
         #region Serialization

--- a/Assets/Scripts/Game/Questing/QuestResource.cs
+++ b/Assets/Scripts/Game/Questing/QuestResource.cs
@@ -27,8 +27,6 @@ namespace DaggerfallWorkshop.Game.Questing
         [NonSerialized]
         QuestResourceBehaviour questResourceBehaviour = null;
 
-        protected TalkManager.QuestInfoResourceType talkManagerType = TalkManager.QuestInfoResourceType.NotSet;
-
         /// <summary>
         /// Symbol of this quest resource (if any).
         /// </summary>
@@ -281,39 +279,24 @@ namespace DaggerfallWorkshop.Game.Questing
         {
             hasPlayerClicked = false;
         }
-        
-        public void AddConversationTopics(TalkManager talkManager)
-        {
-            List<TextFile.Token[]> anyInfoAnswers = null;
-            List<TextFile.Token[]> anyRumorsAnswers = null;
-            if (InfoMessageID != -1)
-            {
-                Message message = ParentQuest.GetMessage(InfoMessageID);
-                anyInfoAnswers = new List<TextFile.Token[]>();
-                if (message != null)
-                {
-                    for (int i = 0; i < message.VariantCount; i++)
-                    {
-                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
-                        anyInfoAnswers.Add(tokens);
-                    }
-                }
 
-                message = ParentQuest.GetMessage(RumorsMessageID);
-                anyRumorsAnswers = new List<TextFile.Token[]>();
-                if (message != null)
-                {
-                    for (int i = 0; i < message.VariantCount; i++)
-                    {
-                        TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
-                        anyRumorsAnswers.Add(tokens);
-                    }
-                }                
+        public List<TextFile.Token[]> GetMessage(int messageId)
+        {
+            Message message = ParentQuest.GetMessage(messageId);
+            return message == null ? null : TokenizeMessage(message);
+        }
+
+        private static List<TextFile.Token[]> TokenizeMessage(Message message)
+        {
+            var tokenList = new List<TextFile.Token[]>();
+            for (int i = 0; i < message.VariantCount; i++)
+            {
+                TextFile.Token[] tokens = message.GetTextTokensByVariant(i, false); // do not expand macros here (they will be expanded just in time by TalkManager class)
+                tokenList.Add(tokens);
             }
 
-            string key = Symbol.Name;
-            talkManager.AddQuestTopicWithInfoAndRumors(ParentQuest.UID, this, key, talkManagerType, anyInfoAnswers, anyRumorsAnswers);
-        }
+            return tokenList;
+        } 
 
         #region Serialization
 

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1920,7 +1920,9 @@ namespace DaggerfallWorkshop.Game
         public void AddQuestTopicWithInfoAndRumors(Quest quest)
         {
             // Add RumorsDuringQuest rumor to rumor mill
-            AddOrReplaceQuestProgressRumor(quest.UID, quest.GetMessage((int)QuestMachine.QuestMessages.RumorsDuringQuest));
+            Message message = quest.GetMessage((int)QuestMachine.QuestMessages.RumorsDuringQuest);
+            if (message != null)
+                AddOrReplaceQuestProgressRumor(quest.UID, message);
             
             // Add topics for the places to see, people to meet and items to handle.
             foreach (QuestResource resource in quest.GetAllResources())

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1916,6 +1916,36 @@ namespace DaggerfallWorkshop.Game
         {
             AssembleTopicLists();
         }
+        
+        public void AddQuestTopicWithInfoAndRumors(Quest quest)
+        {
+            // Add RumorsDuringQuest rumor to rumor mill
+            AddOrReplaceQuestProgressRumor(quest.UID, quest.GetMessage((int)QuestMachine.QuestMessages.RumorsDuringQuest));
+            
+            // Add topics for the places to see, people to meet and items to handle.
+            foreach (QuestResource resource in quest.GetAllResources())
+            {
+                QuestInfoResourceType type = GetQuestInfoResourceType(resource);
+                List<TextFile.Token[]> anyInfoAnswers = resource.GetMessage(resource.InfoMessageID);
+                List<TextFile.Token[]> rumorsAnswers = resource.GetMessage(resource.RumorsMessageID);
+
+                AddQuestTopicWithInfoAndRumors(quest.UID, resource, resource.Symbol.Name, type, anyInfoAnswers, rumorsAnswers);
+            }
+        }
+
+        private static QuestInfoResourceType GetQuestInfoResourceType(QuestResource questResource)
+        {
+            QuestInfoResourceType type;
+            if (questResource is Person)
+                type = QuestInfoResourceType.Person;
+            else if (questResource is Place)
+                type = QuestInfoResourceType.Location;
+            else if (questResource is Item)
+                type = QuestInfoResourceType.Thing;
+            else
+                type = QuestInfoResourceType.NotSet;
+            return type;
+        }
 
         public void AddQuestTopicWithInfoAndRumors(ulong questID, QuestResource questResource, string resourceName, QuestInfoResourceType resourceType, List<TextFile.Token[]> anyInfoAnswers, List<TextFile.Token[]> rumorsAnswers)
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallDaedraSummonedWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallDaedraSummonedWindow.cs
@@ -111,7 +111,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (Input.GetKey(KeyCode.Y))
                 {
                     HandleAnswer(QuestMachine.QuestMessages.AcceptQuest);
-                    QuestMachine.Instance.InstantiateQuest(daedraQuest);
+                    QuestMachine.Instance.StartQuest(daedraQuest);
                 }
                 else if (Input.GetKey(KeyCode.N))
                 {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -134,7 +134,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 // Show accept message, add quest
                 sender.CloseWindow();
                 ShowQuestPopupMessage(offeredQuest, (int)QuestMachine.QuestMessages.AcceptQuest);
-                QuestMachine.Instance.InstantiateQuest(offeredQuest);
+                QuestMachine.Instance.StartQuest(offeredQuest);
 
                 // Assign QuestResourceBehaviour to questor NPC - this will be last NPC clicked
                 // This will ensure quests actions like "hide npc" will operate on questor at quest startup

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -410,13 +410,13 @@ namespace DaggerfallWorkshop.Game.Utility
             lastStartMethod = StartMethods.NewCharacter;
 
             // Start main quest
-            QuestMachine.Instance.InstantiateQuest("_TUTOR__");
-            QuestMachine.Instance.InstantiateQuest("_BRISIEN");
+            QuestMachine.Instance.StartQuest("_TUTOR__");
+            QuestMachine.Instance.StartQuest("_BRISIEN");
 
             // Launch startup optional quest
             if (!string.IsNullOrEmpty(LaunchQuest))
             {
-                QuestMachine.Instance.InstantiateQuest(LaunchQuest);
+                QuestMachine.Instance.StartQuest(LaunchQuest);
                 LaunchQuest = string.Empty;
             }
             // Launch any InitAtGameStart quests
@@ -827,7 +827,7 @@ namespace DaggerfallWorkshop.Game.Utility
         {
             if (!string.IsNullOrEmpty(LaunchQuest))
             {
-                QuestMachine.Instance.InstantiateQuest(LaunchQuest);
+                QuestMachine.Instance.StartQuest(LaunchQuest);
                 LaunchQuest = string.Empty;
             }
         }


### PR DESCRIPTION
Move creation of topics in the talkmanager from quest parsing to quest starting.
This allows parsing of quests without having to clean up the talkmanager afterwards.

See https://forums.dfworkshop.net/viewtopic.php?f=23&t=2995