### PR TITLE
Display launcher options if a key is pressed during startup

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -149,7 +149,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             NativePanel.Components.Add(exitButton);
 
             // If actually validated and we just want to see settings then move direct to settings page
-            if (DaggerfallUnity.Instance.IsPathValidated && DaggerfallUnity.Settings.ShowOptionsAtStart)
+            if (DaggerfallUnity.Instance.IsPathValidated && (DaggerfallUnity.Settings.ShowOptionsAtStart || Input.anyKey))
             {
                 currentStage = SetupStages.Options - 1;
             }
@@ -724,6 +724,24 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
 
         private void OptionsConfirmButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            if (DaggerfallUnity.Settings.ShowOptionsAtStart && !alwayShowOptions.IsChecked)
+            {
+                var messageBox = new DaggerfallMessageBox(uiManager, this, true);
+                messageBox.SetText(GetText("showOptionsAgain"));
+                messageBox.AllowCancel = true;
+                messageBox.ClickAnywhereToClose = true;
+                messageBox.OnClose += () => {
+                    SaveOptionsAndContinue();
+                };
+                uiManager.PushWindow(messageBox);
+                return;
+            }
+
+            SaveOptionsAndContinue();
+        }
+
+        private void SaveOptionsAndContinue()
         {
             DaggerfallUnity.Settings.ShowOptionsAtStart = alwayShowOptions.IsChecked;
             DaggerfallUnity.Settings.VSync = vsync.IsChecked;

--- a/Assets/Scripts/Game/Utility/SceneControl.cs
+++ b/Assets/Scripts/Game/Utility/SceneControl.cs
@@ -43,7 +43,7 @@ namespace DaggerfallWorkshop.Game.Utility
             }
 
             // Check arena2 path is validated OK, otherwise start game setup
-            if (!DaggerfallUnity.Instance.IsPathValidated || DaggerfallUnity.Settings.ShowOptionsAtStart)
+            if (!DaggerfallUnity.Instance.IsPathValidated || DaggerfallUnity.Settings.ShowOptionsAtStart || Input.anyKey)
             {
                 // Enable sky for test models
                 if (defaultSky != null)

--- a/Assets/StreamingAssets/Text/MainMenu.txt
+++ b/Assets/StreamingAssets/Text/MainMenu.txt
@@ -47,3 +47,4 @@ testText,                   Test
 okText,                     OK
 keepSetting,                Keep this setting? Changes will revert in 8 seconds.
 incompatibleMods,           One or more mods are incompatible with current version of the game. Please check mods window for details. Do you wish to continue anyway?
+showOptionsAgain,           Keep a key pressed during game startup to access options again


### PR DESCRIPTION
Should make it easier for players to get the options back than find and edit settings.ini.

This does not automatically turn alwayShowOptions back on, so it can also be used for one-time display of options.