### PR TITLE
Weapon sounds when hitting walls

### DIFF
--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -21,6 +21,7 @@ using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects;
 using DaggerfallWorkshop.Game.Utility;
+using DaggerfallWorkshop.Utility;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -442,6 +443,13 @@ namespace DaggerfallWorkshop.Game
                 // Check if player hit a static exterior door
                 if (GameManager.Instance.PlayerActivate.AttemptExteriorDoorBash(hit))
                 {
+                    return false;
+                }
+
+                // Make walls do a clinging sound (not in classic)
+                if (GameObjectHelper.IsStaticGeometry(hit.transform.gameObject))
+                {
+                    DaggerfallUI.Instance.PlayOneShot(SoundClips.Parry6);
                     return false;
                 }
             }


### PR DESCRIPTION
Add clinging sound when you hit walls with a weapon
Limitations: 
- uses Parry6, I would have preferred a totally distinctive sound instead.
- works for all static objects, so hitting wooden furniture does a clinging sound too, even if one could expect the same sound as doors bashing.
- On the other hand non-static objects like elevators do no sound. I could have checked if the gameObject has a DaggerfallMesh component instead, but I don't know if that would have been okay

Forums: https://forums.dfworkshop.net/viewtopic.php?f=4&t=3172