### PR TITLE
[RFC] More discreet create foe place freely 

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/CreateFoe.cs
+++ b/Assets/Scripts/Game/Questing/Actions/CreateFoe.cs
@@ -290,13 +290,19 @@ namespace DaggerfallWorkshop.Game.Questing
             RaycastHit initialHit;
             if (Physics.Raycast(ray, out initialHit, maxDistance))
             {
-                // Separate out from hit point
-                float extraDistance = UnityEngine.Random.Range(0f, 2f);
-                currentPoint = initialHit.point + initialHit.normal.normalized * (separationDistance + extraDistance);
+                float cos_normal = Vector3.Dot(- spawnDirection, initialHit.normal.normalized);
+                if (cos_normal < 1e-6)
+                    return;
+                float separationForward = separationDistance / cos_normal;
 
                 // Must be greater than minDistance
-                if (initialHit.distance < minDistance)
+                float distanceSlack = initialHit.distance - separationForward - minDistance;
+                if (distanceSlack < 0f)
                     return;
+
+                // Separate out from hit point
+                float extraDistance = UnityEngine.Random.Range(0f, Mathf.Min(2f, distanceSlack));
+                currentPoint = initialHit.point - spawnDirection * (separationForward + extraDistance);
             }
             else
             {

--- a/Assets/Scripts/Game/Utility/FoeSpawner.cs
+++ b/Assets/Scripts/Game/Utility/FoeSpawner.cs
@@ -159,13 +159,19 @@ namespace DaggerfallWorkshop.Game.Utility
             RaycastHit initialHit;
             if (Physics.Raycast(ray, out initialHit, maxDistance))
             {
-                // Separate out from hit point
-                float extraDistance = UnityEngine.Random.Range(0f, 2f);
-                currentPoint = initialHit.point + initialHit.normal.normalized * (separationDistance + extraDistance);
+                float cos_normal = Vector3.Dot(-spawnDirection, initialHit.normal.normalized);
+                if (cos_normal < 1e-6)
+                    return;
+                float separationForward = separationDistance / cos_normal;
 
                 // Must be greater than minDistance
-                if (initialHit.distance < minDistance)
+                float distanceSlack = initialHit.distance - separationForward - minDistance;
+                if (distanceSlack < 0f)
                     return;
+
+                // Separate out from hit point
+                float extraDistance = UnityEngine.Random.Range(0f, Mathf.Min(2f, distanceSlack));
+                currentPoint = initialHit.point - spawnDirection * (separationForward + extraDistance);
             }
             else
             {


### PR DESCRIPTION
Previous algorithm to spawn foes freely would first find a direction slightly outside of player's field of view, check if there's any obstacle in that direction, and if so find a spawning point along the normal of collision point.

Using that normal helps finding a clear location (it should be at least clear from the obstacle just hit, but further tests are still needed), however it changes the direction of the spawning point, moving it away from field of view borders; Either inward (making the foe suddenly appear in front of the player) or outward (not as bad).
Also the code checks the distance of the hit point, not spawning point, making it possible for spawns to happen at a much lower distance than minDistance constraint.

Stream: https://www.twitch.tv/videos/556821863?t=27m40s
![lycanthrope spawn](https://user-images.githubusercontent.com/1211431/75301540-59bb8e00-583b-11ea-91ee-e49d87ece1bd.jpg)
(Lycanthrope appearing in a tavern right in the center of player's field of view, probably taking the normal off the fireplace on the right)

This patch:
- selects a spawn point along the direction selected at first, to be on the border of player's field of view, so foes should never "appear" in front of the player (even if sometimes in places that do not make much logical sense, exactly like before);
- assuming the obstacle is a plane, the new algorithm may choose a spawn point much closer than before as clear from the obstacle (can't beat using the normal here);
- however it will always check that spawn happens further than minDistance, and only add some randomness to the distance if there's enough room to do so in the first place.
