### PR TITLE
Do not update Magic Rounds when the game is loading

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -191,8 +191,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
         void Update()
         {
-            // Don't tick if lastGameMinute not set (pre-init)
-            if (lastGameMinute == 0)
+            // Don't tick if lastGameMinute not set (pre-init) or the game is inactive.
+            if (lastGameMinute == 0 || GameManager.Instance.IsPlayingGame() == false)
                 return;
 
             // Every game minute passing is another magic round, so work out how many minutes have passed


### PR DESCRIPTION
 (or paused/inactive). This prevents issues where it would compare the worldtime of the previous game to the worldtime of the savegame. Which would run up to 2880 magic rounds when it should not.

See forum post https://forums.dfworkshop.net/viewtopic.php?f=5&t=3379