### PR TITLE
Set the race of static NPCs

### DIFF
--- a/Assets/Scripts/Game/Questing/QuestMCP.cs
+++ b/Assets/Scripts/Game/Questing/QuestMCP.cs
@@ -156,8 +156,14 @@ namespace DaggerfallWorkshop.Game.Questing
                 Symbol[] questors = parent.GetQuestors();
                 if (questors.Length > 0)
                     race = parent.GetPerson(questors[0]).Race;
+                else if (QuestMachine.Instance.LastNPCClicked != null)
+                {
+                    // %oth is used in some of the main quests before the questor is actually set. In this
+                    // case try to use the data from the last clicked NPC, which should be the questor.
+                    race = QuestMachine.Instance.LastNPCClicked.Data.race;
+                }
 
-                // Fallback to race of current region 
+                // Fallback to race of current region
                 if (race == Races.None)
                     race = GameManager.Instance.PlayerGPS.GetRaceOfCurrentRegion();
 

--- a/Assets/Scripts/Game/StaticNPC.cs
+++ b/Assets/Scripts/Game/StaticNPC.cs
@@ -85,6 +85,7 @@ namespace DaggerfallWorkshop.Game
             public int factionID;
             public int nameSeed;
             public Genders gender;
+            public Races race;
             public Context context;
 
             // Derived at runtime
@@ -183,6 +184,7 @@ namespace DaggerfallWorkshop.Game
             data.billboardRecordIndex = record;
             data.nameSeed = (int)position ^ buildingKey + GameManager.Instance.PlayerGPS.CurrentLocation.LocationIndex;
             data.gender = ((flags & 32) == 32) ? Genders.Female : Genders.Male;
+            data.race = GetRaceFromFaction(factionId);
             data.buildingKey = buildingKey;
         }
 
@@ -206,6 +208,7 @@ namespace DaggerfallWorkshop.Game
             npcData.factionID = factionID;
             npcData.nameSeed = (nameSeed == -1) ? npcData.hash : nameSeed;
             npcData.gender = gender;
+            npcData.race = GetRaceFromFaction(factionID);
             npcData.context = Context.Custom;
         }
 
@@ -305,6 +308,25 @@ namespace DaggerfallWorkshop.Game
             bool isChildrenFaction = data.factionID == childrenFactionID;
 
             return isChildNPCTexture || isChildrenFaction;
+        }
+
+        /// <summary>
+        /// Return the race corresponding to a given faction ID.
+        /// </summary>
+        /// <param name="factionId"></param>
+        /// <returns>The faction race if available, otherwise the race of the current region.</returns>
+        public static Races GetRaceFromFaction(int factionId)
+        {
+            if (factionId != 0)
+            {
+                FactionFile.FactionData fd;
+                GameManager.Instance.PlayerEntity.FactionData.GetFactionData(factionId, out fd);
+                Races race = RaceTemplate.GetRaceFromFactionRace((FactionFile.FactionRaces)fd.race);
+                if (race != Races.None)
+                    return race;
+            }
+
+            return GameManager.Instance.PlayerGPS.GetRaceOfCurrentRegion();
         }
 
         #endregion

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -745,9 +745,7 @@ namespace DaggerfallWorkshop.Game
             npcData.socialGroup = factionData.sgroup < 5 ? (FactionFile.SocialGroups)factionData.sgroup : FactionFile.SocialGroups.Merchants;
             npcData.guildGroup = (FactionFile.GuildGroups)factionData.ggroup;
             npcData.factionData = factionData;
-            npcData.race = RaceTemplate.GetRaceFromFactionRace((FactionFile.FactionRaces)factionData.race);
-            if (npcData.race == Races.None)
-                npcData.race = GameManager.Instance.PlayerGPS.GetRaceOfCurrentRegion();
+            npcData.race = targetNPC.Data.race;
             npcData.chanceKnowsSomethingAboutWhereIs = DefaultChanceKnowsSomethingAboutWhereIs + FormulaHelper.BonusChanceToKnowWhereIs();
             npcData.chanceKnowsSomethingAboutQuest = DefaultChanceKnowsSomethingAboutQuest;
             npcData.chanceKnowsSomethingAboutOrganizations = DefaultChanceKnowsSomethingAboutOrganizationsStaticNPC;


### PR DESCRIPTION
Static NPC race is now stored in its own dedicated field. If not available from faction data, fallback to race of current region.

This also fixes an issue reported by @petchema in #1902 where Aubki-i was using %oth in a quest before being assigned as questor. The previous workaround was a fallback to race of current region. Now, Aubk-i will properly use the Redguard pool of oathes.