### PR TITLE
fix for missing buildings bug (when doing round-trips between locations)

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -861,6 +861,9 @@ namespace DaggerfallWorkshop
                     terrainArray[index].active = true;
                     terrainArray[index].terrainObject.SetActive(true);
                     terrainArray[index].billboardBatchObject.SetActive(true);
+                    // also set flag for updating locations if this terrain contains a location - so building data gets created again
+                    // this fixes the missing buildings bug - see this forum-thread: https://forums.dfworkshop.net/viewtopic.php?f=4&t=3391&start=10)
+                    terrainArray[index].updateLocation = terrainArray[index].hasLocation;
                 }
                 // If any nature model replacements are used then do extra nature updates for any terrains moving into or out of distance 1 or less.
                 if (TerrainHelper.NatureMeshUsed)


### PR DESCRIPTION
see this forum-thread where the bug was reported:https://forums.dfworkshop.net/viewtopic.php?f=4&t=3391&start=10)

the reason was that StreamingWorld class can reuse terrain array elements when needed - it marks no longer needed terrains as "Pooled" and keeps them in memory until memory is needed for new terrains. If pc turns around and travels back the "Pooled" terrains can get reused. If the "Pooled" terrain  was a location map pixel buildings get destroyed as soon as terrain becomes "Pooled" - so this change enforces that buildings of reused "Pooled" terrains which contain a location are loaded again.