### PR TITLE
[RFC] Travel map dot outlines

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -61,6 +61,8 @@ AccelerateUICopyTexture=False
 SDFFontRendering=True
 EnableGeographicBackgrounds=False
 DungeonExitWagonPrompt=True
+TravelMapLocationsOutline=True
+
 IllegalRestWarning=True
 LargeHUD=false
 LargeHUDScale=1.0

--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -62,7 +62,6 @@ SDFFontRendering=True
 EnableGeographicBackgrounds=False
 DungeonExitWagonPrompt=True
 IllegalRestWarning=True
-LoiterLimitInHours=3
 LargeHUD=false
 LargeHUDScale=1.0
 
@@ -125,3 +124,4 @@ EnemyInfighting=True
 EnhancedCombatAI=True
 GuildQuestListBox=False
 BowLeftHandWithSwitching=False
+LoiterLimitInHours=3

--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -61,7 +61,7 @@ AccelerateUICopyTexture=False
 SDFFontRendering=True
 EnableGeographicBackgrounds=False
 DungeonExitWagonPrompt=True
-TravelMapLocationsOutline=True
+TravelMapLocationsOutline=False
 
 IllegalRestWarning=True
 LargeHUD=false

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -116,6 +116,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         HorizontalSlider helmAndShieldMaterialDisplay;
         Checkbox geographicBackgrounds;
         Checkbox dungeonExitWagonPrompt;
+        Checkbox travelMapLocationsOutline;
 
         // Enhancements
         Checkbox modSystem;
@@ -282,6 +283,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 DaggerfallUnity.Settings.HelmAndShieldMaterialDisplay, "off", "noLeatChai", "noLeat", "on");
             geographicBackgrounds = AddCheckbox(rightPanel, "geographicBackgrounds", DaggerfallUnity.Settings.EnableGeographicBackgrounds);
             dungeonExitWagonPrompt = AddCheckbox(rightPanel, "dungeonExitWagonPrompt", DaggerfallUnity.Settings.DungeonExitWagonPrompt);
+            travelMapLocationsOutline = AddCheckbox(rightPanel, "travelMapLocationsOutline", DaggerfallUnity.Settings.TravelMapLocationsOutline);
         }
 
         private void Enhancements(Panel leftPanel, Panel rightPanel)
@@ -422,6 +424,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.InstantRepairs = instantRepairs.IsChecked;
             DaggerfallUnity.Settings.GuildQuestListBox = guildQuestListBox.IsChecked;
             DaggerfallUnity.Settings.BowLeftHandWithSwitching = bowLeftHandWithSwitching.IsChecked;
+            DaggerfallUnity.Settings.TravelMapLocationsOutline = travelMapLocationsOutline.IsChecked;
 
             DaggerfallUnity.Settings.DungeonAmbientLightScale = dungeonAmbientLightScale.GetValue();
             DaggerfallUnity.Settings.NightAmbientLightScale = nightAmbientLightScale.GetValue();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -116,7 +116,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         HorizontalSlider helmAndShieldMaterialDisplay;
         Checkbox geographicBackgrounds;
         Checkbox dungeonExitWagonPrompt;
-        HorizontalSlider loiterLimitInHours;
 
         // Enhancements
         Checkbox modSystem;
@@ -134,6 +133,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox playerTorchFromItems;
         Checkbox guildQuestListBox;
         Checkbox bowLeftHandWithSwitching;
+        HorizontalSlider loiterLimitInHours;
         HorizontalSlider dungeonAmbientLightScale;
         HorizontalSlider nightAmbientLightScale;
         HorizontalSlider playerTorchLightScale;
@@ -282,8 +282,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 DaggerfallUnity.Settings.HelmAndShieldMaterialDisplay, "off", "noLeatChai", "noLeat", "on");
             geographicBackgrounds = AddCheckbox(rightPanel, "geographicBackgrounds", DaggerfallUnity.Settings.EnableGeographicBackgrounds);
             dungeonExitWagonPrompt = AddCheckbox(rightPanel, "dungeonExitWagonPrompt", DaggerfallUnity.Settings.DungeonExitWagonPrompt);
