### PR TITLE
Allow to get UIWindowType enum value from type

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/UIWindowFactory.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/UIWindowFactory.cs
@@ -56,6 +56,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         UseMagicItem,
         VidPlayer,
         WitchesCovenPopup,
+        NotFound,
     }
 
     public static class UIWindowFactory
@@ -100,6 +101,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             { UIWindowType.UseMagicItem, typeof(DaggerfallUseMagicItemWindow) },
             { UIWindowType.VidPlayer, typeof(DaggerfallVidPlayerWindow) },
             { UIWindowType.WitchesCovenPopup, typeof(DaggerfallWitchesCovenPopupWindow) },
+            { UIWindowType.NotFound, typeof(DaggerfallHUD) },
         };
 
         /// <summary>
@@ -130,6 +132,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
 
             return GetInstance(windowType, args);
+        }
+
+        public static UIWindowType GetType(Type windowType)
+        {
+            foreach (var pair in uiWindowImplementations)
+            {
+                if (pair.Value == windowType)
+                    return pair.Key;
+            }
+            return UIWindowType.NotFound;
         }
 
         private static IUserInterfaceWindow GetInstance(UIWindowType windowType, object[] args)

--- a/Assets/Scripts/Game/UserInterfaceWindows/UIWindowFactory.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/UIWindowFactory.cs
@@ -133,10 +133,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             return GetInstance(windowType, args);
         }
 
-        public static UIWindowType? GetWindowType(Type windowType)
+        public static UIWindowType? GetWindowType(Type type)
         {
-            var pair = uiWindowImplementations.FirstOrDefault(x => x.Value == windowType);
-            return pair.Key;
+            var pair = uiWindowImplementations.FirstOrDefault(x => x.Value == type);
+            if (pair.Value != null)
+                return pair.Key;
+
+            return null;
         }
 
         private static IUserInterfaceWindow GetInstance(UIWindowType windowType, object[] args)

--- a/Assets/Scripts/Game/UserInterfaceWindows/UIWindowFactory.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/UIWindowFactory.cs
@@ -12,6 +12,7 @@
 using DaggerfallWorkshop.Game.UserInterface;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 {
@@ -56,7 +57,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         UseMagicItem,
         VidPlayer,
         WitchesCovenPopup,
-        NotFound,
     }
 
     public static class UIWindowFactory
@@ -101,7 +101,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             { UIWindowType.UseMagicItem, typeof(DaggerfallUseMagicItemWindow) },
             { UIWindowType.VidPlayer, typeof(DaggerfallVidPlayerWindow) },
             { UIWindowType.WitchesCovenPopup, typeof(DaggerfallWitchesCovenPopupWindow) },
-            { UIWindowType.NotFound, typeof(DaggerfallHUD) },
         };
 
         /// <summary>
@@ -134,14 +133,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             return GetInstance(windowType, args);
         }
 
-        public static UIWindowType GetType(Type windowType)
+        public static UIWindowType? GetWindowType(Type windowType)
         {
-            foreach (var pair in uiWindowImplementations)
-            {
-                if (pair.Value == windowType)
-                    return pair.Key;
-            }
-            return UIWindowType.NotFound;
+            var pair = uiWindowImplementations.FirstOrDefault(x => x.Value == windowType);
+            return pair.Key;
         }
 
         private static IUserInterfaceWindow GetInstance(UIWindowType windowType, object[] args)


### PR DESCRIPTION
I was looking for a method to return the type of window that is currently up.   I created GetType in UIWindowFactory to achieve this functionality.

An example of use would be 

            var manager = (UserInterfaceManager)sender;
            if (UIWindowFactory.GetType(manager.TopWindow.GetType()) == UIWindowType.Trade) {
…

thanks 
a