### PR TITLE
Improved keybind label text and tooltips

### DIFF
--- a/Assets/Scripts/Game/ControlsConfigManager.cs
+++ b/Assets/Scripts/Game/ControlsConfigManager.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
@@ -52,11 +53,15 @@ namespace DaggerfallWorkshop.Game
 
         #region Public Properties
 
+        public static string ElongatedButtonText { get => "..."; }
+
         public bool UsingPrimary { get; set; } = true;
 
         #endregion
 
         #region Private Properties
+
+        private int maxButtonTextLength { get => DaggerfallUnity.Settings.SDFFontRendering ? 16 : 10; }
 
         private Dictionary<InputManager.Actions, string> CurrentUnsavedKeybindDict
         {
@@ -124,6 +129,15 @@ namespace DaggerfallWorkshop.Game
             return null;
         }
 
+        public KeyCode GetUnsavedBindingKeyCode(InputManager.Actions action, UnaryBindings binding = UnaryBindings.Current)
+        {
+            var str = GetUnsavedBinding(action, binding);
+            if (!string.IsNullOrEmpty(str))
+                return InputManager.Instance.ParseKeyCodeString(str);
+
+            return KeyCode.None;
+        }
+
         public void SetUnsavedBinding(InputManager.Actions action, string keyCodeString, UnaryBindings binding = UnaryBindings.Current)
         {
             GetUnsavedBindingDictionary(binding)[action] = keyCodeString;
@@ -163,7 +177,11 @@ namespace DaggerfallWorkshop.Game
 
             foreach (Button keybindButton in totalButtons)
             {
-                if (dupes.Contains(keybindButton.Label.Text))
+                // Assumption: button.Name is the action.ToString()
+                var action = (InputManager.Actions)Enum.Parse(typeof(InputManager.Actions), keybindButton.Name);
+                var binding = CurrentUnsavedKeybindDict[action];
+
+                if (dupes.Contains(binding))
                     keybindButton.Label.TextColor = internalDupeColor;
                 else
                     keybindButton.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
@@ -178,7 +196,11 @@ namespace DaggerfallWorkshop.Game
 
             foreach (Button keybindButton in totalButtons)
             {
-                if (dupes.Contains(keybindButton.Label.Text) && keybindButton.Label.TextColor != internalDupeColor)
+                // Assumption: button.Name is the action.ToString()
+                var action = (InputManager.Actions)Enum.Parse(typeof(InputManager.Actions), keybindButton.Name);
+                var binding = CurrentUnsavedKeybindDict[action];
+
+                if (dupes.Contains(binding) && keybindButton.Label.TextColor != internalDupeColor)
                     keybindButton.Label.TextColor = crossDupeColor;
             }
 
@@ -230,6 +252,208 @@ namespace DaggerfallWorkshop.Game
             });
 
             removeAssignmentBox.Show();
