### PR TITLE
Quest typo fixes

### DIFF
--- a/Assets/StreamingAssets/Quests/$CUREVAM.txt
+++ b/Assets/StreamingAssets/Quests/$CUREVAM.txt
@@ -153,7 +153,7 @@ Message:  1025
 <ce>                    will not need to hunt you down.
 
 Message:  1030
-<ce>               Stripling, do not disturb my mediations!
+<ce>               Stripling, do not disturb my meditations!
 <ce>                    Begone, or my hunger will force
 <ce>                            me to slay you!
 

--- a/Assets/StreamingAssets/Quests/10C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/10C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 41
 Quest: 10C00Y00
+DisplayName: Meridia's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/20C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/20C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 61
 Quest: 20C00Y00
+DisplayName: Molag Bal's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/30C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/30C00Y00.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 31
 Quest: 30C00Y00
+DisplayName: Namira's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/40C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/40C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 51
 Quest: 40C00Y00
+DisplayName: Nocturnal's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/50C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/50C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 16
 Quest: 50C00Y00
+DisplayName: Peryite's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/60C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/60C00Y00.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 31
 Quest: 60C00Y00
+DisplayName: Sheogorath's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/70C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/70C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 21
 Quest: 70C00Y00
+DisplayName: Sanguine's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/80C0XY00.txt
+++ b/Assets/StreamingAssets/Quests/80C0XY00.txt
@@ -112,7 +112,7 @@ Message:  1030
  our plans for %reg are ruined.  You will
  find %g2 in the Palace of ___ruler_.  Make
  sure %g3 death cannot be traced back to us.
-     Once you have carried out the assasination,
+     Once you have carried out the assassination,
  wait for me in ___mondung_.  I will bring
  your reward and your next assignment from
  Malacath.

--- a/Assets/StreamingAssets/Quests/80C0XY00.txt
+++ b/Assets/StreamingAssets/Quests/80C0XY00.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 54
 Quest: 80C0XY00
+DisplayName: Malacath's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/90C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/90C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 21
 Quest: 90C00Y00
+DisplayName: Vaernima's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/90C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/90C00Y00.txt
@@ -58,7 +58,7 @@ QuestComplete:  [1004]
 <ce>                   pleased with the news. I hope you
 <ce>                   won't mind if I embellish a little
 <ce>                  about some horrible outrageous sins
-<ce>                   you commited in your journey. Here
+<ce>                   you committed in your journey. Here
 <ce>                   is _artifact_. Use it whenever you
 <ce>                  want a target to be faced with their
 <ce>                     darkest side. Farewell, %pcf,
@@ -82,7 +82,7 @@ We may never know who destroyed that lich in ___mondung_, but he's in our prayer
 Message:  1011
 _qgfriend_ is that creepy =qgfriend_ over at __qgfriend_ to the %di.
 <--->
-_qgfriend_ is the foul-smelling =qgfriend_ I saw at _qgfriend_.
+_qgfriend_ is the foul-smelling =qgfriend_ I saw at __qgfriend_.
 
 Message:  1012
 _qgfriend_ is one of Vaernima's agents of corruption in %reg.

--- a/Assets/StreamingAssets/Quests/A0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y00.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 32
 Quest: A0C00Y00
+DisplayName: The Postman
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y06.txt
@@ -6,6 +6,7 @@
 -- QuestId: 6
 Messages: 15
 Quest: A0C00Y06
+DisplayName: An Unexpected Journey
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y07.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y07.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 11
 Quest: A0C00Y07
+DisplayName: The Exterminator
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y08.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y08.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 34
 Quest: A0C00Y08
+DisplayName: The Assassin
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y10.txt
@@ -73,7 +73,7 @@ RumorsPostsuccess:  [1007]
 <ce>                               Well done!
                                      <--->
 <ce>                        I heard the _giver_ was
-<ce>                    publically embarrassed when some
+<ce>                    publicly embarrassed when some
 <ce>       wandering adventurer beat %g3 champion. Serves %g2 right.
 
 QuestorPostsuccess:  [1008]

--- a/Assets/StreamingAssets/Quests/A0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y10.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 28
 Quest: A0C00Y10
+DisplayName: The Duel
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y11.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 42
 Quest: A0C00Y11
+DisplayName: The Cure
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y12.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 36
 Quest: A0C00Y12
+DisplayName: The First Printing
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y14.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y14.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 21
 Quest: A0C00Y14
+DisplayName: The Delivery Boy
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y14.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y14.txt
@@ -106,9 +106,8 @@ Message:  1014
 
 Message:  1015
 <ce>                    _pickuplocal_ commissioned this
-<ce>                          _painting_ painting.
-<ce>                      It needs to be there for %g3
-<ce>                          gathering tomorrow.
+<ce>                          _painting_. It needs to be there
+<ce>                          for %g3 gathering tomorrow.
 
 Message:  1016
 <ce>                       _pickuplocal_ needs this

--- a/Assets/StreamingAssets/Quests/A0C00Y15.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y15.txt
@@ -113,10 +113,9 @@ Message:  1014
 <ce>                  _pickupregion_ for the celebration.
 
 Message:  1015
-<ce>                   _pickupregion_ commissioned this
-<ce>                          _painting_ painting.
-<ce>                  It needs to be there in time for %g3
-<ce>                               gathering.
+<ce>                    _pickupregion_ commissioned this
+<ce>                          _painting_. It needs to be there
+<ce>                          for %g3 gathering tomorrow.
 
 Message:  1016
 <ce>                       _pickupregion_ needs this

--- a/Assets/StreamingAssets/Quests/A0C00Y15.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y15.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 21
 Quest: A0C00Y15
+DisplayName: The Courier
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y16.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y16.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 55
 Quest: A0C00Y16
+DisplayName: Missing Person Case
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C00Y17.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y17.txt
@@ -6,6 +6,7 @@
 -- QuestId: 17
 Messages: 51
 Quest: A0C00Y17
+DisplayName: The Escort
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C01Y01.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y01.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 14
 Quest: A0C01Y01
+DisplayName: The Bodyguard
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C01Y03.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y03.txt
@@ -6,6 +6,7 @@
 -- QuestId: 3
 Messages: 18
 Quest: A0C01Y03
+DisplayName: The Riddle
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C01Y03.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y03.txt
@@ -30,7 +30,7 @@ AcceptQuest:  [1002]
 <ce>                The only person who might help you find
 <ce>                         _hermit_ is _spouse_.
 <ce>                     %g can be found in ___spouse_.
-<ce>              Take these flowers. They are %g2 favorites.
+<ce>              Take these flowers. They are %g3 favorites.
 <ce>                 They may gain you some favor with %g2.
 <ce>                    Here is a letter with _hermit_'s
 <ce>               riddle inscribed upon it. If you have not

--- a/Assets/StreamingAssets/Quests/A0C01Y03.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y03.txt
@@ -111,14 +111,14 @@ Speak not of love or hate, but tell
  me that I can never buy for myself?
 
 Message:  1015
-On %dat, I spoke with
+On %qdt, I spoke with
  _spouse_. %g told me that
  _hermit_ left to
  study under _teacher_
  in __school_.
 
 Message:  1016
-On %dat, I met with
+On %qdt, I met with
  _hermit_'s teacher,
  _teacher_ of
  __school_. %g said that

--- a/Assets/StreamingAssets/Quests/A0C01Y06.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y06.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 36
 Quest: A0C01Y06
+DisplayName: An Unexpected Journey Part II
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C01Y06.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y06.txt
@@ -69,7 +69,7 @@ QuestLogEntry:  [1010]
  who told me %g3 master,
  _master_, would pay _gold_ gold
  pieces for an unknown but certainly
- dangerous task. He is staying in
+ dangerous task. %g1 is staying in
  _meetingplace_ in __meetingplace_.
 
 Message:  1011

--- a/Assets/StreamingAssets/Quests/A0C01Y09.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y09.txt
@@ -6,6 +6,7 @@
 -- QuestId: 9
 Messages: 62
 Quest: A0C01Y09
+DisplayName: The Birthday Present
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C01Y13.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y13.txt
@@ -4,8 +4,8 @@
 -- Questor: peasant
 -- Repute: 01
 -- QuestId: 13
-Messages: 1006
 Quest: A0C01Y13
+DisplayName: Defamation
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C01Y13.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y13.txt
@@ -181,7 +181,7 @@ Message:  1022
                                      <--->
 <ce>                _giver_ has been keeping some secrets.
                                      <--->
-<ce>              Everone around here has their own stories.
+<ce>              Everyone around here has their own stories.
                                      <--->
 <ce>                     There's always talk at _inn_.
 

--- a/Assets/StreamingAssets/Quests/A0C0XY04.txt
+++ b/Assets/StreamingAssets/Quests/A0C0XY04.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 36
 Quest: A0C0XY04
+DisplayName: The Impostor
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C10Y02.txt
+++ b/Assets/StreamingAssets/Quests/A0C10Y02.txt
@@ -4,8 +4,8 @@
 -- Questor: peasant
 -- Repute: 10
 -- QuestId: 2
-Messages: 21
 Quest: A0C10Y02
+DisplayName: The Abducted Child
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C10Y05.txt
+++ b/Assets/StreamingAssets/Quests/A0C10Y05.txt
@@ -5,8 +5,8 @@
 -- Repute: 10
 -- QuestId: 5
 -- Edited for Daggerfall Unity by Jay_H
-Messages: 21
 Quest: A0C10Y05
+DisplayName: The Matchmaker
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/A0C41Y18.txt
+++ b/Assets/StreamingAssets/Quests/A0C41Y18.txt
@@ -4,8 +4,8 @@
 -- Questor: peasant
 -- Repute: 41
 -- QuestId: 18
-Messages: 51
 Quest: A0C41Y18
+DisplayName: The Mummy's Finger
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/B0B10Y04.txt
+++ b/Assets/StreamingAssets/Quests/B0B10Y04.txt
@@ -24,7 +24,7 @@ RefuseQuest:  [1001]
 <ce>                   when you are less faint of heart.
 
 AcceptQuest:  [1002]
-<ce>               Very well. In a dark pit not to far away,
+<ce>               Very well. In a dark pit not too far away,
 <ce>                   a cursed place called ___mondung_,
 <ce>                      an _soldier_ named =soldier_
 <ce>              has been conspiring with a group of renegade

--- a/Assets/StreamingAssets/Quests/B0B40Y08.txt
+++ b/Assets/StreamingAssets/Quests/B0B40Y08.txt
@@ -35,7 +35,7 @@ AcceptQuest:  [1002]
 
 QuestComplete:  [1004]
 <ce>                        The orc menace has been
