### PR TITLE
AI improve doorways finding

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -1056,7 +1056,7 @@ namespace DaggerfallWorkshop.Game
         void ObstacleCheck(Vector3 direction)
         {
             obstacleDetected = false;
-            const int checkDistance = 1;
+            const float checkDistance = 1f;
             foundUpwardSlope = false;
             foundDoor = false;
 
@@ -1064,10 +1064,11 @@ namespace DaggerfallWorkshop.Game
             // Climbable/not climbable step for the player seems to be at around a height of 0.65f. The player is 1.8f tall.
             // Using the same ratio to height as these values, set the capsule for the enemy. 
             Vector3 p1 = transform.position + (Vector3.up * -originalHeight * 0.1388F);
-            Vector3 p2 = p1 + (Vector3.up * originalHeight * 0.5f);
+            Vector3 p2 = p1 + (Vector3.up * Mathf.Min(originalHeight, 1.75f) / 2);
 
             if (Physics.CapsuleCast(p1, p2, controller.radius / 2, direction, out hit, checkDistance))
             {
+                // Debug.DrawRay(transform.position, direction, Color.red, 2.0f);
                 obstacleDetected = true;
                 DaggerfallEntityBehaviour entityBehaviour2 = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
                 DaggerfallActionDoor door = hit.transform.GetComponent<DaggerfallActionDoor>();
@@ -1108,6 +1109,10 @@ namespace DaggerfallWorkshop.Game
                         foundUpwardSlope = true;
                     }
                 }
+            }
+            else
+            {
+                // Debug.DrawRay(transform.position, direction, Color.green, 2.0f);
             }
         }
 

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -1056,7 +1056,7 @@ namespace DaggerfallWorkshop.Game
         void ObstacleCheck(Vector3 direction)
         {
             obstacleDetected = false;
-            const float checkDistance = 1f;
+            const float checkDistance = 0.8f;
             foundUpwardSlope = false;
             foundDoor = false;
 


### PR DESCRIPTION
This PR does not change the current doorway finding algorithm, that looks good, but tweaks 2 parameters so far:
- limit the height of the capsulecast used to find doorways to 1.75, to match the hack used to allow tall enemies to get thru doors. Without this, tall enemies could technically get thru doors, yet are very reluctant to do so;
- lower capsulecast distance from 1 to 0.8. Long casts was making it hard for enemies to find door openings coming from the sides. Now it's a bit better.