### PR TITLE
FACTION.TXT fixes

### DIFF
--- a/Assets/StreamingAssets/Factions/FACTION.TXT
+++ b/Assets/StreamingAssets/Factions/FACTION.TXT
@@ -200,7 +200,7 @@ maxf: 70
 	region: -1
 	power: 45
 	flags: 1
-	ally: 106
+	enemy: 106
 	enemy: 25
 	face: -1
 	race: -1
@@ -482,7 +482,7 @@ face: -1
 race: -1
 flat: 182 23
 flat: 182 27
-sgroup: 5
+sgroup: 7
 ggroup: -1
 minf: 50
 maxf: 90
@@ -584,7 +584,7 @@ maxf: 95
 	face: -1
 	race: -1
 	flat: 182 23
-        flat: 182 27
+	flat: 182 27
 	sgroup: 7
 	ggroup: 17
 	minf: 20
@@ -601,7 +601,7 @@ maxf: 95
 		face: -1
 		race: -1
 		flat: 184 4
-	        flat: 182 27
+		flat: 182 27
 		sgroup: 7
 		ggroup: 9
 		minf: 40
@@ -907,7 +907,6 @@ maxf: 90
 		region: 22
 		power: 15
 		flags: 0
-		ally: 400
 		face: 54
 		race: 3
 		flat: 183 5
@@ -1063,7 +1062,6 @@ maxf: 90
 		region: 21
 		power: 20
 		flags: 0
-		ally: 204
 		face: 37
 		race: 2
 		flat: 182 10
@@ -1164,7 +1162,6 @@ maxf: 90
 	summon: 17
 	region: -1
 	power: 30
-	ally: 1
 	enemy: 40
 	flags: 0
 	face: -1
@@ -1203,7 +1200,7 @@ maxf: 90
 		flags: 0
 		ally: 355
 		face: 60
-		race: 2
+		race: 5
 		flat: 182 9
 		sgroup: 7
 		ggroup: -1
@@ -1580,11 +1577,10 @@ maxf: 95
 		region: 14
 		power: 20
 		flags: 0
-		ally: 201
 		face: 23
 		race: 3
 		flat: 183 12
-		sgroup: 5
+		sgroup: 7
 		ggroup: -1
 		minf: 20
 		maxf: 90
@@ -1900,8 +1896,8 @@ maxf: 70
 		race: -1
 		flat: 183 5
 		flat: 183 14
-		sgroup: 4
-		ggroup: 15
+		sgroup: 2
+		ggroup: 10
 		minf: 40
 		maxf: 60
 
@@ -2248,7 +2244,7 @@ maxf: 40
 	flat: 182 46
 	flat: 182 45
 	sgroup: 0
-	ggroup: 23
+	ggroup: 11
 	minf: 50
 	maxf: 90
 
@@ -2265,7 +2261,7 @@ maxf: 40
 	flat: 182 15
 	flat: 182 45
 	sgroup: 0
-	ggroup: 23
+	ggroup: 11
 	minf: 50
 	maxf: 90
 
@@ -2282,7 +2278,7 @@ maxf: 40
 	flat: 182 20
 	flat: 182 27
 	sgroup: 0
-	ggroup: 23
+	ggroup: 11
 	minf: 50
 	maxf: 90
 
@@ -2429,7 +2425,7 @@ maxf: 90
 		flat: 182 23
 		flat: 182 27
 		sgroup: 4
-		ggroup: 11
+		ggroup: 4
 		minf: 10
 		maxf: 60
 
@@ -2446,7 +2442,7 @@ maxf: 90
 	flat: 182 25
 	flat: 182 28
 	sgroup: 4
-	ggroup: 11
+	ggroup: 4
 	minf: 10
 	maxf: 40
 
@@ -2463,7 +2459,7 @@ maxf: 90
 	flat: 182 25
 	flat: 182 27
 	sgroup: 4
-	ggroup: 1
+	ggroup: 4
 	minf: 10
 	maxf: 90
 
@@ -2480,7 +2476,7 @@ maxf: 90
 	flat: 182 27
 	flat: 182 19
 	sgroup: 4
-	ggroup: 11
+	ggroup: 4
 	minf: 30
 	maxf: 60
 
@@ -2497,7 +2493,7 @@ maxf: 90
 	flat: 182 28
 	flat: 182 29
 	sgroup: 4
-	ggroup: 15
+	ggroup: 4
 	minf: 30
 	maxf: 90
 