-<ce>                           striken from %reg.
+<ce>                           stricken from %reg.
 <ce>                             All hail %pcn!
 
 RumorsDuringQuest:  [1005]

--- a/Assets/StreamingAssets/Quests/C0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y01.txt
@@ -83,7 +83,7 @@ _prophet_ spends %g3 time in %g3 room in _prophouse_, writing.
 _prophet_ hasn't ever gotten on well with __qgiver_.
 
 RumorsPostsuccess:  [1007]
-That _prophet_ was a charletan who found some fools in __tavern_.
+That _prophet_ was a charlatan who found some fools in __tavern_.
 
 QuestorPostsuccess:  [1008]
 For what thou hast done for the faith, I'd be happy to help thee.
@@ -202,7 +202,7 @@ Message:  1016
 <ce>                                  it.
 
 Message:  1017
-_lover_ -- ah, poor =lover_. Well, %g keeps mostly to %g3-self.
+_lover_ -- ah, poor =lover_. Well, %g keeps mostly to %g2self.
 <--->
 _lover_ is a =lover_ in __lover_. They say %g mourns for %g3 lost love.
 <--->

--- a/Assets/StreamingAssets/Quests/C0B00Y03.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y03.txt
@@ -14,7 +14,7 @@ QuestorOffer:  [1000]
 <ce>                       %pct, one of our clerics,
 <ce>                            a =cleric_ named
 <ce>                     _cleric_ has disappeared while
-<ce>                     on an archeological dig. Will
+<ce>                     on an archaeological dig. Will
 <ce>                         you help us find %g2?
                                      <--->
 <ce>                    I fear that one of our noblest

--- a/Assets/StreamingAssets/Quests/C0B00Y04.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y04.txt
@@ -15,7 +15,7 @@ QuestorOffer:  [1000]
 <ce>                        __qgiver_ often delves
 <ce>                 into mysteries of cosmic proportions,
 <ce>                  and occasionally we misjudge one of
-<ce>                 ours priest's suppleness of sanity in
+<ce>                 our priests' suppleness of sanity in
 <ce>                 the face of eternity. In other words,
 <ce>                  one of our priests has gone off his
 <ce>                    nut. Will you help us bring the

--- a/Assets/StreamingAssets/Quests/C0B10Y07.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y07.txt
@@ -125,6 +125,8 @@ Person _qgiver_ group Questor male
 Person _priest_ group Group_5.0
 Person _enemy_ face 176 group Local_4.0
 
+Place _goalplace_ remote house
+--without goalplace, priest would always spawn in current city. this quest depends on remote locations.
 
 Clock _traveltime_ 00:00 0 flag 1 range 1 2
 
@@ -137,7 +139,7 @@ Foe _spellsword_ is Spellsword
 	start timer _traveltime_ 
 	log 1010 step 0 
 	get item _religitem_ 
-	create npc _priest_ 
+	place npc _priest_ at _goalplace_
 
 _traveltime_ task:
 	end quest 

--- a/Assets/StreamingAssets/Quests/F0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/F0B00Y00.txt
@@ -51,7 +51,7 @@ AcceptQuest:  [1002]
 <ce>                     if you would go to __contact_
 <ce>                         in ___contact_ and get
 <ce>                 the artifact from %g2, I would be most
-<ce>                 appreciative. Time is of the essense,
+<ce>                 appreciative. Time is of the essence,
 <ce>                  for %g says that %g will abandon the
 <ce>                  artifact if someone is not there to
 <ce>               take it in =1stparton_ days. Meanwhilst, I
@@ -97,7 +97,7 @@ QuestLogEntry:  [1010]
 <ce>                 By Dibella, I've been a nervous wreck
 <ce>                 waitin' for you to show up. Here's the
 <ce>                icon -- I'm glad to be rid of it. I can
-<ce>                  feel every cuthroat's eyes on on it.
+<ce>                  feel every cutthroat's eyes on on it.
 <ce>                You better get back to the House before
 <ce>                    they think you ran off with it.
 
@@ -113,7 +113,7 @@ A forgery, in all probability. But very pretty, nevertheless.
 
 Message:  1030
 %qdt:
- The House of Dibella has hired to
+ The House of Dibella has hired
  me to meet with an archaeologist
  who has uncovered an icon for them, pay for it,
  and bring the icon back to the House. This

--- a/Assets/StreamingAssets/Quests/G0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/G0B00Y00.txt
@@ -17,7 +17,7 @@ QuestorOffer:  [1000]
                                      <--->
 <ce>                  The Goddess has spoken to us in our
 <ce>                 auguries, and she demands the blood of
-<ce>                 the foul villian who has profaned her
+<ce>                 the foul villain who has profaned her
 <ce>                  name. Help us to appease our angered
 <ce>                           mistress Kynareth.
 

--- a/Assets/StreamingAssets/Quests/I0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/I0B00Y00.txt
@@ -76,7 +76,7 @@ Perhaps you'd like to speak to those who died because you did not get the _item_
 
 QuestLogEntry:  [1010]
 <ce>                     Here's the _item_, %pcf. Now
-<ce>                    hurry back to the Temple. There
+<ce>                    hurry back to the Temple. There are
 <ce>                    many there waiting to be healed.
 
 Message:  1030

--- a/Assets/StreamingAssets/Quests/K0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y00.txt
@@ -30,7 +30,7 @@ AcceptQuest:  [1002]
 <ce>                   in it is a _mitem_ that I want you
 <ce>            liberate. And, on your way out, please drop this
 <ce>            note off anywhere in the store. I can't resist.
-<ce>                 _competitor_ is going to passing that
+<ce>                 _competitor_ is going to pass that
 <ce>                  _mitem_ to a more secure location in
 <ce>               =2storehouse_ days, so you'll need to move
 <ce>               swiftly. If you're not back in that time,

--- a/Assets/StreamingAssets/Quests/K0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y00.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 17
 Quest: K0C00Y00
+DisplayName: An Object Lesson
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C00Y02.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y02.txt
@@ -6,6 +6,7 @@
 -- QuestId: 2
 Messages: 16
 Quest: K0C00Y02
+DisplayName: Counterfeit Gold
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C00Y02.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y02.txt
@@ -58,7 +58,7 @@ _palace_ is improving its security, due to rumors about thieves in the area.
 The maid at _mansion_ said she saw some undesirables watching the place.
 
 RumorsPostfailure:  [1006]
-%t %rn is seems to think that the head of the smuggling operation is _qgiver_.
+%t %rn seems to think that the head of the smuggling operation is _qgiver_.
 <--->
 _qgiver_ has apparently been smuggling foscarium, pretending its gold.
 <--->

--- a/Assets/StreamingAssets/Quests/K0C00Y04.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y04.txt
@@ -60,7 +60,7 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 _lover_, they say, has caused more deaths than any plague.
 <--->
-_lover_'s last lover died in %g2 arms, trying to satisfy %g3 ... appetite.
+_lover_'s last lover died in %g3 arms, trying to satisfy %g3 ... appetite.
 <--->
 If _lover_ finds out they're finding a duel over %g2 ... %oth, that'll be it.
 

--- a/Assets/StreamingAssets/Quests/K0C00Y04.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y04.txt
@@ -11,7 +11,7 @@ DisplayName: Two Cowards
 QRC:
 
 QuestorOffer:  [1000]
-<ce>                 I'm in an embarassing predicament, I
+<ce>                 I'm in an embarrassing predicament, I
 <ce>                       fear. _lover_ and I have
 <ce>                had ... an understanding, but %g3 lover
 <ce>                 is being distressingly old-fashioned

--- a/Assets/StreamingAssets/Quests/K0C00Y05.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y05.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 20
 Quest: K0C00Y05
+DisplayName: The Lost Child
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y06.txt
@@ -242,7 +242,7 @@ Message:  1022
  nothing, you unnderstand? I used to work for
  this =merchant_ by a name
  of _merchant_. Now %g was a
- crazy one, %g was. Allways trying to find a
+ crazy one, %g was. Always trying to find a
  way to get rich. And always quick to blame
  someone else when %g got caught with %g3
  hands in the cookie jar. That's how I got
@@ -267,7 +267,7 @@ Dear %pcn,
      There is a =noble_
  of my acquaintance who I believe knows more
  about the affair than most. It may be that
- %g even arranged or even commited the
+ %g even arranged or even committed the
  crime. I can say no more, except that %g3
  name is _noble_ and %g lives
  in __noblehome_.
@@ -572,9 +572,9 @@ Message:  1044
 QuestTimeLapse:  [1045]
 %qdt:
  _witness_
- confessed that %g knew who commited the
+ confessed that %g knew who committed the
  burglary and it isn't me. On the other
- hands, _priest_, the true
+ hand, _priest_, the true
  engineer behind it, will be difficult to
  convict. The two places where I might find
  evidence, _witness_ says,

--- a/Assets/StreamingAssets/Quests/K0C00Y07.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y07.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 100
 Quest: K0C00Y07
+DisplayName: The Ransom
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C00Y08.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y08.txt
@@ -6,6 +6,7 @@
 -- QuestId: 8
 Messages: 13
 Quest: K0C00Y08
+DisplayName: A Rare Book
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C00Y09.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y09.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 15
 Quest: K0C00Y09
+DisplayName: The Recompense
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C01Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C01Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 21
 Quest: K0C01Y00
+DisplayName: To Assist the Fate
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C01Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C01Y00.txt
@@ -115,7 +115,7 @@ Message:  1013
 %pcf,
  
      _victim_ is being held in
- ___mondung_. Do your worse.
+ ___mondung_. Do your worst.
  
      We don't mind. The kidnappers are bloody
  freelancers.

--- a/Assets/StreamingAssets/Quests/K0C01Y10.txt
+++ b/Assets/StreamingAssets/Quests/K0C01Y10.txt
@@ -6,6 +6,7 @@
 -- QuestId: 10
 Messages: 16
 Quest: K0C01Y10
+DisplayName: Background Information
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C0XY01.txt
+++ b/Assets/StreamingAssets/Quests/K0C0XY01.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 100
 Quest: K0C0XY01
+DisplayName: The Harpies' Nest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C30Y03.txt
+++ b/Assets/StreamingAssets/Quests/K0C30Y03.txt
@@ -385,7 +385,7 @@ This document bears witness to the ownership
  of _house3_ of __house3_ in %reg.
  Let all who read this know that _patsy_
  is the sole and rightful owner of the
- afore mentioned property.
+ aforementioned property.
 
 
 -- Symbols used in the QRC file:

