### PR TITLE
Improved outdoor footstep tile noises with shallow water and stone paths

### DIFF
--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -64,6 +64,7 @@ namespace DaggerfallWorkshop.Game
         int currentClimateIndex;
         bool isInside = false;
         bool isInOutsideWater = false;
+        bool isInOutsidePath = false;
 
         void Start()
         {
@@ -103,13 +104,16 @@ namespace DaggerfallWorkshop.Game
             // Play splash footsteps whether player is walking on or swimming in exterior water
             bool playerOnExteriorWater = (GameManager.Instance.PlayerMotor.OnExteriorWater == PlayerMotor.OnExteriorWaterMethod.Swimming || GameManager.Instance.PlayerMotor.OnExteriorWater == PlayerMotor.OnExteriorWaterMethod.WaterWalking);
 
-            // Change footstep sounds between winter/summer variants or when player enters/exits an interior space
-            if (playerSeason != currentSeason || playerClimateIndex != currentClimateIndex || isInside != playerInside || playerOnExteriorWater != isInOutsideWater)
+            bool playerOnExteriorPath = GameManager.Instance.PlayerMotor.OnExteriorPath;
+
+            // Change footstep sounds between winter/summer variants, when player enters/exits an interior space, or changes between path, water, or other outdoor ground
+            if (playerSeason != currentSeason || playerClimateIndex != currentClimateIndex || isInside != playerInside || playerOnExteriorWater != isInOutsideWater || playerOnExteriorPath != isInOutsidePath)
             {
                 currentSeason = playerSeason;
                 currentClimateIndex = playerClimateIndex;
                 isInside = playerInside;
                 isInOutsideWater = playerOnExteriorWater;
+                isInOutsidePath = playerOnExteriorPath;
                 if (!isInside)
                     if (currentSeason == DaggerfallDateTime.Seasons.Winter && !WeatherManager.IsSnowFreeClimate(currentClimateIndex))
                     {
@@ -141,6 +145,15 @@ namespace DaggerfallWorkshop.Game
             {
                 currentFootstepSound1 = FootstepSoundSubmerged;
                 currentFootstepSound2 = FootstepSoundSubmerged;
+                clip1 = null;
+                clip2 = null;
+            }
+
+            // walking on path tile
+            if (playerOnExteriorPath)
+            {
+                currentFootstepSound1 = FootstepSoundDungeon1;
+                currentFootstepSound2 = FootstepSoundDungeon2;
                 clip1 = null;
                 clip2 = null;
             }

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -455,6 +455,22 @@ namespace DaggerfallWorkshop.Game
             if (levitateMotor)
                 levitateMotor.IsLevitating = false;
         }
+        /// <summary>
+        /// Check if player is really standing on an shallow water tile, determined by if the water design takes up the majority of the texture.
+        /// </summary>
+        /// <returns>True if player is is on a shallow water tile.</returns>
+        bool OnShallowWaterTile(){
+            return GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 5
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 6
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 8
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 20
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 21
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 23
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 30
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 31
+            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex >= 33 && GameManager.Instance.StreamingWorld.PlayerTileMapIndex <= 36)
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 49;
+        }
 
         /// <summary>
         /// Check if player is really standing on an outdoor water tile, not just positioned above one.
@@ -471,11 +487,7 @@ namespace DaggerfallWorkshop.Game
 
             // Must be outside and over a water tile
             if (GameManager.Instance.PlayerEnterExit.IsPlayerInside
-            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0
-            && GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 20
-            && GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 21
-            && GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 22
-            && GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 23))
+            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0 && !OnShallowWaterTile()))
                 return OnExteriorWaterMethod.None;
             // Must actually be standing on a terrain object not some other object (e.g. player ship)
             RaycastHit hit;
@@ -492,10 +504,7 @@ namespace DaggerfallWorkshop.Game
 
             // Handle swimming/waterwalking
             if (GameManager.Instance.PlayerEntity.IsWaterWalking
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 20
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 21
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 22
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 23)
+            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0 && OnShallowWaterTile()))
                 return OnExteriorWaterMethod.WaterWalking;
             else
                 return OnExteriorWaterMethod.Swimming;

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -60,6 +60,7 @@ namespace DaggerfallWorkshop.Game
         LevitateMotor levitateMotor;
         float freezeMotor = 0;
         OnExteriorWaterMethod onExteriorWaterMethod = OnExteriorWaterMethod.None;
