### PR TITLE
Add genuine keyboard event handlers to UI controls

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -377,6 +377,7 @@ namespace DaggerfallWorkshop.Game
             // Possible to get multiple keydown events per frame, one with character, one with keycode
             // Only accept character or keycode if valid
             lastKeyModifiers = HotkeySequence.GetKeyboardKeyModifiers();
+            hotkeySequenceProcessed = false;
 
             if (Event.current.type == EventType.KeyDown)
             {
@@ -388,11 +389,7 @@ namespace DaggerfallWorkshop.Game
 
                 if (lastCharacterTyped > 255)
                     lastCharacterTyped = (char)0;
-            }
 
-            hotkeySequenceProcessed = false;
-            if (Event.current.type == EventType.KeyUp)
-            {
                 hotkeySequenceProcessed = ProcessHotKeySequences();
             }
 

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -393,6 +393,11 @@ namespace DaggerfallWorkshop.Game
                 hotkeySequenceProcessed = ProcessHotKeySequences();
             }
 
+            if (Event.current.type == EventType.KeyUp)
+            {
+                hotkeySequenceProcessed = ProcessHotKeySequences();
+            }
+
             if (Event.current.type == EventType.Repaint)
             {
                 RenderTexture oldRT = null;

--- a/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
+++ b/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
@@ -88,6 +88,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         float minAutoScale = 0;
         float maxAutoScale = 0;
 
+        public delegate void OnKeyboardEventHandler(BaseScreenComponent sender, Event keyboardEvent);
+        public event OnKeyboardEventHandler OnKeyboardEvent;
+
         public delegate void OnMouseEnterHandler(BaseScreenComponent sender);
         public event OnMouseEnterHandler OnMouseEnter;
 
@@ -885,6 +888,20 @@ namespace DaggerfallWorkshop.Game.UserInterface
         #endregion
 
         #region Protected Methods
+
+        /// <summary>
+        /// KeyDown or KeyUp events that matches hotkey sequence
+        /// Returns whether the event could be delivered
+        /// </summary>
+        protected virtual bool KeyboardEvent(Event keyboardEvent)
+        {
+            if (OnKeyboardEvent != null)
+            {
+                OnKeyboardEvent(this, keyboardEvent);
+                return true;
+            }
+            return false;
+        }
 
         /// <summary>
         /// Mouse clicked inside control area.

--- a/Assets/Scripts/Game/UserInterface/Button.cs
+++ b/Assets/Scripts/Game/UserInterface/Button.cs
@@ -78,9 +78,17 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         new public bool ProcessHotkeySequences(HotkeySequence.KeyModifiers keyModifiers)
         {
-            bool isActivated = shortcutKey.IsDownWith(keyModifiers);
+            bool isKeyDown = Event.current.type == EventType.KeyDown;
+            bool isActivated = isKeyDown ? shortcutKey.IsDownWith(keyModifiers) : shortcutKey.IsUpWith(keyModifiers);
             if (isActivated)
-                TriggerMouseClick();
+            {
+                if (!KeyboardEvent(Event.current))
+                {
+                    // Legacy support fallback, OnMouseClick handlers receive KeyDown events as faked clicks
+                    if (isKeyDown)
+                        TriggerMouseClick();
+                }
+            }
             return isActivated;
         }
 

--- a/Assets/Scripts/Game/UserInterface/Button.cs
+++ b/Assets/Scripts/Game/UserInterface/Button.cs
@@ -78,7 +78,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         new public bool ProcessHotkeySequences(HotkeySequence.KeyModifiers keyModifiers)
         {
-            bool isActivated = shortcutKey.IsUpWith(keyModifiers);
+            bool isActivated = shortcutKey.IsDownWith(keyModifiers);
             if (isActivated)
                 TriggerMouseClick();
             return isActivated;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
@@ -78,6 +78,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         // Handle toggle closing
         KeyCode automapBinding = KeyCode.None;
         HotkeySequence HotkeySequence_toggleClose;
+        bool isCloseWindowDeferred = false;
         readonly KeyCode fallbackKey = KeyCode.Home;
 
         // definitions of hotkey sequences
@@ -706,10 +707,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             HotkeySequence.KeyModifiers keyModifiers = HotkeySequence.GetKeyboardKeyModifiers();
 
-            if (Input.GetKeyUp(KeyCode.Escape) ||
+            if (Input.GetKeyDown(KeyCode.Escape) ||
                 // Toggle window closed with same hotkey used to open it
-                HotkeySequence_toggleClose.IsUpWith(keyModifiers))
+                HotkeySequence_toggleClose.IsDownWith(keyModifiers))
+                isCloseWindowDeferred = true;
+            else if ((Input.GetKeyUp(KeyCode.Escape) ||
+                // Toggle window closed with same hotkey used to open it
+                HotkeySequence_toggleClose.IsUpWith(keyModifiers)) && isCloseWindowDeferred)
             {
+                isCloseWindowDeferred = false;
                 CloseWindow();
                 return;
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -938,7 +938,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -34,6 +34,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         StatsRollout statsRollout;
 
+        bool isCloseWindowDeferred = false;
         bool leveling = false;
 
         const int oghmaBonusPool = 30;
@@ -193,6 +194,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Button exitButton = DaggerfallUI.AddButton(new Rect(50, 179, 39, 19), NativePanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.CharacterSheetExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             // Attribute popup text
             Vector2 pos = new Vector2(141, 6);
@@ -933,6 +935,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (CheckIfDoneLeveling())
                 CloseWindow();
         }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                if (CheckIfDoneLeveling())
+                    isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
+        }
+
 
         private void StatsRollout_OnStatChanged()
         {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -35,6 +35,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         StatsRollout statsRollout;
 
         bool isCloseWindowDeferred = false;
+        bool isInventoryWindowDeferred = false;
+        bool isSpellbookWindowDeferred = false;
+        bool isLogbookWindowDeferred = false;
+        bool isHistoryWindowDeferred = false;
         bool leveling = false;
 
         const int oghmaBonusPool = 30;
@@ -174,21 +178,25 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Button inventoryButton = DaggerfallUI.AddButton(new Rect(3, 151, 65, 12), NativePanel);
             inventoryButton.OnMouseClick += InventoryButton_OnMouseClick;
             inventoryButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.CharacterSheetInventory);
+            inventoryButton.OnKeyboardEvent += InventoryButton_OnKeyboardEvent;
 
             // Spellbook button
             Button spellBookButton = DaggerfallUI.AddButton(new Rect(69, 151, 65, 12), NativePanel);
             spellBookButton.OnMouseClick += SpellBookButton_OnMouseClick;
             spellBookButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.CharacterSheetSpellbook);
+            spellBookButton.OnKeyboardEvent += SpellBookButton_OnKeyboardEvent;
 
             // Logbook button
             Button logBookButton = DaggerfallUI.AddButton(new Rect(3, 165, 65, 12), NativePanel);
             logBookButton.OnMouseClick += LogBookButton_OnMouseClick;
             logBookButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.CharacterSheetLogbook);
