### PR TITLE
Implement vampire guild membership switching

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -979,7 +979,7 @@ namespace DaggerfallWorkshop.Game.Entity
         /// <summary>
         /// Assigns guild memberships to player from classic save tree.
         /// </summary>
-        public void AssignGuildMemberships(SaveTree saveTree)
+        public void AssignGuildMemberships(SaveTree saveTree, bool vampire = false)
         {
             // Find character record, should always be a singleton
             CharacterRecord characterRecord = (CharacterRecord)saveTree.FindRecord(RecordTypes.Character);
@@ -988,7 +988,18 @@ namespace DaggerfallWorkshop.Game.Entity
 
             // Find all guild memberships, and add Daggerfall Unity guild memberships
             List<SaveTreeBaseRecord> guildMembershipRecords = saveTree.FindRecords(RecordTypes.GuildMembership, characterRecord);
-            GameManager.Instance.GuildManager.ImportMembershipData(guildMembershipRecords);
+            List<SaveTreeBaseRecord> oldMembershipRecords = saveTree.FindRecords(RecordTypes.OldGuild, characterRecord);
+
+            if (vampire)
+            {
+                GameManager.Instance.GuildManager.ImportMembershipData(guildMembershipRecords, true);
+                GameManager.Instance.GuildManager.ImportMembershipData(oldMembershipRecords);
+            }
+            else
+            {
+                GameManager.Instance.GuildManager.ImportMembershipData(guildMembershipRecords);
+                GameManager.Instance.GuildManager.ImportMembershipData(oldMembershipRecords, true);
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -104,10 +104,17 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         private readonly Dictionary<FactionFile.GuildGroups, IGuild> memberships = new Dictionary<FactionFile.GuildGroups, IGuild>();
 
+        private readonly Dictionary<FactionFile.GuildGroups, IGuild> vampMemberships = new Dictionary<FactionFile.GuildGroups, IGuild>();
+
+        private Dictionary<FactionFile.GuildGroups, IGuild> Memberships
+        {
+            get { return GameManager.Instance.PlayerEffectManager.HasVampirism() ? vampMemberships : memberships; }
+        }
+
         public List<IGuild> GetMemberships()
         {
             List<IGuild> guilds = new List<IGuild>();
-            foreach (IGuild guild in memberships.Values)
+            foreach (IGuild guild in Memberships.Values)
                 guilds.Add(guild);
             return guilds;
         }
@@ -115,15 +122,15 @@ namespace DaggerfallWorkshop.Game.Guilds
         public void AddMembership(FactionFile.GuildGroups guildGroup, IGuild guild)
         {
             guild.Join();
-            memberships[guildGroup] = guild;
+            Memberships[guildGroup] = guild;
         }
 
         public void RemoveMembership(IGuild guild)
         {
             FactionFile.GuildGroups guildGroup = FactionFile.GuildGroups.None;
-            foreach (FactionFile.GuildGroups group in memberships.Keys)
+            foreach (FactionFile.GuildGroups group in Memberships.Keys)
             {
-                if (memberships[group] == guild)
+                if (Memberships[group] == guild)
                 {
                     guildGroup = group;
                     break;
@@ -132,18 +139,18 @@ namespace DaggerfallWorkshop.Game.Guilds
             if (guildGroup != FactionFile.GuildGroups.None)
             {
                 guild.Leave();
-                memberships.Remove(guildGroup);
+                Memberships.Remove(guildGroup);
             }
         }
 
         public bool HasJoined(FactionFile.GuildGroups guildGroup)
         {
-            return memberships.ContainsKey(guildGroup);
+            return Memberships.ContainsKey(guildGroup);
         }
 
         public bool GetJoinedGuildOfGuildGroup(FactionFile.GuildGroups guildGroup, out IGuild value)
         {
-            if (memberships.TryGetValue(guildGroup, out value))
+            if (Memberships.TryGetValue(guildGroup, out value))
                 return true;
 
             return false;
@@ -151,8 +158,8 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public IGuild JoinGuild(FactionFile.GuildGroups guildGroup, int buildingFactionId = 0)
         {
-            if (memberships.ContainsKey(guildGroup))
-                return memberships[guildGroup];
+            if (Memberships.ContainsKey(guildGroup))
+                return Memberships[guildGroup];
 
             return CreateGuildObj(guildGroup, buildingFactionId);
         }
@@ -201,7 +208,7 @@ namespace DaggerfallWorkshop.Game.Guilds
         public IGuild GetGuild(FactionFile.GuildGroups guildGroup, int buildingFactionId = 0)
         {
             IGuild guild;
-            memberships.TryGetValue(guildGroup, out guild);
+            Memberships.TryGetValue(guildGroup, out guild);
 
             if (guildGroup == FactionFile.GuildGroups.HolyOrder && buildingFactionId > 0)
             {
@@ -273,20 +280,30 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public void ClearMembershipData()
         {
-            memberships.Clear();
+            ClearMembershipData(false);
+            ClearMembershipData(true);
         }
 
-        public Dictionary<int, GuildMembership_v1> GetMembershipData()
+        private void ClearMembershipData(bool vampire = false)
+        {
+            if (vampire)
+                vampMemberships.Clear();
+            else
+                memberships.Clear();
+        }
+
+        public Dictionary<int, GuildMembership_v1> GetMembershipData(bool vampire = false)
         {
             Dictionary<int, GuildMembership_v1> membershipData = new Dictionary<int, GuildMembership_v1>();
-            foreach (FactionFile.GuildGroups guildGroup in memberships.Keys)
-                membershipData[(int)guildGroup] = memberships[guildGroup].GetGuildData();
+            Dictionary<FactionFile.GuildGroups, IGuild> memberDict = vampire ? vampMemberships : memberships;
+            foreach (FactionFile.GuildGroups guildGroup in memberDict.Keys)
+                membershipData[(int)guildGroup] = memberDict[guildGroup].GetGuildData();
             return membershipData;
         }
 
-        public void RestoreMembershipData(Dictionary<int, GuildMembership_v1> data)
+        public void RestoreMembershipData(Dictionary<int, GuildMembership_v1> data, bool vampire = false)
         {
-            ClearMembershipData();
+            ClearMembershipData(vampire);
             if (data != null)
             {
                 foreach (FactionFile.GuildGroups guildGroup in data.Keys)
@@ -296,7 +313,10 @@ namespace DaggerfallWorkshop.Game.Guilds
                     if (guild != null)
                     {
                         guild.RestoreGuildData(guildMembershipData);
-                        memberships[guildGroup] = guild;
+                        if (vampire)
+                            vampMemberships[guildGroup] = guild;
+                        else
+                            memberships[guildGroup] = guild;
                     }
                 }
             }
@@ -305,9 +325,9 @@ namespace DaggerfallWorkshop.Game.Guilds
         /// <summary>
         /// Imports guild membership records from classic save data.
         /// </summary>
-        public void ImportMembershipData(List<SaveTreeBaseRecord> guildMembershipRecords)
+        public void ImportMembershipData(List<SaveTreeBaseRecord> guildMembershipRecords, bool vampire = false)
         {
-            ClearMembershipData();
+            ClearMembershipData(vampire);
             foreach (GuildMembershipRecord record in guildMembershipRecords)
             {
                 FactionFile.GuildGroups guildGroup = GetGuildGroup(record.ParsedData.factionID);
@@ -326,7 +346,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public bool FreeShipTravel()
         {
-            foreach (IGuild guild in memberships.Values)
+            foreach (IGuild guild in Memberships.Values)
                 if (guild.FreeShipTravel())
                     return true;
 
@@ -336,7 +356,7 @@ namespace DaggerfallWorkshop.Game.Guilds
         public int FastTravel(int duration)
         {
             int newDuration = duration;
-            foreach (IGuild guild in memberships.Values)
+            foreach (IGuild guild in Memberships.Values)
                 newDuration = guild.FastTravel(newDuration);
             return newDuration;
         }
@@ -344,14 +364,14 @@ namespace DaggerfallWorkshop.Game.Guilds
         public int DeepBreath(int duration)
         {
             int newDuration = duration;
-            foreach (IGuild guild in memberships.Values)
+            foreach (IGuild guild in Memberships.Values)
                 newDuration = guild.DeepBreath(newDuration);
             return newDuration;
         }
 
         public bool AvoidDeath()
         {
-            foreach (IGuild guild in memberships.Values)
+            foreach (IGuild guild in Memberships.Values)
                 if (guild.AvoidDeath())
                     return true;
             return false;

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -263,7 +263,7 @@ namespace DaggerfallWorkshop.Game.Player
         public void GetRegionFaction(int regionIndex, out FactionFile.FactionData factionData, bool duplicateException = true)
         {
             FactionFile.FactionData[] factions = GameManager.Instance.PlayerEntity.FactionData.FindFactions(
-                (int)FactionFile.FactionTypes.Province, -1, (int)FactionFile.GuildGroups.Region, regionIndex);
+                (int)FactionFile.FactionTypes.Province, -1, -1, regionIndex);
 
             // Should always find a single region
             if (factions == null || factions.Length != 1)

--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -263,7 +263,7 @@ namespace DaggerfallWorkshop.Game.Player
         public void GetRegionFaction(int regionIndex, out FactionFile.FactionData factionData, bool duplicateException = true)
         {
             FactionFile.FactionData[] factions = GameManager.Instance.PlayerEntity.FactionData.FindFactions(
-                (int)FactionFile.FactionTypes.Province, -1, -1, regionIndex);
+                (int)FactionFile.FactionTypes.Province, -1, (int)FactionFile.GuildGroups.Region, regionIndex);
 
             // Should always find a single region
             if (factions == null || factions.Length != 1)

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -1333,6 +1333,7 @@ namespace DaggerfallWorkshop.Game.Serialization
                 if (saveData.bankDeeds != null)
                     RestoreHousesData(saveData.bankDeeds.houses);
                 GameManager.Instance.GuildManager.RestoreMembershipData(saveData.playerData.guildMemberships);
+                GameManager.Instance.GuildManager.RestoreMembershipData(saveData.playerData.vampireMemberships, true);
             }
 
             // Restore faction data to player entity

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -147,6 +147,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public TransportModes transportMode;
         public PlayerPositionData_v1 boardShipPosition;  // Holds the player position from before boarding a ship.
         public Dictionary<int, GuildMembership_v1> guildMemberships;
+        public Dictionary<int, GuildMembership_v1> vampireMemberships;
         public List<string> oneTimeQuestsAccepted;
     }
 

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -186,6 +186,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             }
             // Store guild memberships
             data.guildMemberships = GameManager.Instance.GuildManager.GetMembershipData();
+            data.vampireMemberships = GameManager.Instance.GuildManager.GetMembershipData(true);
             // Store one time quest acceptances
             data.oneTimeQuestsAccepted = GameManager.Instance.QuestListsManager.oneTimeQuestsAccepted;
 
@@ -412,6 +413,7 @@ namespace DaggerfallWorkshop.Game.Serialization
 
             // Restore guild memberships, also done early in SaveLoadManager for interiors
             GameManager.Instance.GuildManager.RestoreMembershipData(data.guildMemberships);
+            GameManager.Instance.GuildManager.RestoreMembershipData(data.vampireMemberships, true);
             // Restore one time quest acceptances
             GameManager.Instance.QuestListsManager.oneTimeQuestsAccepted = data.oneTimeQuestsAccepted;
 

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -584,7 +584,7 @@ namespace DaggerfallWorkshop.Game.Utility
             playerEntity.AssignItemsAndSpells(saveTree);
 
             // Assign guild memberships
-            playerEntity.AssignGuildMemberships(saveTree);
+            playerEntity.AssignGuildMemberships(saveTree, characterDocument.classicTransformedRace == Races.Vampire);
 
             // Assign gold pieces
             playerEntity.GoldPieces = (int)characterRecord.ParsedData.physicalGold;


### PR DESCRIPTION
Switches the guild memberships when player is a vampire, switching back when cured. Nothing else is changed, no reputations or TG/DB initiation processes. I implemented it differently from classic, instead of switching round two data structures I simply access the appropriate one. Trying to minimise the dependencies here and not rely on vampirism triggering the swap.

Classic imports should work too, but I don't have any classic vampire saves so unable to test this. Could someone else test that it works correctly please?

Also fixed a bug with finding region factions.