### PR TITLE
Remove unused assets from mod cache

### DIFF
--- a/Assets/Game/Addons/ModSupport/ImportedComponentAttribute.cs
+++ b/Assets/Game/Addons/ModSupport/ImportedComponentAttribute.cs
@@ -226,6 +226,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         readonly static fsSerializer fsSerializer = new fsSerializer();
         readonly static Dictionary<string, Type> types = new Dictionary<string, Type>();
+        readonly static Dictionary<string, float> deserializedObjects = new Dictionary<string, float>();
 
         #endregion
 
@@ -280,8 +281,24 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// </summary>
         /// <param name="mod">The mod that contains components type and serialized data.</param>
         /// <param name="gameObject">A gameobject instance.</param>
-        public static void Restore(Mod mod, GameObject gameObject)
+        /// <param name="assetname">Persistent and unique assetname inside the mod.</param>
+        public static void Restore(Mod mod, GameObject gameObject, string assetname)
         {
+            if (mod.GUID.Equals("invalid", StringComparison.Ordinal))
+            {
+                Debug.LogErrorFormat("Failed to deserialize asset {0} for mod {1} because mod GUID is invalid.", assetname, mod.Title);
+                return;
+            }
+
+            string assetKey = string.Format("{0}-{1}", mod.GUID, assetname);
+            float instanceID = gameObject.GetInstanceID();
+
+            // Make sure a gameobject is not deserialized more than one time.
+            // This can happen if is removed from cache then readded without being unloaded due to other references.
+            float currentInstanceID;
+            if (deserializedObjects.TryGetValue(assetKey, out currentInstanceID) && currentInstanceID == instanceID)
+                return;
+            
             fsSerializer.Context.Set(mod);
             object instance = gameObject;
             fsData fsData = fsJsonParser.Parse(LoadSerializedFile(mod, gameObject.name));
@@ -289,6 +306,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             if (fsResult.Failed || fsResult.HasWarnings)
                 Debug.LogErrorFormat("Deserialization of {0} from {1} {2} with messages:\n{3}",
                     gameObject.name, mod.Title, fsResult.Succeeded ? "succeeded" : "failed", fsResult.FormattedMessages);
+
+            deserializedObjects[assetKey] = instanceID;
         }
 
         #endregion

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -1026,6 +1026,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             return mods.FirstOrDefault(x => x.FileName.Equals(name, StringComparison.Ordinal));
         }
 
+        internal void PruneCache(float time, float threshold)
+        {
+            foreach (Mod mod in mods)
+                mod.PruneCache(time, threshold);
+        }
+
         /// <summary>
         /// Gets a localized string for a mod system text.
         /// </summary>

--- a/Assets/Game/Addons/ModSupport/ModTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModTypes.cs
@@ -20,11 +20,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
     {
         public Type T;
         public UnityEngine.Object Obj;
+        public float TimeStamp;
 
         public LoadedAsset(Type T, UnityEngine.Object Obj)
         {
             this.T = T;
             this.Obj = Obj;
+            this.TimeStamp = 0;
         }
     }
 

--- a/Assets/Scripts/DaggerfallUnity.cs
+++ b/Assets/Scripts/DaggerfallUnity.cs
@@ -24,6 +24,7 @@ using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.Utility;
+using DaggerfallWorkshop.Game.Utility.ModSupport;
 
 namespace DaggerfallWorkshop
 {
@@ -465,6 +466,29 @@ namespace DaggerfallWorkshop
 
         #endregion
 
+        #region Internal Methods
+
+        /// <summary>
+        /// Removes from cache all assets that have not been accessed from the time in minutes defined by
+        /// <see cref="SettingsManager.AssetCacheThreshold"/>. If equals to <c>0</c> assets are never removed from cache.
+        /// </summary>
+        internal void PruneCache()
+        {
+            if (Settings.AssetCacheThreshold == 0)
+                return;
+
+            float time = Time.realtimeSinceStartup;
+            float threshold = Settings.AssetCacheThreshold * 60;
+
+            MaterialReader.PruneCache(time, threshold);
+            if (ModManager.Instance)
+                ModManager.Instance.PruneCache(time, threshold);
+
+            RaiseOnPruneCacheEvent(time, threshold);
+        }
+
+        #endregion
+
         #region Private Methods
 
         private void SetupSingleton()
@@ -519,6 +543,14 @@ namespace DaggerfallWorkshop
         {
             if (OnSetTextProvider != null)
                 OnSetTextProvider();
+        }
+
+        public delegate void OnPruneCacheEventHandler(float time, float threshold);
+        public event OnPruneCacheEventHandler OnPruneCache;
+        private void RaiseOnPruneCacheEvent(float time, float threshold)
+        {
+            if (OnPruneCache != null)
+                OnPruneCache(time, threshold);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -233,7 +233,6 @@ namespace DaggerfallWorkshop.Game.Utility
             // Filter settings
             DaggerfallUnity.Instance.MaterialReader.MainFilterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
             DaggerfallUnity.Instance.MaterialReader.CompressModdedTextures = DaggerfallUnity.Settings.CompressModdedTextures;
-            DaggerfallUnity.Instance.MaterialReader.AssetCacheThreshold = DaggerfallUnity.Settings.AssetCacheThreshold;
 
             // HUD settings
             DaggerfallHUD hud = DaggerfallUI.Instance.DaggerfallHUD;

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -103,7 +103,6 @@ namespace DaggerfallWorkshop
         public bool MipMaps = true;
         public bool ReadableTextures = false;
         public SupportedAlphaTextureFormats AlphaTextureFormat = SupportedAlphaTextureFormats.ARGB32;
-        public int AssetCacheThreshold;
 
         // Window settings
         public Color DayWindowColor = new Color32(89, 154, 178, 0xff);
@@ -872,15 +871,10 @@ namespace DaggerfallWorkshop
 
         /// <summary>
         /// Removes from cache all materials that have not been accessed from the time in minutes defined
-        /// by <see cref="AssetCacheThreshold"/>. If equals to <c>0</c> assets are never removed from cache.
+        /// by <paramref name="threshold"/>.
         /// </summary>
-        internal void PruneCache()
+        internal void PruneCache(float time, float threshold)
         {
-            if (AssetCacheThreshold == 0)
-                return;
-
-            float time = Time.realtimeSinceStartup;
-            float threshold = AssetCacheThreshold * 60;
             foreach (var item in materialDict.Where(x => time - x.Value.timeStamp > threshold).ToList())
                 materialDict.Remove(item.Key);
         }

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -22,6 +22,7 @@ using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Utility;
+using DaggerfallWorkshop.Game.Utility.ModSupport;
 using DaggerfallWorkshop.Game.Serialization;
 using Unity.Jobs;
 
@@ -658,7 +659,7 @@ namespace DaggerfallWorkshop
             // Keeps memory usage much lower over time
             if (init)
             {
-                DaggerfallUnity.Instance.MaterialReader.PruneCache();
+                DaggerfallUnity.Instance.PruneCache();
                 DaggerfallGC.ThrottledUnloadUnusedAssets();
             }
 


### PR DESCRIPTION
#1671 introduced removal from cache of materials that have not been accessed for a fixed time. This is now extended to mod cache in order to improve memory management for unique assets used by mods.

Timestamp of last access is updated when an asset is requested with `GetAsset()`. As a compromise, assets loaded with `LoadAllAssetsFromBundle()` or `LoadAllAssetsFromBundleAsync()` are not removed before they are actually retrieved.