+            logBookButton.OnKeyboardEvent += LogBookButton_OnKeyboardEvent;
 
             // History button
             Button historyButton = DaggerfallUI.AddButton(new Rect(69, 165, 65, 12), NativePanel);
             historyButton.OnMouseClick += HistoryButton_OnMouseClick;
             historyButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.CharacterSheetHistory);
+            historyButton.OnKeyboardEvent += HistoryButton_OnKeyboardEvent;
 
             // Exit button
             Button exitButton = DaggerfallUI.AddButton(new Rect(50, 179, 39, 19), NativePanel);
@@ -889,10 +897,38 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             uiManager.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
         }
 
+        void InventoryButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isInventoryWindowDeferred = true;
+            } 
+            else if (keyboardEvent.type == EventType.KeyUp && isInventoryWindowDeferred)
+            {
+                isInventoryWindowDeferred = false;
+                uiManager.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
+            }
+        }
+
         private void SpellBookButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             uiManager.PostMessage(DaggerfallUIMessages.dfuiOpenSpellBookWindow);
+        }
+
+        void SpellBookButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isSpellbookWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isSpellbookWindowDeferred)
+            {
+                isSpellbookWindowDeferred = false;
+                uiManager.PostMessage(DaggerfallUIMessages.dfuiOpenSpellBookWindow);
+            }
         }
 
         private void LogBookButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
@@ -901,11 +937,40 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             uiManager.PostMessage(DaggerfallUIMessages.dfuiOpenQuestJournalWindow);
         }
 
+        void LogBookButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isLogbookWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isLogbookWindowDeferred)
+            {
+                isLogbookWindowDeferred = false;
+                uiManager.PostMessage(DaggerfallUIMessages.dfuiOpenQuestJournalWindow);
+            }
+        }
+
         void HistoryButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             DaggerfallMessageBox advantageTextBox = DaggerfallUI.MessageBox(GetClassSpecials());
             advantageTextBox.OnClose += AdvantageTextBox_OnClose;
+        }
+
+        void HistoryButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isHistoryWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isHistoryWindowDeferred)
+            {
+                isHistoryWindowDeferred = false;
+                DaggerfallMessageBox advantageTextBox = DaggerfallUI.MessageBox(GetClassSpecials());
+                advantageTextBox.OnClose += AdvantageTextBox_OnClose;
+            }
         }
 
         void AdvantageTextBox_OnClose()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -58,6 +58,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         // Handle toggle closing
         KeyCode automapBinding = KeyCode.None;
         HotkeySequence HotkeySequence_toggleClose;
+        bool isCloseWindowDeferred = false;
         readonly KeyCode fallbackKey = KeyCode.Home;
 
         // definitions of hotkey sequences
@@ -570,10 +571,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             HotkeySequence.KeyModifiers keyModifiers = HotkeySequence.GetKeyboardKeyModifiers();
 
-            if (Input.GetKeyUp(KeyCode.Escape) ||
+            if (Input.GetKeyDown(KeyCode.Escape) ||
                 // Toggle window closed with same hotkey used to open it
-                HotkeySequence_toggleClose.IsUpWith(keyModifiers))
+                HotkeySequence_toggleClose.IsDownWith(keyModifiers))
+                isCloseWindowDeferred = true;
+            else if ((Input.GetKeyUp(KeyCode.Escape) ||
+                // Toggle window closed with same hotkey used to open it
+                HotkeySequence_toggleClose.IsUpWith(keyModifiers)) && isCloseWindowDeferred)
             {
+                isCloseWindowDeferred = false;
                 CloseWindow();
                 return;
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -451,7 +451,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -80,6 +80,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         PlayerGPS.DiscoveredBuilding buildingDiscoveryData;
         int curingCost = 0;
 
+        bool isCloseWindowDeferred = false;
+
         List<QuestData> questPool;
 
         #endregion
@@ -154,6 +156,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.GuildsExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             NativePanel.Components.Add(mainPanel);
         }
@@ -444,6 +447,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();
+        }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -81,6 +81,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         int curingCost = 0;
 
         bool isCloseWindowDeferred = false;
+        bool isTalkWindowDeferred = false;
+        bool isServiceWindowDeferred = false;
 
         List<QuestData> questPool;
 
@@ -141,6 +143,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             talkButton = DaggerfallUI.AddButton(talkButtonRect, mainPanel);
             talkButton.OnMouseClick += TalkButton_OnMouseClick;
             talkButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.GuildsTalk);
