### PR TITLE
Fixes + improvements for opening/closing UI windows and console

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleUI.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleUI.cs
@@ -41,6 +41,9 @@ namespace Wenzil.Console
         /// </summary>
         public void ToggleConsole(bool force = false)
         {
+            //refresh keybinds if player rebinded it
+            transform.GetComponent<ConsoleController>().GetConsoleKeyBind();
+
             // Do nothing if HUD is not top window (e.g. player in some other menu)
             if (!DaggerfallWorkshop.Game.GameManager.Instance.IsPlayerOnHUD && !force)
                 return;

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -485,7 +485,7 @@ namespace DaggerfallWorkshop.Game
                 return;
 
             // Post message to open options dialog on escape during gameplay
-            if (Input.GetKeyDown(KeyCode.Escape))
+            if (InputManager.Instance.ActionComplete(InputManager.Actions.Escape))
             {
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenPauseOptionsDialog);
             }

--- a/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
+++ b/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
@@ -51,16 +51,16 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         #region Unity
 
+        void Start ()
+        {
+            DaggerfallWorkshop.Game.InputManager.OnSavedKeyBinds += GetPrintScreenKeyBind;
+            GetPrintScreenKeyBind();
+        }
+
         void Update ()
         {
             if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
             {
-                //Trying to set 'prtscrBinding' on Start() or Awake() will set it to 'None'
-                //This 'if' statement avoids calling GetBinding() every Update() for when I GetKeyUp()
-                if(prtscrBinding == KeyCode.None
-                    && InputManager.Instance.GetBinding(InputManager.Actions.PrintScreen) != KeyCode.None)
-                    prtscrBinding = InputManager.Instance.GetBinding(InputManager.Actions.PrintScreen);
-
                 if (Input.GetKeyUp(prtscrBinding))
                     StartCoroutine(TakeScreenshot());
             }
@@ -69,6 +69,11 @@ namespace DaggerfallWorkshop.Game.Serialization
         #endregion
 
         #region Private Methods
+
+        void GetPrintScreenKeyBind()
+        {
+            prtscrBinding = InputManager.Instance.GetBinding(InputManager.Actions.PrintScreen);
+        }
 
         IEnumerator TakeScreenshot()
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -233,6 +233,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public override void OnPush()
         {
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.CharacterSheet);
             Refresh();
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -566,6 +566,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public override void OnPush()
         {
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Inventory);
+
             // Racial override can suppress inventory
             // We still setup and push window normally, actual suppression is done in Update()
             MagicAndEffects.MagicEffects.RacialOverrideEffect racialOverride = GameManager.Instance.PlayerEffectManager.GetRacialOverrideEffect();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
@@ -42,6 +42,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected bool saveSettings = false;
 
+        protected KeyCode toggleClosedBinding;
+
         #endregion
 
         #region Constructors
@@ -148,6 +150,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.OnPush();
 
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Escape);
+
             hud = DaggerfallUI.Instance.DaggerfallHUD;
         }
 
@@ -166,6 +170,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Scale version text based on native panel scaling
             versionTextLabel.TextScale = NativePanel.LocalScale.x * 0.75f;
+
+            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            {
+                // Toggle window closed with same hotkey used to open it
+                if (Input.GetKeyUp(toggleClosedBinding))
+                    CloseWindow();
+            }
         }
 
         public override void Draw()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
@@ -69,7 +69,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             cancelled = false;
             if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
             {
-                if (allowCancel && Input.GetKeyDown(exitKey))
+                if (allowCancel && Input.GetKeyUp(exitKey))
                     CancelWindow();
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -187,6 +187,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public override void OnPush()
         {
             base.OnPush();
+
+            toggleClosedBinding1 = InputManager.Instance.GetBinding(InputManager.Actions.LogBook);
+            toggleClosedBinding2 = InputManager.Instance.GetBinding(InputManager.Actions.NoteBook);
+
             questMessages       = QuestMachine.Instance.GetAllQuestLogMessages();
             lastMessageIndex    = NULLINT;
             currentMessageIndex = 0;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -212,6 +212,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.OnPush();
 
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Rest);
+
             // Reset counters
             minutesOfHour = 0;
             hoursRemaining = 0;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -156,6 +156,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public override void OnPush()
         {
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.CastSpell);
+
             if (buyMode && GameManager.Instance.PlayerEnterExit.IsPlayerInside)
                 buildingDiscoveryData = GameManager.Instance.PlayerEnterExit.BuildingDiscoveryData;
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -316,6 +316,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.OnPush();
 
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.TravelMap);
+
             if(IsSetup)
             {
                 StartIdentify();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUseMagicItemWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUseMagicItemWindow.cs
@@ -49,6 +49,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public override void OnPush()
         {
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.UseMagicItem);
+
             if (!IsSetup)
                 return;
 


### PR DESCRIPTION
Besides the map windows, if the player had previously opened a window and then changed the keybind for it, the window would not refresh the toggle button and would stick to the old keybinding. This was also true for the console window as well. I fixed it by refreshing the bindings in `OnPush()` and `ToggleConsole()` for the windows and console, respectively.

Also, in preparation for the secondary keybind window, I've made the pause window utilize a rebindable toggle like all of the other windows. Previously, it relied on a hardcoded `KeyCode.Escape` and `DaggerfallPopupWindow`'s default 'exitKey' to leave the window without actually using `InputManager.Actions.Escape`. Also, when making this change, I noticed that if the toggled key was held down for too long after exiting the window, that it would pop back up again. I saw that the problem was `DaggerfallPopupWindow` using `GetKeyDown(exitKey)`, so I changed it to `GetKeyUp(exitKey)` to resolve the issue.

EDIT: Added rebindability for PrintScreenManager (I can't believe I forgot about my own submitted feature for a second)