### PR TITLE
Enemy + Mobile NPC Spawn Events

### DIFF
--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -1056,6 +1056,17 @@ namespace DaggerfallWorkshop.Game
                 OnEncounter();
         }
 
+        //OnEnemySpawn
+        public delegate void OnEnemySpawnHandler(GameObject enemy);
+        public static event OnEnemySpawnHandler OnEnemySpawn;
+
+        public virtual void RaiseOnEnemySpawnEvent(GameObject enemy)
+        {
+            if (OnEnemySpawn != null)
+                OnEnemySpawn(enemy);
+        }
+
+
         #endregion
     }
 }

--- a/Assets/Scripts/Game/Serialization/SerializableStateManager.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableStateManager.cs
@@ -420,6 +420,8 @@ namespace DaggerfallWorkshop.Game.Serialization
                 // Restore save data
                 SerializableEnemy serializableEnemy = go.GetComponent<SerializableEnemy>();
                 serializableEnemy.RestoreSaveData(enemies[i]);
+
+                GameManager.Instance?.RaiseOnEnemySpawnEvent(go);
             }
         }
 

--- a/Assets/Scripts/Game/Utility/PopulationManager.cs
+++ b/Assets/Scripts/Game/Utility/PopulationManager.cs
@@ -199,6 +199,8 @@ namespace DaggerfallWorkshop.Game.Utility
                     Vector2 size = poolItem.npc.Asset.GetSize();
                     if (Mathf.Abs(size.y - 2f) > 0.1f)
                         poolItem.npc.Asset.transform.Translate(0, (size.y - 2f) * 0.52f, 0);
+
+                    OnMobileNPCEnable?.Invoke(poolItem);
                 }
 
                 // Mark for recycling
@@ -218,6 +220,8 @@ namespace DaggerfallWorkshop.Game.Utility
                     poolItem.scheduleRecycle = false;
                     if (poolItem.npc.Asset)
                         poolItem.npc.Asset.transform.localPosition = Vector3.zero;
+
+                    OnMobileNPCDisable?.Invoke(poolItem);
                 }
 
                 populationPool[i] = poolItem;
@@ -279,6 +283,8 @@ namespace DaggerfallWorkshop.Game.Utility
             // Add to pool
             populationPool.Add(poolItem);
 
+            OnMobileNPCCreate?.Invoke(poolItem);
+
             return populationPool.Count - 1;
         }
 
@@ -318,6 +324,22 @@ namespace DaggerfallWorkshop.Game.Utility
                     return Races.Breton;
             }
         }
+
+        #endregion
+
+        #region Events
+
+        //OnMobileNPCCreate
+        public delegate void OnMobileNPCCreateHandler(PoolItem poolItem);
+        public static event OnMobileNPCCreateHandler OnMobileNPCCreate;
+
+        //OnMobileNPCEnable
+        public delegate void OnMobileNPCEnableHandler(PoolItem poolItem);
+        public static event OnMobileNPCEnableHandler OnMobileNPCEnable;
+
+        //OnMobileNPCDisable
+        public delegate void OnMobileNPCDisableHandler(PoolItem poolItem);
+        public static event OnMobileNPCDisableHandler OnMobileNPCDisable;
 
         #endregion
     }

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -1152,6 +1152,8 @@ namespace DaggerfallWorkshop.Utility
             if (mobileUnit.Summary.Enemy.Behaviour != MobileBehaviour.Flying)
                 AlignControllerToGround(go.GetComponent<CharacterController>());
 
+            GameManager.Instance?.RaiseOnEnemySpawnEvent(go);
+
             return go;
         }
 
@@ -1213,6 +1215,8 @@ namespace DaggerfallWorkshop.Utility
 
                 // Disable GameObject, caller must set active when ready
                 go.SetActive(false);
+
+                GameManager.Instance?.RaiseOnEnemySpawnEvent(go);
 
                 // Add to list
                 gameObjects.Add(go);

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1544,6 +1544,9 @@ namespace DaggerfallWorkshop.Utility
             {
                 enemy.LoadID = loadID;
             }
+
+            GameManager.Instance?.RaiseOnEnemySpawnEvent(go);
+
         }
 
         private static DaggerfallLoot AddRandomTreasure(


### PR DESCRIPTION
Hooking into enemy / npc spawning isn't super doable currently, making modding a bit tough. This makes modifying enemies itself a lot harder than it should be! Adding spawn events is a major way to make this easier.

All cases I could find correctly trigger these events - dungeon enemies, quest spawns, sleeping encounters, etc.