### PR TITLE
Added Advanced controls window

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -944,9 +944,14 @@ namespace DaggerfallWorkshop.Game
 
         public static HorizontalSlider AddSlider(Vector2 position, Action<HorizontalSlider> setIndicator, float textScale = 1, Panel panel = null)
         {
+            return AddSlider(position, 80.0f, setIndicator, textScale, panel);
+        }
+
+        public static HorizontalSlider AddSlider(Vector2 position, float length, Action<HorizontalSlider> setIndicator, float textScale = 1, Panel panel = null)
+        {
             var slider = new HorizontalSlider();
             slider.Position = position;
-            slider.Size = new Vector2(80.0f, 4.0f);
+            slider.Size = new Vector2(length, 4.0f);
             slider.DisplayUnits = 20;
             slider.BackgroundColor = new Color(0.5f, 0.5f, 0.5f, 0.3f);
             slider.TintColor = new Color(153, 153, 0);

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -36,7 +36,7 @@ namespace DaggerfallWorkshop.Game
         const float deadZone = 0.05f;
         const float inputWaitTotal = 0.0833f;
 
-        KeyCode[] reservedKeys = new KeyCode[] { KeyCode.Escape, KeyCode.BackQuote, KeyCode.F8 };
+        KeyCode[] reservedKeys = new KeyCode[] { };
         Dictionary<KeyCode, Actions> actionKeyDict = new Dictionary<KeyCode, Actions>();
         Dictionary<KeyCode, string> unknownActions = new Dictionary<KeyCode, string>();
         List<Actions> currentActions = new List<Actions>();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -118,7 +118,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Mouse
             Button mouseButton = DaggerfallUI.AddButton(new Rect(80, 190, 80, 10), controlsPanel);
-            mouseButton.BackgroundColor = new Color(1, 0, 0, 0.5f);
+            mouseButton.BackgroundColor = new Color(0.3f, 0.42f, 0.16f, 1f);
+            mouseButton.Label.Text = "ADVANCED";
             mouseButton.OnMouseClick += MouseButton_OnMouseClick;
 
             // Default
@@ -316,7 +317,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void MouseButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            // uiManager.PostMessage(DaggerfallUIMessages.dfuiOpenMouseControlsWindow);
+            if (waitingForInput)
+                return;
+
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+            uiManager.PostMessage(DaggerfallUIMessages.dfuiOpenMouseControlsWindow);
         }
 
         private void DefaultButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -4,16 +4,19 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors: Justin Steele
+// Contributors: jefetienne
 //
 // Notes:
 //
 
 using UnityEngine;
 using System;
+using System.Linq;
+using System.Collections;
 using System.Collections.Generic;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Items;
