### PR TITLE
MeleeDamage raycast fallback

### DIFF
--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -595,8 +595,8 @@ namespace DaggerfallWorkshop.Game
             }
             else
             {
-                RaycastHit unused = new RaycastHit();
-                GameManager.Instance.WeaponManager.WeaponEnvDamage(unused, goModel.transform.forward, arrowHitCollider, true);
+                Transform hitTransform = arrowHitCollider.gameObject.transform;
+                GameManager.Instance.WeaponManager.WeaponDamage(goModel.transform.forward, true, GameManager.Instance.WeaponManager.LastBowUsed, hitTransform, hitTransform.position);
             }
         }
 

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -596,7 +596,7 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 RaycastHit unused = new RaycastHit();
-                GameManager.Instance.WeaponManager.WeaponDamage(unused, goModel.transform.forward, arrowHitCollider, true);
+                GameManager.Instance.WeaponManager.WeaponEnvDamage(unused, goModel.transform.forward, arrowHitCollider, true);
             }
         }
 

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -596,7 +596,7 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 Transform hitTransform = arrowHitCollider.gameObject.transform;
-                GameManager.Instance.WeaponManager.WeaponDamage(goModel.transform.forward, true, GameManager.Instance.WeaponManager.LastBowUsed, hitTransform, hitTransform.position);
+                GameManager.Instance.WeaponManager.WeaponDamage(GameManager.Instance.WeaponManager.LastBowUsed, true, hitTransform, hitTransform.position, goModel.transform.forward);
             }
         }
 

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -838,12 +838,9 @@ namespace DaggerfallWorkshop.Game
             if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach, playerLayerMask))
             {
                 DaggerfallUnityItem strikingWeapon = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;
-                if(!WeaponEnvDamage(strikingWeapon, hit))
-                {
-                    hitEnemy = WeaponDamage(strikingWeapon, false, hit.transform, hit.point, mainCamera.transform.forward);
-                }
-                // Fall back to simple ray for narrow cages https://forums.dfworkshop.net/viewtopic.php?f=5&t=2195#p39524
-                else if (Physics.Raycast(ray, out hit, weapon.Reach, playerLayerMask))
+                if(!WeaponEnvDamage(strikingWeapon, hit)
+                   // Fall back to simple ray for narrow cages https://forums.dfworkshop.net/viewtopic.php?f=5&t=2195#p39524
+                   || Physics.Raycast(ray, out hit, weapon.Reach, playerLayerMask))
                 {
                     hitEnemy = WeaponDamage(strikingWeapon, false, hit.transform, hit.point, mainCamera.transform.forward);
                 }

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -414,7 +414,7 @@ namespace DaggerfallWorkshop.Game
             SheathWeapons();
         }
 
-        // Returns true if hit an enemy entity
+        // Returns true if hit the environment
         public bool WeaponEnvDamage(DaggerfallUnityItem strikingWeapon, RaycastHit hit, Vector3 direction)
         {
             // Check if hit has an DaggerfallAction component
@@ -429,26 +429,26 @@ namespace DaggerfallWorkshop.Game
             if (actionDoor)
             {
                 actionDoor.AttemptBash(true);
-                return false;
+                return true;
             }
 
             // Check if player hit a static exterior door
             if (GameManager.Instance.PlayerActivate.AttemptExteriorDoorBash(hit))
             {
-                return false;
+                return true;
             }
 
             // Make hitting walls do a thud or clinging sound (not in classic)
             if (GameObjectHelper.IsStaticGeometry(hit.transform.gameObject))
             {
                 DaggerfallUI.Instance.PlayOneShot(strikingWeapon == null ? SoundClips.Hit2 : SoundClips.Parry6);
-                return false;
+                return true;
             }
 
-            // Set up for use below
-            return WeaponDamage(direction, false, strikingWeapon, hit.transform, hit.point);
+            return false;
         }
 
+        // Returns true if hit an enemy entity
         public bool WeaponDamage(Vector3 direction, bool arrowHit, DaggerfallUnityItem strikingWeapon, Transform hitTransform, Vector3 impactPosition)
         {
             DaggerfallEntityBehaviour entityBehaviour = hitTransform.GetComponent<DaggerfallEntityBehaviour>();
@@ -838,7 +838,10 @@ namespace DaggerfallWorkshop.Game
             if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach, playerLayerMask))
             {
                 DaggerfallUnityItem strikingWeapon = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;
-                hitEnemy = WeaponEnvDamage(strikingWeapon, hit, mainCamera.transform.forward);
+                if(!WeaponEnvDamage(strikingWeapon, hit, mainCamera.transform.forward))
+                {
+                    hitEnemy = WeaponDamage(mainCamera.transform.forward, false, strikingWeapon, hit.transform, hit.point);
+                }
             }
         }
 

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -842,6 +842,11 @@ namespace DaggerfallWorkshop.Game
                 {
                     hitEnemy = WeaponDamage(mainCamera.transform.forward, false, strikingWeapon, hit.transform, hit.point);
                 }
