### PR TITLE
Allow mods to override allocating player starting equipment and spells, enemy equipment, and modify found items

### DIFF
--- a/Assets/Scripts/Game/EnemyDeath.cs
+++ b/Assets/Scripts/Game/EnemyDeath.cs
@@ -16,6 +16,8 @@ using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Questing;
+using DaggerfallWorkshop.Game.Items;
+using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -98,10 +100,13 @@ namespace DaggerfallWorkshop.Game
 
             entityBehaviour.CorpseLootContainer = loot;
 
-            // Transfer any items owned by entity to loot container
+
+            // Transfer any items owned by entity to loot container, possibly with modifications.
             // Many quests will stash a reward in enemy inventory for player to find
             // This will be in addition to normal random loot table generation
-            loot.Items.TransferAll(entityBehaviour.Entity.Items);
+            DaggerfallUnityItem[] entityItems = entityBehaviour.Entity.Items.Export();
+            FormulaHelper.ModifyFoundLootItems(ref entityItems);
+            loot.Items.Import(entityItems);
 
             // Play body collapse sound
             if (DaggerfallUI.Instance.DaggerfallAudioSource)

--- a/Assets/Scripts/Game/EnemyDeath.cs
+++ b/Assets/Scripts/Game/EnemyDeath.cs
@@ -98,7 +98,6 @@ namespace DaggerfallWorkshop.Game
 
             entityBehaviour.CorpseLootContainer = loot;
 
-
             // Transfer any items owned by entity to loot container
             // Many quests will stash a reward in enemy inventory for player to find
             // This will be in addition to normal random loot table generation

--- a/Assets/Scripts/Game/EnemyDeath.cs
+++ b/Assets/Scripts/Game/EnemyDeath.cs
@@ -16,8 +16,6 @@ using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Questing;
-using DaggerfallWorkshop.Game.Items;
-using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -101,12 +99,10 @@ namespace DaggerfallWorkshop.Game
             entityBehaviour.CorpseLootContainer = loot;
 
 
-            // Transfer any items owned by entity to loot container, possibly with modifications.
+            // Transfer any items owned by entity to loot container
             // Many quests will stash a reward in enemy inventory for player to find
             // This will be in addition to normal random loot table generation
