### PR TITLE
Log warning if texture is not readable but needs to be

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -916,8 +916,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     return true;
 
                 // Seek from mods
-                if (ModManager.Instance != null)
-                    return ModManager.Instance.TryGetAsset(name, null, out tex);
+                if (ModManager.Instance && ModManager.Instance.TryGetAsset(name, null, out tex))
+                {
+                    if (!readOnly && !tex.isReadable)
+                        Debug.LogWarning($"Texture {name} is not readable.");
+
+                    return true;
+                }
             }
 
             tex = null;


### PR DESCRIPTION
Read/Write Enabled flag must be set by mod author if texture is to be edited at runtime (for example to cut a button out of window image).

![texture_not_readable](https://user-images.githubusercontent.com/24359151/90338947-82079680-dfed-11ea-939c-693d214cbb8c.png)
