### PR TITLE
More accurate pursuit formula

### DIFF
--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -542,34 +542,38 @@ namespace DaggerfallWorkshop.Game
             float b = 2 * Vector3.Dot(d, v);
             float c = d.sqrMagnitude;
 
-            Vector3 prediction;
+            Vector3 prediction = assumedCurrentPosition;
 
-            float disc = b * b - 4 * a * c;
-            if (disc >= 0)
+            float t = -1;
+            if (Mathf.Abs(a) >= 1e-5)
             {
-                // find the minimal positive solution
-                float discSqrt = Mathf.Sqrt(disc) * Mathf.Sign(a);
-                float t = (-b - discSqrt) / (2 * a);
-                if (t < 0)
-                    t = (-b + discSqrt) / (2 * a);
-                if (t < 0)
-                    prediction = assumedCurrentPosition;
-                else
+                float disc = b * b - 4 * a * c;
+                if (disc >= 0)
                 {
-                    prediction = assumedCurrentPosition + v * t;
-
-                    // Don't predict target will move through obstacles (prevent predicting movement through walls)
-                    RaycastHit hit;
-                    Ray ray = new Ray(assumedCurrentPosition, (prediction - assumedCurrentPosition).normalized);
-                    if (Physics.Raycast(ray, out hit, (prediction - assumedCurrentPosition).magnitude))
-                        prediction = assumedCurrentPosition;
+                    // find the minimal positive solution
+                    float discSqrt = Mathf.Sqrt(disc) * Mathf.Sign(a);
+                    t = (-b - discSqrt) / (2 * a);
+                    if (t < 0)
+                        t = (-b + discSqrt) / (2 * a);
                 }
             }
             else
             {
-                prediction = assumedCurrentPosition;
+                // degenerated cases
+                if (Mathf.Abs(b) >= 1e-5)
+                    t = -d.sqrMagnitude / b;
             }
 
+            if (t >= 0)
+            {
+                prediction = assumedCurrentPosition + v * t;
+
+                // Don't predict target will move through obstacles (prevent predicting movement through walls)
+                RaycastHit hit;
+                Ray ray = new Ray(assumedCurrentPosition, (prediction - assumedCurrentPosition).normalized);
+                if (Physics.Raycast(ray, out hit, (prediction - assumedCurrentPosition).magnitude))
+                    prediction = assumedCurrentPosition;
+            }
 
             // Store prediction minus lead for next prediction update
             predictedTargetPosWithoutLead = assumedCurrentPosition + lastPositionDiff;

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -548,7 +548,7 @@ namespace DaggerfallWorkshop.Game
             if (disc >= 0)
             {
                 // find the minimal positive solution
-                float discSqrt = Mathf.Sqrt(disc);
+                float discSqrt = Mathf.Sqrt(disc) * Mathf.Sign(a);
                 float t = (-b - discSqrt) / (2 * a);
                 if (t < 0)
                     t = (-b + discSqrt) / (2 * a);


### PR DESCRIPTION
Current pursuit algorithm in EnemySenses compute how much time will be needed to reach the current position of the target, then computes by how much the target will have moved by then. This is only an approximation, because it does both the hypothesis that the target won't move and that it will move. The fastest the target, the less accurate it gets.

One can exploit that inaccuracy by rushing at enemies, that will turn their back, pursuing a position behind them. Hence current algorithm has an additional test to detect that condition, but it doesn't seem to work perfectly, the exploit still exists.

Accurate approach is to compute at what moment the target will be on a sphere centered at pursuer position, growing at its interception speed each second; Or, in 4 dimensions (x, y, z, t), compute the intersection of a cone and a line. This is slightly more expensive, solving a quadratic equation then taking its smallest positive solution, but doesn't seem to suffer from the previous exploit.