### PR TITLE
Ignore secondary binding equivalents for GetMouse methods and HotkeySequences

### DIFF
--- a/Assets/Scripts/Game/HotkeySequence.cs
+++ b/Assets/Scripts/Game/HotkeySequence.cs
@@ -153,17 +153,17 @@ namespace DaggerfallWorkshop.Game
 
         public bool IsDownWith(KeyModifiers pressedModifiers)
         {
-            return InputManager.Instance.GetKeyDown(keyCode) && CheckSetModifiers(pressedModifiers, modifiers);
+            return InputManager.Instance.GetSingleKeyDown(keyCode) && CheckSetModifiers(pressedModifiers, modifiers);
         }
 
         public bool IsUpWith(KeyModifiers pressedModifiers)
         {
-            return InputManager.Instance.GetKeyUp(keyCode) && CheckSetModifiers(pressedModifiers, modifiers);
+            return InputManager.Instance.GetSingleKeyUp(keyCode) && CheckSetModifiers(pressedModifiers, modifiers);
         }
 
         public bool IsPressedWith(KeyModifiers pressedModifiers)
         {
-            return InputManager.Instance.GetKey(keyCode) && CheckSetModifiers(pressedModifiers, modifiers);
+            return InputManager.Instance.GetSingleKey(keyCode) && CheckSetModifiers(pressedModifiers, modifiers);
         }
 
         // Simple method variants if you don't mind building a temporary KeyModifiers

--- a/Assets/Scripts/Game/HotkeySequence.cs
+++ b/Assets/Scripts/Game/HotkeySequence.cs
@@ -153,17 +153,17 @@ namespace DaggerfallWorkshop.Game
 
         public bool IsDownWith(KeyModifiers pressedModifiers)
         {
-            return InputManager.Instance.GetSingleKeyDown(keyCode) && CheckSetModifiers(pressedModifiers, modifiers);
+            return InputManager.Instance.GetKeyDown(keyCode, false) && CheckSetModifiers(pressedModifiers, modifiers);
         }
 
         public bool IsUpWith(KeyModifiers pressedModifiers)
         {
-            return InputManager.Instance.GetSingleKeyUp(keyCode) && CheckSetModifiers(pressedModifiers, modifiers);
+            return InputManager.Instance.GetKeyUp(keyCode, false) && CheckSetModifiers(pressedModifiers, modifiers);
         }
 
         public bool IsPressedWith(KeyModifiers pressedModifiers)
         {
-            return InputManager.Instance.GetSingleKey(keyCode) && CheckSetModifiers(pressedModifiers, modifiers);
+            return InputManager.Instance.GetKey(keyCode, false) && CheckSetModifiers(pressedModifiers, modifiers);
         }
 
         // Simple method variants if you don't mind building a temporary KeyModifiers

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -990,43 +990,19 @@ namespace DaggerfallWorkshop.Game
             return Input.GetMouseButton(button) || (EnableController && GetSingleKey(joystickUICache[button]));
         }
 
-        public bool GetKey(KeyCode key)
+        public bool GetKey(KeyCode key, bool useSecondary = true)
         {
-            return GetSingleKey(key) || GetSingleKey(GetSecondaryBinding(key));
+            return GetSingleKey(key) || (useSecondary && GetSingleKey(GetSecondaryBinding(key)));
         }
 
-        public bool GetKeyDown(KeyCode key)
+        public bool GetKeyDown(KeyCode key, bool useSecondary = true)
         {
-            return GetSingleKeyDown(key) || GetSingleKeyDown(GetSecondaryBinding(key));
+            return GetSingleKeyDown(key) || (useSecondary && GetSingleKeyDown(GetSecondaryBinding(key)));
         }
 
-        public bool GetKeyUp(KeyCode key)
+        public bool GetKeyUp(KeyCode key, bool useSecondary = true)
         {
-            return GetSingleKeyUp(key) || GetSingleKeyUp(GetSecondaryBinding(key));
-        }
-
-        public bool GetSingleKey(KeyCode key)
-        {
-            KeyCode conv = ConvertJoystickButtonKeyCode(key);
-            var k = (((int)conv) < startingAxisKeyCode && Input.GetKey(conv)) || GetAxisKey((int)conv);
-            if (k)
-                LastKeyDown = conv;
-            return k;
-        }
-
-        public bool GetSingleKeyDown(KeyCode key)
-        {
-            KeyCode conv = ConvertJoystickButtonKeyCode(key);
-            var kd = (((int)conv) < startingAxisKeyCode && Input.GetKeyDown(conv)) || GetAxisKeyDown((int)conv);
-            if (kd)
-                LastKeyDown = conv;
-            return kd;
-        }
-
-        public bool GetSingleKeyUp(KeyCode key)
-        {
-            KeyCode conv = ConvertJoystickButtonKeyCode(key);
-            return (((int)conv) < startingAxisKeyCode && Input.GetKeyUp(conv)) || GetAxisKeyUp((int)conv);
+            return GetSingleKeyUp(key) || (useSecondary && GetSingleKeyUp(GetSecondaryBinding(key)));
         }
 
         public bool AnyKeyDown
@@ -1332,6 +1308,30 @@ namespace DaggerfallWorkshop.Game
             keyCodeList = list;
 
             return keyCodeList;
