### PR TITLE
Fix daedra summoning to match classic behavior

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1883,8 +1883,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             if (TryGetOverride("CalculateDaedraSummoningChance", out del))
                 return del(daedraRep, bonus);
 
-            int chance = 30 + daedraRep + bonus;
-            return Mathf.Clamp(chance, 5, 95);
+            return 30 + daedraRep + bonus;
         }
 
         public static int CalculateTradePrice(int cost, int shopQuality, bool selling)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -180,7 +180,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Select appropriate Daedra for summoning attempt.
             int dayOfYear = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.DayOfYear;
             if (summonerFactionData.id == (int) FactionFile.FactionIDs.The_Glenmoril_Witches)
-            {   // Always Hircine at Glenmoril witches. (wonder if this was just a bug in classic, or actually intentional)
+            {   // Always Hircine at Glenmoril witches (reversed from classic: this is intentional)
                 daedraToSummon = daedraData[0];
             }
             else if ((FactionFile.FactionTypes) summonerFactionData.type == FactionFile.FactionTypes.WitchesCoven)
@@ -233,33 +233,35 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     playerEntity.DeductGoldAmount(summonCost);
 
-                    // Default 30% bonus is only applicable to some Daedra in specific weather conditions.
                     WeatherManager weatherManager = GameManager.Instance.WeatherManager;
+
+                    // Sheogorath has a 5% (15% if stormy) chance to replace selected daedra.
+                    int sheoChance = (weatherManager.IsStorming) ? 15 : 5;
+                    if (Dice100.Roll() <= sheoChance)
+                    {
+                        daedraToSummon = daedraData[8];
+                    }
+
+                    // Default 30% bonus is only applicable to some Daedra in specific weather conditions.
                     int bonus = 0;
                     if (daedraToSummon.bonusCond == Weather.WeatherType.Rain && weatherManager.IsRaining ||
                         daedraToSummon.bonusCond == Weather.WeatherType.Thunder && weatherManager.IsStorming ||
                         daedraToSummon.bonusCond == Weather.WeatherType.None)
                         bonus = 30;
 
-                    // Sheogorath has a 5% (15% if stormy) chance to replace selected daedra.
-                    int sheoChance = (weatherManager.IsStorming) ? 15 : 5;
                     // Get summoning chance for selected daedra and roll.
                     int chance = FormulaHelper.CalculateDaedraSummoningChance(playerEntity.FactionData.GetReputation(daedraToSummon.factionId), bonus);
                     int roll = Dice100.Roll();
                     Debug.LogFormat("Summoning {0} with chance = {1}%, Sheogorath chance = {2}%, roll = {3}, summoner rep = {4}, cost: {5}",
                         daedraToSummon.vidFile.Substring(0, daedraToSummon.vidFile.Length-4), chance, sheoChance, roll, summonerFactionData.rep, summonCost);
 
-                    if (roll > chance + sheoChance)
+                    if (roll > chance)
                     {   // Daedra stood you up!
                         DaggerfallUI.MessageBox(SummonFailed, this);
                         // Spawn daedric foes if failed at a witches coven.
                         if (summonerFactionData.ggroup == (int) FactionFile.GuildGroups.Witches)
                             GameObjectHelper.CreateFoeSpawner(true, daedricFoes[Random.Range(0, 5)], Random.Range(1, 4), 4, 64);
                         return;
-                    }
-                    else if (roll > chance)
-                    {   // Sheogorath appears instead.
-                        daedraToSummon = daedraData[8];
                     }
 
                     // Has this Daedra already been summoned by the player?


### PR DESCRIPTION
I reverse-engineered classic function regarding daedra summoning. And as often, I noticed it somewhat contradicts the information found on the UESP. In particular, there is not such thing in classic code as a 95% maximum chance of summoning a dadrea (it's always a roll between 1 and 100), where the "5 % chance" left would be the chance for Sheogorath to replace the daedra.

In classic, it is as follows:
Sheogorath has a 5% chance of replacing the daedra (15% under thunderstorms), so he gets a dedicated roll for that, even with The Glenmoril Witches who usually summon Hircine (this is intentional).
Then, and only after Sheogorath has replaced or not the daedra to summon, the summoning chance is computed and the summoning success or failure roll is done.

I modified DFU's code accordingly.