### PR TITLE
Mod reserved layers

### DIFF
--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -37,10 +37,10 @@ TagManager:
   - 
   - 
   - 
-  - 
-  - 
-  - 
-  - 
+  - ModReserved28
+  - ModReserved29
+  - ModReserved30
+  - ModReserved31
   m_SortingLayers:
   - name: Default
     uniqueID: 0


### PR DESCRIPTION
Mods can request layers and release them using `ModReservedLayer`.

[Requested on forums.](https://forums.dfworkshop.net/viewtopic.php?f=23&p=41393#p41393)

Example:

```cs
var reservedLayer = ModReservedLayer.Request();
if (reservedLayer == null)
{
    Debug.LogError("Failed to get layer");
    return;
}

var go = GameObject.Instantiate(mod.GetAsset<GameObject>("Cube"));
go.layer = reservedLayer.Layer;

// ---
 
Physics.IgnoreLayerCollision(reservedLayer.Layer, LayerMask.NameToLayer("Enemies"), false); 

// ---

reservedLayer.Dispose()
```