### PR TITLE
Early customization of SaveGameWindow is now obsolete

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
@@ -423,15 +423,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             Texture2D tex;
             if (TextureReplacement.TryImportTexture(textureName, true, out tex))
+            {
                 panel.BackgroundTexture = tex;
+                TextureReplacement.LogLegacyUICustomizationMessage(textureName);
+            }
             else
                 panel.BackgroundColor = color;
         }
 
         void SetBackground(Button button, Color color, string textureName)
         {
+#pragma warning disable 0618
             if (!TextureReplacement.TryCustomizeButton(ref button, textureName))
                 button.BackgroundColor = color;
+#pragma warning restore 0618
         }
 
         #endregion

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -603,11 +603,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Import custom texture and label settings for buttons
+        /// Import custom texture and label settings for buttons.
+        /// This feature has been deprecated in favor of <see cref="DaggerfallWorkshop.Game.UserInterfaceWindows.UIWindowFactory"/>.
         /// </summary>
         /// <param name="button">Button</param>
         /// <param name="colorName">Name of texture</param>
-        static public bool TryCustomizeButton(ref Button button, string colorName)
+        [Obsolete("This feature has been deprecated in favor of UIWindowFactory.")]
+        public static bool TryCustomizeButton(ref Button button, string colorName)
         {
             Texture2D tex;
             if (!TryImportTexture(colorName, true, out tex))
@@ -631,6 +633,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 }
             }
 
+            LogLegacyUICustomizationMessage(colorName);
             return true;
         }
 
@@ -853,6 +856,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         public static int FileNameToArchive(string filename)
         {
             return int.Parse(filename.Substring("TEXTURE.".Length));
+        }
+
+        #endregion
+
+        #region  Internal Methods
+
+        internal static void LogLegacyUICustomizationMessage(string textureName)
+        {
+            Debug.LogWarningFormat("Imported texture {0} for legacy support of UI customization. This feature has been deprecated in favor of UIWindowFactory.", textureName);
         }
 
         #endregion


### PR DESCRIPTION
It was previously possible to make small changes to SaveGameWindow, like custom backgrounds and colors.
This is now made unnecessary by new UIWindowFactory which allows much more advanced customization to more than one window, so this feature is now obsolete and will be removed with a future update.