### PR TITLE
Cast when held item condition lowering

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -2223,11 +2223,13 @@ namespace DaggerfallWorkshop.Game.Formulas
         }
 
         /// <summary>
-        /// Reversed from classic. Calculates cost of casting a spell.
+        /// Reversed from classic. Calculates cost of casting a spell. This cost is also used
+        /// to lower item condition when equipping an item whith a "Cast when held" effect.
         /// For now this is only being used for enchanted items, because there is other code for entity-cast spells.
         /// </summary>
         /// <param name="spell">Spell record read from SPELLS.STD.</param>
-        public static int CalculateCastingCost(SpellRecord.SpellRecordData spell)
+        /// <param name="enchantingItem">True if the method is used from the magic item maker.</param>
+        public static int CalculateCastingCost(SpellRecord.SpellRecordData spell, bool enchantingItem= true)
         {
             // Indices into effect settings array for each effect and its subtypes
             byte[] effectIndices = {    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Paralysis
@@ -2330,21 +2332,39 @@ namespace DaggerfallWorkshop.Game.Formulas
                                         0x0F, 0x11, 0x0A, 0x11, // Comprehend Languages
                                         0x0F, 0x0F, 0x05, 0x05 }; // Intensify Fire / Diminish Fire / Wall of --
 
+            // Used to know which Magic School an effect belongs to
+            byte[] effectMagicSchools = { 0, 2, 3, 1, 2, 2, 3, 2, 0, 1,
+                                          1, 2, 3, 5, 4, 5, 3, 3, 1, 3,
+                                          1, 4, 4, 5, 5, 0, 1, 0, 0, 5,
+                                          0, 4, 0, 4, 4, 0, 3, 3, 0, 4,
+                                          4, 4, 5, 3, 3, 0, 0, 4, 4, 4,
+                                          4 };
+
+            // Used to get the skill corresponding to each of the above magic school
+            DFCareer.Skills[] magicSkills = { DFCareer.Skills.Alteration,
+                                              DFCareer.Skills.Restoration,
+                                              DFCareer.Skills.Destruction,
+                                              DFCareer.Skills.Mysticism,
+                                              DFCareer.Skills.Thaumaturgy,
+                                              DFCareer.Skills.Illusion };
+
             // All effects have one of 6 types for their settings depending on which settings (duration, chance, magnitude)
             // they use, which determine how the coefficient values are used with their data to determine spell casting
             // cost /magic item value/enchantment point cost.
             // There is also a 7th type that is supported in classic (see below) but no effect is defined to use it.
-            byte[] settingsTypes = { 1, 2, 3, 4, 5, 4, 4, 2, 1, 6, 5, 6, 1, 3, 3, 3, 1, 4, 2, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 1, 3, 3, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 3, 4, 1, 2, 2, 2, 2, 2, 2, 2 };
+            byte[] settingsTypes = { 1, 2, 3, 4, 5, 4, 4, 2, 1, 6,
+                                     5, 6, 1, 3, 3, 3, 1, 4, 2, 1,
+                                     1, 1, 1, 3, 3, 3, 3, 3, 3, 1,
+                                     3, 3, 1, 1, 1, 2, 2, 1, 1, 1,
+                                     1, 1, 3, 4, 1, 2, 2, 2, 2, 2,
+                                     2 };
 
             // Modifiers for casting ranges
             byte[] rangeTypeModifiers = { 2, 2, 3, 4, 5 };
 
             int cost = 0;
-            int skill = 50;  // 50 is used for item enchantments, which is all this spell is used for now.
-                             // This function could be used as in classic to get casting costs for spells
-                             // cast by entities by replacing skillUsedForEnchantedItemCost with the skill
-                             // of the caster in the effect's spell school.
-
+            int skill = 50; // 50 is used for item enchantments
+            
             for (int i = 0; i < 3; ++i)
             {
                 if (spell.effects[i].type != -1)
@@ -2359,6 +2379,12 @@ namespace DaggerfallWorkshop.Game.Formulas
                     else // Subtype exists
                     {
                         Array.Copy(effectCoefficients, 4 * effectIndices[12 * spell.effects[i].type + spell.effects[i].subType], coefficientsForThisEffect, 0, 4);
+                    }
+
+                    if (!enchantingItem)
+                    {
+                        // If not using the item maker, then player skill corresponding to the effect magic school must be used
+                        skill = GameManager.Instance.PlayerEntity.Skills.GetLiveSkillValue(magicSkills[effectMagicSchools[spell.effects[i].type]]);
                     }
 
                     // Add to the cost based on this effect's settings

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/CastWhenHeld.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/CastWhenHeld.cs
@@ -15,6 +15,7 @@ using DaggerfallConnect.Save;
 using DaggerfallConnect.FallExe;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Items;
+using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 {
@@ -174,8 +175,9 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                         if (casterManager.IsPlayerEntity)
                             casterManager.PlayCastSound(sourceEntity, casterManager.GetCastSoundID(bundle.Settings.ElementType), true);
 
-                        // TODO: Apply durability loss to equipped item on equip
-                        // http://en.uesp.net/wiki/Daggerfall:Magical_Items#Durability_of_Magical_Items
+                        // Classic uses an item last "cast when held" effect spell cost to determine its durability loss on equip
+                        // Here, all effects are considered, as it seems more coherent to do so
+                        sourceItem.LowerCondition(FormulaHelper.CalculateCastingCost(spell, false), sourceEntity.Entity, sourceEntity.Entity.Items);
                     }
 
                     // Store equip time as last reroll time


### PR DESCRIPTION
The behavior was reverse engineered on DF forums by Numidium and Elenwel and confirmed by my own reverse engineering, see here: https://forums.dfworkshop.net/viewtopic.php?f=23&t=3621

Since @Allofich did most of the job some time ago, there was very little to do there.

The only difference from classic is that DFU takes all item "Cast when held" effect costs to lower the item condition, where classic takes only the last one.