### PR TITLE
find revealed locations by a very common substring

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -147,7 +147,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         readonly Dictionary<string, Texture2D> regionTextures = new Dictionary<string, Texture2D>();
         readonly Dictionary<int, Texture2D> importedOverlays = new Dictionary<int, Texture2D>();
 
-        private readonly int maxMatchingResults = 20;
+        private readonly int maxMatchingResults = 1000;
         private string distanceRegionName = null;
         private IDistance distance;
 


### PR DESCRIPTION
that's a consequence of search running in two passes: finding locations whose name best match the given string, then filter the list to only keep already revealed locations. And also the list produced by the first pass having a finite size.

They're screens upon screens of locations matching "Ruins..." (or "Ruins of..." for that matter) in the Wrothgarian Mountains, so only a subset of the names are kept by the first pass; And since the revealed dungeon name is not in the intermediate list (by pure bad luck), the second pass doesn't keep any names.

Simplest fix is just to increase the size of the intermediate list. The first pass creates the list using a priority queue, so it should stay very fast.
Other possibilities include swapping the two passes (search among the name of the locations that are revealed) but I don't know how fast we can create the list of all revealed locations; or add a predicate parameter to the function filtering names, so we can check if the location is revealed just before it's put in the intermediate list.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=3292