### PR TITLE
Changing the magicka in the get method causes bugs during load.

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -388,6 +388,8 @@ namespace DaggerfallWorkshop.Game.Entity
         public void ChangeMaxMagickaModifier(int amount)
         {
             MaxMagickaModifier += amount;
+            if (currentMagicka > MaxMagicka)
+                currentMagicka = MaxMagicka;
         }
 
         public void SetIncreasedWeightAllowanceMultiplier(float amount)
@@ -456,9 +458,6 @@ namespace DaggerfallWorkshop.Game.Entity
 
         int GetCurrentMagicka()
         {
-            if (currentMagicka > MaxMagicka)
-                currentMagicka = MaxMagicka;
-
             return currentMagicka;
         }
 


### PR DESCRIPTION
Logically the cap should only need to be applied when the MaxMagicka changes.
This is the same logic used for health and fatigue.

This fixes forum bug https://forums.dfworkshop.net/viewtopic.php?f=24&t=3075

This reverts commit e1df2c3c2bd72c08f0b8f9d5b7c5b413cbad9eb0

