### PR TITLE
Fixes discrepancies in item stats from classic

### DIFF
--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -47,7 +47,7 @@ namespace DaggerfallWorkshop.Game.Items
         static readonly short[] valueMultipliersByMaterial = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
 
         // Condition multipliers by material type. Iron through Daedric. MaxCondition is baseMaxCondition * value / 4.
-        static readonly short[] conditionMultipliersByMaterial = { 4, 4, 6, 8, 12, 16, 20, 24, 28, 32 };
+        static readonly short[] conditionMultipliersByMaterial = { 4, 6, 6, 8, 12, 16, 20, 24, 28, 32 };
 
         // Enchantment point multipliers by material type. Iron through Daedric. Enchantment points is baseEnchanmentPoints * value / 4.
         static readonly short[] enchantmentPointMultipliersByMaterial = { 3, 4, 7, 5, 6, 5, 7, 8, 10, 12 };
@@ -680,9 +680,9 @@ namespace DaggerfallWorkshop.Game.Items
         {
             item.value *= 3 * valueMultipliersByMaterial[(int)material];
             item.weightInKg = CalculateWeightForMaterial(item, material);
-            item.maxCondition *= conditionMultipliersByMaterial[(int)material] / 4;
+            item.maxCondition = item.maxCondition * conditionMultipliersByMaterial[(int)material] / 4;
             item.currentCondition = item.maxCondition;
-            item.enchantmentPoints *= enchantmentPointMultipliersByMaterial[(int)material] / 4;
+            item.enchantmentPoints = item.enchantmentPoints * enchantmentPointMultipliersByMaterial[(int)material] / 4;
 
             return item;
         }


### PR DESCRIPTION
I've just realised that the fix here for the enchantmentPoints is not getting used in the game. That's probably why it was not noticed up until now.

@Interkarma when you implemented item enchanting you created formula methods (GetItemEnchantmentPower etc) to calculate this from the base points value in the template instead of using the value calculated by Allofich code in ItemBuilder. I'm not sure if this was because of the bug that this PR fixes, or because you were not aware of its existance.

Having it in the item means it is easier for a custom item implementation to alter the points in a different way, which is useful in at least one case but not necessarily a reason to switch if there are good reasons not to.

Either way I think one or the other of these 2 implementation of enchantment point material scaling should be removed. I am happy to do that, but you should decide which we keep I think.