### PR TITLE
fix static doors collider size

### DIFF
--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -1379,7 +1379,8 @@ namespace DaggerfallWorkshop.Utility
                 float width = Mathf.Abs(v2.x - v0.x);
                 float height = Mathf.Abs(v2.y - v0.y);
                 float depth = Mathf.Abs(v2.z - v0.z);
-                Vector3 size = (width > depth) ? new Vector3(width, height, width) : new Vector3(depth, height, depth);
+                float thickness = Mathf.Max(width, depth);
+                Vector3 size = new Vector3(thickness, Mathf.Max(height, thickness), Mathf.Min(height, thickness));
 
                 // Add door to array
                 StaticDoor newDoor = new StaticDoor()


### PR DESCRIPTION
In addition to using the max of width and depth as door thickness, swap Y and Z if Y size is less than Z size.

It seems to work fine (more testing welcome though), but I suspect the logic is not perfectly correct; I suspect Y and Z actually need to be swapped for grounded doors because you're actually entering by its top. As if door dimensions were considered _after_ rotations instead of before; They're really its X, Y and Z sizes, and not local width, height and depth. Or something like that. 
(and that could explain why width and depth can switch roles, probably depending on door orientation).

Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=566