### PR TITLE
Custom flat / model activation

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -148,7 +148,6 @@ namespace DaggerfallWorkshop.Game
             DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName, true);
             CustomModActivation existingActivation;
             if (customModActivations.TryGetValue(goFlatModelName, out existingActivation) && existingActivation.Provider.LoadPriority > provider.LoadPriority) {
-                allowRegistration = false;
                 Debug.Log("Denied custom activation registration from " + provider.Title + " for " + goFlatModelName + " | " + existingActivation.Provider.Title + " has higher load priority");
             } else {
                 customModActivations[goFlatModelName] = new CustomModActivation(customActivation, activationDistance, provider);

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -47,7 +47,6 @@ namespace DaggerfallWorkshop.Game
     /// </summary>
     public class PlayerActivate : MonoBehaviour
     {
-
         PlayerGPS playerGPS;
         PlayerEnterExit playerEnterExit;        // Example component to enter/exit buildings
         GameObject mainCamera;
@@ -121,7 +120,7 @@ namespace DaggerfallWorkshop.Game
         public static void RegisterCustomActivation(Mod provider, uint modelID, CustomActivation customActivation, float activationDistance = DefaultActivationDistance)
         {
             string goModelName = GameObjectHelper.GetGoModelName(modelID);
-            HandleRegisterCustomActivation(provider, goModelName, customActivation, activationDistance);
+            RegisterCustomActivation(provider, goModelName, customActivation, activationDistance);
         }
 
         /// <summary>
@@ -134,7 +133,7 @@ namespace DaggerfallWorkshop.Game
         public static void RegisterCustomActivation(Mod provider, int textureArchive, int textureRecord, CustomActivation customActivation, float activationDistance = DefaultActivationDistance)
         {
             string goFlatName = GameObjectHelper.GetGoFlatName(textureArchive, textureRecord);
-            HandleRegisterCustomActivation(provider, goFlatName, customActivation, activationDistance);
+            RegisterCustomActivation(provider, goFlatName, customActivation, activationDistance);
         }
 
         /// <summary>
@@ -144,13 +143,13 @@ namespace DaggerfallWorkshop.Game
         /// <param name="textureArchive">The texture archive of the flat object that will trigger the custom action upon activation.</param>
         /// <param name="textureRecord">The texture record of the flat object that will trigger the custom action upon activation.</param>
         /// <param name="customActivation">A callback that implements the custom action.</param>
-        private static void HandleRegisterCustomActivation(Mod provider, string goFlatModelName, CustomActivation customActivation, float activationDistance)
+        private static void RegisterCustomActivation(Mod provider, string goFlatModelName, CustomActivation customActivation, float activationDistance)
         {
             DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName, true);
             bool allowRegistration = true;
             CustomModActivation existingActivation;
             if (customModActivations.TryGetValue(goFlatModelName, out existingActivation)) {
-                if(existingActivation.Provider.LoadPriority > provider.LoadPriority) {
+                if (existingActivation.Provider.LoadPriority > provider.LoadPriority) {
                     allowRegistration = false;
                     Debug.Log("Denied custom activation registration from " + provider.Title + " for " + goFlatModelName + " | " + existingActivation.Provider.Title + " has higher load priority");
                 }
@@ -366,11 +365,9 @@ namespace DaggerfallWorkshop.Game
                         flatModelName = flatModelName.Remove(pos + 1);
 
                     CustomModActivation customActivation;
-                    if (customModActivations.TryGetValue(flatModelName, out customActivation))
+                    if (customModActivations.TryGetValue(flatModelName, out customActivation) && hit.distance <= customActivation.ActivationDistance)
                     {
-                        if(hit.distance <= customActivation.ActivationDistance) {
-                            customActivation.Action(hit);
-                        }
+                        customActivation.Action(hit);
                     }
 
                     // Check for custom activation

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -92,30 +92,30 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Allow mods to register custom flat / model activation methods.
-        public delegate void FlatModelActivation(Transform transform);
-        private static Dictionary<string, FlatModelActivation> customFlatModelActivations = new Dictionary<string, FlatModelActivation>();
+        public delegate void CustomActivation(Transform transform);
+        private static Dictionary<string, CustomActivation> customActivations = new Dictionary<string, CustomActivation>();
 
-        public static bool RegisterFlatModelActivation(uint modelID, FlatModelActivation flatModelActivation)
+        public static bool RegisterCustomActivation(uint modelID, CustomActivation customActivation)
         {
             string goModelName = GameObjectHelper.GetGoModelName(modelID);
-            return HandleRegisterFlatModelActivation(goModelName, flatModelActivation);
+            return HandleRegisterCustomActivation(goModelName, customActivation);
         }
 
-        public static bool RegisterFlatModelActivation(int textureArchive, int textureRecord, FlatModelActivation flatModelActivation)
+        public static bool RegisterCustomActivation(int textureArchive, int textureRecord, CustomActivation customActivation)
         {
             string goFlatName = GameObjectHelper.GetGoFlatName(textureArchive, textureRecord);
-            return HandleRegisterFlatModelActivation(goFlatName, flatModelActivation);
+            return HandleRegisterCustomActivation(goFlatName, customActivation);
         }
 
-        public static bool HandleRegisterFlatModelActivation(string goFlatModelName, FlatModelActivation flatModelActivation)
+        public static bool HandleRegisterCustomActivation(string goFlatModelName, CustomActivation customActivation)
         {
-            DaggerfallUnity.LogMessage("HandleRegisterFlatModelActivation: " + goFlatModelName, true);
+            DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName, true);
             if (!CheckCustomActivation(goFlatModelName))
             {
-                customFlatModelActivations.Add(goFlatModelName, flatModelActivation);
+                customActivations.Add(goFlatModelName, customActivation);
                 return true;
             } else {
-                DaggerfallUnity.LogMessage("HandleRegisterFlatModelActivation: " + goFlatModelName + " already registered", true);
+                DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName + " already registered", true);
             }
             return false;
         }
@@ -133,7 +133,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         public static bool CheckCustomActivation(string goFlatModelName) {
-            return customFlatModelActivations.ContainsKey(goFlatModelName);
+            return customActivations.ContainsKey(goFlatModelName);
         }
 
         void Start()
@@ -311,10 +311,10 @@ namespace DaggerfallWorkshop.Game
                     if (pos > 0 && pos < modelName.Length - 1)
                         modelName = modelName.Remove(pos + 1);
 
-                    FlatModelActivation flatModelActivation;
-                    if (customFlatModelActivations.TryGetValue(modelName, out flatModelActivation))
+                    CustomActivation customActivation;
+                    if (customActivations.TryGetValue(modelName, out customActivation))
                     {
-                        flatModelActivation(hit.transform);
+                        customActivation(hit.transform);
                     }
 
                     // Check for custom activation

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -107,7 +107,7 @@ namespace DaggerfallWorkshop.Game
             return HandleRegisterCustomActivation(goFlatName, customActivation);
         }
 
-        public static bool HandleRegisterCustomActivation(string goFlatModelName, CustomActivation customActivation)
+        private static bool HandleRegisterCustomActivation(string goFlatModelName, CustomActivation customActivation)
         {
             DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName, true);
             if (!CheckCustomActivation(goFlatModelName))

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -116,16 +116,16 @@ namespace DaggerfallWorkshop.Game
         public static bool HasCustomActivation(uint modelID)
         {
             string goModelName = GameObjectHelper.GetGoModelName(modelID);
-            return CheckCustomActivation(goModelName);
+            return HasCustomActivation(goModelName);
         }
 
         public static bool HasCustomActivation(int textureArchive, int textureRecord)
         {
             string goFlatName = GameObjectHelper.GetGoFlatName(textureArchive, textureRecord);
-            return CheckCustomActivation(goFlatName);
+            return HasCustomActivation(goFlatName);
         }
 
-        public static bool CheckCustomActivation(string goFlatModelName) {
+        public static bool HasCustomActivation(string goFlatModelName) {
             return customActivations.ContainsKey(goFlatModelName);
         }
 

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -49,19 +49,6 @@ namespace DaggerfallWorkshop.Game
     public class PlayerActivate : MonoBehaviour
     {
 
-        private struct CustomModActivation
-        {
-            internal readonly CustomActivation Action;
-            internal readonly Mod Provider;
-
-            internal CustomModActivation(CustomActivation action, Mod provider)
-            {
-                Action = action;
-                Provider = provider;
-            }
-        }
-        readonly static Dictionary<string, CustomModActivation> customModActivations = new Dictionary<string, CustomModActivation>();
-
         PlayerGPS playerGPS;
         PlayerEnterExit playerEnterExit;        // Example component to enter/exit buildings
         GameObject mainCamera;
@@ -107,22 +94,55 @@ namespace DaggerfallWorkshop.Game
                     closeHours[(int)buildingType] > DaggerfallUnity.Instance.WorldTime.Now.Hour);
         }
 
+        #region custom mod activation
+        private struct CustomModActivation
+        {
+            internal readonly CustomActivation Action;
+            internal readonly Mod Provider;
+
+            internal CustomModActivation(CustomActivation action, Mod provider)
+            {
+                Action = action;
+                Provider = provider;
+            }
+        }
+        readonly static Dictionary<string, CustomModActivation> customModActivations = new Dictionary<string, CustomModActivation>();
         // Allow mods to register custom flat / model activation methods.
         public delegate void CustomActivation(RaycastHit hit);
         //private static readonly Dictionary<string, CustomActivation> customActivations = new Dictionary<string, CustomActivation>();
 
+        /// <summary>
+        /// Registers a custom activation for a model object. Uses the modelID parameter to retrieve the correct object name
+        /// </summary>
+        /// <param name="provider">The mod that provides this override; used to enforce load order.</param>
+        /// <param name="modelID">The model ID of the object that will trigger the custom action upon activation.</param>
+        /// <param name="customActivation">A callback that implements the custom action.</param>
         public static void RegisterCustomActivation(Mod provider, uint modelID, CustomActivation customActivation)
         {
             string goModelName = GameObjectHelper.GetGoModelName(modelID);
             HandleRegisterCustomActivation(provider, goModelName, customActivation);
         }
 
+        /// <summary>
+        /// Registers a custom activation for a flat object. Uses the textureArchive and textureRecord parameters to retrieve the correct object name
+        /// </summary>
+        /// <param name="provider">The mod that provides this override; used to enforce load order.</param>
+        /// <param name="textureArchive">The texture archive of the flat object that will trigger the custom action upon activation.</param>
+        /// <param name="textureRecord">The texture record of the flat object that will trigger the custom action upon activation.</param>
+        /// <param name="customActivation">A callback that implements the custom action.</param>
         public static void RegisterCustomActivation(Mod provider, int textureArchive, int textureRecord, CustomActivation customActivation)
         {
             string goFlatName = GameObjectHelper.GetGoFlatName(textureArchive, textureRecord);
             HandleRegisterCustomActivation(provider, goFlatName, customActivation);
         }
 
+        /// <summary>
+        /// Registers a custom activation for a flat object
+        /// </summary>
+        /// <param name="provider">The mod that provides this override; used to enforce load order.</param>
+        /// <param name="textureArchive">The texture archive of the flat object that will trigger the custom action upon activation.</param>
+        /// <param name="textureRecord">The texture record of the flat object that will trigger the custom action upon activation.</param>
+        /// <param name="customActivation">A callback that implements the custom action.</param>
         private static void HandleRegisterCustomActivation(Mod provider, string goFlatModelName, CustomActivation customActivation)
         {
             DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName, true);
@@ -155,6 +175,7 @@ namespace DaggerfallWorkshop.Game
         public static bool HasCustomActivation(string goFlatModelName) {
             return customModActivations.ContainsKey(goFlatModelName);
         }
+        #endregion
 
         void Start()
         {

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -67,14 +67,14 @@ namespace DaggerfallWorkshop.Game
                                                                     // be done in classic for as far as the view distance.
 
         // Maximum distance from which different object types can be activated, converted from classic units (divided by 40)
-        const float DefaultActivationDistance = 128 * MeshReader.GlobalScale;
-        const float DoorActivationDistance = 128 * MeshReader.GlobalScale;
-        const float TreasureActivationDistance = 128 * MeshReader.GlobalScale;
-        const float PickpocketDistance = 128 * MeshReader.GlobalScale;
-        const float CorpseActivationDistance = 150 * MeshReader.GlobalScale;
+        public const float DefaultActivationDistance = 128 * MeshReader.GlobalScale;
+        public const float DoorActivationDistance = 128 * MeshReader.GlobalScale;
+        public const float TreasureActivationDistance = 128 * MeshReader.GlobalScale;
+        public const float PickpocketDistance = 128 * MeshReader.GlobalScale;
+        public const float CorpseActivationDistance = 150 * MeshReader.GlobalScale;
         //const float TouchSpellActivationDistance = 160 * MeshReader.GlobalScale;
-        const float StaticNPCActivationDistance = 256 * MeshReader.GlobalScale;
-        const float MobileNPCActivationDistance = 256 * MeshReader.GlobalScale;
+        public const float StaticNPCActivationDistance = 256 * MeshReader.GlobalScale;
+        public const float MobileNPCActivationDistance = 256 * MeshReader.GlobalScale;
 
         // Opening and closing hours by building type
         static byte[] openHours  = {  7,  8,  9,  8,  0,  9, 10, 10,  9,  6,  9, 11,  9,  9,  0,  0, 10, 0 };
@@ -97,11 +97,14 @@ namespace DaggerfallWorkshop.Game
         private struct CustomModActivation
         {
             internal readonly CustomActivation Action;
+
+            internal readonly float ActivationDistance;
             internal readonly Mod Provider;
 
-            internal CustomModActivation(CustomActivation action, Mod provider)
+            internal CustomModActivation(CustomActivation action, float activationDistance, Mod provider)
             {
                 Action = action;
+                ActivationDistance = activationDistance;
                 Provider = provider;
             }
         }
@@ -116,10 +119,10 @@ namespace DaggerfallWorkshop.Game
         /// <param name="provider">The mod that provides this override; used to enforce load order.</param>
         /// <param name="modelID">The model ID of the object that will trigger the custom action upon activation.</param>
         /// <param name="customActivation">A callback that implements the custom action.</param>
-        public static void RegisterCustomActivation(Mod provider, uint modelID, CustomActivation customActivation)
+        public static void RegisterCustomActivation(Mod provider, uint modelID, CustomActivation customActivation, float activationDistance = DefaultActivationDistance)
         {
             string goModelName = GameObjectHelper.GetGoModelName(modelID);
-            HandleRegisterCustomActivation(provider, goModelName, customActivation);
+            HandleRegisterCustomActivation(provider, goModelName, customActivation, activationDistance);
         }
 
         /// <summary>
@@ -129,10 +132,10 @@ namespace DaggerfallWorkshop.Game
         /// <param name="textureArchive">The texture archive of the flat object that will trigger the custom action upon activation.</param>
         /// <param name="textureRecord">The texture record of the flat object that will trigger the custom action upon activation.</param>
         /// <param name="customActivation">A callback that implements the custom action.</param>
-        public static void RegisterCustomActivation(Mod provider, int textureArchive, int textureRecord, CustomActivation customActivation)
+        public static void RegisterCustomActivation(Mod provider, int textureArchive, int textureRecord, CustomActivation customActivation, float activationDistance = DefaultActivationDistance)
         {
             string goFlatName = GameObjectHelper.GetGoFlatName(textureArchive, textureRecord);
-            HandleRegisterCustomActivation(provider, goFlatName, customActivation);
+            HandleRegisterCustomActivation(provider, goFlatName, customActivation, activationDistance);
         }
 
         /// <summary>
@@ -142,7 +145,7 @@ namespace DaggerfallWorkshop.Game
         /// <param name="textureArchive">The texture archive of the flat object that will trigger the custom action upon activation.</param>
         /// <param name="textureRecord">The texture record of the flat object that will trigger the custom action upon activation.</param>
         /// <param name="customActivation">A callback that implements the custom action.</param>
-        private static void HandleRegisterCustomActivation(Mod provider, string goFlatModelName, CustomActivation customActivation)
+        private static void HandleRegisterCustomActivation(Mod provider, string goFlatModelName, CustomActivation customActivation, float activationDistance)
         {
             DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName, true);
             bool allowRegistration = true;
@@ -150,12 +153,11 @@ namespace DaggerfallWorkshop.Game
             if (customModActivations.TryGetValue(goFlatModelName, out existingActivation)) {
                 if(existingActivation.Provider.LoadPriority > provider.LoadPriority) {
                     allowRegistration = false;
-                    DaggerfallUnity.LogMessage("Denied custom activation registration from " + provider.Title + " for " + goFlatModelName + " | " + existingActivation.Provider.Title + " has higher load priority");
+                    Debug.Log("Denied custom activation registration from " + provider.Title + " for " + goFlatModelName + " | " + existingActivation.Provider.Title + " has higher load priority");
                 }
             }
-            if(allowRegistration) {
-                //customActivations[goFlatModelName] = customActivation;
-                customModActivations[goFlatModelName] = new CustomModActivation(customActivation, provider);
+            if (allowRegistration) {
+                customModActivations[goFlatModelName] = new CustomModActivation(customActivation, activationDistance, provider);
             }
         }
 
@@ -367,8 +369,9 @@ namespace DaggerfallWorkshop.Game
                     CustomModActivation customActivation;
                     if (customModActivations.TryGetValue(flatModelName, out customActivation))
                     {
-                        customActivation.Action(hit);
-
+                        if(hit.distance <= customActivation.ActivationDistance) {
+                            customActivation.Action(hit);
+                        }
                     }
 
                     // Check for custom activation

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -111,7 +111,6 @@ namespace DaggerfallWorkshop.Game
         readonly static Dictionary<string, CustomModActivation> customModActivations = new Dictionary<string, CustomModActivation>();
         // Allow mods to register custom flat / model activation methods.
         public delegate void CustomActivation(RaycastHit hit);
-        //private static readonly Dictionary<string, CustomActivation> customActivations = new Dictionary<string, CustomActivation>();
 
         /// <summary>
         /// Registers a custom activation for a model object. Uses the modelID parameter to retrieve the correct object name

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -160,18 +160,31 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
+        /// <summary>
+        /// Checks if a model object has a custom activation assigned
+        /// </summary>
+        /// <param name="modelID">The model ID of the object to check.</param>
         public static bool HasCustomActivation(uint modelID)
         {
             string goModelName = GameObjectHelper.GetGoModelName(modelID);
             return HasCustomActivation(goModelName);
         }
 
+        /// <summary>
+        /// Checks if a model object has a custom activation assigned
+        /// </summary>
+        /// <param name="textureArchive">The texture archive of the flat object to check.</param>
+        /// <param name="textureRecord">The texture record of the flat object to check.</param>
         public static bool HasCustomActivation(int textureArchive, int textureRecord)
         {
             string goFlatName = GameObjectHelper.GetGoFlatName(textureArchive, textureRecord);
             return HasCustomActivation(goFlatName);
         }
 
+        /// <summary>
+        /// Checks if an object has a custom activation assigned
+        /// </summary>
+        /// <param name="goFlatModelName">The name of the flat / model object to check.</param>
         public static bool HasCustomActivation(string goFlatModelName) {
             return customModActivations.ContainsKey(goFlatModelName);
         }

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -98,26 +98,21 @@ namespace DaggerfallWorkshop.Game
         public static bool RegisterCustomActivation(uint modelID, CustomActivation customActivation)
         {
             string goModelName = GameObjectHelper.GetGoModelName(modelID);
-            return HandleRegisterCustomActivation(goModelName, customActivation);
+            HandleRegisterCustomActivation(goModelName, customActivation);
+            return true;
         }
 
         public static bool RegisterCustomActivation(int textureArchive, int textureRecord, CustomActivation customActivation)
         {
             string goFlatName = GameObjectHelper.GetGoFlatName(textureArchive, textureRecord);
-            return HandleRegisterCustomActivation(goFlatName, customActivation);
+            HandleRegisterCustomActivation(goFlatName, customActivation);
+            return true;
         }
 
-        private static bool HandleRegisterCustomActivation(string goFlatModelName, CustomActivation customActivation)
+        private static void HandleRegisterCustomActivation(string goFlatModelName, CustomActivation customActivation)
         {
             DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName, true);
-            if (!CheckCustomActivation(goFlatModelName))
-            {
-                customActivations.Add(goFlatModelName, customActivation);
-                return true;
-            } else {
-                DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName + " already registered", true);
-            }
-            return false;
+            customActivations[goFlatModelName] = customActivation;
         }
 
         public static bool HasCustomActivation(uint modelID)
