### PR TITLE
Use faction race ID for oath

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -596,27 +596,25 @@ namespace DaggerfallConnect.Arena2
         }
 
         /// <summary>
-        /// Faction race value does not map to usual race ID.
-        /// Instead it selects from a smaller pool as below.
-        /// For example:
-        ///  * "Daggerfall", and most others, have a race of 3 (Breton)
-        ///  * "Sentinel" has a race of 2 (Redguard)
-        ///  * This is likely involved in how Daggerfall assigns the race of wandering NPCs in towns
-        ///  * When selecting a random face for escorts, it is assigned by the dominant race of region
-        ///  * Not all races found in FACTION.TXT are present here - unsure if these are even used in game
+        /// Faction race value does not map to usual race ID but maps
+        /// to oath selection and is used only for this. Values above 7
+        /// are not used in-game but are guessed from FACTION.TXT.
         /// </summary>
         public enum FactionRaces
         {
             None = -1,
+            Nord = 0,
+            Khajiit = 1,
             Redguard = 2,
             Breton = 3,
-            Nord = 4,           // Guess - not found in faction.txt
-            WoodElf = 5,        // Guess - based on #378 "Sylch Greenwood"
+            Argonian = 4,
+            WoodElf = 5,
+            HighElf = 6,
             DarkElf = 7,
             Skakmat = 11,       // Only used on #304 "Skakmat"
-            Orc = 17,           // Only used on #358 "Orsinium"
+            Orc = 17,           // Only used on #358 "Orsinium" in the original file
             Vampire = 18,
-            Fey = 19,           // Only used on #513 "The Fey"
+            Fey = 19,           // Only used on #513 "The Fey" a.k.a. Le Fay :)
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Entities/RaceTemplate.cs
+++ b/Assets/Scripts/Game/Entities/RaceTemplate.cs
@@ -101,9 +101,8 @@ namespace DaggerfallWorkshop.Game.Entity
         }
 
         /// <summary>
-        /// Get the entity race corresponding to that read from FACTION.TXT.
-        /// Only Breton, Redguard, Nord, Dark Elf and Wood Elf are supported.
-        /// Any other faction race will default to Breton.
+        /// Get the entity race corresponding to that read from FACTION.TXT. Only
+        /// default races are supported.
         /// </summary>
         /// <param name="factionRace">The faction race</param>
         /// <returns>The corresponding entity race.</returns>
@@ -113,18 +112,58 @@ namespace DaggerfallWorkshop.Game.Entity
             {
                 case FactionFile.FactionRaces.None:
                     return Races.None;
-                case FactionFile.FactionRaces.Redguard:
-                    return Races.Redguard;
                 case FactionFile.FactionRaces.Nord:
                     return Races.Nord;
-                case FactionFile.FactionRaces.DarkElf:
-                    return Races.DarkElf;
+                case FactionFile.FactionRaces.Khajiit:
+                    return Races.Khajiit;
+                case FactionFile.FactionRaces.Redguard:
+                    return Races.Redguard;
+                case FactionFile.FactionRaces.Breton:
+                    return Races.Breton;
+                case FactionFile.FactionRaces.Argonian:
+                    return Races.Argonian;
                 case FactionFile.FactionRaces.WoodElf:
                     return Races.WoodElf;
-                case FactionFile.FactionRaces.Breton:
-                default:
-                    return Races.Breton;
+                case FactionFile.FactionRaces.HighElf:
+                    return Races.HighElf;
+                case FactionFile.FactionRaces.DarkElf:
+                    return Races.DarkElf;
             }