--- a/Assets/StreamingAssets/Quests/K0C30Y03.txt
+++ b/Assets/StreamingAssets/Quests/K0C30Y03.txt
@@ -7,6 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 56
 Quest: K0C30Y03
+DisplayName: A Noble's Debts
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/K0C30Y03.txt
+++ b/Assets/StreamingAssets/Quests/K0C30Y03.txt
@@ -252,7 +252,7 @@ That _rock_ must have been mined years ago when ___mondung_ was a mine.
 
 Message:  1029
 <ce>                   This looks like the deed _patsy_
-<ce>                     gave _qgiver_ as collaterial.
+<ce>                     gave _qgiver_ as collateral.
 
 Message:  1030
 <ce>                   This appears to be the gold that

--- a/Assets/StreamingAssets/Quests/K0C30Y03.txt
+++ b/Assets/StreamingAssets/Quests/K0C30Y03.txt
@@ -139,6 +139,7 @@ Message:  1014
 <ce> 
 <ce>
              _patsy_
+
 --eliminating unmarked white spaces. this problem was patched out in previous versions but i still prefer to have lines with blank spaces filled just in case.
 
 Message:  1015

--- a/Assets/StreamingAssets/Quests/L0A01L00.txt
+++ b/Assets/StreamingAssets/Quests/L0A01L00.txt
@@ -5,7 +5,6 @@
 -- Repute: 01
 -- QuestId: 0
 -- Edited for Daggerfall Unity by Jay_H
--- Temp changes to allow joining DB made by Hazelnut
 Messages: 21
 Quest: L0A01L00
 DisplayName: The Acceptance Test
@@ -22,7 +21,7 @@ QuestComplete:  [1004]
 <ce>               town, you will know if there are any guild
 <ce>                  buildings there. It is customary for
 <ce>               the novice to receive payment of a single
-<ce>               gold coin for his first sanctioned death.
+<ce>               gold coin for %pg1 first sanctioned death.
 <ce>                             Here is yours.
 
 RumorsDuringQuest:  [1005]

--- a/Assets/StreamingAssets/Quests/L0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y01.txt
@@ -14,7 +14,7 @@ QuestorOffer:  [1000]
 <ce>                       As you know, %pct, there
 <ce>                     is no room for failure in the
 <ce>                    Dark Brotherhood. Brothers who
-<ce>                     fail us are targetted for an
+<ce>                     fail us are targeted for an
 <ce>                     accounting. You will find and
 <ce>                        correct one such errant
 <ce>                            former member.

--- a/Assets/StreamingAssets/Quests/L0B00Y02.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y02.txt
@@ -39,7 +39,7 @@ AcceptQuest:  [1002]
 <ce>                  has pursued %g3 quarry to a dungeon
 <ce>                         called ___mondung_. If
 <ce>                  you have not found any clues to the
-<ce>                  employer's wherebouts, return here.
+<ce>                  employer's whereabouts, return here.
 <ce>                   I would, of course, prefer for you
 <ce>                         to account =assassin_
 <ce>                   and %g3 employer both, but I'd be

--- a/Assets/StreamingAssets/Quests/L0B40Y04.txt
+++ b/Assets/StreamingAssets/Quests/L0B40Y04.txt
@@ -58,7 +58,7 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 I know what I'm talking about. _knight_ is going to be our next ruler.
 <--->
-Someday _knight_ going to be our ruler. Then we'll know real tyranny.
+Someday _knight_ is going to be our ruler. Then we'll know real tyranny.
 
 RumorsPostfailure:  [1006]
 _knight_ left the court for a while, but %g'll be back. That's for certain.

--- a/Assets/StreamingAssets/Quests/L0B50Y11.txt
+++ b/Assets/StreamingAssets/Quests/L0B50Y11.txt
@@ -94,7 +94,7 @@ Message:  1022
 <ce>                         tell them who did it.
 
 Message:  1023
-<ce>                     _marknpc_ comes here everday
+<ce>                     _marknpc_ comes here every day
 <ce>                   at around 6 o'clock. %g sends %g3
 <ce>                   bodyguards away. %g is only here
 <ce>                          for an hour or so.

--- a/Assets/StreamingAssets/Quests/L0B60Y10.txt
+++ b/Assets/StreamingAssets/Quests/L0B60Y10.txt
@@ -23,7 +23,7 @@ RefuseQuest:  [1001]
 
 AcceptQuest:  [1002]
 <ce>                  Somehow I thought you might try for
-<ce>     this one. Its your funereal. This mark is no arena gladiator.
+<ce>     this one. It's your funeral. This mark is no arena gladiator.
 <ce>                   We're talking about a veteran of
 <ce>                 the Betony war. Killed 9 men, if the
 <ce>                  stories are right. Go to _mondung_
@@ -49,7 +49,7 @@ RumorsDuringQuest:  [1005]
 Such a shame, what's happening in Daggerfall.
 
 RumorsPostfailure:  [1006]
-I hear the queen is pregnant. At least thats what everyone is saying.
+I hear the queen is pregnant. At least that's what everyone is saying.
 
 RumorsPostsuccess:  [1007]
 Did you hear about that war hero? Killed in a duel. What a shame.

--- a/Assets/StreamingAssets/Quests/M0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y00.txt
@@ -60,7 +60,7 @@ QuestorPostsuccess:  [1008]
 
 QuestorPostfailure:  [1009]
 <ce>                  Get outta here. You're so pathetic.
-<ce>                   You couldn't even handle werewolf.
+<ce>                   You couldn't even handle a werewolf.
 
 Message:  1020
 <ce>                   The lycanthrope threat is ended.

--- a/Assets/StreamingAssets/Quests/M0B00Y06.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y06.txt
@@ -47,7 +47,7 @@ RumorsDuringQuest:  [1005]
 RumorsPostfailure:  [1006]
 <ce>                    The Fighter's Guild killed that
 <ce>                      bear that got into _house_.
-<ce>                 Its a good thing we have them around.
+<ce>                 It's a good thing we have them around.
 
 RumorsPostsuccess:  [1007]
 <ce>                That creature mauled some woman before

--- a/Assets/StreamingAssets/Quests/M0B00Y07.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y07.txt
@@ -18,7 +18,7 @@ QuestorOffer:  [1000]
 <ce>                He seems rather confused as to whether
 <ce>                it is a bear or a tiger, but in either
 <ce>                  case, it wanted to eat him. We need
-<ce>                  you to go and slay the animal. You
+<ce>                  you to go and slay the animal. Your
 <ce>                     standard fee is _gold_ gold.
 <ce>                         Want to take it %pcn?
 

--- a/Assets/StreamingAssets/Quests/M0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y16.txt
@@ -52,7 +52,7 @@ RumorsPostfailure:  [1006]
 
 RumorsPostsuccess:  [1007]
 <ce>      Thank %god _dummy_ finally sent someone to kill that giant
-<ce>    in ___mondung_.  It must have killed one of %g2 precious sheep.
+<ce>    in ___mondung_.  It must have killed one of %g3 precious sheep.
 
 QuestorPostsuccess:  [1008]
 <ce>                 It's my old friend Giant-Killer %pcf!

--- a/Assets/StreamingAssets/Quests/M0B00Y17.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y17.txt
@@ -95,6 +95,14 @@ Message:  1021
  I just have to get it back to _dummy_
  in ___dummy_.
 
+ Message:  1022
+%qdt:
+ I found the tiger in ___mondung_,
+ but I killed it. The best I can do now
+ is go to __dummy_ of ___dummy_
+ and apologize to _dummy_
+ for the botched job.
+
 Message:  1030
 <ce>                      Oops. You killed the tiger.
 <ce>                    I wonder what _dummy_ will say?
@@ -241,6 +249,8 @@ until _S.02_ performed:
 _S.03_ task:
 	killed 1 _tiger_ 
 	say 1030 
+	log 1022 step 1
+--adds log in case user missed kill message
 
 variable _S.04_
 _S.05_ task:

--- a/Assets/StreamingAssets/Quests/M0B11Y18.txt
+++ b/Assets/StreamingAssets/Quests/M0B11Y18.txt
@@ -264,9 +264,9 @@ Message:  1061
 
 Message:  1062
 <ce>                 _traitor_ looks at you intently. The
-<ce>               color drains from %g3 face as %g realizes
+<ce>               color drains from his face as he realizes
 <ce>                who you are, and before anyone can stop
-<ce>                 %g2 %g turns and bolts for the door.
+<ce>                 him he turns and bolts for the door.
 
 Message:  1070
 <ce>                    %ra dog, you will pay for your
@@ -281,12 +281,12 @@ Message:  1072
 <ce>                          _traitor_ is dead.
 
 Message:  1073
-<ce>                   _traitor_ throws down %g3 weapon.
-<ce>                   Thinking %g is surrendering, you
+<ce>                   _traitor_ throws down his weapon.
+<ce>                   Thinking he is surrendering, you
 <ce>                   pause in your attack, but instead
-<ce>                    %g twists a ring on %g3 finger.
+<ce>                    he twists a ring on his finger.
 <ce>                   As _traitor_ disappears in a haze
-<ce>                 of light, you faintly hear %g2 shout,
+<ce>                 of light, you faintly hear him shout,
 <ce>                                    
 <ce>                       "Tell that bitch that she
 <ce>                     hasn't seen the last of me!"

--- a/Assets/StreamingAssets/Quests/M0B1XY01.txt
+++ b/Assets/StreamingAssets/Quests/M0B1XY01.txt
@@ -69,7 +69,7 @@ QuestorPostfailure:  [1009]
 <ce>               take care of a bunch of Harpies. Pathetic.
 
 Message:  1020
-<ce>                   Thats five. That should be enough
+<ce>                   That's five. That should be enough
 <ce>                         to hold _questgiver_.
 
 Message:  1030

--- a/Assets/StreamingAssets/Quests/M0B40Y05.txt
+++ b/Assets/StreamingAssets/Quests/M0B40Y05.txt
@@ -49,7 +49,7 @@ RumorsDuringQuest:  [1005]
 <ce>                      to cause us trouble before.
 
 RumorsPostfailure:  [1006]
-<ce>                   Another woodsmen died. I hear it
+<ce>                   Another woodsman died. I hear it
 <ce>                      was _woodsman_. The rest of
 <ce>                  them have decided to log elsewhere.
 
@@ -97,7 +97,7 @@ Message:  1021
 <ce>                    Go to ___house_ and secure his
 <ce>                   promise. Do not visit me again. I
 <ce>                 shall know of your success or failure
-<ce>                  by how the woodsman do their work.
+<ce>                  by how the woodsmen do their work.
 
 Message:  1022
 <ce>                  I should have known better than to
