### PR TITLE
Allow controls to override hotkey sequences

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -621,10 +621,18 @@ namespace DaggerfallWorkshop.Game
 
         public bool ProcessHotKeySequences()
         {
-            if (uiManager.TopWindow != null && uiManager.TopWindow.ParentPanel != null)
+            if (uiManager.TopWindow != null)
             {
-                return uiManager.TopWindow.ParentPanel.ProcessHotkeySequences(lastKeyModifiers);
+                BaseScreenComponent focusControl = uiManager.TopWindow.FocusControl;
+                if (focusControl == null || !focusControl.OverridesHotkeySequences)
+                {
+                    if (uiManager.TopWindow.ParentPanel != null)
+                    {
+                        return uiManager.TopWindow.ParentPanel.ProcessHotkeySequences(lastKeyModifiers);
+                    }
+                }
             }
+
             return false;
         }
 

--- a/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
+++ b/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
@@ -34,6 +34,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         Vector2 size;
         Vector2 rootSize;
         bool useFocus = false;
+        bool overridesHotkeySequences = false;
 
         ToolTip toolTip = null;
         string toolTipText = string.Empty;
@@ -172,6 +173,16 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             get { return useFocus; }
             set { useFocus = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets flag to make control bypass hotkeys.
+        /// When enabled, hotkeys will not be interpreted while this control has focus.
+        /// </summary>
+        public bool OverridesHotkeySequences
+        {
+            get { return overridesHotkeySequences; }
+            set { overridesHotkeySequences = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
Disable hotkey sequences when controls with overridesHotkeySequences flag have the focus

Part of fix for issue #1707 