### PR TITLE
Enable custom items to be added by mods

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -2079,9 +2079,7 @@ namespace Wenzil.Console
                             for (int i = 0; i < customItemTemplates.Length; i++)
                             {
                                 newItem = ItemBuilder.CreateItem(ItemGroups.Weapons, customItemTemplates[i]);
-                                newItem.nativeMaterialValue = (int)material;
-                                newItem = ItemBuilder.SetItemPropertiesByMaterial(newItem, material);
-                                newItem.dyeColor = itemHelper.GetWeaponDyeColor(material);
+                                ItemBuilder.ApplyWeaponMaterial(newItem, material);
                                 playerEntity.Items.AddItem(newItem);
                             }
                         }

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -1963,6 +1963,7 @@ namespace Wenzil.Console
                     return usage;
 
                 PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+                ItemHelper itemHelper = DaggerfallUnity.Instance.ItemHelper;
                 ItemCollection items = playerEntity.Items;
                 DaggerfallUnityItem newItem = null;
 
@@ -1974,10 +1975,10 @@ namespace Wenzil.Console
                         ItemGroups clothing = (playerEntity.Gender == Genders.Male) ? ItemGroups.MensClothing : ItemGroups.WomensClothing;
                         foreach (DyeColors dye in clothingDyes)
                         {
-                            Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(clothing);
+                            Array enumArray = itemHelper.GetEnumArray(clothing);
                             for (int i = 0; i < enumArray.Length; i++)
                             {
-                                ItemTemplate itemTemplate = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(clothing, i);
+                                ItemTemplate itemTemplate = itemHelper.GetItemTemplate(clothing, i);
                                 if ((playerEntity.Gender == Genders.Male && mensUsableClothing.Contains((MensClothing)enumArray.GetValue(i))) ||
                                     womensUsableClothing.Contains((WomensClothing)enumArray.GetValue(i)) || itemTemplate.variants == 0)
                                     itemTemplate.variants = 1;
@@ -1997,7 +1998,7 @@ namespace Wenzil.Console
                     case "armor":
                         foreach (ArmorMaterialTypes material in armorMaterials)
                         {
-                            Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(ItemGroups.Armor);
+                            Array enumArray = itemHelper.GetEnumArray(ItemGroups.Armor);
                             for (int i = 0; i < enumArray.Length; i++)
                             {
                                 Armor armorType = (Armor)enumArray.GetValue(i);
@@ -2041,12 +2042,12 @@ namespace Wenzil.Console
                                     else
                                     {
                                         vs = 1;
-                                        vf = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Armor, i).variants;
+                                        vf = itemHelper.GetItemTemplate(ItemGroups.Armor, i).variants;
                                     }
                                 }
                                 else
                                 {
-                                    vf = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Armor, i).variants;
+                                    vf = itemHelper.GetItemTemplate(ItemGroups.Armor, i).variants;
                                 }
                                 if (vf == 0)
                                     vf = vs + 1;
@@ -2064,7 +2065,7 @@ namespace Wenzil.Console
                     case "magicWeapons":
                         foreach (WeaponMaterialTypes material in weaponMaterials)
                         {
-                            Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(ItemGroups.Weapons);
+                            Array enumArray = itemHelper.GetEnumArray(ItemGroups.Weapons);
                             for (int i = 0; i < enumArray.Length-1; i++)
                             {
                                 newItem = ItemBuilder.CreateWeapon((Weapons)enumArray.GetValue(i), material);
@@ -2072,6 +2073,15 @@ namespace Wenzil.Console
                                     newItem.legacyMagic = new DaggerfallEnchantment[] { new DaggerfallEnchantment() { type = EnchantmentTypes.CastWhenUsed, param = 5 } };
                                     newItem.IdentifyItem();
                                 }
+                                playerEntity.Items.AddItem(newItem);
+                            }
+                            int[] customItemTemplates = itemHelper.GetCustomItemsForGroup(ItemGroups.Weapons);
+                            for (int i = 0; i < customItemTemplates.Length; i++)
+                            {
+                                newItem = ItemBuilder.CreateItem(ItemGroups.Weapons, customItemTemplates[i]);
+                                newItem.nativeMaterialValue = (int)material;
+                                newItem = ItemBuilder.SetItemPropertiesByMaterial(newItem, material);
+                                newItem.dyeColor = itemHelper.GetWeaponDyeColor(material);
                                 playerEntity.Items.AddItem(newItem);
                             }
                         }

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -2058,6 +2058,14 @@ namespace Wenzil.Console
                                     playerEntity.Items.AddItem(newItem);
                                 }
                             }
+                            int[] customItemTemplates = itemHelper.GetCustomItemsForGroup(ItemGroups.Armor);
+                            for (int i = 0; i < customItemTemplates.Length; i++)
+                            {
+                                newItem = ItemBuilder.CreateItem(ItemGroups.Armor, customItemTemplates[i]);
+                                ItemBuilder.SetRace(newItem, playerEntity.Race);
+                                ItemBuilder.ApplyArmorMaterial(newItem, material);
+                                playerEntity.Items.AddItem(newItem);
+                            }
                         }
                         return string.Format("Added all armor types for a {0} {1}", playerEntity.Gender, playerEntity.Race);
 

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -2062,8 +2062,7 @@ namespace Wenzil.Console
                             for (int i = 0; i < customItemTemplates.Length; i++)
                             {
                                 newItem = ItemBuilder.CreateItem(ItemGroups.Armor, customItemTemplates[i]);
-                                ItemBuilder.SetRace(newItem, playerEntity.Race);
-                                ItemBuilder.ApplyArmorMaterial(newItem, material);
+                                ItemBuilder.ApplyArmorSettings(newItem, playerEntity.Gender, playerEntity.Race, material);
                                 playerEntity.Items.AddItem(newItem);
                             }
                         }

--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -1359,7 +1359,7 @@ namespace DaggerfallWorkshop.Game
 
                             MeshRenderer meshRenderer = inner2Elem.gameObject.GetComponent<MeshRenderer>();
                             if (meshRenderer == null)
-                                break;
+                                continue;
 
                             // update materials and set meshes as visited in this run (so "Interior" geometry always is colored
                             // (since we don't disable the mesh, it is also discovered - which is a precondition for being rendered))
@@ -1388,7 +1388,7 @@ namespace DaggerfallWorkshop.Game
 
                                 MeshRenderer meshRenderer = inner3Elem.gameObject.GetComponent<MeshRenderer>();
                                 if (meshRenderer == null)
-                                    break;
+                                    continue;
 
                                 // update materials (omit 2nd parameter so default behavior is initiated which is:
                                 // meshes are marked as not visited in this run (so "Dungeon" geometry that has been discovered in a previous dungeon run is rendered in grayscale)

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -872,7 +872,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return mods;
         }
 
-        private static ToHitAndDamageMods CalculateProficiencyModifiers(DaggerfallEntity attacker, DaggerfallUnityItem weapon)
+        public static ToHitAndDamageMods CalculateProficiencyModifiers(DaggerfallEntity attacker, DaggerfallUnityItem weapon)
         {
             Func<DaggerfallEntity, DaggerfallUnityItem, ToHitAndDamageMods> del;
             if (TryGetOverride("CalculateProficiencyModifiers", out del))
@@ -897,7 +897,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return mods;
         }
 
