### PR TITLE
[RFC] Don't stack equipped items during player deserialization

### DIFF
--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -531,7 +531,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// Existing items will be destroyed.
         /// </summary>
         /// <param name="itemArray">ItemData_v1 array.</param>
-        public void DeserializeItems(ItemData_v1[] itemArray)
+        public void DeserializeItems(ItemData_v1[] itemArray, ulong[] equipTable = null)
         {
             // Clear existing items
             Clear();
@@ -543,6 +543,7 @@ namespace DaggerfallWorkshop.Game.Items
             // Add items to this collection
             for (int i = 0; i < itemArray.Length; i++)
             {
+                bool isEquipped = equipTable != null && (Array.IndexOf(equipTable, itemArray[i].uid) >= 0);
                 if (itemArray[i].className != null)
                 {
                     Type itemClassType;
@@ -551,12 +552,12 @@ namespace DaggerfallWorkshop.Game.Items
                     {
                         DaggerfallUnityItem modItem = (DaggerfallUnityItem)Activator.CreateInstance(itemClassType);
                         modItem.FromItemData(itemArray[i]);
-                        AddItem(modItem, AddPosition.DontCare, true);
+                        AddItem(modItem, noStack: isEquipped);
                         continue;
                     }
                 }
                 DaggerfallUnityItem item = new DaggerfallUnityItem(itemArray[i]);
-                AddItem(item);
+                AddItem(item, noStack: isEquipped);
             }
         }
 

--- a/Assets/Scripts/Game/Serialization/SerializableEnemy.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableEnemy.cs
@@ -167,7 +167,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.QuestFoeSpellQueueIndex = data.questFoeSpellQueueIndex;
             entity.QuestFoeItemQueueIndex = data.questFoeItemQueueIndex;
             entity.WabbajackActive = data.wabbajackActive;
-            entity.Items.DeserializeItems(data.items);
+            entity.Items.DeserializeItems(data.items, data.equipTable);
             entity.ItemEquipTable.DeserializeEquipTable(data.equipTable, entity.Items);
             entity.MaxHealth = data.startingHealth;
             entity.SetHealth(data.currentHealth, true);

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -286,7 +286,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.StartingLevelUpSkillSum = data.playerEntity.startingLevelUpSkillSum;
             if ((entity.CurrentLevelUpSkillSum = data.playerEntity.currentLevelUpSkillSum) == 0)
                 entity.SetCurrentLevelUpSkillSum();
-            entity.Items.DeserializeItems(data.playerEntity.items);
+            entity.Items.DeserializeItems(data.playerEntity.items, data.playerEntity.equipTable);
             entity.WagonItems.DeserializeItems(data.playerEntity.wagonItems);
             entity.OtherItems.DeserializeItems(data.playerEntity.otherItems);
             entity.ItemEquipTable.DeserializeEquipTable(data.playerEntity.equipTable, entity.Items);


### PR DESCRIPTION
Equipped items are not stackable, but this check doesn't work during deserialization, because inventory items are deserialized first, then they're equipped while deserializing the equipTable.

Simplest fix is to disable stacking while deserializing the inventory: use AddItem(..., noStack: true) in ItemCollection.DeserializeItems().

However, if this was done on purpose (so that stacking "self heals" during game loading), this PR instead only prevents the stacking of equipped items.
It's not very satisfying, because equipTable serialized data is used twice, so I submit it as a RFC.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=3560