### PR TITLE
Fix GetKey usage for pausing, screenshots, and console

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
@@ -31,6 +31,7 @@ namespace Wenzil.Console
 
         void Start()
         {
+            DaggerfallWorkshop.Game.InputManager.OnSavedKeyBinds += GetConsoleKeyBind;
         }
 
         void OnEnable()
@@ -52,7 +53,7 @@ namespace Wenzil.Console
 
         void Update()
         {
-            if (Input.GetKeyDown(toggleKey))
+            if (DaggerfallWorkshop.Game.InputManager.Instance.GetKeyDown(toggleKey))
                 ui.ToggleConsole();
             else if (Input.GetKeyDown(KeyCode.Escape) && closeOnEscape)
                 ui.CloseConsole();

--- a/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
+++ b/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
@@ -61,7 +61,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         {
             if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
             {
-                if (Input.GetKeyUp(prtscrBinding))
+                if (InputManager.Instance.GetKeyUp(prtscrBinding))
                     StartCoroutine(TakeScreenshot());
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
@@ -174,7 +174,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
             {
                 // Toggle window closed with same hotkey used to open it
-                if (Input.GetKeyUp(toggleClosedBinding))
+                if (InputManager.Instance.GetKeyUp(toggleClosedBinding))
                     CloseWindow();
             }
         }


### PR DESCRIPTION
They all used to use Input.GetKeyX, which would cause an exception if a user were to bind a an axis button to one of them. Also, the console controller did not properly update its binding - it would have to be opened with the old keybind first, then closed with the new keybind to update the change.

I made all of them InputManager.Instance.GetKeyX, as well as made the console listen for OnSavedKeyBinds to update its own keybind.