### PR TITLE
prevent 3d map from being rotated upside-down

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
@@ -1780,7 +1780,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 Vector3 rotationPoint = rotationPivotAxisPositionView3D;
                 cameraAutomap.transform.RotateAround(rotationPoint, cameraAutomap.transform.right, -rotationAmount * Time.unscaledDeltaTime);
-                UpdateAutomapView();
+                // Prevent the map from being seen upside-down
+                Vector3 transformedUp = cameraAutomap.transform.TransformDirection(Vector3.up);
+                if (transformedUp.y < 0)
+                {
+                    float rotateBack = Vector3.SignedAngle(transformedUp, Vector3.ProjectOnPlane(transformedUp, Vector3.up), cameraAutomap.transform.right);
+                    cameraAutomap.transform.RotateAround(rotationPoint, cameraAutomap.transform.right, rotateBack);
+                }
+                UpdateAutomapView(); 
             }
         }
 


### PR DESCRIPTION
Can cause confusing with no benefits
![upside-down map](https://user-images.githubusercontent.com/1211431/70575558-08d6ba80-1ba7-11ea-92cb-e105707585bc.jpg)
