### PR TITLE
Update joystick minimum force and acceleration

### DIFF
--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -35,10 +35,6 @@ namespace DaggerfallWorkshop.Game
         //if the force is greater than this threshold, round it up to 1
         float joystickMovementThreshold = 0.95F;
 
-        //this arbitrary float value seems to be the minimum force that can be given without unnecessarily
-        //triggering FrictionMotor's UnstickHandling() method, which can create jagged movement at lower force
-        const float controllerMinimumAxisFloat = 0.68f;
-
         public Texture2D controllerCursorImage;
 
         Dictionary<int, String> axisKeyCodeStrings = new Dictionary<int, String>();
@@ -1530,9 +1526,9 @@ namespace DaggerfallWorkshop.Game
                 if (jd <= JoystickDeadzone)
                     return;
 
-                float dist = Mathf.Clamp(jd, controllerMinimumAxisFloat, 1.0F);
+                float dist = jd / JoystickMovementThreshold;
 
-                if (MaximizeJoystickMovement || dist > JoystickMovementThreshold)
+                if (MaximizeJoystickMovement || dist > 1.0F)
                     dist = 1.0F;
 
                 if (horiz > 0)


### PR DESCRIPTION
After having unstick handling removed, there no longer needs to be an arbitrary float value in place that prevented it from going off. Additionally, the `JoystickMovementThreshold` (the ceiling value for maximum movement via joystick) is now used to scale with the distance of the joystick. So if the `JoystickMovementThreshold` is 0.5 and the user moved their joystick at 20% distance from the center, their force would be 0.2 / 0.5 = 40%. Compare this method to having 49% distance as 49% force, but 50% distance = 100% force.