@@ -2838,7 +2834,7 @@ vam: 150
 	flags: 0
 	ally: 366
 	face: 21
-	race: 2
+	race: 3
 	flat: 334 17
 	sgroup: 3
 	ggroup: -1
@@ -2863,6 +2859,22 @@ vam: 150
 		minf: 5
 		maxf: 40
 
+	#377
+	Type: 4
+	name: Lady Bridwell
+	rep: 0
+	summon: -1
+	region: 18
+	power: 4
+	flags: 0
+	face: 31
+	race: 3
+	flat: 182 10
+	sgroup: 3
+	ggroup: -1
+	minf: 10
+	maxf: 30
+
 	#501
 	type: 4
 	name: Lady Northbridge
@@ -2872,7 +2884,7 @@ vam: 150
 	power: 3
 	flags: 0
 	face: 25
-	race: 2
+	race: 3
 	flat: 334 10
 	sgroup: 7
 	ggroup: -1
@@ -2889,6 +2901,7 @@ vam: 150
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 128
@@ -2973,7 +2986,7 @@ summon: -1
 region: 19
 power: 50
 flags: 0
-ruler: 5
+ruler: 3
 face: -1
 race: 3
 flat: 183 5
@@ -3145,7 +3158,7 @@ vam: 158
 	rep: 0
 	summon: -1
 	region: 21
-	power: 400
+	power: 18
 	flags: 0
 	face: 40
 	race: 2
@@ -3161,7 +3174,7 @@ vam: 158
 		rep: 0
 		summon: -1
 		region: 21
-		power: 400
+		power: 20
 		flags: 1
 		face: -1
 		race: 2
@@ -3196,8 +3209,9 @@ vam: 158
 	region: 21
 	power: 25
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 128
@@ -3210,9 +3224,9 @@ vam: 158
 	rep: 0
 	summon: -1
 	region: 21
-	power: 1000
+	power: 40
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 28
 	sgroup: 0
@@ -3266,14 +3280,13 @@ vam: 151
 		flags: 0
 		ally: 400
 		face: -1
-		race: 2
+		race: 3
 		flat: 183 2
 		flat: 182 27
 		sgroup: 7
 		ggroup: 9
 		minf: 20
 		maxf: 50
-
 
 	#401
 	Type: 4
@@ -3334,6 +3347,7 @@ vam: 151
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 128
@@ -3387,6 +3401,8 @@ vam: 154
 	face: 57
 	race: 2
 	flat: 183 4
+	enemy: 406
+	enemy: 355
 	sgroup: 3
 	ggroup: -1
 	minf: 20
@@ -3404,6 +3420,7 @@ vam: 154
 		race: 2
 		flat: 183 2
 		flat: 183 9
+		enemy: 412
 		sgroup: 7
 		ggroup: 9
 		minf: 20
@@ -3427,12 +3444,14 @@ vam: 154
 
 	#406
 	Type: 4
-	name: Lord Khane
+	name: Lord Kain
 	rep: 0
 	summon: -1
 	region: 23
 	power: 10
 	flags: 0
+	ally: 355
+	enemy: 379
 	face: 59
 	race: 2
 	flat: 182 20
@@ -3449,8 +3468,9 @@ vam: 154
 	region: 23
 	power: 25
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 0
@@ -3465,7 +3485,7 @@ vam: 154
 	region: 23
 	power: 3
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 28
 	sgroup: 0
@@ -3537,6 +3557,7 @@ vam: 154
 	region: 24
 	power: 5
 	flags: 0
+	ally: 398
 	face: 44
 	race: 3
 	flat: 346 17
@@ -3553,6 +3574,8 @@ vam: 154
 	region: 24
 	power: 10
 	flags: 0
+	ally: 394
+	ally: 396
 	face: 46
 	race: 7
 	flat: 346 16
@@ -3570,6 +3593,7 @@ vam: 154
 	power: 12
 	flags: 0
 	ally: 393
+	ally: 305
 	face: 45
 	race: 7
 	flat: 346 0
@@ -3639,7 +3663,6 @@ vam: 154
 	power: 22
 	flags: 1
 	ally: 392
-	ally: 357
 	face: 50
 	race: 3
 	flat: 182 46
@@ -3658,6 +3681,7 @@ vam: 154
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 128
@@ -4221,7 +4245,7 @@ power: 52
 flags: 0
 ruler: 7
 face: -1
-race: 2
+race: 3
 flat: 183 10
 flat: 183 8
 sgroup: 3