+        }
+
+        public string GetButtonText(KeyCode key, bool fullString = false)
+        {
+
+            //Daggerfall DOS-inspired, to an extent
+            if (!DaggerfallUnity.Settings.SDFFontRendering)
+            {
+                switch(key)
+                {
+                    case KeyCode.LeftAlt:
+                        return "LALT";
+                    case KeyCode.RightAlt:
+                        return "RALT";
+                    case KeyCode.LeftControl:
+                        return "LCTRL";
+                    case KeyCode.RightControl:
+                        return "RCTRL";
+                    case KeyCode.LeftShift:
+                        return "LSHIFT";
+                    case KeyCode.RightShift:
+                        return "RSHIFT";
+                    case KeyCode.PageUp:
+                        return "PG UP";
+                    case KeyCode.PageDown:
+                        return "PG DN";
+                    case KeyCode.Insert:
+                        return "INS";
+                    case KeyCode.Delete:
+                        return "DEL";
+                    case KeyCode.Backspace:
+                        return "BCKSPC";
+                    case KeyCode.CapsLock:
+                        return "CAPS";
+
+                    case KeyCode.Alpha0:
+                        return "A0";
+                    case KeyCode.Alpha1:
+                        return "A1";
+                    case KeyCode.Alpha2:
+                        return "A2";
+                    case KeyCode.Alpha3:
+                        return "A3";
+                    case KeyCode.Alpha4:
+                        return "A4";
+                    case KeyCode.Alpha5:
+                        return "A5";
+                    case KeyCode.Alpha6:
+                        return "A6";
+                    case KeyCode.Alpha7:
+                        return "A7";
+                    case KeyCode.Alpha8:
+                        return "A8";
+                    case KeyCode.Alpha9:
+                        return "A9";
+
+                    case KeyCode.Keypad0:
+                        return "KPAD0";
+                    case KeyCode.Keypad1:
+                        return "KPAD1";
+                    case KeyCode.Keypad2:
+                        return "KPAD2";
+                    case KeyCode.Keypad3:
+                        return "KPAD3";
+                    case KeyCode.Keypad4:
+                        return "KPAD4";
+                    case KeyCode.Keypad5:
+                        return "KPAD5";
+                    case KeyCode.Keypad6:
+                        return "KPAD6";
+                    case KeyCode.Keypad7:
+                        return "KPAD7";
+                    case KeyCode.Keypad8:
+                        return "KPAD8";
+                    case KeyCode.Keypad9:
+                        return "KPAD9";
+                    case KeyCode.KeypadPeriod:
+                        return "KPAD.";
+                    case KeyCode.KeypadDivide:
+                        return "KPAD/";
+                    case KeyCode.KeypadMultiply:
+                        return "KPAD*";
+                    case KeyCode.KeypadMinus:
+                        return "KPAD-";
+                    case KeyCode.KeypadPlus:
+                        return "KPAD+";
+                    case KeyCode.KeypadEquals:
+                        return "KPAD=";
+                    case KeyCode.KeypadEnter:
+                        return "KPD ENTR";
+                }
+            }
+
+            string text = null;
+
+            switch(key)
+            {
+                case KeyCode.BackQuote:
+                    text = "`";
+                    break;
+                case KeyCode.Minus:
+                    text = "-";
+                    break;
+                case KeyCode.Equals:
+                    text = "=";
+                    break;
+                case KeyCode.Backslash:
+                    text = "\\";
+                    break;
+                case KeyCode.LeftBracket:
+                    text = "[";
+                    break;
+                case KeyCode.RightBracket:
+                    text = "]";
+                    break;
+                case KeyCode.Semicolon:
+                    text = ";";
+                    break;
+                case KeyCode.Quote:
+                    text = "'";
+                    break;
+                case KeyCode.Comma:
+                    text = ",";
+                    break;
+                case KeyCode.Period:
+                    text = ".";
+                    break;
+                case KeyCode.Slash:
+                    text = "/";
+                    break;
+                case KeyCode.KeypadPeriod:
+                    text = "Keypad.";
+                    break;
+                case KeyCode.KeypadDivide:
+                    text = "Keypad/";
+                    break;
+                case KeyCode.KeypadMultiply:
+                    text = "Keypad*";
+                    break;
+                case KeyCode.KeypadMinus:
+                    text = "Keypad-";
+                    break;
+                case KeyCode.KeypadPlus:
+                    text = "Keypad+";
+                    break;
+                case KeyCode.KeypadEquals:
+                    text = "Keypad=";
+                    break;
+                case KeyCode.UpArrow:
+                    text = "Up";
+                    break;
+                case KeyCode.DownArrow:
+                    text = "Down";
+                    break;
+                case KeyCode.LeftArrow:
+                    text = "Left";
+                    break;
+                case KeyCode.RightArrow:
+                    text = "Right";
+                    break;
+                case KeyCode.LeftAlt:
+                    text = "L Alt";
+                    break;
+                case KeyCode.RightAlt:
+                    text = "R Alt";
+                    break;
+                case KeyCode.LeftControl:
+                    text = "L Ctrl";
+                    break;
+                case KeyCode.RightControl:
+                    text = "R Ctrl";
+                    break;
+                case KeyCode.LeftShift:
+                    text = "L Shift";
+                    break;
+                case KeyCode.RightShift:
+                    text = "R Shift";
+                    break;
+                case KeyCode.Return:
+                    text = "Enter";
+                    break;
+            }
+
+            if ((int)key >= (int)KeyCode.JoystickButton0 && (int)key <= (int)KeyCode.JoystickButton19)
+            {
+                text = "Joy B" + (((int)key - 10) % 20);
+            }
+            else if ((int)key >= InputManager.startingAxisKeyCode)
+            {
+                text = "Joy" + (((int)key % InputManager.startingAxisKeyCode) / 2 + 1) + " B" + ((int)key % 2);
+            }
+            else if (string.IsNullOrEmpty(text))
+            {
+                var str = InputManager.Instance.GetKeyString((KeyCode)key);
+                if (str.Length <= maxButtonTextLength || fullString)
+                    //Split camel/pascal case by spaces
+                    text = Regex.Replace(str, "(?<=[a-z])([A-Z])", " $1", RegexOptions.Compiled).Trim();
+                else
+                    text = ElongatedButtonText;
+            }
+
+            return DaggerfallUnity.Settings.SDFFontRendering ? text : text.ToUpper();
         }
 
         #endregion

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -30,7 +30,7 @@ namespace DaggerfallWorkshop.Game
 
         //there are only 16 recognized axes
         const int numAxes = 16;
-        const int startingAxisKeyCode = 5000;
+        public const int startingAxisKeyCode = 5000;
 
         //if the force is greater than this threshold, round it up to 1
         float joystickMovementThreshold = 0.95F;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -213,8 +213,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     }
                 }
 
