### PR TITLE
Fix left handed bow damage and condition lowering

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -1979,7 +1979,7 @@ namespace Wenzil.Console
                             {
                                 ItemTemplate itemTemplate = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(clothing, i);
                                 if ((playerEntity.Gender == Genders.Male && mensUsableClothing.Contains((MensClothing)enumArray.GetValue(i))) ||
-                                    womensUsableClothing.Contains((WomensClothing)enumArray.GetValue(i)))
+                                    womensUsableClothing.Contains((WomensClothing)enumArray.GetValue(i)) || itemTemplate.variants == 0)
                                     itemTemplate.variants = 1;
 
                                 for (int v = 0; v < itemTemplate.variants; v++)
@@ -2032,14 +2032,21 @@ namespace Wenzil.Console
                                         vf = 6;
                                     }
                                 }
-                                else if (armorType == Armor.Gauntlets && material != ArmorMaterialTypes.Leather)
+                                else if (armorType == Armor.Gauntlets || armorType == Armor.Boots)
                                 {
-                                    vs = 1;
+                                    if (material == ArmorMaterialTypes.Leather)
+                                    {
+                                        vf = 1;
+                                    }
+                                    else
+                                    {
+                                        vs = 1;
+                                        vf = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Armor, i).variants;
+                                    }
                                 }
                                 else
                                 {
-                                    ItemTemplate itemTemplate = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Armor, i);
-                                    vf = itemTemplate.variants;
+                                    vf = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Armor, i).variants;
                                 }
                                 if (vf == 0)
                                     vf = vs + 1;

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -921,7 +921,7 @@ namespace DaggerfallWorkshop.Game.Items
                 if (item.nativeMaterialValue == (int)ArmorMaterialTypes.Leather)
                     variant = 0;
                 else
-                    variant = 1;
+                    variant = Mathf.Clamp(variant, 1, 2);
             }
 
             // Store variant

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -35,14 +35,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Rect costPanelRect = new Rect(49, 13, 111, 9);
 
         Rect actionButtonsPanelRect = new Rect(222, 10, 39, 190);
-        Rect wagonButtonRect = new Rect(4, 4, 31, 14);
-        Rect infoButtonRect = new Rect(4, 26, 31, 14);
+        new Rect wagonButtonRect = new Rect(4, 4, 31, 14);
+        new Rect infoButtonRect = new Rect(4, 26, 31, 14);
         Rect selectButtonRect = new Rect(4, 48, 31, 14);
         Rect stealButtonRect = new Rect(4, 102, 31, 14);
         Rect modeActionButtonRect = new Rect(4, 124, 31, 14);
         Rect clearButtonRect = new Rect(4, 146, 31, 14);
 
-        Rect itemInfoPanelRect = new Rect(223, 87, 37, 32);
+        new Rect itemInfoPanelRect = new Rect(223, 87, 37, 32);
         Rect itemBuyInfoPanelRect = new Rect(223, 76, 37, 32);
 
         #endregion
@@ -54,8 +54,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         TextLabel goldLabel;
 
         Panel actionButtonsPanel;
-        Button wagonButton;
-        Button infoButton;
         Button selectButton;
         Button stealButton;
         Button modeActionButton;

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -683,7 +683,7 @@ namespace DaggerfallWorkshop.Game
                 int switchDelay = 0;
                 if (currentRightHandWeapon != null)
                     switchDelay += EquipDelayTimes[currentRightHandWeapon.GroupIndex];
-                if (currentRightHandWeapon != null)
+                if (currentLeftHandWeapon != null)
                     switchDelay += EquipDelayTimes[currentLeftHandWeapon.GroupIndex];
                 if (switchDelay > 0)
                 {

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -376,7 +376,7 @@ namespace DaggerfallWorkshop.Game
                         missile.ElementType = ElementTypes.None;
                         missile.IsArrow = true;
 
-                        lastBowUsed = currentRightHandWeapon;
+                        lastBowUsed = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;;
                     }
                 }
 


### PR DESCRIPTION
The way bows are accessed for the formula differs from melee so it was using the weapon in right hand for damage calc.