-            loiterLimitInHours = AddSlider(rightPanel, "loiterLimitInHours", 3, 12, DaggerfallUnity.Settings.LoiterLimitInHours);
-
         }
 
         private void Enhancements(Panel leftPanel, Panel rightPanel)
@@ -316,6 +314,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             instantRepairs = AddCheckbox(rightPanel, "instantRepairs", DaggerfallUnity.Settings.InstantRepairs);
             guildQuestListBox = AddCheckbox(rightPanel, "guildQuestListBox", DaggerfallUnity.Settings.GuildQuestListBox);
             bowLeftHandWithSwitching = AddCheckbox(rightPanel, "bowLeftHandWithSwitching", DaggerfallUnity.Settings.BowLeftHandWithSwitching);
+            loiterLimitInHours = AddSlider(rightPanel, "loiterLimitInHours", 3, 12, DaggerfallUnity.Settings.LoiterLimitInHours);
         }
 
         private void Video(Panel leftPanel, Panel rightPanel)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -51,13 +51,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int identifyFlashCount                        = 4;
         const int identifyFlashCountSelected                = 2;
         const float identifyFlashInterval                   = 0.5f;
-        const int dotsOutline                               = 1;
+        const int dotsOutlineThickness                      = 1;
+        Color32 dotOutlineColor                             = new Color32(0, 0, 0, 64);
         Vector2[] outlineDisplacements =
         {
-            new Vector2(-0.5f, -0.5f),
-            new Vector2(0.5f, -0.5f),
-            new Vector2(-0.5f, 0.5f),
-            new Vector2(0.5f, 0.5f)
+            new Vector2(-0.5f, -0f),
+            new Vector2(0f, -0.5f),
+            new Vector2(0f, 0.5f),
+            new Vector2(0.5f, 0f)
         };
 
         DaggerfallTravelPopUp popUp;
@@ -284,14 +285,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             regionTextureOverlayPanel.Enabled = false;
 
             // Location dots overlay panel
-            if (dotsOutline > 0)
+            if (dotsOutlineThickness > 0)
             {
                 regionLocationDotsOutlinesOverlayPanel = new Panel[outlineDisplacements.Length];
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                 {
                     Rect modifedPanelRect = regionTextureOverlayPanelRect;
-                    modifedPanelRect.x += outlineDisplacements[i].x;
-                    modifedPanelRect.y += outlineDisplacements[i].y;
+                    modifedPanelRect.x += outlineDisplacements[i].x * dotsOutlineThickness / NativePanel.LocalScale.x;
+                    modifedPanelRect.y += outlineDisplacements[i].y * dotsOutlineThickness / NativePanel.LocalScale.y;
                     regionLocationDotsOutlinesOverlayPanel[i] = DaggerfallUI.AddPanel(modifedPanelRect, NativePanel);
                     regionLocationDotsOutlinesOverlayPanel[i].Enabled = false;
                 }
@@ -694,8 +695,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                                 continue;
                             else
                             {
-                                if (dotsOutline > 0)
-                                    locationDotsOutlinePixelBuffer[offset] = Color.black;
+                                if (dotsOutlineThickness > 0)
+                                    locationDotsOutlinePixelBuffer[offset] = dotOutlineColor;
                                 locationDotsPixelBuffer[offset] = locationPixelColors[index];
                             }
                         }
@@ -704,7 +705,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
 
             // Apply updated color array to texture
