### PR TITLE
Allow long unused textures to be unloaded

### DIFF
--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -529,6 +529,40 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         #region Internal Methods
 
         /// <summary>
+        /// Used internally when the game seeks assets from all mods and handles a global cache.
+        /// This method allows to load directly from bundle without mod cache to avoid
+        /// references that would prevents garbage collection to be performed.
+        /// Shouldn't be used for prefabs because <see cref="ImportedComponentAttribute"/> is currently unsupported.
+        /// </summary>
+        internal T LoadAsset<T>(string assetName)
+            where T : UnityEngine.Object
+        {
+            assetName = ModManager.GetAssetName(assetName);
+
+            T asset = null;
+            bool isVirtual = false;
+
+#if UNITY_EDITOR
+            if (isVirtual = IsVirtual)
+                asset = LoadAssetFromResources<T>(assetName);
+#endif
+
+            if (!isVirtual)
+            {
+                if (!AssetBundle)
+                    LoadAssetBundle();
+
+                asset = AssetBundle.LoadAsset<T>(assetName);
+            }
+
+            if (asset)
+                return asset;
+
+            Debug.LogErrorFormat("Failed to load asset: {0}", assetName);
+            return null;
+        }
+
+        /// <summary>
         /// Checks if this mod is expected to run on current version of Daggerfall Unity.
         /// </summary>
         /// <returns>True if game version is satisfied, false if is not, null if unknown.</returns>

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -390,13 +390,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// Seek asset in all mods with load order.
         /// </summary>
         /// <param name="name">Name of asset to seek.</param>
-        /// <param name="clone">Make a copy of asset?</param>
+        /// <param name="clone">Make a copy of asset? If null is loaded without cache.</param>
         /// <param name="asset">Loaded asset or null.</param>
         /// <remarks>
         /// If multiple mods contain an asset with given name, priority is defined by load order.
         /// </remarks>
         /// <returns>True if asset is found and loaded sucessfully.</returns>
-        public bool TryGetAsset<T>(string name, bool clone, out T asset) where T : UnityEngine.Object
+        public bool TryGetAsset<T>(string name, bool? clone, out T asset) where T : UnityEngine.Object
         {
             var query = from mod in EnumerateModsReverse()
 #if UNITY_EDITOR
@@ -404,7 +404,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 #else
                         where mod.AssetBundle != null && mod.AssetBundle.Contains(name)
 #endif
-                        select mod.GetAsset<T>(name, clone);
+                        select clone.HasValue ? mod.GetAsset<T>(name, clone.Value) : mod.LoadAsset<T>(name);
 
             return (asset = query.FirstOrDefault()) != null;
         }
@@ -414,14 +414,14 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// Check all names for each mod with the given priority.
         /// </summary>
         /// <param name="names">Names of asset to seek ordered by priority.</param>
-        /// <param name="clone">Make a copy of asset?</param>
+        /// <param name="clone">Make a copy of asset? If null is loaded without cache.</param>
         /// <param name="asset">Loaded asset or null.</param>
         /// <remarks>
         /// If multiple mods contain an asset with any of the given names, priority is defined by load order.
         /// If chosen mod contains multiple assets, priority is defined by order of names list.
         /// </remarks>
         /// <returns>True if asset is found and loaded sucessfully.</returns>
-        public bool TryGetAsset<T>(string[] names, bool clone, out T asset) where T : UnityEngine.Object
+        public bool TryGetAsset<T>(string[] names, bool? clone, out T asset) where T : UnityEngine.Object
         {
             var query = from mod in EnumerateModsReverse()
 #if UNITY_EDITOR
@@ -431,7 +431,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                         where mod.AssetBundle != null
                         from name in names where mod.AssetBundle.Contains(name)
 #endif
-                        select mod.GetAsset<T>(name, clone);
+                        select clone.HasValue ? mod.GetAsset<T>(name, clone.Value) : mod.LoadAsset<T>(name);
 
             return (asset = query.FirstOrDefault()) != null;
         }

--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -102,6 +102,7 @@ TerrainDistance=3
 TerrainHeightmapPixelError=5
 SmallerDungeons=False
 CustomBooksImport=True
+AssetCacheThreshold = 25
 
 [Enhancements]
 LypyL_GameConsole=True

--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -103,6 +103,7 @@ namespace DaggerfallWorkshop
         // Keys
         public int key;                             // Key of this material
         public int keyGroup;                        // Group of this material
