### PR TITLE
prevent collisions between all missiles

### DIFF
--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -236,6 +236,7 @@ namespace DaggerfallWorkshop.Game
 
                 goModel.transform.localPosition = adjust;
                 goModel.transform.rotation = Quaternion.LookRotation(GetAimDirection());
+                goModel.layer = gameObject.layer;
             }
 
             // Ignore missile collision with caster (this is a different check to AOE targets)
@@ -519,6 +520,7 @@ namespace DaggerfallWorkshop.Game
             // Add new billboard parented to this missile
             GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(GetMissileTextureArchive(), record, transform);
             go.transform.localPosition = Vector3.zero;
+            go.layer = gameObject.layer;
             myBillboard = go.GetComponent<DaggerfallBillboard>();
             myBillboard.FramesPerSecond = BillboardFramesPerSecond;
             myBillboard.FaceY = true;


### PR DESCRIPTION
Both arrows and spell missiles gameObjects didn't inherit SpellMissiles layer from their parent, so they would collide with one another.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=23&t=3459