### PR TITLE
Speedchanger refinements

### DIFF
--- a/Assets/Scripts/Game/Player/ClimbingMotor.cs
+++ b/Assets/Scripts/Game/Player/ClimbingMotor.cs
@@ -448,7 +448,7 @@ namespace DaggerfallWorkshop.Game
 
             if (!isSlipping)
             {
-                float climbScalar = speedChanger.GetClimbingSpeed();
+                float climbScalar = speedChanger.GetClimbingSpeed(playerMotor.Speed);
                 moveDirection = Vector3.zero;
                 bool movedForward = InputManager.Instance.HasAction(InputManager.Actions.MoveForwards);
                 bool movedBackward = InputManager.Instance.HasAction(InputManager.Actions.MoveBackwards);

--- a/Assets/Scripts/Game/Player/HangingMotor.cs
+++ b/Assets/Scripts/Game/Player/HangingMotor.cs
@@ -193,7 +193,7 @@ namespace DaggerfallWorkshop.Game
             RaycastHit hit;
             if (Physics.SphereCast(controller.transform.position, scanner.HeadHitRadius, controller.transform.up,  out hit, 2f))
             {
-                float playerspeed = speedChanger.GetClimbingSpeed();
+                float playerspeed = speedChanger.GetClimbingSpeed(playerMotor.Speed);
                 Vector3 moveVector = Vector3.zero;
                 if (InputManager.Instance.HasAction(InputManager.Actions.MoveForwards))
                     moveVector += controller.transform.forward;

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -18,7 +18,6 @@ namespace DaggerfallWorkshop.Game
     public class PlayerSpeedChanger : MonoBehaviour
     {
         private PlayerMotor playerMotor;
-        private PlayerEnterExit playerEnterExit;
         private LevitateMotor levitateMotor;
 
         // If checked, the run key toggles between running and walking. Otherwise player runs if the key is held down and walks otherwise
@@ -50,7 +49,6 @@ namespace DaggerfallWorkshop.Game
         private void Start()
         {
             playerMotor = GameManager.Instance.PlayerMotor;
-            playerEnterExit = GameManager.Instance.PlayerEnterExit;
             levitateMotor = GetComponent<LevitateMotor>();
             CanRun = CanRunUnlessRiding;
         }
@@ -99,9 +97,6 @@ namespace DaggerfallWorkshop.Game
                 speed /= 2;
                 speed -= (1 / classicToUnitySpeedUnitRatio);
             }
-
-            if (playerEnterExit.IsPlayerSwimming && !GameManager.Instance.PlayerEntity.IsWaterWalking)
-                speed = GetSwimSpeed(speed);
         }
 
         public bool CanRunUnlessRiding()

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -24,6 +24,7 @@ namespace DaggerfallWorkshop.Game
         // If checked, the run key toggles between running and walking. Otherwise player runs if the key is held down and walks otherwise
         // There must be a button set up in the Input Manager called "Run"
         public bool toggleRun = false;
+        public bool toggleSneak = false;
 
         // Daggerfall base speed constants. (courtesy Allofich)
         public const float classicToUnitySpeedUnitRatio = 39.5f; // was estimated from comparing a walk over the same distance in classic and DF Unity
@@ -40,6 +41,9 @@ namespace DaggerfallWorkshop.Game
 
         public delegate bool CanPlayerRun();
         public CanPlayerRun CanRun { get; set; }
+        public bool runningMode = false;
+        public bool sneakingMode = false;
+
         public bool isRunning = false;
 
         private void Start()
@@ -51,23 +55,38 @@ namespace DaggerfallWorkshop.Game
         }
 
 
+
+        /// <summary>
+        /// Record player input for speed adjustment
+        /// </summary>
+        public void CaptureInputSpeedAdjustment()
+        { 
+            if (!toggleRun)
+                runningMode = InputManager.Instance.HasAction(InputManager.Actions.Run);
+            else
+                runningMode = runningMode ^ InputManager.Instance.ActionStarted(InputManager.Actions.Run);
+
+            if (!toggleSneak)
+                sneakingMode = InputManager.Instance.HasAction(InputManager.Actions.Sneak);
+            else
+                sneakingMode = sneakingMode ^ InputManager.Instance.ActionStarted(InputManager.Actions.Sneak);
+        }
+
         /// <summary>
         /// Determines how speed should be changed based on player's input
         /// </summary>
         /// <param name="speed"></param>
