### PR TITLE
Properly end resting when stopped prematurely

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -447,7 +447,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
                 else if (currentRestMode == RestModes.FullRest)
                 {
-                    DaggerfallMessageBox mb = DaggerfallUI.MessageBox(youAreHealedTextId);
+                    int message = IsPlayerFullyHealed() ? youAreHealedTextId : youWakeUpTextId;
+                    DaggerfallMessageBox mb =  DaggerfallUI.MessageBox(message);
                     mb.OnClose += RestFinishedPopup_OnClose;
                     currentRestMode = RestModes.Selection;
                 }


### PR DESCRIPTION
Previously, if the player is currently resting, and they stop it prematurely via the 'Stop' GUI button, the toggle window key, or the escape key, the hours they slept for would not actually be accounted to raise skills, and neither would there be a popup saying "you wake up" or "you are healed" when done so.

This PR resolves this issue by isolating all exits to `EndRest()` when the player stopped while resting, or `CloseWindow()` if the player was on the selection menu. I also made a small change where if you choose to rest "until fully healed", but end it prematurely, the message will say "You wake up" instead of "You are healed", since the player wouldn't be fully healed. 