### PR TITLE
Added version label to setup wizard

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -437,6 +437,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             titleLabel.HorizontalAlignment = HorizontalAlignment.Center;
             optionsPanel.Components.Add(titleLabel);
 
+            // Add version text
+            TextLabel versionLabel = new TextLabel(DaggerfallUI.DefaultFont);
+            versionLabel.Text = string.Format("{0} v{1}", char.ToUpper(VersionInfo.DaggerfallUnityStatus[0]) + VersionInfo.DaggerfallUnityStatus.Substring(1), VersionInfo.DaggerfallUnityVersion);
+            versionLabel.Position = new Vector2(0, 40);
+            versionLabel.TextScale = 1.0f;
+            versionLabel.HorizontalAlignment = HorizontalAlignment.Center;
+            versionLabel.ShadowPosition = Vector2.zero;
+            versionLabel.TextColor = secondaryTextColor;
+            optionsPanel.Components.Add(versionLabel);
+
             // Add settings path text
             TextLabel settingsPathLabel = new TextLabel();
             settingsPathLabel.Text = DaggerfallUnity.Settings.PersistentDataPath;


### PR DESCRIPTION
https://imgur.com/a/tdHhoRw

I felt like the setup wizard could use a small version label for users to notice which .exe they're opening. It's especially useful in case if a user uses multiple versions for mod compatibility, or if they're transitioning from one version to another and accidentally left the older version pinned to their taskbar, start menu, or on their desktop as a shortcut.