### PR TITLE
Additional fixes and improvements for footstep noises

### DIFF
--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -65,6 +65,7 @@ namespace DaggerfallWorkshop.Game
         bool isInside = false;
         bool isInOutsideWater = false;
         bool isInOutsidePath = false;
+        bool isOnStaticGeometry = false;
 
         void Start()
         {
@@ -105,16 +106,19 @@ namespace DaggerfallWorkshop.Game
             bool playerOnExteriorWater = (GameManager.Instance.PlayerMotor.OnExteriorWater == PlayerMotor.OnExteriorWaterMethod.Swimming || GameManager.Instance.PlayerMotor.OnExteriorWater == PlayerMotor.OnExteriorWaterMethod.WaterWalking);
 
             bool playerOnExteriorPath = GameManager.Instance.PlayerMotor.OnExteriorPath;
+            bool playerOnStaticGeometry = GameManager.Instance.PlayerMotor.OnExteriorStaticGeometry;
 
             // Change footstep sounds between winter/summer variants, when player enters/exits an interior space, or changes between path, water, or other outdoor ground
-            if (playerSeason != currentSeason || playerClimateIndex != currentClimateIndex || isInside != playerInside || playerOnExteriorWater != isInOutsideWater || playerOnExteriorPath != isInOutsidePath)
+            if (playerSeason != currentSeason || playerClimateIndex != currentClimateIndex || isInside != playerInside || playerOnExteriorWater != isInOutsideWater || playerOnExteriorPath != isInOutsidePath || playerOnStaticGeometry != isOnStaticGeometry)
             {
                 currentSeason = playerSeason;
                 currentClimateIndex = playerClimateIndex;
                 isInside = playerInside;
                 isInOutsideWater = playerOnExteriorWater;
                 isInOutsidePath = playerOnExteriorPath;
-                if (!isInside)
+                isOnStaticGeometry = playerOnStaticGeometry;
+                if (!isInside && !playerOnStaticGeometry)
+                {
                     if (currentSeason == DaggerfallDateTime.Seasons.Winter && !WeatherManager.IsSnowFreeClimate(currentClimateIndex))
                     {
                         currentFootstepSound1 = FootstepSoundSnow1;
@@ -125,6 +129,7 @@ namespace DaggerfallWorkshop.Game
                         currentFootstepSound1 = FootstepSoundOutside1;
                         currentFootstepSound2 = FootstepSoundOutside2;
                     }
+                }
                 else if (playerInBuilding)
                 {
                     currentFootstepSound1 = FootstepSoundBuilding1;

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -517,7 +517,7 @@ namespace DaggerfallWorkshop.Game
 
             // Must be outside and actually be standing on a terrain object not some other object (e.g. player ship)
             RaycastHit hit;
-            if (GameManager.Instance.PlayerEnterExit.IsPlayerInside || !Physics.Raycast(transform.position, Vector3.down, out hit, rayDistance))
+            if (GameManager.Instance.PlayerEnterExit.IsPlayerInside || !Physics.Raycast(transform.position, Vector3.down, out hit, rayDistance * 2))
             {
                 return false;
             }

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -19,6 +19,9 @@ namespace DaggerfallWorkshop.Game
     {
         #region Fields
 
+        const float walkingRayDistance = 1.0f;
+        const float ridingRayDistance = 2.0f;
+
         bool isCrouching = false;
 
         bool isRiding = false;
@@ -61,6 +64,7 @@ namespace DaggerfallWorkshop.Game
         float freezeMotor = 0;
         OnExteriorWaterMethod onExteriorWaterMethod = OnExteriorWaterMethod.None;
         bool onExteriorPathMethod = false;
+        bool onExteriorStaticGeometryMethod = false;
 
         #endregion
 
@@ -228,6 +232,14 @@ namespace DaggerfallWorkshop.Game
             get { return onExteriorPathMethod; }
         }
 
+        /// <summary>
+        /// The method by which player is standing on outdoor path.
+        /// </summary>
+        public bool OnExteriorStaticGeometry
+        {
+            get { return onExteriorStaticGeometryMethod; }
+        }
+
         #endregion
 
         #region Event Handlers
@@ -341,6 +353,7 @@ namespace DaggerfallWorkshop.Game
             // Update on water check
             onExteriorWaterMethod = GetOnExteriorWaterMethod();
             onExteriorPathMethod = GetOnExteriorPathMethod();
+            onExteriorStaticGeometryMethod = GetOnExteriorStaticGeometryMethod();
 
             heightChanger.DecideHeightAction();
 
@@ -472,11 +485,8 @@ namespace DaggerfallWorkshop.Game
         /// Same when player is levitating above water they should not hear splash sounds.
         /// </summary>
         /// <returns>True if player is physically in range of an outdoor tile.</returns>
-        bool GetOnExteriorGroundMethod()
+        public bool GetOnExteriorGroundMethod()
         {
-            const float walkingRayDistance = 1.0f;
-            const float ridingRayDistance = 2.0f;
-
             float rayDistance = (GameManager.Instance.TransportManager.IsOnFoot) ? walkingRayDistance : ridingRayDistance;
 
             // Must be outside and actually be standing on a terrain object not some other object (e.g. player ship)
@@ -493,6 +503,28 @@ namespace DaggerfallWorkshop.Game
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Check if player is really standing on an outdoor StaticGeometry object, not just positioned above one.
+        /// For example when player is on their ship they are standing above water but should not be swimming.
+        /// Same when player is levitating above water they should not hear splash sounds.
+        /// </summary>
+        /// <returns>True if player is physically in range of a StaticGeometry object.</returns>
+        bool GetOnExteriorStaticGeometryMethod()
+        {
+            float rayDistance = (GameManager.Instance.TransportManager.IsOnFoot) ? walkingRayDistance : ridingRayDistance;
+
+            // Must be outside and actually be standing on a terrain object not some other object (e.g. player ship)
+            RaycastHit hit;
+            if (GameManager.Instance.PlayerEnterExit.IsPlayerInside || !Physics.Raycast(transform.position, Vector3.down, out hit, rayDistance))
+            {
+                return false;
+            }
+            else
+            {
+                return hit.collider.tag.Equals("StaticGeometry");
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -491,7 +491,7 @@ namespace DaggerfallWorkshop.Game
 
             // Must be outside and actually be standing on a terrain object not some other object (e.g. player ship)
             RaycastHit hit;
-            if (GameManager.Instance.PlayerEnterExit.IsPlayerInside || !Physics.Raycast(transform.position, Vector3.down, out hit, rayDistance))
+            if (GameManager.Instance.PlayerEnterExit.IsPlayerInside || !Physics.Raycast(transform.position, Vector3.down, out hit, rayDistance * 2))
             {
                 return false;
             }

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -485,7 +485,7 @@ namespace DaggerfallWorkshop.Game
         /// Same when player is levitating above water they should not hear splash sounds.
         /// </summary>
         /// <returns>True if player is physically in range of an outdoor tile.</returns>
-        public bool GetOnExteriorGroundMethod()
+        bool GetOnExteriorGroundMethod()
         {
             float rayDistance = (GameManager.Instance.TransportManager.IsOnFoot) ? walkingRayDistance : ridingRayDistance;
 

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -188,6 +188,8 @@ namespace DaggerfallWorkshop
             get { return playerTilemapIndex; }
         }
 
+        public bool IsRepositioningPlayer { get; private set; }
+
         #endregion
 
         #region Structs/Enums
@@ -1318,6 +1320,7 @@ namespace DaggerfallWorkshop
             {
                 // Get target position at terrain height + player standing height
                 // This is our minimum height before player falls through world
+                IsRepositioningPlayer = true;
                 Vector3 targetPosition = new Vector3(position.x, 0, position.z);
                 float height = terrain.SampleHeight(targetPosition + terrain.transform.position) + worldCompensation.y;
                 targetPosition.y = height + controller.height / 2f + 0.15f;
@@ -1337,6 +1340,7 @@ namespace DaggerfallWorkshop
                 CollectLooseObjects();
 
                 ResyncWorldCoordinates();
+                IsRepositioningPlayer = false;
             }
             else
             {


### PR DESCRIPTION
- Static geometry (such as buildings) now also make the hard dungeon footstep noise instead of the grassy terrain noise
- Improved detection for what tile the player is on by extending the raycasting distance
- Fixed an issue where sometimes jumping would make a grass noise, and also improved jumping by playing the tile's footstep noise upon landing

When I was designing the functionality for the landing noise, it also happened to get triggered when the player would load a save, or move into/out of an interior location, because the player would be floating in the air before being repositioned on the ground. To remedy this, I created a _StreamingWorld.IsRepositioning_ bool property that checks if the player is currently being repositioned so it can ignore that footstep noise.