+                // Fall back to simple ray for narrow cages https://forums.dfworkshop.net/viewtopic.php?f=5&t=2195#p39524
+                else if (Physics.Raycast(ray, out hit, weapon.Reach, playerLayerMask))
+                {
+                    hitEnemy = WeaponDamage(mainCamera.transform.forward, false, strikingWeapon, hit.transform, hit.point);
+                }
             }
         }
 

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -415,7 +415,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Returns true if hit the environment
-        public bool WeaponEnvDamage(DaggerfallUnityItem strikingWeapon, RaycastHit hit, Vector3 direction)
+        public bool WeaponEnvDamage(DaggerfallUnityItem strikingWeapon, RaycastHit hit)
         {
             // Check if hit has an DaggerfallAction component
             DaggerfallAction action = hit.transform.gameObject.GetComponent<DaggerfallAction>();
@@ -449,7 +449,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Returns true if hit an enemy entity
-        public bool WeaponDamage(Vector3 direction, bool arrowHit, DaggerfallUnityItem strikingWeapon, Transform hitTransform, Vector3 impactPosition)
+        public bool WeaponDamage(DaggerfallUnityItem strikingWeapon, bool arrowHit, Transform hitTransform, Vector3 impactPosition, Vector3 direction)
         {
             DaggerfallEntityBehaviour entityBehaviour = hitTransform.GetComponent<DaggerfallEntityBehaviour>();
             DaggerfallMobileUnit entityMobileUnit = hitTransform.GetComponentInChildren<DaggerfallMobileUnit>();
@@ -838,14 +838,14 @@ namespace DaggerfallWorkshop.Game
             if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach, playerLayerMask))
             {
                 DaggerfallUnityItem strikingWeapon = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;
-                if(!WeaponEnvDamage(strikingWeapon, hit, mainCamera.transform.forward))
+                if(!WeaponEnvDamage(strikingWeapon, hit))
                 {
-                    hitEnemy = WeaponDamage(mainCamera.transform.forward, false, strikingWeapon, hit.transform, hit.point);
+                    hitEnemy = WeaponDamage(strikingWeapon, false, hit.transform, hit.point, mainCamera.transform.forward);
                 }
                 // Fall back to simple ray for narrow cages https://forums.dfworkshop.net/viewtopic.php?f=5&t=2195#p39524
                 else if (Physics.Raycast(ray, out hit, weapon.Reach, playerLayerMask))
                 {
-                    hitEnemy = WeaponDamage(mainCamera.transform.forward, false, strikingWeapon, hit.transform, hit.point);
+                    hitEnemy = WeaponDamage(strikingWeapon, false, hit.transform, hit.point, mainCamera.transform.forward);
                 }
             }
         }

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -414,7 +414,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Returns true if hit an enemy entity
-        public bool WeaponDamage(RaycastHit hit, Vector3 direction, Collider arrowHitCollider = null, bool arrowHit = false)
+        public bool WeaponEnvDamage(RaycastHit hit, Vector3 direction, Collider arrowHitCollider = null, bool arrowHit = false)
         {
             DaggerfallUnityItem strikingWeapon = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;
 
@@ -456,6 +456,11 @@ namespace DaggerfallWorkshop.Game
             // Set up for use below
             Transform hitTransform = arrowHit ? arrowHitCollider.gameObject.transform : hit.transform;
             Vector3 impactPosition = arrowHit ? hitTransform.position : hit.point;
+            return WeaponDamage(direction, arrowHit, strikingWeapon, hitTransform, impactPosition);
+        }
+
+        private bool WeaponDamage(Vector3 direction, bool arrowHit, DaggerfallUnityItem strikingWeapon, Transform hitTransform, Vector3 impactPosition)
+        {
             DaggerfallEntityBehaviour entityBehaviour = hitTransform.GetComponent<DaggerfallEntityBehaviour>();
             DaggerfallMobileUnit entityMobileUnit = hitTransform.GetComponentInChildren<DaggerfallMobileUnit>();
             EnemyMotor enemyMotor = hitTransform.GetComponent<EnemyMotor>();
@@ -842,7 +847,7 @@ namespace DaggerfallWorkshop.Game
             Ray ray = new Ray(mainCamera.transform.position, mainCamera.transform.forward);
             if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach, playerLayerMask))
             {
-                hitEnemy = WeaponDamage(hit, mainCamera.transform.forward);
+                hitEnemy = WeaponEnvDamage(hit, mainCamera.transform.forward);
             }
         }
 

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -415,10 +415,8 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Returns true if hit an enemy entity
-        public bool WeaponEnvDamage(RaycastHit hit, Vector3 direction)
+        public bool WeaponEnvDamage(DaggerfallUnityItem strikingWeapon, RaycastHit hit, Vector3 direction)
         {
-            DaggerfallUnityItem strikingWeapon = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;
-
             // Check if hit has an DaggerfallAction component
             DaggerfallAction action = hit.transform.gameObject.GetComponent<DaggerfallAction>();
             if (action)
@@ -839,7 +837,8 @@ namespace DaggerfallWorkshop.Game
             Ray ray = new Ray(mainCamera.transform.position, mainCamera.transform.forward);
             if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach, playerLayerMask))
             {
-                hitEnemy = WeaponEnvDamage(hit, mainCamera.transform.forward);
+                DaggerfallUnityItem strikingWeapon = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;
+                hitEnemy = WeaponEnvDamage(strikingWeapon, hit, mainCamera.transform.forward);
             }
         }
 


### PR DESCRIPTION

One can't simply call WeaponDamage() again with a fallback raycast hit if no enemy was struck during a first call of WeaponDamage() with a spherecast, because environment damage may be done twice.
So the major refacto is to split WeaponDamage() into environment damage (WeaponEnvDamage) and enemy damage (WeaponDamage).
I also used that refacto to simplify missiles damage.