+
+            return Races.None;
+        }
+
+        /// <summary>
+        /// Get the FACTION.TXT race ID corresponding to an entity race. Only
+        /// default races are supported.
+        /// </summary>
+        /// <param name="race">The entity race</param>
+        /// <returns>The corresponding faction race.</returns>
+        public static FactionFile.FactionRaces GetFactionRaceFromRace(Races race)
+        {
+            switch (race)
+            {
+                case Races.None:
+                    return FactionFile.FactionRaces.None;
+                case Races.Nord:
+                    return FactionFile.FactionRaces.Nord;
+                case Races.Khajiit:
+                    return FactionFile.FactionRaces.Khajiit;
+                case Races.Redguard:
+                    return FactionFile.FactionRaces.Redguard;
+                case Races.Breton:
+                    return FactionFile.FactionRaces.Breton;
+                case Races.Argonian:
+                    return FactionFile.FactionRaces.Argonian;
+                case Races.WoodElf:
+                    return FactionFile.FactionRaces.WoodElf;
+                case Races.HighElf:
+                    return FactionFile.FactionRaces.HighElf;
+                case Races.DarkElf:
+                    return FactionFile.FactionRaces.DarkElf;
+            }
+
+            return FactionFile.FactionRaces.None;
         }
     }
 

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -540,18 +540,12 @@ namespace DaggerfallWorkshop.Game.Questing
 
         void AssignRace()
         {
-            // Use faction race only for individuals
-            if (isIndividualNPC)
-            {
-                race = RaceTemplate.GetRaceFromFactionRace((FactionFile.FactionRaces)factionData.race);
-                if (race != Races.None)
-                {
-                    return;
-                }
-            }
+            // Try to get the race from the current faction
+            race = RaceTemplate.GetRaceFromFactionRace((FactionFile.FactionRaces)factionData.race);
+            if (race == Races.None)
+                // Otherwise use race of current region
+                race = GameManager.Instance.PlayerGPS.GetRaceOfCurrentRegion();
 
-            // Otherwise use race of current region
-            race = GameManager.Instance.PlayerGPS.GetRaceOfCurrentRegion();
             nameBank = GameManager.Instance.PlayerGPS.GetNameBankOfCurrentRegion();
         }
 

--- a/Assets/Scripts/Game/Questing/QuestMCP.cs
+++ b/Assets/Scripts/Game/Questing/QuestMCP.cs
@@ -12,6 +12,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Formulas;
+using DaggerfallWorkshop.Game.Entity;
 
 namespace DaggerfallWorkshop.Game.Questing
 {
@@ -143,31 +144,23 @@ namespace DaggerfallWorkshop.Game.Questing
                 return parent.GetCurrentLogMessageTime().DateString();
             }
 
-            /// <summary>
-            /// Oaths by race.
-            /// </summary>
-            enum RacialOaths
-            {
-                None = 0,
-                Nord = 201,
-                Khajiit = 202,
-                Redguard = 203,
-                Breton = 204,
-                Argonian = 205,
-                Bosmer = 206,
-                Altmer = 207,
-                Dunmer = 208,
-            }
-
-            // Oaths seem to be declared by NPC race
-            // Daggerfall NPCs have a limited range of races (usually Breton or Redguard).
-            // Have seen Nord oaths used in Daggerfall (e.g. Mages guild questor in Gothway Garden)
-            // Suspect NPCs with race: -1 (e.g. #63) get a random humanoid race within reason
-            // Just returning Nord oaths for now until ready to build this out properly
-            // https://www.imperial-library.info/content/daggerfall-oaths-and-expletives
+            // Oaths are declared by NPC race according to the race index used in FACTION.TXT.
+            // Unfortunately, classic never uses this faction race ID but, instead, uses the
+            // hardcoded index race of each region, which is not the same. In classic, this
+            // results in all NPCs from High Rock saying Nord oaths, while all NPCs in Hammerfell
+            // will say Khajiit oaths.
+            // Instead, DFU uses the faction race ID to return the correct oath.
+            // For the list of oaths, see https://www.imperial-library.info/content/daggerfall-oaths-and-expletives
             public override string Oath()
             {
-                return DaggerfallUnity.Instance.TextProvider.GetRandomText((int)RacialOaths.Nord);
+                // Get the questor race to find the correct oath
+                Races race = Races.None;
+                Symbol[] questors = parent.GetQuestors();
+                if (questors.Length > 0)
+                    race = parent.GetPerson(questors[0]).Race;
+
+                int oathId = (int)RaceTemplate.GetFactionRaceFromRace(race);
+                return DaggerfallUnity.Instance.TextProvider.GetRandomText(201 + oathId);
             }
 
             public override string HomeRegion()

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -745,7 +745,9 @@ namespace DaggerfallWorkshop.Game
             npcData.socialGroup = factionData.sgroup < 5 ? (FactionFile.SocialGroups)factionData.sgroup : FactionFile.SocialGroups.Merchants;
             npcData.guildGroup = (FactionFile.GuildGroups)factionData.ggroup;
             npcData.factionData = factionData;
