### PR TITLE
Correct Bhoriane spelling everywhere

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -165,7 +165,7 @@ namespace DaggerfallConnect.Arena2
             Menevia = 209,
             Alcaire = 210,
             Koegria = 211,
-            Bhoraine = 212,
+            Bhoriane = 212,
             Kambria = 213,
             Phrygia = 214,
             Urvaius = 215,
@@ -404,8 +404,8 @@ namespace DaggerfallConnect.Arena2
             Court_of_Koegria = 533,
             People_of_Koegria = 534,
 
-            Court_of_Bhoraine = 535,
-            People_of_Bhoraine = 536,
+            Court_of_Bhoriane = 535,
+            People_of_Bhoriane = 536,
 
             Court_of_Kambria = 537,
             People_of_Kambria = 538,

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -53,7 +53,7 @@ namespace DaggerfallConnect.Arena2
             "Wrothgarian Mountains", "Daggerfall", "Glenpoint", "Betony", "Sentinel", "Anticlere", "Lainlyn", "Wayrest",
             "Gen Tem High Rock village", "Gen Rai Hammerfell village", "Orsinium Area", "Skeffington Wood",
             "Hammerfell bay coast", "Hammerfell sea coast", "High Rock bay coast", "High Rock sea coast",
-            "Northmoor", "Menevia", "Alcaire", "Koegria", "Bhoraine", "Kambria", "Phrygias", "Urvaius",
+            "Northmoor", "Menevia", "Alcaire", "Koegria", "Bhoriane", "Kambria", "Phrygias", "Urvaius",
             "Ykalon", "Daenia", "Shalgora", "Abibon-Gora", "Kairou", "Pothago", "Myrkwasa", "Ayasofya",
             "Tigonus", "Kozanset", "Satakalaam", "Totambu", "Mournoth", "Ephesus", "Santaki", "Antiphyllos",
             "Bergama", "Gavaudon", "Tulune", "Glenumbra Moors", "Ilessan Hills", "Cybiades"

--- a/Assets/Scripts/DaggerfallUnityEnums.cs
+++ b/Assets/Scripts/DaggerfallUnityEnums.cs
@@ -724,7 +724,7 @@ namespace DaggerfallWorkshop
         Menevia = 33,
         Alcaire = 34,
         Koegria = 35,
-        Bhoraine = 36,
+        Bhoriane = 36,
         Kambria = 37,
         Phrygias = 38,
         Urvaius = 39,

--- a/Assets/StreamingAssets/Factions/FACTION.TXT
+++ b/Assets/StreamingAssets/Factions/FACTION.TXT
@@ -3919,7 +3919,7 @@ vam: 153
 
 #212
 type: 7
-name: Bhoraine
+name: Bhoriane
 rep: 0
 summon: -1
 region: 37
@@ -3938,7 +3938,7 @@ vam: 154
 
 	#535
 	type: 14
-	name: Court of Bhoraine
+	name: Court of Bhoriane
 	rep: 0
 	summon: -1
 	region: 37
@@ -3955,7 +3955,7 @@ vam: 154
 
 	#536
 	type: 15
-	name: People of Bhoraine
+	name: People of Bhoriane
 	rep: 0
 	summon: -1
 	region: 37

--- a/Assets/StreamingAssets/Tables/Quests-Factions.txt
+++ b/Assets/StreamingAssets/Tables/Quests-Factions.txt
@@ -186,7 +186,7 @@ Northmoor,                 0, -1, 208
 Menevia,                   0, -1, 209
 Alcaire,                   0, -1, 210
 Koegria,                   0, -1, 211
-Bhoraine,                  0, -1, 212
+Bhoriane,                  0, -1, 212
 Kambria,                   0, -1, 213
 Phrygia,                   0, -1, 214
 Urvaius,                   0, -1, 215
@@ -374,8 +374,8 @@ Court_of_Alcaire,          0, -1, 531
 People_of_Alcaire,         0, -1, 532
 Court_of_Koegria,          0, -1, 533
 People_of_Koegria,         0, -1, 534
-Court_of_Bhoraine,         0, -1, 535
-People_of_Bhoraine,        0, -1, 536
+Court_of_Bhoriane,         0, -1, 535
+People_of_Bhoriane,        0, -1, 536
 Court_of_Kambria,          0, -1, 537
 People_of_Kambria,         0, -1, 538
 Court_of_Phrygia,          0, -1, 539


### PR DESCRIPTION
Fix Bhoriane county mispelled as Bhoraine in FACTION.TXT, which resulted in similar mistakes in DFU source files.
Discussion here: https://forums.dfworkshop.net/posting.php?mode=reply&f=5&t=4294.