### PR TITLE
Controller fixes, improvements and additional settings related to cursor issue

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -79,6 +79,7 @@ MouseLookSensitivity=1.0
 JoystickLookSensitivity=1.0
 JoystickCursorSensitivity=1.0
 JoystickMovementThreshold=0.9
+JoystickDeadzone=0.0
 HeadBobbing=True
 Handedness=0
 WeaponAttackThreshold=0.03

--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -80,6 +80,7 @@ JoystickLookSensitivity=1.0
 JoystickCursorSensitivity=1.0
 JoystickMovementThreshold=0.9
 JoystickDeadzone=0.0
+EnableController=True
 HeadBobbing=True
 Handedness=0
 WeaponAttackThreshold=0.03

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -184,7 +184,7 @@ namespace DaggerfallWorkshop.Game
 
         public bool UsingController
         {
-            get { return usingControllerCursor; }
+            get { return usingControllerCursor && EnableController; }
         }
 
         public KeyCode LastKeyDown { get; private set; }
@@ -197,7 +197,7 @@ namespace DaggerfallWorkshop.Game
 
         public Vector3 MousePosition {
             get {
-                if (usingControllerCursor)
+                if (UsingController)
                     return controllerCursorPosition;
                 else
                     return Input.mousePosition;
@@ -226,6 +226,8 @@ namespace DaggerfallWorkshop.Game
 
         public bool MaximizeJoystickMovement { get; set; }
         public float JoystickDeadzone { get; set; }
+
+        public bool EnableController { get; set; }
 
         #endregion
 
@@ -438,7 +440,7 @@ namespace DaggerfallWorkshop.Game
             mouseY = Input.GetAxisRaw("Mouse Y");
 
 
-            if ((mouseX == 0F || mouseY == 0F) && !String.IsNullOrEmpty(cameraAxisBindingCache[0]))
+            if (EnableController && (mouseX == 0F || mouseY == 0F) && !String.IsNullOrEmpty(cameraAxisBindingCache[0]))
             {
                 var h = Input.GetAxis(cameraAxisBindingCache[0]);
                 var v = Input.GetAxis(cameraAxisBindingCache[1]);
@@ -487,20 +489,19 @@ namespace DaggerfallWorkshop.Game
             float distMovement = Mathf.Sqrt(horizj * horizj + vertj * vertj);
             float distCamera = Mathf.Sqrt(cameraHorizJ * cameraHorizJ + cameraVertJ * cameraVertJ);
 
-            if (!usingControllerCursor && (distMovement > JoystickDeadzone || distCamera > JoystickDeadzone))
+            if (!UsingController && (distMovement > JoystickDeadzone || distCamera > JoystickDeadzone))
             {
                 usingControllerCursor = true;
                 controllerCursorPosition = Input.mousePosition;
-                Debug.Log(distMovement+","+distCamera);
             }
-            else if (usingControllerCursor && (Input.GetAxis("Mouse X") != 0 || Input.GetAxis("Mouse Y") != 0))
+            else if (UsingController && (Input.GetAxis("Mouse X") != 0 || Input.GetAxis("Mouse Y") != 0))
             {
                 usingControllerCursor = false;
             }
 
             if (CursorVisible)
             {
-                if (usingControllerCursor)
+                if (UsingController)
                 {
                     Cursor.visible = false;
                     //Cursor.lockState = CursorLockMode.Locked;
@@ -906,7 +907,7 @@ namespace DaggerfallWorkshop.Game
 
         public bool GetMouseButtonDown(int button)
         {
-            if (usingControllerCursor)
+            if (UsingController)
                 return GetKeyDown(joystickUICache[button]);
 
             return Input.GetMouseButtonDown(button);
@@ -914,7 +915,7 @@ namespace DaggerfallWorkshop.Game
 
         public bool GetMouseButtonUp(int button)
         {
-            if (usingControllerCursor)
+            if (UsingController)
                 return GetKeyUp(joystickUICache[button]);
 
             return Input.GetMouseButtonUp(button);
@@ -922,7 +923,7 @@ namespace DaggerfallWorkshop.Game
 
         public bool GetMouseButton(int button)
         {
-            if (usingControllerCursor)
+            if (UsingController)
                 return GetKey(joystickUICache[button]);
 
             return Input.GetMouseButton(button);
@@ -1316,7 +1317,7 @@ namespace DaggerfallWorkshop.Game
         // Also updates upAxisRaw and downAxisRaw dictionaries to process GetAxisKeyDown and GetAxisKeyUp events
         float GetAxisRaw(int keyCode, int signage)
         {
-            if (keyCode < startingAxisKeyCode || !axisKeyCodeToInputAxis.ContainsKey(keyCode))
+            if (!EnableController || keyCode < startingAxisKeyCode || !axisKeyCodeToInputAxis.ContainsKey(keyCode))
                 return 0;
 
             String unityInputAxisString = axisKeyCodeToInputAxis[keyCode];
@@ -1404,7 +1405,7 @@ namespace DaggerfallWorkshop.Game
         void FindInputAxisActions()
         {
 
-            if (String.IsNullOrEmpty(movementAxisBindingCache[0]) || String.IsNullOrEmpty(movementAxisBindingCache[1]))
+            if (!EnableController || String.IsNullOrEmpty(movementAxisBindingCache[0]) || String.IsNullOrEmpty(movementAxisBindingCache[1]))
                 return;
 
             float horiz = Input.GetAxis(movementAxisBindingCache[0]);

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -101,6 +101,8 @@ namespace DaggerfallWorkshop.Game
         float controllerCursorHorizontalSpeed = 300.0F;
         float controllerCursorVerticalSpeed = 300.0F;
 
+        bool pauseController = false;
+
         #endregion
 
         #region Structures
@@ -184,7 +186,7 @@ namespace DaggerfallWorkshop.Game
 
         public bool UsingController
         {
-            get { return usingControllerCursor && EnableController; }
+            get { return usingControllerCursor && EnableController && !pauseController; }
         }
 
         public KeyCode LastKeyDown { get; private set; }
@@ -489,15 +491,17 @@ namespace DaggerfallWorkshop.Game
             float distMovement = Mathf.Sqrt(horizj * horizj + vertj * vertj);
             float distCamera = Mathf.Sqrt(cameraHorizJ * cameraHorizJ + cameraVertJ * cameraVertJ);
 
+            bool movingMouse = (Input.GetAxis("Mouse X") != 0 || Input.GetAxis("Mouse Y") != 0);
+            pauseController = movingMouse;
+
             if (!UsingController && (distMovement > JoystickDeadzone || distCamera > JoystickDeadzone))
             {
                 usingControllerCursor = true;
                 controllerCursorPosition = Input.mousePosition;
             }
-            else if (UsingController && (Input.GetAxis("Mouse X") != 0 || Input.GetAxis("Mouse Y") != 0))
-            {
+
+            if (movingMouse)
                 usingControllerCursor = false;
-            }
 
             if (CursorVisible)
             {
@@ -907,26 +911,17 @@ namespace DaggerfallWorkshop.Game
 
         public bool GetMouseButtonDown(int button)
         {
-            if (UsingController)
-                return GetKeyDown(joystickUICache[button]);
-
-            return Input.GetMouseButtonDown(button);
+            return Input.GetMouseButtonDown(button) || GetKeyDown(joystickUICache[button]);
         }
 
         public bool GetMouseButtonUp(int button)
         {
-            if (UsingController)
-                return GetKeyUp(joystickUICache[button]);
-
-            return Input.GetMouseButtonUp(button);
+            return Input.GetMouseButtonUp(button) || GetKeyUp(joystickUICache[button]);
         }
 
         public bool GetMouseButton(int button)
         {
-            if (UsingController)
-                return GetKey(joystickUICache[button]);
-
-            return Input.GetMouseButton(button);
+            return Input.GetMouseButton(button) || GetKey(joystickUICache[button]);
         }
 
         public bool GetKey(KeyCode key)

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -911,17 +911,17 @@ namespace DaggerfallWorkshop.Game
 
         public bool GetMouseButtonDown(int button)
         {
-            return Input.GetMouseButtonDown(button) || GetKeyDown(joystickUICache[button]);
+            return Input.GetMouseButtonDown(button) || (EnableController && GetKeyDown(joystickUICache[button]));
         }
 
         public bool GetMouseButtonUp(int button)
         {
-            return Input.GetMouseButtonUp(button) || GetKeyUp(joystickUICache[button]);
+            return Input.GetMouseButtonUp(button) || (EnableController && GetKeyUp(joystickUICache[button]));
         }
 
         public bool GetMouseButton(int button)
         {
-            return Input.GetMouseButton(button) || GetKey(joystickUICache[button]);
+            return Input.GetMouseButton(button) || (EnableController && GetKey(joystickUICache[button]));
         }
 
         public bool GetKey(KeyCode key)

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -447,16 +447,16 @@ namespace DaggerfallWorkshop.Game
                 var h = Input.GetAxis(cameraAxisBindingCache[0]);
                 var v = Input.GetAxis(cameraAxisBindingCache[1]);
 
-                if (GetAxisActionInversion(AxisActions.CameraHorizontal))
-                    mouseX *= -1;
-                if (GetAxisActionInversion(AxisActions.CameraVertical))
-                    mouseY *= -1;
-
                 if(Mathf.Sqrt(h*h + v*v) > JoystickDeadzone)
                 {
                     mouseX = h;
                     mouseY = v;
                 }
+
+                if (GetAxisActionInversion(AxisActions.CameraHorizontal))
+                    mouseX *= -1;
+                if (GetAxisActionInversion(AxisActions.CameraVertical))
+                    mouseY *= -1;
             }
 
             if(ToggleAutorun)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -157,6 +157,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             moveNextStage = true;
 
+            // Apply joystick settings to input manager to keep consistency between the setup wizard and the game
+            InputManager.Instance.JoystickCursorSensitivity = DaggerfallUnity.Settings.JoystickCursorSensitivity;
+            InputManager.Instance.JoystickDeadzone = DaggerfallUnity.Settings.JoystickDeadzone;
+
             // Override cursor
             Texture2D tex;
             if (TextureReplacement.TryImportTexture("Cursor", true, out tex))
@@ -180,6 +184,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // This is a special realtime setting as font rendering can change at any time, even during the setup process itself
             if (sdfFontRendering != null)
                 sdfFontRendering.IsChecked = DaggerfallUnity.Settings.SDFFontRendering;
+
+            // Sync controller enabling to current setting
+            // This is a special realtime setting as controller enabling can change at any time, even during the setup process itself
+            if (enableController != null)
+            {
+                enableController.IsChecked = DaggerfallUnity.Settings.EnableController;
+                InputManager.Instance.EnableController = DaggerfallUnity.Settings.EnableController;
+            }
 
             // Move to next setup stage
             if (moveNextStage)
@@ -480,6 +492,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             //bool exampleModCheckbox = AddOption(x, "Example", "Example built-in mod", DaggerfallUnity.Settings.ExampleModOption);
 
             enableController = AddOption(x, "enableController", DaggerfallUnity.Settings.EnableController);
+            enableController.OnToggleState += EnableController_OnToggleState;
 
             // Add mod note
             TextLabel modNoteLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(0, 125), GetText("modNote"), optionsPanel);
@@ -545,6 +558,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // Immediately switch font rendering
             DaggerfallUnity.Settings.SDFFontRendering = sdfFontRendering.IsChecked;
+        }
+
+        private void EnableController_OnToggleState()
+        {
+            // Immediately toggle controller
+            DaggerfallUnity.Settings.EnableController = enableController.IsChecked;
         }
 
         //void ShowSummaryPanel()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -67,6 +67,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox playerNudity;
         Checkbox clickToAttack;
         Checkbox sdfFontRendering;
+        Checkbox enableController;
         Checkbox retro320x200WorldRendering;
 
         Color unselectedTextColor = new Color(0.6f, 0.6f, 0.6f, 1f);
@@ -478,6 +479,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             sdfFontRendering.OnToggleState += SDFFontRendering_OnToggleState;
             //bool exampleModCheckbox = AddOption(x, "Example", "Example built-in mod", DaggerfallUnity.Settings.ExampleModOption);
 
+            enableController = AddOption(x, "enableController", DaggerfallUnity.Settings.EnableController);
+
             // Add mod note
             TextLabel modNoteLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(0, 125), GetText("modNote"), optionsPanel);
             modNoteLabel.HorizontalAlignment = HorizontalAlignment.Center;
@@ -761,6 +764,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.Handedness = GetHandedness(leftHandWeapons.IsChecked);
             DaggerfallUnity.Settings.PlayerNudity = playerNudity.IsChecked;
             DaggerfallUnity.Settings.ClickToAttack = clickToAttack.IsChecked;
+            DaggerfallUnity.Settings.EnableController = enableController.IsChecked;
             DaggerfallUnity.Settings.SaveSettings();
 
             if (ModManager.Instance)

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -219,6 +219,8 @@ namespace DaggerfallWorkshop.Game.Utility
 
             InputManager.Instance.JoystickDeadzone = DaggerfallUnity.Settings.JoystickDeadzone;
 
+            InputManager.Instance.EnableController = DaggerfallUnity.Settings.EnableController;
+
             // Set shadow resolution
             GameManager.UpdateShadowResolution();
 

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -217,6 +217,8 @@ namespace DaggerfallWorkshop.Game.Utility
 
             InputManager.Instance.JoystickMovementThreshold = DaggerfallUnity.Settings.JoystickMovementThreshold;
 
+            InputManager.Instance.JoystickDeadzone = DaggerfallUnity.Settings.JoystickDeadzone;
+
             // Set shadow resolution
             GameManager.UpdateShadowResolution();
 

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -140,6 +140,7 @@ namespace DaggerfallWorkshop
         public float JoystickLookSensitivity { get; set; }
         public float JoystickCursorSensitivity { get; set; }
         public float JoystickMovementThreshold { get; set; }
+        public float  JoystickDeadzone { get; set; }
 
         public bool HeadBobbing { get; set; }
         public int Handedness { get; set; }
@@ -280,6 +281,7 @@ namespace DaggerfallWorkshop
             JoystickCursorSensitivity = GetFloat(sectionControls, "JoystickCursorSensitivity", 0.1f, 5.0f);
             JoystickMovementThreshold = GetFloat(sectionControls, "JoystickMovementThreshold", 0.0f, 1.0f);
             MovementAcceleration = GetBool(sectionControls, "MovementAcceleration");
+            JoystickDeadzone = GetFloat(sectionControls, "JoystickDeadzone", 0.001f, 1.0f);
             ToggleSneak = GetBool(sectionControls, "ToggleSneak");
             HeadBobbing = GetBool(sectionControls, "HeadBobbing");
             Handedness = GetInt(sectionControls, "Handedness", 0, 3);
@@ -409,6 +411,7 @@ namespace DaggerfallWorkshop
             SetFloat(sectionControls, "JoystickCursorSensitivity", JoystickCursorSensitivity);
             SetFloat(sectionControls, "JoystickMovementThreshold", JoystickMovementThreshold);
             SetBool(sectionControls, "MovementAcceleration", MovementAcceleration);
+            SetFloat(sectionControls, "JoystickDeadzone", JoystickDeadzone);
             SetBool(sectionControls, "ToggleSneak", ToggleSneak);
             SetBool(sectionControls, "HeadBobbing", HeadBobbing);
             SetInt(sectionControls, "Handedness", Handedness);

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -140,7 +140,8 @@ namespace DaggerfallWorkshop
         public float JoystickLookSensitivity { get; set; }
         public float JoystickCursorSensitivity { get; set; }
         public float JoystickMovementThreshold { get; set; }
-        public float  JoystickDeadzone { get; set; }
+        public float JoystickDeadzone { get; set; }
+        public bool EnableController { get; set; }
 
         public bool HeadBobbing { get; set; }
         public int Handedness { get; set; }
@@ -282,6 +283,7 @@ namespace DaggerfallWorkshop
             JoystickMovementThreshold = GetFloat(sectionControls, "JoystickMovementThreshold", 0.0f, 1.0f);
             MovementAcceleration = GetBool(sectionControls, "MovementAcceleration");
             JoystickDeadzone = GetFloat(sectionControls, "JoystickDeadzone", 0.001f, 1.0f);
+            EnableController = GetBool(sectionControls, "EnableController");
             ToggleSneak = GetBool(sectionControls, "ToggleSneak");
             HeadBobbing = GetBool(sectionControls, "HeadBobbing");
             Handedness = GetInt(sectionControls, "Handedness", 0, 3);
@@ -412,6 +414,7 @@ namespace DaggerfallWorkshop
             SetFloat(sectionControls, "JoystickMovementThreshold", JoystickMovementThreshold);
             SetBool(sectionControls, "MovementAcceleration", MovementAcceleration);
             SetFloat(sectionControls, "JoystickDeadzone", JoystickDeadzone);
+            SetBool(sectionControls, "EnableController", EnableController);
             SetBool(sectionControls, "ToggleSneak", ToggleSneak);
             SetBool(sectionControls, "HeadBobbing", HeadBobbing);
             SetInt(sectionControls, "Handedness", Handedness);

--- a/Assets/StreamingAssets/Text/MainMenu.txt
+++ b/Assets/StreamingAssets/Text/MainMenu.txt
@@ -31,6 +31,8 @@ clickToAttack,              Click to attack
 clickToAttackInfo,          Enable a simple click to trigger attacks
 sdfFontRendering,           SDF Font Rendering
 sdfFontRenderingInfo,       Enable for smooth fonts at high resolutions
+enableController,           Enable Controller
+enableControllerInfo,       Allow joysticks or other controllers to be detected and used in-game
 
 findArena2Tip,              Tip: Daggerfall contains a folder called 'arena2'
 foundArena2But,             Found 'arena2' but


### PR DESCRIPTION
- Added "joystick deadzone" setting, a value between 0 and 1.0 (0-100%) that is the minimum percentage of joystick movement required to be recognized by the game. This should help with joysticks that have issues such as drifting or are too sensitive and generate small amounts of movement that get captured in other ways.

- Added "Enable Controller" setting to the setup wizard that can disable the controller in realtime, and will have to be re-enabled by the use of a mouse.

- Improvements to the cursor flickering and clicking bug. _(**Note**: If you do not have the flickering issue and want to test this, just keep a joystick moved in one direction with one hand and move your mouse with the other.)_ The flickering is caused by a constant tug-of-war between the cursor going into "mouse mode" and "controller mode" if the controller is generating movement on its own. Even if the deadzone setting still doesn't help, now the mouse takes priority over the controller whenever the mouse is moving, minimizing the flickering. I also changed the logic of the `GetMouseButton()` so it can recognize both the mouse or controller button clicking better even while flickering.

- Joystick deadzone and cursor speed is now applied upon loading the setup wizard. If in the future these options get room to have their own sliders in the advanced settings menu, I think any adjustments also should be applied in realtime.