### PR TITLE
Less stroboscopic fire walls

### DIFF
--- a/Assets/Scripts/API/BaseImageFile.cs
+++ b/Assets/Scripts/API/BaseImageFile.cs
@@ -298,6 +298,16 @@ namespace DaggerfallConnect.Arena2
             return emissionColors;
         }
 
+        public Color32[] GetFireWallColors32(ref Color32[] srcTexture, int width, int height, Color neutralColor, float scale)
+        {
+            Color32[] emissionColors = new Color32[width * height];
+
+            for (int i = 0; i < emissionColors.Length; i++)
+                emissionColors[i] = Color32.Lerp(neutralColor, srcTexture[i], scale);
+
+            return emissionColors;
+        }
+
         #endregion
 
         #region Protected Methods

--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -117,6 +117,7 @@ namespace DaggerfallWorkshop
         public FilterMode filterMode;               // Filter mode of this material
         public int singleFrameCount;                // Number of frames in single animated material
         public int[] atlasFrameCounts;              // Array of frame counts for animated materials
+        public int framesPerSecond;                 // Number of frames per second in single animated material
 
         // Windows
         public bool isWindow;                       // True if this is a window material

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -87,6 +87,9 @@ namespace DaggerfallWorkshop
     {
         #region Fields
 
+        // Constants
+        public const int FireWallsArchive = 356;
+
         // General settings
         public bool AtlasTextures = true;
         public bool CompressSkyTextures = false;
@@ -448,6 +451,7 @@ namespace DaggerfallWorkshop
                 recordScales = recordScales,
                 recordOffsets = recordOffsets,
                 singleFrameCount = results.textureFile.GetFrameCount(record),
+                framesPerSecond = archive == FireWallsArchive ? 5 : 0, // Slow down fire walls
             };
             materialDict.Add(key, newcm);
 

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -67,6 +67,8 @@ namespace DaggerfallWorkshop.Utility
                     // Assign animation properties
                     c.TargetMaterial = cm.material;
                     c.AnimationFrames = materials;
+                    if (cm.framesPerSecond > 0)
+                        c.FramesPerSecond = cm.framesPerSecond;
                 }
             }
         }

--- a/Assets/Scripts/Utility/TextureReader.cs
+++ b/Assets/Scripts/Utility/TextureReader.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Utility
         public const int AnimalsTextureArchive = 201;
         public const int LightsTextureArchive = 210;
         public const int FixedTreasureFlatsArchive = 216;
+        public const int FireWallsArchive = 356;
         //public int[] MiscFlatsTextureArchives = new int[] { 97, 205, 211, 212, 213, 301 };
 
         /// <summary>
@@ -261,8 +262,20 @@ namespace DaggerfallWorkshop.Utility
             {
                 if (settings.createEmissionMap || (settings.autoEmission && isEmissive) && !isWindow)
                 {
-                    // Just reuse albedo map for basic colour emission
-                    emissionMap = albedoMap;
+                    if (settings.archive != FireWallsArchive)
+                        // Just reuse albedo map for basic colour emission
+                        emissionMap = albedoMap;
+                    else
+                    {
+                        // Mantellan Crux fire walls - lessen stroboscopic effect
+                        Color fireColor = new Color(0.706f, 0.271f, 0.086f); // Average of dim frame (0)
+                        // Color fireColor = new Color(0.773f, 0.38f, 0.122f); // Average of average frames (1 and 3)
+                        // Color fireColor = new Color(0.851f, 0.506f, 0.165f); // Average of bright frame (2)
+                        Color32[] firewallEmissionColors = textureFile.GetFireWallColors32(ref albedoColors, sz.Width, sz.Height, fireColor, 0.3f);
+                        emissionMap = new Texture2D(sz.Width, sz.Height, ParseTextureFormat(alphaTextureFormat), MipMaps);
+                        emissionMap.SetPixels32(firewallEmissionColors);
+                        emissionMap.Apply(true, !settings.stayReadable);
+                    }
                     resultEmissive = true;
                 }
 


### PR DESCRIPTION

Lower the contrast of Fire god chamber fire walls, and slow down the animation, so it gets less aggressive on the eyes.

