### PR TITLE
Added support for secondary keybindings

### DIFF
--- a/Assets/Scripts/Game/ControlsConfigManager.cs
+++ b/Assets/Scripts/Game/ControlsConfigManager.cs
@@ -203,12 +203,6 @@ namespace DaggerfallWorkshop.Game
 
         #region Private Methods
 
-        private IEnumerable<string> GetValues(UnaryBindings binding)
-        {
-            var dict = GetUnsavedBindingDictionary(binding);
-            return dict.Select(kv => kv.Value);
-        }
-
         private Dictionary<InputManager.Actions, string> GetUnsavedBindingDictionary(UnaryBindings ub)
         {
             switch(ub)

--- a/Assets/Scripts/Game/ControlsConfigManager.cs
+++ b/Assets/Scripts/Game/ControlsConfigManager.cs
@@ -1,0 +1,244 @@
+﻿// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2020 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: jefetienne
+// Contributors:    
+// 
+// Notes:
+//
+
+using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.UserInterface;
+using DaggerfallWorkshop.Game.Utility;
+
+namespace DaggerfallWorkshop.Game
+{
+    /// <summary>
+    /// ControlsConfigManager singleton class for controls settings and configuration. Related to the controls windows.
+    /// </summary>
+    public class ControlsConfigManager : MonoBehaviour
+    {
+        #region Enums
+
+        public enum UnaryBindings
+        {
+            Primary,
+            Secondary,
+            Current
+        }
+
+        #endregion
+
+        #region Fields
+
+        private Color crossDupeColor = new Color(0, 0.58f, 1);
+        private Color internalDupeColor = new Color(1, 0, 0);
+
+        private Dictionary<InputManager.Actions, string> PrimaryUnsavedKeybindDict = new Dictionary<InputManager.Actions, string>();
+        private Dictionary<InputManager.Actions, string> SecondaryUnsavedKeybindDict = new Dictionary<InputManager.Actions, string>();
+
+        #endregion
+
+        #region Public Properties
+
+        public bool UsingPrimary { get; set; } = true;
+
+        #endregion
+
+        #region Private Properties
+
+        private Dictionary<InputManager.Actions, string> CurrentUnsavedKeybindDict
+        {
+            get { return UsingPrimary ? PrimaryUnsavedKeybindDict : SecondaryUnsavedKeybindDict; }
+        }
+
+        #endregion
+
+        #region Singleton
+
+        static ControlsConfigManager instance = null;
+        public static ControlsConfigManager Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    if (!FindSingleton(out instance))
+                    {
+                        GameObject go = new GameObject();
+                        go.name = "ControlsConfigManager";
+                        instance = go.AddComponent<ControlsConfigManager>();
+                    }
+                }
+                return instance;
+            }
+        }
+
+        public static bool HasInstance
+        {
+            get
+            {
+                return (instance != null);
+            }
+        }
+
+        #endregion
+
+        #region Public Static Methods
+
+        public static bool FindSingleton(out ControlsConfigManager singletonOut)
+        {
+            singletonOut = GameObject.FindObjectOfType<ControlsConfigManager>();
+            if (singletonOut == null)
+            {
+                DaggerfallUnity.LogMessage("Could not locate ControlsConfigManager GameObject instance in scene!", true);
+                return false;
+            }
+
+            return true;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public string GetUnsavedBinding(InputManager.Actions action, UnaryBindings binding = UnaryBindings.Current)
+        {
+            var dict = GetUnsavedBindingDictionary(binding);
+            string ret;
+
+            if (dict.TryGetValue(action, out ret))
+                return ret;
+            
+            return null;
+        }
+
+        public void SetUnsavedBinding(InputManager.Actions action, string keyCodeString, UnaryBindings binding = UnaryBindings.Current)
+        {
+            GetUnsavedBindingDictionary(binding)[action] = keyCodeString;
+        }
+
+        public HashSet<String> GetDuplicates(IEnumerable<String> texts)
+        {
+            HashSet<String> recorded = new HashSet<String>();
+            HashSet<String> dupes = new HashSet<String>();
+            foreach (String str in texts)
+            {
+                if(!recorded.Contains(str))
+                    recorded.Add(str);
+                else if (str != KeyCode.None.ToString())
+                    dupes.Add(str);
+            }
+            return dupes;
+        }
+
+        public bool InternalDuplicateKeyCodesExist(UnaryBindings binding)
+        {
+            var dict = GetUnsavedBindingDictionary(binding);
+
+            return GetDuplicates(dict.Select(kv => kv.Value)).Count > 0;
+        }
+
+        public bool CheckDuplicateKeyCodes(IEnumerable<Button> totalButtons)
+        {
+            IEnumerable<String> pkeyList = PrimaryUnsavedKeybindDict.Select(kv => kv.Value);
+            IEnumerable<String> skeyList = SecondaryUnsavedKeybindDict.Select(kv => kv.Value);
+
+            var dupes = GetDuplicates(UsingPrimary ? pkeyList : skeyList);
+
+            bool noRedDupes = dupes.Count == 0;
+
+            foreach (Button keybindButton in totalButtons)
+            {
+                if (dupes.Contains(keybindButton.Label.Text))
+                    keybindButton.Label.TextColor = internalDupeColor;
+                else
+                    keybindButton.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
+            }
+
+            // Concat both lists together
+            // Remove any duplicates from inside each list, to find the duplicates between the two lists
+            var list = new HashSet<string>(pkeyList).Concat(new HashSet<String>(skeyList));
+
+            // Get duplicates between primary and secondary key lists
+            dupes = GetDuplicates(list);
+
+            foreach (Button keybindButton in totalButtons)
+            {
+                if (dupes.Contains(keybindButton.Label.Text) && keybindButton.Label.TextColor != internalDupeColor)
+                    keybindButton.Label.TextColor = crossDupeColor;
+            }
+
+            return noRedDupes && dupes.Count == 0;
+        }
+
+        public void ResetUnsavedKeybinds()
+        {
+            foreach (InputManager.Actions a in Enum.GetValues(typeof(InputManager.Actions)))
+            {
+                PrimaryUnsavedKeybindDict[a] = InputManager.Instance.GetKeyString(InputManager.Instance.GetBinding(a, true));
+            }
+
+            foreach (InputManager.Actions a in Enum.GetValues(typeof(InputManager.Actions)))
+            {
+                SecondaryUnsavedKeybindDict[a] = InputManager.Instance.GetKeyString(InputManager.Instance.GetBinding(a, false));
+            }
+        }
+
+        public void SetAllKeyBindValues()
+        {
+            SetKeyBindValues(true);
+            SetKeyBindValues(false);
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private IEnumerable<string> GetValues(UnaryBindings binding)
+        {
+            var dict = GetUnsavedBindingDictionary(binding);
+            return dict.Select(kv => kv.Value);
+        }
+
+        private Dictionary<InputManager.Actions, string> GetUnsavedBindingDictionary(UnaryBindings ub)
+        {
+            switch(ub)
+            {
+                case UnaryBindings.Primary:
+                    return PrimaryUnsavedKeybindDict;
+                case UnaryBindings.Secondary:
+                    return SecondaryUnsavedKeybindDict;
+                default:
+                    return CurrentUnsavedKeybindDict;
+            }
+        }
+
+        private void SetKeyBindValues(bool primary)
+        {
+            var dict = primary ? PrimaryUnsavedKeybindDict : SecondaryUnsavedKeybindDict;
+            foreach(var action in dict.Keys)
+            {
+                KeyCode code = InputManager.Instance.ParseKeyCodeString(dict[action]);
+
+                // Rebind only if new code is different
+                KeyCode curCode = InputManager.Instance.GetBinding(action, primary);
+                if (curCode != code)
+                {
+                    InputManager.Instance.SetBinding(code, action, primary);
+                    Debug.LogFormat("({0}) Bound Action {1} with Code {2} ({3})", primary ? "Primary" : "Secondary", action, code.ToString(), (int)code);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Game/ControlsConfigManager.cs
+++ b/Assets/Scripts/Game/ControlsConfigManager.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: jefetienne
-// Contributors:    
+// Contributors:    Gavin Clayton (interkarma@dfworkshop.net)
 // 
 // Notes:
 //
@@ -39,11 +39,13 @@ namespace DaggerfallWorkshop.Game
 
         #region Fields
 
-        private Color crossDupeColor = new Color(0, 0.58f, 1);
-        private Color internalDupeColor = new Color(1, 0, 0);
+        private readonly Color crossDupeColor = new Color(0, 0.58f, 1);
+        private readonly Color internalDupeColor = new Color(1, 0, 0);
 
-        private Dictionary<InputManager.Actions, string> PrimaryUnsavedKeybindDict = new Dictionary<InputManager.Actions, string>();
-        private Dictionary<InputManager.Actions, string> SecondaryUnsavedKeybindDict = new Dictionary<InputManager.Actions, string>();
+        private readonly Dictionary<InputManager.Actions, string> PrimaryUnsavedKeybindDict 
+            = new Dictionary<InputManager.Actions, string>();
+        private readonly Dictionary<InputManager.Actions, string> SecondaryUnsavedKeybindDict
+            = new Dictionary<InputManager.Actions, string>();
 
         #endregion
 
@@ -130,11 +132,13 @@ namespace DaggerfallWorkshop.Game
         {
             HashSet<String> recorded = new HashSet<String>();
             HashSet<String> dupes = new HashSet<String>();
+            String none = KeyCode.None.ToString();
+
             foreach (String str in texts)
             {
-                if(!recorded.Contains(str))
+                if (!recorded.Contains(str))
                     recorded.Add(str);
-                else if (str != KeyCode.None.ToString())
+                else if (str != none)
                     dupes.Add(str);
             }
             return dupes;
@@ -144,13 +148,13 @@ namespace DaggerfallWorkshop.Game
         {
             var dict = GetUnsavedBindingDictionary(binding);
 
-            return GetDuplicates(dict.Select(kv => kv.Value)).Count > 0;
+            return GetDuplicates(dict.Values).Count > 0;
         }
 
         public bool CheckDuplicateKeyCodes(IEnumerable<Button> totalButtons)
         {
-            IEnumerable<String> pkeyList = PrimaryUnsavedKeybindDict.Select(kv => kv.Value);
-            IEnumerable<String> skeyList = SecondaryUnsavedKeybindDict.Select(kv => kv.Value);
+            IEnumerable<String> pkeyList = PrimaryUnsavedKeybindDict.Values;
+            IEnumerable<String> skeyList = SecondaryUnsavedKeybindDict.Values;
 
             var dupes = GetDuplicates(UsingPrimary ? pkeyList : skeyList);
 
@@ -219,7 +223,7 @@ namespace DaggerfallWorkshop.Game
         private void SetKeyBindValues(bool primary)
         {
             var dict = primary ? PrimaryUnsavedKeybindDict : SecondaryUnsavedKeybindDict;
-            foreach(var action in dict.Keys)
+            foreach (var action in dict.Keys)
             {
                 KeyCode code = InputManager.Instance.ParseKeyCodeString(dict[action]);
 

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -683,25 +683,22 @@ namespace DaggerfallWorkshop.Game
 
             if (alt.ContainsKey(code))
             {
-                //error
-                Debug.Log(code+","+alt[code]);
+                alt.Remove(code);
+            }
+
+            ClearBinding(action, primary);
+
+            if (!dict.ContainsKey(code))
+            {
+                dict.Add(code, action);
             }
             else
             {
-               ClearBinding(action, primary);
-
-                if (!dict.ContainsKey(code))
-                {
-                    dict.Add(code, action);
-                }
-                else
-                {
-                    dict.Remove(code);
-                    dict.Add(code, action);
-                }
-
-                MapSecondaryBindings(action);
+                dict.Remove(code);
+                dict.Add(code, action);
             }
+
+            MapSecondaryBindings(action);
         }
 
         /// <summary>
@@ -778,7 +775,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Unbinds a KeyCode to an action via Action
         /// </summary>
-        public void ClearBinding(Actions action, bool removePrimary)
+        public void ClearBinding(Actions action, bool removePrimary = true)
         {
             var dict = removePrimary ? actionKeyDict : secondaryActionKeyDict;
             foreach (var binding in dict.Where(kvp => kvp.Value == action).ToList())
@@ -988,26 +985,17 @@ namespace DaggerfallWorkshop.Game
 
         public bool GetKey(KeyCode key)
         {
-            if (GetSingleKey(key))
-                return true;
-
-            return GetSingleKey(GetSecondaryBinding(key));
+            return GetSingleKey(key) || GetSingleKey(GetSecondaryBinding(key));
         }
 
         public bool GetKeyDown(KeyCode key)
         {
-            if (GetSingleKeyDown(key))
-                return true;
-
-            return GetSingleKeyDown(GetSecondaryBinding(key));
+            return GetSingleKeyDown(key) || GetSingleKeyDown(GetSecondaryBinding(key));
         }
 
         public bool GetKeyUp(KeyCode key)
         {
-            if (GetSingleKeyUp(key))
-                return true;
-
-            return GetSingleKeyUp(GetSecondaryBinding(key));
+            return GetSingleKeyUp(key) || GetSingleKeyUp(GetSecondaryBinding(key));
         }
 
         public bool AnyKeyDown
@@ -1091,8 +1079,9 @@ namespace DaggerfallWorkshop.Game
 
         KeyCode GetSecondaryBinding(KeyCode a)
         {
-            if(primarySecondaryKeybindDict.ContainsKey((int)a))
-                return (KeyCode)primarySecondaryKeybindDict[(int)a];
+            int ret;
+            if(primarySecondaryKeybindDict.TryGetValue((int)a, out ret))
+                return (KeyCode)ret;
 
             return KeyCode.None;
         }

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -934,31 +934,31 @@ namespace DaggerfallWorkshop.Game
             SetBinding(KeyCode.F9, Actions.QuickSave);
             SetBinding(KeyCode.F12, Actions.QuickLoad);
 
-            //default xbox controller
+            //default xbox controller, windows 10
             SetBinding(KeyCode.JoystickButton7, Actions.Escape, false);
 
             SetBinding(KeyCode.JoystickButton3, Actions.Jump, false);
             SetBinding(KeyCode.JoystickButton4, Actions.AutoRun, false);
 
             SetBinding(KeyCode.JoystickButton6, Actions.Rest, false);
-            SetBinding(KeyCode.JoystickButton10, Actions.Transport, false);
+            SetBinding(KeyCode.JoystickButton9, Actions.Transport, false);
 
-            SetBinding((KeyCode)5004, Actions.RecastSpell, false);
+            SetBinding((KeyCode)5005, Actions.RecastSpell, false);
             SetBinding(KeyCode.JoystickButton1, Actions.UseMagicItem, false);
 
             SetBinding(KeyCode.JoystickButton2, Actions.ReadyWeapon, false);
-            SetBinding((KeyCode)5010, Actions.SwingWeapon, false);
+            SetBinding((KeyCode)5004, Actions.SwingWeapon, false);
             SetBinding(KeyCode.JoystickButton5, Actions.SwitchHand, false);
 
-            SetBinding((KeyCode)5014, Actions.Status, false);
-            SetBinding((KeyCode)5015, Actions.CharacterSheet, false);
+            SetBinding((KeyCode)5013, Actions.Status, false);
+            SetBinding((KeyCode)5012, Actions.CharacterSheet, false);
 
             SetBinding(KeyCode.JoystickButton0, Actions.ActivateCenterObject, false);
 
-            SetBinding(KeyCode.JoystickButton9, Actions.Sneak, false);
+            SetBinding(KeyCode.JoystickButton8, Actions.Sneak, false);
 
-            SetBinding((KeyCode)5013, Actions.AutoMap, false);
-            SetBinding((KeyCode)5012, Actions.TravelMap, false);
+            SetBinding((KeyCode)5011, Actions.AutoMap, false);
+            SetBinding((KeyCode)5010, Actions.TravelMap, false);
 
             SetAxisBinding("Axis1", AxisActions.MovementHorizontal);
             SetAxisBinding("Axis2", AxisActions.MovementVertical);
@@ -1203,31 +1203,31 @@ namespace DaggerfallWorkshop.Game
             TestSetBinding(KeyCode.F9, Actions.QuickSave);
             TestSetBinding(KeyCode.F12, Actions.QuickLoad);
 
-            //default xbox controller
+            //default xbox controller, windows 10
             TestSetBinding(KeyCode.JoystickButton7, Actions.Escape, false);
 
             TestSetBinding(KeyCode.JoystickButton3, Actions.Jump, false);
             TestSetBinding(KeyCode.JoystickButton4, Actions.AutoRun, false);
 
             TestSetBinding(KeyCode.JoystickButton6, Actions.Rest, false);
-            TestSetBinding(KeyCode.JoystickButton10, Actions.Transport, false);
+            TestSetBinding(KeyCode.JoystickButton9, Actions.Transport, false);
 
-            TestSetBinding((KeyCode)5004, Actions.RecastSpell, false);
+            TestSetBinding((KeyCode)5005, Actions.RecastSpell, false);
             TestSetBinding(KeyCode.JoystickButton1, Actions.UseMagicItem, false);
 
             TestSetBinding(KeyCode.JoystickButton2, Actions.ReadyWeapon, false);
-            TestSetBinding((KeyCode)5010, Actions.SwingWeapon, false);
+            TestSetBinding((KeyCode)5004, Actions.SwingWeapon, false);
             TestSetBinding(KeyCode.JoystickButton5, Actions.SwitchHand, false);
 
-            TestSetBinding((KeyCode)5014, Actions.Status, false);
-            TestSetBinding((KeyCode)5015, Actions.CharacterSheet, false);
+            TestSetBinding((KeyCode)5013, Actions.Status, false);
+            TestSetBinding((KeyCode)5012, Actions.CharacterSheet, false);
 
             TestSetBinding(KeyCode.JoystickButton0, Actions.ActivateCenterObject, false);
 
-            TestSetBinding(KeyCode.JoystickButton9, Actions.Sneak, false);
+            TestSetBinding(KeyCode.JoystickButton8, Actions.Sneak, false);
 
-            TestSetBinding((KeyCode)5013, Actions.AutoMap, false);
-            TestSetBinding((KeyCode)5012, Actions.TravelMap, false);
+            TestSetBinding((KeyCode)5011, Actions.AutoMap, false);
+            TestSetBinding((KeyCode)5010, Actions.TravelMap, false);
 
             TestSetAxisBinding("Axis1", AxisActions.MovementHorizontal);
             TestSetAxisBinding("Axis2", AxisActions.MovementVertical);

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -686,7 +686,7 @@ namespace DaggerfallWorkshop.Game
             }
             else
             {
-               ClearBinding(code, primary);
+               ClearBinding(action, primary);
 
                 if (!dict.ContainsKey(code))
                 {
@@ -698,7 +698,7 @@ namespace DaggerfallWorkshop.Game
                     dict.Add(code, action);
                 }
 
-                FindSecondaryBindings(action);
+                MapSecondaryBindings(action);
             }
         }
 
@@ -776,16 +776,12 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Unbinds a KeyCode to an action via Action
         /// </summary>
-        public void ClearBinding(Actions action)
+        public void ClearBinding(Actions action, bool removePrimary)
         {
-            foreach (var binding in actionKeyDict.Where(kvp => kvp.Value == action).ToList())
+            var dict = removePrimary ? actionKeyDict : secondaryActionKeyDict;
+            foreach (var binding in dict.Where(kvp => kvp.Value == action).ToList())
             {
-                actionKeyDict.Remove(binding.Key);
-            }
-
-            foreach (var binding in secondaryActionKeyDict.Where(kvp => kvp.Value == action).ToList())
-            {
-                secondaryActionKeyDict.Remove(binding.Key);
+                dict.Remove(binding.Key);
             }
         }
 
@@ -1083,7 +1079,7 @@ namespace DaggerfallWorkshop.Game
             movementAxisBindingCache[1] = GetAxisBinding(AxisActions.MovementVertical);
 
             foreach(Actions a in Enum.GetValues(typeof(Actions)))
-                FindSecondaryBindings(a);
+                MapSecondaryBindings(a);
         }
 
         KeyCode GetSecondaryBinding(KeyCode a)
@@ -1100,7 +1096,7 @@ namespace DaggerfallWorkshop.Game
             primarySecondaryKeybindDict[(int)secondary] = (int)primary;
         }
 
-        void FindSecondaryBindings(Actions a)
+        void MapSecondaryBindings(Actions a)
         {
             KeyCode primKey = actionKeyDict.FirstOrDefault(x => x.Value == a).Key;
             KeyCode secKey = secondaryActionKeyDict.FirstOrDefault(x => x.Value == a).Key;

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -676,29 +676,30 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         public void SetBinding(KeyCode code, Actions action, bool primary = true)
         {
-            // Not allowing multi-bind at this time as the front-end doesn't support it
-            //ClearBinding(action);
-
-            if(actionKeyDict.ContainsKey(code) && secondaryActionKeyDict.ContainsKey(code))
-            {
-               ClearBinding(code, false);
-               ClearBinding(code, true);
-            }
-            
             var dict = primary ? actionKeyDict : secondaryActionKeyDict;
-            //var alt = primary ? secondaryActionKeyDict : actionKeyDict;
+            var alt = primary ? secondaryActionKeyDict : actionKeyDict;
 
-            if (!dict.ContainsKey(code))
+            if (alt.ContainsKey(code))
             {
-                dict.Add(code, action);
+                //error
+                Debug.Log(code+","+alt[code]);
             }
             else
             {
-                dict.Remove(code);
-                dict.Add(code, action);
-            }
+               ClearBinding(code, primary);
 
-            FindSecondaryBindings(action);
+                if (!dict.ContainsKey(code))
+                {
+                    dict.Add(code, action);
+                }
+                else
+                {
+                    dict.Remove(code);
+                    dict.Add(code, action);
+                }
+
+                FindSecondaryBindings(action);
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -830,14 +830,19 @@ namespace DaggerfallWorkshop.Game
 
             // If unknown actions were detected in this run, make sure we append them back to the settings file, so we won't break
             // the newer builds potentially using them.
+            // If the key has been rebinded, then ignore the unknown action, as it should be repopulated in a newer build
             foreach (var item in unknownActions)
             {
-                keyBindsData.actionKeyBinds.Add(GetKeyString(item.Key), item.Value);
+                var key = GetKeyString(item.Key);
+                if (!keyBindsData.actionKeyBinds.ContainsKey(key))
+                    keyBindsData.actionKeyBinds.Add(key, item.Value);
             }
 
             foreach (var item in secondaryUnknownActions)
             {
-                keyBindsData.secondaryActionKeyBinds.Add(GetKeyString(item.Key), item.Value);
+                var key = GetKeyString(item.Key);
+                if (!keyBindsData.secondaryActionKeyBinds.ContainsKey(key))
+                    keyBindsData.secondaryActionKeyBinds.Add(key, item.Value);
             }
 
             foreach (var item in joystickUIDict)

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -934,32 +934,6 @@ namespace DaggerfallWorkshop.Game
             SetBinding(KeyCode.F9, Actions.QuickSave);
             SetBinding(KeyCode.F12, Actions.QuickLoad);
 
-            //default xbox controller, windows 10
-            SetBinding(KeyCode.JoystickButton7, Actions.Escape, false);
-
-            SetBinding(KeyCode.JoystickButton3, Actions.Jump, false);
-            SetBinding(KeyCode.JoystickButton4, Actions.AutoRun, false);
-
-            SetBinding(KeyCode.JoystickButton6, Actions.Rest, false);
-            SetBinding(KeyCode.JoystickButton9, Actions.Transport, false);
-
-            SetBinding((KeyCode)5005, Actions.RecastSpell, false);
-            SetBinding(KeyCode.JoystickButton1, Actions.UseMagicItem, false);
-
-            SetBinding(KeyCode.JoystickButton2, Actions.ReadyWeapon, false);
-            SetBinding((KeyCode)5004, Actions.SwingWeapon, false);
-            SetBinding(KeyCode.JoystickButton5, Actions.SwitchHand, false);
-
-            SetBinding((KeyCode)5013, Actions.Status, false);
-            SetBinding((KeyCode)5012, Actions.CharacterSheet, false);
-
-            SetBinding(KeyCode.JoystickButton0, Actions.ActivateCenterObject, false);
-
-            SetBinding(KeyCode.JoystickButton8, Actions.Sneak, false);
-
-            SetBinding((KeyCode)5011, Actions.AutoMap, false);
-            SetBinding((KeyCode)5010, Actions.TravelMap, false);
-
             SetAxisBinding("Axis1", AxisActions.MovementHorizontal);
             SetAxisBinding("Axis2", AxisActions.MovementVertical);
             SetAxisBinding("Axis4", AxisActions.CameraHorizontal);
@@ -1202,32 +1176,6 @@ namespace DaggerfallWorkshop.Game
             TestSetBinding(KeyCode.F8, Actions.PrintScreen);
             TestSetBinding(KeyCode.F9, Actions.QuickSave);
             TestSetBinding(KeyCode.F12, Actions.QuickLoad);
-
-            //default xbox controller, windows 10
-            TestSetBinding(KeyCode.JoystickButton7, Actions.Escape, false);
-
-            TestSetBinding(KeyCode.JoystickButton3, Actions.Jump, false);
-            TestSetBinding(KeyCode.JoystickButton4, Actions.AutoRun, false);
-
-            TestSetBinding(KeyCode.JoystickButton6, Actions.Rest, false);
-            TestSetBinding(KeyCode.JoystickButton9, Actions.Transport, false);
-
-            TestSetBinding((KeyCode)5005, Actions.RecastSpell, false);
-            TestSetBinding(KeyCode.JoystickButton1, Actions.UseMagicItem, false);
-
-            TestSetBinding(KeyCode.JoystickButton2, Actions.ReadyWeapon, false);
-            TestSetBinding((KeyCode)5004, Actions.SwingWeapon, false);
-            TestSetBinding(KeyCode.JoystickButton5, Actions.SwitchHand, false);
-
-            TestSetBinding((KeyCode)5013, Actions.Status, false);
-            TestSetBinding((KeyCode)5012, Actions.CharacterSheet, false);
-
-            TestSetBinding(KeyCode.JoystickButton0, Actions.ActivateCenterObject, false);
-
-            TestSetBinding(KeyCode.JoystickButton8, Actions.Sneak, false);
-
-            TestSetBinding((KeyCode)5011, Actions.AutoMap, false);
-            TestSetBinding((KeyCode)5010, Actions.TravelMap, false);
 
             TestSetAxisBinding("Axis1", AxisActions.MovementHorizontal);
             TestSetAxisBinding("Axis2", AxisActions.MovementVertical);

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -95,7 +95,6 @@ namespace DaggerfallWorkshop.Game
         bool negVerticalImpulse;
         bool moveAcceleration;
 
-        float joystickCameraSensitivity = 1.0f;
         float joystickUIMouseSensitivity = 1.0f;
         bool cursorVisible = true;
         bool usingControllerCursor;
@@ -933,7 +932,7 @@ namespace DaggerfallWorkshop.Game
             SetBinding(KeyCode.JoystickButton7, Actions.Escape, false);
 
             SetBinding(KeyCode.JoystickButton3, Actions.Jump, false);
-            SetBinding(KeyCode.JoystickButton4, Actions.Run, false);
+            SetBinding(KeyCode.JoystickButton4, Actions.AutoRun, false);
 
             SetBinding(KeyCode.JoystickButton6, Actions.Rest, false);
             SetBinding(KeyCode.JoystickButton10, Actions.Transport, false);
@@ -1210,7 +1209,7 @@ namespace DaggerfallWorkshop.Game
             TestSetBinding(KeyCode.JoystickButton7, Actions.Escape, false);
 
             TestSetBinding(KeyCode.JoystickButton3, Actions.Jump, false);
-            TestSetBinding(KeyCode.JoystickButton4, Actions.Run, false);
+            TestSetBinding(KeyCode.JoystickButton4, Actions.AutoRun, false);
 
             TestSetBinding(KeyCode.JoystickButton6, Actions.Rest, false);
             TestSetBinding(KeyCode.JoystickButton10, Actions.Transport, false);

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -608,13 +608,14 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Finds first keycode bound to a specific action.
         /// </summary>
-        public KeyCode GetBinding(Actions action)
+        public KeyCode GetBinding(Actions action, bool primary = true)
         {
-            if (actionKeyDict.ContainsValue(action))
+            var dict = primary ? actionKeyDict : secondaryActionKeyDict;
+            if (dict.ContainsValue(action))
             {
-                foreach (var k in actionKeyDict.Keys)
+                foreach (var k in dict.Keys)
                 {
-                    if (actionKeyDict[k] == action)
+                    if (dict[k] == action)
                         return k;
                 }
             }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -204,7 +204,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             foreach (InputManager.Actions a in Enum.GetValues(typeof(InputManager.Actions)))
             {
                 UnsavedKeybindDict[a] = InputManager.Instance.GetKeyString(InputManager.Instance.GetBinding(a));
-                Debug.Log(a.ToString()+": "+UnsavedKeybindDict[a]+","+((int)InputManager.Instance.GetBinding(a)));
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -246,13 +246,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Remove any duplicates from inside each list, to find the duplicates between the two lists
             var list = new HashSet<string>(pkeyList).Concat(new HashSet<String>(skeyList));
 
-            // Get duplicates between primary and secondary key lists (orange text color)
+            // Get duplicates between primary and secondary key lists
             dupes = GetDuplicates(list);
 
             foreach (Button keybindButton in totalButtons)
             {
-                // Orange overrides red
-                if (dupes.Contains(keybindButton.Label.Text))
+                if (dupes.Contains(keybindButton.Label.Text) && keybindButton.Label.TextColor != internalDupeColor)
                     keybindButton.Label.TextColor = crossDupeColor;
             }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -177,6 +177,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupKeybindButtons(lookKeys, 32, 36, 270, 103, true);
             SetupKeybindButtons(uiKeys, 36, 40, 270, 148, true);
 
+            InstanceCheckDuplicates();
+
             #endregion
         }
 
@@ -276,16 +278,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void SaveAllKeyBindValues()
         {
-            foreach(var action in CurrentUnsavedKeybindDict.Keys)
+            SaveKeyBindValues(true);
+            SaveKeyBindValues(false);
+        }
+
+        private void SaveKeyBindValues(bool primary)
+        {
+            var dict = primary ? PrimaryUnsavedKeybindDict : SecondaryUnsavedKeybindDict;
+            foreach(var action in dict.Keys)
             {
-                KeyCode code = InputManager.Instance.ParseKeyCodeString(CurrentUnsavedKeybindDict[action]);
+                KeyCode code = InputManager.Instance.ParseKeyCodeString(dict[action]);
 
                 // Rebind only if new code is different
-                KeyCode curCode = InputManager.Instance.GetBinding(action, UsingPrimary);
+                KeyCode curCode = InputManager.Instance.GetBinding(action, primary);
                 if (curCode != code)
                 {
-                    InputManager.Instance.SetBinding(code, action, UsingPrimary);
-                    Debug.LogFormat("Bound Action {0} with Code {1}", action, code.ToString());
+                    InputManager.Instance.SetBinding(code, action, primary);
+                    Debug.LogFormat("({0}) Bound Action {1} with Code {2}", primary ? "Primary" : "Secondary", action, code.ToString());
                 }
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -47,6 +47,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         List<Button> uiKeys = new List<Button>();
         List<List<Button>> allKeys = new List<List<Button>>();
 
+        Button currentBindingsButton = new Button();
+
         string[] actions = Enum.GetNames(typeof(InputManager.Actions));
         const string nativeTextureName = "CNFG00I0.IMG";
         const string mLookAltTextureName = "CNFG00I1.IMG";
@@ -58,11 +60,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Static Fields
 
-        private static Color orangeColor = new Color(1, 0.56f, 0);
-        private static Color redColor = new Color(1, 0, 0);
+        private static Color crossDupeColor = new Color(0, 0.58f, 1);
+        private static Color internalDupeColor = new Color(1, 0, 0);
 
         private static Dictionary<InputManager.Actions, string> PrimaryUnsavedKeybindDict = new Dictionary<InputManager.Actions, string>();
         private static Dictionary<InputManager.Actions, string> SecondaryUnsavedKeybindDict = new Dictionary<InputManager.Actions, string>();
+
+        private static bool internalDuplicates = false;
 
         #endregion
 
@@ -154,6 +158,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             #region Keybind Buttons
 
+            currentBindingsButton = DaggerfallUI.AddButton(new Rect(268, 0, 50, 8), controlsPanel);
+            currentBindingsButton.Label.ShadowPosition = Vector2.zero;
+            currentBindingsButton.Outline.Enabled = true;
+            currentBindingsButton.OnMouseClick += CurrentBindingsButton_OnMouseClick;
+            currentBindingsButton.Label.Text = UsingPrimary ? "Primary" : "Secondary";
+
             ResetUnsavedDictionary();
             DaggerfallJoystickControlsWindow.ResetUnsavedSettings();
 
@@ -222,12 +232,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             foreach (Button keybindButton in totalButtons)
             {
                 if (dupes.Contains(keybindButton.Label.Text))
-                    keybindButton.Label.TextColor = redColor;
+                    keybindButton.Label.TextColor = internalDupeColor;
                 else
                     keybindButton.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
             }
 
             noRedDupes = dupes.Count == 0;
+            internalDuplicates = !noRedDupes;
 
             // Concat both lists together
             // Remove any duplicates from inside each list, to find the duplicates between the two lists
@@ -240,7 +251,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 // Orange overrides red
                 if (dupes.Contains(keybindButton.Label.Text))
-                    keybindButton.Label.TextColor = orangeColor;
+                    keybindButton.Label.TextColor = crossDupeColor;
             }
 
             return noRedDupes && dupes.Count == 0;
@@ -341,6 +352,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupKeybindButtons(lookKeys, 32, 36, 269, 102, false);
             SetupKeybindButtons(uiKeys, 36, 40, 269, 147, false);
 
+            currentBindingsButton.Label.Text = UsingPrimary ? "Primary" : "Secondary";
+
             InstanceCheckDuplicates();
         }
 
@@ -419,6 +432,25 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             else
             {
                 CancelWindow();
+            }
+        }
+
+        private void CurrentBindingsButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            if (waitingForInput)
+                return;
+
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+
+            if (internalDuplicates)
+            {
+                ShowMultipleAssignmentsMessage();
+            }
+            else
+            {
+                UsingPrimary = !UsingPrimary;
+
+                UpdateKeybindButtons();
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -202,7 +202,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void ResetUnsavedDictionary()
         {
             foreach (InputManager.Actions a in Enum.GetValues(typeof(InputManager.Actions)))
+            {
                 UnsavedKeybindDict[a] = InputManager.Instance.GetKeyString(InputManager.Instance.GetBinding(a));
+                Debug.Log(a.ToString()+": "+UnsavedKeybindDict[a]+","+((int)InputManager.Instance.GetBinding(a)));
+            }
         }
 
         private void SaveAllKeyBindValues()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
@@ -397,7 +397,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             IEnumerable<String> keyList = UnsavedKeybindDict.Select(kv => kv.Value);
 
-            var dupes = DaggerfallControlsWindow.GetDuplicates(keyList);
+            var dupes = ControlsConfigManager.Instance.GetDuplicates(keyList);
 
             AllowCancel = dupes.Count == 0;
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -134,8 +134,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             weaponAttackThresholdTextbox = AddTextbox("Mouse Weapon Attack Threshold", 215, 80, DaggerfallUnity.Settings.WeaponAttackThreshold.ToString());
 
-
             continueButton.OnMouseClick += ContinueButton_OnMouseClick;
+
+            CheckDuplicates();
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -161,7 +161,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         //**might delete this, since reset defaults is in the main controls window
         private void SetupKeybindButton(Button button, InputManager.Actions action)
         {
-            button.Label.Text = DaggerfallControlsWindow.UnsavedKeybindDict[action];
+            button.Label.Text = DaggerfallControlsWindow.CurrentUnsavedKeybindDict[action];
             button.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
         }
 
@@ -312,17 +312,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void CheckDuplicates()
         {
-            IEnumerable<String> keyList = DaggerfallControlsWindow.UnsavedKeybindDict.Select(kv => kv.Value);
-
-            var dupes = DaggerfallControlsWindow.GetDuplicates(keyList);
-
-            foreach (Button keybindButton in buttonGroup)
-            {
-                if (dupes.Contains(keybindButton.Label.Text))
-                    keybindButton.Label.TextColor = new Color(1, 0, 0);
-                else
-                    keybindButton.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
-            }
+            DaggerfallControlsWindow.CheckDuplicates(buttonGroup);
         }
 
         //a workaround solution to setting the 'waitingForInput' instance variable in a

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -162,7 +162,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         //**might delete this, since reset defaults is in the main controls window
         private void SetupKeybindButton(Button button, InputManager.Actions action)
         {
-            button.Label.Text = DaggerfallControlsWindow.CurrentUnsavedKeybindDict[action];
+            button.Label.Text = ControlsConfigManager.Instance.GetUnsavedBinding(action);
             button.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
         }
 
@@ -313,7 +313,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void CheckDuplicates()
         {
-            DaggerfallControlsWindow.CheckDuplicates(buttonGroup);
+            ControlsConfigManager.Instance.CheckDuplicateKeyCodes(buttonGroup);
         }
 
         //a workaround solution to setting the 'waitingForInput' instance variable in a


### PR DESCRIPTION

[[Images](https://imgur.com/a/7wrMblw)]

Adds support for secondary keybinds, which can be accessed via a small toggle button at the top right of the controls window. By default, they are unpopulated, although later in the future I will create ControllerConfigs that will have loadout configurations specific to the controller type and OS.

Any cross-unary conflicts will be highlighted as blue (to help colorblind people distinguish it from yellow or red/"dark yellow"), and the player cannot "Continue" until resolving them, but can switch between primary and secondary. Any internal (red) conflicts made, and they cannot switch between primary and secondary until that gets resolved first.

To not bloat the controls window and avoid static code, I made a ControlsConfigManager that sets aside much of the cross-window logic from the main controls window. Also fixed a bug with unknown actions - if the player had an unknown action that was bound to a certain key, using that same key to rebind to an existent action would cause an exception and fail to update Keybinds.txt. Now, if it is rebinded, it will erase the unknown action (as it should be repopulated anyway if they switch to a newer version.)