### PR TITLE
Change Automap toggle to GetKey method

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAutomapWindow.cs
@@ -70,7 +70,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         // Handle toggle closing
         KeyCode automapBinding = KeyCode.None;
-        HotkeySequence HotkeySequence_toggleClose;
         bool isCloseWindowDeferred = false;
         readonly KeyCode fallbackKey = KeyCode.Home;
 
@@ -529,8 +528,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 automapBinding = InputManager.Instance.GetBinding(InputManager.Actions.AutoMap);
 
-                // Store toggle closed binding for this window
-                HotkeySequence_toggleClose = new HotkeySequence(automapBinding, HotkeySequence.KeyModifiers.None, true);
                 // update hotkey sequences taking current toggleClosedBinding into account
                 SetupHotkeySequences();
                 // update button tool tip texts - since hotkeys changed
@@ -702,11 +699,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (Input.GetKeyDown(KeyCode.Escape) ||
                 // Toggle window closed with same hotkey used to open it
-                HotkeySequence_toggleClose.IsDownWith(keyModifiers))
+                InputManager.Instance.GetKeyDown(automapBinding))
                 isCloseWindowDeferred = true;
             else if ((Input.GetKeyUp(KeyCode.Escape) ||
                 // Toggle window closed with same hotkey used to open it
-                HotkeySequence_toggleClose.IsUpWith(keyModifiers)) && isCloseWindowDeferred)
+                InputManager.Instance.GetKeyUp(automapBinding)) && isCloseWindowDeferred)
             {
                 isCloseWindowDeferred = false;
                 CloseWindow();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -50,7 +50,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         // Handle toggle closing
         KeyCode automapBinding = KeyCode.None;
-        HotkeySequence HotkeySequence_toggleClose;
         bool isCloseWindowDeferred = false;
         readonly KeyCode fallbackKey = KeyCode.Home;
 
@@ -469,8 +468,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 automapBinding = InputManager.Instance.GetBinding(InputManager.Actions.AutoMap);
 
-                // Store toggle closed binding for this window
-                HotkeySequence_toggleClose = new HotkeySequence(automapBinding, HotkeySequence.KeyModifiers.None, true);
                 // update hotkey sequences taking current toggleClosedBinding into account
                 SetupHotkeySequences();
                 // update button tool tip texts - since hotkeys changed
@@ -566,11 +563,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (Input.GetKeyDown(KeyCode.Escape) ||
                 // Toggle window closed with same hotkey used to open it
-                HotkeySequence_toggleClose.IsDownWith(keyModifiers))
+                InputManager.Instance.GetKeyDown(automapBinding))
                 isCloseWindowDeferred = true;
             else if ((Input.GetKeyUp(KeyCode.Escape) ||
                 // Toggle window closed with same hotkey used to open it
-                HotkeySequence_toggleClose.IsUpWith(keyModifiers)) && isCloseWindowDeferred)
+                InputManager.Instance.GetKeyUp(automapBinding)) && isCloseWindowDeferred)
             {
                 isCloseWindowDeferred = false;
                 CloseWindow();


### PR DESCRIPTION
For bindable combo keycodes to work properly when closing a window that has a binding using Shift/Ctrl/Alt.