### PR TITLE
Fix SearchItems method when no template index specified

### DIFF
--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -596,7 +596,7 @@ namespace DaggerfallWorkshop.Game.Items
             {
                 if (templateIndex == -1)
                 {
-                    if (item.GroupIndex == (int)itemGroup)
+                    if (item.ItemGroup == itemGroup)
                     {
                         results.Add(item);
                     }


### PR DESCRIPTION
This has been around for a while undetected. Just added some code that uses this and was scratching my head for a while... hope this can go into .26 but not a big issue if not.