### PR TITLE
Prompt warnings for modlist mismatches in saves

### DIFF
--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -550,7 +550,10 @@ namespace DaggerfallWorkshop.Game
             {
                 if (SaveLoadManager.Instance.HasQuickSave(GameManager.Instance.PlayerEntity.Name))
                 {
-                    SaveLoadManager.Instance.QuickLoad();
+                    GameManager.Instance.SaveLoadManager.PromptQuickLoadGame(GameManager.Instance.PlayerEntity.Name, () =>
+                    {
+                        SaveLoadManager.Instance.QuickLoad();
+                    });
                 }
             }
         }

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -1190,9 +1190,20 @@ namespace DaggerfallWorkshop.Game.Serialization
 
                         if (mod.ModInfo.ModVersion != record.version)
                         {
-                            message.Add("- " + record.title + " (v. " + record.version + ")");
-                            message.Add("Incoming version: '" + mod.Title + " (v. " + mod.ModInfo.ModVersion + ")'");
-                            message.Add(String.Empty);
+                            bool? comp = ModManager.IsVersionLowerOrEqual(record.version, mod.ModInfo.ModVersion);
+
+                            if (comp == false)
+                            {
+                                message.Add("- " + record.title + " (v. " + record.version + ")");
+                                message.Add("Incoming version is older: '" + mod.Title + " (v. " + mod.ModInfo.ModVersion + ")'");
+                                message.Add(String.Empty);
+                            }
+                            else if (comp == null)
+                            {
+                                message.Add("- " + record.title + " (v. " + record.version + ")");
+                                message.Add("Incoming version is different: '" + mod.Title + " (v. " + mod.ModInfo.ModVersion + ")'");
+                                message.Add(String.Empty);
+                            }
                         }
                     }
                     else

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -811,7 +811,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         ModInfo_v1[] GetModInfoData()
         {
             List<ModInfo_v1> records = new List<ModInfo_v1>();
-            foreach (var mod in ModManager.Instance.GetAllMods())
+            foreach (var mod in ModManager.Instance.Mods)
             {
                 if (mod.Enabled)
                 {
@@ -1187,20 +1187,20 @@ namespace DaggerfallWorkshop.Game.Serialization
             SaveData_v1 saveData = Deserialize(typeof(SaveData_v1), saveDataJson) as SaveData_v1;
 
             // Use dictionary for faster indexing
-            Dictionary<string, Mod> dict = ModManager.Instance.GetAllMods().ToDictionary(m => m.GUID);
+            Dictionary<string, Mod> dict = ModManager.Instance.Mods.ToDictionary(m => m.GUID);
             // Need to use a string collection because of MessageBox's SetText method
             List<string> message = new List<string>();
 
             if (saveData.modInfoData != null && saveData.modInfoData.Length > 0)
             {
+                Mod mod;
+
                 // Verify that every mod recorded in the save is included in the current mod list, or has a newer version loaded
                 // Otherwise add a warning for each missing mod or version conflict
                 foreach (ModInfo_v1 record in saveData.modInfoData)
                 {
-                    if (dict.ContainsKey(record.guid))
+                    if (dict.TryGetValue(record.guid, out mod))
                     {
-                        Mod mod = dict[record.guid];
-
                         if (mod.ModInfo.ModVersion != record.version)
                         {
                             bool? comp = ModManager.IsVersionLowerOrEqual(record.version, mod.ModInfo.ModVersion);

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -450,11 +450,22 @@ namespace DaggerfallWorkshop.Game.Serialization
             return key != -1;
         }
 
+        /// <summary>
+        /// Checks for a mod mismatch in the QuickSave, and displays a warning message before proceeding
+        /// </summary>
+        /// <param name="characterName">Character's name in the save</param>
+        /// <param name="loadGameAction">The steps taken to load a save after finding no mismatches, or after user proceeds to load anyway</param>
         public void PromptQuickLoadGame(string characterName, Action loadGameAction)
         {
             PromptLoadGame(characterName, quickSaveName, loadGameAction);
         }
 
+        /// <summary>
+        /// Checks for a mod mismatch in a save, and displays a warning message before proceeding
+        /// </summary>
+        /// <param name="characterName">Character's name in the save</param>
+        /// <param name="saveName">Name of the save to be loaded</param>
+        /// <param name="loadGameAction">The steps taken to load a save after finding no mismatches, or after user proceeds to load anyway</param>
         public void PromptLoadGame(string characterName, string saveName, Action loadGameAction)
         {
             string[] modMessage = SaveModConflictMessage(characterName, saveName);
@@ -1171,17 +1182,19 @@ namespace DaggerfallWorkshop.Game.Serialization
             else
                 path = GetSaveFolder(key);
 
-            //read save game data
+            // Read save game data
             string saveDataJson = ReadSaveFile(Path.Combine(path, saveDataFilename));
             SaveData_v1 saveData = Deserialize(typeof(SaveData_v1), saveDataJson) as SaveData_v1;
 
-            //use dictionary for faster indexing
+            // Use dictionary for faster indexing
             Dictionary<string, Mod> dict = ModManager.Instance.GetAllMods().ToDictionary(m => m.GUID);
-            //need to use a string collection because of MessageBox's SetText method
+            // Need to use a string collection because of MessageBox's SetText method
             List<string> message = new List<string>();
 
             if (saveData.modInfoData != null && saveData.modInfoData.Length > 0)
             {
+                // Verify that every mod recorded in the save is included in the current mod list, or has a newer version loaded
+                // Otherwise add a warning for each missing mod or version conflict
                 foreach (ModInfo_v1 record in saveData.modInfoData)
                 {
                     if (dict.ContainsKey(record.guid))
@@ -1214,7 +1227,7 @@ namespace DaggerfallWorkshop.Game.Serialization
                     }
                 }
 
-                if(message.Count > 0)
+                if (message.Count > 0)
                 {
                     message.Insert(0, "The currently used mods do not match the ones used by this save:");
                     message.Insert(1, String.Empty);

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -158,6 +158,11 @@ namespace DaggerfallWorkshop.Game.Serialization
 
             // Update save game enumerations
             GameManager.Instance.SaveLoadManager.EnumerateSaves();
+
+            OnLoad += (_ => {
+                saveDataJsonCache = null;
+                saveDataCache = null;
+            });
         }
 
         static bool sceneUnloaded = false;

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -94,6 +94,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public SceneCache_v1 sceneCache;
         public TravelMapSaveData travelMapData;
         public AdvancedClimbingData_v1 advancedClimbingState;
+        public ModInfo_v1[] modInfoData;
     }
 
     #endregion
@@ -447,6 +448,16 @@ namespace DaggerfallWorkshop.Game.Serialization
         public string characterName;
         public DateAndTime_v1 dateAndTime;
         public string dfuVersion;
+    }
+
+    [fsObject("v1")]
+    public class ModInfo_v1
+    {
+        public string fileName;
+        public string title;
+        public string guid;
+        public string version;
+        public int loadPriority;
     }
 
     #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySaveGameWindow.cs
@@ -499,8 +499,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     return;
                 }
 
-                loadingLabel.Text = TextManager.Instance.GetText("DaggerfallUI", "loading");
-                loading = true;
+                GameManager.Instance.SaveLoadManager.PromptLoadGame(currentPlayerName, saveNameTextBox.Text, () =>
+                {
+                    loadingLabel.Text = TextManager.Instance.GetText("DaggerfallUI", "loading");
+                    loading = true;
+                });
             }
         }
 


### PR DESCRIPTION
[[Forum post](https://forums.dfworkshop.net/viewtopic.php?f=22&p=44732&sid=3c2b933a14b59a211a0b54c797f6cb4d#p44732)]

[[Images](https://imgur.com/a/sDN4tUb)]

SaveData.txt will now serialize information about mods used at the time of saving - `fileName`, `title`, `guid`, `version` and `loadPriority`. While this serialized information is mainly used for displaying mod incompatibilities when a player loads or quickloads a save, they can also be useful for mod creators to warn players about particular versions or incompatibilities with mods in their own way as well.

Loading a game will compare the saved `ModInfo_v1[]` in SaveData.txt by the currently enabled and loaded-in mods against its GUID. If it cannot find the a mod with the same GUID, then it will say "Mod is either not loaded or has been altered." If it has been found, then it will compare against their versions and warn if the loaded mod is older than the recorded one, or if the versions are incompatible (e.g. '1.0' vs 'banana').

There is an issue with the scrollbar getting in the way of the first line of text, but I think that should be resolved as a separate PR just to extend the message box width a bit more.