-            DaggerfallUnityItem[] entityItems = entityBehaviour.Entity.Items.Export();
-            FormulaHelper.ModifyFoundLootItems(ref entityItems);
-            loot.Items.Import(entityItems);
+            loot.Items.TransferAll(entityBehaviour.Entity.Items);
 
             // Play body collapse sound
             if (DaggerfallUI.Instance.DaggerfallAudioSource)

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -375,7 +375,6 @@ namespace DaggerfallWorkshop.Game.Entity
                 // they are better than the value in the definition.
                 for (int i = 0; i < ArmorValues.Length; i++)
                 {
-                     // BUG? this is using mobs armor val if it's less than equipment, contrary to comment above
                     if (ArmorValues[i] > (sbyte)(mobileEnemy.ArmorValue * 5))
                     {
                         ArmorValues[i] = (sbyte)(mobileEnemy.ArmorValue * 5);

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -92,6 +92,9 @@ namespace DaggerfallWorkshop.Game.Entity
 
         public bool WabbajackActive { get; set; }
 
+        public delegate void EnemyStartingEquipment(PlayerEntity player, EnemyEntity enemyEntity, int variant);
+        public static EnemyStartingEquipment AssignEnemyEquipment = DaggerfallUnity.Instance.ItemHelper.AssignEnemyStartingEquipment;
+
         #endregion
 
         #region Constructors
@@ -333,98 +336,8 @@ namespace DaggerfallWorkshop.Game.Entity
 
         public void SetEnemyEquipment(int variant)
         {
-            PlayerEntity player = GameManager.Instance.PlayerEntity;
-            int itemLevel = player.Level;
-            Genders playerGender = player.Gender;
-            Races race = player.Race;
-            int chance = 0;
-
-            // City watch never have items above iron or steel
-            if (entityType == EntityTypes.EnemyClass && mobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
-                itemLevel = 1;
-
-            if (variant == 0)
-            {
-                // right-hand weapon
-                int item = UnityEngine.Random.Range((int)Game.Items.Weapons.Broadsword, (int)(Game.Items.Weapons.Longsword) + 1);
-                Items.DaggerfallUnityItem weapon = Game.Items.ItemBuilder.CreateWeapon((Items.Weapons)item, Game.Items.ItemBuilder.RandomMaterial(itemLevel));
-                ItemEquipTable.EquipItem(weapon, true, false);
-                items.AddItem(weapon);
-
-                chance = 50;
-
-                // left-hand shield
-                item = UnityEngine.Random.Range((int)Game.Items.Armor.Buckler, (int)(Game.Items.Armor.Round_Shield) + 1);
-                if (Dice100.SuccessRoll(chance))
-                {
-                    Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, (Items.Armor)item, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
-                    ItemEquipTable.EquipItem(armor, true, false);
-                    items.AddItem(armor);
-                }
-                // left-hand weapon
-                else if (Dice100.SuccessRoll(chance))
-                {
-                    item = UnityEngine.Random.Range((int)Game.Items.Weapons.Dagger, (int)(Game.Items.Weapons.Shortsword) + 1);
-                    weapon = Game.Items.ItemBuilder.CreateWeapon((Items.Weapons)item, Game.Items.ItemBuilder.RandomMaterial(itemLevel));
-                    ItemEquipTable.EquipItem(weapon, true, false);
-                    items.AddItem(weapon);
-                }
-            }
-            else
-            {
-                // right-hand weapon
-                int item = UnityEngine.Random.Range((int)Game.Items.Weapons.Claymore, (int)(Game.Items.Weapons.Battle_Axe) + 1);
-                Items.DaggerfallUnityItem weapon = Game.Items.ItemBuilder.CreateWeapon((Items.Weapons)item, Game.Items.ItemBuilder.RandomMaterial(itemLevel));
-                ItemEquipTable.EquipItem(weapon, true, false);
-                items.AddItem(weapon);
-
-                if (variant == 1)
-                    chance = 75;
-                else if (variant == 2)
-                    chance = 90;
-            }
-            // helm
-            if (Dice100.SuccessRoll(chance))
-            {
-                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Helm, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
-                ItemEquipTable.EquipItem(armor, true, false);
-                items.AddItem(armor);
-            }
-            // right pauldron
-            if (Dice100.SuccessRoll(chance))
-            {
-                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Right_Pauldron, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
-                ItemEquipTable.EquipItem(armor, true, false);
-                items.AddItem(armor);
-            }
-            // left pauldron
-            if (Dice100.SuccessRoll(chance))
-            {
-                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Left_Pauldron, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
-                ItemEquipTable.EquipItem(armor, true, false);
-                items.AddItem(armor);
-            }
-            // cuirass
-            if (Dice100.SuccessRoll(chance))
-            {
-                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Cuirass, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
-                ItemEquipTable.EquipItem(armor, true, false);
-                items.AddItem(armor);
-            }
-            // greaves
-            if (Dice100.SuccessRoll(chance))
-            {
-                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Greaves, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
-                ItemEquipTable.EquipItem(armor, true, false);
-                items.AddItem(armor);
-            }
-            // boots
-            if (Dice100.SuccessRoll(chance))
-            {
-                Items.DaggerfallUnityItem armor = Game.Items.ItemBuilder.CreateArmor(playerGender, race, Game.Items.Armor.Boots, Game.Items.ItemBuilder.RandomArmorMaterial(itemLevel));
-                ItemEquipTable.EquipItem(armor, true, false);
-                items.AddItem(armor);
-            }
+            // Assign the enemies starting equipment.
+            AssignEnemyEquipment(GameManager.Instance.PlayerEntity, this, variant);
 
             // Initialize armor values to 100 (no armor)
             for (int i = 0; i < ArmorValues.Length; i++)
@@ -462,28 +375,10 @@ namespace DaggerfallWorkshop.Game.Entity
                 // they are better than the value in the definition.
                 for (int i = 0; i < ArmorValues.Length; i++)
                 {
+                     // BUG? this is using mobs armor val if it's less than equipment, contrary to comment above
                     if (ArmorValues[i] > (sbyte)(mobileEnemy.ArmorValue * 5))
                     {
                         ArmorValues[i] = (sbyte)(mobileEnemy.ArmorValue * 5);
-                    }
-                }
-            }
-
-            // Chance for poisoned weapon
-            if (player.Level > 1)
-            {
-                Items.DaggerfallUnityItem weapon = ItemEquipTable.GetItem(Game.Items.EquipSlots.RightHand);
-                if (weapon != null && (entityType == EntityTypes.EnemyClass || mobileEnemy.ID == (int)MobileTypes.Orc
-                        || mobileEnemy.ID == (int)MobileTypes.Centaur || mobileEnemy.ID == (int)MobileTypes.OrcSergeant))
-                {
-                    int chanceToPoison = 5;
-                    if (mobileEnemy.ID == (int)MobileTypes.Assassin)
-                        chanceToPoison = 60;
-
-                    if (Dice100.SuccessRoll(chanceToPoison))
-                    {
-                        // Apply poison
-                        weapon.poisonType = (Items.Poisons)UnityEngine.Random.Range(128, 135 + 1);
                     }
                 }
             }

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1574,13 +1574,20 @@ namespace DaggerfallWorkshop.Game.Formulas
             return cost;
         }
 
-        public static int CalculateCost(int baseItemValue, int shopQuality)
+        /// <summary>
+        /// Calculate the cost of something in a given shop.
+        /// </summary>
+        /// <param name="baseValue">Base value</param>
+        /// <param name="shopQuality">Shop quality 0-20</param>
+        /// <param name="conditionPercentage">Condition of item as a percentage, -1 indicates condition not applicable</param>
+        /// <returns>Shop specific cost</returns>
+        public static int CalculateCost(int baseValue, int shopQuality, int conditionPercentage = -1)
         {
-            Func<int, int, int> del;
+            Func<int, int, int, int> del;
             if (TryGetOverride("CalculateCost", out del))
-                return del(baseItemValue, shopQuality);
+                return del(baseValue, shopQuality, conditionPercentage);
 
-            int cost = baseItemValue;
+            int cost = baseValue;
 
             if (cost < 1)
                 cost = 1;
@@ -1593,6 +1600,10 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         public static int CalculateItemRepairCost(int baseItemValue, int shopQuality, int condition, int max, IGuild guild)
         {
+            Func<int, int, int, int, IGuild, int> del;
+            if (TryGetOverride("CalculateItemRepairCost", out del))
+                return del(baseItemValue, shopQuality, condition, max, guild);
+
             // Don't cost already repaired item
             if (condition == max)
                 return 0;
@@ -1769,6 +1780,21 @@ namespace DaggerfallWorkshop.Game.Formulas
                 return true;
             else
                 return false;
+        }
+
+        /// <summary>
+        /// Allows loot found in containers and enemy corpses to be modified.
+        /// </summary>
+        /// <param name="lootItems">An array of the loot items</param>
+        /// <returns>The number of items modified.</returns>
+        public static int ModifyFoundLootItems(ref DaggerfallUnityItem[] lootItems)
+        {
+            Func<DaggerfallUnityItem[], int> del;
+            if (TryGetOverride("ModifyFoundLootItems", out del))
+                return del(lootItems);
+
+            // DFU does no post-processing of loot items hence report zero changes, this is solely for mods to override.
+            return 0;
         }
 
         #endregion

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -433,6 +433,12 @@ namespace DaggerfallWorkshop.Game.Items
             get { return repairData; }
         }
 
+        /// <summary>Gets current item condition as a percentage of max.</summary>
+        public int ConditionPercentage
+        {
+            get { return 100 * currentCondition / maxCondition; }
+        }
+
         #endregion
 
         #region Constructors

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -119,7 +119,7 @@ namespace DaggerfallWorkshop.Game.Items
             {   // %qua
                 if (parent.maxCondition > 0 && parent.currentCondition <= parent.maxCondition)
                 {
-                    int conditionPercentage = 100 * parent.currentCondition / parent.maxCondition;
+                    int conditionPercentage = parent.ConditionPercentage;
                     int i = 0;
                     while (conditionPercentage > conditionThresholds[i])
                         i++;

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -25,6 +25,7 @@ using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Utility.AssetInjection;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -1196,66 +1197,117 @@ namespace DaggerfallWorkshop.Game.Items
             }
         }
 
-        /// <summary>
-        /// Assigns starting spells to the spellbook item for a new character.
-        /// </summary>
-        public void AssignStartingSpells(PlayerEntity playerEntity, CharacterDocument characterDocument)
+        public void AssignEnemyStartingEquipment(PlayerEntity player, EnemyEntity enemyEntity, int variant)
         {
-            if (characterDocument.classIndex > 6 && !characterDocument.isCustom) // Class does not have starting spells
-                return;
+            int itemLevel = player.Level;
+            Genders playerGender = player.Gender;
+            Races race = player.Race;
+            int chance = 0;
 
-            // Get starting set based on class
-            int spellSetIndex = -1;
-            if (characterDocument.isCustom)
+            // City watch never have items above iron or steel
+            if (enemyEntity.EntityType == EntityTypes.EnemyClass && enemyEntity.MobileEnemy.ID == (int)MobileTypes.Knight_CityWatch)
+                itemLevel = 1;
+
+            if (variant == 0)
             {
-                DFCareer dfc = characterDocument.career;
+                // right-hand weapon
+                int item = UnityEngine.Random.Range((int)Weapons.Broadsword, (int)(Weapons.Longsword) + 1);
+                DaggerfallUnityItem weapon = ItemBuilder.CreateWeapon((Weapons)item, ItemBuilder.RandomMaterial(itemLevel));
+                enemyEntity.ItemEquipTable.EquipItem(weapon, true, false);
+                enemyEntity.Items.AddItem(weapon);
 
-                // Custom class uses Spellsword starting spells if it has at least 1 primary or major magic skill
-                if (Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.PrimarySkill1) ||
-                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.PrimarySkill2) ||
-                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.PrimarySkill3) ||
-                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.MajorSkill1) ||
-                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.MajorSkill2) ||
-                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.MajorSkill3))
+                chance = 50;
+
+                // left-hand shield
+                item = UnityEngine.Random.Range((int)Armor.Buckler, (int)(Armor.Round_Shield) + 1);
+                if (Dice100.SuccessRoll(chance))
                 {
-                    spellSetIndex = 1;
+                    DaggerfallUnityItem armor = ItemBuilder.CreateArmor(playerGender, race, (Items.Armor)item, ItemBuilder.RandomArmorMaterial(itemLevel));
+                    enemyEntity.ItemEquipTable.EquipItem(armor, true, false);
+                    enemyEntity.Items.AddItem(armor);
+                }
+                // left-hand weapon
+                else if (Dice100.SuccessRoll(chance))
+                {
+                    item = UnityEngine.Random.Range((int)Weapons.Dagger, (int)(Weapons.Shortsword) + 1);
+                    weapon = ItemBuilder.CreateWeapon((Weapons)item, ItemBuilder.RandomMaterial(itemLevel));
+                    enemyEntity.ItemEquipTable.EquipItem(weapon, true, false);
+                    enemyEntity.Items.AddItem(weapon);
                 }
             }
             else
             {
-                spellSetIndex = characterDocument.classIndex;
+                // right-hand weapon
+                int item = UnityEngine.Random.Range((int)Weapons.Claymore, (int)(Weapons.Battle_Axe) + 1);
+                DaggerfallUnityItem weapon = ItemBuilder.CreateWeapon((Weapons)item, ItemBuilder.RandomMaterial(itemLevel));
+                enemyEntity.ItemEquipTable.EquipItem(weapon, true, false);
+                enemyEntity.Items.AddItem(weapon);
+
+                if (variant == 1)
+                    chance = 75;
+                else if (variant == 2)
+                    chance = 90;
+            }
+            // helm
+            if (Dice100.SuccessRoll(chance))
+            {
+                DaggerfallUnityItem armor = ItemBuilder.CreateArmor(playerGender, race, Armor.Helm, ItemBuilder.RandomArmorMaterial(itemLevel));
+                enemyEntity.ItemEquipTable.EquipItem(armor, true, false);
+                enemyEntity.Items.AddItem(armor);
+            }
+            // right pauldron
+            if (Dice100.SuccessRoll(chance))
+            {
+                DaggerfallUnityItem armor = ItemBuilder.CreateArmor(playerGender, race, Armor.Right_Pauldron, ItemBuilder.RandomArmorMaterial(itemLevel));
+                enemyEntity.ItemEquipTable.EquipItem(armor, true, false);
+                enemyEntity.Items.AddItem(armor);
+            }
+            // left pauldron
+            if (Dice100.SuccessRoll(chance))
+            {
+                DaggerfallUnityItem armor = ItemBuilder.CreateArmor(playerGender, race, Armor.Left_Pauldron, ItemBuilder.RandomArmorMaterial(itemLevel));
+                enemyEntity.ItemEquipTable.EquipItem(armor, true, false);
+                enemyEntity.Items.AddItem(armor);
+            }
+            // cuirass
+            if (Dice100.SuccessRoll(chance))
+            {
+                DaggerfallUnityItem armor = ItemBuilder.CreateArmor(playerGender, race, Armor.Cuirass, ItemBuilder.RandomArmorMaterial(itemLevel));
+                enemyEntity.ItemEquipTable.EquipItem(armor, true, false);
+                enemyEntity.Items.AddItem(armor);
+            }
+            // greaves
+            if (Dice100.SuccessRoll(chance))
+            {
+                DaggerfallUnityItem armor = ItemBuilder.CreateArmor(playerGender, race, Armor.Greaves, ItemBuilder.RandomArmorMaterial(itemLevel));
+                enemyEntity.ItemEquipTable.EquipItem(armor, true, false);
+                enemyEntity.Items.AddItem(armor);
+            }
+            // boots
+            if (Dice100.SuccessRoll(chance))
+            {
+                DaggerfallUnityItem armor = ItemBuilder.CreateArmor(playerGender, race, Armor.Boots, ItemBuilder.RandomArmorMaterial(itemLevel));
+                enemyEntity.ItemEquipTable.EquipItem(armor, true, false);
+                enemyEntity.Items.AddItem(armor);
             }
 
