### PR TITLE
Ensure that the scaling vectors are not initialised with zeros. URGENT FIX!

### DIFF
--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -867,9 +867,6 @@ namespace DaggerfallConnect.Arena2
                 recordsOut[i].XPos = reader.ReadInt32();
                 recordsOut[i].YPos = reader.ReadInt32();
                 recordsOut[i].ZPos = reader.ReadInt32();
-                recordsOut[i].XScale = 1;
-                recordsOut[i].ZScale = 1;
-                recordsOut[i].YScale = 1;
                 recordsOut[i].NullValue2 = reader.ReadUInt32();
                 recordsOut[i].XRotation = 0;
                 recordsOut[i].YRotation = reader.ReadInt16();

--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -364,6 +364,8 @@ namespace DaggerfallConnect
         /// <summary>
         /// 3D object data, such as buildings, walls, tables, cages, etc.
         /// </summary>
+        ///
+        [fsObject(Processor = typeof(RmbBlock3dObjectRecordProcessor))]
         public struct RmbBlock3dObjectRecord
         {
             /// <summary>ID of model to be loaded.</summary>
@@ -1233,6 +1235,22 @@ namespace DaggerfallConnect
                     resources.Remove("LightResource");
                 if (type == DFBlock.RdbResourceTypes.Model || type == DFBlock.RdbResourceTypes.Light)
                     resources.Remove("FlatResource");
+            }
+        }
+
+        public class RmbBlock3dObjectRecordProcessor : fsObjectProcessor
+        {
+            // Invoked after serialization has finished. Update any state inside of instance, modify the output data, etc.
+            public override void OnAfterSerialize(Type storageType, object instance, ref fsData data)
+            {
+                // Remove any unused (zero) scale values from serialized form.
+                Dictionary<string, fsData> rmb3dObj = data.AsDictionary;
+                if (rmb3dObj["XScale"].AsDouble == 0)
+                    rmb3dObj.Remove("XScale");
+                if (rmb3dObj["YScale"].AsDouble == 0)
+                    rmb3dObj.Remove("YScale");
+                if (rmb3dObj["ZScale"].AsDouble == 0)
+                    rmb3dObj.Remove("ZScale");
             }
         }
 

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -438,7 +438,7 @@ namespace DaggerfallWorkshop
 
                 // Get model transform
                 Vector3 modelRotation = new Vector3(-obj.XRotation / BlocksFile.RotationDivisor, -obj.YRotation / BlocksFile.RotationDivisor, -obj.ZRotation / BlocksFile.RotationDivisor);
-                Vector3 modelScale = new Vector3(obj.XScale, obj.YScale, obj.ZScale);
+                Vector3 modelScale = RMBLayout.GetModelScaleVector(obj);
                 Matrix4x4 modelMatrix = Matrix4x4.TRS(modelPosition, Quaternion.Euler(modelRotation), modelScale);
 
                 // Does this model have doors?

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -51,6 +51,16 @@ namespace DaggerfallWorkshop.Utility
         #region Layout Methods
 
         /// <summary>
+        /// Gets the model scale vector, converting zeros to 1s if needed.
+        /// </summary>
+        /// <param name="obj">RmbBlock3dObjectRecord structure</param>
+        /// <returns>Vector3 with the scaling factors</returns>
+        public static Vector3 GetModelScaleVector(DFBlock.RmbBlock3dObjectRecord obj)
+        {
+            return new Vector3(obj.XScale == 0 ? 1 : obj.XScale, obj.YScale == 0 ? 1 : obj.YScale, obj.ZScale == 0 ? 1 : obj.YScale);
+        }
+
+        /// <summary>
         /// Gets block data with validation.
         /// </summary>
         /// <param name="blockName">Block name.</param>
@@ -710,7 +720,7 @@ namespace DaggerfallWorkshop.Utility
                     // Get model transform
                     Vector3 modelPosition = new Vector3(obj.XPos, -obj.YPos, obj.ZPos) * MeshReader.GlobalScale;
                     Vector3 modelRotation = new Vector3(-obj.XRotation / BlocksFile.RotationDivisor, -obj.YRotation / BlocksFile.RotationDivisor, -obj.ZRotation / BlocksFile.RotationDivisor);
-                    Vector3 modelScale = new Vector3(obj.XScale, obj.YScale, obj.ZScale);
+                    Vector3 modelScale = GetModelScaleVector(obj);
                     Matrix4x4 modelMatrix = subRecordMatrix * Matrix4x4.TRS(modelPosition, Quaternion.Euler(modelRotation), modelScale);
 
                     // Get model data
@@ -782,7 +792,7 @@ namespace DaggerfallWorkshop.Utility
                 // Get model transform
                 Vector3 modelPosition = new Vector3(obj.XPos, -obj.YPos + propsOffsetY, obj.ZPos + BlocksFile.RMBDimension) * MeshReader.GlobalScale;
                 Vector3 modelRotation = new Vector3(-obj.XRotation / BlocksFile.RotationDivisor, -obj.YRotation / BlocksFile.RotationDivisor, -obj.ZRotation / BlocksFile.RotationDivisor);
-                Vector3 modelScale = new Vector3(obj.XScale, obj.YScale, obj.ZScale);
+                Vector3 modelScale = GetModelScaleVector(obj);
                 Matrix4x4 modelMatrix = Matrix4x4.TRS(modelPosition, Quaternion.Euler(modelRotation), modelScale);
 
                 // Get model data


### PR DESCRIPTION
Tried to use a fsSerializer post-processor but couldn't as the DFBlock is a struct and that means there's no way to adjust the values because the obj is passed by value.
This enables world data override files to continue to work without every single model requiring 3 new float values to be added.