@@ -4291,7 +4315,7 @@ vam: 158
 	region: 44
 	power: 51
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 183 9
 	sgroup: 3
@@ -4308,7 +4332,7 @@ vam: 158
 	region: 44
 	power: 45
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 27
 	sgroup: 0
@@ -4326,7 +4350,7 @@ vam: 158
 	power: 20
 	flags: 0
 	face: -1
-	race: -1
+	race: 2
 	flat: 183 3
 	flat: 182 45
 	sgroup: 7
@@ -4361,7 +4385,7 @@ vam: 158
 	region: 45
 	power: 50
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 183 9
 	sgroup: 3
@@ -4378,7 +4402,7 @@ vam: 158
 	region: 45
 	power: 3
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 27
 	sgroup: 0
@@ -4414,7 +4438,7 @@ vam: 158
 	region: 46
 	power: 50
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 27
 	sgroup: 3
@@ -4431,7 +4455,7 @@ vam: 158
 	region: 46
 	power: 15
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 28
 	sgroup: 0
@@ -4467,7 +4491,7 @@ vam: 158
 	region: 47
 	power: 50
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 28
 	sgroup: 3
@@ -4484,7 +4508,7 @@ vam: 158
 	region: 47
 	power: 50
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 28
 	sgroup: 0
@@ -4520,7 +4544,7 @@ vam: 158
 	region: 48
 	power: 51
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 28
 	sgroup: 3
@@ -4537,7 +4561,7 @@ vam: 158
 	region: 48
 	power: 25
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 27
 	sgroup: 0
@@ -4573,7 +4597,7 @@ vam: 157
 	region: 49
 	power: 50
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 27
 	sgroup: 3
@@ -4590,7 +4614,7 @@ vam: 157
 	region: 49
 	power: 5
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 27
 	sgroup: 0
@@ -4626,7 +4650,7 @@ vam: 155
 	region: 50
 	power: 50
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 183 9
 	sgroup: 3
@@ -4643,7 +4667,7 @@ vam: 155
 	region: 50
 	power: 60
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 28
 	sgroup: 0
@@ -4680,7 +4704,7 @@ vam: 154
 	region: 51
 	power: 51
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 183 9
 	sgroup: 3
@@ -4697,7 +4721,7 @@ vam: 154
 	region: 51
 	power: 15
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 28
 	sgroup: 0
@@ -4733,7 +4757,7 @@ vam: 155
 	region: 52
 	power: 50
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 28
 	sgroup: 3
@@ -4750,7 +4774,7 @@ vam: 155
 	region: 52
 	power: 20
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 27
 	sgroup: 0
@@ -4768,7 +4792,7 @@ vam: 155
 	power: 17
 	flags: 0
 	face: -1
-	race: -1
+	race: 2
 	flat: 183 3
 	flat: 182 28
 	sgroup: 7
@@ -4803,10 +4827,10 @@ vam: 154
 	region: 53
 	power: 51
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 183 9
-	sgroup: 3
+	sgroup: 2
 	ggroup: 15
 	flags: 0
 	minf: 20
@@ -4818,9 +4842,9 @@ vam: 154
 	rep: 0
 	summon: -1
 	region: 53
-	power: 3
+	power: 2
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 28
 	sgroup: 0
@@ -4856,7 +4880,7 @@ vam: 155
 	region: 54
 	power: 51
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 27
 	sgroup: 3
@@ -4873,7 +4897,7 @@ vam: 155
 	region: 54
 	power: 5
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 27
 	sgroup: 0
@@ -4909,7 +4933,7 @@ vam: 155
 	region: 55
 	power: 51
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 28
 	sgroup: 3
@@ -4926,7 +4950,7 @@ vam: 155
 	region: 55
 	power: 4
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 28
 	sgroup: 0
@@ -4934,23 +4958,6 @@ vam: 155
 	flags: 0
 	minf: 5
 	maxf: 30
-
-	#417
-	type: 2
-	name: The Knights of the Hawk
-	rep: 0
-	summon: -1
-	region: 55
-	power: 25
-	flags: 0
-	face: -1
-	race: -1
-	flat: 183 2
-	flat: 183 9
-	sgroup: 7
-	ggroup: 9
-	minf: 20
-	maxf: 60
 
 #231
 type: 7
@@ -4979,7 +4986,7 @@ vam: 157
 	region: 56
 	power: 25
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 28
 	sgroup: 3
@@ -4996,7 +5003,7 @@ vam: 157
 	region: 56
 	power: 3
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 28
 	sgroup: 0
