### PR TITLE
Remove GC in drawing Panels

### DIFF
--- a/Assets/Scripts/Game/UserInterface/Panel.cs
+++ b/Assets/Scripts/Game/UserInterface/Panel.cs
@@ -121,10 +121,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 DrawBorder();
 
             // Draw child components
-            foreach (BaseScreenComponent component in components)
+            BaseScreenComponent comp;
+            for (int i = 0; i < components.Count; i++)
             {
-                if (component.Enabled)
-                    component.Draw();
+                comp = components[i];
+                if (comp.Enabled)
+                    comp.Draw();
             }
         }
 


### PR DESCRIPTION
Using the Unity profiler, I found that using a foreach loop of a BaseScreenComponentCollection class allocates memory when getting the Enumerator, and Panel.Draw() is called every frame using that loop. The setup wizard alone took 0.7 KB before under DaggerfallUI.OnGUI(), now it is 0.