### PR TITLE
Improved output of 'startquest' command

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -2211,7 +2211,7 @@ namespace Wenzil.Console
         {
             public static readonly string name = "startquest";
             public static readonly string description = "Starts the specified quest";
-            public static readonly string usage = "startquest {quest name}";
+            public static readonly string usage = "startquest {quest ID}";
 
             public static string Execute(params string[] args)
             {
@@ -2219,10 +2219,16 @@ namespace Wenzil.Console
                     return usage;
                 UnityEngine.Random.InitState(Time.frameCount);
                 Quest quest = GameManager.Instance.QuestListsManager.GetQuest(args[0]);
-                if (quest != null)
-                    QuestMachine.Instance.StartQuest(quest);
 
-                return "Finished";
+                if (quest != null)
+                {
+                    QuestMachine.Instance.StartQuest(quest);
+                    return "Started quest '" + quest.DisplayName + "'";
+                }
+                else
+                {
+                    return "Quest ID '" + args[0] + "' could not be found";
+                }
             }
         }
 


### PR DESCRIPTION
 The console command 'startquest' will now say "Added quest {quest display name}" if it is a valid ID and "Quest ID '{id}' could not be found" otherwise.

It used to only return "Finished", which seemed ambiguous if it meant I finished that quest or if it got completed it for me. It also didn't say if the player used a valid quest id or not.