### PR TITLE
[RFC] make ghosts and wraiths highlights slightly emissive

### DIFF
--- a/Assets/Scripts/API/BaseImageFile.cs
+++ b/Assets/Scripts/API/BaseImageFile.cs
@@ -12,8 +12,8 @@
 #region Using Statements
 using System;
 using System.IO;
-using UnityEngine;
 using DaggerfallConnect.Utility;
+using UnityEngine;
 #endregion
 
 namespace DaggerfallConnect.Arena2
@@ -334,8 +334,12 @@ namespace DaggerfallConnect.Arena2
                     {
                         // Feed albedoColors into emission to really pop lighter features like ribs and skulls
                         // Use otherEmission (with Color.black) for flatter more stealthy ghost
-                        //emissionColors[dstRow + borderSize + x] = albedoColors[dstRow + borderSize + x];
-                        emissionColors[dstRow + borderSize + x] = otherEmission;
+                        float H;
+                        float S;
+                        float V;
+                        Color.RGBToHSV(albedoColors[dstRow + borderSize + x], out H, out S, out V);
+                        float emission = Mathf.Pow(V, 1.9f);
+                        emissionColors[dstRow + borderSize + x] = Color.Lerp(otherEmission, albedoColors[dstRow + borderSize + x], Mathf.Clamp01(emission));
                     }
                 }
             }


### PR DESCRIPTION
I do like the version of ghosts and wraiths in master, it's really close to classic in term of look and stealthiness, with just more details up close with some lighting. This PR is just an alternative that I find interesting.

It make ghosts and wraiths highlights slightly emissive (more focused on highlights than just a constant emissive value). Shouldn't make much difference under bright light, including classic high ambient light conditions.
In dark places however, it gives a hint of the baddies, as if they were slightly phosphorescent
![spectres highlights 3](https://user-images.githubusercontent.com/1211431/85956727-0d6a9100-b988-11ea-86c5-74d8158f7f70.jpg)