@@ -305,14 +300,14 @@ namespace DaggerfallWorkshop.Game
                     // Check for functional interior furniture: Ladders, Bookshelves.
                     ActivateLaddersAndShelves(hit);
 
-                    // Invoke any matched custom model activations registered by mods.
-                    string modelName = hit.transform.gameObject.name;
-                    int pos = modelName.IndexOf(']');
-                    if (pos > 0 && pos < modelName.Length - 1)
-                        modelName = modelName.Remove(pos + 1);
+                    // Invoke any matched custom flat / model activations registered by mods.
+                    string flatModelName = hit.transform.gameObject.name;
+                    int pos = flatModelName.IndexOf(']');
+                    if (pos > 0 && pos < flatModelName.Length - 1)
+                        flatModelName = flatModelName.Remove(pos + 1);
 
                     CustomActivation customActivation;
-                    if (customActivations.TryGetValue(modelName, out customActivation))
+                    if (customActivations.TryGetValue(flatModelName, out customActivation))
                     {
                         customActivation(hit.transform);
                     }

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -93,7 +93,7 @@ namespace DaggerfallWorkshop.Game
 
         // Allow mods to register custom flat / model activation methods.
         public delegate void CustomActivation(Transform transform);
-        private static Dictionary<string, CustomActivation> customActivations = new Dictionary<string, CustomActivation>();
+        private static readonly Dictionary<string, CustomActivation> customActivations = new Dictionary<string, CustomActivation>();
 
         public static void RegisterCustomActivation(uint modelID, CustomActivation customActivation)
         {

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -95,18 +95,16 @@ namespace DaggerfallWorkshop.Game
         public delegate void CustomActivation(Transform transform);
         private static Dictionary<string, CustomActivation> customActivations = new Dictionary<string, CustomActivation>();
 
-        public static bool RegisterCustomActivation(uint modelID, CustomActivation customActivation)
+        public static void RegisterCustomActivation(uint modelID, CustomActivation customActivation)
         {
             string goModelName = GameObjectHelper.GetGoModelName(modelID);
             HandleRegisterCustomActivation(goModelName, customActivation);
-            return true;
         }
 
-        public static bool RegisterCustomActivation(int textureArchive, int textureRecord, CustomActivation customActivation)
+        public static void RegisterCustomActivation(int textureArchive, int textureRecord, CustomActivation customActivation)
         {
             string goFlatName = GameObjectHelper.GetGoFlatName(textureArchive, textureRecord);
             HandleRegisterCustomActivation(goFlatName, customActivation);
-            return true;
         }
 
         private static void HandleRegisterCustomActivation(string goFlatModelName, CustomActivation customActivation)

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -10,7 +10,6 @@
 //
 
 using UnityEngine;
-using System;
 using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.UserInterface;
@@ -467,10 +466,10 @@ namespace DaggerfallWorkshop.Game
                             }
 
                             // Attempt to unlock building
