### PR TITLE
Add reset of drained stats to free temple healing

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Destruction/DrainEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Destruction/DrainEffect.cs
@@ -99,6 +99,12 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                 forcedRoundsRemaining = 0;
         }
 
+        public virtual void CureAttributeDamage()
+        {
+            // Fully heal magnitude of attribute drained by this effect
+            HealAttributeDamage(drainStat, magnitude);
+        }
+
         void ShowPlayerDrained()
         {
             // Output "you feel drained." if the host manager is player

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Destruction/DrainEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Destruction/DrainEffect.cs
@@ -99,12 +99,6 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                 forcedRoundsRemaining = 0;
         }
 
-        public virtual void CureAttributeDamage()
-        {
-            // Fully heal magnitude of attribute drained by this effect
-            HealAttributeDamage(drainStat, magnitude);
-        }
-
         void ShowPlayerDrained()
         {
             // Output "you feel drained." if the host manager is player

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
@@ -618,6 +618,19 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         }
 
         /// <summary>
+        /// Cure all attribute damage by this effect.
+        /// </summary>
+        public virtual void CureAttributeDamage()
+        {
+            for (int i = 0; i < DaggerfallStats.Count; i++)
+            {
+                int amount = GetAttributeMod((DFCareer.Stats)i);
+                if (amount < 0)
+                    HealAttributeDamage((DFCareer.Stats)i, Mathf.Abs(amount));
+            }
+        }
+
+        /// <summary>
         /// Heal skill damage by amount.
         /// Does nothing if this effect does not damage skills.
         /// Skill will not heal past 0.
@@ -638,6 +651,19 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
             SetSkillMod(skill, result);
             Debug.LogFormat("Healed {0}'s {1} by {2} points", GetPeeredEntityBehaviour(manager).name, skill.ToString(), amount);
+        }
+
+        /// <summary>
+        /// Cure all skill damage by this effect.
+        /// </summary>
+        public virtual void CureSkillDamage()
+        {
+            for (int i = 0; i < DaggerfallSkills.Count; i++)
+            {
+                int amount = GetSkillMod((DFCareer.Skills)i);
+                if (amount < 0)
+                    HealSkillDamage((DFCareer.Skills)i, Mathf.Abs(amount));
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -671,7 +671,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                     int damage = Mathf.Abs(mod);
                     if (remaining > damage)
                     {
-                        effect.HealAttributeDamage(stat, remaining - damage);
+                        effect.HealAttributeDamage(stat, damage);
                         remaining -= damage;
                     }
                     else

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1426,6 +1426,19 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             }
         }
 
+        public void CureAllDrainEffects()
+        {
+            // Cure all drain effects
+            EndIncumbentEffect<DrainStrength>();
+            EndIncumbentEffect<DrainIntelligence>();
+            EndIncumbentEffect<DrainWillpower>();
+            EndIncumbentEffect<DrainAgility>();
+            EndIncumbentEffect<DrainEndurance>();
+            EndIncumbentEffect<DrainPersonality>();
+            EndIncumbentEffect<DrainSpeed>();
+            EndIncumbentEffect<DrainLuck>();
+        }
+
         public void CureAll()
         {
             DaggerfallEntity entity = entityBehaviour.Entity;
@@ -1434,6 +1447,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             entity.CurrentMagicka = entity.MaxMagicka;
             CureAllPoisons();
             CureAllDiseases();
+            CureAllDrainEffects();
         }
 
         public bool HasVampirism()

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1448,17 +1448,54 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             }
         }
 
