### PR TITLE
Remove invalid assets from cache

### DIFF
--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -636,7 +636,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                 if (IsAssetLoaded(assetName))
                 {
                     la = loadedAssets[assetName];
-                    return la.Obj as T;
+                    if (la.Obj)
+                        return la.Obj as T;
+
+                    loadedAssets.Remove(assetName);
+                    Debug.LogWarningFormat("Removed asset {0} from cache of mod {1} because object is unloaded.", assetName, Title);
                 }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
If a mod loads an asset, unloads it and then requests it again, the invalid asset is removed from cache to allow it to be loaded again. Previously, the load operation would have failed.

Mods should not unload cached assets (of course additons to the API can be proposed  if actually needed) but this should handle the issue more graciously for the player.