@@ -26,9 +29,350 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     /// </summary>
     public class DaggerfallUnityMouseControlsWindow : DaggerfallPopupWindow
     {
+
+        #region Fields
+
+        Color mainPanelBackgroundColor = new Color(0.0f, 0.0f, 0.0f, 1.0f);
+        Color keybindButtonBackgroundColor = new Color(0.2f, 0.2f, 0.2f, 1.0f);
+        Color continueButtonBackgroundColor = new Color(0.5f, 0.0f, 0.0f, 1.0f);
+
+        Panel mainPanel;
+        TextLabel titleLabel;
+        Button escapeKeybindButton = new Button();
+        Button consoleKeybindButton = new Button();
+        Button screenshotKeybindButton = new Button();
+        Button quickSaveKeybindButton = new Button();
+        Button quickLoadKeybindButton = new Button();
+        HorizontalSlider mouseSensitivitySlider;
+        HorizontalSlider weaponSensitivitySlider;
+        HorizontalSlider moveSpeedAccelerationSlider;
+        Checkbox invertMouseVerticalCheckbox;
+        Checkbox mouseSmoothingCheckbox;
+        TextBox weaponAttackThresholdTextbox;
+
+        List<Button> buttonGroup = new List<Button>();
+
+        bool waitingForInput = false;
+
+        #endregion
+
+        #region Constructors
+
         public DaggerfallUnityMouseControlsWindow(IUserInterfaceManager uiManager, DaggerfallBaseWindow previous = null)
             : base(uiManager, previous)
         {
         }
+
+        #endregion
+
+        #region Unity
+
+        public override void Update()
+        {
+            base.Update();
+        }
+
+        #endregion
+
+        #region Setup
+
+        protected override void Setup()
+        {
+            DaggerfallWorkshop.Game.InputManager.OnSavedKeyBinds += OnUpdateValues;
+
+            // Always dim background
+            ParentPanel.BackgroundColor = ScreenDimColor;
+
+            // Main panel
+            Vector2 mainPanelSize = new Vector2(318, 170);
+            mainPanel = new Panel();
+            mainPanel.HorizontalAlignment = HorizontalAlignment.Center;
+            mainPanel.VerticalAlignment = VerticalAlignment.Middle;
+            mainPanel.Size = mainPanelSize;
+            mainPanel.Outline.Enabled = true;
+            SetBackground(mainPanel, mainPanelBackgroundColor, "mainPanelBackgroundColor");
+            NativePanel.Components.Add(mainPanel);
+
+            // Title label
+            titleLabel = new TextLabel();
+            titleLabel.ShadowPosition = Vector2.zero;
+            titleLabel.Position = new Vector2(4, 4);
+            titleLabel.Text = "Configure Advanced Controls";
+            titleLabel.HorizontalAlignment = HorizontalAlignment.Center;
+            mainPanel.Components.Add(titleLabel);
+
+            // Continue button
+            Button continueButton = new Button();
+            continueButton.Label.Text = "CONTINUE";
+            continueButton.Size = new Vector2(80, 10);
+            continueButton.HorizontalAlignment = HorizontalAlignment.Right;
+            continueButton.VerticalAlignment = VerticalAlignment.Bottom;
+            SetBackground(continueButton, continueButtonBackgroundColor, "continueButtonBackgroundColor");
+            mainPanel.Components.Add(continueButton);
+
+            // keybind buttons
+            SetupKeybindButton(escapeKeybindButton, InputManager.Actions.Escape, 20, 20);
+            SetupKeybindButton(consoleKeybindButton, InputManager.Actions.ToggleConsole, 115, 20);
+            SetupKeybindButton(screenshotKeybindButton, InputManager.Actions.PrintScreen, 210, 20);
+            SetupKeybindButton(quickSaveKeybindButton, InputManager.Actions.QuickSave, 20, 40);
+            SetupKeybindButton(quickLoadKeybindButton, InputManager.Actions.QuickLoad, 115, 40);
+
+            mouseSensitivitySlider = CreateSlider("Mouse Sensitivity", 15, 80, 0.1f, 8.0f, DaggerfallUnity.Settings.MouseLookSensitivity);
+
+            weaponSensitivitySlider = CreateSlider("Weapon Sensitivity", 115, 80, 0.1f, 10.0f, DaggerfallUnity.Settings.WeaponSensitivity);
+
+            moveSpeedAccelerationSlider = CreateSlider("Movement Acceleration", 215, 80, InputManager.minAcceleration, InputManager.maxAcceleration, DaggerfallUnity.Settings.MoveSpeedAcceleration);
+
+            invertMouseVerticalCheckbox = AddOption(20, 100, "Invert Mouse", DaggerfallUnity.Settings.InvertMouseVertical);
+
+            mouseSmoothingCheckbox = AddOption(20, 110, "Mouse Smoothing", DaggerfallUnity.Settings.MouseLookSmoothing);
+
+            weaponAttackThresholdTextbox = AddTextbox("Weapon Attack Threshold", 115, 100, DaggerfallUnity.Settings.WeaponAttackThreshold.ToString());
+
+
+            continueButton.OnMouseClick += ContinueButton_OnMouseClick;
+        }
+
+        #endregion
+
+        #region Overrides
+
+        public override void OnPush()
+        {
+            OnReturn();
+        }
+
+        public override void OnReturn()
+        {
+            UpdateKeybindButtons();
+            CheckDuplicates();
+        }
+
+        #endregion
+
+        #region Private methods
+
+        //for "reset defaults" overload
+        //**might delete this, since reset defaults is in the main controls window
+        private void SetupKeybindButton(Button button, InputManager.Actions action)
+        {
+            button.Label.Text = DaggerfallControlsWindow.UnsavedKeybindDict[action];
+            button.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
+        }
+
+        //for initialization
+        private void SetupKeybindButton(Button button, InputManager.Actions action, int x, int y)
+        {
+            Panel panel = new Panel();
+            panel.Position = new Vector2(x, y);
+            panel.Size = new Vector2(85, 15);
+
+            Panel labelPanel = new Panel();
+            labelPanel.Size = new Vector2(40, 10);
+            labelPanel.Position = new Vector2(0, 0);
+            labelPanel.HorizontalAlignment = HorizontalAlignment.Left;
+            labelPanel.VerticalAlignment = VerticalAlignment.Middle;
+
+            TextLabel label = new TextLabel();
+            label.Position = new Vector2(0, 0);
+            label.HorizontalAlignment = HorizontalAlignment.Right;
+            label.VerticalAlignment = VerticalAlignment.Middle;
+            label.ShadowPosition = Vector2.zero;
+
+            //"ToggleConsole" is too long as a word when looking in non-SDF font view
+            //"Screenshot" is a better word and is one letter less than "PrintScreen"
+            label.Text = action == InputManager.Actions.ToggleConsole ? "Console"
+                                   : action == InputManager.Actions.PrintScreen ? "Screenshot"
+                                   : action.ToString();
+
+            label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
+
+            button.Name = action.ToString();
+            button.Label.ShadowPosition = Vector2.zero;
+            button.Label.TextScale = 0.9f;
+            button.Size = new Vector2(43, 10);
+            button.Position = new Vector2(43, 0);
+            button.HorizontalAlignment = HorizontalAlignment.Right;
+            button.VerticalAlignment = VerticalAlignment.Middle;
+
+            SetBackground(button, keybindButtonBackgroundColor, "advancedKeybindBackgroundColor");
+            button.OnMouseClick += KeybindButton_OnMouseClick;
+
+            buttonGroup.Add(button);
+
+            labelPanel.Components.Add(label);
+            panel.Components.Add(labelPanel);
+            panel.Components.Add(button);
+            mainPanel.Components.Add(panel);
+
+            SetupKeybindButton(button, action);
+        }
+
+        private void UpdateKeybindButtons()
+        {
+            SetupKeybindButton(escapeKeybindButton, InputManager.Actions.Escape);
+            SetupKeybindButton(consoleKeybindButton, InputManager.Actions.ToggleConsole);
+            SetupKeybindButton(screenshotKeybindButton, InputManager.Actions.PrintScreen);
+            SetupKeybindButton(quickSaveKeybindButton, InputManager.Actions.QuickSave);
+            SetupKeybindButton(quickLoadKeybindButton, InputManager.Actions.QuickLoad);
+        }
+
+        /// <summary>
+        /// Add a slider with a numerical indicator.
+        /// </summary>
+        private HorizontalSlider CreateSlider(string text, int x, int y, float minValue, float maxValue, float startValue)
+        {
+            Panel sliderPanel = new Panel();
+            sliderPanel.Position = new Vector2(x, y);
+            sliderPanel.Size = new Vector2(70.0f, 45);
+
+            TextLabel label = new TextLabel();
+            label.Position = new Vector2(0, 0);
+            label.HorizontalAlignment = HorizontalAlignment.Center;
+            label.VerticalAlignment = VerticalAlignment.Top;
+            label.ShadowPosition = Vector2.zero;
+            label.Text = text;
+
+            sliderPanel.Components.Add(label);
+
+            Action<HorizontalSlider> setIndicator = ((s) => s.SetIndicator(minValue, maxValue, startValue));
+            HorizontalSlider slider = DaggerfallUI.AddSlider(new Vector2(0, 6), 70.0f, setIndicator, 0.9f, sliderPanel);
+
+            mainPanel.Components.Add(sliderPanel);
+
+            return slider;
+        }
+
+        Checkbox AddOption(float x, float y, string str, bool isChecked)
+        {
+            Checkbox checkbox = new Checkbox();
+            checkbox.Label.Text = str;
+            checkbox.IsChecked = isChecked;
+            checkbox.Position = new Vector2(x, y);
+            mainPanel.Components.Add(checkbox);
+
+            return checkbox;
+        }
+
+        private TextBox AddTextbox(string title, int x, int y, string text)
+        {
+            Panel panel = new Panel();
+            panel.Position = new Vector2(x, y);
+            panel.Size = new Vector2(100.0f, 20);
+
+            TextLabel label = new TextLabel();
+            label.Position = new Vector2(0, 0);
+            label.HorizontalAlignment = HorizontalAlignment.Left;
+            label.VerticalAlignment = VerticalAlignment.Top;
+            label.ShadowPosition = Vector2.zero;
+            label.Text = title;
+
+            panel.Components.Add(label);
+
+            TextBox textBox = new TextBox();
+            textBox.Position = new Vector2(0, 10);
+            textBox.HorizontalAlignment = HorizontalAlignment.Left;
+            //textBox.VerticalAlignment = VerticalAlignment.Top;
+            textBox.FixedSize = true;
+            textBox.Size = new Vector2(30, 6);
+            textBox.MaxCharacters = 5;
+            textBox.Cursor.Enabled = false;
+            textBox.DefaultText = text;
+            textBox.DefaultTextColor = Color.white;
+            textBox.HasFocusOutlineColor = Color.white;
+            textBox.LostFocusOutlineColor = Color.white;
+            textBox.UseFocus = true;
+
+            panel.Components.Add(textBox);
+
+            mainPanel.Components.Add(panel);
+
+            return textBox;
+        }
+
+        //from DaggerfallUnitySaveGameWindow
+        void SetBackground(BaseScreenComponent panel, Color color, string textureName)
+        {
+            Texture2D tex;
+            if (TextureReplacement.TryImportTexture(textureName, true, out tex))
+            {
+                panel.BackgroundTexture = tex;
+                TextureReplacement.LogLegacyUICustomizationMessage(textureName);
+            }
+            else
+                panel.BackgroundColor = color;
+        }
+
+        private void CheckDuplicates()
+        {
+            IEnumerable<String> keyList = DaggerfallControlsWindow.UnsavedKeybindDict.Select(kv => kv.Value);
+
+            var dupes = DaggerfallControlsWindow.GetDuplicates(keyList);
+
+            foreach (Button keybindButton in buttonGroup)
+            {
+                if (dupes.Contains(keybindButton.Label.Text))
+                    keybindButton.Label.TextColor = new Color(1, 0, 0);
+                else
+                    keybindButton.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
+            }
+        }
+
+        //a workaround solution to setting the 'waitingForInput' instance variable in a
+        //static IEnumerator method. IEnumerator methods can't accept out/ref parameters
+        private void SetWaitingForInput(bool b)
+        {
+            waitingForInput = b;
+            AllowCancel = !b;
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        private void OnUpdateValues()
+        {
+            DaggerfallUnity.Settings.MouseLookSensitivity = mouseSensitivitySlider.GetValue();
+            DaggerfallUnity.Settings.WeaponSensitivity = weaponSensitivitySlider.GetValue();
+            DaggerfallUnity.Settings.MoveSpeedAcceleration = moveSpeedAccelerationSlider.GetValue();
+            DaggerfallUnity.Settings.InvertMouseVertical = invertMouseVerticalCheckbox.IsChecked;
+            DaggerfallUnity.Settings.MouseLookSmoothing = mouseSmoothingCheckbox.IsChecked;
+
+            float weaponAttackThresholdValue;
+            if (float.TryParse(weaponAttackThresholdTextbox.Text, out weaponAttackThresholdValue))
+                DaggerfallUnity.Settings.WeaponAttackThreshold = Mathf.Clamp(weaponAttackThresholdValue, 0.001f, 1.0f);
+
+            DaggerfallUnity.Settings.SaveSettings();
+
+            GameManager.Instance.StartGameBehaviour.ApplyStartSettings();
+        }
+
+        private void ContinueButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            if (waitingForInput)
+                return;
+
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+            CancelWindow();
+        }
+
+        private void KeybindButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            if (waitingForInput)
+                return;
+
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+            Button thisKeybindButton = (Button)sender;
+
+            InputManager.Instance.StartCoroutine(WaitForKeyPress(thisKeybindButton));
+        }
+
+        IEnumerator WaitForKeyPress(Button button)
+        {
+            yield return DaggerfallControlsWindow.WaitForKeyPress(button, CheckDuplicates, SetWaitingForInput);
+        }
+
+        #endregion
+
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -48,6 +48,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         HorizontalSlider moveSpeedAccelerationSlider;
         Checkbox invertMouseVerticalCheckbox;
         Checkbox mouseSmoothingCheckbox;
