### PR TITLE
Add furniture category which are present, just rare

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -108,6 +108,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 { ItemGroups.Books } },
             { DFLocation.BuildingTypes.ClothingStore, new List<ItemGroups>()
                 { ItemGroups.MensClothing, ItemGroups.WomensClothing } },
+            { DFLocation.BuildingTypes.FurnitureStore, new List<ItemGroups>()
+                { ItemGroups.Furniture } },
             { DFLocation.BuildingTypes.GemStore, new List<ItemGroups>()
                 { ItemGroups.Gems, ItemGroups.Jewellery } },
             { DFLocation.BuildingTypes.GeneralStore, new List<ItemGroups>()


### PR DESCRIPTION
Players can never have anything that will be sellable, but this gives mods the chance to flesh out or repurpose furniture stores if they want to.

See https://forums.dfworkshop.net/viewtopic.php?f=5&t=3550