### PR TITLE
Relax permissions to allow window extension by mods

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -259,7 +259,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public int CurrentHealth { get { return GetCurrentHealth(); } set { SetHealth(value); } }
         public float CurrentHealthPercent { get { return GetCurrentHealth() / (float)MaxHealth; } }
         public int RawMaxHealth { get { return GetRawMaxHealth(); } }
-        public int MaxFatigue { get { return (stats.LiveStrength + stats.LiveEndurance) * 64; } }
+        public int MaxFatigue { get { return (stats.LiveStrength + stats.LiveEndurance) * FatigueMultiplier; } }
         public int CurrentFatigue { get { return GetCurrentFatigue(); } set { SetFatigue(value); } }
         public int MaxMagicka { get { return GetMaxMagicka(); } set { maxMagicka = value; } }
         public int RawMaxMagicka { get { return GetRawMaxMagicka(); } }

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -228,11 +228,11 @@ namespace DaggerfallWorkshop.Game
                 {   // Update Animation frame?
                     if (lastFrameTime == 0)
                     {
-                        lastFrameTime = Time.time;
+                        lastFrameTime = Time.unscaledTime;
                     }
-                    else if (Time.time > lastFrameTime + animFrameTime)
+                    else if (Time.unscaledTime > lastFrameTime + animFrameTime)
                     {
-                        lastFrameTime = Time.time;
+                        lastFrameTime = Time.unscaledTime;
                         frameIndex = (frameIndex == 3) ? 0 : frameIndex + 1;
                         ridingTexture = ridingTexures[frameIndex];
                     }
@@ -266,7 +266,7 @@ namespace DaggerfallWorkshop.Game
                     }
                 }
                 // Time for a whinney?
-                if (neighTime < Time.time)
+                if (neighTime < Time.time && dfAudioSource.AudioSource.enabled)
                 {
                     dfAudioSource.AudioSource.PlayOneShot(neighClip, RidingVolumeScale * DaggerfallUnity.Settings.SoundVolume);
                     neighTime = Time.time + Random.Range(2, 40);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTavernWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTavernWindow.cs
@@ -30,16 +30,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         #region UI Controls
 
         Panel mainPanel = new Panel();
-        Button roomButton;
-        Button talkButton;
-        Button foodButton;
-        Button exitButton;
+        protected Button roomButton;
+        protected Button talkButton;
+        protected Button foodButton;
+        protected Button exitButton;
 
         #endregion
 
         #region UI Textures
 
-        Texture2D baseTexture;
+        protected Texture2D baseTexture;
 
         #endregion
 
@@ -61,11 +61,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             TextManager.Instance.GetLocalizedText("tavernStew") };
         byte[] tavernFoodAndDrinkPrices = { 1, 1, 2, 3, 1, 1, 2, 3, 2, 2, 3 };
 
-        StaticNPC merchantNPC;
-        PlayerGPS.DiscoveredBuilding buildingData;
-        RoomRental_v1 rentedRoom;
-        int daysToRent = 0;
-        int tradePrice = 0;
+        protected StaticNPC merchantNPC;
+        protected PlayerGPS.DiscoveredBuilding buildingData;
+        protected RoomRental_v1 rentedRoom;
+        protected int daysToRent = 0;
+        protected int tradePrice = 0;
 
         bool isCloseWindowDeferred = false;
         bool isTalkWindowDeferred = false;
@@ -170,7 +170,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             inputMessageBox.Show();
         }
 