+        Checkbox clickToAttackCheckbox;
         TextBox weaponAttackThresholdTextbox;
 
         List<Button> buttonGroup = new List<Button>();
@@ -126,6 +127,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             invertMouseVerticalCheckbox = AddOption(20, 100, "Invert Mouse", DaggerfallUnity.Settings.InvertMouseVertical);
 
             mouseSmoothingCheckbox = AddOption(20, 110, "Mouse Smoothing", DaggerfallUnity.Settings.MouseLookSmoothing);
+
+            clickToAttackCheckbox = AddOption(20, 120, "Click to Attack", DaggerfallUnity.Settings.ClickToAttack);
 
             weaponAttackThresholdTextbox = AddTextbox("Weapon Attack Threshold", 115, 100, DaggerfallUnity.Settings.WeaponAttackThreshold.ToString());
 
@@ -338,6 +341,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.MoveSpeedAcceleration = moveSpeedAccelerationSlider.GetValue();
             DaggerfallUnity.Settings.InvertMouseVertical = invertMouseVerticalCheckbox.IsChecked;
             DaggerfallUnity.Settings.MouseLookSmoothing = mouseSmoothingCheckbox.IsChecked;
+            DaggerfallUnity.Settings.ClickToAttack = clickToAttackCheckbox.IsChecked;
 
             float weaponAttackThresholdValue;
             if (float.TryParse(weaponAttackThresholdTextbox.Text, out weaponAttackThresholdValue))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -91,7 +91,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.VerticalAlignment = VerticalAlignment.Middle;
             mainPanel.Size = mainPanelSize;
             mainPanel.Outline.Enabled = true;
