### PR TITLE
Right-clicking clothing in inventory window changes its clothing variant

### DIFF
--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -126,6 +126,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public delegate void OnItemClickHandler(DaggerfallUnityItem item);
         public event OnItemClickHandler OnItemClick;
 
+        public delegate void OnItemRightClickHandler(DaggerfallUnityItem item);
+        public event OnItemRightClickHandler OnItemRightClick;
+
         public delegate void OnItemHoverHandler(DaggerfallUnityItem item);
         public event OnItemHoverHandler OnItemHover;
 
@@ -334,6 +337,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 itemButtons[i].ToolTip = toolTip;
                 itemButtons[i].Tag = i;
                 itemButtons[i].OnMouseClick += ItemButton_OnMouseClick;
+                itemButtons[i].OnRightMouseClick += ItemButton_OnRightMouseClick;
                 itemButtons[i].OnMouseEnter += ItemButton_OnMouseEnter;
                 itemButtons[i].OnMouseScrollUp += ItemButton_OnMouseEnter;
                 itemButtons[i].OnMouseScrollDown += ItemButton_OnMouseEnter;
@@ -520,7 +524,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #region Event handlers
 
-        void ItemButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void ItemButton_OnClick(BaseScreenComponent sender, Vector2 position, bool rightClick)
         {
             // Get index
             int index = (GetScrollIndex() * listWidth) + (int)sender.Tag;
@@ -529,10 +533,23 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             // Get item and raise item click event
             DaggerfallUnityItem item = items[index];
-            if (item != null && OnItemClick != null)
-                OnItemClick(item);
+
+            if(!rightClick && item != null && OnItemClick != null)
+                    OnItemClick(item);
+            else if (item != null && OnItemRightClick != null)
+                    OnItemRightClick(item);
 
             ItemButton_OnMouseEnter(sender);
+        }
+
+        void ItemButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            ItemButton_OnClick(sender, position, false);
+        }
+
+        void ItemButton_OnRightMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            ItemButton_OnClick(sender, position, true);
         }
 
         void ItemButton_OnMouseEnter(BaseScreenComponent sender)

--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -534,7 +534,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // Get item and raise item click event
             DaggerfallUnityItem item = items[index];
 
-            if(!rightClick && item != null && OnItemClick != null)
+            if (!rightClick && item != null && OnItemClick != null)
                     OnItemClick(item);
             else if (item != null && OnItemRightClick != null)
                     OnItemRightClick(item);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -367,6 +367,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             };
             NativePanel.Components.Add(localItemListScroller);
             localItemListScroller.OnItemClick += LocalItemListScroller_OnItemClick;
+            localItemListScroller.OnItemRightClick += LocalItemListScroller_OnItemRightClick;
             if (itemInfoPanelLabel != null)
                 localItemListScroller.OnItemHover += ItemListScroller_OnHover;
 
@@ -380,6 +381,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             };
             NativePanel.Components.Add(remoteItemListScroller);
             remoteItemListScroller.OnItemClick += RemoteItemListScroller_OnItemClick;
+            remoteItemListScroller.OnItemRightClick += RemoteItemListScroller_OnItemRightClick;
             SetRemoteItemsAnimation();
 
             if (itemInfoPanelLabel != null)
@@ -453,6 +455,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             paperDoll.Position = new Vector2(49, 13);
             paperDoll.OnMouseMove += PaperDoll_OnMouseMove;
             paperDoll.OnMouseClick += PaperDoll_OnMouseClick;
+            paperDoll.OnRightMouseClick += PaperDoll_OnRightMouseClick;
             paperDoll.ToolTip = defaultToolTip;
             paperDoll.Refresh();
         }
@@ -1844,18 +1847,24 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        protected virtual void PaperDoll_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        private DaggerfallUnityItem PaperDoll_GetItem(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             // Get equip value
             byte value = paperDoll.GetEquipIndex((int)position.x, (int)position.y);
             if (value == 0xff)
-                return;
+                return null;
 
             // Get item
             EquipSlots slot = (EquipSlots)value;
             DaggerfallUnityItem item = playerEntity.ItemEquipTable.GetItem(slot);
-            if (item == null)
+            return item;
+        }
+
+        protected virtual void PaperDoll_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            DaggerfallUnityItem item = PaperDoll_GetItem(sender, position);
+            if(item == null)
                 return;
 
             // Handle click based on action
@@ -1876,6 +1885,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 UseItem(item);
             }
+        }
+
+        protected virtual void PaperDoll_OnRightMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            DaggerfallUnityItem item = PaperDoll_GetItem(sender, position);
+            if(item == null)
+                return;
+
+            NextVariant(item);
         }
 
         protected virtual void LocalItemListScroller_OnItemClick(DaggerfallUnityItem item)
@@ -1915,6 +1933,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 ShowInfoPopup(item);
             }
+        }
+
+        protected virtual void LocalItemListScroller_OnItemRightClick(DaggerfallUnityItem item)
+        {
+            NextVariant(item);
         }
 
         protected virtual void RemoteItemListScroller_OnItemClick(DaggerfallUnityItem item)
@@ -1957,6 +1980,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 ShowInfoPopup(item);
             }
+        }
+
+        protected virtual void RemoteItemListScroller_OnItemRightClick(DaggerfallUnityItem item)
+        {
+            NextVariant(item);
         }
 
         protected void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)


### PR DESCRIPTION
This adjustment is both a quality of life improvement as well as a small bugfix.

Before this commit was made, if you click the "Use" button and then click an article of clothing, it will change its appearance. However, if you click an article of clothing that has a magical effect, it will not only change its variant but it will also incidentally cast the magic effect as well. This means it's only possible to change a magic clothing's appearance without casting only if you equip it and click it on the paper doll.

I made a nice little workaround and improvement to this by making it so if you right-click on the paper doll, or on the "local" and "remote" item panels, it will change its variant without casting a magic effect, and without having to click the "Use" button.