-            if (spellSetIndex == -1)
-                return;
-
-            // Get the set's spell indices
-            TextAsset spells = Resources.Load<TextAsset>("StartingSpells") as TextAsset;
-            List<CareerStartingSpells> startingSpells = SaveLoadManager.Deserialize(typeof(List<CareerStartingSpells>), spells.text) as List<CareerStartingSpells>;
-            List<StartingSpell> spellsToAdd = new List<StartingSpell>();
-            for (int i = 0; i < startingSpells[spellSetIndex].SpellsList.Length; i++)
+            // Chance for poisoned weapon
+            if (player.Level > 1)
             {
-                spellsToAdd.Add(startingSpells[spellSetIndex].SpellsList[i]);
-            }
-
-            // Add spells to player from standard list
-            foreach (StartingSpell spell in spellsToAdd)
-            {
-                SpellRecord.SpellRecordData spellData;
-                GameManager.Instance.EntityEffectBroker.GetClassicSpellRecord(spell.SpellID, out spellData);
-                if (spellData.index == -1)
+                DaggerfallUnityItem weapon = enemyEntity.ItemEquipTable.GetItem(EquipSlots.RightHand);
+                if (weapon != null && (enemyEntity.EntityType == EntityTypes.EnemyClass || enemyEntity.MobileEnemy.ID == (int)MobileTypes.Orc
+                        || enemyEntity.MobileEnemy.ID == (int)MobileTypes.Centaur || enemyEntity.MobileEnemy.ID == (int)MobileTypes.OrcSergeant))
                 {
-                    Debug.LogError("Failed to locate starting spell in standard spells list.");
-                    continue;
-                }
+                    int chanceToPoison = 5;
+                    if (enemyEntity.MobileEnemy.ID == (int)MobileTypes.Assassin)
+                        chanceToPoison = 60;
 
-                EffectBundleSettings bundle;
-                if (!GameManager.Instance.EntityEffectBroker.ClassicSpellRecordDataToEffectBundleSettings(spellData, BundleTypes.Spell, out bundle))
-                {
-                    Debug.LogError("Failed to create effect bundle for starting spell.");
-                    continue;
+                    if (Dice100.SuccessRoll(chanceToPoison))
+                    {
+                        // Apply poison
+                        weapon.poisonType = (Items.Poisons)UnityEngine.Random.Range(128, 135 + 1);
+                    }
                 }
-                playerEntity.AddSpell(bundle);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -446,7 +446,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     {
                         case WindowModes.Sell:
                             modeActionEnabled = true;
-                            cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality) * item.stackCount;
+                            cost += FormulaHelper.CalculateCost(item.value, buildingDiscoveryData.quality, item.ConditionPercentage) * item.stackCount;
                             break;
                         case WindowModes.SellMagic: // TODO: Fencing base price higher and guild rep affects it. Implement new formula or can this be used?
                             modeActionEnabled = true;

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -390,14 +390,14 @@ namespace DaggerfallWorkshop.Game.Utility
                 }
             }
 