-            SetBackground(mainPanel, mainPanelBackgroundColor, "mainPanelBackgroundColor");
+            SetBackground(mainPanel, mainPanelBackgroundColor, "advancedControlsMainPanelBackgroundColor");
             NativePanel.Components.Add(mainPanel);
 
             // Title label
@@ -108,7 +108,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             continueButton.Size = new Vector2(80, 10);
             continueButton.HorizontalAlignment = HorizontalAlignment.Right;
             continueButton.VerticalAlignment = VerticalAlignment.Bottom;
-            SetBackground(continueButton, continueButtonBackgroundColor, "continueButtonBackgroundColor");
+            SetBackground(continueButton, continueButtonBackgroundColor, "advancedControlsContinueButtonBackgroundColor");
             mainPanel.Components.Add(continueButton);
 
             // keybind buttons
@@ -199,7 +199,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             button.HorizontalAlignment = HorizontalAlignment.Right;
             button.VerticalAlignment = VerticalAlignment.Middle;
 
-            SetBackground(button, keybindButtonBackgroundColor, "advancedKeybindBackgroundColor");
+            SetBackground(button, keybindButtonBackgroundColor, "advancedControlsKeybindBackgroundColor");
             button.OnMouseClick += KeybindButton_OnMouseClick;
 
             buttonGroup.Add(button);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -181,7 +181,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             //"ToggleConsole" is too long as a word when looking in non-SDF font view
             //"Screenshot" is a better word and is one letter less than "PrintScreen"