+        }
+
+        bool GetSingleKey(KeyCode key)
+        {
+            KeyCode conv = ConvertJoystickButtonKeyCode(key);
+            var k = (((int)conv) < startingAxisKeyCode && Input.GetKey(conv)) || GetAxisKey((int)conv);
+            if (k)
+                LastKeyDown = conv;
+            return k;
+        }
+
+        bool GetSingleKeyDown(KeyCode key)
+        {
+            KeyCode conv = ConvertJoystickButtonKeyCode(key);
+            var kd = (((int)conv) < startingAxisKeyCode && Input.GetKeyDown(conv)) || GetAxisKeyDown((int)conv);
+            if (kd)
+                LastKeyDown = conv;
+            return kd;
+        }
+
+        bool GetSingleKeyUp(KeyCode key)
+        {
+            KeyCode conv = ConvertJoystickButtonKeyCode(key);
+            return (((int)conv) < startingAxisKeyCode && Input.GetKeyUp(conv)) || GetAxisKeyUp((int)conv);
         }
 
         //Converts all joystick KeyCodes to be controller-agnostic (e.g. "Joystick3Button0" to "JoystickButton0")

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -977,17 +977,17 @@ namespace DaggerfallWorkshop.Game
 
         public bool GetMouseButtonDown(int button)
         {
-            return Input.GetMouseButtonDown(button) || (EnableController && GetKeyDown(joystickUICache[button]));
+            return Input.GetMouseButtonDown(button) || (EnableController && GetSingleKeyDown(joystickUICache[button]));
         }
 
         public bool GetMouseButtonUp(int button)
         {
-            return Input.GetMouseButtonUp(button) || (EnableController && GetKeyUp(joystickUICache[button]));
+            return Input.GetMouseButtonUp(button) || (EnableController && GetSingleKeyUp(joystickUICache[button]));
         }
 
         public bool GetMouseButton(int button)
         {
-            return Input.GetMouseButton(button) || (EnableController && GetKey(joystickUICache[button]));
+            return Input.GetMouseButton(button) || (EnableController && GetSingleKey(joystickUICache[button]));
         }
 
         public bool GetKey(KeyCode key)
@@ -1003,6 +1003,30 @@ namespace DaggerfallWorkshop.Game
         public bool GetKeyUp(KeyCode key)
         {
             return GetSingleKeyUp(key) || GetSingleKeyUp(GetSecondaryBinding(key));
+        }
+
+        public bool GetSingleKey(KeyCode key)
+        {
+            KeyCode conv = ConvertJoystickButtonKeyCode(key);
+            var k = (((int)conv) < startingAxisKeyCode && Input.GetKey(conv)) || GetAxisKey((int)conv);
+            if (k)
+                LastKeyDown = conv;
+            return k;
+        }
+
+        public bool GetSingleKeyDown(KeyCode key)
+        {
+            KeyCode conv = ConvertJoystickButtonKeyCode(key);
+            var kd = (((int)conv) < startingAxisKeyCode && Input.GetKeyDown(conv)) || GetAxisKeyDown((int)conv);
+            if (kd)
+                LastKeyDown = conv;
+            return kd;
+        }
+
+        public bool GetSingleKeyUp(KeyCode key)
+        {
+            KeyCode conv = ConvertJoystickButtonKeyCode(key);
+            return (((int)conv) < startingAxisKeyCode && Input.GetKeyUp(conv)) || GetAxisKeyUp((int)conv);
         }
 
         public bool AnyKeyDown
@@ -1308,30 +1332,6 @@ namespace DaggerfallWorkshop.Game
             keyCodeList = list;
 
             return keyCodeList;
-        }
-
-        bool GetSingleKey(KeyCode key)
-        {
-            KeyCode conv = ConvertJoystickButtonKeyCode(key);
-            var k = (((int)conv) < startingAxisKeyCode && Input.GetKey(conv)) || GetAxisKey((int)conv);
-            if (k)
-                LastKeyDown = conv;
-            return k;
-        }
-
-        bool GetSingleKeyDown(KeyCode key)
-        {
-            KeyCode conv = ConvertJoystickButtonKeyCode(key);
-            var kd = (((int)conv) < startingAxisKeyCode && Input.GetKeyDown(conv)) || GetAxisKeyDown((int)conv);
-            if (kd)
-                LastKeyDown = conv;
-            return kd;
-        }
-
-        bool GetSingleKeyUp(KeyCode key)
-        {
-            KeyCode conv = ConvertJoystickButtonKeyCode(key);
-            return (((int)conv) < startingAxisKeyCode && Input.GetKeyUp(conv)) || GetAxisKeyUp((int)conv);
         }
 
         //Converts all joystick KeyCodes to be controller-agnostic (e.g. "Joystick3Button0" to "JoystickButton0")


### PR DESCRIPTION
Small oversight when designing secondary keybinds allowed `GetMouse` methods and `HotkeySequences` to look for the secondary equivalents of a specific key when it wasn't supposed to. Created a default parameter for GetKey methods to look for the secondary by default, but set them to false instead for the `HotkeySequence` methods, and used the `GetSingleKey` methods for the `GetMouse` methods.