+        bool onExteriorPathMethod = false;
 
         #endregion
 
@@ -219,6 +220,14 @@ namespace DaggerfallWorkshop.Game
             get { return onExteriorWaterMethod; }
         }
 
+        /// <summary>
+        /// The method by which player is standing on outdoor path.
+        /// </summary>
+        public bool OnExteriorPath
+        {
+            get { return onExteriorPathMethod; }
+        }
+
         #endregion
 
         #region Event Handlers
@@ -331,6 +340,7 @@ namespace DaggerfallWorkshop.Game
         {
             // Update on water check
             onExteriorWaterMethod = GetOnExteriorWaterMethod();
+            onExteriorPathMethod = GetOnExteriorPathMethod();
 
             heightChanger.DecideHeightAction();
 
@@ -455,6 +465,36 @@ namespace DaggerfallWorkshop.Game
             if (levitateMotor)
                 levitateMotor.IsLevitating = false;
         }
+
+        /// <summary>
+        /// Check if player is really standing on an outdoor tile, not just positioned above one.
+        /// For example when player is on their ship they are standing above water but should not be swimming.
+        /// Same when player is levitating above water they should not hear splash sounds.
+        /// </summary>
+        /// <returns>True if player is physically in range of an outdoor tile.</returns>
+        bool GetOnExteriorGroundMethod()
+        {
+            const float walkingRayDistance = 1.0f;
+            const float ridingRayDistance = 2.0f;
+
+            float rayDistance = (GameManager.Instance.TransportManager.IsOnFoot) ? walkingRayDistance : ridingRayDistance;
+
+            // Must be outside and actually be standing on a terrain object not some other object (e.g. player ship)
+            RaycastHit hit;
+            if (GameManager.Instance.PlayerEnterExit.IsPlayerInside || !Physics.Raycast(transform.position, Vector3.down, out hit, rayDistance))
+            {
+                return false;
+            }
+            else
+            {
+                DaggerfallTerrain terrain = hit.transform.GetComponent<DaggerfallTerrain>();
+                if (!terrain)
+                    return false;
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Check if player is really standing on an shallow water tile, determined by if the water design takes up the majority of the texture.
         /// </summary>
@@ -473,6 +513,16 @@ namespace DaggerfallWorkshop.Game
         }
 
         /// <summary>
+        /// Check if player is really standing on a path tile.
+        /// </summary>
+        /// <returns>True if player is is on a path tile.</returns>
+        bool OnPathTile(){
+            return GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 46
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 47
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 55;
+        }
+
+        /// <summary>
         /// Check if player is really standing on an outdoor water tile, not just positioned above one.
         /// For example when player is on their ship they are standing above water but should not be swimming.
         /// Same when player is levitating above water they should not hear splash sounds.
@@ -480,34 +530,25 @@ namespace DaggerfallWorkshop.Game
         /// <returns>True if player is physically in range of an outdoor water tile.</returns>
         OnExteriorWaterMethod GetOnExteriorWaterMethod()
         {
-            const float walkingRayDistance = 1.0f;
-            const float ridingRayDistance = 2.0f;
-
-            float rayDistance = (GameManager.Instance.TransportManager.IsOnFoot) ? walkingRayDistance : ridingRayDistance;
-
-            // Must be outside and over a water tile
-            if (GameManager.Instance.PlayerEnterExit.IsPlayerInside
-            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0 && !OnShallowWaterTile()))
-                return OnExteriorWaterMethod.None;
-            // Must actually be standing on a terrain object not some other object (e.g. player ship)
-            RaycastHit hit;
-            if (!Physics.Raycast(transform.position, Vector3.down, out hit, rayDistance))
-            {
-                return OnExteriorWaterMethod.None;
-            }
-            else
-            {
-                DaggerfallTerrain terrain = hit.transform.GetComponent<DaggerfallTerrain>();
-                if (!terrain)
-                    return OnExteriorWaterMethod.None;
-            }
+            bool onShallowWaterTile = OnShallowWaterTile();
+            if(!GetOnExteriorGroundMethod()
+            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0 && !onShallowWaterTile))
+               return OnExteriorWaterMethod.None;
 
             // Handle swimming/waterwalking
