### PR TITLE
Fix quest faction macro expansion

### DIFF
--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -439,6 +439,13 @@ namespace DaggerfallWorkshop
             return factions[0].id;
         }
 
+        public int GetCurrentRegionVampireClan()
+        {
+            FactionFile.FactionData factionData;
+            GameManager.Instance.PlayerEntity.FactionData.GetRegionFaction(CurrentRegionIndex, out factionData);
+            return factionData.vam;
+        }
+
         /// <summary>
         /// Checks if player is inside a location world cell, optionally inside location rect, optionally outside
         /// </summary>


### PR DESCRIPTION
Quest faction macro wasn't expanded correctly when referring to another NPC than the questor. Again, the issue was reported by our quest expert @JayH2971: https://forums.dfworkshop.net/viewtopic.php?f=31&t=2109 :)

I also fixed factions IDs of vampire involved in quests since I noticed they were wrong while I was checking my fix against quest `R0C60Y24`, which uses `==vampire_` in the same way quest `P0B10L08 ` uses `==daedra_`.