+            talkButton.OnKeyboardEvent += TalkButton_OnKeyboardEvent;
 
             // Service button
             serviceLabel.Position = new Vector2(0, 1);
@@ -151,6 +154,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             serviceButton.Components.Add(serviceLabel);
             serviceButton.OnMouseClick += ServiceButton_OnMouseClick;
             serviceButton.Hotkey = DaggerfallShortcut.GetBinding(Services.GetServiceShortcutButton(service));
+            serviceButton.OnKeyboardEvent += ServiceButton_OnKeyboardEvent;
 
             // Exit button
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
@@ -297,7 +301,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             GameManager.Instance.TalkManager.TalkToStaticNPC(serviceNPC);
         }
 
-        private void ServiceButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void TalkButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isTalkWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isTalkWindowDeferred)
+            {
+                isTalkWindowDeferred = false;
+                GameManager.Instance.TalkManager.TalkToStaticNPC(serviceNPC);
+            }
+        }
+
+        private void DoGuildService()
         {
             // Check access to service
             if (!guild.CanAccessService(service))
@@ -320,12 +338,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             switch (service)
             {
                 case GuildServices.Quests:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     GetQuest();
                     break;
 
                 case GuildServices.Identify:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     CloseWindow();
                     uiManager.PushWindow(UIWindowFactory.GetInstanceWithArgs(UIWindowType.Trade, new object[] { uiManager, this, DaggerfallTradeWindow.WindowModes.Identify, guild }));
                     break;
@@ -336,12 +352,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
 
                 case GuildServices.Training:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     TrainingService();
                     break;
 
                 case GuildServices.Donate:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     DonationService();
                     break;
 
@@ -350,7 +364,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
 
                 case GuildServices.BuyPotions:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     CloseWindow();
                     tradeWindow = (DaggerfallTradeWindow)UIWindowFactory.GetInstanceWithArgs(UIWindowType.Trade, new object[] { uiManager, this, DaggerfallTradeWindow.WindowModes.Buy, guild });
                     tradeWindow.MerchantItems = GetMerchantPotions();
@@ -358,7 +371,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
 
                 case GuildServices.MakePotions:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     MakePotionService();
                     break;
 
@@ -369,7 +381,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
 
                 case GuildServices.MakeSpells:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     CloseWindow();
                     if (GameManager.Instance.PlayerEntity.Items.Contains(ItemGroups.MiscItems, (int)MiscItems.Spellbook))
                         uiManager.PushWindow(DaggerfallUI.Instance.DfSpellMakerWindow);
@@ -378,7 +389,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
 
                 case GuildServices.BuyMagicItems:   // TODO: switch items depending on npcService?
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     CloseWindow();
                     tradeWindow = (DaggerfallTradeWindow)UIWindowFactory.GetInstanceWithArgs(UIWindowType.Trade, new object[] { uiManager, this, DaggerfallTradeWindow.WindowModes.Buy, guild });
                     tradeWindow.MerchantItems = GetMerchantMagicItems();
@@ -386,7 +396,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
 
                 case GuildServices.MakeMagicItems:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     CloseWindow();
                     uiManager.PushWindow(DaggerfallUI.Instance.DfItemMakerWindow);
                     break;
@@ -397,14 +406,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
 
                 case GuildServices.Teleport:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     CloseWindow();
                     DaggerfallUI.Instance.DfTravelMapWindow.ActivateTeleportationTravel();
                     uiManager.PushWindow(DaggerfallUI.Instance.DfTravelMapWindow);
                     break;
 
                 case GuildServices.DaedraSummoning:
-                    DaedraSummoningService((int) npcService);
+                    DaedraSummoningService((int)npcService);
                     break;
 
                 case GuildServices.ReceiveArmor:
@@ -421,11 +429,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     msgBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRandomTokens(spyMasterGreetingTextId));
                     msgBox.ClickAnywhereToClose = true;
                     msgBox.OnClose += SpyMasterGreetingPopUp_OnClose;
-                    msgBox.Show();                    
+                    msgBox.Show();
                     break;
 
                 case GuildServices.BuySoulgems:
-                    DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
                     CloseWindow();
                     tradeWindow = (DaggerfallTradeWindow)UIWindowFactory.GetInstanceWithArgs(UIWindowType.Trade, new object[] { uiManager, this, DaggerfallTradeWindow.WindowModes.Buy, guild });
                     tradeWindow.MerchantItems = GetMerchantMagicItems(true);
@@ -440,6 +447,26 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     else
                         DaggerfallUI.MessageBox("Guild service not yet implemented.");
                     break;
+            }
+        }
+
+        private void ServiceButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+            DoGuildService();
+        }
+
+        void ServiceButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isServiceWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isServiceWindowDeferred)
+            {
+                isServiceWindowDeferred = false;
+                DoGuildService();
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1999,7 +1999,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In DaggerfallInventoryWindow ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -194,6 +194,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         ItemCollection.AddPosition preferredOrder = ItemCollection.AddPosition.DontCare;
 
         KeyCode toggleClosedBinding;
+        bool isCloseWindowDeferred = false;
         private int maxAmount;
 
         bool suppressInventory = false;
@@ -315,6 +316,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Button exitButton = DaggerfallUI.AddButton(exitButtonRect, NativePanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.InventoryExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             // Setup initial state
             SelectTabPage(TabPages.WeaponsAndArmor);
@@ -1993,7 +1995,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();
+        }
 
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In DaggerfallInventoryWindow ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantRepairPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantRepairPopupWindow.cs
@@ -141,7 +141,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantRepairPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantRepairPopupWindow.cs
@@ -45,6 +45,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         StaticNPC merchantNPC;
 
+        bool isCloseWindowDeferred = false;
+
         #endregion
 
         #region Constructors
@@ -92,6 +94,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MerchantExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             NativePanel.Components.Add(mainPanel);
         }
