### PR TITLE
Upgrade support for providers of mobile person graphics

### DIFF
--- a/Assets/Scripts/Game/MobilePersonMotor.cs
+++ b/Assets/Scripts/Game/MobilePersonMotor.cs
@@ -411,7 +411,7 @@ namespace DaggerfallWorkshop.Game
             // Aim low to better detect stairs
             tempTargetScenePosition.y += 0.1f;
             Ray ray = new Ray(transform.position, tempTargetScenePosition - transform.position);
-            bool collision = Physics.Raycast(transform.position, tempTargetScenePosition - transform.position, Vector3.Distance(transform.position, tempTargetScenePosition));
+            bool collision = Physics.Raycast(transform.position, tempTargetScenePosition - transform.position, Vector3.Distance(transform.position, tempTargetScenePosition), ~mobileAsset.GetLayerMask());
             // Debug.DrawRay(transform.position, tempTargetScenePosition - transform.position, collision ? Color.red : Color.green, 1f);
             return !collision;
         }

--- a/Assets/Scripts/Game/MobilePersonMotor.cs
+++ b/Assets/Scripts/Game/MobilePersonMotor.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2020 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -390,7 +390,7 @@ namespace DaggerfallWorkshop.Game
                 var customMobilePersonAsset = customMobilePersonAssetGo.GetComponent<MobilePersonAsset>();
                 if (customMobilePersonAsset)
                 {
-                    GameObject.Destroy(mobilePersonAsset.gameObject);
+                    mobilePersonAsset.gameObject.SetActive(false);
                     customMobilePersonAssetGo.transform.SetParent(gameObject.transform);
                     mobilePersonAsset = customMobilePersonAsset;
                     mobilePersonAsset.Trigger = GetComponent<CapsuleCollider>();

--- a/Assets/Scripts/Internal/MobilePersonBillboard.cs
+++ b/Assets/Scripts/Internal/MobilePersonBillboard.cs
@@ -62,6 +62,15 @@ namespace DaggerfallWorkshop
         /// </summary>
         /// <returns>Size of npc.</returns>
         public abstract Vector3 GetSize();
+
+        /// <summary>
+        /// Gets a bitmask that provides all the layers used by this asset.
+        /// </summary>
+        /// <returns>A layer mask.</returns>
+        public virtual int GetLayerMask()
+        {
+            return 1 << gameObject.layer;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes some regressions:

- Unity 2019 doesn't allow to destroy or reparent gameobjects that are part of prefab instances. When a mod provides an override, the default gameobject is only deactivated instead.
- Custom providers of MobilePersonAsset that use colliders need to define a layermask to support functionality that checks for geometry in the way of npc path (regression introduced some time ago with `MobilePersonMotor.IsDirectionClear()`).