### PR TITLE
force UnityEngine.Random reseeding when parsing quests

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/PickOneOf.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PickOneOf.cs
@@ -82,7 +82,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             bool success = false;
             if(ParentQuest != null)
             {
-                UnityEngine.Random.InitState(System.Environment.TickCount);
+                UnityEngine.Random.InitState(GameManager.Instance.QuestMachine.InternalSeed);
                 selected = taskSymbols[UnityEngine.Random.Range(0, taskSymbols.Length)];
                 Task task = ParentQuest.GetTask(selected);
 

--- a/Assets/Scripts/Game/Questing/Actions/PickOneOf.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PickOneOf.cs
@@ -82,7 +82,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             bool success = false;
             if(ParentQuest != null)
             {
-                //UnityEngine.Random.InitState(System.Environment.TickCount);
+                UnityEngine.Random.InitState(System.Environment.TickCount);
                 selected = taskSymbols[UnityEngine.Random.Range(0, taskSymbols.Length)];
                 Task task = ParentQuest.GetTask(selected);
 

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -224,6 +224,11 @@ namespace DaggerfallWorkshop.Game.Questing
             get { return Path.Combine(Application.persistentDataPath, questLogFilename); }
         }
 
+        /// <summary>
+        /// Return a new random seed
+        /// </summary>
+        public int InternalSeed { get { return internalSeed.Next(); } }
+
         #endregion
 
         #region Structs & Enums

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -86,6 +86,8 @@ namespace DaggerfallWorkshop.Game.Questing
         StaticNPC lastNPCClicked;
         Dictionary<int, IQuestAction> factionListeners = new Dictionary<int, IQuestAction>();
 
+        System.Random internalSeed = new System.Random();
+
         #endregion
 
         #region Properties
@@ -635,6 +637,8 @@ namespace DaggerfallWorkshop.Game.Questing
         public Quest ParseQuest(string questName, string[] questSource, int factionId = 0, bool partialParse = false)
         {
             LogFormat("\r\n\r\nParsing quest {0}", questName);
+
+            UnityEngine.Random.InitState(internalSeed.Next());
 
             try
             {


### PR DESCRIPTION
No optimisation attempt, QuestMachine.ParseQuest can be called several times during the same frame and is not in a hot path so I'm using System.Random as randomness source.
Generating a list of quests feels just as fast as before.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=3399
https://forums.dfworkshop.net/viewtopic.php?f=27&t=924&p=39061#p39056