-            if (GameManager.Instance.PlayerEntity.IsWaterWalking
-            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0 && OnShallowWaterTile()))
+            if (GameManager.Instance.PlayerEntity.IsWaterWalking || onShallowWaterTile)
                 return OnExteriorWaterMethod.WaterWalking;
             else
                 return OnExteriorWaterMethod.Swimming;
+        }
+
+        /// <summary>
+        /// Check if player is really standing on an outdoor path tile, not just positioned above one.
+        /// </summary>
+        /// <returns>True if player is physically in range of an outdoor path tile.</returns>
+        bool GetOnExteriorPathMethod()
+        {
+            return GetOnExteriorGroundMethod() && OnPathTile();
         }
 
         #endregion

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -470,9 +470,13 @@ namespace DaggerfallWorkshop.Game
             float rayDistance = (GameManager.Instance.TransportManager.IsOnFoot) ? walkingRayDistance : ridingRayDistance;
 
             // Must be outside and over a water tile
-            if (GameManager.Instance.PlayerEnterExit.IsPlayerInside || GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0)
+            if (GameManager.Instance.PlayerEnterExit.IsPlayerInside
+            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0
+            && GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 20
+            && GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 21
+            && GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 22
+            && GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 23))
                 return OnExteriorWaterMethod.None;
-
             // Must actually be standing on a terrain object not some other object (e.g. player ship)
             RaycastHit hit;
             if (!Physics.Raycast(transform.position, Vector3.down, out hit, rayDistance))
@@ -487,7 +491,11 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Handle swimming/waterwalking
-            if (GameManager.Instance.PlayerEntity.IsWaterWalking)
+            if (GameManager.Instance.PlayerEntity.IsWaterWalking
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 20
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 21
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 22
+            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 23)
                 return OnExteriorWaterMethod.WaterWalking;
             else
                 return OnExteriorWaterMethod.Swimming;

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -499,24 +499,26 @@ namespace DaggerfallWorkshop.Game
         /// Check if player is really standing on an shallow water tile, determined by if the water design takes up the majority of the texture.
         /// </summary>
         /// <returns>True if player is is on a shallow water tile.</returns>
-        bool OnShallowWaterTile(){
+        bool OnShallowWaterTile()
+        {
             return GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 5
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 6
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 8
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 20
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 21
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 23
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 30
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 31
-            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex >= 33 && GameManager.Instance.StreamingWorld.PlayerTileMapIndex <= 36)
-            || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 49;
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 6
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 8
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 20
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 21
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 23
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 30
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 31
+                || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex >= 33 && GameManager.Instance.StreamingWorld.PlayerTileMapIndex <= 36)
+                || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 49;
         }
 
         /// <summary>
         /// Check if player is really standing on a path tile.
         /// </summary>
         /// <returns>True if player is is on a path tile.</returns>
-        bool OnPathTile(){
+        bool OnPathTile()
+        {
             return GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 46
                 || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 47
                 || GameManager.Instance.StreamingWorld.PlayerTileMapIndex == 55;
@@ -531,8 +533,8 @@ namespace DaggerfallWorkshop.Game
         OnExteriorWaterMethod GetOnExteriorWaterMethod()
         {
             bool onShallowWaterTile = OnShallowWaterTile();
-            if(!GetOnExteriorGroundMethod()
-            || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0 && !onShallowWaterTile))
+            if (!GetOnExteriorGroundMethod()
+                || (GameManager.Instance.StreamingWorld.PlayerTileMapIndex != 0 && !onShallowWaterTile))
                return OnExteriorWaterMethod.None;
 
             // Handle swimming/waterwalking


### PR DESCRIPTION
If a player is walking on shallow water, the PlayerMotor won't recognize it as a water tile and will make the PlayerFootsteps play regular grass terrain footstep noises. In my commit, I added additional index tiles that are corner pieces between ground and water to make splash noises, without actually being submerged in the water and set to "swimming."

I also added stone paths (indices 46, 47, 55) to use the dungeon tile floor noise, which I think fits nicely.