### PR TITLE
Custom dialog buttons (WIP)

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -379,7 +379,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Once a button has been added the owner is expecting some kind of input from player
             // Don't allow a messagebox with buttons to be cancelled with escape
             AllowCancel = false;
-            Debug.Log("Updating panel sizes for custom buttons");
             UpdatePanelSizes();
 
             return button;


### PR DESCRIPTION
This WIP has been built off the custom-flat-model-activation PR I submitted and allows custom dialog buttons to be used in message boxes. 

I didn't have to change much to get this to work but I consider this a prototype as I'm not too familiar with UI-related things in DFU and can probably use some advice on how to properly implement this.

I've added one method: **AddCustomButton** which is almost a straight copy of the **AddButton** method. The **messageBoxButton** argument isn't used at the moment since I'd prefer to get some input on proper implementation. 

Instead of a **MessageBoxButtons** enum, it takes a string as the **tag** parameter and uses that to set up the **Button** instance. The **tag** name is also used to load an image named _button<tag>_ which is then set as the background texture for the button.

I have also copied the event handler and delegate for button clicks to change the parameter from MessageBoxButtons enum to a string. Other than that, it still operates the same.

[Example](https://i.imgur.com/qUFVBFN.png)

I have created a custom image: [Letters / numbers](https://i.imgur.com/UwzgZ3H.png) and an empty button graphic: [Empty button](https://i.imgur.com/8oaI6Q8.png) to allow modders to create their own button labels. Right now, I'm using static images in the example but I do see a possibility to create these custom buttons dynamically if the code is expanded a bit.

I'm open to any suggestions / advice and criticism, I'm still new to this and welcome the opportunity to learn