### PR TITLE
Sink nature flats slightly into ground on slopes

### DIFF
--- a/Assets/Scripts/Terrain/TerrainHelper.cs
+++ b/Assets/Scripts/Terrain/TerrainHelper.cs
@@ -460,7 +460,8 @@ namespace DaggerfallWorkshop
         // Drops nature flats based on random chance scaled by simple rules
         public static void LayoutNatureBillboards(DaggerfallTerrain dfTerrain, DaggerfallBillboardBatch dfBillboardBatch, float terrainScale, int terrainDist)
         {
-            const float maxSteepness = 50f;         // 50
+            const float maxSteepness = 50f;             // 50
+            const float slopeSinkRatio = 70f;           // Sink flats slightly into ground as slope increases to prevent floaty trees.
             const float baseChanceOnDirt = 0.2f;        // 0.2
             const float baseChanceOnGrass = 0.9f;       // 0.4
             const float baseChanceOnStone = 0.05f;      // 0.05
@@ -568,7 +569,7 @@ namespace DaggerfallWorkshop
                     // Sample height and position billboard
                     Vector3 pos = new Vector3(x * scale, 0, y * scale);
                     float height2 = terrain.SampleHeight(pos + terrain.transform.position);
-                    pos.y = height2;
+                    pos.y = height2 - (steepness / slopeSinkRatio);
 
                     // Add to batch unless a mesh replacement is found
                     int record = Random.Range(1, 32);


### PR DESCRIPTION
Sink nature flats slightly into ground as slope increases to hide floaty trees on sloped ground a bit. Sinks the flats proportional to angle of ground, with a max of 50/70 = 0.714 unity units on y axis.

Based on a suggestion from discord. Ratio seemed a good balance between no floating and buried sprites. Could be tuned more.