### PR TITLE
Add clearclick to S0000009

### DIFF
--- a/Assets/StreamingAssets/Quests/S0000009.txt
+++ b/Assets/StreamingAssets/Quests/S0000009.txt
@@ -254,6 +254,10 @@ _S.13_ task:
 	when _clickedElysana_ and _giveLetter_ 
 	prompt QuestorOffer yes _yes_ no _no_ 
 
+_clearclick_ task:
+	when _clickedElysana_ and not _giveLetter_
+	clear _clickedElysana_ _clearclick_ 
+
 _S.14_ task:
 	end quest 
 


### PR DESCRIPTION
Clear _clickedElysana_ until the _giveLetter_ timer has expired. This prevents the quest prompt from popping up as soon as the _giveLetter_ timer expires when you clicked Elysana at any time after the quest started.
Forum post: https://forums.dfworkshop.net/viewtopic.php?f=5&t=3368