### PR TITLE
fix quicksave overwriting save0 if used first

### DIFF
--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -145,6 +145,9 @@ namespace DaggerfallWorkshop.Game.Serialization
             // Init classic game startup time at startup
             // This will also be modified when deserializing save game data
             DaggerfallUnity.Instance.WorldTime.Now.SetClassicGameStartTime();
+
+            // Update save game enumerations
+            GameManager.Instance.SaveLoadManager.EnumerateSaves();
         }
 
         static bool sceneUnloaded = false;
@@ -190,7 +193,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         /// Gets array of save keys for the specified character.
         /// </summary>
         /// <param name="characterName">Name of character.</param>
-        /// <returns>Array of save keys, excluding </returns>
+        /// <returns>Array of save keys</returns>
         public int[] GetCharacterSaveKeys(string characterName)
         {
             if (!enumeratedCharacterSaves.ContainsKey(characterName))


### PR DESCRIPTION
Reading the list of existing save slots only happens when opening save window interface; So if quicksave is used first, it will see an empty list of slots and overwrite save0.

Fixed by reading folders once at initialization, alternative would be to check if it needs to be done in several places (QuickSave, HasQuickSave, QuickLoad, at least)

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=3303