### PR TITLE
fix classic load by swapping free action and climbing effects

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/Climbing.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Alteration/Climbing.cs
@@ -24,7 +24,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         public override void SetProperties()
         {
             properties.Key = EffectKey;
-            properties.ClassicKey = MakeClassicKey(26, 255);
+            properties.ClassicKey = MakeClassicKey(28, 255);
             properties.GroupName = TextManager.Instance.GetText("ClassicEffects", "climbing");
             properties.SubGroupName = string.Empty;
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1578);

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/FreeAction.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Restoration/FreeAction.cs
@@ -24,7 +24,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         public override void SetProperties()
         {
             properties.Key = EffectKey;
-            properties.ClassicKey = MakeClassicKey(28, 255);
+            properties.ClassicKey = MakeClassicKey(26, 255);
             properties.GroupName = TextManager.Instance.GetText(textDatabase, "freeAction");
             properties.SubGroupName = string.Empty;
             properties.SpellMakerDescription = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(1576);


### PR DESCRIPTION
Attachment: classic save with custom spells using all effects

Only other difference is missing effects (Shield, Dispell, Comprehend languages)

[SAVE4.zip](https://github.com/Interkarma/daggerfall-unity/files/3963960/SAVE4.zip)
