### PR TITLE
ImportedComponentAttribute now supports dependencies

### DIFF
--- a/Assets/Game/Addons/ModSupport/ImportedComponentAttribute.cs
+++ b/Assets/Game/Addons/ModSupport/ImportedComponentAttribute.cs
@@ -304,7 +304,21 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             if (types.TryGetValue(typeName, out type))
                 return type;
 
-            return types[typeName] = mod.GetCompiledType(typeName);
+            if ((type = mod.GetCompiledType(typeName)) == null && mod.ModInfo.Dependencies != null)
+            {
+                for (int i = 0; i < mod.ModInfo.Dependencies.Length; i++)
+                {
+                    ModDependency dependency = mod.ModInfo.Dependencies[i];
+                    if (!dependency.IsOptional)
+                    {
+                        Mod target = ModManager.Instance.GetModFromName(dependency.Name);
+                        if (target != null && (type = target.GetCompiledType(typeName)) != null)
+                            break;
+                    }
+                }
+            }
+
+            return types[typeName] = type;
         }
 
         private static string LoadSerializedFile(Mod mod, string name)


### PR DESCRIPTION
Added support for serialization of prefabs inside a mod with custom components defined by other mods.

How to use component from mod A for a prefab in mod B:

- [ImportedComponent](https://github.com/Interkarma/daggerfall-unity/blob/27e3e4668890b28cb26355a98e4bca08053805ec/Assets/Game/Addons/ModSupport/ImportedComponentAttribute.cs#L31) attribute must be placed on the component class definition in mod A.
- Component from mod A must be added to prefab included with mod B using the "Add Component" button from prefab inspector, like any other component. This means that component class type must be available in Editor when the mod is built. Raw .cs or .dll files are enough, is not needed to have the entire mod source code.
- Mod A must be defined as a [dependency](https://github.com/Interkarma/daggerfall-unity/blob/27e3e4668890b28cb26355a98e4bca08053805ec/Assets/Game/Addons/ModSupport/ModTypes.cs#L102) of mod B.