### PR TITLE
Do not call Resources.UnloadUnusedAssets() more than once every 3 mins

### DIFF
--- a/Assets/Scripts/Game/UserInterface/UserInterfaceWindow.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceWindow.cs
@@ -128,7 +128,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             uiManager.PopWindow();
             RaiseOnCloseHandler();
-            Resources.UnloadUnusedAssets();
+            DaggerfallGC.ThrottledUnloadUnusedAssets();
         }
 
         public void PopWindow()

--- a/Assets/Scripts/Internal/DaggerfallGC.cs
+++ b/Assets/Scripts/Internal/DaggerfallGC.cs
@@ -14,16 +14,12 @@ using UnityEngine;
 
 namespace DaggerfallWorkshop
 {
-    public class DaggerfallGC
+    public static class DaggerfallGC
     {
         // Min time between two unused assets collections
         private const float uuaThrottleDelay = 180f;
 
         private static float uuaTimer = Time.realtimeSinceStartup;
-
-        private DaggerfallGC()
-        {
-        }
 
         public static void ThrottledUnloadUnusedAssets()
         {

--- a/Assets/Scripts/Internal/DaggerfallGC.cs
+++ b/Assets/Scripts/Internal/DaggerfallGC.cs
@@ -1,0 +1,40 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2020 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Pango (petchema@concept-micro.com)
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using UnityEngine;
+
+namespace DaggerfallWorkshop
+{
+    public class DaggerfallGC
+    {
+        // Min time between two unused assets collections
+        private const float uuaThrottleDelay = 180f;
+
+        private static float uuaTimer = Time.realtimeSinceStartup;
+
+        private DaggerfallGC()
+        {
+        }
+
+        public static void ThrottledUnloadUnusedAssets()
+        {
+            if (Time.realtimeSinceStartup >= uuaTimer)
+                ForcedUnloadUnusedAssets();
+        }
+
+        public static void ForcedUnloadUnusedAssets()
+        {
+            Resources.UnloadUnusedAssets();
+            uuaTimer = Time.realtimeSinceStartup + uuaThrottleDelay;
+        }
+    }
+}

--- a/Assets/Scripts/Internal/DaggerfallGC.cs.meta
+++ b/Assets/Scripts/Internal/DaggerfallGC.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70ef55862ca84432ba15b526522f7ae3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -659,7 +659,7 @@ namespace DaggerfallWorkshop
             if (init)
             {
                 DaggerfallUnity.Instance.MaterialReader.PruneCache();
-                Resources.UnloadUnusedAssets();
+                DaggerfallGC.ThrottledUnloadUnusedAssets();
             }
 
             // Set terrain neighbours


### PR DESCRIPTION
Daggerfall Unity needs to explicitly call Resources.UnloadUnusedAssets() because it barely uses SceneManager.LoadScene() which is the way games usually indirectly call it.

This is currently done in two places, including while closing UI windows, a path taken often enough during normal gameplay to prevent unused assets to pile up too much.

However this can be a lengthy operation that blocks the whole environment as it calls GC.Collect() internally, and can make sound skip which can be pretty annoying once you noticed it (issue #1539).

This patch makes sure the call to UnloadUnusedAssets() does not happen more than once every 3 minutes, a tradeoff sufficient to make that issue much less noticeable, yet should prevent unused assets to stay around forever.

It should be noted that, while not required, for optimal efficiency all code using Resources.UnloadUnusedAssets() (say mods) should call either ThrottledUnloadUnusedAssets() or ForcedUnloadUnusedAssets() instead to prevent unnecessary collections.