-        public void CureAllDrainEffects()
+        public void CureAllAttributes()
         {
-            // Cure all drain effects
-            IEntityEffect[] effects = FindIncumbentEffects<DrainEffect>();
-            if (effects != null && effects.Length > 0)
+            foreach (LiveEffectBundle bundle in instancedBundles)
             {
-                foreach (IEntityEffect effect in effects)
+                foreach (IEntityEffect effect in bundle.liveEffects)
                 {
-                    (effect as DrainEffect).CureAttributeDamage();
+                    (effect as BaseEntityEffect).CureAttributeDamage();
                 }
             }
+        }
+
+        public void CureAllSkills()
+        {
+            foreach (LiveEffectBundle bundle in instancedBundles)
+            {
+                foreach (IEntityEffect effect in bundle.liveEffects)
+                {
+                    (effect as BaseEntityEffect).CureSkillDamage();
+                }
+            }
+        }
+
+        public bool HasDamagedAttributes()
+        {
+            foreach (LiveEffectBundle bundle in instancedBundles)
+            {
+                foreach (IEntityEffect effect in bundle.liveEffects)
+                {
+                    if (!(effect as BaseEntityEffect).AllAttributesHealed())
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool HasDamagedSkills()
+        {
+            foreach (LiveEffectBundle bundle in instancedBundles)
+            {
+                foreach (IEntityEffect effect in bundle.liveEffects)
+                {
+                    if (!(effect as BaseEntityEffect).AllSkillsHealed())
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         public void CureAll()
@@ -1469,7 +1506,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             entity.CurrentMagicka = entity.MaxMagicka;
             CureAllPoisons();
             CureAllDiseases();
-            CureAllDrainEffects();
+            CureAllAttributes();
+            CureAllSkills();
         }
 
         public bool HasVampirism()

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -595,7 +595,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// <summary>
         /// Searches all effects in all bundles to find incumbent of type T.
         /// </summary>
-        /// <typeparam name="T">Found incumbent effect of type T or null.</typeparam>
+        /// <typeparam name="T">Effect class to search for.</typeparam>
+        /// <returns>Found incumbent effect of type T or null.</returns>
         public IEntityEffect FindIncumbentEffect<T>()
         {
             foreach (LiveEffectBundle bundle in instancedBundles)
@@ -608,6 +609,27 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Searches all effects in all bundles to find all incumbents of type T.
+        /// Useful for finding all effects inheriting from a specific parent effect.
+        /// </summary>
+        /// <typeparam name="T">Effect class to search for.</typeparam>
+        /// <returns>All found incumbent effect of type T. Can be null or empty.</returns>
+        public IEntityEffect[] FindIncumbentEffects<T>()
+        {
+            List<IEntityEffect> effects = new List<IEntityEffect>();
+            foreach (LiveEffectBundle bundle in instancedBundles)
+            {
+                foreach (IEntityEffect effect in bundle.liveEffects)
+                {
+                    if (effect is T)
+                        effects.Add(effect);
+                }
+            }
+
+            return effects.ToArray();
         }
 
         /// <summary>
@@ -1429,14 +1451,14 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public void CureAllDrainEffects()
         {
             // Cure all drain effects
-            EndIncumbentEffect<DrainStrength>();
-            EndIncumbentEffect<DrainIntelligence>();
-            EndIncumbentEffect<DrainWillpower>();
-            EndIncumbentEffect<DrainAgility>();
-            EndIncumbentEffect<DrainEndurance>();
-            EndIncumbentEffect<DrainPersonality>();
-            EndIncumbentEffect<DrainSpeed>();
-            EndIncumbentEffect<DrainLuck>();
+            IEntityEffect[] effects = FindIncumbentEffects<DrainEffect>();
+            if (effects != null && effects.Length > 0)
+            {
+                foreach (IEntityEffect effect in effects)
+                {
+                    (effect as DrainEffect).CureAttributeDamage();
+                }
+            }
         }
 
         public void CureAll()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -22,6 +22,8 @@ using System;
 using DaggerfallWorkshop.Game.Guilds;
 using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.Utility;
+using DaggerfallWorkshop.Game.MagicAndEffects;
+using DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -62,6 +64,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int TooGenerousId = 702;
         const int DonationThanksId = 703;
         const int SorcerorMagickaRecharge = 465;
+        const int TempleResetStats = 403;
 
         Texture2D baseTexture;
         PlayerEntity playerEntity;
@@ -168,10 +171,27 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 messageBox.Show();
             }
             // Check for free healing (Temple members)
-            if (guild.FreeHealing() && playerEntity.CurrentHealth < playerEntity.MaxHealth)
+            if (guild.FreeHealing())
             {
-                playerEntity.SetHealth(playerEntity.MaxHealth);
-                DaggerfallUI.MessageBox(350);
+                // Free heal
+                if (playerEntity.CurrentHealth < playerEntity.MaxHealth)
+                {
+                    playerEntity.SetHealth(playerEntity.MaxHealth);
+                    DaggerfallUI.MessageBox(350);
+                }
+                // Check for free stat restoration (Temple members)
+                EntityEffectManager playerEffectMgr = playerEntity.EntityBehaviour.GetComponent<EntityEffectManager>();
+                if (playerEffectMgr != null)
+                {
+                    IEntityEffect drainEffect = playerEffectMgr.FindIncumbentEffect<DrainEffect>();
+                    if (drainEffect != null)
+                    {
+                        DaggerfallMessageBox messageBox =
+                            new DaggerfallMessageBox(uiManager, DaggerfallMessageBox.CommonMessageBoxButtons.YesNo, TempleResetStats, uiManager.TopWindow);
+                        messageBox.OnButtonClick += ConfirmStatReset_OnButtonClick;
+                        messageBox.Show();
+                    }
+                }
             }
             // Check for magicka restoration (sorcerers)
             if (guild.FreeMagickaRecharge() && playerEntity.CurrentMagicka < playerEntity.MaxMagicka)
@@ -183,6 +203,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 // Refill magicka
                 playerEntity.SetMagicka(playerEntity.MaxMagicka);
+            }
+        }
+
+        private void ConfirmStatReset_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
+        {
+            CloseWindow();
+            if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
+            {
+                EntityEffectManager playerEffectMgr = playerEntity.EntityBehaviour.GetComponent<EntityEffectManager>();
+                playerEffectMgr.CureAllDrainEffects();
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -183,8 +183,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 EntityEffectManager playerEffectMgr = playerEntity.EntityBehaviour.GetComponent<EntityEffectManager>();
                 if (playerEffectMgr != null)
                 {
-                    IEntityEffect drainEffect = playerEffectMgr.FindIncumbentEffect<DrainEffect>();
-                    if (drainEffect != null)
+                    if (playerEffectMgr.HasDamagedAttributes())
                     {
                         DaggerfallMessageBox messageBox =
                             new DaggerfallMessageBox(uiManager, DaggerfallMessageBox.CommonMessageBoxButtons.YesNo, TempleResetStats, uiManager.TopWindow);
@@ -212,7 +211,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
             {
                 EntityEffectManager playerEffectMgr = playerEntity.EntityBehaviour.GetComponent<EntityEffectManager>();
-                playerEffectMgr.CureAllDrainEffects();
+                playerEffectMgr.CureAllAttributes();
             }
         }
 


### PR DESCRIPTION
The reset doesn't work correctly yet in this PR. Need Interkarma to take a look because I don't understand the effect system well enough to know why calling EndIncumbentEffect<DrainStrength>() for instance doesn't seem to work.