### PR TITLE
fix Clocks that would return 0 days

### DIFF
--- a/Assets/StreamingAssets/Quests/R0C20Y07.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y07.txt
@@ -119,7 +119,7 @@ Place _itemdung_ remote dungeon13
 
 Clock _1stparton_ 00:00 0 flag 1 range 2 5
 --changed flags on timer, was giving very short time limits before
-Clock _2ndparton_ 00:00 0 flag 2 range 1 2
+Clock _2ndparton_ 00:00 0 flag 3 range 1 2
 
 Foe _giant_ is Giant
 

--- a/Assets/StreamingAssets/Quests/R0C20Y22.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y22.txt
@@ -166,7 +166,8 @@ Person _orsinium_ face 184 faction Orsinium anyInfo 1012 rumors 1013
 
 Place orcCastle permanent OrsiniumCastle3
 
-Clock _queston_ 00:00 0 flag 2 range 3 5
+--changed flags on timer, was giving very short time limits before
+Clock _queston_ 00:00 0 flag 3 range 3 5
 
 Foe _note_ is 3 Orc
 Foe _F.01_ is Orc_sergeant


### PR DESCRIPTION
Clocks with
- both timerValue0 = timerValue1 = 0 and
- neither flag & 1 or flag & 16

Will have a final clockTimeInSeconds of 0, not overridden by a travel time.
![Capture d’écran du 2020-09-15 20-56-58](https://user-images.githubusercontent.com/1211431/93258027-ffb1f400-f79d-11ea-95ff-381f4c0c2a70.jpg)
(source https://www.twitch.tv/videos/741689738?t=4h16m16s )

Until Clock implementation is changed, a workaround for those cases is to modify flag to have either flag & 1 or flag & 16.
Fortunately, there's only 2 such instances.