### PR TITLE
Add check for DaggerfallActionDoor on door prefab

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -1010,12 +1010,12 @@ namespace DaggerfallWorkshop
                 go.transform.rotation = Quaternion.Euler(modelRotation);
                 go.transform.position = modelPosition;
 
-                // Get action door script
+                // Get action door script and assign loadID
                 DaggerfallActionDoor actionDoor = go.GetComponent<DaggerfallActionDoor>();
-
-                // Assign loadID
                 if (actionDoor)
                     actionDoor.LoadID = loadID;
+                else
+                    Debug.LogError($"Failed to get DaggerfallActionDoor on {modelId}. Make sure is added to door prefab.");
 
                 if (SaveLoadManager.Instance != null)
                     go.AddComponent<SerializableActionDoor>();

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1146,13 +1146,19 @@ namespace DaggerfallWorkshop.Utility
 
             // Get action door script
             DaggerfallActionDoor actionDoor = go.GetComponent<DaggerfallActionDoor>();
+            if (actionDoor)
+            {
+                // Set starting lock value
+                byte[] lockValues = { 0x00, 0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C, 0x0E, 0x10, 0x12, 0x14, 0x19, 0x1E, 0x32, 0x80, 0xFF };
+                actionDoor.StartingLockValue = lockValues[obj.Resources.ModelResource.TriggerFlag_StartingLock >> 4];
 
-            // Set starting lock value
-            byte[] lockValues = { 0x00, 0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C, 0x0E, 0x10, 0x12, 0x14, 0x19, 0x1E, 0x32, 0x80, 0xFF };
-            actionDoor.StartingLockValue = lockValues[obj.Resources.ModelResource.TriggerFlag_StartingLock >> 4];
-
-            // Set LoadID
-            actionDoor.LoadID = loadID;
+                // Set LoadID
+                actionDoor.LoadID = loadID;
+            }
+            else
+            {
+                Debug.LogError($"Failed to get DaggerfallActionDoor on {modelId}. Make sure is added to door prefab.");
+            }
 
             return go;
         }


### PR DESCRIPTION
When providing a replacement for _DaggerfallActionDoor_ prefab,  `DaggerfallActionDoor` component must be added by mod author. If component is missing an error message is now logged.