### PR TITLE
Add enhancement setting to use bows in left hand

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -120,3 +120,4 @@ CombatVoices=True
 EnemyInfighting=True
 EnhancedCombatAI=True
 GuildQuestListBox=False
+BowLeftHandWithSwitching=False

--- a/Assets/Scripts/Game/Items/ItemEquipTable.cs
+++ b/Assets/Scripts/Game/Items/ItemEquipTable.cs
@@ -123,11 +123,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             // Equipping a shield will always unequip 2H weapon
-            if (item.ItemGroup == ItemGroups.Armor &&
-                (item.TemplateIndex == (int)Armor.Kite_Shield ||
-                item.TemplateIndex == (int)Armor.Round_Shield ||
-                item.TemplateIndex == (int)Armor.Tower_Shield ||
-                item.TemplateIndex == (int)Armor.Buckler))
+            if (GetItemHands(item) == ItemHands.LeftOnly)
             {
                 // If holding a 2H weapon then unequip
                 DaggerfallUnityItem rightHandItem = equipTable[(int)EquipSlots.RightHand];
@@ -437,7 +433,7 @@ namespace DaggerfallWorkshop.Game.Items
         {
             // If a 2H weapon is currently equipped then next weapon will always replace it in right hand
             DaggerfallUnityItem rightHandItem = equipTable[(int)EquipSlots.RightHand];
-            if (rightHandItem != null && GetItemHands(rightHandItem) == ItemHands.Both)
+            if (rightHandItem != null && GetItemHands(rightHandItem) == ItemHands.Both && GetItemHands(item) != ItemHands.LeftOnly)
                 return EquipSlots.RightHand;
 
             // Find best hand for this item
@@ -629,9 +625,11 @@ namespace DaggerfallWorkshop.Game.Items
                 case Weapons.Staff:
                 case Weapons.Flail:
                 case Weapons.Warhammer:
+                    return ItemHands.Both;
+
                 case Weapons.Short_Bow:
                 case Weapons.Long_Bow:
-                    return ItemHands.Both;
+                    return DaggerfallUnity.Settings.BowLeftHandWithSwitching ? ItemHands.LeftOnly : ItemHands.Both;
             }
 
             // Compare against supported armor types

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -132,6 +132,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox instantRepairs;
         Checkbox playerTorchFromItems;
         Checkbox guildQuestListBox;
+        Checkbox bowLeftHandWithSwitching;
         HorizontalSlider dungeonAmbientLightScale;
         HorizontalSlider nightAmbientLightScale;
         HorizontalSlider playerTorchLightScale;
@@ -311,6 +312,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             allowMagicRepairs = AddCheckbox(rightPanel, "allowMagicRepairs", DaggerfallUnity.Settings.AllowMagicRepairs);
             instantRepairs = AddCheckbox(rightPanel, "instantRepairs", DaggerfallUnity.Settings.InstantRepairs);
             guildQuestListBox = AddCheckbox(rightPanel, "guildQuestListBox", DaggerfallUnity.Settings.GuildQuestListBox);
+            bowLeftHandWithSwitching = AddCheckbox(rightPanel, "bowLeftHandWithSwitching", DaggerfallUnity.Settings.BowLeftHandWithSwitching);
         }
 
         private void Video(Panel leftPanel, Panel rightPanel)
@@ -414,6 +416,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.AllowMagicRepairs = allowMagicRepairs.IsChecked;
             DaggerfallUnity.Settings.InstantRepairs = instantRepairs.IsChecked;
             DaggerfallUnity.Settings.GuildQuestListBox = guildQuestListBox.IsChecked;
