### PR TITLE
Reduce GC alloc of SongManager

### DIFF
--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -62,6 +62,14 @@ namespace DaggerfallWorkshop.Game
             public PlayerMusicWeather weather;
             public PlayerMusicTime time;
             public bool arrested;
+
+            //minimize GC alloc of struct.Equals(object o) with this method instead
+            public bool Equals(PlayerMusicContext pmc) {
+                return  environment == pmc.environment
+                        && weather == pmc.weather
+                        && time == pmc.time
+                        && arrested == pmc.arrested;
+            }
         }
 
         PlayerMusicContext currentContext;


### PR DESCRIPTION
I was looking at #1539 and while I can't seem to reproduce the issue, I minimized GC allocation of SongManager in hopes that it might help with the sound issue. It reduced the GCAlloc from 284 B to 0 B.

Calling struct.Equals(object o) by default will "call Object.Equals(Object) on each field of the current instance and obj and returns true if all fields are equal."

https://docs.microsoft.com/en-us/dotnet/api/system.valuetype.equals?view=netframework-4.8#System_ValueType_Equals_System_Object_

Let me know if this fix was useful.