-            if (dotsOutline > 0)
+            if (dotsOutlineThickness > 0)
             {
                 locationDotsOutlineTexture.SetPixels32(locationDotsOutlinePixelBuffer);
                 locationDotsOutlineTexture.Apply();
@@ -713,7 +714,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             locationDotsTexture.Apply();
 
             // Present texture
-            if (dotsOutline > 0)
+            if (dotsOutlineThickness > 0)
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                     regionLocationDotsOutlinesOverlayPanel[i].BackgroundTexture = locationDotsOutlineTexture;
             regionLocationDotsOverlayPanel.BackgroundTexture = locationDotsTexture;
@@ -731,7 +732,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (!RegionSelected || !zoom)
             {
                 regionTextureOverlayPanel.BackgroundTextureLayout = BackgroundLayout.StretchToFill;
-                if (dotsOutline > 0)
+                if (dotsOutlineThickness > 0)
                     for (int i = 0; i < outlineDisplacements.Length; i++)
                         regionLocationDotsOutlinesOverlayPanel[i].BackgroundTextureLayout = BackgroundLayout.StretchToFill;
                 regionLocationDotsOverlayPanel.BackgroundTextureLayout = BackgroundLayout.StretchToFill;
@@ -773,12 +774,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Set cropped area in location dots panel - always at classic dimensions            
             Rect locationDotsNewRect = new Rect(startX, startY, width / zoomfactor, height / zoomfactor);
-            if (dotsOutline > 0)
+            if (dotsOutlineThickness > 0)
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                 {
                     Rect modifiedRect = locationDotsNewRect;
-                    modifiedRect.x += outlineDisplacements[i].x;
-                    modifiedRect.y += outlineDisplacements[i].y;
+                    modifiedRect.x += outlineDisplacements[i].x * dotsOutlineThickness / NativePanel.LocalScale.x;
+                    modifiedRect.y += outlineDisplacements[i].y * dotsOutlineThickness / NativePanel.LocalScale.y;
                     regionLocationDotsOutlinesOverlayPanel[i].BackgroundTextureLayout = BackgroundLayout.Cropped;
                     regionLocationDotsOutlinesOverlayPanel[i].BackgroundCroppedRect = modifiedRect;
                 }
@@ -1073,7 +1074,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             selectedRegion = region;
             selectedRegionMapNames = mapNames;
             regionTextureOverlayPanel.Enabled = true;
-            if (dotsOutline > 0)
+            if (dotsOutlineThickness > 0)
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                     regionLocationDotsOutlinesOverlayPanel[i].Enabled = true;
             regionLocationDotsOverlayPanel.Enabled = true;
@@ -1095,7 +1096,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             locationSelected = false;
             mapIndex = 0;
             regionTextureOverlayPanel.Enabled = false;
-            if (dotsOutline > 0)
+            if (dotsOutlineThickness > 0)
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                     regionLocationDotsOutlinesOverlayPanel[i].Enabled = false;
             regionLocationDotsOverlayPanel.Enabled = false;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -51,6 +51,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int identifyFlashCount                        = 4;
         const int identifyFlashCountSelected                = 2;
         const float identifyFlashInterval                   = 0.5f;
+        const int dotsOutline                               = 1;
 
         DaggerfallTravelPopUp popUp;
 
@@ -648,7 +649,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 for (int x = 0; x < width; x++)
                 {
-                    int offset = (int)((((height - y - 1) * width) + x) * scale);
+                    int offset = GetOffset(width, height, x, y);
                     if (offset >= (width * height))
                         continue;
                     int sampleRegion = DaggerfallUnity.Instance.ContentReader.MapFileReader.GetPoliticIndex(originX + x, originY + y) - 128;
@@ -666,7 +667,17 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                             if (index == -1)
                                 continue;
                             else
+                            {
+                                if (dotsOutline > 0)
+                                    for (int y1 = Math.Max(0, y - dotsOutline); y1 < Math.Min(height, y + dotsOutline + 1); y1++)
+                                        for (int x1 = Math.Max(0, x - dotsOutline); x1 < Math.Min(width, x + dotsOutline + 1); x1++)
+                                        {
+                                            int offset1 = GetOffset(width, height, x1, y1);
+                                            if (locationDotsPixelBuffer[offset1].a == (byte)0)
+                                                locationDotsPixelBuffer[offset1] = Color.black;
+                                        }
                                 locationDotsPixelBuffer[offset] = locationPixelColors[index];
+                            }
                         }
                     }
                 }
@@ -678,6 +689,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Present texture
             regionLocationDotsOverlayPanel.BackgroundTexture = locationDotsTexture;
