### PR TITLE
Null check for list of effects when applying in the biog file

### DIFF
--- a/Assets/Scripts/API/BiogFile.cs
+++ b/Assets/Scripts/API/BiogFile.cs
@@ -405,6 +405,9 @@ namespace DaggerfallConnect.Arena2
 
         public static void ApplyEffects(List<string> effects, PlayerEntity playerEntity)
         {
+            if (effects == null)
+                return;
+
             foreach (string effect in effects)
             {
                 ApplyPlayerEffect(playerEntity, effect);


### PR DESCRIPTION
If the list of effects is null the game will permanently lock up. So I simply added a check to see if the list is null and if so return the "ApplyEffects" function.