-            label.Text = action == InputManager.Actions.ToggleConsole ? "Console"
+            label.Text = action == InputManager.Actions.Escape ? "Pause"
+                                   : action == InputManager.Actions.ToggleConsole ? "Console"
                                    : action == InputManager.Actions.PrintScreen ? "Screenshot"
                                    : action.ToString();
 

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -172,7 +172,7 @@ namespace DaggerfallWorkshop.Game.Utility
 
         #region Common Startup
 
-        void ApplyStartSettings()
+        public void ApplyStartSettings()
         {
             // Resolution
             if (DaggerfallUnity.Settings.ExclusiveFullscreen && DaggerfallUnity.Settings.Fullscreen)


### PR DESCRIPTION
Advanced Controls Window:
https://i.imgur.com/rVtBFgf.png

Button to access it:
https://i.imgur.com/IuxBN6A.png

Alas, it is here. The advanced controls window contains keybinds for non-classic controls, which are pausing, toggling the console, screenshotting, quicksaving, and quickloading. It can be opened from where the 'MOUSE' button was, which is now an overlaid green button called "ADVANCED".

Like the main control window, it will detect duplicates and highlight them as red. However, _you will still be able to exit out of the advanced controls window_, so that way you can find which keybind you're conflicting with in the main window, but you won't be allowed click 'continue' in the main controls window until it's resolved.

Also, for ease of access, I've also added some settings from the setup wizard onto this window, so it's easier for the player to make adjustments to rather than having to exit and reload their game every time.

The only minor annoyance that you might find is that rebinding the 'Escape' key to an action will properly set it, but it will also close the window if there are no duplicates. I feel like this can be fixed in another pull request.