### PR TITLE
WIP: ghosts and wraiths shader

### DIFF
--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -125,6 +125,11 @@ namespace DaggerfallWorkshop.Game
                 MeshRenderer meshRenderer = dfMobile.GetComponent<MeshRenderer>();
                 if (meshRenderer)
                 {
+                    if (dfMobile.Summary.Enemy.Behaviour == MobileBehaviour.Spectral)
+                    {
+                        meshRenderer.material.shader = Shader.Find("Daggerfall/GhostShader");
+                        meshRenderer.material.SetFloat("_Cutoff", 0.5f);
+                    }
                     if (dfMobile.Summary.Enemy.NoShadow)
                     {
                         meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;

--- a/Assets/Shaders/GhostShader.shader
+++ b/Assets/Shaders/GhostShader.shader
@@ -1,0 +1,65 @@
+﻿Shader "Daggerfall/GhostShader" {
+	Properties {
+        _Color("Color", Color) = (1,1,1,1)
+		_MainTex ("Albedo (RGB)", 2D) = "white" {}
+        _BumpMap ("Bumpmap", 2D) = "bump" {}
+        _EmissionMap("Emission Map", 2D) = "white" {}
+        _EmissionColor("Emission Color", Color) = (0,0,0)
+        _Cutoff ("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+        _Transparency ("Transparency", Range(0.0, 1.0)) = 0.5
+		_Glossiness ("Smoothness", Range(0.0, 1.0)) = 0.0
+		_Metallic ("Metallic", Range(0.0, 1.0)) = 0.0
+	}
+	SubShader {
+		Tags { "Queue" = "Transparent" "IgnoreProjector" = "True" "RenderType" = "Transparent" }
+		LOD 200
+
+		CGPROGRAM
+		// Physically based Standard lighting model
+		#pragma surface surf Standard alpha:blend vertex:vert
+
+		// Use shader model 3.0 target, to get nicer looking lighting
+		#pragma target 3.0
+
+        half4 _Color;
+		sampler2D _MainTex;
+        sampler2D _BumpMap;
+        sampler2D _EmissionMap;
+        half4 _EmissionColor;
+        
+		struct Input {
+			float2 uv_MainTex;
+            float2 uv_BumpMap;
+            float2 uv_EmissionMap;
+		};
+        
+        half _Cutoff;
+        half _Transparency;
+		half _Glossiness;
+		half _Metallic;
+		
+        void vert (inout appdata_full v)
+        {
+            // Transform billboard normal for lighting support
+            // Comment out this line to stop light changing as billboards rotate
+            v.normal = mul((float3x3)UNITY_MATRIX_V, v.normal);
+        }
+
+		void surf (Input IN, inout SurfaceOutputStandard o) {
+			// Albedo comes from a texture tinted by color
+			fixed4 c = tex2D (_MainTex, IN.uv_MainTex) * _Color;
+            clip (c.a - _Cutoff);
+            
+            half3 emission = tex2D(_EmissionMap, IN.uv_EmissionMap).rgb * _EmissionColor;
+			o.Albedo = c.rgb - emission; // Emission cancels out other lights
+            o.Normal = UnpackNormal (tex2D (_BumpMap, IN.uv_BumpMap));
+            o.Emission = emission;
+			// Metallic and smoothness come from slider variables
+			o.Metallic = _Metallic;
+			o.Smoothness = _Glossiness;
+			o.Alpha = lerp(c.a * _Transparency, 1.0, saturate(dot(10.0 * half3(0.2126, 0.7152, 0.0722), emission)));
+		}
+		ENDCG
+	}
+	FallBack "Diffuse"
+}

--- a/Assets/Shaders/GhostShader.shader.meta
+++ b/Assets/Shaders/GhostShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: bf15c7c5b18dd46d6b388566c7308470
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/RequiredShaderVariants.shadervariants
+++ b/Assets/Shaders/RequiredShaderVariants.shadervariants
@@ -96,6 +96,9 @@ ShaderVariantCollection:
   - first: {fileID: 15106, guid: 0000000000000000f000000000000000, type: 0}
     second:
       variants: []
+  - first: {fileID: 4800000, guid: 3a75d81502a8b4b7fb733569265fee21, type: 3}
+    second:
+      variants: []
   - first: {fileID: 4800000, guid: 5bff224b61060e0408662aba62db27b3, type: 3}
     second:
       variants: []
@@ -111,7 +114,7 @@ ShaderVariantCollection:
   - first: {fileID: 4800000, guid: 9e17799a9c6ba5d41bf2993505b5ba6a, type: 3}
     second:
       variants: []
-  - first: {fileID: 4800000, guid: c3b8c2f21d1ea43498ec1f71a3055a89, type: 3}
+  - first: {fileID: 4800000, guid: 9e6df0875b8898444a3b513dc8afd6dd, type: 3}
     second:
       variants: []
   - first: {fileID: 4800000, guid: b3b66e5aa3f45264cb796d5d0318b834, type: 3}
@@ -120,9 +123,9 @@ ShaderVariantCollection:
   - first: {fileID: 4800000, guid: c00ec253908944d40b3d24bf64b4bb31, type: 3}
     second:
       variants: []
-  - first: {fileID: 4800000, guid: 3a75d81502a8b4b7fb733569265fee21, type: 3}
+  - first: {fileID: 4800000, guid: c3b8c2f21d1ea43498ec1f71a3055a89, type: 3}
     second:
       variants: []
-  - first: {fileID: 4800000, guid: 9e6df0875b8898444a3b513dc8afd6dd, type: 3}
+  - first: {fileID: 4800000, guid: bf15c7c5b18dd46d6b388566c7308470, type: 3}
     second:
       variants: []


### PR DESCRIPTION
Use semi-transparent shader for ghosts and wraiths. This works quite well with modded textures, but SetSoectral() is lacking for
classic textures (not extracting emissive map for the eyes, nor extracting all the details of the original textures)
![ghost and wraith](https://user-images.githubusercontent.com/1211431/85805957-08220200-b74e-11ea-8eb7-321fbd686ff4.jpg)
modded (DREAM):
![modded ghosts](https://user-images.githubusercontent.com/1211431/85828897-a5e6f280-b789-11ea-9d93-e0465b1c8719.jpg)
