### PR TITLE
Replace mispelled "sorceror" with "sorcerer" in quests

### DIFF
--- a/Assets/StreamingAssets/Quests/L0B30Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B30Y03.txt
@@ -46,7 +46,7 @@ AcceptQuest:  [1002]
 <ce>                               and foot.
 
 QuestFail:  [1003]
-<ce>                       The sorceror still lives,
+<ce>                       The sorcerer still lives,
 <ce>                          %pcf. Do not fail in
 <ce>                            this assignment.
 
@@ -63,7 +63,7 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 Things are quiet at the Mages Guild. Makes me think of a sleeping dragon.
 <--->
-Sometime somebody's gonna do something about that wicked sorceror.
+Sometime somebody's gonna do something about that wicked sorcerer.
 
 RumorsPostfailure:  [1006]
 <ce>                 Well, the mage left the Mages Guild,

--- a/Assets/StreamingAssets/Quests/N0B20Y05.txt
+++ b/Assets/StreamingAssets/Quests/N0B20Y05.txt
@@ -68,7 +68,7 @@ The Mages Guild has sent someone to deal with that mad wizard in ___mondung_.
 Everyone's just holding their breath, waiting for that wizard's next move.
 
 RumorsPostfailure:  [1006]
-Not even the Mages Guild could do anything about that crazed sorceror.
+Not even the Mages Guild could do anything about that crazed sorcerer.
 <--->
 No one knows where that _wizard_ is, but nowhere's safe until %g1's gone.
 

--- a/Assets/StreamingAssets/Quests/P0B00L06.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L06.txt
@@ -135,11 +135,11 @@ Message:  1015
 <ce>                 right one for this, being sufficiently
 <ce>                 mettlesome, thewy, in short, puissant
 <ce>                            to aid _mage_, a
-<ce>                  sorceror who fears that %g3 research
+<ce>                  sorcerer who fears that %g3 research
 <ce>                  has attracted the, ah, inquisitorial
 <ce>                attention of a local tribe of vampires.
 <ce>                  Too much work had made the poor old
-<ce>                 sorceror, well, oversensitive. If you
+<ce>                 sorcerer, well, oversensitive. If you
 <ce>                   would just pop on over to %g3 lab,
 <ce>                       ___mondung_, and get these
 <ce>                 precious notes, I would be very, very,
@@ -206,7 +206,7 @@ Message:  1020
  about increasing funding. Going nowhere.
 
 Message:  1021
-%qdt: A sorceror named
+%qdt: A sorcerer named
  _mage_ has come close
  to major discoveries about %vam
  and _vamp_ has sent me

--- a/Assets/StreamingAssets/Quests/R0C10Y04.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y04.txt
@@ -18,7 +18,7 @@ QuestorOffer:  [1000]
 <ce>                 they may be right. I am in need of an
 <ce>                 assassin with enough time to travel to
 <ce>                      ___mondung_ and destroy the
-<ce>               necromantic sorceror there. I am prepared
+<ce>               necromantic sorcerer there. I am prepared
 <ce>             to pay _reward_ gold pieces for this service.
 <ce>                          Are you interested?
 
@@ -33,7 +33,7 @@ AcceptQuest:  [1002]
 <ce>                     luck, %pcf, and show no mercy.
 
 QuestFail:  [1003]
-<ce>           I don't want to see you again until that sorceror
+<ce>           I don't want to see you again until that sorcerer
 <ce>                                is dead.
 
 QuestComplete:  [1004]
@@ -45,17 +45,17 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 You can almost feel the malevolent magicka building.
 <--->
-Some sorceror has vowed to reduce _questgiver_'s land to rubble.
+Some sorcerer has vowed to reduce _questgiver_'s land to rubble.
 
 RumorsPostfailure:  [1006]
-That sorceror in ___mondung_ has apparently moved on.
+That sorcerer in ___mondung_ has apparently moved on.
 <--->
-Apparently some adventurer spooked the sorceror out of ___mondung_.
+Apparently some adventurer spooked the sorcerer out of ___mondung_.
 
 RumorsPostsuccess:  [1007]
 The Mad Wizard of ___mondung_ was apparently slain by a brave %ra.
 <--->
-Had that sorceror survived, _questgiver_ would have been in deep trouble.
+Had that sorcerer survived, _questgiver_ would have been in deep trouble.
 
 QuestorPostsuccess:  [1008]
 Ah, the slayer of the mad wizard is back. How are you, my friend?
@@ -74,10 +74,10 @@ QuestorPostfailure:  [1009]
 
 Message:  1011
 <ce>              _questgiver_ is a noble with a real hatred
-<ce>                   for a sorceror called _fakename_.
+<ce>                   for a sorcerer called _fakename_.
                                      <--->
 <ce>             _questgiver_ is a noble who has been plagued
-<ce>                    by a sorceror called _fakename_.
+<ce>                    by a sorcerer called _fakename_.
 
 Message:  1012
 _fakename_ the wizard is dead.

--- a/Assets/StreamingAssets/Quests/R0C4XY23.txt
+++ b/Assets/StreamingAssets/Quests/R0C4XY23.txt
@@ -106,7 +106,7 @@ _oblivion_ is a powerful mage living in ___oblivion_.
 _oblivion_ of ___oblivion_?  %g's in league with the Daedra, I hear.
 
 Message:  1014
-_oblivion_ is some kind of sorceror, I think.  Try __oblivion_ in ___oblivion_.
+_oblivion_ is some kind of sorcerer, I think.  Try __oblivion_ in ___oblivion_.
 <--->
 <ce>  A dangerous meddler in daedric affairs.  You'll find _oblivion_ in
 <ce>                     ___oblivion_, at __oblivion_.


### PR DESCRIPTION
Fixes done to quest texts only, to avoid any potentially breaking change.