### PR TITLE
Improved robustness of ModManager.TryGetAsset()

### DIFF
--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -529,11 +529,17 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         #region Internal Methods
 
         /// <summary>
-        /// Used internally when the game seeks assets from all mods and handles a global cache.
-        /// This method allows to load directly from bundle without mod cache to avoid
-        /// references that would prevents garbage collection to be performed.
-        /// Shouldn't be used for prefabs because <see cref="ImportedComponentAttribute"/> is currently unsupported.
+        /// Loads an asset without cache. In most cases <see cref="GetAsset{T}(string, bool)"/> should be used instead.
         /// </summary>
+        /// <typeparam name="T">The asset must be assignable to this type to be accepted.</typeparam>
+        /// <param name="assetName">The name of the asset with or without extension.</param>
+        /// <remarks>
+        /// This method allows to load directly from bundle without mod cache to avoid references that would prevent
+        /// garbage collection to be performed. For example is used internally when the game seeks assets from all mods
+        /// and handles a global cache.
+        /// Shouldn't be used for prefabs because <see cref="ImportedComponentAttribute"/> is currently unsupported.
+        /// </remarks>
+        /// <returns>Returns the loaded asset if found; otherwise returns null without logging errors.</returns>
         internal T LoadAsset<T>(string assetName)
             where T : UnityEngine.Object
         {
@@ -555,11 +561,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                 asset = AssetBundle.LoadAsset<T>(assetName);
             }
 
-            if (asset)
-                return asset;
-
-            Debug.LogErrorFormat("Failed to load asset: {0}", assetName);
-            return null;
+            return asset;
         }
 
         /// <summary>

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -406,7 +406,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 #endif
                         select clone.HasValue ? mod.GetAsset<T>(name, clone.Value) : mod.LoadAsset<T>(name);
 
-            return (asset = query.FirstOrDefault()) != null;
+            return (asset = query.FirstOrDefault(x => x != null)) != null;
         }
 
         /// <summary>
@@ -433,7 +433,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 #endif
                         select clone.HasValue ? mod.GetAsset<T>(name, clone.Value) : mod.LoadAsset<T>(name);
 
-            return (asset = query.FirstOrDefault()) != null;
+            return (asset = query.FirstOrDefault(x => x != null)) != null;
         }
 
         /// <summary>


### PR DESCRIPTION
`ModManager.TryGetAsset()` now doesn't return null if the first asset found can't be loaded but it keep seeking for a valid result instead.

This fixes an issue where a texture could be retrieved properly if a mod contains both texture and xml configuration file (with the same name), while it failed if it contains only the xml file because our internal code only considers the filename (unlike Unity API that also checks type).

`Mod.LoadAsset()` returns null without logging errors if asset is not found, which is consistent with Unity API (i.e. `Resources.Load()`).