### PR TITLE
Require confirmation before spellbook sorting

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -870,17 +870,29 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         // Not implemented in Daggerfall, could be useful. Possibly move through different sorts (lexigraphic, date added, cost etc.)
         public void SortButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
-            var spellsBefore = GameManager.Instance.PlayerEntity.GetSpells();
-            GameManager.Instance.PlayerEntity.SortSpellsAlpha();
-            var spellsAfter = GameManager.Instance.PlayerEntity.GetSpells();
-            if (spellsAfter.SequenceEqual(spellsBefore))
+            DaggerfallMessageBox mb = new DaggerfallMessageBox(uiManager, DaggerfallMessageBox.CommonMessageBoxButtons.YesNo, TextManager.Instance.GetText(textDatabase, "sortSpells"), this);
+            mb.OnButtonClick += SortSpellsConfirm_OnButtonClick;
+            mb.Show();
+        }
+
+        private void SortSpellsConfirm_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
+        {
+            if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
             {
-                // List was already in alphabetic order, switch to magicka cost
-                GameManager.Instance.PlayerEntity.SortSpellsPointCost();
+                var spellsBefore = GameManager.Instance.PlayerEntity.GetSpells();
+                GameManager.Instance.PlayerEntity.SortSpellsAlpha();
+                var spellsAfter = GameManager.Instance.PlayerEntity.GetSpells();
+                if (spellsAfter.SequenceEqual(spellsBefore))
+                {
+                    // List was already in alphabetic order, switch to magicka cost
+                    GameManager.Instance.PlayerEntity.SortSpellsPointCost();
+                }
+                RefreshSpellsList(false);
+                SetDefaults();
+                DaggerfallUI.Instance.PlayOneShot(editSpellBook);
             }
-            RefreshSpellsList(false);
-            SetDefaults();
-            DaggerfallUI.Instance.PlayOneShot(editSpellBook);
+
+            CloseWindow();
         }
 
         public void SpellNameLabel_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/StreamingAssets/Text/SpellmakerUI.txt
+++ b/Assets/StreamingAssets/Text/SpellmakerUI.txt
@@ -23,5 +23,6 @@ nameSpell,                  Name spell
 enterSpellName,             Enter spell name :
 noEffectsError,             You must add at least one effect to this spell.
 deleteSpell,                Do you want to delete this spell?
+sortSpells,                 Do you want to sort spells?
 effectNotFoundError,        <effect not found>
 noItemToActivate,           You have no usable magic item


### PR DESCRIPTION
A drawback of adding keyboard shortcuts to form buttons is that sometimes people trigger actions by inadvertedly pressing game keys.

Most common I've seen is W (forward) key pressed in inventory. Either selects the wagon or displays a message if the player has no wagon, it's relatively harmless.

Another a more annoying I'm starting to see is people pressing S (backward) key in the spellbook, reordering their spellbook.

This patch adds a confirmation before spellbook sorting.
Alternatively, the player could be asked what sort order to use.