+            // Apply biography effects to player entity
+            BiogFile.ApplyEffects(characterDocument.biographyEffects, playerEntity);
+
             // Assign starting gear to player entity
             AssignStartingEquipment(playerEntity, characterDocument);
             
             // Assign starting spells to player entity
             AssignStartingSpells(playerEntity, characterDocument);
-
-            // Apply biography effects to player entity
-            BiogFile.ApplyEffects(characterDocument.biographyEffects, playerEntity);
 
             // Assign starting level up skill sum
             playerEntity.SetCurrentLevelUpSkillSum();

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -109,7 +109,7 @@ namespace DaggerfallWorkshop.Game.Utility
 
             // Assign default player equipment & spells allocation methods
             AssignStartingEquipment = DaggerfallUnity.Instance.ItemHelper.AssignStartingGear;
-            AssignStartingSpells = DaggerfallUnity.Instance.ItemHelper.AssignStartingSpells;
+            AssignStartingSpells = SetStartingSpells;
         }
 
         void Start()
@@ -763,6 +763,69 @@ namespace DaggerfallWorkshop.Game.Utility
             // Weapon hand and equip state not serialized currently
             // Interim measure is to reset weapon manager state on new game
             GameManager.Instance.WeaponManager.Reset();
+        }
+
+        /// <summary>
+        /// Assigns starting spells to the spellbook item for a new character.
+        /// </summary>
+        void SetStartingSpells(PlayerEntity playerEntity, CharacterDocument characterDocument)
+        {
+            if (characterDocument.classIndex > 6 && !characterDocument.isCustom) // Class does not have starting spells
+                return;
+
+            // Get starting set based on class
+            int spellSetIndex = -1;
+            if (characterDocument.isCustom)
+            {
+                DFCareer dfc = characterDocument.career;
+
+                // Custom class uses Spellsword starting spells if it has at least 1 primary or major magic skill
+                if (Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.PrimarySkill1) ||
+                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.PrimarySkill2) ||
+                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.PrimarySkill3) ||
+                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.MajorSkill1) ||
+                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.MajorSkill2) ||
+                    Enum.IsDefined(typeof(DFCareer.MagicSkills), (int)dfc.MajorSkill3))
+                {
+                    spellSetIndex = 1;
+                }
+            }
+            else
+            {
+                spellSetIndex = characterDocument.classIndex;
+            }
+
+            if (spellSetIndex == -1)
+                return;
+
+            // Get the set's spell indices
+            TextAsset spells = Resources.Load<TextAsset>("StartingSpells") as TextAsset;
+            List<CareerStartingSpells> startingSpells = SaveLoadManager.Deserialize(typeof(List<CareerStartingSpells>), spells.text) as List<CareerStartingSpells>;
+            List<StartingSpell> spellsToAdd = new List<StartingSpell>();
+            for (int i = 0; i < startingSpells[spellSetIndex].SpellsList.Length; i++)
+            {
+                spellsToAdd.Add(startingSpells[spellSetIndex].SpellsList[i]);
+            }
+
+            // Add spells to player from standard list
+            foreach (StartingSpell spell in spellsToAdd)
+            {
+                SpellRecord.SpellRecordData spellData;
+                GameManager.Instance.EntityEffectBroker.GetClassicSpellRecord(spell.SpellID, out spellData);
+                if (spellData.index == -1)
+                {
+                    Debug.LogError("Failed to locate starting spell in standard spells list.");
+                    continue;
+                }
+
+                EffectBundleSettings bundle;
+                if (!GameManager.Instance.EntityEffectBroker.ClassicSpellRecordDataToEffectBundleSettings(spellData, BundleTypes.Spell, out bundle))
+                {
+                    Debug.LogError("Failed to create effect bundle for starting spell.");
+                    continue;
+                }
+                playerEntity.AddSpell(bundle);
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -16,6 +16,7 @@ using DaggerfallConnect;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.MagicAndEffects;
+using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop
 {
@@ -67,6 +68,8 @@ namespace DaggerfallWorkshop
         {
             LootChanceMatrix matrix = LootTables.GetMatrix(LootTableKey);
             DaggerfallUnityItem[] newitems = LootTables.GenerateRandomLoot(matrix, GameManager.Instance.PlayerEntity);
+
+            FormulaHelper.ModifyFoundLootItems(ref newitems);
 
             collection.Import(newitems);
         }

--- a/Assets/StreamingAssets/Tables/QuestList-Classic.txt
+++ b/Assets/StreamingAssets/Tables/QuestList-Classic.txt
@@ -138,7 +138,7 @@ B0B40Y09, KnightlyOrder, M, 4, 0, Passed.
 B0B50Y11, KnightlyOrder, M, 5, 0, Passed
 B0B60Y12, KnightlyOrder, M, 6, 0, Passed.
 B0B70Y14, KnightlyOrder, M, 7, 0, Passed.
-B0B70Y16, KnightlyOrder, M, 7, X, Passed.
+B0B70Y16, KnightlyOrder, M, 7, 0, Passed.
 B0B71Y03, KnightlyOrder, M, 7, 1, Passed.	Discovered a new op-code: _0x3c_ 19
 B0B80Y17, KnightlyOrder, M, 8, 0, Passed.
 B0B81Y02, KnightlyOrder, M, 8, 1, Passed


### PR DESCRIPTION
- Introduced delegates for player starting equipment and spell assignment. (Moved them to be called after items from biog questions are added to player, so mods can adjust)
- Introduced delegate for assigning enemy starting equipment.
- Added a new formula that is called when loot items are generated for loot piles. This is for mods and LootRealism will use it to have found armor, weapons, and books be in a random condition.

You can see an example of usage here: https://github.com/ajrb/dfunity-mods/blob/startingStuff/LootRealism/Scripts/LootRealismMod.cs