### PR TITLE
Support for runtime materials

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
@@ -1,0 +1,160 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2020 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: TheLacus
+// Contributors:     
+// 
+// Notes:
+//
+
+using System;
+using UnityEngine;
+using DaggerfallWorkshop.Game;
+
+namespace DaggerfallWorkshop.Utility.AssetInjection
+{
+    /// <summary>
+    /// Defines a Daggerfall material to be created at runtime.
+    /// </summary>
+    [Serializable]
+    public struct RuntimeMaterial
+    {
+        [Tooltip("Material index on the MeshRenderer")]
+        public int Index;
+
+        [Tooltip("Daggerfall texture archive.")]
+        public int Archive;
+
+        [Tooltip("Daggerfall Texture record.")]
+        public int Record;
+
+        [Tooltip("Use texture for current climate and season. Archive must be the base archive.")]
+        public bool ApplyClimate;
+    }
+
+    /// <summary>
+    /// Holds a list of archives and records and uses them to assign materials when the prefab is instantiated at runtime.
+    /// Materials are automatically applied on Awake but can also be manually reapplied.
+    /// </summary>
+    [RequireComponent(typeof(MeshRenderer))]
+    public sealed class RuntimeMaterials : MonoBehaviour
+    {
+        [SerializeField]
+        [HideInInspector]
+        private bool hasAppliedMaterials = false;
+
+        [SerializeField]
+        [Tooltip("List of materials to be assigned at runtime with Daggerfall textures.")]
+        private RuntimeMaterial[] Materials;
+
+        void Awake()
+        {
+            // Apply materials when the gameobject is first instantiated (not when cloned).
+            if (!hasAppliedMaterials)
+                ApplyMaterials(false);
+        }
+
+        /// <summary>
+        /// Applies materials to MeshRender found on gameobject.
+        /// </summary>
+        [ContextMenu("Reapply Materials")]
+        public void ApplyMaterials()
+        {
+            if (Application.isPlaying)
+                ApplyMaterials(true);
+        }
+
+        /// <summary>
+        /// Applies materials to MeshRender found on gameobject.
+        /// </summary>
+        public void ApplyMaterials(RuntimeMaterial[] materials)
+        {
+            if (Materials == null || Materials.Length == 0)
+                throw new ArgumentException("Materials array doesn't contain any item.", "materials");
+
+            if (Application.isPlaying)
+            {
+                Materials = materials;
+                ApplyMaterials(true);
+            }
+        }
+
+        private void ApplyMaterials(bool force)
+        {
+            if (Materials == null || Materials.Length == 0)
+                return;
+
+            try
+            {
+                var meshRenderer = GetComponent<MeshRenderer>();
+                if (!meshRenderer)
+                {
+                    Debug.LogErrorFormat("Failed to find MeshRenderer on {0}.", name);
+                    return;
+                }
+
+                ClimateBases climate = ClimateSwaps.FromAPIClimateBase(GameManager.Instance.PlayerGPS.ClimateSettings.ClimateType);
+                ClimateSeason season = DaggerfallUnity.Instance.WorldTime.Now.SeasonValue == DaggerfallDateTime.Seasons.Winter ? ClimateSeason.Winter : ClimateSeason.Summer;
+
+                Material[] materials = meshRenderer.sharedMaterials;
+                for (int i = 0; i < Materials.Length; i++)
+                {
+                    int index = Materials[i].Index;
+
+                    if (!force && materials[index])
+                        Debug.LogWarningFormat("A runtime material is being assigned to {0} (index {1}) but current material is not equal to null." +
+                        " Make sure you are not including unnecessary auto-generated materials.", meshRenderer.name, i);
+
+                    materials[index] = GetMaterial(Materials[i], climate, season);
+                    if (!materials[index])
+                        Debug.LogErrorFormat("Failed to find material for {0} (index {1}).", meshRenderer.name, i);
+                }
+                meshRenderer.sharedMaterials = materials;
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+            finally
+            {
+                hasAppliedMaterials = true;
+            }
+        }
+
+        private Material GetMaterial(RuntimeMaterial runtimeMaterial, ClimateBases climate, ClimateSeason season)
+        {
+            int archive = runtimeMaterial.Archive;
+            int record = runtimeMaterial.Record;
+
+            if (runtimeMaterial.ApplyClimate)
+                archive = ClimateSwaps.ApplyClimate(archive, record, climate, season);
+
+            return DaggerfallUnity.Instance.MaterialReader.GetMaterial(archive, record);
+        }
+
+#if UNITY_EDITOR
+        [ContextMenu("Init from MeshRenderer")]
+        private void InitFromMeshRenderer()
+        {
+            var meshRenderer = GetComponent<MeshRenderer>();
+            if (meshRenderer)
+            {
+                Materials = new RuntimeMaterial[meshRenderer.sharedMaterials.Length];
+                for (int i = 0; i < Materials.Length; i++)
+                {
+                    Materials[i] = new RuntimeMaterial()
+                    {
+                        Index = i
+                    };
+                }
+            }
+            else
+            {
+                Materials = null;
+            }
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs.meta
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a6e6870983c00144809e2c44cdd0bc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -384,6 +384,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             // Check object and all children
             foreach (var meshRenderer in go.GetComponentsInChildren<MeshRenderer>())
             {
+                if (meshRenderer.gameObject.GetComponent<RuntimeMaterials>())
+                    continue;
+
                 // Check all materials
                 Material[] materials = meshRenderer.sharedMaterials;
                 for (int i = 0; i < materials.Length; i++)


### PR DESCRIPTION
# Summary
Added a component that holds a list of archives and records and uses them to assign materials when the prefab is instantiated at runtime. Materials are automatically applied on Awake but can also be manually reapplied.

It allows to "reference" a classic Daggerfall material from a prefab provided by a mod.

![runtime_mat_0](https://user-images.githubusercontent.com/24359151/78404508-e1e14000-75fe-11ea-9f5a-8f80701d32c0.png)

![runtime_mat_2](https://user-images.githubusercontent.com/24359151/78406042-11457c00-7602-11ea-9b33-e367fc3e1df1.png)

# More Informations

Mod authors can use this component to provide a list of archive-record tuples associated to a material index. This is a better alternative than including classic textures with the mod because it doesn't require texture duplicates for each mod and has full support for texture replacement with load order. 

The reason to specify material index (instead of using array order) is to allow the use of classic materials along with custom ones. As a convenience i added an entry in the context menu named "Init from MeshRenderer".

Materials can be manuallly reapplied with `void ApplyMaterials(RuntimeMaterial[] materials)` or from the inspector with the context menu entry "Reapply Materials".

![runtime_mat_1](https://user-images.githubusercontent.com/24359151/78404511-e279d680-75fe-11ea-8f12-18b241916392.png)

# How To Test

- Create a prefab and add component **Runtime Materials**.
- Set target archive-record (for example 23-0).
- Launch play mode, pause and drag the prefab inside the scene. Materials are assigned immediately from Awake().

![runtime_mat](https://user-images.githubusercontent.com/24359151/78453075-b0fd1b80-768f-11ea-89e0-cd9ed675a71a.gif)

