### PR TITLE
Fix horse gallop sound clipping when repeatedly jumping

### DIFF
--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -6,6 +6,7 @@
 // Original Author: Hazelnut
 
 using UnityEngine;
+using System.Collections;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallConnect.Arena2;
@@ -150,6 +151,8 @@ namespace DaggerfallWorkshop.Game
         DaggerfallAudioSource dfAudioSource;
         AudioSource ridingAudioSource;
 
+        private bool stoppedRidingAudio;
+
         ImageData ridingTexture;
         ImageData[] ridingTexures = new ImageData[4];
         float lastFrameTime = 0;
@@ -199,6 +202,13 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
+        IEnumerator StopRidingAudio()
+        {
+            stoppedRidingAudio = true;
+            yield return new WaitForSecondsRealtime(0.2f);
+            ridingAudioSource.Stop();
+        }
+
         // Update is called once per frame
         void Update()
         {
@@ -211,7 +221,8 @@ namespace DaggerfallWorkshop.Game
                     lastFrameTime = 0;
                     frameIndex = 0;
                     ridingTexture = ridingTexures[0];
-                    ridingAudioSource.Stop();
+                    if (!stoppedRidingAudio)
+                        StartCoroutine(StopRidingAudio());
                 }
                 else
                 {   // Update Animation frame?
@@ -228,6 +239,8 @@ namespace DaggerfallWorkshop.Game
                     // Get appropriate hoof sound for horse
                     if (mode == TransportModes.Horse)
                     {
+                        stoppedRidingAudio = false;
+
                         if (!wasMovingLessThanHalfSpeed && playerMotor.IsMovingLessThanHalfSpeed)
                         {
                             wasMovingLessThanHalfSpeed = true;


### PR DESCRIPTION
Holding space while jumping makes an unpleasing clipped horse noise. This fix delays the stopping of the audio by 0.2 seconds, just enough to get at least one gallop noise in when colliding with the ground. It's not perfect, and sometimes it might fail to make a sound, but I think it's a step up from what it currently is at the moment.

(Also, I think my VSCode editor is automatically normalizing the line endings and I'm having trouble finding another editor that won't do this, sorry about that)