### PR TITLE
Change crouch action to "key-down" (ActionStarted)

### DIFF
--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -128,7 +128,7 @@ namespace DaggerfallWorkshop.Game
             bool swimming = levitateMotor.IsSwimming;
             bool crouching = playerMotor.IsCrouching;
             bool riding = playerMotor.IsRiding;
-            bool pressedCrouch = InputManager.Instance.ActionComplete(InputManager.Actions.Crouch);
+            bool pressedCrouch = InputManager.Instance.ActionStarted(InputManager.Actions.Crouch);
             bool climbing = climbingMotor.IsClimbing;
             bool levitating = playerMotor.IsLevitating;
             //timerMax = timerSlow;


### PR DESCRIPTION
The sneak action either uses ActionStarted when in toggled mode, or HasAction when not. To keep a consistency for all physical actions, I believe the crouch action should be changed to "ActionStarted" as well.