### PR TITLE
Remove changes from PR#1808

### DIFF
--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -151,8 +151,6 @@ namespace DaggerfallWorkshop.Game
         DaggerfallAudioSource dfAudioSource;
         AudioSource ridingAudioSource;
 
-        private bool stoppedRidingAudio;
-
         ImageData ridingTexture;
         ImageData[] ridingTexures = new ImageData[4];
         float lastFrameTime = 0;
@@ -202,13 +200,6 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
-        IEnumerator StopRidingAudio()
-        {
-            stoppedRidingAudio = true;
-            yield return new WaitForSecondsRealtime(0.2f);
-            ridingAudioSource.Stop();
-        }
-
         // Update is called once per frame
         void Update()
         {
@@ -221,8 +212,7 @@ namespace DaggerfallWorkshop.Game
                     lastFrameTime = 0;
                     frameIndex = 0;
                     ridingTexture = ridingTexures[0];
-                    if (!stoppedRidingAudio)
-                        StartCoroutine(StopRidingAudio());
+                    ridingAudioSource.Stop();
                 }
                 else
                 {   // Update Animation frame?
@@ -239,8 +229,6 @@ namespace DaggerfallWorkshop.Game
                     // Get appropriate hoof sound for horse
                     if (mode == TransportModes.Horse)
                     {
-                        stoppedRidingAudio = false;
-
                         if (!wasMovingLessThanHalfSpeed && playerMotor.IsMovingLessThanHalfSpeed)
                         {
                             wasMovingLessThanHalfSpeed = true;


### PR DESCRIPTION
The changes to improve horse jumping sounds broke the stopping of sounds when horse/cart stops. This commit removes those changes, as I think this is worse than clipped no sound if a player holds space to bunny hop the horse.

See: https://forums.dfworkshop.net/viewtopic.php?f=5&t=4191

I'd be happy to put in a change to prevent bunny hopping horses which would be a better approach to the issue than allowing the sound to play longer. TBH if players want to hold space, I care very little what it sounds like as it's a silly thing to do when playing, which is why preventing that action would be my preference here if something has to be changed.