### PR TITLE
Added ability to filter quests to Active Only in Quest Debugger

### DIFF
--- a/Assets/Scripts/Game/UserInterface/DaggerfallShortcut.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallShortcut.cs
@@ -63,6 +63,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             DebuggerToggle,
             DebuggerPrevQuest,
             DebuggerNextQuest,
+            DebuggerActiveQuestToggle,
 
             // Rest menu
             RestForAWhile,

--- a/Assets/Scripts/Game/UserInterface/HUDQuestDebugger.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDQuestDebugger.cs
@@ -46,6 +46,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         ulong[] allQuests;
         int currentQuestIndex;
         Quest currentQuest;
+        bool activeQuestToggle = false;
 
         DisplayState displayState = DisplayState.Nothing;
 
@@ -153,6 +154,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 MovePreviousQuest();
             else if (DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.DebuggerNextQuest).IsDownWith(keyModifiers))
                 MoveNextQuest();
+            else if (DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.DebuggerActiveQuestToggle).IsDownWith(keyModifiers))
+                ToggleActiveQuestView();
         }
 
         private void QuestMachine_OnTick()
@@ -470,6 +473,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 currentQuestIndex = 0;
 
             SetCurrentQuest(QuestMachine.Instance.GetQuest(allQuests[currentQuestIndex]));
+            if (activeQuestToggle && !ActiveQuest(currentQuest))
+                MoveNextQuest();
         }
 
         void MovePreviousQuest()
@@ -481,6 +486,34 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 currentQuestIndex = allQuests.Length - 1;
 
             SetCurrentQuest(QuestMachine.Instance.GetQuest(allQuests[currentQuestIndex]));
+            if (activeQuestToggle && !ActiveQuest(currentQuest))
+                MovePreviousQuest();
+        }
+
+        void ToggleActiveQuestView()
+        {
+            ulong[] activeQuests = QuestMachine.Instance.GetAllActiveQuests();
+            activeQuestToggle = !activeQuestToggle;
+
+            if (activeQuestToggle && activeQuests.Length == 0)
+            {
+                DaggerfallUI.AddHUDText("No Currently Active Quests. Showing all Quests");
+                activeQuestToggle = false;
+            }
+
+            if (activeQuestToggle && (currentQuest.QuestComplete || currentQuest.QuestTombstoned))
+                MoveNextQuest();
+        }
+
+        bool ActiveQuest(Quest currentQuest)
+        {
+            ulong[] activeQuests = QuestMachine.Instance.GetAllActiveQuests();
+            if (activeQuests.Length > 0)
+            {
+                if (currentQuest.QuestComplete || currentQuest.QuestTombstoned)
+                    return false;
+            }
+            return true;
         }
 
         void EnableGlobalVars(bool value)

--- a/Assets/StreamingAssets/Text/DialogShortcuts.txt
+++ b/Assets/StreamingAssets/Text/DialogShortcuts.txt
@@ -51,9 +51,10 @@ OptionsHeadBobbing,   H
 HUDToggle,            Shift-F10
 
 -- Debugger
-DebuggerToggle,       Shift-Tab
-DebuggerPrevQuest,    LeftBracket
-DebuggerNextQuest,    RightBracket
+DebuggerToggle,             Shift-Tab
+DebuggerPrevQuest,          LeftBracket
+DebuggerNextQuest,          RightBracket
+DebuggerActiveQuestToggle,  A
 
 -- Rest menu
 RestForAWhile,        F


### PR DESCRIPTION
Hi, 
I had thought that the quest debugger only showed active quests, but it was always showing all quests for me.  I added some functionality to the quest debugger to allow you to show all quests or just active quests.  
You can flip between all quests and active quests by pressing "A".   
I default to all quests upon start so that it aligns with current functionality.'
Thanks 
a


Added Dialog Shortcut to select between all quests and active quests only (shortcut = letter A)
Defaults to all quests upon starting the quest debugger.