@@ -134,6 +137,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();
+        }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantRepairPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMerchantRepairPopupWindow.cs
@@ -46,6 +46,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         StaticNPC merchantNPC;
 
         bool isCloseWindowDeferred = false;
+        bool isRepairWindowDeferred = false;
+        bool isTalkWindowDeferred = false;
+        bool isSellWindowDeferred = false;
 
         #endregion
 
@@ -79,16 +82,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             repairButton = DaggerfallUI.AddButton(repairButtonRect, mainPanel);
             repairButton.OnMouseClick += RepairButton_OnMouseClick;
             repairButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MerchantRepair);
+            repairButton.OnKeyboardEvent += RepairButton_OnKeyboardEvent;
 
             // Talk button
             talkButton = DaggerfallUI.AddButton(talkButtonRect, mainPanel);
             talkButton.OnMouseClick += TalkButton_OnMouseClick;
             talkButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MerchantTalk);
+            talkButton.OnKeyboardEvent += TalkButton_OnKeyboardEvent;
 
             // Sell button
             sellButton = DaggerfallUI.AddButton(sellButtonRect, mainPanel);
             sellButton.OnMouseClick += SellButton_OnMouseClick;
             sellButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MerchantSell);
+            sellButton.OnKeyboardEvent += SellButton_OnKeyboardEvent;
 
             // Exit button
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
@@ -119,6 +125,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             uiManager.PushWindow(UIWindowFactory.GetInstanceWithArgs(UIWindowType.Trade, new object[] { uiManager, this, DaggerfallTradeWindow.WindowModes.Repair, null }));
         }
 
+        void RepairButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isRepairWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isRepairWindowDeferred)
+            {
+                isRepairWindowDeferred = false;
+                CloseWindow();
+                uiManager.PushWindow(UIWindowFactory.GetInstanceWithArgs(UIWindowType.Trade, new object[] { uiManager, this, DaggerfallTradeWindow.WindowModes.Repair, null }));
+            }
+        }
+
         private void TalkButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
@@ -126,11 +147,41 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             GameManager.Instance.TalkManager.TalkToStaticNPC(merchantNPC);
         }
 
+        void TalkButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isTalkWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isTalkWindowDeferred)
+            {
+                isTalkWindowDeferred = true;
+                CloseWindow();
+                GameManager.Instance.TalkManager.TalkToStaticNPC(merchantNPC);
+            }
+        }
+
         private void SellButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();
             uiManager.PushWindow(UIWindowFactory.GetInstanceWithArgs(UIWindowType.Trade, new object[] { uiManager, this, DaggerfallTradeWindow.WindowModes.Sell, null }));
+        }
+
+        void SellButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isSellWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isSellWindowDeferred)
+            {
+                isSellWindowDeferred = false;
+                CloseWindow();
+                uiManager.PushWindow(UIWindowFactory.GetInstanceWithArgs(UIWindowType.Trade, new object[] { uiManager, this, DaggerfallTradeWindow.WindowModes.Sell, null }));
+            }
         }
 
         private void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -331,6 +331,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             button.OnMouseClick += ButtonClickHandler;
             button.DefaultButton = defaultButton;
             button.Hotkey = DaggerfallShortcut.GetBinding(ToShortcutButton(messageBoxButton));
+            button.OnKeyboardEvent += ButtonKeyboardEvent;
             buttons.Add(button);
 
             // Once a button has been added the owner is expecting some kind of input from player

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -42,6 +42,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         DaggerfallMessageBox nextMessageBox;
         int customYPos = -1;
         float presentationTime = 0;
+        bool isActivateButtonDeferred = false;
 
         KeyCode extraProceedBinding = KeyCode.None;
 
@@ -426,13 +427,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void ButtonClickHandler(BaseScreenComponent sender, Vector2 position)
         {
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             ActivateButton(sender);
         }
 
         void ButtonKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            if (keyboardEvent.type == EventType.KeyUp)
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isActivateButtonDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isActivateButtonDeferred)
+            {
+                isActivateButtonDeferred = false;
                 ActivateButton(sender);
+            }
         }
 
         void UpdatePanelSizes()
@@ -555,7 +565,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             if (OnButtonClick != null)
                 OnButtonClick(sender, messageBoxButton);
-            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -416,11 +416,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Private Methods
 
-        void ButtonClickHandler(BaseScreenComponent sender, Vector2 position)
+        private void ActivateButton(BaseScreenComponent sender)
         {
             buttonClicked = true;
             selectedButton = (MessageBoxButtons)sender.Tag;
             RaiseOnButtonClickEvent(this, selectedButton);
+        }
+
+        void ButtonClickHandler(BaseScreenComponent sender, Vector2 position)
+        {
+            ActivateButton(sender);
+        }
+
+        void ButtonKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyUp)
+                ActivateButton(sender);
         }
 
         void UpdatePanelSizes()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPlayerHistoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPlayerHistoryWindow.cs
@@ -118,7 +118,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPlayerHistoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPlayerHistoryWindow.cs
@@ -32,6 +32,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         int pageLines;
         int pageStartLine = 0;
 
+        bool isCloseWindowDeferred = false;
+
         public int ClassId { get; protected set; }
 
         public DaggerfallPlayerHistoryWindow(IUserInterfaceManager uiManager)
@@ -64,6 +66,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Button exitButton = DaggerfallUI.AddButton(new Rect(277, 187, 32, 10), NativePanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.HistoryExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             LayoutPage();
             DaggerfallUI.Instance.PlayOneShot(SoundClips.OpenBook);
@@ -111,6 +114,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             pageStartLine = 0; // Go back to the first page
             CloseWindow();
+        }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                pageStartLine = 0; // Go back to the first page
+                CloseWindow();
+            }
         }
 
         public override void OnPush()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -66,6 +66,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button downArrowButton;
         Button exitButton;
 
