### PR TITLE
More Disease info, can be charged with Breaking and Entering

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Diseases/DiseaseEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Diseases/DiseaseEffect.cs
@@ -238,9 +238,14 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             return diseaseDataSources[(int)diseaseType];
         }
 
-        protected bool IsDiseasePermanent()
+        public bool IsDiseasePermanent()
         {
             return (diseaseData.daysOfSymptomsMin == permanentDiseaseValue);
+        }
+
+        public bool IsDiseaseCompleted()
+        {
+            return (daysOfSymptomsLeft == completedDiseaseValue);
         }
 
         #endregion

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -949,7 +949,8 @@ namespace DaggerfallWorkshop.Game
                 if (Dice100.SuccessRoll(chance))
                 {
                     // Success - player has forced their way into building
-                    playerEntity.CrimeCommitted = PlayerEntity.Crimes.Breaking_And_Entering;
+                    if (Dice100.SuccessRoll(10)) // 10% chance someone saw you breaking in, as with Attempted
+                        playerEntity.CrimeCommitted = PlayerEntity.Crimes.Breaking_And_Entering;
                     playerEntity.TallyCrimeGuildRequirements(true, 1);
                     TransitionInterior(doorOwner, door, true);
                     return true;


### PR DESCRIPTION
Currently, only "Attempted Breaking and Entering" is supported. This allows for the potential upgrade of the crime to full Breaking and Entering when you successfully break into the location. The check for Attempted Breaking and Entering is a Dice100.SuccessRoll(10). I did the same for Breaking and Entering (10% chance "someone saw you" breaking into the location). Guards are currently not being called for Breaking and Entering

Should guards ever be called for Breaking & Entering? I figure if this is implemented, being charged with Breaking and Entering in classic DFU is going to be a fairly edge case (probably: guards got summoned for Attempted B&E, you broke in, went back outside, and the guards arrested you).

Also, made IsDiseasePermanent() public instead of protected and added IsDiseaseCompleted() for modders.