### PR TITLE
Bindable KeyCode combinations

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -82,6 +82,7 @@ namespace DaggerfallWorkshop.Game
         DaggerfallFont[] daggerfallFonts = new DaggerfallFont[5];
         char lastCharacterTyped;
         KeyCode lastKeyCode;
+        bool processHotkeys;
         HotkeySequence.KeyModifiers lastKeyModifiers;
         bool hotkeySequenceProcessed = false;
         FadeBehaviour fadeBehaviour = null;
@@ -176,6 +177,8 @@ namespace DaggerfallWorkshop.Game
             get { return globalFilterMode; }
             set { globalFilterMode = value; }
         }
+
+        public Event KeyEvent { get; private set; } = new Event();
 
         public char LastCharacterTyped
         {
@@ -380,17 +383,13 @@ namespace DaggerfallWorkshop.Game
                 if (Event.current.character != (char)0)
                     lastCharacterTyped = Event.current.character;
 
-                if (Event.current.keyCode != KeyCode.None)
-                    lastKeyCode = Event.current.keyCode;
-
                 if (lastCharacterTyped > 255)
                     lastCharacterTyped = (char)0;
-
-                hotkeySequenceProcessed = ProcessHotKeySequences();
             }
 
-            if (Event.current.type == EventType.KeyUp)
+            if (processHotkeys)
             {
+                processHotkeys = false;
                 hotkeySequenceProcessed = ProcessHotKeySequences();
             }
 
@@ -415,6 +414,16 @@ namespace DaggerfallWorkshop.Game
                     RenderTexture.active = oldRT;
                 }
             }
+        }
+
+        public void OnKeyPress(KeyCode key, bool down)
+        {
+            KeyEvent.type = down ? EventType.KeyDown : EventType.KeyUp;
+            KeyEvent.keyCode = key;
+
+            if (down && key != KeyCode.None)
+                lastKeyCode = key;
+            processHotkeys = true;
         }
 
         private void InstantiatePersistentWindowInstances()

--- a/Assets/Scripts/Game/UserInterface/Button.cs
+++ b/Assets/Scripts/Game/UserInterface/Button.cs
@@ -78,11 +78,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         new public bool ProcessHotkeySequences(HotkeySequence.KeyModifiers keyModifiers)
         {
-            bool isKeyDown = Event.current.type == EventType.KeyDown;
+            bool isKeyDown = DaggerfallUI.Instance.KeyEvent.type == EventType.KeyDown;
             bool isActivated = isKeyDown ? shortcutKey.IsDownWith(keyModifiers) : shortcutKey.IsUpWith(keyModifiers);
             if (isActivated)
             {
-                if (!KeyboardEvent(Event.current))
+                if (!KeyboardEvent(DaggerfallUI.Instance.KeyEvent))
                 {
                     // Legacy support fallback, OnMouseClick handlers receive KeyDown events as faked clicks
                     if (isKeyDown)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -392,27 +392,38 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 setWaitingForInput(true);
                 yield return null;
             }
+
+            KeyCode code1 = InputManager.Instance.LastSingleKeyDown;
+
+            yield return new WaitForSecondsRealtime(0.05f);
+
+            while (!InputManager.Instance.AnyKeyDown)
+            {
+                if (InputManager.Instance.AnyKeyUp)
+                    break;
+
+                setWaitingForInput(true);
+                yield return null;
+            }
+
             setWaitingForInput(false);
 
-            KeyCode code = InputManager.Instance.LastKeyDown;
+            KeyCode code2 = InputManager.Instance.LastSingleKeyDown;
+            KeyCode code = code1 == code2 ? code1 : InputManager.Instance.GetComboCode(code1, code2);
 
-            if (code != KeyCode.None)
+            if (code != KeyCode.None && InputManager.Instance.ReservedKeys.FirstOrDefault(x => x == code) == KeyCode.None)
             {
-                if(InputManager.Instance.ReservedKeys.FirstOrDefault(x => x == code) == KeyCode.None)
-                {
-                    button.Label.Text = ControlsConfigManager.Instance.GetButtonText(code);
-                    button.SuppressToolTip = button.Label.Text != ControlsConfigManager.ElongatedButtonText;
-                    button.ToolTipText = ControlsConfigManager.Instance.GetButtonText(code, true);
+                button.Label.Text = ControlsConfigManager.Instance.GetButtonText(code);
+                button.SuppressToolTip = button.Label.Text != ControlsConfigManager.ElongatedButtonText;
+                button.ToolTipText = ControlsConfigManager.Instance.GetButtonText(code, true);
 
-                    var action = (InputManager.Actions)Enum.Parse(typeof(InputManager.Actions), button.Name);
-
-                    ControlsConfigManager.Instance.SetUnsavedBinding(action, InputManager.Instance.GetKeyString(code));
-                    checkDuplicates();
-                }
-                else
-                {
-                    button.Label.Text = currentLabel;
-                }
+                var action = (InputManager.Actions)Enum.Parse(typeof(InputManager.Actions), button.Name);
+                ControlsConfigManager.Instance.SetUnsavedBinding(action, InputManager.Instance.GetKeyString(code));
+                checkDuplicates();
+            }
+            else
+            {
+                button.Label.Text = currentLabel;
             }
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
@@ -542,7 +542,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             SetWaitingForInput(false);
 
-            KeyCode code = InputManager.Instance.LastKeyDown;
+            KeyCode code = InputManager.Instance.LastSingleKeyDown;
 
             if (code != KeyCode.None)
             {


### PR DESCRIPTION
Introduces a way for players to bind a combination to a single action in the controls window, e.g. "LeftShift + K", "RightControl + K", "K + V", "[ + /", "Joy3B0 + JoyB2".

Since KeyCodes are 32-bit integers, the max length of the KeyCode enum is around 300, and the axis KeyCodes are less than 16-bits long, I managed to store two KeyCodes into one as *15* bits each. (I chose 15 instead of 16 so the most significant bit isn't 1 and becomes a negative number.) You can create a combo by using `GetComboCode(key1, key2)`.

When binding in the controls window, it will make sure that:
 - There is no duplicate combo (e.g. two "LeftShift + K"s)
 - The modifier is not used independently in any other binding (e.g "LeftShift + K" and "LeftShift")
 - The modifier is not used as a key (e.g. "LeftShift + K" and "F + LeftShift")

When pressing a combo, it will make sure that:
 - The modifier is "held first" - meaning it is being held solely without any other keys that are combo'd to that modifier (e.g. LeftShift+K jumps, LeftShift+L opens a menu. It checks to make sure that either 'K' or 'L' are not being held. It will ignore keys that are not combo'd to it, like 'W' for forward.)
- It will also check to make sure no other modifiers are being held.

If a modifier is being pressed, the system will ignore the combo'd key as being pressed independently (e.g. Shift+Space sheathes weapon, Space jumps. When holding Shift, `GetKey(KeyCode.Space)` will return false so it prevents jumping.)

In order to detect other non-independently binded keys as being held, the way input got handled had to be rewritten to a polling system that examines every `KeyCode`. It sounds expensive, but I managed to optimize it as best as possible and for it to be only 0.05-0.08 ms more time spent in the `Update()` function according to the Unity Profiler, which is unnoticeable (at least on my end). Also, because of the new system, I was able to remove much of the old joystick axis code.

`HotkeySequences` used the Unity `Event.current` system in `OnGUI()` for key detection, but couldn't sync to the polling system and detect any GetKey methods. I had to rewrite that part so `DaggerfallUI` has an event-driven `OnKeyPress` method and uses a custom `Event` that gets modified in order to get the `HotkeySequences` working again.