-        private static ToHitAndDamageMods CalculateRacialModifiers(DaggerfallEntity attacker, DaggerfallUnityItem weapon, PlayerEntity player)
+        public static ToHitAndDamageMods CalculateRacialModifiers(DaggerfallEntity attacker, DaggerfallUnityItem weapon, PlayerEntity player)
         {
             Func<DaggerfallEntity, DaggerfallUnityItem, PlayerEntity, ToHitAndDamageMods> del;
             if (TryGetOverride("CalculateRacialModifiers", out del))
@@ -1096,7 +1096,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             item.LowerCondition(amount, owner);
         }
 
-        private static int CalculateWeaponToHit(DaggerfallUnityItem weapon)
+        public static int CalculateWeaponToHit(DaggerfallUnityItem weapon)
         {
             Func<DaggerfallUnityItem, int> del;
             if (TryGetOverride("CalculateWeaponToHit", out del))
@@ -1105,7 +1105,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return weapon.GetWeaponMaterialModifier() * 10;
         }
 
-        private static int CalculateArmorToHit(DaggerfallEntity target, int struckBodyPart)
+        public static int CalculateArmorToHit(DaggerfallEntity target, int struckBodyPart)
         {
             Func<DaggerfallEntity, int, int> del;
             if (TryGetOverride("CalculateArmorToHit", out del))
@@ -1119,7 +1119,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return armorValue;
         }
 
-        private static int CalculateAdrenalineRushToHit(DaggerfallEntity attacker, DaggerfallEntity target)
+        public static int CalculateAdrenalineRushToHit(DaggerfallEntity attacker, DaggerfallEntity target)
         {
             Func<DaggerfallEntity, DaggerfallEntity, int> del;
             if (TryGetOverride("CalculateAdrenalineRushToHit", out del))
@@ -1141,7 +1141,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return chanceToHitMod;
         }
 
-        private static int CalculateStatsToHit(DaggerfallEntity attacker, DaggerfallEntity target)
+        public static int CalculateStatsToHit(DaggerfallEntity attacker, DaggerfallEntity target)
         {
             Func<DaggerfallEntity, DaggerfallEntity, int> del;
             if (TryGetOverride("CalculateStatDiffsToHit", out del))
@@ -1158,7 +1158,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             return chanceToHitMod;
         }
 
