### PR TITLE
For numeric input, accept numeric keys even without shifting

### DIFF
--- a/Assets/Scripts/Game/UserInterface/TextBox.cs
+++ b/Assets/Scripts/Game/UserInterface/TextBox.cs
@@ -233,12 +233,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
                     int value = (int)character;
                     if (value < 0x30 || value > 0x39)
                     {
-                        if (character == minus)
+                        // Allow negative numbers only if not natural
+                        if (character == minus && numericMode != NumericMode.Natural)
                         {
-                            // Allow negative numbers only if not natural
-                            if (numericMode == NumericMode.Natural)
-                                return;
-
                             if (cursorPosition != 0 || (text.Length > 0 && text[0] == minus))
                                 return;
                         }
@@ -250,8 +247,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         }
                         else
                         {
-                            // For numeric only accept characters 0 - 9
-                            return;
+                            // Also accept numeric keys, even when not shifted
+                            KeyCode keyCode = DaggerfallUI.Instance.LastKeyCode;
+                            if (numericMode == NumericMode.Natural && keyCode >= KeyCode.Alpha0 && keyCode <= KeyCode.Alpha9)
+                                character = (char)(keyCode - KeyCode.Alpha0 + 0x30);
+                            else
+                                // For numeric only accept characters 0 - 9
+                                return;
                         }
                     }
                 }


### PR DESCRIPTION
In some locales, numeric keys normally require shifting to get digits.
Bypass this requirement for numeric inputs.

Added difficulty: on french keyboard, the 6 key is the shifted dash (-) key, so there's an ambiguity for relative numbers. So I restricted this to NATURAL numeric inputs.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=3192