### PR TITLE
Preprocessor definiton for separate development persistent path

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -93,7 +93,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// </summary>
         internal string ModDataDirectory
         {
-            get { return Path.Combine(Application.persistentDataPath, Path.Combine("Mods", dataFolder)); }
+            get { return Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, Path.Combine("Mods", dataFolder)); }
         }
 
         /// <summary>

--- a/Assets/Game/Addons/ModSupport/ModSettings/PresetPicker.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/PresetPicker.cs
@@ -411,7 +411,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             Preset preset = settings.Presets[listBox.SelectedIndex];
             string fileName = string.Join("_", preset.Title.Split(Path.GetInvalidFileNameChars())) + ".json";
 
-            string dirPath = ModManager.CombinePaths(Application.persistentDataPath, "Mods", "ExportedPresets", mod.FileName);
+            string dirPath = ModManager.CombinePaths(DaggerfallUnity.Settings.PersistentDataPath, "Mods", "ExportedPresets", mod.FileName);
             string filePath = Path.Combine(dirPath, fileName);
 
             var messageBox = new DaggerfallMessageBox(uiManager, this, true);

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -139,8 +139,8 @@ namespace Wenzil.Console
 
                         string regionJson = SaveLoadManager.Serialize(region.GetType(), region);
                         string fileName = WorldDataReplacement.GetDFRegionReplacementFilename(playerGPS.CurrentRegionIndex);
-                        File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), regionJson);
-                        return "Region data json written to " + Path.Combine(Application.persistentDataPath, fileName);
+                        File.WriteAllText(Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName), regionJson);
+                        return "Region data json written to " + Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName);
                     }
                     return error;
                 }
@@ -169,8 +169,8 @@ namespace Wenzil.Console
 
                         string locJson = SaveLoadManager.Serialize(location.GetType(), location);
                         string fileName = WorldDataReplacement.GetDFLocationReplacementFilename(location.RegionIndex, location.LocationIndex);
-                        File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), locJson);
-                        return "Location data json written to " + Path.Combine(Application.persistentDataPath, fileName);
+                        File.WriteAllText(Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName), locJson);
+                        return "Location data json written to " + Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName);
                     }
                     return error;
                 }
@@ -194,9 +194,9 @@ namespace Wenzil.Console
                     {
                         blockIndex += string.Format("{0}: {1}\n", b, blockBsa.GetRecordName(b));
                     }
-                    string fileName = Path.Combine(Application.persistentDataPath, "BlockIndex.txt");
+                    string fileName = Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, "BlockIndex.txt");
                     File.WriteAllText(fileName, blockIndex);
-                    return "Block index data written to " + Path.Combine(Application.persistentDataPath, fileName);
+                    return "Block index data written to " + Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName);
                 }
                 else
                 {
@@ -213,8 +213,8 @@ namespace Wenzil.Console
                     {
                         string blockJson = SaveLoadManager.Serialize(blockData.GetType(), blockData);
                         string fileName = WorldDataReplacement.GetDFBlockReplacementFilename(blockData.Name);
-                        File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), blockJson);
-                        return "Block data json written to " + Path.Combine(Application.persistentDataPath, fileName);
+                        File.WriteAllText(Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName), blockJson);
+                        return "Block data json written to " + Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName);
                     }
                     return error;
                 }
@@ -244,7 +244,7 @@ namespace Wenzil.Console
                         }
                     }
                     string locJson = SaveLoadManager.Serialize(locBlocks.GetType(), locBlocks);
-                    string fileName = Path.Combine(Application.persistentDataPath, "LocationBlockNames.json");
+                    string fileName = Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, "LocationBlockNames.json");
                     File.WriteAllText(fileName, locJson);
                     return "Location block names json written to " + fileName;
                 }
@@ -260,7 +260,7 @@ namespace Wenzil.Console
                             locIndex += string.Format("{0}, {1}: {2}\n", region, dfLoc.LocationIndex, dfLoc.Name);
                         }
                     }
-                    string fileName = Path.Combine(Application.persistentDataPath, "LocationIndex.txt");
+                    string fileName = Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, "LocationIndex.txt");
                     File.WriteAllText(fileName, locIndex);
                     return "Location index written to " + fileName;
                 }
@@ -304,7 +304,7 @@ namespace Wenzil.Console
                     for (int i = 0; i < args.Length; i++)
                         blocks = blocks + "-" + args[i];
 
-                    string fileName = Path.Combine(Application.persistentDataPath, blocks.Substring(1) + "-locations.json");
+                    string fileName = Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, blocks.Substring(1) + "-locations.json");
                     File.WriteAllText(fileName, locJson);
                     return "Location block names json written to " + fileName;
 
@@ -336,8 +336,8 @@ namespace Wenzil.Console
                         Quality = blockData.RmbBlock.FldHeader.BuildingDataList[recordIndex].Quality,
                     };
                     string buildingJson = SaveLoadManager.Serialize(buildingData.GetType(), buildingData);