-        private void InputMessageBox_OnGotUserInput(DaggerfallInputMessageBox sender, string input)
+        protected virtual void InputMessageBox_OnGotUserInput(DaggerfallInputMessageBox sender, string input)
         {
             daysToRent = 0;
             bool result = int.TryParse(input, out daysToRent);
@@ -209,7 +209,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        private void ConfirmRenting_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
+        protected virtual void ConfirmRenting_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
         {
             CloseWindow();
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
@@ -225,7 +225,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        private void RentRoom()
+        protected virtual void RentRoom()
         {
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
             PlayerEnterExit playerEnterExit = GameManager.Instance.PlayerEnterExit;
@@ -281,7 +281,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        private void DoFoodAndDrink()
+        protected virtual void DoFoodAndDrink()
         {
             CloseWindow();
             uint gameMinutes = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
@@ -302,7 +302,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        public void FoodAndDrink_OnItemPicked(int index, string foodOrDrinkName)
+        protected virtual void FoodAndDrink_OnItemPicked(int index, string foodOrDrinkName)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             CloseWindow();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -75,14 +75,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         KeyCode toggleClosedBinding;
 
-        Panel borderPanel;
-        Panel regionTextureOverlayPanel;
-        Panel[] regionLocationDotsOutlinesOverlayPanel;
-        Panel regionLocationDotsOverlayPanel;
-        Panel playerRegionOverlayPanel;
-        Panel identifyOverlayPanel;
+        protected Panel borderPanel;
+        protected Panel regionTextureOverlayPanel;
+        protected Panel[] regionLocationDotsOutlinesOverlayPanel;
+        protected Panel regionLocationDotsOverlayPanel;
+        protected Panel playerRegionOverlayPanel;
+        protected Panel identifyOverlayPanel;
 
-        TextLabel regionLabel;
+        protected TextLabel regionLabel;
 
         Texture2D overworldTexture;
         Texture2D identifyTexture;
@@ -105,15 +105,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Texture2D rightArrowTexture;
         Texture2D borderTexture;
 
-        Button findButton;
-        Button atButton;
-        Button exitButton;
-        Button horizontalArrowButton    = new Button();
-        Button verticalArrowButton      = new Button();
-        Button dungeonsFilterButton     = new Button();
-        Button templesFilterButton      = new Button();
-        Button homesFilterButton        = new Button();
-        Button townsFilterButton        = new Button();
+        protected Button findButton;
+        protected Button atButton;
+        protected Button exitButton;
+        protected Button horizontalArrowButton    = new Button();
+        protected Button verticalArrowButton      = new Button();
+        protected Button dungeonsFilterButton     = new Button();
+        protected Button templesFilterButton      = new Button();
+        protected Button homesFilterButton        = new Button();
+        protected Button townsFilterButton        = new Button();
 
         Rect playerRegionOverlayPanelRect   = new Rect(0, 0, 320, 200);
         Rect regionTextureOverlayPanelRect  = new Rect(0, regionPanelOffset, 320, 160);
@@ -516,7 +516,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         }
 
-        void SetupArrowButtons()
+        protected virtual void SetupArrowButtons()
         {
             // Vertical arrow
             if (selectedRegionMapNames.Length > 2)
@@ -660,7 +660,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
 
         // Updates location dots
-        void UpdateMapLocationDotsTexture()
+        protected virtual void UpdateMapLocationDotsTexture()
         {
             // Get map and dimensions
             string mapName = selectedRegionMapNames[mapIndex];
@@ -1107,7 +1107,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
 
         // Check if location with MapSummary summary is already discovered
-        bool checkLocationDiscovered(ContentReader.MapSummary summary)
+        protected virtual bool checkLocationDiscovered(ContentReader.MapSummary summary)
         {
             if (GameManager.Instance.PlayerGPS.HasDiscoveredLocation(summary.ID) ||
                 summary.Discovered ||

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -199,6 +199,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             get { return identifying && findingLocation && RegionSelected; }
         }
 
+        public ContentReader.MapSummary LocationSummary { get => locationSummary; }
+
         public void ActivateTeleportationTravel()
         {
             teleportationTravel = true;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -39,14 +39,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Panel transportToggleColorPanel;
         Panel sleepToggleColorPanel;
 
-        Button beginButton;
-        Button exitButton;
-        Button cautiousToggleButton;
-        Button recklessToggleButton;
-        Button footHorseToggleButton;
-        Button shipToggleButton;
-        Button campOutToggleButton;
-        Button innToggleButton;
+        protected Button beginButton;
+        protected Button exitButton;
+        protected Button cautiousToggleButton;
+        protected Button recklessToggleButton;
+        protected Button footHorseToggleButton;
+        protected Button shipToggleButton;
+        protected Button campOutToggleButton;
+        protected Button innToggleButton;
         Texture2D nativeTexture;
         Texture2D greenCheckboxTexture;
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -407,7 +407,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region events
 
-        public void BeginButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
+        public virtual void BeginButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
         {
             Refresh();
 
@@ -468,14 +468,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             doFastTravel = true; // initiate fast travel (Update() function will perform fast travel when this flag is true)
         }
 
-        public void ExitButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
+        public virtual void ExitButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             doFastTravel = false;
             DaggerfallUI.Instance.UserInterfaceManager.PopWindow();
         }
 
-        protected void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        protected virtual void ExitButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
             if (keyboardEvent.type == EventType.KeyDown)
             {
@@ -490,7 +490,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        public void SpeedButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
+        public virtual void SpeedButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
 
@@ -498,53 +498,53 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Refresh();
         }
 
-        public void SpeedButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        public virtual void SpeedButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
         {
             if (keyboardEvent.type == EventType.KeyDown)
                 ToggleSpeedButtonOnScrollHandler(sender);
         }
 
-        public void ToggleSpeedButtonOnScrollHandler(BaseScreenComponent sender)
+        public virtual void ToggleSpeedButtonOnScrollHandler(BaseScreenComponent sender)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             speedCautious = !speedCautious;
             Refresh();
         }
 
-        public void TransportModeButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
+        public virtual void TransportModeButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             travelShip = (sender == shipToggleButton);
             Refresh();
         }
 
-        public void TransportModeButtonOnKeyboardHandler(BaseScreenComponent sender, Event keyboardEvent)
+        public virtual void TransportModeButtonOnKeyboardHandler(BaseScreenComponent sender, Event keyboardEvent)
         {
             if (keyboardEvent.type == EventType.KeyDown)
                 ToggleTransportModeButtonOnScrollHandler(sender);
         }
 
-        public void ToggleTransportModeButtonOnScrollHandler(BaseScreenComponent sender)
+        public virtual void ToggleTransportModeButtonOnScrollHandler(BaseScreenComponent sender)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             travelShip = !travelShip;
             Refresh();
         }
 
-        public void SleepModeButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
+        public virtual void SleepModeButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             sleepModeInn = (sender == innToggleButton);
             Refresh();
         }
 
-        public void SleepModeButtonOnKeyboardandler(BaseScreenComponent sender, Event keyboardEvent)
+        public virtual void SleepModeButtonOnKeyboardandler(BaseScreenComponent sender, Event keyboardEvent)
         {
             if (keyboardEvent.type == EventType.KeyDown)
                 ToggleSleepModeButtonOnScrollHandler(sender);
         }
 
-        public void ToggleSleepModeButtonOnScrollHandler(BaseScreenComponent sender)
+        public virtual void ToggleSleepModeButtonOnScrollHandler(BaseScreenComponent sender)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             sleepModeInn = !sleepModeInn;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -29,7 +29,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const string nativeImgName = "TRAV0I04.IMG";
 
         const float secondsCountdownTickFastTravel = 0.05f; // time used for fast travel countdown for one tick
-        TravelTimeCalculator travelTimeCalculator = new TravelTimeCalculator();
+        protected TravelTimeCalculator travelTimeCalculator = new TravelTimeCalculator();
 
         Color32 toggleColor = new Color32(85, 117, 48, 255);
         const string greenCheckboxTextureFilename = "GreenCheckbox";
@@ -71,14 +71,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Vector2 shipPos             = new Vector2(165, 63.25f);
         DFPosition endPos           = new DFPosition(109, 158);
 
-        TextLabel availableGoldLabel;
-        TextLabel tripCostLabel;
-        TextLabel travelTimeLabel;
+        protected TextLabel availableGoldLabel;
+        protected TextLabel tripCostLabel;
+        protected TextLabel travelTimeLabel;
 
-        int travelTimeMinutes;
-        int countdownValueTravelTimeDays; // used for remaining days in fast travel countdown
-        bool doFastTravel = false; // flag used to indicate Update() function that fast travel should happen
-        float waitTimer = 0;
+        protected int travelTimeTotalMins;
+        protected int countdownValueTravelTimeDays; // used for remaining days in fast travel countdown
+        protected bool doFastTravel = false; // flag used to indicate Update() function that fast travel should happen
+        protected float waitTimer = 0;
 
         bool isCloseWindowDeferred = false;
 
@@ -251,14 +251,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         #region Methods
 
         //Update when player pushes buttons etc.
-        void Refresh()
+        protected virtual void Refresh()
         {
             UpdateTogglePanels();
             UpdateLabels();
         }
 
         //Updates the positions for the panels to indicate which button is selected
-        void UpdateTogglePanels()
+        protected virtual void UpdateTogglePanels()
         {
             if (speedCautious)
                 speedToggleColorPanel.Position = cautiousPanelPos;
@@ -275,22 +275,22 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         }
 
         //Updates text labels
-        void UpdateLabels()
+        protected virtual void UpdateLabels()
         {
             availableGoldLabel.Text = GameManager.Instance.PlayerEntity.GoldPieces.ToString();
-            travelTimeMinutes = travelTimeCalculator.CalculateTravelTime(endPos, speedCautious, sleepModeInn, travelShip, hasHorse, hasCart);
+            travelTimeTotalMins = travelTimeCalculator.CalculateTravelTime(endPos, speedCautious, sleepModeInn, travelShip, hasHorse, hasCart);
 
             // Players can have fast travel benefit from guild memberships
-            travelTimeMinutes = GameManager.Instance.GuildManager.FastTravel(travelTimeMinutes);
+            travelTimeTotalMins = GameManager.Instance.GuildManager.FastTravel(travelTimeTotalMins);
 
-            int travelTimeDaysTotal = (travelTimeMinutes / 1440);
+            int travelTimeDaysTotal = (travelTimeTotalMins / 1440);
 
             // Classic always adds 1. For DF Unity, only add 1 if there is a remainder to round up.
-            if ((travelTimeMinutes % 1440) > 0)
+            if ((travelTimeTotalMins % 1440) > 0)
                 travelTimeDaysTotal += 1;
 
             travelTimeCalculator.CalculateTripCost(
-                travelTimeMinutes,
+                travelTimeTotalMins,
                 sleepModeInn,
                 hasShip,
                 travelShip
@@ -302,7 +302,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             countdownValueTravelTimeDays = travelTimeDaysTotal;
         }
 
-        bool TickCountdown()
+        protected virtual bool TickCountdown()
         {
             bool finished = false;
 
@@ -338,7 +338,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     GameManager.Instance.PlayerEntity.CurrentMagicka = GameManager.Instance.PlayerEntity.MaxMagicka;
             }
 
-            DaggerfallUnity.WorldTime.DaggerfallDateTime.RaiseTime(travelTimeMinutes * 60);
+            DaggerfallUnity.WorldTime.DaggerfallDateTime.RaiseTime(travelTimeTotalMins * 60);
 
             // Halt random enemy spawns for next playerEntity update so player isn't bombarded by spawned enemies at the end of a long trip
             GameManager.Instance.PlayerEntity.PreventEnemySpawns = true;
@@ -382,13 +382,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         // Return whether player has enough gold for the selected travel options
         // Taverns only accept gold pieces
-        bool enoughGoldCheck()
+        protected virtual bool enoughGoldCheck()
         {
             return (GameManager.Instance.PlayerEntity.GetGoldAmount() >= travelTimeCalculator.TotalCost) &&
                    (GameManager.Instance.PlayerEntity.GoldPieces >= travelTimeCalculator.PiecesCost);
         }
 
-        void showNotEnoughGoldPopup()
+        protected virtual void showNotEnoughGoldPopup()
         {
             const int notEnoughGoldTextId = 454;
 
@@ -439,7 +439,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// <summary>
         /// Button handler for travel-with-incubating-disease confirmation pop up.
         /// </summary>
-        void ConfirmTravelPopupDiseasedButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
+        protected virtual void ConfirmTravelPopupDiseasedButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
         {
             DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
             sender.CloseWindow();
@@ -452,7 +452,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 return;
         }
 
-        void CallFastTravelGoldCheck()
+        protected virtual void CallFastTravelGoldCheck()
         {
             if (!enoughGoldCheck())
             {

--- a/Assets/Scripts/Game/Utility/TravelTimeCalculator.cs
+++ b/Assets/Scripts/Game/Utility/TravelTimeCalculator.cs
@@ -174,6 +174,7 @@ namespace DaggerfallWorkshop.Game.Utility
 
         public int PiecesCost { get { return piecesCost; } }
         public int TotalCost { get { return totalCost; } }
+        public int OceanPixels { get { return pixelsTraveledOnOcean; } }
         #endregion
     }
 }

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -254,6 +254,11 @@ namespace DaggerfallWorkshop.Utility
 
         #region Public Utility Functions
 
+        public static string LocationTypeName()
+        {
+            return CityType(null);
+        }
+
         public static void SetFactionIdsAndRegionID(int faction1, int faction2, int region)
         {
             idFaction1 = faction1;


### PR DESCRIPTION
So here'a another of my messy grab bags of trivial changes. I am happy to merge myself unless anyone has a concern with any of this. Nothing controversial I think.

- Allow tavern window extension by mods, this is for Ralzars Calories mod so he can modify the tavern food & drink menu action.

- Allow travel map and popup extension by mods, for a new auto travel mod I'm making.

- Change horse animation to use unscaled time so it doesn't go mad at higher time acceleration - since it's in the players face, it doesn't look good.

- Expose the location type display name mapping from macros to public use.