### PR TITLE
Make constant effects go into effect immediately on load

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -2131,6 +2131,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                     effect.EnchantmentParam = effectData.enchantmentParam;
                     effect.Resume(effectData, this, instancedBundle.caster);
                     effect.RestoreSaveData(effectData.effectSpecific);
+                    // Make constant effects go in effect immediately rather than next update.
+                    effect.ConstantEffect();
                     instancedBundle.liveEffects.Add(effect);
 
                     // Cache racial override effect


### PR DESCRIPTION
Start constant effects when they are resumed on load. Otherwise things like increased magicka are capped before the new max goes into effect.

Related forum post: https://forums.dfworkshop.net/viewtopic.php?f=24&t=3075