-                    File.WriteAllText(Path.Combine(Application.persistentDataPath, fileName), buildingJson);
-                    return "Building data written to " + Path.Combine(Application.persistentDataPath, fileName);
+                    File.WriteAllText(Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName), buildingJson);
+                    return "Building data written to " + Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName);
                 }
                 return error;
             }

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -1569,7 +1569,7 @@ namespace DaggerfallWorkshop.Game
 
         string GetKeyBindsSavePath()
         {
-            return Path.Combine(Application.persistentDataPath, keyBindsFilename);
+            return Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, keyBindsFilename);
         }
 
         bool HasKeyBindsSave()

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -221,7 +221,7 @@ namespace DaggerfallWorkshop.Game.Questing
         /// </summary>
         private static string LogPath
         {
-            get { return Path.Combine(Application.persistentDataPath, questLogFilename); }
+            get { return Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, questLogFilename); }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
+++ b/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
@@ -111,7 +111,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             if (string.IsNullOrEmpty(result) || !Directory.Exists(result))
             {
                 // Default to dataPath
-                result = Path.Combine(Application.persistentDataPath, rootScreenshotsFolder);
+                result = Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, rootScreenshotsFolder);
                 if (!Directory.Exists(result))
                 {
                     // Attempt to create path

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -657,7 +657,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             if (string.IsNullOrEmpty(result) || !Directory.Exists(result))
             {
                 // Default to dataPath
-                result = Path.Combine(Application.persistentDataPath, rootSaveFolder);
+                result = Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, rootSaveFolder);
                 if (!Directory.Exists(result))
                 {
                     // Attempt to create path

--- a/Assets/Scripts/GenerateDiagLog.cs
+++ b/Assets/Scripts/GenerateDiagLog.cs
@@ -304,7 +304,7 @@ namespace DaggerfallWorkshop
             StreamWriter sw = null;
             try
             {
-                string filePath = Path.Combine(Application.persistentDataPath, fileName);
+                string filePath = Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, fileName);
                 fs = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite);
                 sw = new StreamWriter(fs);
                 if (File.Exists(filePath))

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -50,21 +50,22 @@ namespace DaggerfallWorkshop
         IniData defaultIniData = null;
         IniData userIniData = null;
 
-        static string devPersistentPath = null;
+        string persistentPath = null;
 
         public string PersistentDataPath
         {
             get
             {
-#if UNITY_EDITOR && SEPARATE_DEV_PERSISTENT_PATH
-                if (string.IsNullOrEmpty(devPersistentPath))
+                if (string.IsNullOrEmpty(persistentPath))
                 {
-                    devPersistentPath = String.Concat(Application.persistentDataPath, ".devenv");
-                    Directory.CreateDirectory(devPersistentPath);
-                }
-                return devPersistentPath;
+#if UNITY_EDITOR && SEPARATE_DEV_PERSISTENT_PATH
+                    persistentPath = String.Concat(Application.persistentDataPath, ".devenv");
+                    Directory.CreateDirectory(persistentPath);
+#else
+                    persistentPath = Application.persistentDataPath;
 #endif
-                return Application.persistentDataPath; 
+                }
+                return persistentPath;
             }
         }
 

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -9,6 +9,8 @@
 // Notes:
 //
 
+//#define SEPARATE_DEV_PERSISTENT_PATH
+
 using UnityEngine;
 using System;
 using System.Globalization;
@@ -48,9 +50,22 @@ namespace DaggerfallWorkshop
         IniData defaultIniData = null;
         IniData userIniData = null;
 
+        static string devPersistentPath = null;
+
         public string PersistentDataPath
         {
-            get { return Application.persistentDataPath; }
+            get
+            {
+#if UNITY_EDITOR && SEPARATE_DEV_PERSISTENT_PATH
+                if (string.IsNullOrEmpty(devPersistentPath))
+                {
+                    devPersistentPath = String.Concat(Application.persistentDataPath, ".devenv");
+                    Directory.CreateDirectory(devPersistentPath);
+                }
+                return devPersistentPath;
+#endif
+                return Application.persistentDataPath; 
+            }
         }
 
         public SettingsManager()
@@ -476,7 +491,7 @@ namespace DaggerfallWorkshop
 
             // Must have settings.ini in persistent data path
             string message;
-            string userIniPath = Path.Combine(Application.persistentDataPath, settingsIniName);
+            string userIniPath = Path.Combine(PersistentDataPath, settingsIniName);
             if (!File.Exists(userIniPath))
             {
                 // Create file
@@ -502,7 +517,7 @@ namespace DaggerfallWorkshop
             {
                 try
                 {
-                    string path = Path.Combine(Application.persistentDataPath, settingsIniName);
+                    string path = Path.Combine(PersistentDataPath, settingsIniName);
                     if (File.Exists(path))
                     {
                         iniParser.WriteFile(path, userIniData);


### PR DESCRIPTION
Added a commented-out preprocessor definition under `SettingsManager` called `SEPARATE_DEV_PERSISTENT_PATH`, which allows development under the Unity editor to use a separate data directory called "DaggerfallUnity.devenv", which is alongside the default path. This is useful for separating recreational saves and settings from the development side for organization, and to prevent wiping of settings not yet implemented in the stable release.

I grepped and replaced all instances of `Application.persistentDataPath` with `DaggerfallUnity.Settings.PersistentDataPath`.