### PR TITLE
Mod support for custom resting prevention

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -568,7 +568,18 @@ namespace DaggerfallWorkshop.Game
                     }
                     else
                     {
-                        if (!GiveOffer())
+                        var preventedRestMessage = GameManager.Instance.GetPreventedRestMessage();
+                        if (preventedRestMessage != null)
+                        {
+                            if (preventedRestMessage != "")
+                                MessageBox(preventedRestMessage);
+                            else
+                            {
+                                const int cannotRestNow = 355;
+                                MessageBox(cannotRestNow);
+                            }
+                        }
+                        else if (!GiveOffer())
                         {
                             racialOverride = GameManager.Instance.PlayerEffectManager.GetRacialOverrideEffect(); // Allow custom race to block rest (e.g. vampire not sated)
                             if (racialOverride != null && !racialOverride.CheckStartRest(GameManager.Instance.PlayerEntity))

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -44,6 +44,8 @@ namespace DaggerfallWorkshop.Game
         float initialQualitySettingsShadowDistance;
         //Texture2D pauseScreenshot;
 
+        Dictionary<Func<bool>, string> preventRestConditions = new Dictionary<Func<bool>, string>();
+
         GameObject playerObject = null;
         Camera mainCamera = null;
         RetroRenderer retroRenderer = null;
@@ -592,6 +594,46 @@ namespace DaggerfallWorkshop.Game
                     hudDisabledByPause = false;
                 }
             }
+        }
+
+        /// <summary>
+        /// Iterates through conditions if rest is should be prevented
+        /// </summary>
+        /// <returns>Non-null message string if prevented, null otherwise</returns>
+        public string GetPreventedRestMessage()
+        {
+            if (preventRestConditions != null && preventRestConditions.Count > 0)
+            {
+                foreach (var kv in preventRestConditions)
+                {
+                    if (kv.Key())
+                        return kv.Value;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Registers a boolean method that prevents the player from starting or continuing to rest
+        /// </summary>
+        /// <param name="handler">The method returning a boolean whether the player can rest
+        /// <param name="message">The message to be displayed
+        public void RegisterPreventRestCondition(Func<bool> handler, string message)
+        {
+            // If the message is null, it is assumed by the game that there was no prevention, so we must set it to be the empty string instead
+            if (message == null)
+                message = "";
+            preventRestConditions[handler] = message;
+        }
+
+        /// <summary>
+        /// Unregisters a boolean method from being used to prevent the player from resting
+        /// </summary>
+        /// <param name="handler">The method returning a boolean whether the player can rest
+        public void UnregisterPreventRestCondition(Func<bool> handler)
+        {
+            preventRestConditions.Remove(handler);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -75,6 +75,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected int totalHours = 0;
         protected float waitTimer = 0;
         protected bool enemyBrokeRest = false;
+        protected string preventedRestMessage = null;
         protected int remainingHoursRented = -1;
         protected Vector3 allocatedBed;
         protected bool ignoreAllocatedBed = false;
@@ -235,6 +236,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             totalHours = 0;
             waitTimer = 0;
             enemyBrokeRest = false;
+            preventedRestMessage = null;
             abortRestForEnemySpawn = false;
 
             // Get references
@@ -333,6 +335,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 return true;
             }
 
+            preventedRestMessage = GameManager.Instance.GetPreventedRestMessage();
+
+            if (preventedRestMessage != null)
+                return true;
+
             // Do nothing if another window has taken over UI
             // This will stop rest from progressing further until player dismisses top window
             if (uiManager.TopWindow != this)
@@ -379,6 +386,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 enemyBrokeRest = true;
                 return true;
             }
+
+            preventedRestMessage = GameManager.Instance.GetPreventedRestMessage();
+
+            if (preventedRestMessage != null)
+                return true;
 
             // Tick vitals to end
             if (currentRestMode == RestModes.TimedRest)
@@ -429,6 +441,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 DaggerfallMessageBox mb = DaggerfallUI.MessageBox(enemiesNearby);
                 mb.OnClose += RestFinishedPopup_OnClose;
+            }
+            else if (preventedRestMessage != null)
+            {
+                if (preventedRestMessage != "")
+                {
+                    DaggerfallMessageBox mb = DaggerfallUI.MessageBox(preventedRestMessage);
+                    mb.OnClose += RestFinishedPopup_OnClose;
+                }
+                else
+                {
+                    const int cannotRestNow = 355;
+                    DaggerfallMessageBox mb = DaggerfallUI.MessageBox(cannotRestNow);
+                    mb.OnClose += RestFinishedPopup_OnClose;
+                }
             }
             else
             {


### PR DESCRIPTION
Allows modders to register conditions and messages for preventing or interrupting a rest via `GameManager` with `RegisterPreventRestCondition`. The conditions can also be unregistered as well with `UnregisterPreventRestCondition`.