+        bool isCloseWindowDeferred = false;
+
         public JournalDisplay DisplayMode { get; set; }
 
         public enum JournalDisplay
@@ -143,6 +145,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton.Size                 = new Vector2(30, 9);
             exitButton.OnMouseClick         += ExitButton_OnMouseClick;
             exitButton.Hotkey               = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.JournalExit);
+            exitButton.OnKeyboardEvent      += ExitButton_OnKeyboardEvent;
             exitButton.Name                 = "exit_button";
             mainPanel.Components.Add(exitButton);
 
@@ -301,6 +304,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();
+        }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         void QuestLogLabel_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -308,7 +308,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -78,6 +78,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected Vector3 allocatedBed;
         protected bool ignoreAllocatedBed = false;
         protected bool abortRestForEnemySpawn = false;
+        bool isCloseWindowDeferred = false;
 
         protected PlayerEntity playerEntity;
         protected DaggerfallHUD hud;
@@ -154,6 +155,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             stopButton = DaggerfallUI.AddButton(stopButtonRect, counterPanel);
             stopButton.OnMouseClick += StopButton_OnMouseClick;
             stopButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.RestStop);
+            stopButton.OnKeyboardEvent += StopButton_OnKeyboardEvent;
+
 
             // Store toggle closed binding for this window
             toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Rest);
@@ -641,6 +644,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallUI.Instance.PopToHUD();
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+        }
+
+        protected void StopButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         private void RestFinishedPopup_OnClose()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -648,7 +648,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void StopButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -844,7 +844,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 isCloseWindowDeferred = true;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -112,6 +112,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         List<EffectBundleSettings> offeredSpells = new List<EffectBundleSettings>();
         PlayerGPS.DiscoveredBuilding buildingDiscoveryData;
         int presentedCost;
+        bool isCloseWindowDeferred = false;
 
         #endregion
 
@@ -411,6 +412,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.SpellbookExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             // Scroller buttons
             upArrowButton = DaggerfallUI.AddButton(upArrowButtonRect, mainPanel);
@@ -838,6 +840,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             CloseWindow();
+        }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         void SwapButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartWindow.cs
@@ -24,6 +24,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         Texture2D nativeTexture;
 
+        private Button loadGameButton;
+        private Button newGameButton;
+        private Button exitButton;
+
+        bool isLoadGameDeferred = false;
+        bool isNewGameDeferred = false;
+        bool isExitGameDeferred = false;
+
         public DaggerfallStartWindow(IUserInterfaceManager uiManager)
             : base(uiManager)
         {
@@ -40,24 +48,26 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             NativePanel.BackgroundTexture = nativeTexture;
 
             // Setup buttons
-            DaggerfallUI.AddButton(new Vector2(72, 45), new Vector2(147, 15), DaggerfallUIMessages.dfuiOpenLoadSavedGameWindow, NativePanel);
-            DaggerfallUI.AddButton(new Vector2(72, 99), new Vector2(147, 15), DaggerfallUIMessages.dfuiStartNewGame, NativePanel);
-            DaggerfallUI.AddButton(new Vector2(125, 145), new Vector2(41, 15), DaggerfallUIMessages.dfuiExitGame, NativePanel);
+            loadGameButton = DaggerfallUI.AddButton(new Vector2(72, 45), new Vector2(147, 15), DaggerfallUIMessages.dfuiOpenLoadSavedGameWindow, NativePanel);
+            loadGameButton.OnMouseClick += LoadGameButton_OnMouseClick;
+            loadGameButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MainMenuLoad);
+            loadGameButton.OnKeyboardEvent += LoadGameButton_OnKeyboardEvent;
+
+            newGameButton = DaggerfallUI.AddButton(new Vector2(72, 99), new Vector2(147, 15), DaggerfallUIMessages.dfuiStartNewGame, NativePanel);
+            newGameButton.OnMouseClick += NewGameButton_OnMouseClick;
+            newGameButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MainMenuStart);
+            newGameButton.OnKeyboardEvent += NewGameButton_OnKeyboardEvent;
+
+            exitButton = DaggerfallUI.AddButton(new Vector2(125, 145), new Vector2(41, 15), DaggerfallUIMessages.dfuiExitGame, NativePanel);
+            exitButton.OnMouseClick += ExitButton_OnMouseClick;
+            exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MainMenuExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
         }
 
         public override void Update()
         {
             base.Update();
             InputManager.Instance.CursorVisible = true;
-
-            HotkeySequence.KeyModifiers keyModifiers = HotkeySequence.GetKeyboardKeyModifiers();
-            // Shortcuts for options
-            if (DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MainMenuLoad).IsUpWith(keyModifiers))
-                LoadGame();
-            else if (DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MainMenuStart).IsUpWith(keyModifiers))
-                StartNewGame();
-            else if (DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.MainMenuExit).IsUpWith(keyModifiers))
-                ExitGame();
         }
 
         void LoadGame()
@@ -92,5 +102,54 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     break;
             }
         }
+
+        void LoadGameButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            LoadGame();
+        }
+
+        void LoadGameButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+                isLoadGameDeferred = true;
+            else if (keyboardEvent.type == EventType.KeyUp && isLoadGameDeferred)
+            {
+                isLoadGameDeferred = false;
+                LoadGame();
+            }
+        }
+
+        void NewGameButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            StartNewGame();
+        }
+
+        void NewGameButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+                isNewGameDeferred = true;
+            else if (keyboardEvent.type == EventType.KeyUp && isNewGameDeferred)
+            {
+                isNewGameDeferred = false;
+                StartNewGame();
+            }
+        }
+
+        void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            ExitGame();
+        }
+
+        void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+                isExitGameDeferred = true;
+            else if (keyboardEvent.type == EventType.KeyUp && isExitGameDeferred)
+            {
+                isExitGameDeferred = false;
+                ExitGame();
+            }
+        }
+
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -1598,7 +1598,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         protected void ButtonGoodbye_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -241,6 +241,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
         // Used to store indexes of copied talk fragments so they can be entered into Notebook in chronological order
         List<int> copyIndexes;
 