-                            UnityEngine.Random.InitState(Time.frameCount);
+                            Random.InitState(Time.frameCount);
                             player.TallySkill(DFCareer.Skills.Lockpicking, 1);
                             int chance = FormulaHelper.CalculateExteriorLockpickingChance(buildingLockValue, skillValue);
-                            int roll = UnityEngine.Random.Range(1, 101);
+                            int roll = Random.Range(1, 101);
                             Debug.LogFormat("Attempting pick against lock strength {0}. Chance={1}, Roll={2}.", buildingLockValue, chance, roll);
                             if (chance > roll)
                             {
@@ -733,7 +732,7 @@ namespace DaggerfallWorkshop.Game
                 DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
                 return;
             }
-            UnityEngine.Random.InitState(Time.frameCount);
+            Random.InitState(Time.frameCount);
             UserInterfaceManager uiManager = DaggerfallUI.Instance.UserInterfaceManager;
             switch (loot.ContainerType)
             {
@@ -935,7 +934,7 @@ namespace DaggerfallWorkshop.Game
 
                 // Roll for chance to open - Lower lock values have a higher chance
                 PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
-                UnityEngine.Random.InitState(Time.frameCount);
+                Random.InitState(Time.frameCount);
                 int chance = 25 - lockValue;
                 if (Dice100.SuccessRoll(chance))
                 {
@@ -1433,7 +1432,7 @@ namespace DaggerfallWorkshop.Game
             {
                 if (Dice100.FailedRoll(33))
                 {
-                    int pinchedGoldPieces = UnityEngine.Random.Range(0, 6) + 1;
+                    int pinchedGoldPieces = Random.Range(0, 6) + 1;
                     player.GoldPieces += pinchedGoldPieces;
                     string gotGold;
                     if (pinchedGoldPieces == 1)

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -51,10 +51,10 @@ namespace DaggerfallWorkshop.Game
 
         private struct CustomModActivation
         {
-            internal readonly Delegate Action;
+            internal readonly CustomActivation Action;
             internal readonly Mod Provider;
 
-            internal CustomModActivation(Delegate action, Mod provider)
+            internal CustomModActivation(CustomActivation action, Mod provider)
             {
                 Action = action;
                 Provider = provider;
@@ -108,8 +108,8 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Allow mods to register custom flat / model activation methods.
-        public delegate void CustomActivation(Transform transform);
-        private static readonly Dictionary<string, CustomActivation> customActivations = new Dictionary<string, CustomActivation>();
+        public delegate void CustomActivation(RaycastHit hit);
+        //private static readonly Dictionary<string, CustomActivation> customActivations = new Dictionary<string, CustomActivation>();
 
         public static void RegisterCustomActivation(Mod provider, uint modelID, CustomActivation customActivation)
         {
@@ -123,7 +123,7 @@ namespace DaggerfallWorkshop.Game
             HandleRegisterCustomActivation(provider, goFlatName, customActivation);
         }
 
-        private static void HandleRegisterCustomActivation(Mod provider, string goFlatModelName, Delegate customActivation)
+        private static void HandleRegisterCustomActivation(Mod provider, string goFlatModelName, CustomActivation customActivation)
         {
             DaggerfallUnity.LogMessage("HandleRegisterCustomActivation: " + goFlatModelName, true);
             bool allowRegistration = true;
@@ -153,7 +153,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         public static bool HasCustomActivation(string goFlatModelName) {
-            return customActivations.ContainsKey(goFlatModelName);
+            return customModActivations.ContainsKey(goFlatModelName);
         }
 
         void Start()
@@ -334,8 +334,8 @@ namespace DaggerfallWorkshop.Game
                     CustomModActivation customActivation;
                     if (customModActivations.TryGetValue(flatModelName, out customActivation))
                     {
-                        //customActivation(hit.transform);
-                        
+                        customActivation.Action(hit);
+
                     }
 
                     // Check for custom activation
@@ -433,10 +433,10 @@ namespace DaggerfallWorkshop.Game
                             }
 
                             // Attempt to unlock building
-                            Random.InitState(Time.frameCount);
+                            UnityEngine.Random.InitState(Time.frameCount);
                             player.TallySkill(DFCareer.Skills.Lockpicking, 1);
                             int chance = FormulaHelper.CalculateExteriorLockpickingChance(buildingLockValue, skillValue);
-                            int roll = Random.Range(1, 101);
+                            int roll = UnityEngine.Random.Range(1, 101);
                             Debug.LogFormat("Attempting pick against lock strength {0}. Chance={1}, Roll={2}.", buildingLockValue, chance, roll);
                             if (chance > roll)
                             {
@@ -699,7 +699,7 @@ namespace DaggerfallWorkshop.Game
                 DaggerfallUI.SetMidScreenText(HardStrings.youAreTooFarAway);
                 return;
             }
-            Random.InitState(Time.frameCount);
+            UnityEngine.Random.InitState(Time.frameCount);
             UserInterfaceManager uiManager = DaggerfallUI.Instance.UserInterfaceManager;
             switch (loot.ContainerType)
             {
@@ -901,7 +901,7 @@ namespace DaggerfallWorkshop.Game
 
                 // Roll for chance to open - Lower lock values have a higher chance
                 PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
-                Random.InitState(Time.frameCount);
+                UnityEngine.Random.InitState(Time.frameCount);
                 int chance = 25 - lockValue;
                 if (Dice100.SuccessRoll(chance))
                 {
@@ -1399,7 +1399,7 @@ namespace DaggerfallWorkshop.Game
             {
                 if (Dice100.FailedRoll(33))
                 {
-                    int pinchedGoldPieces = Random.Range(0, 6) + 1;
+                    int pinchedGoldPieces = UnityEngine.Random.Range(0, 6) + 1;
                     player.GoldPieces += pinchedGoldPieces;
                     string gotGold;
                     if (pinchedGoldPieces == 1)

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -114,6 +114,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return go;
         }
 
+        public static string GetFlatReplacementName (int archive, int record)
+        {
+            return string.Format("DaggerfallBillboard [TEXTURE.{0:000}, Index={1}] [Replacement]", archive, record);
+        }
+
         /// <summary>
         /// Seek and import a GameObject from mods to replace a Daggerfall billboard.
         /// </summary>
@@ -129,7 +134,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             if (!TryImportGameObject(archive, record, true, out go))
                 return null;
 
-            go.name = string.Format("DaggerfallBillboard [Replacement] [TEXTURE.{0:000}, Index={1}]", archive, record);
+            go.name = GetFlatReplacementName(archive, record);
             go.transform.parent = parent;
 
             // Assign position
@@ -170,13 +175,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         {
             GameObject go = null;
 
-            string name = string.Format("DaggerfallBillboard [Replacement] [TEXTURE.{0:000}, Index={1}]", archive, record);
+            string name = GetFlatReplacementName(archive, record);
             for (int i = 0; i < parent.childCount; i++)
             {
                 Transform transform = parent.GetChild(i);
                 if (transform.name == name)
                     AlignToBase((go = transform.gameObject).transform, position, archive, record, inDungeon);
-                else if (transform.name.StartsWith("DaggerfallBillboard [Replacement]"))
+                else if (transform.name.EndsWith(" [Replacement]"))
                     GameObject.Destroy(transform.gameObject);
             }
 

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -280,7 +280,7 @@ namespace DaggerfallWorkshop.Utility
             DaggerfallBillboard dfBillboard = go.AddComponent<DaggerfallBillboard>();
             dfBillboard.SetMaterial(archive, record);
 
-            if (PlayerActivate.CheckCustomActivation(flatName)) 
+            if (PlayerActivate.HasCustomActivation(flatName)) 
             {
                 // Add box collider to flats with actions for raycasting - only flats that can be activated directly need this, so this can possibly be restricted in future
                 // Skip this for flats that already have a collider assigned from elsewhere (e.g. NPC flats)

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -90,6 +90,11 @@ namespace DaggerfallWorkshop.Utility
             return string.Format("DaggerfallMesh [ID={0}]", modelID);
         }
 
+        public static string GetGoFlatName(int textureArchive, int textureRecord)
+        {
+            return string.Format("DaggerfallBillboard [TEXTURE.{0:000}, Index={1}]", textureArchive, textureRecord);
+        }
+
         /// <summary>
         /// Adds a single DaggerfallMesh game object to scene.
         /// </summary>
@@ -268,11 +273,22 @@ namespace DaggerfallWorkshop.Utility
 
         public static GameObject CreateDaggerfallBillboardGameObject(int archive, int record, Transform parent)
         {
-            GameObject go = new GameObject(string.Format("DaggerfallBillboard [TEXTURE.{0:000}, Index={1}]", archive, record));
+            string flatName = GetGoFlatName(archive, record);
+            GameObject go = new GameObject(flatName);
             if (parent) go.transform.parent = parent;
 
             DaggerfallBillboard dfBillboard = go.AddComponent<DaggerfallBillboard>();
             dfBillboard.SetMaterial(archive, record);
+
+            if(PlayerActivate.CheckCustomActivation(flatName)) {
+                // Add box collider to flats with actions for raycasting - only flats that can be activated directly need this, so this can possibly be restricted in future
+                // Skip this for flats that already have a collider assigned from elsewhere (e.g. NPC flats)
+                if (!go.GetComponent<Collider>())
+                {
+                    Collider col = go.AddComponent<BoxCollider>();
+                    col.isTrigger = true;
+                }
+            }
 
             return go;
         }

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -280,7 +280,8 @@ namespace DaggerfallWorkshop.Utility
             DaggerfallBillboard dfBillboard = go.AddComponent<DaggerfallBillboard>();
             dfBillboard.SetMaterial(archive, record);
 
-            if(PlayerActivate.CheckCustomActivation(flatName)) {
+            if (PlayerActivate.CheckCustomActivation(flatName)) 
+            {
                 // Add box collider to flats with actions for raycasting - only flats that can be activated directly need this, so this can possibly be restricted in future
                 // Skip this for flats that already have a collider assigned from elsewhere (e.g. NPC flats)
                 if (!go.GetComponent<Collider>())

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -250,7 +250,7 @@ namespace DaggerfallWorkshop.Utility
                                 dfMesh.SetDungeonTextures(textureTable);
 
                             // Add action component to door if it also has an action
-                            if (HasAction(obj))
+                            if (HasAction(obj, ref blockData))
                             {
                                 AddActionModelHelper(cgo, actionLinkDict, obj, ref blockData, serialize);
                             }
@@ -626,7 +626,7 @@ namespace DaggerfallWorkshop.Utility
                         }
 
                         // Check if model has an action record
-                        bool hasAction = HasAction(obj);
+                        bool hasAction = HasAction(obj, ref blockData);
 
                         // Get GameObject
                         Transform parent = (hasAction) ? actionModelsParent : modelsParent;
@@ -743,11 +743,16 @@ namespace DaggerfallWorkshop.Utility
         /// <summary>
         /// Check is model has action record.
         /// </summary>
-        private static bool HasAction(DFBlock.RdbObject obj)
+        private static bool HasAction(DFBlock.RdbObject obj, ref DFBlock blockData)
         {
             DFBlock.RdbActionResource action = obj.Resources.ModelResource.ActionResource;
-            if (action.Flags != 0)
+            if (action.Flags != 0) {
                 return true;
+            }
+            uint modelID = blockData.RdbBlock.ModelReferenceList[obj.Resources.ModelResource.ModelIndex].ModelIdNum;
+            if(PlayerActivate.HasCustomActivation(modelID)) {
+                return true;
+            }
             return false;
         }
 

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -250,7 +250,7 @@ namespace DaggerfallWorkshop.Utility
                                 dfMesh.SetDungeonTextures(textureTable);
 
                             // Add action component to door if it also has an action
-                            if (HasAction(obj, ref blockData))
+                            if (HasAction(obj))
                             {
                                 AddActionModelHelper(cgo, actionLinkDict, obj, ref blockData, serialize);
                             }
@@ -626,7 +626,7 @@ namespace DaggerfallWorkshop.Utility
                         }
 
                         // Check if model has an action record
-                        bool hasAction = HasAction(obj, ref blockData);
+                        bool hasAction = HasAction(obj);
 
                         // Get GameObject
                         Transform parent = (hasAction) ? actionModelsParent : modelsParent;
@@ -651,7 +651,7 @@ namespace DaggerfallWorkshop.Utility
                             }
 
                             // Add or combine
-                            if (combiner == null || hasAction)
+                            if (combiner == null || hasAction || PlayerActivate.HasCustomActivation(modelId))
                             {
                                 standaloneObject = AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent, hasAction);
                                 standaloneObject.GetComponent<DaggerfallMesh>().SetDungeonTextures(textureTable);
@@ -743,14 +743,10 @@ namespace DaggerfallWorkshop.Utility
         /// <summary>
         /// Check is model has action record.
         /// </summary>
-        private static bool HasAction(DFBlock.RdbObject obj, ref DFBlock blockData)
+        private static bool HasAction(DFBlock.RdbObject obj)
         {
             DFBlock.RdbActionResource action = obj.Resources.ModelResource.ActionResource;
             if (action.Flags != 0) {
-                return true;
-            }
-            uint modelID = blockData.RdbBlock.ModelReferenceList[obj.Resources.ModelResource.ModelIndex].ModelIdNum;
-            if(PlayerActivate.HasCustomActivation(modelID)) {
                 return true;
             }
             return false;

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -746,10 +746,7 @@ namespace DaggerfallWorkshop.Utility
         private static bool HasAction(DFBlock.RdbObject obj)
         {
             DFBlock.RdbActionResource action = obj.Resources.ModelResource.ActionResource;
-            if (action.Flags != 0) {
-                return true;
-            }
-            return false;
+            return (action.Flags != 0);
         }
 
         /// <summary>


### PR DESCRIPTION
These changes extend the custom model activation registration to include flats which was previously not possible. Any flat with a custom activation assigned will have a collider added to it's GameObject to allow for raycasting to succeed. Also, models with custom activations are excluded from the combinedMesh during dungeon assembly.

This allows modders to create custom activations for any model / flat they choose and enables them to implement things like resting at campfires, dungeon beds, etc. 

I have created a custom test dungeon (just a simple room) with a classic model (broomstick cabinet) and flat (campfire) as well as a replacement for both cases (a scarecrow flat is substituted for a white cube and the empty bookshelf is replaced with a bookshelf model I quickly made). Upon activation the cabinet, scarecrow cube and bookshelf will display a text message. Activating the campfire will present you with the Resting UI. 

You can find the dungeon here: [https://github.com/BadLuckBurt/dfu-custom-flat-model-activation-demo/releases](url) and it's source code here: [https://github.com/BadLuckBurt/dfu-custom-flat-model-activation-demo](url)

I have also tested to see what happens when an object already has an action assigned from classic DF using the throne room lever in PH and both actions fire after PlayerActivate.Update() finishes.

I'm open to suggestions and willing to make any changes required for this request to be accepted.