@@ -122,7 +122,7 @@ Message:  1025
 Message:  1030
 %qdt:
  The spriggan has convinced me that
- it is not the villian. Apparently a
+ it is not the villain. Apparently a
  woodsman named _woodsman_
  in ___house_ has been
  cutting down its trees. If I can get

--- a/Assets/StreamingAssets/Quests/M0B50Y09.txt
+++ b/Assets/StreamingAssets/Quests/M0B50Y09.txt
@@ -63,7 +63,7 @@ QuestorPostfailure:  [1009]
 
 QuestLogEntry:  [1010]
 On %qdt,
- The Fighers Guild of ___qgiver_
+ The Fighters Guild of ___qgiver_
  charged me with the duty of destroying a
  gargoyle that lairs in ___dungeon_.
  I have =2dung_ days to finish the task.

--- a/Assets/StreamingAssets/Quests/M0B50Y09.txt
+++ b/Assets/StreamingAssets/Quests/M0B50Y09.txt
@@ -39,7 +39,7 @@ QuestComplete:  [1004]
 <ce>                            for such a deed.
 
 RumorsDuringQuest:  [1005]
-<ce>                  The mages guild has refused to kill
+<ce>                  The Mages Guild has refused to kill
 <ce>                that rampaging gargoyle. They claim its
 <ce>                    not their fault. Lazy bastards.
 

--- a/Assets/StreamingAssets/Quests/M0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y13.txt
@@ -15,7 +15,7 @@ QuestorOffer:  [1000]
 <ce>                            I am _qgiver_.
 <ce>                 The Fighter's Guild doesn't hand out
 <ce>                  charity work. If I weren't short on
-<ce>                 fighter's right now, I'd have to send
+<ce>                 fighters right now, I'd have to send
 <ce>                 you away %pcn. I do need a fighter to
 <ce>                  chase off some barbarian that's
 <ce>                  running wild. Do it for me and I'll

--- a/Assets/StreamingAssets/Quests/N0B00Y09.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y09.txt
@@ -17,7 +17,7 @@ QuestorOffer:  [1000]
 <ce>            If we can get a representative of the Guild over
 <ce>            to a place within a reasonable distance of here,
 <ce>                    the eminent scholar, _scholar_,
-<ce>            and has agreed to share %g3 research. Would you
+<ce>            has agreed to share %g3 research. Would you
 <ce>                         be available for this?
                                      <--->
 <ce>                     The Mages Guild of ___qgiver_
@@ -221,7 +221,7 @@ Message:  1019
 <ce>                look alike anyhow. When they don't yield
 <ce>                results, the Guild will just throw more
 <ce>                assistants at it or give up the project
-<ce>                  in embarassment. The Mages Guild is
+<ce>                  in embarrassment. The Mages Guild is
 <ce>                  simply a tedious pack of researchers
 <ce>                   who don't have to worry about gold
 <ce>                  and thus are never happier than when

--- a/Assets/StreamingAssets/Quests/N0B00Y17.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y17.txt
@@ -34,7 +34,7 @@ AcceptQuest:  [1002]
 <ce>               self.  By all reports, a masterful little
 <ce>              piece of work, but according to my research,
 <ce>             impossible.  The internal azimuth vectors are
-<ce>              such that I cannnot reconcile the externally
+<ce>              such that I cannot reconcile the externally
 <ce>             manifested lateral flow lines ... Well, having
 <ce>             the piece to study would help me immeasurably,
 <ce>             but I have not had much luck tracking it down.
@@ -84,7 +84,7 @@ RumorsPostsuccess:  [1007]
 <ce>                %g3 research.  Hey, that was you, right?
 
 QuestorPostsuccess:  [1008]
-<ce>        Eh?  Oh, my good friend %pcf.  You searched all of %ra
+<ce>        Eh?  Oh, my good friend %pcf.  You searched all of %reg
 <ce>                       for that _item_ I wanted.
 
 QuestorPostfailure:  [1009]
@@ -190,7 +190,7 @@ Message:  1032
 _contact_ --
  
  Please send me:
-   3 doz. newt's tongues (dessicated)
+   3 doz. newt's tongues (desiccated)
    4.25 oz. powdered unicorn horn (pure northern ONLY!)
    1 _ingredient_ (FRESH this time, for %god's sake)
    A jar of basilisk eyes

--- a/Assets/StreamingAssets/Quests/N0B10Y01.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y01.txt
@@ -11,7 +11,7 @@ DisplayName: Atronach Hunting
 QRC:
 
 QuestorOffer:  [1000]
-<ce>          Rather embarassing, but one of our experiments has
+<ce>          Rather embarrassing, but one of our experiments has
 <ce>           prematurely evacuated our laboratory. Even worse,
 <ce>              it left before it was fed so it's doubtless
 <ce>             going to be ill-tempered. Thankfully, it is a
@@ -32,7 +32,7 @@ QuestorOffer:  [1000]
 <ce>              that can easily be traced back to this Guild
 <ce>               and our maladministration. You're the type
 <ce>                   who could end this affair with the
-<ce>                     minimum of embarassment, yes?
+<ce>                     minimum of embarrassment, yes?
 
 RefuseQuest:  [1001]
 <ce>               A pity indeed. Well, I suppose some other
@@ -59,7 +59,7 @@ QuestFail:  [1003]
 
 QuestComplete:  [1004]
 <ce>              The hunter returns! You have saved us some
-<ce>                  considerable discomforture with your
+<ce>                  considerable discomfiture with your
 <ce>                precipitate amelioration of our atronach
 <ce>                 crisis. A first-rate job, all around.
 <ce>                   Accept your gold and my gratitude.

--- a/Assets/StreamingAssets/Quests/N0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y03.txt
@@ -131,6 +131,8 @@ Foe _F.01_ is 4 Knight
 	log 1010 step 0
 	create npc at _magesguild_ 
 
+variable _oneday_
+
 _timeout_ task:
 	when _oneday_ and not _S.07_ 
 	end quest 

--- a/Assets/StreamingAssets/Quests/N0B11Y18.txt
+++ b/Assets/StreamingAssets/Quests/N0B11Y18.txt
@@ -12,7 +12,7 @@ DisplayName: Former Student Part I
 QRC:
 
 QuestorOffer:  [1000]
-<ce>               You are loyal member of the Mages Guild,
+<ce>               You are a loyal member of the Mages Guild,
 <ce>                 are you not, %pct?  I have some guild
 <ce>                  business of the gravest import that
 <ce>                      I would like you to handle.
@@ -21,7 +21,7 @@ RefuseQuest:  [1001]
 <ce>              Perhaps you are not as loyal as I thought.
 
 AcceptQuest:  [1002]
-<ce>               Very good.  There is a rebel mage that we
+<ce>               Very good. There is a rebel mage that we
 <ce>                need eliminated, by the name of _rebel_.
 <ce>              A former pupil of mine, showed some promise
 <ce>            but lacked the loyalty to the ancient principles

--- a/Assets/StreamingAssets/Quests/N0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/N0B20Y02.txt
@@ -103,7 +103,7 @@ Message:  1011
 
 Message:  1012
 <ce>                     Fool! You should know better
-<ce>                      that to disturb a mage in a
+<ce>                      than to disturb a mage in a
 <ce>                      spell trance. You shall pay
 <ce>                       for this! Leave this guild
 <ce>                      hall now. I will bring this

--- a/Assets/StreamingAssets/Quests/N0B21Y14.txt
+++ b/Assets/StreamingAssets/Quests/N0B21Y14.txt
@@ -81,13 +81,13 @@ The Oracle has no eyes but she is said to be the wisest woman in Tamriel.
 <--->
 The Oracle has traditionally been the counselor to the monarchs of Sentinel.
 <--->
-The Oracle advised King Cameron against warring with Daggerfall.
+The Oracle advised King Camaron against warring with Daggerfall.
 <--->
-King Cameron didn't the Oracle's advice against warring with Daggerfall.
+King Camaron didn't the Oracle's advice against warring with Daggerfall.
 <--->
 The Oracle knew that Sentinel would lose the war with Daggerfall.
 <--->
-If Cameron of Sentinel had listened to the Oracle, he'd be alive today.
+If Camaron of Sentinel had listened to the Oracle, he'd be alive today.
 
 Message:  1014
 %qdt: I got a letter

--- a/Assets/StreamingAssets/Quests/N0B21Y14.txt
+++ b/Assets/StreamingAssets/Quests/N0B21Y14.txt
@@ -105,7 +105,7 @@ Message:  1015
 <ce>               speaking with %g2, but I am not permitted
 <ce>                 to enter %g3 company in _noblehouse_.
 <ce>              My mistress, the Oracle, intends to come to
-<ce>                       __temple_ speak with %g3
+<ce>                       __temple_ to speak with %g3
 <ce>                Grace, and I last heard that she was in
 <ce>                  __oracletemple_. I am not familiar
 <ce>               with these parts, so I don't know how far

--- a/Assets/StreamingAssets/Quests/N0B21Y14.txt
+++ b/Assets/StreamingAssets/Quests/N0B21Y14.txt
@@ -178,7 +178,7 @@ Message:  1020
 <ce>                             answer, %pct.
 
 Message:  1021
-%dat:
+%qdt:
  _noble_ refuses to go
  into hiding until %g knows
  that %g3 love, _love_,

--- a/Assets/StreamingAssets/Quests/N0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y11.txt
@@ -29,7 +29,7 @@ QuestorOffer:  [1000]
 <ce>                       _ingredient_, which we are
 <ce>                   fresh out of. If you got some for
 <ce>                     me, I would be very grateful.
-<ce>                      You standing with the guild
+<ce>                      Your standing with the guild
 <ce>                         would surely improve.
 
 RefuseQuest:  [1001]

--- a/Assets/StreamingAssets/Quests/O0B10Y07.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y07.txt
@@ -48,7 +48,7 @@ QuestComplete:  [1004]
 <ce>                           not long from now.
 
 RumorsDuringQuest:  [1005]
-%t %rn is evidentally proud of %g3 new _jewelry_. Everyone wants to see it.
+%t %rn is evidently proud of %g3 new _jewelry_. Everyone wants to see it.
 <--->
 Security is up in _palace_, apparently because of the new _jewelry_.
 

--- a/Assets/StreamingAssets/Quests/P0A01L00.txt
+++ b/Assets/StreamingAssets/Quests/P0A01L00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 31
 Quest: P0A01L00
+DisplayName: The Rite of Acceptance
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/P0B00L01.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L01.txt
@@ -55,7 +55,7 @@ That nervous =pawn_ finally left __pawn_. Must've missed %g3 nighttime meeting.
 That =vampire_ in __vampire_ was muttering about that %ra %g's always with.
 
 RumorsPostsuccess:  [1007]
-The %rt apparently changed %g3 mind about the existance of vampires in %reg.
+The %rt apparently changed %g3 mind about the existence of vampires in %reg.
 <--->
 The %rt was going to put more guards out at night, but changed %g3 mind.
 

--- a/Assets/StreamingAssets/Quests/P0B00L01.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L01.txt
@@ -6,6 +6,7 @@
 -- QuestId: 1
 Messages: 27
 Quest: P0B00L01
+DisplayName: The Vampire's Letter
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/P0B00L03.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L03.txt
@@ -6,6 +6,7 @@
 -- QuestId: 3
 Messages: 27
 Quest: P0B00L03
+DisplayName: Territorial Battles
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/P0B00L04.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L04.txt
@@ -6,6 +6,7 @@
 -- QuestId: 4
 Messages: 17
 Quest: P0B00L04
+DisplayName: An Old Enemy
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/P0B00L04.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L04.txt
@@ -156,7 +156,7 @@ Message:  1013
 <ce>                   with the deed completed. Farewell.
 
 Message:  1014
-%dat:
+%qdt:
  _vamp_ has sent me to
  ___mondung_ where
  I am to slay =vampire_, a

--- a/Assets/StreamingAssets/Quests/P0B00L06.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L06.txt
@@ -6,6 +6,7 @@
 -- QuestId: 6
 Messages: 24
 Quest: P0B00L06
+DisplayName: Deadly Knowledge
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/P0B00L06.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L06.txt
@@ -164,7 +164,7 @@ Message:  1018
 <ce>                       vampires could be anyone.
 
 Message:  1019
-%dat: _mg_ of
+%qdt: _mg_ of
  __mg_ in ___mg_
  wants me to go to ___mondung_
  to take _mage_'s
@@ -206,7 +206,7 @@ Message:  1020
  about increasing funding. Going nowhere.
 
 Message:  1021
-%dat: A sorceror named
+%qdt: A sorceror named
  _mage_ has come close
  to major discoveries about %vam
  and _vamp_ has sent me

--- a/Assets/StreamingAssets/Quests/P0B00L06.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L06.txt
@@ -186,7 +186,7 @@ Message:  1020
  How is one cured of vampirism (find
  that Vampires of the Iliac Bay book,
  references to a society of former
- vampires)? Slaying the preeminant member
+ vampires)? Slaying the preeminent member
  of the same bloodline, from what I can
  gather from personal interviews and
  whatnot. (Note to me: that rather

--- a/Assets/StreamingAssets/Quests/P0B01L02.txt
+++ b/Assets/StreamingAssets/Quests/P0B01L02.txt
@@ -6,6 +6,7 @@
 -- QuestId: 2
 Messages: 31
 Quest: P0B01L02
+DisplayName: The Vampire Relic
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/P0B10L07.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L07.txt
@@ -127,7 +127,7 @@ Message:  1016
 Message:  1017
 <ce>                     A pale young boy hands you a
 <ce>                      letter before scurrying away
-<ce>                        with suprising agility.
+<ce>                        with surprising agility.
 
 
 -- Symbols used in the QRC file:

--- a/Assets/StreamingAssets/Quests/P0B10L07.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L07.txt
@@ -91,7 +91,7 @@ Message:  1012
  as soon as possible.
 
 Message:  1013
-%dat: _vamp_
+%qdt: _vamp_
  wants me to go to ___mondung_
  and throttle _knight_,
  a knight who refuses to bend to the

--- a/Assets/StreamingAssets/Quests/P0B10L07.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L07.txt
@@ -6,6 +6,7 @@
 -- QuestId: 7
 Messages: 18
 Quest: P0B10L07
+DisplayName: Intimidation
 -- Message panels
 QRC:
 
@@ -188,7 +189,9 @@ _S.03_ task:
 _S.04_ task:
 	injured _F.00_ 
 	say 1014 
-	restrain foe _F.00_ task _S.04_ 
+	restrain foe _F.00_
+--task _S.04_ 
+--This was appended to the restrain foe action, not sure why
 
 _S.05_ task:
 	killed 1 _F.00_ 

--- a/Assets/StreamingAssets/Quests/P0B10L08.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L08.txt
@@ -6,6 +6,7 @@
 -- QuestId: 8
 Messages: 22
 Quest: P0B10L08
+DisplayName: A Test of Determination
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/P0B10L08.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L08.txt
@@ -34,9 +34,7 @@ RumorsDuringQuest:  [1005]
 Strange things are afoot in ___mondung_. Even stranger than usual, I should say.
 
 RumorsPostfailure:  [1006]
-Things have quieted down around ___mondung_. But the daedra stars burn at night
-<--->
-.
+Things have quieted down around ___mondung_. But the daedra stars burn at night.
 
 RumorsPostsuccess:  [1007]
 ___mondung_ has quieted. Even the daedra stars glowed softer last night.
@@ -161,10 +159,7 @@ Message:  1019
 <ce>                         You have failed %vam,
 <ce>                      %pcf. The Coven of ==daedra_
 <ce>                     challenged us, and you were an
-<ce>                 embarassment. It is a night of shame.
-
-Message:  1020
-Error: Questtext 1020 Called.
+<ce>                 embarrassment. It is a night of shame.
 
 Message:  1021
 <ce>                    A terribly pale, wild-eyed boy

--- a/Assets/StreamingAssets/Quests/P0B10L10.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L10.txt
@@ -21,7 +21,7 @@ Error: Questtext 1002 Called.
 QuestComplete:  [1004]
 <ce>                  It is not an easy thing for one of
 <ce>                   our kind to travel. With the added
-<ce>                        encumberance of _vamp_,
+<ce>                        encumbrance of _vamp_,
 <ce>                  I can only imagine your tribulation.
 <ce>                 Add to it the terror of that venomous
 <ce>                         =mage_, and I can see

--- a/Assets/StreamingAssets/Quests/P0B10L10.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L10.txt
@@ -6,6 +6,7 @@
 -- QuestId: 10
 Messages: 18
 Quest: P0B10L10
+DisplayName: The Chaperone
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/P0B10L10.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L10.txt
@@ -94,7 +94,7 @@ Message:  1013
 <ce>                           more interesting!
 
 Message:  1014
-%dat:
+%qdt:
  I am escorting _vamp_
  to _vamp2_ in ___vamp2_.
  I must make it to __vamp2_

--- a/Assets/StreamingAssets/Quests/P0B20L09.txt
+++ b/Assets/StreamingAssets/Quests/P0B20L09.txt
@@ -6,6 +6,7 @@
 -- QuestId: 9
 Messages: 22
 Quest: P0B20L09
+DisplayName: The Vanguard
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/P0B20L09.txt
+++ b/Assets/StreamingAssets/Quests/P0B20L09.txt
@@ -81,7 +81,7 @@ Message:  1012
  at __vamp_ in ___vamp_.
 
 Message:  1013
-%dat:
+%qdt:
  _vamp_ has sent me to
  ___mondung_, where a group of impudent
  werecreatures have dared intrude on

--- a/Assets/StreamingAssets/Quests/Q0C00Y01.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y01.txt
@@ -12,7 +12,7 @@ DisplayName: The Libel
 QRC:
 
 QuestorOffer:  [1000]
-<ce>                      We would use thee to find a
+<ce>                      We would use thee to find
 <ce>                  a perfidious document circulated by
 <ce>                  our enemies in an effort to suppress
 <ce>                 our coven. I know wherein this packet

--- a/Assets/StreamingAssets/Quests/Q0C00Y04.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y04.txt
@@ -132,8 +132,6 @@ Message:  1017
 <ce>                   been desecrated! I am disappointed
 <ce>                   that you cannot do this one simple
 <ce>                             thing for me.
-                                     <--->
- 
 
 -- Symbols used in the QRC file:
 --

--- a/Assets/StreamingAssets/Quests/Q0C0XY02.txt
+++ b/Assets/StreamingAssets/Quests/Q0C0XY02.txt
@@ -34,7 +34,7 @@ AcceptQuest:  [1002]
 <ce>                        _mitem_ will be crafted
 <ce>                for thee. Now, journey thou to farthest
 <ce>                     __tavern_ and seek the one who has
-<ce>                    betrayed us, a villianous =man_
+<ce>                    betrayed us, a villainous =man_
 <ce>                       who calls %g2-self _man_.
 <ce>                Give to %g2 this _jewelry_, tell %g2 it
 <ce>                is a gift from %g3 old lover, and then
@@ -50,7 +50,7 @@ AcceptQuest:  [1002]
 
 QuestComplete:  [1004]
 <ce>                       Good %pcf, thy promise to
-<ce>                      the ==qgiver_ is fulfilled.
+<ce>                      ==qgiver_ is fulfilled.
 <ce>                         Here is the _mitem_ I
 <ce>                         promised. Poor _man_.
 <ce>                I hope they allow %g2 to suffer deeply,

--- a/Assets/StreamingAssets/Quests/Q0C10Y00.txt
+++ b/Assets/StreamingAssets/Quests/Q0C10Y00.txt
@@ -221,5 +221,8 @@ _S.14_ task:
 
 _S.15_ task:
 	when _pchasitem1_ and _pchasitem2_ and _pchasitem3_ 
-	give pc _reward1_ and _reward2_ and _reward3_ 
+	give pc _reward1_
+	give pc _reward2_
+	give pc _reward3_ 
 	end quest 
+--changed to multi-line give pc reward, as I know this implementation works fine. --JayH

--- a/Assets/StreamingAssets/Quests/R0C10Y00.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 22
 Quest: R0C10Y00
+DisplayName: Jewel Smuggling
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y01.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y01.txt
@@ -6,6 +6,7 @@
 -- QuestId: 1
 Messages: 22
 Quest: R0C10Y01
+DisplayName: Contraband Trade
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y02.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y02.txt
@@ -6,6 +6,7 @@
 -- QuestId: 2
 Messages: 31
 Quest: R0C10Y02
+DisplayName: Gold Smuggling
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y04.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y04.txt
@@ -6,6 +6,7 @@
 -- QuestId: 4
 Messages: 21
 Quest: R0C10Y04
+DisplayName: The Evil Wizard
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y05.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y05.txt
@@ -15,7 +15,7 @@ QuestorOffer:  [1000]
 <ce>                       _qgfriend_. To cement our
 <ce>                       friendship, I have agreed
 <ce>                        to arrange the death of
-<ce>                         a consistant threat to
+<ce>                         a consistent threat to
 <ce>                          %g2 -- some sort of
 <ce>                      monster. This foul parasite
 <ce>                        lives in a decrepit old

--- a/Assets/StreamingAssets/Quests/R0C10Y05.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y05.txt
@@ -6,6 +6,7 @@
 -- QuestId: 5
 Messages: 31
 Quest: R0C10Y05
+DisplayName: Deadly Diplomacy
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y06.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y06.txt
@@ -6,6 +6,7 @@
 -- QuestId: 6
 Messages: 12
 Quest: R0C10Y06
+DisplayName: The Heirloom
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y08.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y08.txt
@@ -89,7 +89,7 @@ Message:  1011
 <ce>           _transporter_ is a nervous-looking =transporter_
 <ce>                   with connections to _questgiver_.
                                      <--->
-A =transporter_ -- %g's %di of here at __tranporter_.
+A =transporter_ -- %g's %di of here at __transporter_.
 
 Message:  1012
 <ce>                        You pick up the _item_.
@@ -97,7 +97,7 @@ Message:  1012
 
 Message:  1015
 %qdt:
-_questgiver_ of
+_questgiver_
  has sent me to _itemplace_
  in __itemplace_ to steal
  a certain _item_, then deliver it to

--- a/Assets/StreamingAssets/Quests/R0C10Y08.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y08.txt
@@ -6,6 +6,7 @@
 -- QuestId: 8
 Messages: 21
 Quest: R0C10Y08
+DisplayName: Theft from a Temple
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y09.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y09.txt
@@ -6,6 +6,7 @@
 -- QuestId: 9
 Messages: 21
 Quest: R0C10Y09
+DisplayName: The Procurer
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y10.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y10.txt
@@ -6,6 +6,7 @@
 -- QuestId: 10
 Messages: 11
 Quest: R0C10Y10
+DisplayName: Weapon Supply
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y11.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y11.txt
@@ -6,6 +6,7 @@
 -- QuestId: 11
 Messages: 16
 Quest: R0C10Y11
+DisplayName: Contraband Goods
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y12.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y12.txt
@@ -6,6 +6,7 @@
 -- QuestId: 12
 Messages: 24
 Quest: R0C10Y12
+DisplayName: Smuggled Goods
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y12.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y12.txt
@@ -15,7 +15,7 @@ QuestorOffer:  [1000]
 <ce>                  awkward indeed. I'm in possession of
 <ce>                   a certain ... item that is not, to
 <ce>                  be blunt, legally mine. If you would
-<ce>                     carry it a contact of mine in
+<ce>                     carry it to a contact of mine in
 <ce>                        ___contact_, you will be
 <ce>                handsomely rewarded. Does _reward_ gold
 <ce>                       pieces sound fair to you?
@@ -58,7 +58,7 @@ Those guards are even searching _questgiver_'s house for that _item_ shipment.
 It's a complete mystery where that _item_ disappeared. Everyone's curious.
 
 RumorsPostfailure:  [1006]
-What an embarassment for _questgiver_. The stolen _item_ was traced to %g2.
+What an embarrassment for _questgiver_. The stolen _item_ was traced to %g2.
 <--->
 I hear _questgiver_ tried to smuggle the _item_ to ___contact_.
 

--- a/Assets/StreamingAssets/Quests/R0C10Y13.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y13.txt
@@ -6,6 +6,7 @@
 -- QuestId: 13
 Messages: 21
 Quest: R0C10Y13
+DisplayName: A Peace Offering
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y14.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y14.txt
@@ -6,6 +6,7 @@
 -- QuestId: 14
 Messages: 11
 Quest: R0C10Y14
+DisplayName: Forgotten Equipment
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y15.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y15.txt
@@ -6,6 +6,7 @@
 -- QuestId: 15
 Messages: 17
 Quest: R0C10Y15
+DisplayName: The Fourth Man
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y17.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y17.txt
@@ -6,6 +6,7 @@
 -- QuestId: 17
 Messages: 13
 Quest: R0C10Y17
+DisplayName: A Special Substance
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y18.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y18.txt
@@ -6,6 +6,7 @@
 -- QuestId: 18
 Messages: 22
 Quest: R0C10Y18
+DisplayName: An Item on Loan
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y20.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y20.txt
@@ -6,6 +6,7 @@
 -- QuestId: 20
 Messages: 16
 Quest: R0C10Y20
+DisplayName: A Rare Ingredient
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y21.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y21.txt
@@ -6,6 +6,7 @@
 -- QuestId: 21
 Messages: 16
 Quest: R0C10Y21
+DisplayName: The Temple of the Orcs
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C10Y21.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y21.txt
@@ -54,7 +54,7 @@ QuestComplete:  [1004]
 <ce>                     _reward_ gold pieces. Go wild.
 
 RumorsDuringQuest:  [1005]
-There's a orc community in ___mondung_ that's been bothering _qgfriend_.
+There's an orc community in ___mondung_ that's been bothering _qgfriend_.
 <--->
 ___mondung_ was, I think, an orc temple years ago. Now they're bringing it back.
 

--- a/Assets/StreamingAssets/Quests/R0C11Y03.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y03.txt
@@ -97,7 +97,7 @@ _questgiver_? Why, %g's a noble. Involved in some daedric activity lately.
 <--->
 _questgiver_'s a noble, %di of here.
 <--->
-like so many other nobles, _questgiver_ has about a dozen projects brewing.
+Like so many other nobles, _questgiver_ has about a dozen projects brewing.
 <--->
 _questgiver_ has a lot of faith in alchemistry, like a lot of nobles do.
 

--- a/Assets/StreamingAssets/Quests/R0C11Y03.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y03.txt
@@ -6,6 +6,7 @@
 -- QuestId: 3
 Messages: 21
 Quest: R0C11Y03
+DisplayName: The Heartless Daedra
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C11Y16.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y16.txt
@@ -6,6 +6,7 @@
 -- QuestId: 16
 Messages: 17
 Quest: R0C11Y16
+DisplayName: Espionage Equipment
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C11Y19.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y19.txt
@@ -6,6 +6,7 @@
 -- QuestId: 19
 Messages: 22
 Quest: R0C11Y19
+DisplayName: The Emperor's Gift
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C11Y26.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y26.txt
@@ -6,6 +6,7 @@
 -- QuestId: 26
 Messages: 51
 Quest: R0C11Y26
+DisplayName: The Mad Ripper
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C11Y26.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y26.txt
@@ -16,7 +16,7 @@ QuestorOffer:  [1000]
 <ce>              and constabulary are helpless against him.
 <ce>            They have no clues to his identity whatsoever.
 <ce>               I know you have some resources and rather
-<ce>                untraditional contacts. Can you try and
+<ce>                nontraditional contacts. Can you try and
 <ce>                 help me in this matter, for the good
 <ce>             of all %reg -- and a substantial sum of gold?
 

--- a/Assets/StreamingAssets/Quests/R0C11Y27.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y27.txt
@@ -6,6 +6,7 @@
 -- QuestId: 27
 Messages: 13
 Quest: R0C11Y27
+DisplayName: A Special Substance
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C11Y28.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y28.txt
@@ -106,7 +106,7 @@ QuestLogEntry:  [1010]
 <ce>                       these notes to a _vamp_,
 <ce>                       a =vamp_ you will find at
 <ce>                      _hookerhouse_. If anything
-<ce>               should happen to me, I want somone to be
+<ce>               should happen to me, I want someone to be
 <ce>              able to continue on in the investigations.
 <ce>                        That will be _vamp_ and
 <ce>                   you, %pcf. So don't get yourself
@@ -143,7 +143,7 @@ _contact_,
  I would very much like to meet with you
  about your fascinating mortuary studies of
  the Slayer victims. As you know, I have
- done similiar investigations and would be
+ done similar investigations and would be
  happy to share my knowledge and experience
  with a distinguished colleague.
  
@@ -152,7 +152,7 @@ _contact_,
  staying at _hookerhouse_,
  but perhaps you would rather meet at
  _bookstore_ so I might
- see the corpses in question. In either,
+ see the corpses in question. In either
  case I look forward to receiving your
  courier and note.
  

--- a/Assets/StreamingAssets/Quests/R0C11Y28.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y28.txt
@@ -6,6 +6,7 @@
 -- QuestId: 28
 Messages: 51
 Quest: R0C11Y28
+DisplayName: The Mad Slayer
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C20Y07.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y07.txt
@@ -6,6 +6,7 @@
 -- QuestId: 7
 Messages: 12
 Quest: R0C20Y07
+DisplayName: The Lost Sapphire
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/R0C20Y22.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y22.txt
@@ -6,6 +6,7 @@
 -- QuestId: 22
 Messages: 31
 Quest: R0C20Y22
+DisplayName: Business with Orcs
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/S0000001.txt
+++ b/Assets/StreamingAssets/Quests/S0000001.txt
@@ -32,7 +32,7 @@ QuestFail:  [1003]
 <ce>                    I wanted some real proof, %pcf.
 
 QuestComplete:  [1004]
-<ce>             This what I most feared. Poor _brother_. As I
+<ce>             This is what I most feared. Poor _brother_. As I
 <ce>                promised, here's what I've heard about
 <ce>              Lysandus. I don't know how much of this is
 <ce>             secret, but I trust you. Lysandus was in love
@@ -41,7 +41,7 @@ QuestComplete:  [1004]
 <ce>             his queen found out. They say that while her
 <ce>               husband was gone, Queen Mynisera banished
 <ce>              Medora from the court. My sister Aubk-i is
-<ce>            queen now, part of the treaty to insure peace,
+<ce>            queen now, part of the treaty to ensure peace,
 <ce>            but Mynisera still resides at Castle Daggerfall
 <ce>                     as the dowager Queen mother.
 <ce>                                    
@@ -105,7 +105,7 @@ QuestLogEntry:  [1010]
  the kingdom. I cannot say I missed the love; I received
  much attention from the doctors, priests, and herbalists
  constantly at court. Certainly I was not to be the sort
- of warrior that King Cameron was, but one of my dearest
+ of warrior that King Camaron was, but one of my dearest
  friends, a priest of Stendarr said that I might be the
  first scholar-king in the history of Sentinel.
  
@@ -168,7 +168,7 @@ The Underking used to have a crypt around here -- ___ukcrypt_, just %di of here.
 <--->
 No one has heard much of the Underking since his crypt ___ukcrypt_ was abandoned.
 <--->
-King Cameron himself drove the Underking's servants out of ___ukcrypt_.
+King Camaron himself drove the Underking's servants out of ___ukcrypt_.
 
 Message:  1013
 The Underking is supposed to be centuries old.
@@ -179,7 +179,7 @@ He is a lich of great power. So they say.
 <--->
 I heard he kidnapped Prince _brother_.
 <--->
-King Cameron blamed the Underking for Prince _brother_'s death. Never made sense to me though.
+King Camaron blamed the Underking for Prince _brother_'s death. Never made sense to me though.
 <--->
 They say Tiber Septim never really died. He became the Underking.
 <--->
@@ -233,8 +233,7 @@ Message:  1019
  by the Underking years ago.
 
 Message:  1020
-<ce>                             You pick up a
-<ce>                          Death Certificate.
+<ce>                You pick up a death certificate.
 
 Message:  1030
 _brother_ was a prince of Sentinel. He died years ago.
@@ -243,17 +242,17 @@ _brother_ came down with a fever and eventually died.
 <--->
 Wasn't he the scholar prince?
 <--->
-_brother_ like books more than swords. It used to drive King Cameron crazy.
+_brother_ liked books more than swords. It used to drive King Camaron crazy.
 <--->
-He was the only prince never to recieve a public funeral.
+He was the only prince never to receive a public funeral.
 
 Message:  1031
-<ce> Old King Cameron, may his soul rest in peace, never liked _brother_.
+<ce> Old King Camaron, may his soul rest in peace, never liked _brother_.
  He would have preferred Greklith to be his heir.
                                      <--->
 I heard that _brother_'s former nursemaid was sent to Skyrim with a chest full of gold. 
 <--->
-King Cameron seemed far too happy when _brother_ died.
+King Camaron seemed far too happy when _brother_ died.
 <--->
 I heard he died of a fever.
 <--->
@@ -318,8 +317,6 @@ Place _dirennitower_ permanent DirenniTowerEntry
 Place _agentplace_ remote tavern
 
 Clock _S.13_ 3.00:00 7.00:00
--1002 edited to remove additional 'to'
-
 
 --	Quest start-up:
 	dialog link for location _ukcrypt_ 

--- a/Assets/StreamingAssets/Quests/S0000004.txt
+++ b/Assets/StreamingAssets/Quests/S0000004.txt
@@ -13,7 +13,7 @@ QuestorOffer:  [1000]
 <ce>               scandals in the Bay of which I am totally
 <ce>             ignorant. I could give you some information,
 <ce>              but nothing is without a price, that I know
-<ce>               well. I need a champion who does fear the
+<ce>               well. I need a champion who doesn't fear the
 <ce>                 fire of Oblivion. Are you interested?
 
 RefuseQuest:  [1001]
@@ -52,7 +52,7 @@ QuestComplete:  [1004]
 <ce>                                    
 <ce>            The letter you seek is in the hands of Gortwog,
 <ce>            the Warlord of the Orcs. He bought it from the
-<ce>            thieves guild of Daggerfall after one of their
+<ce>            Thieves Guild of Daggerfall after one of their
 <ce>                  number stole it from Queen Aubk-i.
 <ce>                                    
 <ce>            I confess I don't know why the Emperor sent it

--- a/Assets/StreamingAssets/Quests/S0000010.txt
+++ b/Assets/StreamingAssets/Quests/S0000010.txt
@@ -50,7 +50,7 @@ QuestComplete:  [1004]
 <ce>               of Tiber Septim from the Underking. King
 <ce>                 Lysandus did not die in the battle of
 <ce>              Cryngaine. He was slain by treachery before
-<ce>              it. The monument to him in Hammerfell is an
+<ce>              it. The monument to him in High Rock is an
 <ce>                 empty tomb. His remains were secretly
 <ce>              taken to an ancient tomb in Menevia, which
 <ce>                I will now reveal to you. I do not know

--- a/Assets/StreamingAssets/Quests/S0000012.txt
+++ b/Assets/StreamingAssets/Quests/S0000012.txt
@@ -31,12 +31,12 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>               Good. I have long had my suspicions about
 <ce>               Aubk-i's loyalty to the emperor. She is a
-<ce>             daughter of the late King Cameron, who ruled
-<ce>               Hammerfell from his citidel in Sentinel.
+<ce>             daughter of the late King Camaron, who ruled
+<ce>               Hammerfell from his citadel in Sentinel.
 <ce>                                    
 <ce>                My husband King Lysandus, %god rest his
-<ce>             soul, died at Cryngaine, as did King Cameron.
-<ce>              Lysandus body was not recovered, so he has
+<ce>             soul, died at Cryngaine, as did King Camaron.
+<ce>              Lysandus' body was not recovered, so he has
 <ce>              a monument erected there rather than a true
 <ce>                      tomb. Ah...my mind wanders.
 <ce>                                    
@@ -94,7 +94,7 @@ Message:  1015
 <ce>              this is rather embarrassing. The letter was
 <ce>             stolen from me the same day I received it. I
 <ce>              never did read it. I have been hoping that
-<ce>             the letter would turn up, or the the Emperor
+<ce>             the letter would turn up, or the Emperor
 <ce>              would send another letter. If you find the
 <ce>             letter, I would be most grateful if you would
 <ce>               let me personally deliver it to Mynisera.

--- a/Assets/StreamingAssets/Quests/S0000013.txt
+++ b/Assets/StreamingAssets/Quests/S0000013.txt
@@ -10,8 +10,8 @@ QRC:
 QuestorOffer:  [1000]
 <ce>                    %pcf, I do not know even how to
 <ce>               broach this subject. I need you to promise
-<ce>               me on your ancestor's honor that you will
-<ce>              do what you can to help me and never breath
+<ce>               me on your ancestors' honor that you will
+<ce>              do what you can to help me and never breathe
 <ce>                of what I say or what you see to anyone
 <ce>                   else anywhere. Will you so swear?
 
@@ -95,9 +95,9 @@ QuestLogEntry:  [1010]
 <ce>      after all the stallion orcs had been killed and the stro ...
 <ce>     (for mare orcs are seldom weaker than stallion orcs in an ...
 <ce>        only old and sick remained in the rude cam ... who could
-<ce>        speak base Cyrodil ... ied and begged for mercy for the
+<ce>        speak base Cyrodilic ... ied and begged for mercy for the
 <ce>        children, but Prince Klaius said that the children would
-<ce>       grow strong and hearty and and only an unwise leader would
+<ce>       grow strong and hearty and only an unwise leader would
 <ce>       show mercy to the subhumans. He gave his men leave to make
 <ce>      sport with killing the children, and they were all murdered
 <ce>        in ways that I cannot pen. I witnessed it, my lady, and

--- a/Assets/StreamingAssets/Quests/S0000020.txt
+++ b/Assets/StreamingAssets/Quests/S0000020.txt
@@ -42,7 +42,7 @@ So, Mynisera seeks to sweet talk me.
  people may not be so lenient toward a
  %ra wandering the halls of Orsinium.
  If you can survive my realm and find
- the letter, you make take it back to
+ the letter, you may take it back to
  her. I will also consider you to be
  a worthy %ra.
 
@@ -55,7 +55,7 @@ Lord Gortwog,
  have you and the Orcish people sought
  formal recognition by the empire. My dead
  husband King Lysandus supported your claim
- to sovreign rule. I would now help you in
+ to sovereign rule. I would now help you in
  your cause. Sadly, a minor missive from
  the emperor has been misplaced. For me to
  truly hold the trust and ear of Emperor

--- a/Assets/StreamingAssets/Quests/S0000502.txt
+++ b/Assets/StreamingAssets/Quests/S0000502.txt
@@ -14,14 +14,14 @@ Message:  1020
 %qdt:
  _rebel_, the rebel mage
  who was once my quarry, has
- asked me to meet %g3 messenger
+ asked me to meet his messenger
  in _tavern_ in __tavern_.
 
 Message:  1021
 %qdt:
  An atronach sent by _rebel_
- informed me that %g would like me
- to help %g2 explore Direnni Tower
+ informed me that he would like me
+ to help him explore Direnni Tower
  on the Isle of Balfiera.
  _rebel_ will meet me there,
  somewhere.
@@ -51,9 +51,9 @@ Message:  1032
 <ce>                                    
 <ce>                    "Hello %pcn.  I am =atronach_,
 <ce>                      humble servant of _rebel_.
-<ce>                 %g asks if you would like to explore
+<ce>                 He asks if you would like to explore
 <ce>                 Direnni Tower on the Isle of Balfiera
-<ce>                  with %g2.  A magical place full of
+<ce>                  with him.  A magical place full of
 <ce>                 wonders beyond imagining.  My master
 <ce>               will meet you there in =towertime_ days."
 <ce>                                    

--- a/Assets/StreamingAssets/Quests/S0000988.txt
+++ b/Assets/StreamingAssets/Quests/S0000988.txt
@@ -14,7 +14,7 @@ Dear %pcf,
  Numidium, but you need to.
  
  The legend dates back to the earliest parts of
- the third era.
+ the Third Era.
  
  Numidium was supposed to be a giant so big his
  hands could knock the moons from the sky. I do
@@ -87,7 +87,7 @@ Dear %pcf,
 <ce>                               A Friend
 
 Message:  1020
-<ce>       You approached by a young page who smiles in recognition
+<ce>       You are approached by a young page who smiles in recognition
 <ce>        and does not ask your name before he hands you a letter
 <ce>         addressed to you. To all of your questions, he merely
 <ce>                responds with a blank look and a smile.
@@ -111,7 +111,7 @@ Message:  1020
 <ce>             A redfaced courier startles you with a cry of
 <ce>                  "Letter for %pcn! Hey that must be
 <ce>                 you. Here, take this. Gotta go. Other
-<ce>                        deliveries to be made.
+<ce>                        deliveries to be made."
 
 
 -- Symbols used in the QRC file:

--- a/Assets/StreamingAssets/Quests/T0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/T0C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 31
 Quest: T0C00Y00
+DisplayName: Lady Azura's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/T0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/T0C00Y00.txt
@@ -35,7 +35,7 @@ AcceptQuest:  [1002]
 <ce>                 You would! Oh jolly good. Well, this
 <ce>                perfectly awful priest is also a Healer,
 <ce>                if that means anything. Isn't that just
-<ce>              typical?  As usual with these self-rightous
+<ce>              typical?  As usual with these self-righteous
 <ce>                      types, =monster_ is secluded
 <ce>                       in ___mondung_, cleansing
 <ce>                or some such ridiculous thing.  Anyway,

--- a/Assets/StreamingAssets/Quests/U0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/U0C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 43
 Quest: U0C00Y00
+DisplayName: Beothiah's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/V0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/V0C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 31
 Quest: V0C00Y00
+DisplayName: Clavicus Vile's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/V0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/V0C00Y00.txt
@@ -11,7 +11,7 @@ QRC:
 
 QuestorOffer:  [1000]
 <ce>                My needs are rather ... modest, but my
-<ce>             offer, I think you will agree, is altruistism
+<ce>             offer, I think you will agree, is altruism
 <ce>               and generosity indissoluble. In return for
 <ce>                        _artifact_, an artifact
 <ce>            of great power, I only ask that you exterminate
@@ -97,7 +97,8 @@ Message:  1020
  located in the dungeon ___mondung_.
  A =contact_ named _contact_ will
  wait for =1stparton_ days for me at __contact_
- in ___contact_ to give me the _artifact_.
+ in ___contact_ to give me the Masque
+ of Clavicus Vile.
 
 Message:  1030
 <ce>                     You have slain the werewolf,

--- a/Assets/StreamingAssets/Quests/W0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/W0C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 46
 Quest: W0C00Y00
+DisplayName: Hermaeus Mora's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/X0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/X0C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 31
 Quest: X0C00Y00
+DisplayName: Hircine's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/X0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/X0C00Y00.txt
@@ -26,7 +26,7 @@ RefuseQuest:  [1001]
                                      <--->
 <ce>                 Seldom am I summoned, even rarer are
 <ce>                    the occasions when I am free to
-<ce>                 answer a summonings. To be perfectly
+<ce>                 answer a summoning. To be perfectly
 <ce>                  blunt, this was a waste of my very
 <ce>                            precious time.
 

--- a/Assets/StreamingAssets/Quests/Y0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/Y0C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 31
 Quest: Y0C00Y00
+DisplayName: Mehrunes Dagon's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Quests/Z0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/Z0C00Y00.txt
@@ -6,6 +6,7 @@
 -- QuestId: 0
 Messages: 42
 Quest: Z0C00Y00
+DisplayName: Mephala's Quest
 -- Message panels
 QRC:
 

--- a/Assets/StreamingAssets/Tables/QuestList-Classic.txt
+++ b/Assets/StreamingAssets/Tables/QuestList-Classic.txt
@@ -228,7 +228,7 @@ R0C11Y03, Nobility, N, 1, 1, Passed
 R0C11Y16, Nobility, N, 1, 1, Passed
 R0C11Y19, Nobility, N, 1, 1, Passed
 R0C11Y26, Nobility, M, 1, 1, Passed
-R0C11Y27, Nobility, N, 1, 1, Passed
+-R0C11Y27, Nobility, N, 1, 1, duplicate of r0c10y17
 R0C11Y28, Nobility, M, 1, 1, Needs %vcn macro implementation to get vamp clan of _vamp_ npc to be tested
 R0C20Y07, Nobility, N, 2, 0, Passed
 R0C20Y22, Nobility, M, 2, 0, Passed

--- a/Assets/StreamingAssets/Tables/QuestList-Classic.txt
+++ b/Assets/StreamingAssets/Tables/QuestList-Classic.txt
@@ -161,37 +161,37 @@ A0C00Y00, Commoners, N, 0, 0, Passed
 A0C00Y06, Commoners, M, 0, 0, Passed
 A0C00Y07, Commoners, M, 0, 0, Passed
 A0C00Y08, Commoners, M, 0, 0, Passed
-A0C00Y10, Commoners, N, 0, 0,
+A0C00Y10, Commoners, N, 0, 0, Passed
 A0C00Y11, Commoners, M, 0, 0, Passed
 A0C00Y12, Commoners, M, 0, 0, Passed
-A0C00Y14, Commoners, N, 0, 0,
-A0C00Y15, Commoners, N, 0, 0,
+A0C00Y14, Commoners, N, 0, 0, Passed
+A0C00Y15, Commoners, N, 0, 0, Passed
 -A0C00Y16, Commoners, M, 0, 0, FAILED. _hidingplace_ not marked on map when player asks about _missingperson_. Can be found from debug marker.
-A0C00Y17, Commoners, M, 0, 0,
-A0C01Y01, Commoners, N, 0, 1,
-A0C01Y03, Commoners, M, 0, 1,
-A0C01Y06, Commoners, M, 0, 1,
-A0C01Y09, Commoners, N, 0, 1,
-A0C01Y13, Commoners, M, 0, 1,
-A0C0XY04, Commoners, M, 0, X,
-A0C10Y02, Commoners, N, 1, 0,
-A0C10Y05, Commoners, M, 1, 0,
-A0C41Y18, Commoners, M, 4, 1,
+A0C00Y17, Commoners, M, 0, 0, Passed
+A0C01Y01, Commoners, N, 0, 1, Passed
+A0C01Y03, Commoners, M, 0, 1, Passed
+A0C01Y06, Commoners, M, 0, 1, Passed
+A0C01Y09, Commoners, N, 0, 1, Passed
+A0C01Y13, Commoners, M, 0, 1, Passed
+A0C0XY04, Commoners, M, 0, X, Passed
+A0C10Y02, Commoners, N, 1, 0, Passed
+A0C10Y05, Commoners, M, 1, 0, Passed
+A0C41Y18, Commoners, M, 4, 1, Passed
 
 -- Merchants
-K0C00Y00, Merchants, M, 0, 0,
-K0C00Y02, Merchants, N, 0, 0,
-K0C00Y03, Merchants, M, 0, 0,
+K0C00Y00, Merchants, M, 0, 0, Passed
+K0C00Y02, Merchants, N, 0, 0, Passed
+K0C00Y03, Merchants, M, 0, 0, Passed
 K0C00Y04, Merchants, M, 0, 0, Passed
-K0C00Y05, Merchants, M, 0, 0,
--K0C00Y06, Merchants, M, 0, 0, "A Mix-Up"
-K0C00Y07, Merchants, M, 0, 0,
-K0C00Y08, Merchants, M, 0, 0,
+K0C00Y05, Merchants, M, 0, 0, Passed
+-K0C00Y06, Merchants, M, 0, 0, "A Mix-Up", tons of branching paths to test, NPCs wouldn't always show up in correct buildings
+K0C00Y07, Merchants, M, 0, 0, Passed
+K0C00Y08, Merchants, M, 0, 0, Passed
 K0C00Y09, Merchants, M, 0, 0, Passed
-K0C01Y00, Merchants, N, 0, 1,
-K0C01Y10, Merchants, M, 0, 1,
-K0C0XY01, Merchants, M, 0, X,
-K0C30Y03, Merchants, M, 3, 0,
+K0C01Y00, Merchants, N, 0, 1, Passed
+K0C01Y10, Merchants, M, 0, 1, Passed
+K0C0XY01, Merchants, M, 0, X, Passed
+K0C30Y03, Merchants, M, 3, 0, Passed
 
 -- Vampires
 P0A01L00, Vampires, P, 0, 1, Passed
@@ -206,32 +206,32 @@ P0B10L10, Vampires, M, 1, 0, Passed
 P0B20L09, Vampires, M, 2, 0, Passed
 
 -- Nobility
-R0C10Y00, Nobility, N, 1, 0,
-R0C10Y01, Nobility, M, 1, 0,
-R0C10Y02, Nobility, N, 1, 0,
-R0C10Y04, Nobility, N, 1, 0,
-R0C10Y05, Nobility, N, 1, 0,
-R0C10Y06, Nobility, N, 1, 0,
-R0C10Y08, Nobility, N, 1, 0,
-R0C10Y09, Nobility, N, 1, 0,
-R0C10Y10, Nobility, N, 1, 0,
-R0C10Y11, Nobility, M, 1, 0,
-R0C10Y12, Nobility, M, 1, 0,
-R0C10Y13, Nobility, M, 1, 0,
-R0C10Y14, Nobility, M, 1, 0,
-R0C10Y15, Nobility, N, 1, 0,
-R0C10Y17, Nobility, N, 1, 0,
-R0C10Y18, Nobility, N, 1, 0,
-R0C10Y20, Nobility, N, 1, 0,
-R0C10Y21, Nobility, N, 1, 0,
-R0C11Y03, Nobility, N, 1, 1,
-R0C11Y16, Nobility, N, 1, 1,
-R0C11Y19, Nobility, N, 1, 1,
-R0C11Y26, Nobility, M, 1, 1, Adds journal entries which need %qdat - assuming thats the date of entry and not quest start
-R0C11Y27, Nobility, N, 1, 1,
+R0C10Y00, Nobility, N, 1, 0, Passed
+R0C10Y01, Nobility, M, 1, 0, Passed
+R0C10Y02, Nobility, N, 1, 0, Passed
+R0C10Y04, Nobility, N, 1, 0, Passed
+R0C10Y05, Nobility, N, 1, 0, Passed
+R0C10Y06, Nobility, N, 1, 0, Passed
+R0C10Y08, Nobility, N, 1, 0, Passed
+R0C10Y09, Nobility, N, 1, 0, Passed
+R0C10Y10, Nobility, N, 1, 0, Passed
+R0C10Y11, Nobility, M, 1, 0, Passed
+R0C10Y12, Nobility, M, 1, 0, Passed
+R0C10Y13, Nobility, M, 1, 0, Passed
+R0C10Y14, Nobility, M, 1, 0, Passed
+R0C10Y15, Nobility, N, 1, 0, Passed
+R0C10Y17, Nobility, N, 1, 0, Passed
+R0C10Y18, Nobility, N, 1, 0, Passed
+R0C10Y20, Nobility, N, 1, 0, Passed
+R0C10Y21, Nobility, N, 1, 0, Passed
+R0C11Y03, Nobility, N, 1, 1, Passed
+R0C11Y16, Nobility, N, 1, 1, Passed
+R0C11Y19, Nobility, N, 1, 1, Passed
+R0C11Y26, Nobility, M, 1, 1, Passed
+R0C11Y27, Nobility, N, 1, 1, Passed
 R0C11Y28, Nobility, M, 1, 1, Needs %vcn macro implementation to get vamp clan of _vamp_ npc to be tested
-R0C20Y07, Nobility, N, 2, 0,
-R0C20Y22, Nobility, M, 2, 0,
+R0C20Y07, Nobility, N, 2, 0, Passed
+R0C20Y22, Nobility, M, 2, 0, Passed
 R0C30Y25, Nobility, N, 3, 0, Passed
 -R0C40Y23, Nobility, N, 4, 0, BROKEN. QRC file is missing in DF+DFQFIX. Duplicate of r0c4xy23.
 R0C4XY23, Nobility, M, 4, X, Passed


### PR DESCRIPTION
Just used UESP as a guide to find typos in quests, to fix them. Also updates the quest list to show that everything enabled has passed testing.