### PR TITLE
Added Autorun action and keybind

### DIFF
--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -267,7 +267,6 @@ namespace DaggerfallWorkshop.Game
             Crouch,
             Slide,
             Run,
-            AutoRun,
 
             Rest,
             Transport,
@@ -306,6 +305,8 @@ namespace DaggerfallWorkshop.Game
             QuickLoad,
 
             PrintScreen,
+
+            AutoRun,
             
             Unknown,
         }
@@ -759,7 +760,7 @@ namespace DaggerfallWorkshop.Game
             SetBinding(KeyCode.RightControl, Actions.Slide);
             SetBinding(KeyCode.LeftShift, Actions.Run);
             SetBinding(KeyCode.RightShift, Actions.Run);
-            SetBinding(KeyCode.F, Actions.AutoRun);
+            SetBinding(KeyCode.Mouse2, Actions.AutoRun);
 
             SetBinding(KeyCode.R, Actions.Rest);
             SetBinding(KeyCode.T, Actions.Transport);
@@ -972,7 +973,7 @@ namespace DaggerfallWorkshop.Game
             TestSetBinding(KeyCode.RightControl, Actions.Slide);
             TestSetBinding(KeyCode.LeftShift, Actions.Run);
             TestSetBinding(KeyCode.RightShift, Actions.Run);
-            TestSetBinding(KeyCode.F, Actions.AutoRun);
+            TestSetBinding(KeyCode.Mouse2, Actions.AutoRun);
 
             TestSetBinding(KeyCode.R, Actions.Rest);
             TestSetBinding(KeyCode.T, Actions.Transport);

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -238,6 +238,8 @@ namespace DaggerfallWorkshop.Game
             set { joystickMovementThreshold = value; }
         }
 
+        public bool MaximizeJoystickMovement { get; set; }
+
         #endregion
 
         #region Enums
@@ -1300,7 +1302,7 @@ namespace DaggerfallWorkshop.Game
             {
                 float dist = Mathf.Clamp(Mathf.Sqrt(horiz*horiz + vert*vert), controllerMinimumAxisFloat, 1.0F);
 
-                if (dist > JoystickMovementThreshold)
+                if (MaximizeJoystickMovement || dist > JoystickMovementThreshold)
                     dist = 1.0F;
 
                 if (horiz > 0)
@@ -1321,6 +1323,7 @@ namespace DaggerfallWorkshop.Game
                 }
                 else if (vert < 0)
                 {
+                    ToggleAutorun = false;
                     currentActions.Add(Actions.MoveBackwards);
                     vert = -dist;
                 }

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -177,6 +177,8 @@ namespace DaggerfallWorkshop.Game
             get { return (vertical < -deadZone || vertical > deadZone) ? vertical : 0; }
         }
 
+        public bool ToggleAutorun { get; set; }
+
         public bool UsingController
         {
             get { return usingControllerCursor; }
@@ -265,6 +267,7 @@ namespace DaggerfallWorkshop.Game
             Crouch,
             Slide,
             Run,
+            AutoRun,
 
             Rest,
             Transport,
@@ -442,6 +445,12 @@ namespace DaggerfallWorkshop.Game
             mouseY = Input.GetAxisRaw("Mouse Y");
             if (mouseY == 0F && !String.IsNullOrEmpty(cameraAxisBindingCache[1]))
                 mouseY = Input.GetAxis(cameraAxisBindingCache[1]) * JoystickCameraSensitivity;
+
+
+            if(ToggleAutorun)
+            {
+                ApplyVerticalForce(1);
+            }
 
             // Process actions from input sources
             FindKeyboardActions();
@@ -750,6 +759,7 @@ namespace DaggerfallWorkshop.Game
             SetBinding(KeyCode.RightControl, Actions.Slide);
             SetBinding(KeyCode.LeftShift, Actions.Run);
             SetBinding(KeyCode.RightShift, Actions.Run);
+            SetBinding(KeyCode.F, Actions.AutoRun);
 
             SetBinding(KeyCode.R, Actions.Rest);
             SetBinding(KeyCode.T, Actions.Transport);
@@ -962,6 +972,7 @@ namespace DaggerfallWorkshop.Game
             TestSetBinding(KeyCode.RightControl, Actions.Slide);
             TestSetBinding(KeyCode.LeftShift, Actions.Run);
             TestSetBinding(KeyCode.RightShift, Actions.Run);
+            TestSetBinding(KeyCode.F, Actions.AutoRun);
 
             TestSetBinding(KeyCode.R, Actions.Rest);
             TestSetBinding(KeyCode.T, Actions.Transport);
@@ -1254,6 +1265,7 @@ namespace DaggerfallWorkshop.Game
                             ApplyVerticalForce(1);
                             break;
                         case Actions.MoveBackwards:
+                            ToggleAutorun = false;
                             ApplyVerticalForce(-1);
                             break;
                         case Actions.TurnLeft:

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -115,6 +115,8 @@ namespace DaggerfallWorkshop.Game
                 speed /= 2;
                 speed -= (1 / classicToUnitySpeedUnitRatio);
             }
