### PR TITLE
Prevent point blank spellcasting into low obstacles

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -77,6 +77,7 @@ namespace DaggerfallWorkshop.Game
         Vector3 detourDestination;
         CharacterController controller;
         DaggerfallMobileUnit mobile;
+        Collider myCollider;
         DaggerfallEntityBehaviour entityBehaviour;
         EnemyBlood entityBlood;
         EntityEffectManager entityEffectManager;
@@ -102,6 +103,7 @@ namespace DaggerfallWorkshop.Game
             senses = GetComponent<EnemySenses>();
             controller = GetComponent<CharacterController>();
             mobile = GetComponentInChildren<DaggerfallMobileUnit>();
+            myCollider = gameObject.GetComponent<Collider>();
             IsHostile = mobile.Summary.Enemy.Reactions == MobileReactions.Hostile;
             flies = CanFly();
             swims = mobile.Summary.Enemy.Behaviour == MobileBehaviour.Aquatic;
@@ -648,6 +650,22 @@ namespace DaggerfallWorkshop.Game
             // Check that there is a clear path to shoot projectile
             Vector3 sphereCastDir = senses.PredictNextTargetPos(speed);
             if (sphereCastDir == EnemySenses.ResetPlayerPos)
+                return false;
+
+            // No point blank shooting special handling here, makes enemies favor other attack types (melee, touch spells,...)
+
+            bool myColliderWasEnabled = false;
+            if (myCollider)
+            {
+                myColliderWasEnabled = myCollider.enabled;
+                // Exclude enemy collider from CheckSphere test
+                myCollider.enabled = false;
+            }
+            bool isSpaceInsufficient = Physics.CheckSphere(transform.position, radius, ignoreMaskForShooting);
+            if (myCollider)
+                myCollider.enabled = myColliderWasEnabled;
+
+            if (isSpaceInsufficient)
                 return false;
 
             float sphereCastDist = (sphereCastDir - transform.position).magnitude;


### PR DESCRIPTION
When enemy casters can see their target but are right behind some obstacle (say low obstacles like tables, fountains,...), the SphereCast used to check whether they're free to cast can miss the obstacle and allow them to cast, potentially damaging themselves (in classic lich style). An easily reproducible example of such behavior can be triggered in Orsinium entrance hall, if you agro the orc shaman but keep tables in his way.

Starting SphereCast from some position behind the caster could be a workaround, but since its radius is usually larger than caster's capsule radius, it's not very satisfactory (you don't start the SphereCast from inside a "known empty space"; The right offset would also depend on enemy capsule radius).
So instead I prepend the SphereCast test with a SphereCheck at its origin, temporarily excluding caster's collider.

I do not check whether that SphereCheck hits the target (point blank shooting), so HasClearPathToShootProjectile() will return false in this case, favoring other attack types (melee, touch spells,...)