### PR TITLE
(Regression fix) Allow some hotkey sequences to look for secondary bindings

### DIFF
--- a/Assets/Scripts/Game/HotkeySequence.cs
+++ b/Assets/Scripts/Game/HotkeySequence.cs
@@ -28,12 +28,15 @@ namespace DaggerfallWorkshop.Game
         private readonly KeyCode keyCode;
         private readonly KeyModifiers modifiers;
 
+        private readonly bool useSecondary;
+
         public static HotkeySequence None = new HotkeySequence(KeyCode.None, KeyModifiers.None);
 
-        public HotkeySequence(KeyCode keyCode, KeyModifiers modifiers)
+        public HotkeySequence(KeyCode keyCode, KeyModifiers modifiers, bool useSecondary = false)
         {
             this.keyCode = keyCode;
             this.modifiers = modifiers;
+            this.useSecondary = useSecondary;
             // Add inferred virtuals
             if ((modifiers & (KeyModifiers.LeftCtrl | KeyModifiers.RightCtrl)) != 0)
                 this.modifiers |= KeyModifiers.Ctrl;
@@ -153,17 +156,17 @@ namespace DaggerfallWorkshop.Game
 
         public bool IsDownWith(KeyModifiers pressedModifiers)
         {
-            return InputManager.Instance.GetKeyDown(keyCode, false) && CheckSetModifiers(pressedModifiers, modifiers);
+            return InputManager.Instance.GetKeyDown(keyCode, useSecondary) && CheckSetModifiers(pressedModifiers, modifiers);
         }
 
         public bool IsUpWith(KeyModifiers pressedModifiers)
         {
-            return InputManager.Instance.GetKeyUp(keyCode, false) && CheckSetModifiers(pressedModifiers, modifiers);
+            return InputManager.Instance.GetKeyUp(keyCode, useSecondary) && CheckSetModifiers(pressedModifiers, modifiers);
         }
 
         public bool IsPressedWith(KeyModifiers pressedModifiers)
         {
-            return InputManager.Instance.GetKey(keyCode, false) && CheckSetModifiers(pressedModifiers, modifiers);
+            return InputManager.Instance.GetKey(keyCode, useSecondary) && CheckSetModifiers(pressedModifiers, modifiers);
         }
 
         // Simple method variants if you don't mind building a temporary KeyModifiers

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
@@ -530,7 +530,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 automapBinding = InputManager.Instance.GetBinding(InputManager.Actions.AutoMap);
 
                 // Store toggle closed binding for this window
-                HotkeySequence_toggleClose = new HotkeySequence(automapBinding, HotkeySequence.KeyModifiers.None);
+                HotkeySequence_toggleClose = new HotkeySequence(automapBinding, HotkeySequence.KeyModifiers.None, true);
                 // update hotkey sequences taking current toggleClosedBinding into account
                 SetupHotkeySequences();
                 // update button tool tip texts - since hotkeys changed

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -470,7 +470,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 automapBinding = InputManager.Instance.GetBinding(InputManager.Actions.AutoMap);
 
                 // Store toggle closed binding for this window
-                HotkeySequence_toggleClose = new HotkeySequence(automapBinding, HotkeySequence.KeyModifiers.None);
+                HotkeySequence_toggleClose = new HotkeySequence(automapBinding, HotkeySequence.KeyModifiers.None, true);
                 // update hotkey sequences taking current toggleClosedBinding into account
                 SetupHotkeySequences();
                 // update button tool tip texts - since hotkeys changed


### PR DESCRIPTION
The `toggle_close` hotkey sequences under the Automap windows must look for the secondary bindings so that way the menus can be toggled off with either button. Otherwise, by default `HotkeySequence`s will not.