### PR TITLE
Move racial paralysis immunity from saving throw to immunity check.

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1174,14 +1174,7 @@ namespace DaggerfallWorkshop.Game.Formulas
 
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
             if ((effectFlags & DFCareer.EffectFlags.Paralysis) != 0)
-            {
                 toleranceFlags |= GetToleranceFlag(target.Career.Paralysis);
-                // Innate immunity if high elf. Start with 100 saving throw, but can be modified by
-                // tolerance flags. Note this differs from classic, where high elves have 100% immunity
-                // regardless of tolerance flags.
-                if (target == playerEntity && playerEntity.Race == Races.HighElf)
-                    savingThrow = 100;
-            }
             if ((effectFlags & DFCareer.EffectFlags.Magic) != 0)
             {
                 toleranceFlags |= GetToleranceFlag(target.Career.Magic);

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -589,7 +589,9 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// <returns>True if entity immune to paralysis.</returns>
         public bool IsEntityImmuneToParalysis()
         {
-            return entityBehaviour.Entity.Career.Paralysis == DFCareer.Tolerance.Immune || entityBehaviour.Entity.IsImmuneToParalysis;
+            if (entityBehaviour.Entity.Career.Paralysis == DFCareer.Tolerance.Immune || entityBehaviour.Entity.IsImmuneToParalysis)
+                return true;
+            return IsPlayerEntity && (((PlayerEntity) entityBehaviour.Entity).GetLiveRaceTemplate().ImmunityFlags & DFCareer.EffectFlags.Paralysis) != 0;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -584,14 +584,21 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         }
 
         /// <summary>
-        /// Checks if peered entity is globally immune to paralysis from career or effect system.
+        /// Checks if peered entity is globally immune to paralysis from career, race or effect system.
         /// </summary>
         /// <returns>True if entity immune to paralysis.</returns>
         public bool IsEntityImmuneToParalysis()
         {
             if (entityBehaviour.Entity.Career.Paralysis == DFCareer.Tolerance.Immune || entityBehaviour.Entity.IsImmuneToParalysis)
                 return true;
-            return IsPlayerEntity && (((PlayerEntity) entityBehaviour.Entity).GetLiveRaceTemplate().ImmunityFlags & DFCareer.EffectFlags.Paralysis) != 0;
+            // Players with racial immunity are immune unless they have a specific weakness.
+            if (IsPlayerEntity && (((PlayerEntity) entityBehaviour.Entity).GetLiveRaceTemplate().ImmunityFlags & DFCareer.EffectFlags.Paralysis) != 0)
+            {
+                return entityBehaviour.Entity.Career.Paralysis != DFCareer.Tolerance.LowTolerance &&
+                       entityBehaviour.Entity.Career.Paralysis != DFCareer.Tolerance.CriticalWeakness;
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Forum thread: https://forums.dfworkshop.net/viewtopic.php?f=24&t=3157

This makes High Elves 100% resistant to paralysis, regardless of the source of the paralysis or magic weaknesses.