-                buttonGroup[j].Label.Text = ControlsConfigManager.Instance.GetUnsavedBinding(key);
+                var code = ControlsConfigManager.Instance.GetUnsavedBindingKeyCode(key);
+                buttonGroup[j].Label.Text = ControlsConfigManager.Instance.GetButtonText(code);
                 buttonGroup[j].Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
+
+                buttonGroup[j].ToolTip = defaultToolTip;
+                buttonGroup[j].SuppressToolTip = buttonGroup[j].Label.Text != ControlsConfigManager.ElongatedButtonText;
+                buttonGroup[j].ToolTipText = ControlsConfigManager.Instance.GetButtonText(code, true);
             }
         }
 
@@ -395,11 +400,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 if(InputManager.Instance.ReservedKeys.FirstOrDefault(x => x == code) == KeyCode.None)
                 {
-                    button.Label.Text = InputManager.Instance.GetKeyString(code);
+                    button.Label.Text = ControlsConfigManager.Instance.GetButtonText(code);
+                    button.SuppressToolTip = button.Label.Text != ControlsConfigManager.ElongatedButtonText;
+                    button.ToolTipText = ControlsConfigManager.Instance.GetButtonText(code, true);
 
                     var action = (InputManager.Actions)Enum.Parse(typeof(InputManager.Actions), button.Name);
 
-                    ControlsConfigManager.Instance.SetUnsavedBinding(action, button.Label.Text);
+                    ControlsConfigManager.Instance.SetUnsavedBinding(action, InputManager.Instance.GetKeyString(code));
                     checkDuplicates();
                 }
                 else

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
@@ -241,7 +241,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         //for "reset defaults" overload
         private void SetupKeybindButton(Button button, string action)
         {
-            button.Label.Text = UnsavedKeybindDict[action];
+            if (action == leftClickString || action == rightClickString)
+            {
+                var code = InputManager.Instance.ParseKeyCodeString(UnsavedKeybindDict[action]);
+                button.Label.Text = ControlsConfigManager.Instance.GetButtonText(code);
+
+                button.ToolTip = defaultToolTip;
+                button.SuppressToolTip = button.Label.Text != ControlsConfigManager.ElongatedButtonText;
+                button.ToolTipText = ControlsConfigManager.Instance.GetButtonText(code, true);
+            }
+            else
+                button.Label.Text = UnsavedKeybindDict[action];
+
             button.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
         }
 
@@ -551,12 +562,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     }
                     else
                     {
-                        button.Label.Text = InputManager.Instance.GetKeyString(code);
+                        button.Label.Text = ControlsConfigManager.Instance.GetButtonText(code);
+                        button.SuppressToolTip = button.Label.Text != ControlsConfigManager.ElongatedButtonText;
+                        button.ToolTipText = ControlsConfigManager.Instance.GetButtonText(code, true);
                     }
 
                     string actionKey = button.Name;
 
-                    UnsavedKeybindDict[actionKey] = button.Label.Text;
+                    UnsavedKeybindDict[actionKey] = InputManager.Instance.GetKeyString(code);
                     CheckDuplicates();
                 }
                 else

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -158,12 +158,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Private methods
 
-        //for "reset defaults" overload
-        //**might delete this, since reset defaults is in the main controls window
         private void SetupKeybindButton(Button button, InputManager.Actions action)
         {
-            button.Label.Text = ControlsConfigManager.Instance.GetUnsavedBinding(action);
+            var code = ControlsConfigManager.Instance.GetUnsavedBindingKeyCode(action);
+            button.Label.Text = ControlsConfigManager.Instance.GetButtonText(code);
             button.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
+
+            button.ToolTip = defaultToolTip;
+            button.SuppressToolTip = button.Label.Text != ControlsConfigManager.ElongatedButtonText;
+            button.ToolTipText = ControlsConfigManager.Instance.GetButtonText(code, true);
         }
 
         //for initialization


### PR DESCRIPTION
https://imgur.com/a/rBGxQzS

- Changed the display of KeyCodes without altering the strings that are serialized in Keybinds.txt. Non-alphabetic keys are displayed as their true character, except for numbers. Joystick buttons are displayed as "Joy BX" and Joystick axis buttons are displayed as "JoyX BY".
- When in non-SDF rendering, it will display certain KeyCode strings in a Daggerfall DOS-inspired format (barring some such as "SPCEBAR", mouse buttons like "M 1" and "M 2", etc.)
- If the KeyCode string is too long (in preparation for custom combo codes), the label text will display `...` and you can hover over it to see its full name. The tooltip gets updated/disappears if a smaller-length KeyCode string is binded. If you would like to test this, change the `ControlsConfigManager.maxButtonTextLength` to a small number.