+        public float timeStamp;                     // Time in seconds from startup during last access
 
         // Textures
         public Texture2D albedoMap;                 // Albedo texture of material

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -223,6 +223,7 @@ namespace DaggerfallWorkshop.Game.Utility
             // Filter settings
             DaggerfallUnity.Instance.MaterialReader.MainFilterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
             DaggerfallUnity.Instance.MaterialReader.CompressModdedTextures = DaggerfallUnity.Settings.CompressModdedTextures;
+            DaggerfallUnity.Instance.MaterialReader.AssetCacheThreshold = DaggerfallUnity.Settings.AssetCacheThreshold;
 
             // HUD settings
             DaggerfallHUD hud = DaggerfallUI.Instance.DaggerfallHUD;

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using DaggerfallConnect;
 using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
@@ -99,6 +100,7 @@ namespace DaggerfallWorkshop
         public bool MipMaps = true;
         public bool ReadableTextures = false;
         public SupportedAlphaTextureFormats AlphaTextureFormat = SupportedAlphaTextureFormats.ARGB32;
+        public int AssetCacheThreshold;
 
         // Window settings
         public Color DayWindowColor = new Color32(89, 154, 178, 0xff);
@@ -347,7 +349,7 @@ namespace DaggerfallWorkshop
             int key = MakeTextureKey((short)archive, (byte)record, (byte)frame);
             if (materialDict.ContainsKey(key))
             {
-                CachedMaterial cm = materialDict[key];
+                CachedMaterial cm = GetMaterialFromCache(key);
                 rectOut = cm.singleRect;
                 return cm.material;
             }
