### PR TITLE
Support for precompiled mods (experimental)

### DIFF
--- a/Assets/Game/Addons/ModSupport/Editor/ModAssemblyBuilder.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/ModAssemblyBuilder.cs
@@ -1,0 +1,94 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2020 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: TheLacus
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Compilation;
+using UnityEngine;
+
+namespace DaggerfallWorkshop.Game.Utility
+{
+    internal static class ModAssemblyBuilder
+    {
+        /// <summary>
+        /// Compiles C# files using AssemblyBuilder API.
+        /// </summary>
+        /// <param name="assemblyPath">Path to .dll to be created (directory must exist and be writable).</param>
+        /// <param name="scriptPaths">Paths to C# files.</param>
+        /// <returns>Value indicating if operation was succesful.</returns>
+        internal static bool Compile(string assemblyPath, params string[] scriptPaths)
+        {
+            var assemblyBuilder = new AssemblyBuilder(assemblyPath, scriptPaths)
+            {
+                referencesOptions = ReferencesOptions.UseEngineModules,
+                buildTargetGroup = BuildTargetGroup.Standalone,
+                additionalReferences = GetAdditionalReferences()
+            };
+
+            assemblyBuilder.buildFinished += AssemblyBuilder_buildFinished;
+
+            try
+            {
+                if (!assemblyBuilder.Build())
+                {
+                    Debug.LogError($"Failed to start build of assembly {assemblyPath}.");
+                    return false;
+                }
+
+                while (assemblyBuilder.status != AssemblyBuilderStatus.Finished)
+                    System.Threading.Thread.Sleep(10);
+            }
+            finally
+            {
+                assemblyBuilder.buildFinished -= AssemblyBuilder_buildFinished;
+            }
+
+            if (!File.Exists(assemblyPath))
+            {
+                Debug.LogError($"Failed to build {assemblyPath}.");
+                return false;
+            }
+
+            return true;
+        }
+
+        private static string[] GetAdditionalReferences()
+        {
+            var references = new List<string>();
+
+            foreach (Assembly assembly in CompilationPipeline.GetAssemblies(AssembliesType.PlayerWithoutTestAssemblies))
+                references.Add(assembly.outputPath);
+
+            return references.ToArray();
+        }
+
+        private static void AssemblyBuilder_buildFinished(string assemblyPath, CompilerMessage[] compilerMessages)
+        {
+            foreach (CompilerMessage compilerMessage in compilerMessages)
+            {
+                if (compilerMessage.type == CompilerMessageType.Error)
+                {
+                    Debug.LogError(compilerMessage.message);
+                }
+                else
+                {
+                    // Ignore warning for type already defined in 'Assembly-CSharp' where mod source code is compiled in editor.
+                    if (compilerMessage.message.IndexOf("CS0436", StringComparison.Ordinal) != -1)
+                        continue;
+
+                    Debug.LogWarning(compilerMessage.message);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Game/Addons/ModSupport/Editor/ModAssemblyBuilder.cs.meta
+++ b/Assets/Game/Addons/ModSupport/Editor/ModAssemblyBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5df6ac7c52ecb52438bedee3df39ded5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -1000,7 +1000,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                 }
                 catch (Exception ex)
                 {
-                    Debug.LogError(ex.Message);
+                    Debug.LogError($"Failed to seek mod loader on {Title}: {ex.Message}");
+                    CheckMissingReferences(assemblies[i]);
                     continue;
                 }
             }
@@ -1133,6 +1134,21 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             Debug.Log(string.Format("Loaded asset bundle for mod: {0}", Title));
 #endif
             yield return request.assetBundle;
+        }
+
+        private void CheckMissingReferences(Assembly assembly)
+        {
+            var missingReferences = new List<string>();
+
+            Assembly[] loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            foreach (AssemblyName assemblyName in assembly.GetReferencedAssemblies())
+            {
+                if (loadedAssemblies.FirstOrDefault(x => x.GetName().FullName.Equals(assemblyName.FullName)) == null)
+                    missingReferences.Add(assemblyName.FullName);
+            }
+
+            if (missingReferences.Count > 0)
+                Debug.LogError($"{Title} requires the following missing assemblies:\n{string.Join("\n", missingReferences)}.");
         }
 
         #endregion


### PR DESCRIPTION
Add option to Mod Builder to pre-compile C# scripts to a .dll file and add it to asset bundle as a binary asset.