-        public void HandleInputSpeedAdjustment(ref float speed)
+        public void ApplyInputSpeedAdjustment(ref float speed)
         {
             if (playerMotor.IsGrounded)
             {
                 if (!CanRun())
                     isRunning = false;
-                else if (!toggleRun)
-                    isRunning = InputManager.Instance.HasAction(InputManager.Actions.Run);
                 else
-                    isRunning = playerMotor.IsRunning ^ InputManager.Instance.ActionStarted(InputManager.Actions.Run);
+                    isRunning = runningMode;
 
                 // Handle sneak key. Reduces movement speed to half, then subtracts 1 in classic speed units
-                if (InputManager.Instance.HasAction(InputManager.Actions.Sneak))
+                if (sneakingMode)
                 {
                     isRunning = false;
                     speed /= 2;

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -45,6 +45,7 @@ namespace DaggerfallWorkshop.Game
         public bool sneakingMode = false;
 
         public bool isRunning = false;
+        public bool isSneaking = false;
 
         private void Start()
         {
@@ -60,7 +61,7 @@ namespace DaggerfallWorkshop.Game
         /// Record player input for speed adjustment
         /// </summary>
         public void CaptureInputSpeedAdjustment()
-        { 
+        {
             if (!toggleRun)
                 runningMode = InputManager.Instance.HasAction(InputManager.Actions.Run);
             else
@@ -80,18 +81,8 @@ namespace DaggerfallWorkshop.Game
         {
             if (playerMotor.IsGrounded)
             {
-                if (!CanRun())
-                    isRunning = false;
-                else
-                    isRunning = runningMode;
-
-                // Handle sneak key. Reduces movement speed to half, then subtracts 1 in classic speed units
-                if (sneakingMode)
-                {
-                    isRunning = false;
-                    speed /= 2;
-                    speed -= (1 / classicToUnitySpeedUnitRatio);
-                }
+                isRunning = CanRun() && runningMode && !sneakingMode;
+                isSneaking = sneakingMode;
             }
             else
             {
@@ -102,6 +93,12 @@ namespace DaggerfallWorkshop.Game
 
             if (isRunning)
                 speed = GetRunSpeed(speed);
+            else if (isSneaking)
+            {
+                // Handle sneak key. Reduces movement speed to half, then subtracts 1 in classic speed units
+                speed /= 2;
+                speed -= (1 / classicToUnitySpeedUnitRatio);
+            }
 
             if (playerEnterExit.IsPlayerSwimming && !GameManager.Instance.PlayerEntity.IsWaterWalking)
                 speed = GetSwimSpeed(speed);

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -18,6 +18,7 @@ namespace DaggerfallWorkshop.Game
     public class PlayerSpeedChanger : MonoBehaviour
     {
         private PlayerMotor playerMotor;
+        private PlayerEnterExit playerEnterExit;
         private LevitateMotor levitateMotor;
 
         // If checked, the run key toggles between running and walking. Otherwise player runs if the key is held down and walks otherwise
@@ -44,9 +45,11 @@ namespace DaggerfallWorkshop.Game
         private void Start()
         {
             playerMotor = GameManager.Instance.PlayerMotor;
+            playerEnterExit = GameManager.Instance.PlayerEnterExit;
             levitateMotor = GetComponent<LevitateMotor>();
             CanRun = CanRunUnlessRiding;
         }
+
 
         /// <summary>
         /// Determines how speed should be changed based on player's input
@@ -80,6 +83,9 @@ namespace DaggerfallWorkshop.Game
 
             if (isRunning)
                 speed = GetRunSpeed(speed);
+
+            if (playerEnterExit.IsPlayerSwimming && !GameManager.Instance.PlayerEntity.IsWaterWalking)
+                speed = GetSwimSpeed(speed);
         }
 
         public bool CanRunUnlessRiding()

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -174,12 +174,12 @@ namespace DaggerfallWorkshop.Game
             return (baseSpeed * (player.Skills.GetLiveSkillValue(DFCareer.Skills.Swimming) / 200f)) + (baseSpeed / 4);
         }
 
-        public float GetClimbingSpeed()
+        public float GetClimbingSpeed(float baseSpeed)
         {
             // Climbing effect states "target can climb twice as well" - doubling climbing speed
             Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
             float climbingBoost = player.IsEnhancedClimbing ? 2f : 1f;
-            return (playerMotor.Speed / 3) * climbingBoost;
+            return (baseSpeed / 3) * climbingBoost;
         }
     }
 }

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -39,6 +39,7 @@ namespace DaggerfallWorkshop.Game
 
         public delegate bool CanPlayerRun();
         public CanPlayerRun CanRun { get; set; }
+        public bool isRunning = false;
 
         private void Start()
         {
@@ -55,28 +56,30 @@ namespace DaggerfallWorkshop.Game
         {
             if (playerMotor.IsGrounded)
             {
-                if (InputManager.Instance.HasAction(InputManager.Actions.Run) && CanRun())
-                {
-                    try
-                    {
-                        // If running isn't on a toggle, then use the appropriate speed depending on whether the run button is down
-                        if (!toggleRun)
-                            speed = GetRunSpeed(speed);
-                        else
-                            speed = (speed == GetBaseSpeed() ? GetRunSpeed(speed) : GetBaseSpeed());
-                    }
-                    catch
-                    {
-                        speed = GetRunSpeed(speed);
-                    }
-                }
+                if (!CanRun())
+                    isRunning = false;
+                else if (!toggleRun)
+                    isRunning = InputManager.Instance.HasAction(InputManager.Actions.Run);
+                else
+                    isRunning = playerMotor.IsRunning ^ InputManager.Instance.ActionStarted(InputManager.Actions.Run);
+
                 // Handle sneak key. Reduces movement speed to half, then subtracts 1 in classic speed units
-                else if (InputManager.Instance.HasAction(InputManager.Actions.Sneak))
+                if (InputManager.Instance.HasAction(InputManager.Actions.Sneak))
                 {
+                    isRunning = false;
                     speed /= 2;
                     speed -= (1 / classicToUnitySpeedUnitRatio);
                 }
             }
+            else
+            {
+                if (!CanRun())
+                    isRunning = false;
+                // you can't switch running on/off while in mid air
+            }
+
+            if (isRunning)
+                speed = GetRunSpeed(speed);
         }
 
         public bool CanRunUnlessRiding()

--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -235,7 +235,7 @@ namespace DaggerfallWorkshop.Game
             {
                 float volumeScale = FootstepVolumeScale;
                 if (playerMotor.IsMovingLessThanHalfSpeed)
-                    volumeScale *= 0.35f;
+                    volumeScale *= 0.5f;
 
                 if (!alternateStep)
                     customAudioSource.PlayOneShot(clip1, volumeScale * DaggerfallUnity.Settings.SoundVolume);

--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -233,10 +233,14 @@ namespace DaggerfallWorkshop.Game
             // Play sound if over distance threshold
             if (distance > threshold && customAudioSource && clip1 && clip2)
             {
+                float volumeScale = FootstepVolumeScale;
+                if (playerMotor.IsSneaking)
+                    volumeScale *= 0.35f;
+
                 if (!alternateStep)
-                    customAudioSource.PlayOneShot(clip1, FootstepVolumeScale * DaggerfallUnity.Settings.SoundVolume);
+                    customAudioSource.PlayOneShot(clip1, volumeScale * DaggerfallUnity.Settings.SoundVolume);
                 else
-                    customAudioSource.PlayOneShot(clip2, FootstepVolumeScale * DaggerfallUnity.Settings.SoundVolume);
+                    customAudioSource.PlayOneShot(clip2, volumeScale * DaggerfallUnity.Settings.SoundVolume);
 
                 alternateStep = (!alternateStep);
                 distance = 0f;

--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -234,7 +234,7 @@ namespace DaggerfallWorkshop.Game
             if (distance > threshold && customAudioSource && clip1 && clip2)
             {
                 float volumeScale = FootstepVolumeScale;
-                if (playerMotor.IsSneaking)
+                if (playerMotor.IsMovingLessThanHalfSpeed)
                     volumeScale *= 0.35f;
 
                 if (!alternateStep)

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -98,11 +98,6 @@ namespace DaggerfallWorkshop.Game
             get { return speedChanger.isRunning; }
         }
 
-        public bool IsSneaking
-        {
-            get { return speedChanger.isSneaking; }
-        }
-
         public bool IsStandingStill
         {
             get

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -296,6 +296,9 @@ namespace DaggerfallWorkshop.Game
                 grounded = true;
             }
 
+            speed = speedChanger.GetBaseSpeed();
+            speedChanger.ApplyInputSpeedAdjustment(ref speed);
+
             if (grounded)
             {
                 acrobatMotor.Jumping = false;
@@ -335,8 +338,7 @@ namespace DaggerfallWorkshop.Game
             if (levitateMotor && levitateMotor.IsLevitating)
                 return;
 
-            speed = speedChanger.GetBaseSpeed();
-            speedChanger.HandleInputSpeedAdjustment(ref speed);
+            speedChanger.CaptureInputSpeedAdjustment();
 
             UpdateSmoothFollower();
         }

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -50,7 +50,6 @@ namespace DaggerfallWorkshop.Game
         private FrictionMotor frictionMotor;
         private AcrobatMotor acrobatMotor;
         private PlayerGroundMotor groundMotor;
-        private PlayerEnterExit playerEnterExit;
         private PlayerMoveScanner playerScanner;
 
         private CollisionFlags collisionFlags = 0;
@@ -235,7 +234,6 @@ namespace DaggerfallWorkshop.Game
             frictionMotor = GetComponent<FrictionMotor>();
             acrobatMotor = GetComponent<AcrobatMotor>();
             playerScanner = GetComponent<PlayerMoveScanner>();
-            playerEnterExit = GameManager.Instance.PlayerEnterExit;
             rappelMotor = GetComponent<RappelMotor>();
             //hangingMotor = GetComponent<HangingMotor>();
 
@@ -339,8 +337,6 @@ namespace DaggerfallWorkshop.Game
 
             speed = speedChanger.GetBaseSpeed();
             speedChanger.HandleInputSpeedAdjustment(ref speed);
-            if (playerEnterExit.IsPlayerSwimming && !GameManager.Instance.PlayerEntity.IsWaterWalking)
-                speed = speedChanger.GetSwimSpeed(speed);
 
             UpdateSmoothFollower();
         }

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -49,6 +49,7 @@ namespace DaggerfallWorkshop.Game
         private PlayerSpeedChanger speedChanger;
         private FrictionMotor frictionMotor;
         private AcrobatMotor acrobatMotor;
+        private PlayerEnterExit playerEnterExit;
         private PlayerGroundMotor groundMotor;
         private PlayerMoveScanner playerScanner;
 
@@ -239,6 +240,7 @@ namespace DaggerfallWorkshop.Game
             frictionMotor = GetComponent<FrictionMotor>();
             acrobatMotor = GetComponent<AcrobatMotor>();
             playerScanner = GetComponent<PlayerMoveScanner>();
+            playerEnterExit = GameManager.Instance.PlayerEnterExit;
             rappelMotor = GetComponent<RappelMotor>();
             //hangingMotor = GetComponent<HangingMotor>();
 
@@ -301,8 +303,7 @@ namespace DaggerfallWorkshop.Game
                 grounded = true;
             }
 
-            speed = speedChanger.GetBaseSpeed();
-            speedChanger.ApplyInputSpeedAdjustment(ref speed);
+            UpdateSpeed();
 
             if (grounded)
             {
@@ -323,7 +324,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             playerScanner.FindStep(moveDirection);
-            
+
             acrobatMotor.ApplyGravity(ref moveDirection);
 
             acrobatMotor.HitHead(ref moveDirection);
@@ -346,6 +347,14 @@ namespace DaggerfallWorkshop.Game
             speedChanger.CaptureInputSpeedAdjustment();
 
             UpdateSmoothFollower();
+        }
+
+        private void UpdateSpeed()
+        {
+            speed = speedChanger.GetBaseSpeed();
+            speedChanger.ApplyInputSpeedAdjustment(ref speed);
+            if (playerEnterExit.IsPlayerSwimming && !GameManager.Instance.PlayerEntity.IsWaterWalking)
+                speed = speedChanger.GetSwimSpeed(speed);
         }
 
         // Store point that we're in contact with for use in FixedUpdate if needed

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -95,7 +95,7 @@ namespace DaggerfallWorkshop.Game
 
         public bool IsRunning
         {
-            get { return speed == speedChanger.GetRunSpeed(speedChanger.GetBaseSpeed()); }
+            get { return speedChanger.isRunning; }
         }
 
         public bool IsStandingStill

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -97,6 +97,11 @@ namespace DaggerfallWorkshop.Game
             get { return speedChanger.isRunning; }
         }
 
+        public bool IsSneaking
+        {
+            get { return speedChanger.isSneaking; }
+        }
+
         public bool IsStandingStill
         {
             get

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -242,7 +242,7 @@ namespace DaggerfallWorkshop.Game
                     // refresh audio volume to reflect global changes
                     float volumeScale = RidingVolumeScale;
                     if (playerMotor.IsMovingLessThanHalfSpeed)
-                        volumeScale *= 0.35f;
+                        volumeScale *= 0.5f;
 
                     ridingAudioSource.volume = volumeScale * DaggerfallUnity.Settings.SoundVolume;
                     ridingAudioSource.pitch = playerMotor.IsRunning ? 1.2f : 1f;

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -205,8 +205,7 @@ namespace DaggerfallWorkshop.Game
             // Handle horse & cart riding animation & sounds.
             if (mode == TransportModes.Horse || mode == TransportModes.Cart)
             {
-                // refresh audio volume to reflect global changes
-                ridingAudioSource.volume = RidingVolumeScale * DaggerfallUnity.Settings.SoundVolume;
+
                 if (playerMotor.IsStandingStill || !playerMotor.IsGrounded || GameManager.IsGamePaused)
                 {   // Stop animation frames and sound playing.
                     lastFrameTime = 0;
@@ -240,11 +239,16 @@ namespace DaggerfallWorkshop.Game
                             ridingAudioSource.clip = dfAudioSource.GetAudioClip((int)horseRidingSound2);
                         }
                     }
+                    // refresh audio volume to reflect global changes
+                    float volumeScale = RidingVolumeScale;
+                    if (playerMotor.IsSneaking)
+                        volumeScale *= 0.35f;
+
+                    ridingAudioSource.volume = volumeScale * DaggerfallUnity.Settings.SoundVolume;
                     ridingAudioSource.pitch = playerMotor.IsRunning ? 1.2f : 1f;
 
                     if (!ridingAudioSource.isPlaying)
                     {
-                        ridingAudioSource.volume = RidingVolumeScale * DaggerfallUnity.Settings.SoundVolume;
                         ridingAudioSource.Play();
                     }
                 }

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -241,7 +241,7 @@ namespace DaggerfallWorkshop.Game
                     }
                     // refresh audio volume to reflect global changes
                     float volumeScale = RidingVolumeScale;
-                    if (playerMotor.IsSneaking)
+                    if (playerMotor.IsMovingLessThanHalfSpeed)
                         volumeScale *= 0.35f;
 
                     ridingAudioSource.volume = volumeScale * DaggerfallUnity.Settings.SoundVolume;


### PR DESCRIPTION
FIx for #1588, and then some (like lowering player's noise volume when sneaking).

Note: 
playerMotor.speed is determined by both world conditions and player's input. While it's only required during FixedUpdate() for modifying movement(*), player's input can change with each Update() so that input must be recorded separately.
*. Except in LevitateMotor, that can adjust movement with each frame. If we care, we could update speed with each Update() too.
