### PR TITLE
Fix windows not toggling closed after rebinding key

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -209,9 +209,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Update player paper doll for first time
             UpdatePlayerValues();
             characterPortrait.Refresh();
-
-            // Store toggle closed binding for this window
-            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.CharacterSheet);
         }
 
         #endregion
@@ -234,6 +231,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public override void OnPush()
         {
             Refresh();
+            // Store toggle closed binding for this window
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.CharacterSheet);
         }
 
         public override void OnReturn()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    Hazelnut
+// Contributors:    Hazelnut, Numidium
 // 
 // Notes:
 //

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -329,9 +329,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             UpdateAccessoryItemsDisplay();
             UpdateLocalTargetIcon();
             UpdateRemoteTargetIcon();
-
-            // Store toggle closed binding for this window
-            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Inventory);
         }
 
         public override void Update()
@@ -574,6 +571,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Local items always points to player inventory
             localItems = PlayerEntity.Items;
+
+            // Reload binding if changed since last push
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Inventory);
 
             // Start a new dropped items target
             droppedItems.Clear();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -171,10 +171,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             questMessages = QuestMachine.Instance.GetAllQuestLogMessages();
 
-            // Store toggle closed bindings for this window
-            toggleClosedBinding1 = InputManager.Instance.GetBinding(InputManager.Actions.LogBook);
-            toggleClosedBinding2 = InputManager.Instance.GetBinding(InputManager.Actions.NoteBook);
-
 #if LAYOUT
             SetBackgroundColors();
 #endif
@@ -191,6 +187,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             lastMessageIndex    = NULLINT;
             currentMessageIndex = 0;
             selectedEntry       = NULLINT;
+
+            // Store toggle closed bindings for this window
+            toggleClosedBinding1 = InputManager.Instance.GetBinding(InputManager.Actions.LogBook);
+            toggleClosedBinding2 = InputManager.Instance.GetBinding(InputManager.Actions.NoteBook);
+
             DaggerfallUI.Instance.PlayOneShot(openJournal);
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Lypyl (lypyl@dfworkshop.net), Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    Hazelnut, TheLacus
+// Contributors:    Hazelnut, TheLacus, Numidium
 // 
 // Notes:
 //
@@ -323,6 +323,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 CloseRegionPanel();
             }
 
+            // Store toggle closed binding for this window
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.TravelMap);
+
         }
 
         public override void OnPop()
@@ -479,10 +482,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             NativePanel.Components.Add(verticalArrowButton);
             verticalArrowButton.Name = "verticalArrowButton";
             verticalArrowButton.OnMouseClick += ArrowButtonClickHandler;
-
-            // Store toggle closed binding for this window
-            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.TravelMap);
-
         }
 
         void SetupArrowButtons()


### PR DESCRIPTION
If the user changes the key binding for the inventory, character sheet, journal, or travel map windows then the toggle bindings do not update.