### PR TITLE
Degrade equipped "when held" magic items over time

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -509,10 +509,6 @@ namespace DaggerfallWorkshop.Game.Entity
             if (preventNormalizingReputations)
                 preventNormalizingReputations = false;
 
-            // Reset isResting flag. If still resting DaggerfallRestWindow will set it to true again for the next update.
-            if (isResting)
-                isResting = false;
-
             HandleStartingCrimeGuildQuests();
 
             // Reset surrender to guards dialogue if no guards are nearby

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/CastWhenHeld.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/CastWhenHeld.cs
@@ -134,7 +134,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                         if (casterManager.IsPlayerEntity)
                             casterManager.PlayCastSound(sourceEntity, casterManager.GetCastSoundID(bundle.Settings.ElementType));
 
-                        // TODO: Apply durability loss to equipped item on equip and over time
+                        // TODO: Apply durability loss to equipped item on equip
                         // http://en.uesp.net/wiki/Daggerfall:Magical_Items#Durability_of_Magical_Items
                     }
                 }

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/CastWhenHeld.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/CastWhenHeld.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Numidium
 // 
 // Notes:
 //

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -79,6 +79,9 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         RacialOverrideEffect racialOverrideEffect;
         PassiveSpecialsEffect passiveSpecialsEffect;
 
+        const int normalMagicItemDegradeRate = 4;
+        const int restingMagicItemDegradeRate = 60;
+
         #endregion
 
         #region Properties
@@ -1622,13 +1625,18 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                     }
                 }
 
-                // If bundle has an item source keep it alive until item breaks or is unequipped
                 if (bundle.fromEquippedItem != null)
                 {
-                    hasRemainingEffectRounds = true;
+                    hasRemainingEffectRounds = true; // If bundle has an item source keep it alive until item breaks or is unequipped
 
-                    // TODO: Manage item damage the longer it is equipped
-                    // See http://en.uesp.net/wiki/Daggerfall:Magical_Items#Durability_of_Magical_Items
+                    // Degrade item at an average of 1 point per 4 rounds when awake and not travelling and 1 point hourly when resting/loitering
+                    if (!GameManager.Instance.EntityEffectBroker.SyntheticTimeIncrease)
+                    {
+                        int degradeRate = GameManager.Instance.PlayerEntity.IsResting ? restingMagicItemDegradeRate : normalMagicItemDegradeRate;
+
+                        if (UnityEngine.Random.Range(0, degradeRate) == 0)
+                            bundle.fromEquippedItem.LowerCondition(1, entityBehaviour.Entity, entityBehaviour.Entity.Items);
+                    }
                 }
 
                 // Expire this bundle once all effects have 0 rounds remaining

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -430,6 +430,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     currentRestMode = RestModes.Selection;
                 }
             }
+
+            GameManager.Instance.PlayerEntity.IsResting = false;
         }
 
         bool TickVitals()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    Hazelnut
+// Contributors:    Hazelnut, Numidium
 // 
 // Notes:
 //


### PR DESCRIPTION
I used @petchema 's findings here: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2584&start=40

I tried using the "%" operator on the current game second but that was giving me race condition issues. I opted to use randomness since it wouldn't need to use the current game time. If introducing randomness to the mix doesn't feel right then I could rework the magic round loop.

Still need to find out how much to degrade on equip.