### PR TITLE
Keybind right-click removals

### DIFF
--- a/Assets/Scripts/Game/ControlsConfigManager.cs
+++ b/Assets/Scripts/Game/ControlsConfigManager.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Utility;
 
@@ -201,6 +202,33 @@ namespace DaggerfallWorkshop.Game
         {
             SetKeyBindValues(true);
             SetKeyBindValues(false);
+        }
+
+        public void PromptRemoveKeybindMessage(Button button, Action checkDuplicates)
+        {
+            if (button.Label.Text == KeyCode.None.ToString())
+                return;
+
+            DaggerfallMessageBox removeAssignmentBox = new DaggerfallMessageBox(DaggerfallUI.UIManager, DaggerfallUI.UIManager.TopWindow);
+            removeAssignmentBox.PauseWhileOpen = true;
+
+            removeAssignmentBox.SetText($"Are you sure you want to remove the keybind for {button.Name} ('{button.Label.Text}')?");
+            removeAssignmentBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
+            removeAssignmentBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No, true);
+
+            removeAssignmentBox.OnButtonClick += ((s, messageBoxButton) =>
+            {
+                if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
+                {
+                    button.Label.Text = KeyCode.None.ToString();
+                    var action = (InputManager.Actions)Enum.Parse(typeof(InputManager.Actions), button.Name);
+                    SetUnsavedBinding(action, button.Label.Text);
+                    checkDuplicates();
+                }
+                s.CloseWindow();
+            });
+
+            removeAssignmentBox.Show();
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -206,6 +206,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     controlsPanel.Components.Add(buttonGroup[j]);
                     buttonGroup[j].Name = actions[i];
                     buttonGroup[j].OnMouseClick += KeybindButton_OnMouseClick;
+                    buttonGroup[j].OnRightMouseClick += KeybindButton_OnMouseRightClick;
                     if (i == endPoint - 1)
                     {
                         allKeys.Add(buttonGroup);
@@ -362,6 +363,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Button thisKeybindButton = (Button)sender;
 
             InputManager.Instance.StartCoroutine(WaitForKeyPress(thisKeybindButton, CheckDuplicates, SetWaitingForInput));
+        }
+
+        private void KeybindButton_OnMouseRightClick(BaseScreenComponent sender, Vector2 position)
+        {
+            if (waitingForInput || ((Button)sender).Label.Text == KeyCode.None.ToString())
+                return;
+
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+
+            ControlsConfigManager.Instance.PromptRemoveKeybindMessage((Button)sender, CheckDuplicates);
         }
 
         public static IEnumerator WaitForKeyPress(Button button, System.Action checkDuplicates, System.Action<bool> setWaitingForInput)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -204,6 +204,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             SetBackground(button, keybindButtonBackgroundColor, "advancedControlsKeybindBackgroundColor");
             button.OnMouseClick += KeybindButton_OnMouseClick;
+            button.OnRightMouseClick += KeybindButton_OnMouseRightClick;
 
             buttonGroup.Add(button);
 
@@ -366,6 +367,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Button thisKeybindButton = (Button)sender;
 
             InputManager.Instance.StartCoroutine(WaitForKeyPress(thisKeybindButton));
+        }
+
+        private void KeybindButton_OnMouseRightClick(BaseScreenComponent sender, Vector2 position)
+        {
+            if (waitingForInput || ((Button)sender).Label.Text == KeyCode.None.ToString())
+                return;
+
+            DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+
+            ControlsConfigManager.Instance.PromptRemoveKeybindMessage((Button)sender, CheckDuplicates);
         }
 
         IEnumerator WaitForKeyPress(Button button)


### PR DESCRIPTION
Added ability to right-click a keybind button which prompts if the player if they would like to set it to 'None'. This is useful for secondary keybinds where someone might accidentally bind the wrong button or no longer would like to use it. As of right now, they  would have to find an unused key to bind to it or set it to None in the Keybinds.txt file, but actually having an in-place removal would help with this issue.

One problem I encountered was the fact that DFU always assumed the primary keybinds (`InputManager.actionKeyDict`) to be non-`None` since there wasn't any need for them to be in the first place. This made finding secondary KeyCode equivalents based off of the primary KeyCode a problem if it was set to `None`, since there can always be duplicate `None`s. So I created an `existingKeyDict` that attempts to fill missing KeyCodes in primary binds with the secondary for the `FindKeyboardActions` and `GetKey` methods.