+        bool isCloseWindowDeferred = false;
+
         public DaggerfallTalkWindow(IUserInterfaceManager uiManager, DaggerfallBaseWindow previous = null)
             : base(uiManager, previous)
         {
@@ -714,6 +716,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             buttonGoodbye.Name = "button_goodbye";
             buttonGoodbye.OnMouseClick += ButtonGoodbye_OnMouseClick;
             buttonGoodbye.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TalkExit);
+            buttonGoodbye.OnKeyboardEvent += ButtonGoodbye_OnKeyboardEvent;
+
             mainPanel.Components.Add(buttonGoodbye);
 
             buttonLogbook = new Button {
@@ -1590,6 +1594,21 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();
+        }
+
+        protected void ButtonGoodbye_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTavernWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTavernWindow.cs
@@ -64,6 +64,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         int daysToRent = 0;
         int tradePrice = 0;
 
+        bool isCloseWindowDeferred = false;
+
         #endregion
 
         #region Constructors
@@ -112,6 +114,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TavernExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             NativePanel.Components.Add(mainPanel);
         }
@@ -124,6 +127,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();
+        }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         private void RoomButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTavernWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTavernWindow.cs
@@ -131,7 +131,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTeleportPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTeleportPopUp.cs
@@ -47,6 +47,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         DaggerfallTravelMapWindow travelWindow = null;
         DFPosition destinationPos;
         string destinationName;
+        bool isCloseWindowDeferred = false;
+        bool isTeleportAwayDeferred = false;
 
         public DFPosition DestinationPos { get { return destinationPos; } set { destinationPos = value; } }
         public string DestinationName { get { return destinationName; } set { destinationName = value; } }
@@ -87,11 +89,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             yesButton = DaggerfallUI.AddButton(yesButtonRect, mainPanel);
             yesButton.OnMouseClick += YesButton_OnMouseClick;
             yesButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.Yes);
+            yesButton.OnKeyboardEvent += YesButton_OnKeyboardEvent;
 
             // No button
             noButton = DaggerfallUI.AddButton(noButtonRect, mainPanel);
             noButton.OnMouseClick += NoButton_OnMouseClick;
             noButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.No);
+            noButton.OnKeyboardEvent += NoButton_OnKeyboardEvent;
 
             NativePanel.Components.Add(mainPanel);
         }
@@ -114,7 +118,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             CloseWindow();
         }
 
-        private void YesButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        void NoButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
+        }
+
+
+        private void TeleportAway()
         {
             DaggerfallUI.Instance.FadeBehaviour.SmashHUDToBlack();
 
@@ -132,6 +151,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUI.Instance.FadeBehaviour.FadeHUDFromBlack();
         }
 
+        private void YesButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            TeleportAway();
+        }
+
+        void YesButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+                isTeleportAwayDeferred = true;
+            else if (keyboardEvent.type == EventType.KeyUp && isTeleportAwayDeferred)
+            {
+                isTeleportAwayDeferred = false;
+                TeleportAway();
+            }
+        }
+
         #endregion
+
     }
 }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTeleportPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTeleportPopUp.cs
@@ -120,7 +120,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         void NoButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 isCloseWindowDeferred = true;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -237,6 +237,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Button exitButton = DaggerfallUI.AddButton(exitButtonRect, NativePanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TradeExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             // Setup initial state
             SelectTabPage((WindowMode == WindowModes.Identify) ? TabPages.MagicItems : TabPages.WeaponsAndArmor);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -176,7 +176,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -56,6 +56,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Vector2 baseSize;
 
         KeyCode toggleClosedBinding;
+        bool isCloseWindowDeferred = false;
 
         #endregion
 
@@ -128,6 +129,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TransportExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             NativePanel.Components.Add(mainPanel);
 
@@ -170,6 +172,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             CloseWindow();
+        }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         private void FootButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -96,12 +96,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             footButton = DaggerfallUI.AddButton(footButtonRect, mainPanel);
             footButton.OnMouseClick += FootButton_OnMouseClick;
             footButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TransportFoot);
+            footButton.OnKeyboardEvent += FootButton_OnKeyboardEvent;
 
             // Horse button
             horseButton = DaggerfallUI.AddButton(horseButtonRect, mainPanel);
             if (hasHorse) {
                 horseButton.OnMouseClick += HorseButton_OnMouseClick;
                 horseButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TransportHorse);
+                horseButton.OnKeyboardEvent += HorseButton_OnKeyboardEvent;
             }
             else {
                 horseButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, horseDisabledRect, disabledTextureSize);
@@ -111,6 +113,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (hasCart) {
                 cartButton.OnMouseClick += CartButton_OnMouseClick;
                 cartButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TransportCart);
+                cartButton.OnKeyboardEvent += CartButton_OnKeyboardEvent;
             }
             else {
                 cartButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, cartDisabledRect, disabledTextureSize);
@@ -120,6 +123,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (hasShip) {
                 shipButton.OnMouseClick += ShipButton_OnMouseClick;
                 shipButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TransportShip);
+                shipButton.OnKeyboardEvent += ShipButton_OnKeyboardEvent;
             }
             else {
                 shipButton.BackgroundTexture = ImageReader.GetSubTexture(disabledTexture, shipDisabledRect, disabledTextureSize);
@@ -195,11 +199,31 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             CloseWindow();
         }
 
