### PR TITLE
bash-closing doors

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -178,31 +178,33 @@ namespace DaggerfallWorkshop
 
         public void AttemptBash(bool byPlayer)
         {
-            if (!IsOpen)
+            // Play bash sound if flagged and ready
+            if (PlaySounds && BashSound > 0 && audioSource)
             {
-                // Play bash sound if flagged and ready
-                if (PlaySounds && BashSound > 0 && audioSource)
-                {
-                    DaggerfallAudioSource dfAudioSource = GetComponent<DaggerfallAudioSource>();
-                    if (dfAudioSource != null)
-                        dfAudioSource.PlayOneShot(BashSound);
-                }
-
-                // Cannot bash magically held doors
-                if (!IsMagicallyHeld)
-                {
-                    // Roll for chance to open
-                    int chance = 20 - CurrentLockValue;
-                    if (Dice100.SuccessRoll(chance))
-                    {
-                        CurrentLockValue = 0;
-                        ToggleDoor(true);
-                    }
-                }
-
-                if (byPlayer && Game.GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeonCastle)
-                    Game.GameManager.Instance.MakeEnemiesHostile();
+                DaggerfallAudioSource dfAudioSource = GetComponent<DaggerfallAudioSource>();
+                if (dfAudioSource != null)
+                    dfAudioSource.PlayOneShot(BashSound);
             }
+
+            if (IsOpen)
+            {
+                // Bash-close the door
+                ToggleDoor(true);
+            }
+            // Cannot bash magically held doors
+            else if (!IsMagicallyHeld)
+            {
+                // Roll for chance to open
+                int chance = 20 - CurrentLockValue;
+                if (Dice100.SuccessRoll(chance))
+                {
+                    CurrentLockValue = 0;
+                    ToggleDoor(true);
+                }
+            }
+
+            if (byPlayer && Game.GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeonCastle)
+                Game.GameManager.Instance.MakeEnemiesHostile();
         }
 
         public void SetInteriorDoorSounds()


### PR DESCRIPTION
(Splitting #1645 in two separate PRs)

Sometimes enemies hide behind or "inside" opened doors, and player weapons miss them because they're bashing the door instead.

While trying to add door bashing sound in this case, I checked classic Daggerfall behavior and noticed that it does bash-closing of the door (usually; sometimes it gets confused and bash-opens already opened doors), and that attracts enemies attention just like bash-opening.