-            npcData.race = Races.Breton; // TODO: find a way to get race for static npc
+            npcData.race = RaceTemplate.GetRaceFromFactionRace((FactionFile.FactionRaces)factionData.race);
+            if (npcData.race == Races.None)
+                npcData.race = GameManager.Instance.PlayerGPS.GetRaceOfCurrentRegion();
             npcData.chanceKnowsSomethingAboutWhereIs = DefaultChanceKnowsSomethingAboutWhereIs + FormulaHelper.BonusChanceToKnowWhereIs();
             npcData.chanceKnowsSomethingAboutQuest = DefaultChanceKnowsSomethingAboutQuest;
             npcData.chanceKnowsSomethingAboutOrganizations = DefaultChanceKnowsSomethingAboutOrganizationsStaticNPC;

--- a/Assets/Scripts/Game/TalkManagerMCP.cs
+++ b/Assets/Scripts/Game/TalkManagerMCP.cs
@@ -14,21 +14,6 @@ namespace DaggerfallWorkshop.Game
 {
     public partial class TalkManager : IMacroContextProvider
     {
-        /// <summary>
-        /// Oaths by race.
-        /// </summary>
-        enum RacialOaths
-        {
-            None = 0,
-            Nord = 201,
-            Khajiit = 202,
-            Redguard = 203,
-            Breton = 204,
-            Argonian = 205,
-            Bosmer = 206,
-            Altmer = 207,
-            Dunmer = 208,
-        }
 
         public class TalkManagerContext
         {
@@ -120,40 +105,18 @@ namespace DaggerfallWorkshop.Game
                 }
                 return TextManager.Instance.GetLocalizedText("resolvingError");
             }
+
+            // Oaths are declared by NPC race according to the race index used in FACTION.TXT.
+            // Unfortunately, classic never uses this faction race ID but, instead, uses the
+            // hardcoded index race of each region, which is not the same. In classic, this
+            // results in all NPCs from High Rock saying Nord oaths, while all NPCs in Hammerfell
+            // will say Khajiit oaths.
+            // Instead, DFU uses the faction race ID to return the correct oath.
+            // For the list of oaths, see https://www.imperial-library.info/content/daggerfall-oaths-and-expletives
             public override string Oath()
             {
-                RacialOaths whichOath = RacialOaths.None;
-                switch (parent.npcRace)
-                {
-                    case Races.Argonian:
-                        whichOath = RacialOaths.Argonian;
-                        break;
-                    case Races.Breton:
-                        whichOath = RacialOaths.Breton;
-                        break;
-                    case Races.DarkElf:
-                        whichOath = RacialOaths.Dunmer;
-                        break;
-                    case Races.HighElf:
-                        whichOath = RacialOaths.Altmer;
-                        break;
-                    case Races.Khajiit:
-                        whichOath = RacialOaths.Khajiit;
-                        break;
-                    case Races.Nord:
-                        whichOath = RacialOaths.Nord;
-                        break;
-                    case Races.Redguard:
-                        whichOath = RacialOaths.Redguard;
-                        break;
-                    //case Races.Vampire:                       // TODO: Restore this via racial override effect
-                    //    whichOath = RacialOaths.Dunmer;
-                    //    break;
-                    case Races.WoodElf:
-                        whichOath = RacialOaths.Bosmer;
-                        break;
-                }
-                return DaggerfallUnity.Instance.TextProvider.GetRandomText((int)whichOath);
+                int oathId = (int)RaceTemplate.GetFactionRaceFromRace(parent.npcRace);
+                return DaggerfallUnity.Instance.TextProvider.GetRandomText(201 + oathId);
             }
 
             // He/She


### PR DESCRIPTION
This actually fixes a bug from classic to make NPCs use the correct oath from their respective races.

Oaths are declared by NPC race according to the race index used in FACTION.TXT. Unfortunately, classic never uses this faction race ID but, instead, uses the hardcoded index race of each region, which is not the same. In classic, this results in all NPCs from High Rock saying Nord oaths, while all NPCs in Hammerfell will say Khajiit oaths.

Instead, DFU uses the faction race ID to return the correct oath.

So now, when talking to Morgiah when she doesn't like you, be aware:

![Morgiah oath](https://user-images.githubusercontent.com/46795115/88693618-cc3cdc80-d0ff-11ea-9b7c-856dc1d4bb9a.png)

@deepfighter, finally, FACTION.TXT race ID has found its intended use :)