### PR TITLE
Fix main quest questors issues

### DIFF
--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -84,7 +84,7 @@ namespace DaggerfallWorkshop.Game.Questing
         public bool IsQuestor
         {
             get { return isQuestor; }
-            set { SetQuestorStatus(value); }
+            set { isQuestor = value; }
         }
 
         public bool IsIndividualNPC
@@ -485,17 +485,6 @@ namespace DaggerfallWorkshop.Game.Questing
             isDestroyed = true;
         }
 
-        /// <summary>
-        /// Set Person as questor and assign questor data if needed.
-        /// Uses last clicked NPC data so has to be called after talking to the actual questor.
-        /// </summary>
-        private void SetQuestorStatus(bool status)
-        {
-            isQuestor = status;
-            if (isQuestor)
-                questorData = QuestMachine.Instance.LastNPCClicked.Data;
-        }
-
         #endregion
 
         #region Private Methods
@@ -887,8 +876,9 @@ namespace DaggerfallWorkshop.Game.Questing
                 return false;
             }
 
-            // Set as questor
-            IsQuestor = true;
+            // Set questor data
+            questorData = QuestMachine.Instance.LastNPCClicked.Data;
+            isQuestor = true;
 
             // Setup Person resource
             FactionFile.FactionData factionData = GetFactionData(questorData.factionID);

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -506,14 +506,10 @@ namespace DaggerfallWorkshop.Game.Questing
                 questors.Remove(key);
             }
 
-            // Unset questor flag
-            Person personResource = GetPerson(personSymbol);
-            if (personResource != null)
-                personResource.IsQuestor = false;
-
             // Destroy QuestResourceBehaviour from target object if present in scene and not an individual NPC
             // If target object not present in scene then QuestResourceBehaviour simply wont be added next time as Person is no longer a questor
             // Individual NPCs have a permanent QuestResourceBehaviour attached as they have special usage in long-running quests - it must not be removed
+            Person personResource = GetPerson(personSymbol);
             if (personResource != null && personResource.QuestResourceBehaviour != null && !personResource.IsIndividualNPC)
                 MonoBehaviour.Destroy(personResource.QuestResourceBehaviour);
         }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -814,7 +814,9 @@ namespace DaggerfallWorkshop.Game
                         continue;
                     foreach (Person person in quest.GetAllResources(typeof(Person)))
                     {
-                        if (GameManager.Instance.QuestMachine.IsNPCDataEqual(person.QuestorData, lastTargetStaticNPC.Data))
+                        if (person.IsQuestor &&
+                            (GameManager.Instance.QuestMachine.IsNPCDataEqual(person.QuestorData, lastTargetStaticNPC.Data) ||
+                             person.IsIndividualNPC && person.FactionData.id == lastTargetStaticNPC.Data.factionID))
                         {
                             TextFile.Token[] tokens = dictQuestorPostQuestMessage[questID];
 


### PR DESCRIPTION
This fixes issue #1688  which is related to my previous PR #1583.

Because main quest questors are added using the `add _NPC_ as questor` command, they are not always the last clicked NPCs, so we can't rely on this data to select quest related post success and post failure greetings. Instead, we can use faction IDs since all main quest questors are individual NPCs, having a unique faction ID. However to do that, we must also keep the `Person.isQuestor` flag as true, but this should not have any consequences since the `drop _NPC_ as questor` command effectively clears the NPC from the quest list of questors.