### PR TITLE
Discard virtual mods without a valid title

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -587,6 +587,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                         continue;
                     }
 
+                    if (string.IsNullOrWhiteSpace(modInfo.ModTitle))
+                    {
+                        Debug.LogError($"Discarded {manifestPath} because it doesn't have a valid title.");
+                        continue;
+                    }
+
                     if (mods.Any(x => x.ModInfo.GUID == modInfo.GUID))
                     {
                         Debug.LogWarningFormat("Ignoring virtual mod {0} because release mod is already loaded.", modInfo.ModTitle);


### PR DESCRIPTION
Title is a mandatory property of ModInfo manifest file. An empty or null title causes several issues so mods without a valid title are now ignored logging an error.