### PR TITLE
Same as #1484 with EnableTextureArrays = False

### DIFF
--- a/Assets/Shaders/DaggerfallTilemap.shader
+++ b/Assets/Shaders/DaggerfallTilemap.shader
@@ -55,7 +55,7 @@ Shader "Daggerfall/Tilemap" {
 		void surf (Input IN, inout SurfaceOutputStandard o)
 		{
 			// Get offset to tile in atlas
-			int index = tex2D(_TilemapTex, IN.uv_MainTex).a * _MaxIndex;
+			int index = tex2D(_TilemapTex, IN.uv_MainTex).a * _MaxIndex + 0.5;
 			int xpos = index % _TilesetDim;
 			int ypos = index / _TilesetDim;
 			float2 uv = float2(xpos, ypos) / _TilesetDim;


### PR DESCRIPTION
Same as #1484 but in DaggerfallTilemap.shader

No regression found on my hardware with EnableTextureArrays = False, but ideally it should be tested with hardware that require that setting...

Forums https://forums.dfworkshop.net/viewtopic.php?f=5&t=3456