### PR TITLE
Improvements to joystick attack swinging

### DIFF
--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -177,6 +177,11 @@ namespace DaggerfallWorkshop.Game
             get { return (vertical < -deadZone || vertical > deadZone) ? vertical : 0; }
         }
 
+        public bool UsingController
+        {
+            get { return usingControllerCursor; }
+        }
+
         public KeyCode LastKeyDown { get; private set; }
 
         public bool CursorVisible
@@ -460,7 +465,11 @@ namespace DaggerfallWorkshop.Game
             var horizj = Input.GetAxis(horizBinding);
             var vertj = Input.GetAxis(vertBinding);
 
-            if (!usingControllerCursor && (horizj != 0 || vertj != 0))
+            if (!usingControllerCursor &&
+                (horizj != 0
+                || vertj != 0
+                || Input.GetAxis(cameraAxisBindingCache[0]) != 0
+                || Input.GetAxis(cameraAxisBindingCache[1]) != 0))
             {
                 usingControllerCursor = true;
                 controllerCursorPosition = Input.mousePosition;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -130,7 +130,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             clickToAttackCheckbox = AddOption(20, 120, "Click to Attack", DaggerfallUnity.Settings.ClickToAttack);
 
-            weaponAttackThresholdTextbox = AddTextbox("Weapon Attack Threshold", 115, 100, DaggerfallUnity.Settings.WeaponAttackThreshold.ToString());
+            weaponAttackThresholdTextbox = AddTextbox("Mouse Weapon Attack Threshold", 115, 100, DaggerfallUnity.Settings.WeaponAttackThreshold.ToString());
 
 
             continueButton.OnMouseClick += ContinueButton_OnMouseClick;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -118,9 +118,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupKeybindButton(quickSaveKeybindButton, InputManager.Actions.QuickSave, 20, 40);
             SetupKeybindButton(quickLoadKeybindButton, InputManager.Actions.QuickLoad, 115, 40);
 
-            mouseSensitivitySlider = CreateSlider("Mouse Sensitivity", 15, 80, 0.1f, 8.0f, DaggerfallUnity.Settings.MouseLookSensitivity);
+            mouseSensitivitySlider = CreateSlider("Mouse Look Sensitivity", 15, 80, 0.1f, 8.0f, DaggerfallUnity.Settings.MouseLookSensitivity);
 
-            weaponSensitivitySlider = CreateSlider("Weapon Sensitivity", 115, 80, 0.1f, 10.0f, DaggerfallUnity.Settings.WeaponSensitivity);
+            weaponSensitivitySlider = CreateSlider("Mouse Weapon Sensitivity", 115, 80, 0.1f, 10.0f, DaggerfallUnity.Settings.WeaponSensitivity);
 
             moveSpeedAccelerationSlider = CreateSlider("Movement Acceleration", 215, 80, InputManager.minAcceleration, InputManager.maxAcceleration, DaggerfallUnity.Settings.MoveSpeedAcceleration);
 

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -44,6 +44,8 @@ namespace DaggerfallWorkshop.Game
         private const int MaxBowHeldDrawnSeconds = 10;
         private const float BowSwitchDivisor = 1.7f;
 
+        private const float resetJoystickSwingRadius = 0.4f;
+
         public FPSWeapon ScreenWeapon;              // Weapon displayed in FPS view
         public bool Sheathed;                       // Weapon is sheathed
         public float SphereCastRadius = 0.25f;      // Radius of SphereCast used to target attacks
@@ -60,6 +62,7 @@ namespace DaggerfallWorkshop.Game
         PlayerEntity playerEntity;
         GameObject player;
         GameObject mainCamera;
+        bool joystickSwungOnce = false;
         bool isClickAttack = false;
         bool isAttacking = false;
         bool isDamageFinished = false;
@@ -757,9 +760,27 @@ namespace DaggerfallWorkshop.Game
             // Track action for idle plus all eight mouse directions
             var sum = _gesture.Add(InputManager.Instance.MouseX, InputManager.Instance.MouseY) * weaponSensitivity;
 
-            // Short mouse gestures are ignored
-            if (_gesture.TravelDist/_longestDim < AttackThreshold)
+            if (InputManager.Instance.UsingController)
+            {
+                float x = InputManager.Instance.MouseX;
+                float y = InputManager.Instance.MouseY;
+
+                bool inResetJoystickSwingRadius = (x >= -resetJoystickSwingRadius && x <= resetJoystickSwingRadius && y >= -resetJoystickSwingRadius && y <= resetJoystickSwingRadius);
+
+                if (joystickSwungOnce || inResetJoystickSwingRadius)
+                {
+                    if (inResetJoystickSwingRadius)
+                        joystickSwungOnce = false;
+
+                    return MouseDirections.None;
+                }
+            }
+            else if (_gesture.TravelDist/_longestDim < AttackThreshold)
+            {
                 return MouseDirections.None;
+            }
+
+            joystickSwungOnce = true;
 
             // Treat mouse movement as a vector from the origin
             // The angle of the vector will be used to determine the angle of attack/swing


### PR DESCRIPTION
(This is pertaining to having `ClickToAttack` disabled)

As of right now, the `WeaponAttackThreshold` is shared with both the mouse and the joystick. For gameplay experience, this threshold isn't really needed for a joystick since it does not move like a mouse, and makes it harder to attack. If the `WeaponAttackThreshold` is set very low (<0.001), the player can hold their joystick in one direction and the game will automatically constantly swing the weapon, giving an unfair advantage over the mouse.

This change removes the WeaponAttackThreshold from being calculated if the player is using a controller (via `InputManager.Instance.UsingController`), but also prevents automatic swinging by having the player let go of the joystick (or moving it close to the middle) in order to swing again.