@@ -5004,6 +5011,23 @@ vam: 157
 	flags: 0
 	minf: 5
 	maxf: 30
+
+	#417
+	type: 2
+	name: The Knights of the Hawk
+	rep: 0
+	summon: -1
+	region: 56
+	power: 25
+	flags: 0
+	face: -1
+	race: 2
+	flat: 183 2
+	flat: 183 9
+	sgroup: 7
+	ggroup: 9
+	minf: 20
+	maxf: 60
 
 #232
 type: 7
@@ -5032,7 +5056,7 @@ vam: 157
 	region: 57
 	power: 45
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 27
 	sgroup: 3
@@ -5049,7 +5073,7 @@ vam: 157
 	region: 57
 	power: 3
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 27
 	sgroup: 0
@@ -5185,7 +5209,7 @@ vam: 151
 
 	#581
 	type: 14
-	name: Court of Ilessen Hills
+	name: Court of Ilessan Hills
 	rep: 0
 	summon: -1
 	region: 61
@@ -5202,7 +5226,7 @@ vam: 151
 
 	#582
 	type: 15
-	name: People of Ilessen Hills
+	name: People of Ilessan Hills
 	rep: 0
 	summon: -1
 	region: 61
@@ -5244,7 +5268,7 @@ vam: 158
 	region: 62
 	power: 3
 	face: -1
-	race: 3
+	race: 2
 	flat: 183 3
 	flat: 182 27
 	sgroup: 3
@@ -5261,7 +5285,7 @@ vam: 158
 	region: 62
 	power: 1
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
 	flat: 182 27
 	sgroup: 0
@@ -5296,7 +5320,7 @@ maxf: 80
 	power: 1
 	flags: 1
 	face: 1
-	race: 3
+	race: 2
 	flat: 184 20
 	sgroup: 7
 	ggroup: -1
@@ -5312,7 +5336,7 @@ region: 17
 power: 50
 flags: 1
 face: 2
-race: 2
+race: 3
 flat: 183 17
 sgroup: 2
 ggroup: -1
@@ -5335,45 +5359,48 @@ maxf: 80
 	minf: 40
 	maxf: 80
 
-#306
-type: 2
-name: The Necromancers
+#305
+type: 4
+name: King of Worms
 rep: 0
-summon: 17
-region: 62
+summon: -1
+region: -1
 power: 50
 flags: 1
-face: -1
+ally: 394
+enemy: 353
+face: 5
 race: -1
 flat: 178 4
-flat: 178 4
 sgroup: 7
-ggroup: 14
-minf: 10
+ggroup: -1
+minf: 20
 maxf: 70
 
-	#305
-	type: 4
-	name: King of Worms
+	#306
+	type: 2
+	name: The Necromancers
 	rep: 0
-	summon: -1
-	region: 62
+	summon: 17
+	region: -1
 	power: 50
 	flags: 1
-	face: 5
-	race: 2
-	flat: 178 4
+	enemy: 354
+	face: -1
+	race: -1
+	flat: 178 3
+	flat: 178 5
 	sgroup: 7
-	ggroup: -1
-	minf: 20
+	ggroup: 14
+	minf: 10
 	maxf: 70
 
 #350
-type: 2
+type: 7
 name: The Septim Empire
 rep: 0
 summon: -1
-region: 61
+region: -1
 power: 72
 flags: 0
 face: -1
@@ -5381,7 +5408,7 @@ race: -1
 flat: 182 16
 flat: 182 27
 sgroup: 3
-ggroup: 9
+ggroup: 15
 minf: 1
 maxf: 80
 vam: 150
@@ -5430,7 +5457,7 @@ vam: 150
 			race: 0
 			flat: 182 27
 			sgroup: 3
-			ggroup: 9
+			ggroup: -1
 			minf: 10
 			maxf: 80
 #353
@@ -5438,10 +5465,11 @@ type: 4
 name: The Underking
 rep: 0
 summon: -1
-region: 62
+region: -1
 power: 65
 flags: 1
 enemy: 350
+enemy: 305
 face: 8
 race: -1
 flat: 184 0
@@ -5455,14 +5483,15 @@ maxf: 80
 	name: Agents of The Underking
 	rep: 0
 	summon: -1
-	region: 62
+	region: -1
 	power: 50
 	flags: 0
+	enemy: 306
 	race: -1
 	flat: 182 26
 	flat: 182 23
 	sgroup: 7
-	ggroup: 1
+	ggroup: 12
 	minf: 25
 	maxf: 90
 
