### PR TITLE
Don't suppress world when inside a building

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -501,7 +501,7 @@ namespace DaggerfallWorkshop.Game
                 world.TeleportToCoordinates(pos.X, pos.Y, StreamingWorld.RepositionMethods.None);
                 dfUnity.ContentReader.GetLocation(summary.RegionIndex, summary.MapIndex, out location);
                 StartBuildingInterior(location, exteriorDoors[0], start);
-                world.suppressWorld = true;
+                world.suppressWorld = false;
             }
             else
             {


### PR DESCRIPTION
Fix list of houses for sale not available when loading the game inside a bank: https://forums.dfworkshop.net/viewtopic.php?f=24&t=3034