-        private static int CalculateSkillsToHit(DaggerfallEntity attacker, DaggerfallEntity target)
+        public static int CalculateSkillsToHit(DaggerfallEntity attacker, DaggerfallEntity target)
         {
             Func<DaggerfallEntity, DaggerfallEntity, int> del;
             if (TryGetOverride("CalculateSkillsToHit", out del))

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -2456,7 +2456,7 @@ namespace DaggerfallWorkshop.Game.Formulas
                 multiplier = GetArmorEnchantmentMultiplier((ArmorMaterialTypes)item.NativeMaterialValue);
 
             // Final enchantment power is basePower + basePower*multiplier (rounded down)
-            int basePower = item.enchantmentPoints;
+            int basePower = item.ItemTemplate.enchantmentPoints;
             return basePower + Mathf.FloorToInt(basePower * multiplier);
         }
 

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -576,7 +576,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             {
                 if (attacker == player || (AIAttacker != null && AIAttacker.EntityType == EntityTypes.EnemyClass))
                 {
-                    if (CalculateSuccessfulHit(attacker, target, chanceToHitMod, struckBodyPart) > 0)
+                    if (CalculateSuccessfulHit(attacker, target, chanceToHitMod, struckBodyPart))
                     {
                         minBaseDamage = CalculateHandToHandMinDamage(attacker.Skills.GetLiveSkillValue(DFCareer.Skills.HandToHand));
                         maxBaseDamage = CalculateHandToHandMaxDamage(attacker.Skills.GetLiveSkillValue(DFCareer.Skills.HandToHand));
@@ -615,7 +615,7 @@ namespace DaggerfallWorkshop.Game.Formulas
 
                         int reflexesChance = 50 - (10 * ((int)player.Reflexes - 2));
 
-                        if (DFRandom.rand() % 100 < reflexesChance && minBaseDamage > 0 && CalculateSuccessfulHit(attacker, target, chanceToHitMod, struckBodyPart) > 0)
+                        if (DFRandom.rand() % 100 < reflexesChance && minBaseDamage > 0 && CalculateSuccessfulHit(attacker, target, chanceToHitMod, struckBodyPart))
                         {
                             int hitDamage = UnityEngine.Random.Range(minBaseDamage, maxBaseDamage + 1);
                             // Apply special monster attack effects
@@ -639,7 +639,7 @@ namespace DaggerfallWorkshop.Game.Formulas
                 // Mod hook for adjusting final hit chance mod. (is a no-op in DFU)
                 chanceToHitMod = AdjustWeaponHitChanceMod(attacker, target, chanceToHitMod, weaponAnimTime, weapon);
 
-                if (CalculateSuccessfulHit(attacker, target, chanceToHitMod, struckBodyPart) > 0)
+                if (CalculateSuccessfulHit(attacker, target, chanceToHitMod, struckBodyPart))
                 {
                     damage = CalculateWeaponAttackDamage(attacker, target, damageModifiers, weaponAnimTime, weapon);
 
@@ -938,15 +938,14 @@ namespace DaggerfallWorkshop.Game.Formulas
         }
 
         /// <summary>
-        /// Calculates whether an attack on a target is successful. Returns 1 on success and 0 otherwise.
-        /// (uses an int instead of bool to fit common override signature)
+        /// Calculates whether an attack on a target is successful or not.
         /// </summary>
-        public static int CalculateSuccessfulHit(DaggerfallEntity attacker, DaggerfallEntity target, int chanceToHitMod, int struckBodyPart)
+        public static bool CalculateSuccessfulHit(DaggerfallEntity attacker, DaggerfallEntity target, int chanceToHitMod, int struckBodyPart)
         {
             if (attacker == null || target == null)
-                return 0;
+                return false;
 
-            Func<DaggerfallEntity, DaggerfallEntity, int, int, int> del;
+            Func<DaggerfallEntity, DaggerfallEntity, int, int, bool> del;
             if (TryGetOverride("CalculateSuccessfulHit", out del))
                 return del(attacker, target, chanceToHitMod, struckBodyPart);
 
@@ -1014,10 +1013,7 @@ namespace DaggerfallWorkshop.Game.Formulas
 
             Mathf.Clamp(chanceToHit, 3, 97);
 
-            if (Dice100.SuccessRoll(chanceToHit))
-                return 1;
-            else
-                return 0;
+            return Dice100.SuccessRoll(chanceToHit);
         }
 
         static int GetBonusOrPenaltyByEnemyType(DaggerfallEntity attacker, EnemyEntity AITarget)

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -53,6 +53,13 @@ namespace DaggerfallWorkshop.Game.Formulas
         // Approximation of classic frame updates
         public const int classicFrameUpdate = 980;
 
+        /// <summary>Struct for return values of formula that affect damage and to-hit chance.</summary>
+        public struct ToHitAndDamageMods
+        {
+            public int damageMod;
+            public int toHitMod;
+        }
+
         #region Basic Formulas
 
         public static int DamageModifier(int strength)
@@ -427,10 +434,78 @@ namespace DaggerfallWorkshop.Game.Formulas
             return (handToHandSkill / 5) + 1;
         }
 
-        public struct ToHitAndDamageMods
+        public static int CalculateWeaponMinDamage(Weapons weapon)
         {
-            public int damageMod;
-            public int toHitMod;
+            Func<Weapons, int> del;
+            if (TryGetOverride("CalculateWeaponMinDamage", out del))
+                return del(weapon);
+
+            switch (weapon)
+            {
+                case Weapons.Dagger:
+                case Weapons.Tanto:
+                case Weapons.Wakazashi:
+                case Weapons.Shortsword:
+                case Weapons.Broadsword:
+                case Weapons.Staff:
+                case Weapons.Mace:
+                    return 1;
+                case Weapons.Longsword:
+                case Weapons.Claymore:
+                case Weapons.Battle_Axe:
+                case Weapons.War_Axe:
+                case Weapons.Flail:
+                    return 2;
+                case Weapons.Saber:
+                case Weapons.Katana:
+                case Weapons.Dai_Katana:
+                case Weapons.Warhammer:
+                    return 3;
+                case Weapons.Short_Bow:
+                case Weapons.Long_Bow:
+                    return 4;
+                default:
+                    return 0;
+            }
+        }
+
+        public static int CalculateWeaponMaxDamage(Weapons weapon)
+        {
+            Func<Weapons, int> del;
+            if (TryGetOverride("CalculateWeaponMaxDamage", out del))
+                return del(weapon);
+
+            switch (weapon)
+            {
+                case Weapons.Dagger:
+                    return 6;
+                case Weapons.Tanto:
+                case Weapons.Shortsword:
+                case Weapons.Staff:
+                    return 8;
+                case Weapons.Wakazashi:
+                    return 10;
+                case Weapons.Broadsword:
+                case Weapons.Saber:
+                case Weapons.Battle_Axe:
+                case Weapons.Mace:
+                    return 12;
+                case Weapons.Flail:
+                    return 14;
+                case Weapons.Longsword:
+                case Weapons.Katana:
+                case Weapons.War_Axe:
+                case Weapons.Short_Bow:
+                    return 16;
+                case Weapons.Claymore:
+                case Weapons.Warhammer:
+                case Weapons.Long_Bow:
+                    return 18;
+                case Weapons.Dai_Katana:
+                    return 21;
+                default:
+                    return 0;
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -983,12 +983,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             if (TryGetOverride("CalculateWeaponToHit", out del))
                 return del(weapon);
 
-            int chanceToHitMod = 0;
-            if (weapon.GetWeaponMaterialModifier() > 0)
-            {
-                chanceToHitMod += weapon.GetWeaponMaterialModifier() * 10;
-            }
-            return chanceToHitMod;
+            return weapon.GetWeaponMaterialModifier() * 10;
         }
 
         private static int CalculateArmorToHit(DaggerfallEntity target, int struckBodyPart)

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -825,7 +825,7 @@ namespace DaggerfallWorkshop.Game.Formulas
         private static ToHitAndDamageMods CalculateRacialModifiers(DaggerfallEntity attacker, DaggerfallUnityItem weapon, PlayerEntity player)
         {
             Func<DaggerfallEntity, DaggerfallUnityItem, PlayerEntity, ToHitAndDamageMods> del;
-            if (TryGetOverride("CalculateSwingModifiers", out del))
+            if (TryGetOverride("CalculateRacialModifiers", out del))
                 return del(attacker, weapon, player);
 
             ToHitAndDamageMods mods = new ToHitAndDamageMods();

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -2442,117 +2442,88 @@ namespace DaggerfallWorkshop.Game.Formulas
         /// <returns>Item max enchantment power.</returns>
         public static int GetItemEnchantmentPower(DaggerfallUnityItem item)
         {
+            Func<DaggerfallUnityItem, int> del;
+            if (TryGetOverride("GetItemEnchantmentPower", out del))
+                return del(item);
+
             if (item == null)
                 throw new Exception("GetItemEnchantmentPower: item is null");
 
+            float multiplier = 0f;
             if (item.ItemGroup == ItemGroups.Weapons)
-                return GetWeaponEnchantmentPower(item);
+                multiplier = GetWeaponEnchantmentMultiplier((WeaponMaterialTypes)item.NativeMaterialValue);
             else if (item.ItemGroup == ItemGroups.Armor)
-                return GetArmorEnchantmentPower(item);
-            else
-                return item.ItemTemplate.enchantmentPoints;
-        }
-
-        public static int GetWeaponEnchantmentPower(DaggerfallUnityItem item)
-        {
-            if (item == null || item.ItemGroup != ItemGroups.Weapons)
-                throw new Exception("GetWeaponEnchantmentPower: item is null or not a weapon type");
-
-            // UESP lists regular material power progression in weapon matrix: https://en.uesp.net/wiki/Daggerfall:Enchantment_Power#Weapons
-            // Enchantment power values for staves are inaccurate in UESP weapon matrix (confirmed in classic)
-            // The below yields correct enchantment power for staves matching classic
-            float multiplier;
-            switch((WeaponMaterialTypes)item.NativeMaterialValue)
-            {
-                default:       
-                case WeaponMaterialTypes.Steel:         // Steel uses base enchantment power
-                    multiplier = 0;
-                    break;
-                case WeaponMaterialTypes.Iron:          // Iron is -25% from base
-                    multiplier = -0.25f;
-                    break;
-                case WeaponMaterialTypes.Silver:        // Silver is +75% from base
-                    multiplier = 0.75f;
-                    break;
-                case WeaponMaterialTypes.Elven:         // Elven is +25% from base
-                    multiplier = 0.25f;
-                    break;
-                case WeaponMaterialTypes.Dwarven:       // Dwarven is +50% from base
-                    multiplier = 0.5f;
-                    break;
-                case WeaponMaterialTypes.Mithril:       // Mithril is +25% from base
-                    multiplier = 0.25f;
-                    break;
-                case WeaponMaterialTypes.Adamantium:    // Adamantium is +75% from base
-                    multiplier = 0.75f;
-                    break;
-                case WeaponMaterialTypes.Ebony:         // Ebony is +100% from base
-                    multiplier = 1.0f;
-                    break;
-                case WeaponMaterialTypes.Orcish:        // Orcish is +150% from base
-                    multiplier = 1.5f;
-                    break;
-                case WeaponMaterialTypes.Daedric:       // Daedric is +200% from base
-                    multiplier = 2.0f;
-                    break;
-            }
+                multiplier = GetArmorEnchantmentMultiplier((ArmorMaterialTypes)item.NativeMaterialValue);
 
             // Final enchantment power is basePower + basePower*multiplier (rounded down)
-            int basePower = item.ItemTemplate.enchantmentPoints;
+            int basePower = item.enchantmentPoints;
             return basePower + Mathf.FloorToInt(basePower * multiplier);
         }
 
-        public static int GetArmorEnchantmentPower(DaggerfallUnityItem item)
+        public static float GetWeaponEnchantmentMultiplier(WeaponMaterialTypes weaponMaterial)
         {
-            if (item == null || item.ItemGroup != ItemGroups.Armor)
-                throw new Exception("GetArmorEnchantmentPower: item is null or not an armour type");
+            // UESP lists regular material power progression in weapon matrix: https://en.uesp.net/wiki/Daggerfall:Enchantment_Power#Weapons
+            // Enchantment power values for staves are inaccurate in UESP weapon matrix (confirmed in classic)
+            // The below yields correct enchantment power for staves matching classic
+            switch(weaponMaterial)
+            {
+                default:       
+                case WeaponMaterialTypes.Steel:         // Steel uses base enchantment power
+                    return 0f;
+                case WeaponMaterialTypes.Iron:          // Iron is -25% from base
+                    return -0.25f;
+                case WeaponMaterialTypes.Silver:        // Silver is +75% from base
+                    return 0.75f;
+                case WeaponMaterialTypes.Elven:         // Elven is +25% from base
+                    return 0.25f;
+                case WeaponMaterialTypes.Dwarven:       // Dwarven is +50% from base
+                    return 0.5f;
+                case WeaponMaterialTypes.Mithril:       // Mithril is +25% from base
+                    return 0.25f;
+                case WeaponMaterialTypes.Adamantium:    // Adamantium is +75% from base
+                    return 0.75f;
+                case WeaponMaterialTypes.Ebony:         // Ebony is +100% from base
+                    return 1.0f;
+                case WeaponMaterialTypes.Orcish:        // Orcish is +150% from base
+                    return 1.5f;
+                case WeaponMaterialTypes.Daedric:       // Daedric is +200% from base
+                    return 2.0f;
+            }
+        }
 
+        public static float GetArmorEnchantmentMultiplier(ArmorMaterialTypes armorMaterial)
+        {
             // UESP lists highly variable material power progression in armour matrix: https://en.uesp.net/wiki/Daggerfall:Enchantment_Power#Armor
             // This indicates certain armour types don't follow the same general material progression patterns for enchantment point multipliers
             // Yet to confirm this in classic - but not entirely confident in accuracy of UESP information here either
             // For now using consistent progression for enchantment point multipliers and can improve later if required
-            float multiplier;
-            switch ((ArmorMaterialTypes)item.NativeMaterialValue)
+            switch (armorMaterial)
             {
                 default:
                 case ArmorMaterialTypes.Leather:        // Leather/Chain/Steel all use base enchantment power
                 case ArmorMaterialTypes.Chain:
                 case ArmorMaterialTypes.Chain2:
                 case ArmorMaterialTypes.Steel:
-                    multiplier = 0;
-                    break;
+                    return 0f;
                 case ArmorMaterialTypes.Iron:           // Iron is -25% from base
-                    multiplier = -0.25f;
-                    break;
+                    return -0.25f;
                 case ArmorMaterialTypes.Silver:         // Silver is +75% from base
-                    multiplier = 0.75f;
-                    break;
+                    return 0.75f;
                 case ArmorMaterialTypes.Elven:          // Elven is +25% from base
-                    multiplier = 0.25f;
-                    break;
+                    return 0.25f;
                 case ArmorMaterialTypes.Dwarven:        // Dwarven is +50% from base
-                    multiplier = 0.5f;
-                    break;
+                    return 0.5f;
                 case ArmorMaterialTypes.Mithril:        // Mithril is +25% from base
-                    multiplier = 0.25f;
-                    break;
+                    return 0.25f;
                 case ArmorMaterialTypes.Adamantium:     // Adamantium is +75% from base
-                    multiplier = 0.75f;
-                    break;
+                    return 0.75f;
                 case ArmorMaterialTypes.Ebony:          // Ebony is +100% from base
-                    multiplier = 1.0f;
-                    break;
+                    return 1.0f;
                 case ArmorMaterialTypes.Orcish:         // Orcish is +150% from base
-                    multiplier = 1.5f;
-                    break;
+                    return 1.5f;
                 case ArmorMaterialTypes.Daedric:        // Daedric is +200% from base
-                    multiplier = 2.0f;
-                    break;
+                    return 2.0f;
             }
-
-            // Final enchantment power is basePower + basePower*multiplier (rounded down)
-            int basePower = item.ItemTemplate.enchantmentPoints;
-            return basePower + Mathf.FloorToInt(basePower * multiplier);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -790,7 +790,7 @@ namespace DaggerfallWorkshop.Game.Items
             return data;
         }
 
-        public SoundClips GetEquipSound()
+        public virtual SoundClips GetEquipSound()
         {
             switch (itemGroup)
             {
@@ -848,7 +848,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
         }
 
-        public SoundClips GetSwingSound()
+        public virtual SoundClips GetSwingSound()
         {
             switch (TemplateIndex)
             {
@@ -880,7 +880,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
         }
 
-        public int GetWeaponSkillUsed()
+        public virtual int GetWeaponSkillUsed()
         {
             switch (TemplateIndex)
             {
@@ -913,7 +913,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
         }
 
-        public short GetWeaponSkillIDAsShort()
+        public virtual short GetWeaponSkillIDAsShort()
         {
             int skill = GetWeaponSkillUsed();
             switch (skill)
@@ -939,12 +939,12 @@ namespace DaggerfallWorkshop.Game.Items
             return (DFCareer.Skills)GetWeaponSkillIDAsShort();
         }
 
-        public int GetBaseDamageMin()
+        public virtual int GetBaseDamageMin()
         {
             return FormulaHelper.CalculateWeaponMinDamage((Weapons)TemplateIndex);
         }
 
-        public int GetBaseDamageMax()
+        public virtual int GetBaseDamageMax()
         {
             return FormulaHelper.CalculateWeaponMaxDamage((Weapons)TemplateIndex);
         }
@@ -1031,7 +1031,7 @@ namespace DaggerfallWorkshop.Game.Items
             return result;
         }
 
-        public int GetShieldArmorValue()
+        public virtual int GetShieldArmorValue()
         {
             switch (TemplateIndex)
             {
@@ -1052,7 +1052,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Get body parts protected by a shield.
         /// </summary>
-        public BodyParts[] GetShieldProtectedBodyParts()
+        public virtual BodyParts[] GetShieldProtectedBodyParts()
         {
             switch (TemplateIndex)
             {

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -941,70 +941,12 @@ namespace DaggerfallWorkshop.Game.Items
 
         public int GetBaseDamageMin()
         {
-            switch (TemplateIndex)
-            {
-                case (int)Weapons.Dagger:
-                case (int)Weapons.Tanto:
-                case (int)Weapons.Wakazashi:
-                case (int)Weapons.Shortsword:
-                case (int)Weapons.Broadsword:
-                case (int)Weapons.Staff:
-                case (int)Weapons.Mace:
-                    return 1;
-                case (int)Weapons.Longsword:
-                case (int)Weapons.Claymore:
-                case (int)Weapons.Battle_Axe:
-                case (int)Weapons.War_Axe:
-                case (int)Weapons.Flail:
-                    return 2;
-                case (int)Weapons.Saber:
-                case (int)Weapons.Katana:
-                case (int)Weapons.Dai_Katana:
-                case (int)Weapons.Warhammer:
-                    return 3;
-                case (int)Weapons.Short_Bow:
-                case (int)Weapons.Long_Bow:
-                    return 4;
-
-                default:
-                    return 0;
-            }
+            return FormulaHelper.CalculateWeaponMinDamage((Weapons)TemplateIndex);
         }
 
         public int GetBaseDamageMax()
         {
-            switch (TemplateIndex)
-            {
-                case (int)Weapons.Dagger:
-                    return 6;
-                case (int)Weapons.Tanto:
-                case (int)Weapons.Shortsword:
-                case (int)Weapons.Staff:
-                    return 8;
-                case (int)Weapons.Wakazashi:
-                    return 10;
-                case (int)Weapons.Broadsword:
-                case (int)Weapons.Saber:
-                case (int)Weapons.Battle_Axe:
-                case (int)Weapons.Mace:
-                    return 12;
-                case (int)Weapons.Flail:
-                    return 14;
-                case (int)Weapons.Longsword:
-                case (int)Weapons.Katana:
-                case (int)Weapons.War_Axe:
-                case (int)Weapons.Short_Bow:
-                    return 16;
-                case (int)Weapons.Claymore:
-                case (int)Weapons.Warhammer:
-                case (int)Weapons.Long_Bow:
-                    return 18;
-                case (int)Weapons.Dai_Katana:
-                    return 21;
-
-                default:
-                    return 0;
-            }
+            return FormulaHelper.CalculateWeaponMaxDamage((Weapons)TemplateIndex);
         }
 
         public int GetWeaponMaterialModifier()

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -146,7 +146,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Gets inventory texture record.
         /// </summary>
-        public int InventoryTextureRecord
+        public virtual int InventoryTextureRecord
         {
             get { return GetInventoryTextureRecord(); }
         }
@@ -422,7 +422,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Gets native material value.
         /// </summary>
-        public int NativeMaterialValue
+        public virtual int NativeMaterialValue
         {
             get { return nativeMaterialValue; }
         }

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -165,7 +165,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// Gets or sets item group index.
         /// Setting will reset item data from new template.
         /// </summary>
-        public int GroupIndex
+        public virtual int GroupIndex
         {
             get { return groupIndex; }
             set { SetItem(itemGroup, value); }
@@ -977,7 +977,7 @@ namespace DaggerfallWorkshop.Game.Items
             }
         }
 
-        public int GetMaterialArmorValue()
+        public virtual int GetMaterialArmorValue()
         {
             int result = 0;
             if (!IsShield)
@@ -1123,6 +1123,21 @@ namespace DaggerfallWorkshop.Game.Items
                 default:
                     return BodyParts.None;
             }
+        }
+
+        public virtual EquipSlots GetEquipSlot()
+        {
+            return EquipSlots.None;
+        }
+
+        public virtual ItemHands GetItemHands()
+        {
+            return ItemHands.None;
+        }
+
+        public virtual WeaponTypes GetWeaponType()
+        {
+            return WeaponTypes.None;
         }
 
         public void LowerCondition(int amount, DaggerfallEntity unequipFromOwner = null, ItemCollection removeFromCollectionWhenBreaks = null)

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -20,6 +20,7 @@ using DaggerfallWorkshop.Game.Questing;
 using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using DaggerfallWorkshop.Game.Formulas;
+using UnityEngine;
 
 namespace DaggerfallWorkshop.Game.Items
 {
@@ -190,7 +191,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Resolve this item's name.
         /// </summary>
-        public string ItemName
+        public virtual string ItemName
         {
             get { return DaggerfallUnity.Instance.ItemHelper.ResolveItemName(this); }
         }
@@ -198,7 +199,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Resolve this item's full name (mainly for tooltips).
         /// </summary>
-        public string LongName
+        public virtual string LongName
         {
             get { return DaggerfallUnity.Instance.ItemHelper.ResolveItemLongName(this); }
         }
@@ -223,7 +224,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>
         /// Gets current variant of this item.
         /// </summary>
-        public int CurrentVariant
+        public virtual int CurrentVariant
         {
             get { return currentVariant; }
             set { SetCurrentVariant(value); }

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -1226,6 +1226,14 @@ namespace DaggerfallWorkshop.Game.Items
         }
 
         /// <summary>
+        /// Gets the enchantment points of this item.
+        /// </summary>
+        public virtual int GetEnchantmentPower()
+        {
+            return FormulaHelper.GetItemEnchantmentPower(this);
+        }
+
+        /// <summary>
         /// Set enchantments on this item. Any existing enchantments will be overwritten.
         /// </summary>
         /// <param name="enchantments">Array of enchantment settings. Maximum of 10 enchantments are applied.</param>

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -47,7 +47,7 @@ namespace DaggerfallWorkshop.Game.Items
         static readonly short[] valueMultipliersByMaterial = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
 
         // Condition multipliers by material type. Iron through Daedric. MaxCondition is baseMaxCondition * value / 4.
-        static readonly short[] conditionMultipliersByMaterial = { 4, 4, 6, 8, 12, 16, 20, 24, 28, 32 };
+        static readonly short[] conditionMultipliersByMaterial = { 4, 6, 6, 8, 12, 16, 20, 24, 28, 32 };
 
         // Enchantment point multipliers by material type. Iron through Daedric. Enchantment points is baseEnchanmentPoints * value / 4.
         static readonly short[] enchantmentPointMultipliersByMaterial = { 3, 4, 7, 5, 6, 5, 7, 8, 10, 12 };
@@ -680,9 +680,9 @@ namespace DaggerfallWorkshop.Game.Items
         {
             item.value *= 3 * valueMultipliersByMaterial[(int)material];
             item.weightInKg = CalculateWeightForMaterial(item, material);
-            item.maxCondition *= conditionMultipliersByMaterial[(int)material] / 4;
+            item.maxCondition = item.maxCondition * conditionMultipliersByMaterial[(int)material] / 4;
             item.currentCondition = item.maxCondition;
-            item.enchantmentPoints *= enchantmentPointMultipliersByMaterial[(int)material] / 4;
+            item.enchantmentPoints = item.enchantmentPoints * enchantmentPointMultipliersByMaterial[(int)material] / 4;
 
             return item;
         }

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -482,23 +482,7 @@ namespace DaggerfallWorkshop.Game.Items
             int groupIndex = DaggerfallUnity.Instance.ItemHelper.GetGroupIndex(ItemGroups.Armor, (int)armor);
             DaggerfallUnityItem newItem = new DaggerfallUnityItem(ItemGroups.Armor, groupIndex);
 
-            // Adjust for gender
-            if (gender == Genders.Female)
-                newItem.PlayerTextureArchive = firstFemaleArchive;
-            else
-                newItem.PlayerTextureArchive = firstMaleArchive;
-
-            // Adjust for body morphology
-            SetRace(newItem, race);
-
-            // Adjust material
-            ApplyArmorMaterial(newItem, material);
-
-            // Adjust for variant
-            if (variant >= 0)
-                SetVariant(newItem, variant);
-            else
-                RandomizeArmorVariant(newItem);
+            ApplyArmorSettings(newItem, gender, race, material, variant);
 
             return newItem;
         }
@@ -524,22 +508,31 @@ namespace DaggerfallWorkshop.Game.Items
             else
                 newItem = CreateItem(ItemGroups.Armor, customItemTemplates[groupIndex - enumArray.Length]);
 
-            // Adjust for gender
-            if (gender == Genders.Female)
-                newItem.PlayerTextureArchive = firstFemaleArchive;
-            else
-                newItem.PlayerTextureArchive = firstMaleArchive;
-
-            // Adjust for body morphology
-            SetRace(newItem, race);
-
-            // Random armor material
-            ArmorMaterialTypes material = RandomArmorMaterial(playerLevel);
-            ApplyArmorMaterial(newItem, material);
-
-            RandomizeArmorVariant(newItem);
+            ApplyArmorSettings(newItem, gender, race, RandomArmorMaterial(playerLevel));
 
             return newItem;
+        }
+
+        /// <summary>Set gender, body morphology and material of armor</summary>
+        public static void ApplyArmorSettings(DaggerfallUnityItem armor, Genders gender, Races race, ArmorMaterialTypes material, int variant = 0)
+        {
+            // Adjust for gender
+            if (gender == Genders.Female)
+                armor.PlayerTextureArchive = firstFemaleArchive;
+            else
+                armor.PlayerTextureArchive = firstMaleArchive;
+
+            // Adjust for body morphology
+            SetRace(armor, race);
+
+            // Adjust material
+            ApplyArmorMaterial(armor, material);
+
+            // Adjust for variant
+            if (variant >= 0)
+                SetVariant(armor, variant);
+            else
+                RandomizeArmorVariant(armor);
         }
 
         /// <summary>Set material and adjust armor stats accordingly</summary>

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -881,9 +881,14 @@ namespace DaggerfallWorkshop.Game.Items
                 if (item.nativeMaterialValue >= (int)ArmorMaterialTypes.Iron)
                     variant = UnityEngine.Random.Range(1, 4);
             }
+            else if (item.IsOfTemplate(ItemGroups.Armor, (int)Armor.Boots) && (item.nativeMaterialValue >= (int)ArmorMaterialTypes.Iron))
+            {
+                variant = UnityEngine.Random.Range(1, 3);
+            }
             else if (item.IsOfTemplate(ItemGroups.Armor, (int)Armor.Helm))
+            {
                 variant = UnityEngine.Random.Range(0, item.ItemTemplate.variants);
-
+            }
             SetVariant(item, variant);
         }
 

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -419,10 +419,8 @@ namespace DaggerfallWorkshop.Game.Items
                 newItem.currentCondition = 0; // not sure if this is necessary, but classic does it
             }
             else
-            {   // Adjust material
-                newItem.nativeMaterialValue = (int)material;
-                newItem = SetItemPropertiesByMaterial(newItem, material);
-                newItem.dyeColor = DaggerfallUnity.Instance.ItemHelper.GetWeaponDyeColor(material);
+            {
+                ApplyWeaponMaterial(newItem, material);
             }
             return newItem;
         }
@@ -448,10 +446,7 @@ namespace DaggerfallWorkshop.Game.Items
  
             // Random weapon material
             WeaponMaterialTypes material = RandomMaterial(playerLevel);
-            newItem.nativeMaterialValue = (int)material;
-
-            newItem = SetItemPropertiesByMaterial(newItem, material);
-            newItem.dyeColor = itemHelper.GetWeaponDyeColor(material);
+            ApplyWeaponMaterial(newItem, material);
 
             // Handle arrows
             if (groupIndex == 18)
@@ -462,6 +457,14 @@ namespace DaggerfallWorkshop.Game.Items
             }
 
             return newItem;
+        }
+
+        /// <summary>Set material and adjust weapon stats accordingly</summary>
+        public static void ApplyWeaponMaterial(DaggerfallUnityItem weapon, WeaponMaterialTypes material)
+        {
+            weapon.nativeMaterialValue = (int)material;
+            weapon = SetItemPropertiesByMaterial(weapon, material);
+            weapon.dyeColor = DaggerfallUnity.Instance.ItemHelper.GetWeaponDyeColor(material);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -46,13 +46,6 @@ namespace DaggerfallWorkshop.Game.Items
         // Value multipliers by material type. Iron through Daedric. Value is baseValue * ( 3 * value).
         static readonly short[] valueMultipliersByMaterial = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
 
-        // Condition multipliers by material type. Iron through Daedric. MaxCondition is baseMaxCondition * value / 4.
-<<<<<<< HEAD
-        static readonly short[] conditionMultipliersByMaterial = { 4, 6, 6, 8, 12, 16, 20, 24, 28, 32 };
-=======
-        static readonly short[] conditionMultipliersByMaterial = { 4, 4, 6, 8, 12, 16, 20, 24, 28, 32 };
->>>>>>> 7b9ac03215ea3c6374a6050cda6441f9bec95349
-
         // Enchantment point/gold value data for item powers
         static readonly int[] extraSpellPtsEnchantPts = { 0x1F4, 0x1F4, 0x1F4, 0x1F4, 0xC8, 0xC8, 0xC8, 0x2BC, 0x320, 0x384, 0x3E8 };
         static readonly int[] potentVsEnchantPts = { 0x320, 0x384, 0x3E8, 0x4B0 };

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -46,6 +46,9 @@ namespace DaggerfallWorkshop.Game.Items
         // Value multipliers by material type. Iron through Daedric. Value is baseValue * ( 3 * value).
         static readonly short[] valueMultipliersByMaterial = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
 
+        // Condition multipliers by material type. Iron through Daedric. MaxCondition is baseMaxCondition * value / 4.
+        static readonly short[] conditionMultipliersByMaterial = { 4, 6, 6, 8, 12, 16, 20, 24, 28, 32 };
+
         // Enchantment point/gold value data for item powers
         static readonly int[] extraSpellPtsEnchantPts = { 0x1F4, 0x1F4, 0x1F4, 0x1F4, 0xC8, 0xC8, 0xC8, 0x2BC, 0x320, 0x384, 0x3E8 };
         static readonly int[] potentVsEnchantPts = { 0x320, 0x384, 0x3E8, 0x4B0 };

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -47,7 +47,11 @@ namespace DaggerfallWorkshop.Game.Items
         static readonly short[] valueMultipliersByMaterial = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
 
         // Condition multipliers by material type. Iron through Daedric. MaxCondition is baseMaxCondition * value / 4.
+<<<<<<< HEAD
         static readonly short[] conditionMultipliersByMaterial = { 4, 6, 6, 8, 12, 16, 20, 24, 28, 32 };
+=======
+        static readonly short[] conditionMultipliersByMaterial = { 4, 4, 6, 8, 12, 16, 20, 24, 28, 32 };
+>>>>>>> 7b9ac03215ea3c6374a6050cda6441f9bec95349
 
         // Enchantment point/gold value data for item powers
         static readonly int[] extraSpellPtsEnchantPts = { 0x1F4, 0x1F4, 0x1F4, 0x1F4, 0xC8, 0xC8, 0xC8, 0x2BC, 0x320, 0x384, 0x3E8 };

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -158,6 +158,9 @@ namespace DaggerfallWorkshop.Game.Items
         /// <returns>DaggerfallUnityItem.</returns>
         public static DaggerfallUnityItem CreateItem(ItemGroups itemGroup, int templateIndex)
         {
+            if (templateIndex > ItemHelper.LastDFTemplate)
+                return new DaggerfallUnityItem(itemGroup, templateIndex);
+
             // Create item
             int groupIndex = DaggerfallUnity.Instance.ItemHelper.GetGroupIndex(itemGroup, templateIndex);
             if (groupIndex == -1)

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -49,9 +49,6 @@ namespace DaggerfallWorkshop.Game.Items
         // Condition multipliers by material type. Iron through Daedric. MaxCondition is baseMaxCondition * value / 4.
         static readonly short[] conditionMultipliersByMaterial = { 4, 6, 6, 8, 12, 16, 20, 24, 28, 32 };
 
-        // Enchantment point multipliers by material type. Iron through Daedric. Enchantment points is baseEnchanmentPoints * value / 4.
-        static readonly short[] enchantmentPointMultipliersByMaterial = { 3, 4, 7, 5, 6, 5, 7, 8, 10, 12 };
-
         // Enchantment point/gold value data for item powers
         static readonly int[] extraSpellPtsEnchantPts = { 0x1F4, 0x1F4, 0x1F4, 0x1F4, 0xC8, 0xC8, 0xC8, 0x2BC, 0x320, 0x384, 0x3E8 };
         static readonly int[] potentVsEnchantPts = { 0x320, 0x384, 0x3E8, 0x4B0 };
@@ -698,7 +695,6 @@ namespace DaggerfallWorkshop.Game.Items
             item.weightInKg = CalculateWeightForMaterial(item, material);
             item.maxCondition = item.maxCondition * conditionMultipliersByMaterial[(int)material] / 4;
             item.currentCondition = item.maxCondition;
-            item.enchantmentPoints = item.enchantmentPoints * enchantmentPointMultipliersByMaterial[(int)material] / 4;
 
             return item;
         }

--- a/Assets/Scripts/Game/Items/ItemEquipTable.cs
+++ b/Assets/Scripts/Game/Items/ItemEquipTable.cs
@@ -245,7 +245,10 @@ namespace DaggerfallWorkshop.Game.Items
         /// <returns>EquipSlot.</returns>
         public EquipSlots GetEquipSlot(DaggerfallUnityItem item)
         {
-            EquipSlots result = EquipSlots.None;
+            // Check for a custom item defining an equip slot, and return if so, else if None then continue
+            EquipSlots result = item.GetEquipSlot();
+            if (result != EquipSlots.None)
+                return result;
 
             // Resolve based on equipment category
             switch (item.ItemGroup)
@@ -642,8 +645,8 @@ namespace DaggerfallWorkshop.Game.Items
                     return ItemHands.LeftOnly;
             }
 
-            // Nothing found
-            return ItemHands.None;
+            // Nothing found, return custom item value or None.
+            return item.GetItemHands();
         }
 
         #endregion

--- a/Assets/Scripts/Game/PlayerFootsteps.cs
+++ b/Assets/Scripts/Game/PlayerFootsteps.cs
@@ -227,7 +227,7 @@ namespace DaggerfallWorkshop.Game
             // Check if player is grounded
             // Note: In classic, submerged "footstep" sound is only played when walking on the floor while in the water, but it sounds like a swimming sound
             // and when outside is played while swimming at the water's surface, so it seems better to play it all the time while submerged in water.
-            if (currentFootstepSound1 != FootstepSoundSubmerged)
+            if (!playerMotor.IsSwimming)
             {
                 if (!IsGrounded())
                 {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1333,7 +1333,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     prohibited = true;
 
                 // Check for prohibited material
-                else if (((item.NativeMaterialValue >> 8) == 2)
+                else if (((item.nativeMaterialValue >> 8) == 2)
                     && (1 << (item.NativeMaterialValue & 0xFF) & (int)playerEntity.Career.ForbiddenMaterials) != 0)
                     prohibited = true;
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs
@@ -198,7 +198,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 int totalEnchantmentCost = GetTotalEnchantmentCost();
                 int totalGoldCost = GetTotalGoldCost();
-                enchantmentCostLabel.Text = string.Format("{0}/{1}", totalEnchantmentCost, FormulaHelper.GetItemEnchantmentPower(selectedItem));
+                int itemEnchantmentPower = selectedItem.GetEnchantmentPower();
+
+                enchantmentCostLabel.Text = string.Format("{0}/{1}", totalEnchantmentCost, itemEnchantmentPower);
+                Debug.LogFormat("used: {0} onBuild: {1}", itemEnchantmentPower, selectedItem.enchantmentPoints);
+
                 goldCostLabel.Text = totalGoldCost.ToString();
             }
 
@@ -713,7 +717,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Get costs
             int totalEnchantmentCost = GetTotalEnchantmentCost();
             int totalGoldCost = GetTotalGoldCost();
-            int itemEnchantmentPower = FormulaHelper.GetItemEnchantmentPower(selectedItem);
+            int itemEnchantmentPower = selectedItem.GetEnchantmentPower();
 
             // Check for available gold and display "You do not have the gold to properly pay the enchanter." if not enough
             int playerGold = GameManager.Instance.PlayerEntity.GetGoldAmount();

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -249,6 +249,12 @@ namespace DaggerfallWorkshop
                                         WeaponMaterialTypes material = ItemBuilder.RandomMaterial(playerEntity.Level);
                                         ItemBuilder.ApplyWeaponMaterial(item, material);
                                     }
+                                    else if (itemGroup == ItemGroups.Armor)
+                                    {
+                                        ArmorMaterialTypes material = ItemBuilder.RandomArmorMaterial(playerEntity.Level);
+                                        ItemBuilder.SetRace(item, playerEntity.Race);
+                                        ItemBuilder.ApplyArmorMaterial(item, material);
+                                    }
 
                                     items.AddItem(item);
                                 }

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -247,9 +247,7 @@ namespace DaggerfallWorkshop
                                     if (itemGroup == ItemGroups.Weapons)
                                     {
                                         WeaponMaterialTypes material = ItemBuilder.RandomMaterial(playerEntity.Level);
-                                        item.nativeMaterialValue = (int)material;
-                                        item = ItemBuilder.SetItemPropertiesByMaterial(item, material);
-                                        item.dyeColor = DaggerfallUnity.Instance.ItemHelper.GetWeaponDyeColor(material);
+                                        ItemBuilder.ApplyWeaponMaterial(item, material);
                                     }
 
                                     items.AddItem(item);

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -17,6 +17,7 @@ using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using DaggerfallWorkshop.Game.Formulas;
+using DaggerfallConnect.FallExe;
 
 namespace DaggerfallWorkshop
 {
@@ -194,7 +195,7 @@ namespace DaggerfallWorkshop
                         System.Array enumArray = DaggerfallUnity.Instance.ItemHelper.GetEnumArray(itemGroup);
                         for (int j = 0; j < enumArray.Length; ++j)
                         {
-                            DaggerfallConnect.FallExe.ItemTemplate itemTemplate = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(itemGroup, j);
+                            ItemTemplate itemTemplate = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(itemGroup, j);
                             if (itemTemplate.rarity <= shopQuality)
                             {
                                 int stockChance = chanceMod * 5 * (21 - itemTemplate.rarity) / 100;
@@ -225,6 +226,23 @@ namespace DaggerfallWorkshop
                                         if (DaggerfallUnity.Settings.PlayerTorchFromItems && item.IsOfTemplate(ItemGroups.UselessItems2, (int)UselessItems2.Oil))
                                             item.stackCount = Random.Range(5, 20 + 1);  // Shops stock 5-20 bottles
                                     }
+                                    items.AddItem(item);
+                                }
+                            }
+                        }
+                        // Add any modded items registered for shop stocking
+                        int[] itemTemplateIndexes = DaggerfallUnity.Instance.ItemHelper.GetItemShopStock(itemGroup);
+                        for (int j = 0; j < itemTemplateIndexes.Length; j++)
+                        {
+                            ItemTemplate itemTemplate = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(itemGroup, itemTemplateIndexes[j]);
+                            if (itemTemplate.rarity <= shopQuality)
+                            {
+                                int stockChance = chanceMod * 5 * (21 - itemTemplate.rarity) / 100;
+                                if (Dice100.SuccessRoll(stockChance))
+                                {
+                                    // TODO: Allow new item classes to be instantiated here...
+
+                                    DaggerfallUnityItem item = ItemBuilder.CreateItem(itemGroup, itemTemplateIndexes[j]);
                                     items.AddItem(item);
                                 }
                             }

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -18,6 +18,7 @@ using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallConnect.FallExe;
+using DaggerfallWorkshop.Game.Entity;
 
 namespace DaggerfallWorkshop
 {
@@ -252,8 +253,7 @@ namespace DaggerfallWorkshop
                                     else if (itemGroup == ItemGroups.Armor)
                                     {
                                         ArmorMaterialTypes material = ItemBuilder.RandomArmorMaterial(playerEntity.Level);
-                                        ItemBuilder.SetRace(item, playerEntity.Race);
-                                        ItemBuilder.ApplyArmorMaterial(item, material);
+                                        ItemBuilder.ApplyArmorSettings(item, playerEntity.Gender, playerEntity.Race, material);
                                     }
 
                                     items.AddItem(item);

--- a/Assets/Scripts/Utility/ClimateSwaps.cs
+++ b/Assets/Scripts/Utility/ClimateSwaps.cs
@@ -239,13 +239,13 @@ namespace DaggerfallWorkshop.Utility
             // Exclude ranges which return a false-positive from this method but actually use normal emission
             // Currently spells and lights
             if (archive >= 375 && archive <= 379 ||
-                archive == 210)
+                archive == 210 || archive == 280)
             {
                 return false;
             }
 
             // Normalise archive index
-            archive = (archive - (archive / 100) * 100);
+            archive = archive % 100;
 
             // First check if texture archive even has a window, based on known archives
             switch (archive)

--- a/Assets/Scripts/Utility/ImageReader.cs
+++ b/Assets/Scripts/Utility/ImageReader.cs
@@ -448,7 +448,7 @@ namespace DaggerfallWorkshop.Utility
 
             // Get colors array without mask
             Color32[] colors = imageData.dfBitmap.GetColor32(imageData.alphaIndex, 0xff, maskColor, true);
-            if (colors == null)
+            if (colors == null || colors.Length == 0)
                 return;
 
             // Create new Texture2D from mask

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -123,7 +123,7 @@ namespace DaggerfallWorkshop.Utility
             { "%kno", FactionOrderName }, // A knightly guild name
             { "%lev", GuildTitle }, // Rank in guild that you are in.
             { "%lp", LocalPalace },  //  Local / palace (?) dungeon
-            { "%ln", null },  //  Random lastname
+            { "%ln", LastName },  //  Random lastname
             { "%loc", MarkLocationOnMap }, // Location marked on map (comment Nystul: this seems to be context dependent - it is used both in direction dialogs (7333) and map reveal dialogs (7332) - it seems to return the name of the building and reveal the map only if a 7332 dialog was chosen
             { "%lt1", TitleOfLordOfFaction1 }, // Title of _fl1
             { "%ltn", LegalReputation }, // In the eyes of the law you are.......
@@ -986,6 +986,11 @@ namespace DaggerfallWorkshop.Utility
         private static string LocationOfRegionalBuilding(IMacroContextProvider mcp)
         {   // %fcn
             return GameManager.Instance.TalkManager.LocationOfRegionalBuilding;
+        }
+
+        private static string LastName(IMacroContextProvider mcp)
+        {   // %ln
+            return DaggerfallUnity.Instance.NameHelper.Surname(GetRandomNameBank());
         }
 
         private static string FemaleName(IMacroContextProvider mcp)

--- a/Assets/Scripts/Utility/TextureReader.cs
+++ b/Assets/Scripts/Utility/TextureReader.cs
@@ -10,9 +10,7 @@
 //
 
 using UnityEngine;
-using UnityEngine.Rendering;
 using System.IO;
-using System.Collections;
 using System.Collections.Generic;
 using DaggerfallConnect;
 using DaggerfallConnect.Utility;
@@ -970,6 +968,29 @@ namespace DaggerfallWorkshop.Utility
             new DaggerfallTextureIndex() { archive = 253, record = 52 },
             new DaggerfallTextureIndex() { archive = 253, record = 75 },
             new DaggerfallTextureIndex() { archive = 253, record = 77 },
+
+            // Frost daedra
+            new DaggerfallTextureIndex() { archive = 280, record = 0 },
+            new DaggerfallTextureIndex() { archive = 280, record = 1 },
+            new DaggerfallTextureIndex() { archive = 280, record = 2 },
+            new DaggerfallTextureIndex() { archive = 280, record = 3 },
+            new DaggerfallTextureIndex() { archive = 280, record = 4 },
+            new DaggerfallTextureIndex() { archive = 280, record = 5 },
+            new DaggerfallTextureIndex() { archive = 280, record = 6 },
+            new DaggerfallTextureIndex() { archive = 280, record = 7 },
+            new DaggerfallTextureIndex() { archive = 280, record = 8 },
+            new DaggerfallTextureIndex() { archive = 280, record = 9 },
+            new DaggerfallTextureIndex() { archive = 280, record = 10 },
+            new DaggerfallTextureIndex() { archive = 280, record = 11 },
+            new DaggerfallTextureIndex() { archive = 280, record = 12 },
+            new DaggerfallTextureIndex() { archive = 280, record = 13 },
+            new DaggerfallTextureIndex() { archive = 280, record = 14 },
+            new DaggerfallTextureIndex() { archive = 280, record = 15 },
+            new DaggerfallTextureIndex() { archive = 280, record = 16 },
+            new DaggerfallTextureIndex() { archive = 280, record = 17 },
+            new DaggerfallTextureIndex() { archive = 280, record = 18 },
+            new DaggerfallTextureIndex() { archive = 280, record = 19 },
+            new DaggerfallTextureIndex() { archive = 400, record = 3 }, // corpse
 
             // Fire daedra
             new DaggerfallTextureIndex() { archive = 281, record = 0 },

--- a/Assets/StreamingAssets/Quests/N0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y03.txt
@@ -131,7 +131,8 @@ Foe _F.01_ is 4 Knight
 	log 1010 step 0
 	create npc at _magesguild_ 
 
-_oneday_ task:
+_timeout_ task:
+	when _oneday_ and not _S.07_ 
 	end quest 
 
 _clickonqgiver_ task:
@@ -174,7 +175,6 @@ _S.08_ task:
 
 _questdone_ task:
 	when _S.10_ and _S.07_ 
-	when _oneday_ and not _S.07_ 
 	make _treasure_ permanent 
 	end quest 
 


### PR DESCRIPTION
Builds on the rudimentary support I added for the locator device 2 years ago.

Now uses the item templates file and defines a template index which for custom items is used for the group index as well.

Regarding paperdoll items, Weapons and armor are fully functional and tested. Clothing may need a bit more work which I will look at soon but I wanted to get this on the list of PRs so people can start to review the changes. Corresponding changes can be found in my Archs mod and Loot Realism on this branch: https://github.com/ajrb/dfunity-mods/tree/moderateWeaponMaterials

Loot realism now adds 2 new weapons: Archers Axe and Light Flail, and also a new lighter set of mail armor allowing players who can't wear plate to get high level material armor pieces.

NOTE: This PR builds on #1747 and as such contains all of those changes as well. (first 9 commits) Either review & merge this one and I'll close that one, or review & merge #1747 first and then this should lose all those changes to allow it to be reviewed separately.