+            DaggerfallUnity.Settings.BowLeftHandWithSwitching = bowLeftHandWithSwitching.IsChecked;
 
             DaggerfallUnity.Settings.DungeonAmbientLightScale = dungeonAmbientLightScale.GetValue();
             DaggerfallUnity.Settings.NightAmbientLightScale = nightAmbientLightScale.GetValue();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -221,7 +221,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             arrowCountTextLabel.Enabled = false;
             if (!largeHUDEnabled && ShowArrowCount && !GameManager.Instance.WeaponManager.Sheathed)
             {
-                DaggerfallUnityItem held = GameManager.Instance.PlayerEntity.ItemEquipTable.GetItem(EquipSlots.RightHand);
+                EquipSlots slot = DaggerfallUnity.Settings.BowLeftHandWithSwitching ? EquipSlots.LeftHand : EquipSlots.RightHand;
+                DaggerfallUnityItem held = GameManager.Instance.PlayerEntity.ItemEquipTable.GetItem(slot);
                 if (held != null && held.ItemGroup == ItemGroups.Weapons &&
                     (held.TemplateIndex == (int)Weapons.Long_Bow || held.TemplateIndex == (int)Weapons.Short_Bow))
                 {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1133,8 +1133,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void SetEquipDelayTime(bool setTime)
         {
-            ushort[] equipDelayTimes = { 500, 700, 1200, 900, 900, 1800, 1600, 1700, 1700, 3000, 3400, 2000, 2200, 2000, 2200, 2000, 4000, 5000 };
-
             int delayTimeRight = 0;
             int delayTimeLeft = 0;
             PlayerEntity player = GameManager.Instance.PlayerEntity;
@@ -1147,21 +1145,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     // Add delay for unequipping old item
                     if (lastRightHandItem != null)
-                        delayTimeRight = equipDelayTimes[lastRightHandItem.GroupIndex];
+                        delayTimeRight = WeaponManager.EquipDelayTimes[lastRightHandItem.GroupIndex];
 
                     // Add delay for equipping new item
                     if (currentRightHandItem != null)
-                        delayTimeRight += equipDelayTimes[currentRightHandItem.GroupIndex];
+                        delayTimeRight += WeaponManager.EquipDelayTimes[currentRightHandItem.GroupIndex];
                 }
                 if (lastLeftHandItem != currentLeftHandItem)
                 {
                     // Add delay for unequipping old item
                     if (lastLeftHandItem != null)
-                        delayTimeLeft = equipDelayTimes[lastLeftHandItem.GroupIndex];
+                        delayTimeLeft = WeaponManager.EquipDelayTimes[lastLeftHandItem.GroupIndex];
 
                     // Add delay for equipping new item
                     if (currentLeftHandItem != null)
-                        delayTimeLeft += equipDelayTimes[currentLeftHandItem.GroupIndex];
+                        delayTimeLeft += WeaponManager.EquipDelayTimes[currentLeftHandItem.GroupIndex];
                 }
             }
             else

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -34,6 +34,9 @@ namespace DaggerfallWorkshop.Game
         const float defaultBowReach = 50f;
         public const float defaultWeaponReach = 2.25f;
 
+        // Equip delay times for weapons
+        public static ushort[] EquipDelayTimes = { 500, 700, 1200, 900, 900, 1800, 1600, 1700, 1700, 3000, 3400, 2000, 2200, 2000, 2200, 2000, 4000, 5000 };
+
         // Max time-length of a trail of mouse positions for attack gestures
         private const float MaxGestureSeconds = 1.0f;
 
@@ -679,6 +682,22 @@ namespace DaggerfallWorkshop.Game
                 DaggerfallUI.Instance.PopupMessage(HardStrings.usingRightHand);
             else
                 DaggerfallUI.Instance.PopupMessage(HardStrings.usingLeftHand);
+
+            if (DaggerfallUnity.Settings.BowLeftHandWithSwitching)
+            {
+                int switchDelay = 0;
+                if (currentRightHandWeapon != null)
+                    switchDelay += EquipDelayTimes[currentRightHandWeapon.GroupIndex];
+                if (currentRightHandWeapon != null)
+                    switchDelay += EquipDelayTimes[currentLeftHandWeapon.GroupIndex];
+                if (switchDelay > 0)
+                {
+                    if (UsingRightHand)
+                        EquipCountdownRightHand += switchDelay / 4;
+                    else
+                        EquipCountdownLeftHand += switchDelay / 4;
+                }
+            }
 
             ApplyWeapon();
         }

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -180,6 +180,7 @@ namespace DaggerfallWorkshop
         public bool EnemyInfighting { get; set; }
         public bool EnhancedCombatAI { get; set; }
         public bool GuildQuestListBox { get; set; }
+        public bool BowLeftHandWithSwitching { get; set; }
 
         #endregion
 
@@ -303,6 +304,7 @@ namespace DaggerfallWorkshop
             EnemyInfighting = GetBool(sectionEnhancements, "EnemyInfighting");
             EnhancedCombatAI = GetBool(sectionEnhancements, "EnhancedCombatAI");
             GuildQuestListBox = GetBool(sectionEnhancements, "GuildQuestListBox");
+            BowLeftHandWithSwitching = GetBool(sectionEnhancements, "BowLeftHandWithSwitching");
         }
 
         /// <summary>
@@ -414,6 +416,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionEnhancements, "EnemyInfighting", EnemyInfighting);
             SetBool(sectionEnhancements, "EnhancedCombatAI", EnhancedCombatAI);
             SetBool(sectionEnhancements, "GuildQuestListBox", GuildQuestListBox);
+            SetBool(sectionEnhancements, "BowLeftHandWithSwitching", BowLeftHandWithSwitching);
 
             // Write settings to persistent file
             WriteSettingsFile();

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -89,6 +89,8 @@ loiterLimitInHours,                                 Maximum loiter time in hours
 loiterLimitInHoursInfo,                             Change default loiter time limit in hours
 guildQuestListBox,                                  Guild quest player selection
 guildQuestListBoxInfo,                              Presents eligible guild quests in a list box
+bowLeftHandWithSwitching,                           Equip bows in left hand only with switch delay
+bowLeftHandWithSwitchingInfo,                       Equip bows in left hand and allow 1H weapon switching - switching has a short delay
 
 modSystem,                                          Mod System
 modSystemInfo,                                      Enable support for mods.

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -89,7 +89,7 @@ loiterLimitInHours,                                 Maximum loiter time in hours
 loiterLimitInHoursInfo,                             Change default loiter time limit in hours
 guildQuestListBox,                                  Guild quest player selection
 guildQuestListBoxInfo,                              Presents eligible guild quests in a list box
-bowLeftHandWithSwitching,                           Equip bows in left hand only with switch delay
+bowLeftHandWithSwitching,                           Equip bows in left hand only
 bowLeftHandWithSwitchingInfo,                       Equip bows in left hand and allow 1H weapon switching - switching has a short delay
 
 modSystem,                                          Mod System


### PR DESCRIPTION
This allows weapon switching between a melee and a bow without having to access the inventory. Think... sling the bow over shoulder and draw a blade. Introduces a switching delay for all weapon switches which is half the average weapon equip delay of the two weapons.

Playing a character who uses a mix of ranged and melee is a pain, and it seems reasonable to me for this to be a balanced tweak of the Daggerfall weapon system. If you would rather it goes in a mod, then I'll do that, but I feel it's a nice enough change for a core enhancement.