### PR TITLE
Fix dungeon exit and other static door overlap

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
+++ b/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
@@ -129,7 +129,8 @@ namespace DaggerfallWorkshop
                 {
                     found = true;
                     doorOut = Doors[i];
-                    break;
+                    if (doorOut.doorType == DoorTypes.DungeonExit)
+                        break;
                 }
             }
 


### PR DESCRIPTION
I case they're several static door hits, give higher priority to dungeon exit
Alternate implementation would be to add static doors deduplication in RemoveOverlappingDoors(), but I'm not sure it's worth the extra complexity.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=24&t=3390