### PR TITLE
Made RdbResource.TriggerFlag_StartingLock public so it gets exported …

### DIFF
--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -992,7 +992,7 @@ namespace DaggerfallConnect
             public UInt16 ModelIndex;
 
             /// <summary>Trigger flag and starting lock for doors.</summary>
-            internal UInt32 TriggerFlag_StartingLock;
+            public UInt32 TriggerFlag_StartingLock;
 
             /// <summary>ID of sound to play when action is executed. Also used for spell and text index.</summary>
             public Byte SoundIndex;


### PR DESCRIPTION
…/ imported properly for WorldData overrides. Without it, it's not possible to assign the trigger type for classic activation behaviours of models / flats, making custom dungeons with classic activators impossible.