@@ -5474,6 +5503,7 @@ summon: -1
 region: 7
 power: 5
 flags: 1
+ally: 406
 enemy: 379
 face: 38
 race: 2
@@ -5491,6 +5521,7 @@ maxf: 40
 	region: 7
 	power: 5
 	flags: 0
+	enemy: 411
 	face: -1
 	race: -1
 	flat: 182 20
@@ -5511,6 +5542,7 @@ flags: 16
 ruler: 1
 race: 17
 flat: 182 3
+flat: 182 11
 sgroup: 3
 ggroup: 24
 minf: 20
@@ -5525,11 +5557,14 @@ vam: 153
 	region: 27
 	power: 50
 	flags: 1
+	enemy: 409
+	enemy: 368
+	enemy: 408
 	face: 13
-	race: -1
+	race: 17
 	flat: 183 19
 	sgroup: 3
-	ggroup: 9
+	ggroup: -1
 	minf: 20
 	maxf: 50
 
@@ -5541,8 +5576,9 @@ vam: 153
 	region: 27
 	power: 25
 	face: -1
-	race: 3
+	race: 17
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 128
@@ -5557,8 +5593,9 @@ vam: 153
 	region: 27
 	power: 5
 	face: -1
-	race: 3
+	race: 17
 	flat: 182 20
+	flat: 182 28
 	sgroup: 0
 	ggroup: 4
 	flags: 0
@@ -5577,7 +5614,7 @@ face: 14
 race: 3
 flat: 182 20
 sgroup: 7
-ggroup: 15
+ggroup: -1
 minf: 5
 maxf: 30
 
@@ -5586,11 +5623,11 @@ maxf: 30
 	name: The Order of the Cup
 	rep: 0
 	summon: -1
-	region: 44
+	region: 40
 	power: 10
 	flags: 0
 	face: -1
-	race: -1
+	race: 3
 	flat: 183 3
 	sgroup: 7
 	ggroup: 9
@@ -5607,7 +5644,7 @@ power: 3
 flags: 0
 ally: 108
 face: 15
-race: 2
+race: 3
 flat: 182 19
 sgroup: 3
 ggroup: -1
@@ -5658,26 +5695,10 @@ flags: 0
 face: 30
 race: 3
 flat: 182 23
-sgroup: 1
+sgroup: 2
 ggroup: -1
 minf: 10
 maxf: 40
-
-#377
-Type: 4
-name: Lady Bridwell
-rep: 0
-summon: -1
-region: 18
-power: 4
-flags: 0
-face: 31
-race: 3
-flat: 180 0
-sgroup: 3
-ggroup: -1
-minf: 10
-maxf: 30
 
 #378
 Type: 4
@@ -5999,7 +6020,7 @@ race: -1
 flat: 182 4
 flat: 182 38
 sgroup: 0
-ggroup: 1
+ggroup: 4
 minf: 0
 maxf: 10
 
@@ -6016,7 +6037,7 @@ race: -1
 flat: 182 15
 flat: 182 10
 sgroup: 0
-ggroup: 1
+ggroup: 4
 minf: 0
 maxf: 10
 
@@ -6029,10 +6050,10 @@ region: 17
 power: 5
 flags: 128
 flags: 4
-flat: 180
 face: -1
 race: 3
 flat: 182 18
+flat: 182 27
 sgroup: 3
 ggroup: 15
 minf: 20
@@ -6050,6 +6071,7 @@ vam: 153
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 0
@@ -6066,6 +6088,7 @@ vam: 153
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 0
 	ggroup: 4
 	flags: 0
@@ -6081,10 +6104,10 @@ region: 2
 power: 35
 flags: 128
 flags: 4
-flat: 180
 face: -1
-race: 3
+race: 2
 flat: 182 18
+flat: 182 27
 sgroup: 3
 ggroup: 15
 minf: 20
@@ -6099,8 +6122,9 @@ vam: 155
 	region: 2
 	power: 5
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 0
@@ -6115,8 +6139,9 @@ vam: 155
 	region: 2
 	power: 5
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
+	flat: 182 28
 	sgroup: 0
 	ggroup: 4
 	flags: 0
@@ -6132,10 +6157,10 @@ region: 1
 power: 5
 flags: 128
 flags: 4
-flat: 180
 face: -1
-race: 3
+race: 2
 flat: 182 18
+flat: 182 27
 sgroup: 3
 ggroup: 15
 minf: 20