+        }
+
+        private int GetOffset(int width, int height, int x, int y)
+        {
+            return (int)((((height - y - 1) * width) + x) * scale);
         }
 
         // Zoom and pan region texture

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -676,7 +676,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 for (int x = 0; x < width; x++)
                 {
-                    int offset = GetOffset(width, height, x, y);
+                    int offset = (int)((((height - y - 1) * width) + x) * scale);
                     if (offset >= (width * height))
                         continue;
                     int sampleRegion = DaggerfallUnity.Instance.ContentReader.MapFileReader.GetPoliticIndex(originX + x, originY + y) - 128;
@@ -718,11 +718,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                     regionLocationDotsOutlinesOverlayPanel[i].BackgroundTexture = locationDotsOutlineTexture;
             regionLocationDotsOverlayPanel.BackgroundTexture = locationDotsTexture;
-        }
-
-        private int GetOffset(int width, int height, int x, int y)
-        {
-            return (int)((((height - y - 1) * width) + x) * scale);
         }
 
         // Zoom and pan region texture

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -52,7 +52,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const int identifyFlashCountSelected                = 2;
         const float identifyFlashInterval                   = 0.5f;
         const int dotsOutlineThickness                      = 1;
-        Color32 dotOutlineColor                             = new Color32(0, 0, 0, 64);
+        Color32 dotOutlineColor                             = new Color32(0, 0, 0, 128);
         Vector2[] outlineDisplacements =
         {
             new Vector2(-0.5f, -0f),

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -285,7 +285,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             regionTextureOverlayPanel.Enabled = false;
 
             // Location dots overlay panel
-            if (dotsOutlineThickness > 0)
+            if (DaggerfallUnity.Settings.TravelMapLocationsOutline)
             {
                 regionLocationDotsOutlinesOverlayPanel = new Panel[outlineDisplacements.Length];
                 for (int i = 0; i < outlineDisplacements.Length; i++)
@@ -695,7 +695,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                                 continue;
                             else
                             {
-                                if (dotsOutlineThickness > 0)
+                                if (DaggerfallUnity.Settings.TravelMapLocationsOutline)
                                     locationDotsOutlinePixelBuffer[offset] = dotOutlineColor;
                                 locationDotsPixelBuffer[offset] = locationPixelColors[index];
                             }
@@ -705,7 +705,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
 
             // Apply updated color array to texture
-            if (dotsOutlineThickness > 0)
+            if (DaggerfallUnity.Settings.TravelMapLocationsOutline)
             {
                 locationDotsOutlineTexture.SetPixels32(locationDotsOutlinePixelBuffer);
                 locationDotsOutlineTexture.Apply();
@@ -714,7 +714,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             locationDotsTexture.Apply();
 
             // Present texture
-            if (dotsOutlineThickness > 0)
+            if (DaggerfallUnity.Settings.TravelMapLocationsOutline)
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                     regionLocationDotsOutlinesOverlayPanel[i].BackgroundTexture = locationDotsOutlineTexture;
             regionLocationDotsOverlayPanel.BackgroundTexture = locationDotsTexture;
@@ -727,7 +727,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (!RegionSelected || !zoom)
             {
                 regionTextureOverlayPanel.BackgroundTextureLayout = BackgroundLayout.StretchToFill;
-                if (dotsOutlineThickness > 0)
+                if (DaggerfallUnity.Settings.TravelMapLocationsOutline)
                     for (int i = 0; i < outlineDisplacements.Length; i++)
                         regionLocationDotsOutlinesOverlayPanel[i].BackgroundTextureLayout = BackgroundLayout.StretchToFill;
                 regionLocationDotsOverlayPanel.BackgroundTextureLayout = BackgroundLayout.StretchToFill;
@@ -769,7 +769,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Set cropped area in location dots panel - always at classic dimensions            
             Rect locationDotsNewRect = new Rect(startX, startY, width / zoomfactor, height / zoomfactor);
-            if (dotsOutlineThickness > 0)
+            if (DaggerfallUnity.Settings.TravelMapLocationsOutline)
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                 {
                     Rect modifiedRect = locationDotsNewRect;
@@ -1069,7 +1069,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             selectedRegion = region;
             selectedRegionMapNames = mapNames;
             regionTextureOverlayPanel.Enabled = true;
-            if (dotsOutlineThickness > 0)
+            if (DaggerfallUnity.Settings.TravelMapLocationsOutline)
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                     regionLocationDotsOutlinesOverlayPanel[i].Enabled = true;
             regionLocationDotsOverlayPanel.Enabled = true;
@@ -1091,7 +1091,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             locationSelected = false;
             mapIndex = 0;
             regionTextureOverlayPanel.Enabled = false;
-            if (dotsOutlineThickness > 0)
+            if (DaggerfallUnity.Settings.TravelMapLocationsOutline)
                 for (int i = 0; i < outlineDisplacements.Length; i++)
                     regionLocationDotsOutlinesOverlayPanel[i].Enabled = false;
             regionLocationDotsOverlayPanel.Enabled = false;

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -124,7 +124,6 @@ namespace DaggerfallWorkshop
         public bool EnableArrowCounter { get; set; }
         public bool DungeonExitWagonPrompt { get; set; }
         public bool IllegalRestWarning { get; set; }
-        public int LoiterLimitInHours { get; set; }
         public bool LargeHUD { get; set; }
         public float LargeHUDScale { get; set; }
 
@@ -186,6 +185,7 @@ namespace DaggerfallWorkshop
         public bool EnhancedCombatAI { get; set; }
         public bool GuildQuestListBox { get; set; }
         public bool BowLeftHandWithSwitching { get; set; }
+        public int LoiterLimitInHours { get; set; }
 
         #endregion
 
@@ -259,7 +259,6 @@ namespace DaggerfallWorkshop
             EnableArrowCounter = GetBool(sectionGUI, "EnableArrowCounter");
             DungeonExitWagonPrompt = GetBool(sectionGUI, "DungeonExitWagonPrompt");
             IllegalRestWarning = GetBool(sectionGUI, "IllegalRestWarning");
-            LoiterLimitInHours = GetInt(sectionGUI, "LoiterLimitInHours");
             LargeHUD = GetBool(sectionGUI, "LargeHUD");
             LargeHUDScale = GetFloat(sectionGUI, "LargeHUDScale", 0.25f, 2.0f);
 
@@ -315,6 +314,7 @@ namespace DaggerfallWorkshop
             EnhancedCombatAI = GetBool(sectionEnhancements, "EnhancedCombatAI");
             GuildQuestListBox = GetBool(sectionEnhancements, "GuildQuestListBox");
             BowLeftHandWithSwitching = GetBool(sectionEnhancements, "BowLeftHandWithSwitching");
+            LoiterLimitInHours = GetInt(sectionEnhancements, "LoiterLimitInHours");
         }
 
         /// <summary>
@@ -383,7 +383,6 @@ namespace DaggerfallWorkshop
             SetBool(sectionGUI, "EnableArrowCounter", EnableArrowCounter);
             SetBool(sectionGUI, "DungeonExitWagonPrompt", DungeonExitWagonPrompt);
             SetBool(sectionGUI, "IllegalRestWarning", IllegalRestWarning);
-            SetInt(sectionGUI, "LoiterLimitInHours", LoiterLimitInHours);
             SetBool(sectionGUI, "LargeHUD", LargeHUD);
             SetFloat(sectionGUI, "LargeHUDScale", LargeHUDScale);
 
@@ -432,6 +431,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionEnhancements, "EnhancedCombatAI", EnhancedCombatAI);
             SetBool(sectionEnhancements, "GuildQuestListBox", GuildQuestListBox);
             SetBool(sectionEnhancements, "BowLeftHandWithSwitching", BowLeftHandWithSwitching);
+            SetInt(sectionEnhancements, "LoiterLimitInHours", LoiterLimitInHours);
 
             // Write settings to persistent file
             WriteSettingsFile();

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -123,6 +123,7 @@ namespace DaggerfallWorkshop
         public bool EnableGeographicBackgrounds { get; set; }
         public bool EnableArrowCounter { get; set; }
         public bool DungeonExitWagonPrompt { get; set; }
+        public bool TravelMapLocationsOutline { get; set; }
         public bool IllegalRestWarning { get; set; }
         public bool LargeHUD { get; set; }
         public float LargeHUDScale { get; set; }
@@ -258,6 +259,7 @@ namespace DaggerfallWorkshop
             EnableGeographicBackgrounds = GetBool(sectionGUI, "EnableGeographicBackgrounds");
             EnableArrowCounter = GetBool(sectionGUI, "EnableArrowCounter");
             DungeonExitWagonPrompt = GetBool(sectionGUI, "DungeonExitWagonPrompt");
+            TravelMapLocationsOutline = GetBool(sectionGUI, "TravelMapLocationsOutline");
             IllegalRestWarning = GetBool(sectionGUI, "IllegalRestWarning");
             LargeHUD = GetBool(sectionGUI, "LargeHUD");
             LargeHUDScale = GetFloat(sectionGUI, "LargeHUDScale", 0.25f, 2.0f);
@@ -382,6 +384,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionGUI, "EnableGeographicBackgrounds", EnableGeographicBackgrounds);
             SetBool(sectionGUI, "EnableArrowCounter", EnableArrowCounter);
             SetBool(sectionGUI, "DungeonExitWagonPrompt", DungeonExitWagonPrompt);
+            SetBool(sectionGUI, "TravelMapLocationsOutline", TravelMapLocationsOutline);
             SetBool(sectionGUI, "IllegalRestWarning", IllegalRestWarning);
             SetBool(sectionGUI, "LargeHUD", LargeHUD);
             SetFloat(sectionGUI, "LargeHUDScale", LargeHUDScale);

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -87,6 +87,8 @@ geographicBackgrounds,                              Geographic backgrounds
 geographicBackgroundsInfo,                          Contextual character backgrounds based on geographic location
 dungeonExitWagonPrompt,                             Dungeon wagon access prompt
 dungeonExitWagonPromptInfo,                         Prompt for wagon access on dungeon exit. (Wagon is always accessible within 5m of exit)
+travelMapLocationsOutline,                          Outline regional map locations
+travelMapLocationsOutlineInfo,                      Draw an outline around locations on regional maps to improve visibility
 guildQuestListBox,                                  Guild quest player selection
 guildQuestListBoxInfo,                              Presents eligible guild quests in a list box
 bowLeftHandWithSwitching,                           Equip bows in left hand only

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -87,12 +87,12 @@ geographicBackgrounds,                              Geographic backgrounds
 geographicBackgroundsInfo,                          Contextual character backgrounds based on geographic location
 dungeonExitWagonPrompt,                             Dungeon wagon access prompt
 dungeonExitWagonPromptInfo,                         Prompt for wagon access on dungeon exit. (Wagon is always accessible within 5m of exit)
-loiterLimitInHours,                                 Maximum loiter time in hours
-loiterLimitInHoursInfo,                             Change default loiter time limit in hours
 guildQuestListBox,                                  Guild quest player selection
 guildQuestListBoxInfo,                              Presents eligible guild quests in a list box
 bowLeftHandWithSwitching,                           Equip bows in left hand only
 bowLeftHandWithSwitchingInfo,                       Equip bows in left hand and allow 1H weapon switching - switching has a short delay
+loiterLimitInHours,                                 Maximum loiter time in hours
+loiterLimitInHoursInfo,                             Change default loiter time limit in hours
 
 modSystem,                                          Mod System
 modSystemInfo,                                      Enable support for mods.


### PR DESCRIPTION
Make region maps more accessible to color blinds by adding an outline to location pixels.
It actually makes it easier to point at locations, so it could be seen as a general improvement.

Forums: https://forums.dfworkshop.net/viewtopic.php?f=4&p=43718#p43717

The implementation uses Panels for the outlines, works well but may be too hackish?
Also, ir probably needs to be made an option or have a keyboard toggle.
![outlines 2 - 128](https://user-images.githubusercontent.com/1211431/82137710-c16ded80-981a-11ea-8c43-1461539ea6c6.jpg)

