### PR TITLE
Stop headbobbing animation while player is not grounded

### DIFF
--- a/Assets/Scripts/Game/Player/HeadBobber.cs
+++ b/Assets/Scripts/Game/Player/HeadBobber.cs
@@ -82,7 +82,7 @@ namespace DaggerfallWorkshop.Game
                 GameManager.Instance.PlayerEntity.CurrentHealth < 1 ||
                 GameManager.IsGamePaused ||
                 climbingMotor.IsClimbing ||
-				!playerMotor.IsGrounded)
+			    !playerMotor.IsGrounded)
                 return;
 
             GetBobbingStyle();

--- a/Assets/Scripts/Game/Player/HeadBobber.cs
+++ b/Assets/Scripts/Game/Player/HeadBobber.cs
@@ -81,7 +81,8 @@ namespace DaggerfallWorkshop.Game
             if (!DaggerfallUnity.Settings.HeadBobbing ||
                 GameManager.Instance.PlayerEntity.CurrentHealth < 1 ||
                 GameManager.IsGamePaused ||
-                climbingMotor.IsClimbing)
+                climbingMotor.IsClimbing ||
+				!playerMotor.IsGrounded)
                 return;
 
             GetBobbingStyle();


### PR DESCRIPTION
One very small adjustment I wanted to make was the fact that the headbobbing animation, if enabled, would continue to play even if the player is in the air. I found it more noticeable if you are jumping while riding on a horse, and the camera still continues to shake. This simple added condition to check for if the player is grounded or not should fix this issue.