### PR TITLE
Disable head bobbing while in cursor mode

### DIFF
--- a/Assets/Scripts/Game/Player/HeadBobber.cs
+++ b/Assets/Scripts/Game/Player/HeadBobber.cs
@@ -80,6 +80,7 @@ namespace DaggerfallWorkshop.Game
         {
             if (!DaggerfallUnity.Settings.HeadBobbing ||
                 GameManager.Instance.PlayerEntity.CurrentHealth < 1 ||
+                GameManager.Instance.PlayerMouseLook.cursorActive ||
                 GameManager.IsGamePaused ||
                 climbingMotor.IsClimbing ||
 			    !playerMotor.IsGrounded)

--- a/Assets/Scripts/Game/PlayerMouseLook.cs
+++ b/Assets/Scripts/Game/PlayerMouseLook.cs
@@ -29,7 +29,7 @@ namespace DaggerfallWorkshop.Game
         Vector2 _smoothMouse;
         float cameraPitch = 0.0f;
         float cameraYaw = 0.0f;
-        bool cursorActive;
+        public bool cursorActive;
         float pitchMax = PitchMax;
         float pitchMin = PitchMin;
 


### PR DESCRIPTION
While in cursor mode the player can't adjust his/her view direction with the mouse, but if head bobbing is on it will change view direction, making the view roll over as the player walks around.

This leads to embarrassing moments, because whether the mouse cursor is displayed or not becomes totally secondary to the player when (s)he starts looking at his/her feet, then the landscape upside-down, then the sky, and repeat. People get utterly confused, and the obvious conclusion is usually "the game bugged out", and fixed by restarting it.

I'm not sure whether cursor mode should be totally disabled until fully implemented, but at bare minimum the interaction between cursor mode and head bobbing has to be handled somehow; That's what this PR does.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=2776