### PR TITLE
Fix %god macro to match classic behavior

### DIFF
--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -72,6 +72,19 @@ namespace DaggerfallConnect.Arena2
         };
 
         /// <summary>
+        /// Region temple faction IDs, extracted from FALL.EXE.
+        /// </summary>
+        private static readonly int[] regionTemples = {
+            106,  82,   0,   0,   0,  98,   0,  0,   0,  92,
+              0, 106,   0,   0,   0,  84,  36,  8,  84,  88,
+             82,  88,  98,  92,   0,   0,  82,  0,   0,   0,
+              0,   0,  88,  94,  36,  94, 106, 84, 106, 106,
+             88,  98,  82,  98,  84,  94,  36, 88,  94,  36,
+             98,  84, 106,  88, 106,  88,  92, 84,  98,  88,
+             82,  94
+        };
+
+        /// <summary>
         /// Block file prefixes.
         /// </summary>
         private readonly string[] rmbBlockPrefixes = {
@@ -233,6 +246,13 @@ namespace DaggerfallConnect.Arena2
         public static byte[] RegionRaces
         {
             get { return regionRaces; }
+        }
+
+        /// <summary>
+        /// Gets region temple faction IDs.
+        /// </summary>
+        public static int[] RegionTemples {
+            get { return regionTemples; }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1607,10 +1607,6 @@ namespace DaggerfallWorkshop.Game.Entity
         /// </summary>
         public void RegionPowerAndConditionsUpdate(bool updateConditions)
         {
-            int[] TemplesAssociatedWithRegions =    { 106, 82, 0, 0, 0, 98, 0, 0, 0, 92, 0, 106, 0, 0, 0, 84, 36, 8, 84, 88, 82, 88, 98, 92, 0, 0, 82, 0,
-                                                        0, 0, 0, 0, 88, 94, 36, 94, 106, 84, 106, 106, 88, 98, 82, 98, 84, 94, 36, 88, 94, 36, 98, 84, 106,
-                                                       88, 106, 88, 92, 84, 98, 88, 82, 94};
-
             // Note: For some reason rumor updating is disabled in classic while the player is serving jail time. There's no clear reason for this,
             // so not replicating that here.
             GameManager.Instance.TalkManager.RefreshRumorMill();
@@ -1957,7 +1953,7 @@ namespace DaggerfallWorkshop.Game.Entity
 
                             // Plague
                             FactionFile.FactionData temple;
-                            FactionData.GetFactionData(TemplesAssociatedWithRegions[factionData.FactionDict[key].region], out temple);
+                            FactionData.GetFactionData(MapsFile.RegionTemples[factionData.FactionDict[key].region], out temple);
 
                             if (regionData[factionData.FactionDict[key].region].Flags[(int)RegionDataFlags.PlagueEnding])
                                 TurnOffConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PlagueEnding);
@@ -1990,7 +1986,7 @@ namespace DaggerfallWorkshop.Game.Entity
                             }
 
                             // Persecuted temple
-                            if (TemplesAssociatedWithRegions[factionData.FactionDict[key].region] != 0)
+                            if (MapsFile.RegionTemples[factionData.FactionDict[key].region] != 0)
                             {
                                 if (Dice100.FailedRoll((temple.power - factionData.FactionDict[key].power + 5) / 5))
                                     TurnOffConditionFlag(factionData.FactionDict[key].region, RegionDataFlags.PersecutedTemple);

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -11,7 +11,6 @@
 
 using UnityEngine;
 using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using DaggerfallConnect;
 using DaggerfallWorkshop.Game.Entity;
@@ -40,7 +39,6 @@ namespace DaggerfallWorkshop.Game.Questing
         bool isIndividualNPC = false;
         bool isIndividualAtHome = false;
         string displayName = string.Empty;
-        string godName = string.Empty;
         Symbol homePlaceSymbol = null;
         Symbol lastAssignedPlaceSymbol = null;
         bool assignedToHome = false;
@@ -100,11 +98,6 @@ namespace DaggerfallWorkshop.Game.Questing
         public string DisplayName
         {
             get { return displayName; }
-        }
-
-        public string GodName
-        {
-            get { return godName; }
         }
 
         public string HomeTownName
@@ -269,7 +262,6 @@ namespace DaggerfallWorkshop.Game.Questing
                 AssignHUDFace(faceIndex);
                 AssignDisplayName();
                 AssignHomeTown();
-                AssignGod();
 
                 // Is NPC at home?
                 isIndividualAtHome = atHome;
@@ -283,7 +275,6 @@ namespace DaggerfallWorkshop.Game.Questing
         {
             // TODO:
             //  * Support for home town/building (believe this is just random unless NPC moved from a Place)
-            //  * Support for %god (TEXT.RSC 4077-4084)
             //  * Support for pronoun (%g1, %g2, %g2, %g2self, %g3)
             //  * Support for class (not sure what NPCs have a class, need to see this used in a quest)
             //  * Support for faction (believe this is just the name of faction they belong to, e.g. The Merchants)
@@ -698,11 +689,6 @@ namespace DaggerfallWorkshop.Game.Questing
                 HomeBuildingName);
         }
 
-        void AssignGod()
-        {
-            godName = GetRandomGodName();
-        }
-
         Genders GetGender(string genderName)
         {
             Genders gender;
@@ -861,16 +847,6 @@ namespace DaggerfallWorkshop.Game.Questing
                 throw new Exception(string.Format("Could not find faction data for FactionID {0}", factionID));
 
             return factionData;
-        }
-
-        public static string GetRandomGodName()
-        {
-            const int minGodID = 4077;
-            const int maxGodID = 4084;
-
-            // Select a random god for this NPC
-            int godID = UnityEngine.Random.Range(minGodID, maxGodID + 1);
-            return DaggerfallUnity.Instance.TextProvider.GetRandomText(godID);
         }
 
         #endregion
@@ -1099,7 +1075,6 @@ namespace DaggerfallWorkshop.Game.Questing
             public bool isIndividualNPC;
             public bool isIndividualAtHome;
             public string displayName;
-            public string godName;
             public Symbol homePlaceSymbol;
             public Symbol lastAssignedPlaceSymbol;
             public bool assignedToHome;
@@ -1123,7 +1098,6 @@ namespace DaggerfallWorkshop.Game.Questing
             data.isIndividualNPC = isIndividualNPC;
             data.isIndividualAtHome = isIndividualAtHome;
             data.displayName = displayName;
-            data.godName = godName;
             data.homePlaceSymbol = homePlaceSymbol;
             data.lastAssignedPlaceSymbol = lastAssignedPlaceSymbol;
             data.assignedToHome = assignedToHome;
@@ -1157,7 +1131,6 @@ namespace DaggerfallWorkshop.Game.Questing
             isIndividualNPC = data.isIndividualNPC;
             isIndividualAtHome = data.isIndividualAtHome;
             displayName = data.displayName;
-            godName = data.godName;
             homePlaceSymbol = data.homePlaceSymbol;
             lastAssignedPlaceSymbol = data.lastAssignedPlaceSymbol;
             assignedToHome = data.assignedToHome;

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -440,6 +440,14 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
+        /// Gets the dominant temple in player's current region.
+        /// </summary>
+        public int GetTempleOfCurrentRegion()
+        {
+            return MapsFile.RegionTemples[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
+        }
+
+        /// <summary>
         /// Checks if player is inside a location world cell, optionally inside location rect, optionally outside
         /// </summary>
         /// <returns>True if player inside a township</returns>

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -100,7 +100,7 @@ namespace DaggerfallWorkshop.Utility
             { "%g3", Pronoun3 },  // His/Her
             { "%gii", GoldCarried }, // Amount of gold in hand
             { "%gdd", GodDesc }, // God description i.e. God of Logic
-            { "%god", God }, // Some god (listed in TEXT.RSC)
+            { "%god", God }, // God of current region or current temple
             { "%gtp", GoldToPay }, // Amount of fine
             { "%hea", HpMod }, // HP Modifier
             { "%hmd", HealRateMod }, // Healing rate modifer


### PR DESCRIPTION
This fixes %god macro expansion to match classic, see the issue reported by @JayH2971 here: https://forums.dfworkshop.net/viewtopic.php?f=31&p=45914#p45914. I fixed only `QuestMCP.God()` here, but the method could have been used globally.

While doing so, I moved an array extracted from FALL.EXE to `MapsFile` since it is also used in classic for the %god macro.

@ajrb 