### PR TITLE
exclude player from weapon hit checks

### DIFF
--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -43,6 +43,7 @@ namespace DaggerfallWorkshop.Game
         public FPSWeapon ScreenWeapon;              // Weapon displayed in FPS view
         public bool Sheathed;                       // Weapon is sheathed
         public float SphereCastRadius = 0.25f;      // Radius of SphereCast used to target attacks
+        int playerLayerMask = 0;
         [Range(0, 1)]
         public float AttackThreshold = 0.05f;       // Minimum mouse gesture travel distance for an attack. % of screen
         public float ChanceToBeParried = 0.1f;      // Example: Chance for player hit to be parried
@@ -187,6 +188,7 @@ namespace DaggerfallWorkshop.Game
             weaponSensitivity = DaggerfallUnity.Settings.WeaponSensitivity;
             mainCamera = GameObject.FindGameObjectWithTag("MainCamera");
             player = transform.gameObject;
+            playerLayerMask = ~(1 << LayerMask.NameToLayer("Player"));
             _gesture = new Gesture();
             _longestDim = Math.Max(Screen.width, Screen.height);
             SetMelee(ScreenWeapon);
@@ -836,10 +838,9 @@ namespace DaggerfallWorkshop.Game
                 return;
 
             // Fire ray along player facing using weapon range
-            // Origin point of ray is set back slightly to fix issue where strikes against enemy capsules touching player capsule do not connect
             RaycastHit hit;
-            Ray ray = new Ray(mainCamera.transform.position + -mainCamera.transform.forward * 0.1f, mainCamera.transform.forward);
-            if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach))
+            Ray ray = new Ray(mainCamera.transform.position, mainCamera.transform.forward);
+            if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach, playerLayerMask))
             {
                 hitEnemy = WeaponDamage(hit, mainCamera.transform.forward);
             }


### PR DESCRIPTION
Seems to help hitting enemies at very close range

Forums: https://forums.dfworkshop.net/viewtopic.php?f=4&t=3172