@@ -493,7 +495,7 @@ namespace DaggerfallWorkshop
             int key = MakeTextureKey((short)archive, (byte)0, (byte)0, AtlasKeyGroup);
             if (materialDict.ContainsKey(key))
             {
-                CachedMaterial cm = materialDict[key];
+                CachedMaterial cm = GetMaterialFromCache(key);
                 if (cm.filterMode == MainFilterMode)
                 {
                     // Properties are the same
@@ -588,7 +590,7 @@ namespace DaggerfallWorkshop
             int key = MakeTextureKey((short)archive, (byte)0, (byte)0, TileMapKeyGroup);
             if (materialDict.ContainsKey(key))
             {
-                CachedMaterial cm = materialDict[key];
+                CachedMaterial cm = GetMaterialFromCache(key);
                 if (cm.filterMode == MainFilterMode)
                 {
                     // Properties are the same
@@ -644,7 +646,7 @@ namespace DaggerfallWorkshop
             int key = MakeTextureKey((short)archive, (byte)0, (byte)0, TileMapKeyGroup);
             if (materialDict.ContainsKey(key))
             {
-                CachedMaterial cm = materialDict[key];
+                CachedMaterial cm = GetMaterialFromCache(key);
                 if (cm.filterMode == MainFilterMode)
                 {
                     // Properties are the same
@@ -711,7 +713,7 @@ namespace DaggerfallWorkshop
             int key = MakeTextureKey((short)archive, (byte)record, (byte)frame);
             if (materialDict.ContainsKey(key))
             {
-                cachedMaterialOut = materialDict[key];
+                cachedMaterialOut = GetMaterialFromCache(key);
                 return true;
             }
             else
@@ -764,7 +766,7 @@ namespace DaggerfallWorkshop
             int key = MakeTextureKey((short)archive, (byte)0, (byte)0, AtlasKeyGroup);
             if (materialDict.ContainsKey(key))
             {
-                cachedMaterialOut = materialDict[key];
+                cachedMaterialOut = GetMaterialFromCache(key);
                 return true;
             }
 
@@ -784,7 +786,7 @@ namespace DaggerfallWorkshop
             int key = MakeTextureKey((short)archive, (byte)record, (byte)frame, CustomBillboardKeyGroup);
             if (materialDict.ContainsKey(key))
             {
-                cachedMaterialOut = materialDict[key];
+                cachedMaterialOut = GetMaterialFromCache(key);
                 return true;
             }
 
@@ -865,6 +867,21 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
+        /// Removes from cache all materials that have not been accessed from the time in minutes defined
+        /// by <see cref="AssetCacheThreshold"/>. If equals to <c>0</c> assets are never removed from cache.
+        /// </summary>
+        internal void PruneCache()
+        {
+            if (AssetCacheThreshold == 0)
+                return;
+
+            float time = Time.realtimeSinceStartup;
+            float threshold = AssetCacheThreshold * 60;
+            foreach (var item in materialDict.Where(x => time - x.Value.timeStamp > threshold).ToList())
+                materialDict.Remove(item.Key);
+        }
+
+        /// <summary>
         /// Clears material cache dictionary, forcing material to reload.
         /// </summary>
         public void ClearCache()
@@ -931,7 +948,23 @@ namespace DaggerfallWorkshop
             materialOut = GetMaterial(archive, record);
             int key = MakeTextureKey((short)archive, (byte)record);
 
-            return materialDict[key];
+            return GetMaterialFromCache(key);
+        }
+
+        private CachedMaterial GetMaterialFromCache(int key)
+        {
+            CachedMaterial cachedMaterial = materialDict[key];
+
+            // Update timestamp of last access, but only if difference is
+            // significant to limit the number of reassignment to dictionary.
+            float time = Time.realtimeSinceStartup;
+            if (time - cachedMaterial.timeStamp > 59)
+            {
+                cachedMaterial.timeStamp = time;
+                materialDict[key] = cachedMaterial;
+            }
+
+            return cachedMaterial;
         }
 
         private bool ReadyCheck()

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -162,6 +162,7 @@ namespace DaggerfallWorkshop
         public int TerrainDistance { get; set; }
         public float TerrainHeightmapPixelError { get; set; }
         public bool SmallerDungeons { get; set; }
+        public int AssetCacheThreshold { get; set; }
 
         // [Enhancements]
         public bool LypyL_GameConsole { get; set; }
@@ -285,6 +286,7 @@ namespace DaggerfallWorkshop
             TerrainDistance = GetInt(sectionExperimental, "TerrainDistance", 1, 4);
             TerrainHeightmapPixelError = GetFloat(sectionExperimental, "TerrainHeightmapPixelError", 1, 10);
             SmallerDungeons = GetBool(sectionExperimental, "SmallerDungeons");
+            AssetCacheThreshold = GetInt(sectionExperimental, "AssetCacheThreshold", 0, 120);
 
             LypyL_GameConsole = GetBool(sectionEnhancements, "LypyL_GameConsole");
             LypyL_ModSystem = GetBool(sectionEnhancements, "LypyL_ModSystem");
@@ -395,6 +397,7 @@ namespace DaggerfallWorkshop
             SetInt(sectionExperimental, "TerrainDistance", TerrainDistance);
             SetFloat(sectionExperimental, "TerrainHeightmapPixelError", TerrainHeightmapPixelError);
             SetBool(sectionExperimental, "SmallerDungeons", SmallerDungeons);
+            SetInt(sectionExperimental, "AssetCacheThreshold", AssetCacheThreshold);
 
             SetBool(sectionEnhancements, "LypyL_GameConsole", LypyL_GameConsole);
             SetBool(sectionEnhancements, "LypyL_ModSystem", LypyL_ModSystem);

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -655,7 +655,10 @@ namespace DaggerfallWorkshop
             // If this is an init we can use the load time to unload unused assets
             // Keeps memory usage much lower over time
             if (init)
+            {
+                DaggerfallUnity.Instance.MaterialReader.PruneCache();
                 Resources.UnloadUnusedAssets();
+            }
 
             // Set terrain neighbours
             UpdateNeighbours();

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -307,7 +307,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 // If the first match is a texture array, is returned successfully.
                 // If the first match is the first texture in the archive, an array is created at runtime.
                 Texture texture;
-                if (ModManager.Instance.TryGetAsset(names, false, out texture) && texture.dimension == TextureDimension.Tex2DArray)
+                if (ModManager.Instance.TryGetAsset(names, null, out texture) && texture.dimension == TextureDimension.Tex2DArray)
                 {
                     if ((textureArray = texture as Texture2DArray).depth == depth)
                         return true;
@@ -888,7 +888,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             {
                 // Seek from mods
                 if (ModManager.Instance != null)
-                    return ModManager.Instance.TryGetAsset(name, false, out material);
+                    return ModManager.Instance.TryGetAsset(name, null, out material);
             }
 
             material = null;
@@ -917,7 +917,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
                 // Seek from mods
                 if (ModManager.Instance != null)
-                    return ModManager.Instance.TryGetAsset(name, false, out tex);
+                    return ModManager.Instance.TryGetAsset(name, null, out tex);
             }
 
             tex = null;


### PR DESCRIPTION
Added experimental setting "AssetCacheThreshold". If different than zero, this is the time in minutes from last access for which a texture can be stored in cache. During fast travels textures that exceed this value are removed to allow Unity to unload them if unused.