### PR TITLE
Set player race before generating backstory

### DIFF
--- a/Assets/Scripts/API/BiogFile.cs
+++ b/Assets/Scripts/API/BiogFile.cs
@@ -16,6 +16,7 @@ using System.IO;
 using System.Collections.Generic;
 using DaggerfallWorkshop.Game.Entity;
 using UnityEngine;
+using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.Player;
 using DaggerfallWorkshop.Utility;
@@ -176,6 +177,7 @@ namespace DaggerfallConnect.Arena2
             }
             #endregion
 
+            GameManager.Instance.PlayerEntity.BirthRaceTemplate = characterDocument.raceTemplate; // Need correct race set when parsing %ra macro
             List<string> backStory = new List<string>();
             TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(tokensStart + classIndex);
             MacroHelper.ExpandMacros(ref tokens, (IMacroContextProvider)this);


### PR DESCRIPTION
Addresses the bug described here: https://forums.dfworkshop.net/viewtopic.php?f=24&t=2220
The %ra macro, which uses the PlayerEntity's BirthRaceTemplate, is used while generating player backstory. Since BirthRaceTemplate is not set until after the player exits the new game wizard, %ra expands into the default race name i.e. Breton.
Setting the race template before generating backstory gives the macro helper the info it needs.