### PR TITLE
Prevent backward timetravel issues.

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -352,6 +352,10 @@ namespace DaggerfallWorkshop.Game.Entity
                 climbingMotor = GameManager.Instance.ClimbingMotor;
 
             uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
+            if (gameMinutes < lastGameMinutes)
+            {
+                throw new Exception(string.Format("lastGameMinutes {0} greater than gameMinutes: {1}", lastGameMinutes, gameMinutes));
+            }
 
             // Wait until game has started and the game time has been set.
             // If the game time is taken before then "30" is returned, which causes an initial player fatigue loss

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -337,11 +337,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Halt random enemy spawns for next playerEntity update so player isn't bombarded by spawned enemies at the end of a long trip
             GameManager.Instance.PlayerEntity.PreventEnemySpawns = true;
 
-            // Vampires and characters with Damage from Sunlight disadvantage always arrive just after 6pm regardless of travel type
+            // Vampires and characters with Damage from Sunlight disadvantage never arrive between 6am and 6pm regardless of travel type
             // Otherwise raise arrival time to just after 7am if cautious travel would arrive at night
             if (GameManager.Instance.PlayerEffectManager.HasVampirism() || GameManager.Instance.PlayerEntity.Career.DamageFromSunlight)
             {
-                DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.RaiseTime((DaggerfallDateTime.DuskHour - DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.Hour) * 3600);
+                if (DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.IsDay)
+                {
+                    DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.RaiseTime(
+                        (DaggerfallDateTime.DuskHour - DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.Hour) * 3600);
+                }
             }
             else if (speedCautious)
             {

--- a/Assets/Scripts/Utility/DaggerfallDateTime.cs
+++ b/Assets/Scripts/Utility/DaggerfallDateTime.cs
@@ -343,6 +343,10 @@ namespace DaggerfallWorkshop.Utility
         /// <param name="seconds">Amount in seconds to raise time values.</param>
         public void RaiseTime(float seconds)
         {
+            if (seconds < 0f)
+            {
+                throw new InvalidOperationException(string.Format("Time increases should always be positive. Got {0}", seconds));
+            }
             // Increment seconds by any amount
             Second += seconds;
 


### PR DESCRIPTION
Fix for https://forums.dfworkshop.net/viewtopic.php?f=24&t=3309
0.10.17 - Vampire fast travel DFU hangs CUREVAM if target dungeon not present in region

The dungeon had nothing to do with it.
It was the fast travel going back 40 minutes in time. That made the unsigned integer calculation for how many minutes had passed return a huge number. (136 years) which triggered creating the vampire cure quest 591 times, which quickly runs out of random dungeons to assign.