+        private void FootButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyUp)
+            {
+                // Reset to normal on foot walking.
+                GameManager.Instance.TransportManager.TransportMode = TransportModes.Foot;
+                CloseWindow();
+            }
+        }
+
         private void HorseButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             // Change to riding a horse.
             GameManager.Instance.TransportManager.TransportMode = TransportModes.Horse;
             CloseWindow();
+        }
+
+        private void HorseButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyUp)
+            {
+                // Change to riding a horse.
+                GameManager.Instance.TransportManager.TransportMode = TransportModes.Horse;
+                CloseWindow();
+            }
         }
 
         private void CartButton_OnMouseClick(BaseScreenComponent sender, Vector2 position) {
@@ -208,10 +232,30 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             CloseWindow();
         }
 
+        private void CartButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyUp)
+            {
+                // Change to riding a cart.
+                GameManager.Instance.TransportManager.TransportMode = TransportModes.Cart;
+                CloseWindow();
+            }
+        }
+
         private void ShipButton_OnMouseClick(BaseScreenComponent sender, Vector2 position) {
             // Teleport to your ship, or back.
             GameManager.Instance.TransportManager.TransportMode = TransportModes.Ship;
             CloseWindow();
+        }
+
+        private void ShipButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyUp)
+            {
+                // Teleport to your ship, or back.
+                GameManager.Instance.TransportManager.TransportMode = TransportModes.Ship;
+                CloseWindow();
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -174,6 +174,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             cautiousToggleButton = DaggerfallUI.AddButton(cautiousButtonRect, NativePanel);
             cautiousToggleButton.OnMouseClick += SpeedButtonOnClickHandler;
             cautiousToggleButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TravelSpeedToggle);
+            cautiousToggleButton.OnKeyboardEvent += SpeedButton_OnKeyboardEvent;
             cautiousToggleButton.OnMouseScrollUp += ToggleSpeedButtonOnScrollHandler;
             cautiousToggleButton.OnMouseScrollDown += ToggleSpeedButtonOnScrollHandler;
 
@@ -185,6 +186,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             footHorseToggleButton = DaggerfallUI.AddButton(footHorseButtonRect, NativePanel);
             footHorseToggleButton.OnMouseClick += TransportModeButtonOnClickHandler;
             footHorseToggleButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TravelTransportModeToggle);
+            footHorseToggleButton.OnKeyboardEvent += TransportModeButtonOnKeyboardHandler;
             footHorseToggleButton.OnMouseScrollUp += ToggleTransportModeButtonOnScrollHandler;
             footHorseToggleButton.OnMouseScrollDown += ToggleTransportModeButtonOnScrollHandler;
 
@@ -196,6 +198,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             innToggleButton = DaggerfallUI.AddButton(innsButtonRect, NativePanel);
             innToggleButton.OnMouseClick += SleepModeButtonOnClickHandler;
             innToggleButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TravelInnCampOutToggle);
+            innToggleButton.OnKeyboardEvent += SleepModeButtonOnKeyboardandler;
             innToggleButton.OnMouseScrollUp += ToggleSleepModeButtonOnScrollHandler;
             innToggleButton.OnMouseScrollDown += ToggleSleepModeButtonOnScrollHandler;
 
@@ -492,12 +495,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
 
-            if (position == Vector2.zero)
-                // Hotkey
-                speedCautious = !speedCautious;
-            else
-                speedCautious = (sender == cautiousToggleButton);
+            speedCautious = (sender == cautiousToggleButton);
             Refresh();
+        }
+
+        public void SpeedButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+                ToggleSpeedButtonOnScrollHandler(sender);
         }
 
         public void ToggleSpeedButtonOnScrollHandler(BaseScreenComponent sender)
@@ -510,13 +515,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public void TransportModeButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
-            
-            if (position == Vector2.zero)
-                // Hotkey
-                travelShip = !travelShip;
-            else
-                travelShip = (sender == shipToggleButton);
+            travelShip = (sender == shipToggleButton);
             Refresh();
+        }
+
+        public void TransportModeButtonOnKeyboardHandler(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+                ToggleTransportModeButtonOnScrollHandler(sender);
         }
 
         public void ToggleTransportModeButtonOnScrollHandler(BaseScreenComponent sender)
@@ -529,13 +535,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public void SleepModeButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
-
-            if (position == Vector2.zero)
-                // Hotkey
-                sleepModeInn = !sleepModeInn;
-            else
-                sleepModeInn = (sender == innToggleButton);
+            sleepModeInn = (sender == innToggleButton);
             Refresh();
+        }
+
+        public void SleepModeButtonOnKeyboardandler(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+                ToggleSleepModeButtonOnScrollHandler(sender);
         }
 
         public void ToggleSleepModeButtonOnScrollHandler(BaseScreenComponent sender)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -477,7 +477,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -80,6 +80,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         bool doFastTravel = false; // flag used to indicate Update() function that fast travel should happen
         float waitTimer = 0;
 
+        bool isCloseWindowDeferred = false;
+
         bool speedCautious  = true;
         bool travelShip     = true;
         bool sleepModeInn   = true;
@@ -167,6 +169,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton = DaggerfallUI.AddButton(exitButtonRect, NativePanel);
             exitButton.OnMouseClick += ExitButtonOnClickHandler;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.TravelExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             cautiousToggleButton = DaggerfallUI.AddButton(cautiousButtonRect, NativePanel);
             cautiousToggleButton.OnMouseClick += SpeedButtonOnClickHandler;
@@ -467,6 +470,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             doFastTravel = false;
             DaggerfallUI.Instance.UserInterfaceManager.PopWindow();