@@ -6150,8 +6175,9 @@ vam: 157
 	region: 1
 	power: 25
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 0
@@ -6166,8 +6192,9 @@ vam: 157
 	region: 1
 	power: 3
 	face: -1
-	race: 3
+	race: 2
 	flat: 182 20
+	flat: 182 28
 	sgroup: 0
 	ggroup: 4
 	flags: 0
@@ -6183,10 +6210,10 @@ region: 12
 power: 5
 flags: 128
 flags: 4
-flat: 180
 face: -1
 race: 3
 flat: 182 18
+flat: 182 27
 sgroup: 3
 ggroup: 15
 minf: 20
@@ -6203,6 +6230,7 @@ vam: 157
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 0
@@ -6219,6 +6247,7 @@ vam: 157
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 0
 	ggroup: 4
 	flags: 0
@@ -6234,9 +6263,11 @@ region: 10
 power: 5
 flags: 16
 flags: 128
+ruler: 12
 face: -1
-race: 0
+race: 3
 flat: 183 10
+flat: 183 11
 sgroup: 3
 ggroup: 15
 minf: 40
@@ -6269,6 +6300,7 @@ vam: 153
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 3
 	ggroup: 15
 	flags: 128
@@ -6285,11 +6317,12 @@ vam: 153
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 0
 	ggroup: 4
 	flags: 128
 	minf: 40
-	maxf: 70		
+	maxf: 70
 
 #196
 type: 7
@@ -6302,7 +6335,8 @@ flags: 0
 ruler: 9
 face: -1
 race: 3
-flat: 183 6
+flat: 183 7
+flat: 183 8
 sgroup: 3
 ggroup: 15
 minf: 20
@@ -6319,6 +6353,7 @@ vam: 150
 	face: -1
 	race: 3
 	flat: 183 3
+	flat: 183 14
 	sgroup: 3
 	ggroup: 15
 	flags: 0
@@ -6335,6 +6370,7 @@ vam: 150
 	face: -1
 	race: 3
 	flat: 182 20
+	flat: 182 28
 	sgroup: 0
 	ggroup: 4
 	flags: 0

--- a/Assets/StreamingAssets/Factions/FACTION.TXT.meta
+++ b/Assets/StreamingAssets/Factions/FACTION.TXT.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 648986e63328932408a2c7fea94b0b20
+guid: eec1f931cad88984bbd1835f70f8ad6e
 DefaultImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
This fixes a lot of errors in FACTION.TXT. My fix is built on top of DelphiSnake's one, which was itself built on top of PLRDLF's fix. To check the list of DelphiSnake's changes: http://slushpool.dfworkshop.net/fact-changes.txt

What I also changed:
- Lady Bridwell is now properly listed under the Daggerfall faction: doing quests for her will now also raise reputation with Daggerfall.
- The Knights of the Hawk are now properly listed under Antiphyllos: this fixes an issue in-game were a member of this order could't rent a room for free in the region taverns.
- King of Worms now appears on top of The Necromancers, as every other guild leader.
- King of Worms and The Necromancers race set to -1 (just for the sake of consistency, since this field is not used at all in classic nor in DFU).
- Necromancers male and female flats are set to "174 3" and "174 5" respectively, instead of using King of Worms' one.
- The Septim Empire's region is set to -1 and its guild group to 15 (Region).
- Isle of Balfiera ruler is set to 11 (Lady) and its race to 3 (Breton).
- Lord Khane is renamed to Lord Kain to remain consistent with lore.
- Added a female flat to the Court of Lainlyn.
- Changes in allies and enemies:
  - Baron Shrike is now the enemy of both Lord Kain and Lord Harth while the last two are allies.
  - The Host of the Horn and The Host of the True Horn are enemies.
  - Gortwog and Princess Elysana are now allied to Lord Woodborne.
  - Prince Helseth is now allied to Princess Morgiah and Karethys.
  - Princess Morgiah is now allied to the King of Worms.
  - King of Worms and The Underking are enemies.
  - Necromancers and Agents of the Underking are enemies.
  - The Temple of Stendarr is now the enemy of Boethiah instead of its ally (makes much more sense).
  - Lord Quistley is no longer allied to Lady Doryanna Flyte.
  - Charvek-si is no longer allied to Sentinel.
  - Br'itsa is no longer allied to Lord Harth.
  - The School of Julianos is no longer allied to Clavicus Vile.
  - The Temple of Kynareth and Lord Coulder are no longer allied to Daggerfall.

Concerning allies and enemies, there is probably more to do.