### PR TITLE
Don't show holiday text message unless HUD is top window

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -319,7 +319,7 @@ namespace DaggerfallWorkshop.Game
             // Count down holiday text display
             if (holidayTextTimer > 0)
                 holidayTextTimer -= Time.deltaTime;
-            if (holidayTextTimer <= 0 && holidayTextPrimed)
+            if (holidayTextTimer <= 0 && holidayTextPrimed && GameManager.Instance.IsPlayerOnHUD)
             {
                 holidayTextPrimed = false;
                 ShowHolidayText();


### PR DESCRIPTION
It can mess with non-modal UI's like those used by Tedious Travel etc.

I think this works well, but I would be interested in other devs opinions before this one gets merged. Motivated by holiday message boxes messing up the travel UI of my upcoming Travel Options mod when they pop up at the wrong time.