+        }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                doFastTravel = false;
+                DaggerfallUI.Instance.UserInterfaceManager.PopWindow();
+            }
         }
 
         public void SpeedButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUseMagicItemWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUseMagicItemWindow.cs
@@ -21,6 +21,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     {
 
         KeyCode toggleClosedBinding;
+        bool isCloseWindowDeferred = false;
 
         List<DaggerfallUnityItem> magicUseItems = new List<DaggerfallUnityItem>();
 
@@ -64,11 +65,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         public override void Update()
         {
+            base.Update();
+
             // Toggle window closed with same hotkey used to open it
-            if (InputManager.Instance.GetKeyUp(toggleClosedBinding))
+            if (InputManager.Instance.GetKeyDown(toggleClosedBinding))
+                isCloseWindowDeferred = true;
+            else if (InputManager.Instance.GetKeyUp(toggleClosedBinding) && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
                 CloseWindow();
-            else
-                base.Update();
+            }
         }
 
         void Refresh()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
@@ -175,7 +175,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
-            Debug.Log("In ExitButton_OnKeyboardEvent");
             if (keyboardEvent.type == EventType.KeyDown)
             {
                 DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
@@ -46,6 +46,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         StaticNPC witchNPC;
 
         bool isCloseWindowDeferred = false;
+        bool isTalkWindowDeferred = false;
+        bool isSummonDeferred = false;
+        bool isGetQuestDeferred = false;
 
         #endregion
 
@@ -79,16 +82,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             talkButton = DaggerfallUI.AddButton(talkButtonRect, mainPanel);
             talkButton.OnMouseClick += TalkButton_OnMouseClick;
             talkButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.WitchesTalk);
+            talkButton.OnKeyboardEvent += TalkButton_OnKeyboardEvent;
 
             // Summon button
             summonButton = DaggerfallUI.AddButton(summonButtonRect, mainPanel);
             summonButton.OnMouseClick += SummonButton_OnMouseClick;
             summonButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.WitchesDaedraSummon);
+            summonButton.OnKeyboardEvent += SummonButton_OnKeyboardEvent;
 
             // Quest button
             questButton = DaggerfallUI.AddButton(questButtonRect, mainPanel);
             questButton.OnMouseClick += QuestButton_OnMouseClick;
             questButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.WitchesQuest);
+            questButton.OnKeyboardEvent += QuestButton_OnKeyboardEvent;
 
             // Exit button
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
@@ -154,22 +160,69 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void TalkButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();
             GameManager.Instance.TalkManager.TalkToStaticNPC(witchNPC);
         }
 
+        void TalkButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isTalkWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isTalkWindowDeferred)
+            {
+                isTalkWindowDeferred = false;
+                CloseWindow();
+                GameManager.Instance.TalkManager.TalkToStaticNPC(witchNPC);
+            }
+        }
+
         private void SummonButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             DaedraSummoningService(witchNPC.Data.factionID);
+        }
+
+        void SummonButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isSummonDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isSummonDeferred)
+            {
+                isSummonDeferred = false;
+                DaedraSummoningService(witchNPC.Data.factionID);
+            }
         }
 
         private void QuestButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             GetQuest();
+        }
+
+        void QuestButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isGetQuestDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isGetQuestDeferred)
+            {
+                isGetQuestDeferred = false;
+                GetQuest();
+            }
         }
 
         private void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
@@ -45,6 +45,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         StaticNPC witchNPC;
 
+        bool isCloseWindowDeferred = false;
+
         #endregion
 
         #region Constructors
@@ -92,6 +94,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             exitButton = DaggerfallUI.AddButton(exitButtonRect, mainPanel);
             exitButton.OnMouseClick += ExitButton_OnMouseClick;
             exitButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.WitchesExit);
+            exitButton.OnKeyboardEvent += ExitButton_OnKeyboardEvent;
 
             NativePanel.Components.Add(mainPanel);
         }
@@ -168,6 +171,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             CloseWindow();
+        }
+
+        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            Debug.Log("In ExitButton_OnKeyboardEvent");
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                isCloseWindowDeferred = true;
+            }
+            else if (keyboardEvent.type == EventType.KeyUp && isCloseWindowDeferred)
+            {
+                isCloseWindowDeferred = false;
+                CloseWindow();
+            }
         }
 
         #endregion


### PR DESCRIPTION
This is a fix for the issue discussed in #1783:
    
Keyboard events can leak from game to UI or from UI to game:
- to prevent leaks from UI to game, UI controls can be triggered on KeyUp, so that the key is released before the game takes control back. However if the player releases game keys after opening the UI, that can activate UI buttons ("W" in inventory, "S" in spellbook,...);
- to prevent leaks from game to UI, UI controls can be triggered on KeyDown, so that keys have to be pressed again inside the UI to have an effect. However this means keys can still be pressed after the UI closed, leaking key events into the game.
    
It should be clear now that those two situations are symetric, and that none fixes all problems. UI controls need to be able to handle KeyDown and KeyUp explicitly.
    
With this PR, buttons can:
- (unchanged) have a OnMouseClick handler; They will only react to mouse events;
- (unchanged) also have a Hotkey hotkey sequence; When the sequence is pressed, the OnMouseClick handler receives the event as a faked click;
 - but now also have a OnKeyboardEvent handler; In that case no click will be faked, and the keyboard handler will receive both KeyDown and KeyUp events.
    
With that in place, controls should react to KeyDown events in general, but the buttons that close the UI, or maybe even yield control to another UI window, should use a keyboard handler. For safety, they should be armed by KeyDown events (possibly giving user feedback by emitting a sound), and activated by KeyUp events if previously armed.
    
I'm very pleased with this, feels like sound design.I even used it to fix #1805 and simplify fast travel popup code :)
It needs more testing, but I'm releasing it for public scrutiny.