### PR TITLE
Added backup escape key method (Shift-Escape)

### DIFF
--- a/Assets/Scripts/Game/UserInterface/DaggerfallShortcut.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallShortcut.cs
@@ -58,6 +58,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             // General
             HUDToggle,
+            Pause,
 
             // Debugger
             DebuggerToggle,

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -253,6 +253,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 renderHUD = !renderHUD;
             }
 
+            if (DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.Pause).IsUpWith(keyModifiers))
+            {
+                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenPauseOptionsDialog);
+            }
+
             flickerController.NextCycle();
 
             // Don't display persistent HUD elements during initial startup

--- a/Assets/StreamingAssets/Text/DialogShortcuts.txt
+++ b/Assets/StreamingAssets/Text/DialogShortcuts.txt
@@ -49,6 +49,7 @@ OptionsHeadBobbing,   H
 
 -- General
 HUDToggle,            Shift-F10
+Pause,                Shift-Escape
 
 -- Debugger
 DebuggerToggle,       Shift-Tab


### PR DESCRIPTION
Working with the controller PR with the added advanced controls window, if someone were to rebind the pause button to the controller, then replayed the game without the controller, then they would be stuck and unable to change their keybinds without modifying Keybinds.txt.

This PR adds a hardcoded Shift-Escape keybind allowing the player to access the DaggerfallPauseOptionsWindow in case if they fall into this situation.