### PR TITLE
Disable soultrap after capturing soul

### DIFF
--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -127,7 +127,10 @@ namespace DaggerfallWorkshop.Game.Entity
             {
                 // Attempt soul trap and allow entity to die based on outcome
                 if (AttemptSoulTrap())
+                {
+                    SoulTrapActive = false;
                     return base.SetHealth(amount, restoreMode);
+                }
             }
 
             return currentHealth;


### PR DESCRIPTION
 to prevent capturing multiple souls when killing an enemy by multiple damage sources.

Related form thread: https://forums.dfworkshop.net/viewtopic.php?f=24&t=3187