+
+            InputManager.Instance.MaximizeJoystickMovement = isRunning;
         }
 
         public bool CanRunUnlessRiding()

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -69,6 +69,19 @@ namespace DaggerfallWorkshop.Game
                 sneakingMode = InputManager.Instance.HasAction(InputManager.Actions.Sneak);
             else
                 sneakingMode = sneakingMode ^ InputManager.Instance.ActionStarted(InputManager.Actions.Sneak);
+
+            if (InputManager.Instance.ActionStarted(InputManager.Actions.AutoRun))
+            {
+                InputManager.Instance.ToggleAutorun = !InputManager.Instance.ToggleAutorun;
+
+                ToggleRun = InputManager.Instance.ToggleAutorun;
+                runningMode = runningMode ^ InputManager.Instance.ToggleAutorun;
+            }
+
+            if (InputManager.Instance.ActionStarted(InputManager.Actions.MoveBackwards))
+            {
+                ToggleRun = false;
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -43,6 +43,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button screenshotKeybindButton = new Button();
         Button quickSaveKeybindButton = new Button();
         Button quickLoadKeybindButton = new Button();
+        Button autoRunKeybindButton = new Button();
         HorizontalSlider mouseSensitivitySlider;
         HorizontalSlider weaponSensitivitySlider;
         HorizontalSlider moveSpeedAccelerationSlider;
@@ -113,10 +114,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // keybind buttons
             SetupKeybindButton(escapeKeybindButton, InputManager.Actions.Escape, 20, 20);
+            SetupKeybindButton(autoRunKeybindButton, InputManager.Actions.AutoRun, 20, 40);
             SetupKeybindButton(consoleKeybindButton, InputManager.Actions.ToggleConsole, 115, 20);
-            SetupKeybindButton(screenshotKeybindButton, InputManager.Actions.PrintScreen, 210, 20);
-            SetupKeybindButton(quickSaveKeybindButton, InputManager.Actions.QuickSave, 20, 40);
-            SetupKeybindButton(quickLoadKeybindButton, InputManager.Actions.QuickLoad, 115, 40);
+            SetupKeybindButton(screenshotKeybindButton, InputManager.Actions.PrintScreen, 115, 40);
+            SetupKeybindButton(quickSaveKeybindButton, InputManager.Actions.QuickSave, 210, 20);
+            SetupKeybindButton(quickLoadKeybindButton, InputManager.Actions.QuickLoad, 210, 40);
 
             mouseSensitivitySlider = CreateSlider("Mouse Look Sensitivity", 15, 80, 0.1f, 8.0f, DaggerfallUnity.Settings.MouseLookSensitivity);
 
@@ -219,6 +221,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupKeybindButton(screenshotKeybindButton, InputManager.Actions.PrintScreen);
             SetupKeybindButton(quickSaveKeybindButton, InputManager.Actions.QuickSave);
             SetupKeybindButton(quickLoadKeybindButton, InputManager.Actions.QuickLoad);
+            SetupKeybindButton(autoRunKeybindButton, InputManager.Actions.AutoRun);
         }
 
         /// <summary>


### PR DESCRIPTION
Pressing the middle mouse button will toggle autorun mode, which defaults to sprinting forward without holding any keys. While in autorun mode, the run key also becomes togglable, so you can resort to simply pressing the run key once to toggle it between autowalking and autorunning.

Pressing the Autorun key again, or just moving backwards, will cancel it.

I rearranged the order of the advanced control keybinds so similar actions are grouped on top of each other.