### PR TITLE
Improve doorways pathfinding (again)

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Game
         public float OpenDoorDistance = 2f;         // Maximum distance to open door
         const float attackSpeedDivisor = 2f;        // How much to slow down during attack animations
         float stopDistance = 1.7f;                  // Used to prevent orbiting
+        const float doorCrouchingHeight = 1.65f;    // How low enemies dive to pass thru doors
         bool flies;                                 // The enemy can fly
         bool swims;                                 // The enemy can swim
         bool pausePursuit;                          // pause to wait for the player to come closer to ground
@@ -1079,7 +1080,7 @@ namespace DaggerfallWorkshop.Game
             // Climbable/not climbable step for the player seems to be at around a height of 0.65f. The player is 1.8f tall.
             // Using the same ratio to height as these values, set the capsule for the enemy. 
             Vector3 p1 = transform.position + (Vector3.up * -originalHeight * 0.1388F);
-            Vector3 p2 = p1 + (Vector3.up * Mathf.Min(originalHeight, 1.75f) / 2);
+            Vector3 p2 = p1 + (Vector3.up * Mathf.Min(originalHeight, doorCrouchingHeight) / 2);
 
             if (Physics.CapsuleCast(p1, p2, controller.radius / 2, direction, out hit, checkDistance))
             {
@@ -1374,15 +1375,15 @@ namespace DaggerfallWorkshop.Game
         {
             // If enemy bumps into something, temporarily reduce their height to 1.65, which should be short enough to fit through most if not all doorways.
             // Unfortunately, while the enemy is shortened, projectiles will not collide with the top of the enemy for the difference in height.
-            if (!resetHeight && controller && ((controller.collisionFlags & CollisionFlags.CollidedSides) != 0) && originalHeight > 1.65f)
+            if (!resetHeight && controller && ((controller.collisionFlags & CollisionFlags.CollidedSides) != 0) && originalHeight > doorCrouchingHeight)
             {
                 // Adjust the center of the controller so that sprite doesn't sink into the ground
-                centerChange = (1.65f - controller.height) / 2;
+                centerChange = (doorCrouchingHeight - controller.height) / 2;
                 Vector3 newCenter = controller.center;
                 newCenter.y += centerChange;
                 controller.center = newCenter;
                 // Adjust the height
-                controller.height = 1.65f;
+                controller.height = doorCrouchingHeight;
                 resetHeight = true;
                 heightChangeTimer = 0.5f;
             }

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -1070,7 +1070,8 @@ namespace DaggerfallWorkshop.Game
         void ObstacleCheck(Vector3 direction)
         {
             obstacleDetected = false;
-            const float checkDistance = 0.8f;
+            // Rationale: follow walls at 45° incidence; is that optimal? At least it seems very good
+            float checkDistance = controller.radius / Mathf.Sqrt(2f);
             foundUpwardSlope = false;
             foundDoor = false;
 


### PR DESCRIPTION
This is basically an improvement over #1733.

In #1733 is conservatively lowered pathfinding probe distance from 1 to 0.8f. After more testing, lowering this distance further improves AI performance.
The first thing to notice, is that because probing is done using a CapsureCast with half the player's capsule radius, everything in probing geometry is proportional to player's capsule radius.
Second, if you consider the cast of following a flat surface (typically a wall), there's some relation between the ratio of probe length to capsule radius and the angle of incidence of probing: sin a = r / 2l
![spherecast pathfinding](https://user-images.githubusercontent.com/1211431/87246784-b963b000-c44f-11ea-8ea9-0edd8cff65c4.png)
Very low incidence will make it hard to find doorways, very high would probably slow down progression along the wall, and a = 45° <=> l = r / sqrt(2) seems to give good results. The only other values I tried were a = 30° <=> l = r is worse (and so should be even higher values of l) and a = 60° <=> l = r / sqrt(3) that felt okay but somewhat slower.
The only bad side effect I could think of, and the reason I was conservative the first time around, is that enemies start avoiding obstacles from a shorter distance, however I have no evidence this is a real problem (the original probe length of 1 seems to have been chosen arbitrarily in retrospect).


I also slightly modified probe height from 1.75f to 1.65f (and factorized that height), since it has been modified since c282fc667a43f486be91e09fe77cafc351ad5e3f
By the way, it seems Unity 2019.4 seems to also help tall enemies not getting stuck into doors