### PR TITLE
Prevent the use of weapon while climbing

### DIFF
--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -235,8 +235,8 @@ namespace DaggerfallWorkshop.Game
                 }
             }
 
-            // Do nothing if player paralyzed
-            if (GameManager.Instance.PlayerEntity.IsParalyzed)
+            // Do nothing if player paralyzed or is climbing
+            if (GameManager.Instance.PlayerEntity.IsParalyzed || GameManager.Instance.ClimbingMotor.IsClimbing)
             {
                 ShowWeapons(false);
                 return;


### PR DESCRIPTION
Seems to be what classic does according to my observations.

This is the simplest implementation, No weapon drawn sound is played when you're finished climbing.
