### PR TITLE
Fix import of classic old guild records

### DIFF
--- a/Assets/Scripts/API/Save/GuildMembershipRecord.cs
+++ b/Assets/Scripts/API/Save/GuildMembershipRecord.cs
@@ -87,7 +87,8 @@ namespace DaggerfallConnect.Save
         void ReadNativeGuildMembershipData()
         {
             // Must be a guild membership type
-            if (recordType != RecordTypes.GuildMembership)
+            if (recordType != RecordTypes.GuildMembership &&
+                recordType != RecordTypes.OldGuild)
                 return;
 
             // Prepare stream

--- a/Assets/Scripts/API/Save/SaveTree.cs
+++ b/Assets/Scripts/API/Save/SaveTree.cs
@@ -241,6 +241,7 @@ namespace DaggerfallConnect.Save
                         record = new SpellRecord(reader, length);
                         break;
                     case RecordTypes.GuildMembership:
+                    case RecordTypes.OldGuild:
                         record = new GuildMembershipRecord(reader, length);
                         break;
                     case RecordTypes.DiseaseOrPoison:

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -328,22 +328,22 @@ namespace DaggerfallWorkshop.Game.Guilds
         public void ImportMembershipData(List<SaveTreeBaseRecord> guildMembershipRecords, bool vampire = false)
         {
             ClearMembershipData(vampire);
-            try
+            foreach (GuildMembershipRecord record in guildMembershipRecords)
             {
-                foreach (GuildMembershipRecord record in guildMembershipRecords)
-                {
-                    FactionFile.GuildGroups guildGroup = GetGuildGroup(record.ParsedData.factionID);
-                    IGuild guild = CreateGuildObj(guildGroup, record.ParsedData.factionID);
-                    AddMembership(guildGroup, guild);
+                FactionFile.GuildGroups guildGroup = GetGuildGroup(record.ParsedData.factionID);
+                IGuild guild = CreateGuildObj(guildGroup, record.ParsedData.factionID);
+                if (vampire)
+                    vampMemberships[guildGroup] = guild;
+                else
+                    memberships[guildGroup] = guild;
 
-                    // Set rank and time from parsed data.
-                    guild.Rank = record.ParsedData.rank;
-                    guild.ImportLastRankChange(record.ParsedData.timeOfLastRankChange);
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.LogErrorFormat("ImportMembershipData() encountered exception {0}", ex.Message);
+                if (vampire == GameManager.Instance.PlayerEffectManager.HasVampirism())
+                    // Player should only join guilds from either his standard or vampire membership lists, not both
+                    guild.Join();
+
+                // Set rank and time from parsed data.
+                guild.Rank = record.ParsedData.rank;
+                guild.ImportLastRankChange(record.ParsedData.timeOfLastRankChange);
             }
         }
 


### PR DESCRIPTION
This fixes #1849 properly, by importing old guild membership records. @Interkarma I removed your exception handling code since it shouldn't be required anymore. However if you prefer that it remains, I will put it back.

@ajrb, could you review the changes as well? I provided a classic save with a character cured from vampirism in #1849, having a single old guild record (Kynareth at novice rank). I had to modify GuildMembership.RestoreMembershipData to avoid an importation bug where this old guild membership was overwriting the actual player membership in Kynareth at patriarch rank.