### PR TITLE
Handle interior guard spawns for taverns and houses

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -622,11 +622,10 @@ namespace DaggerfallWorkshop.Game.Entity
             if (!GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && GameManager.Instance.HowManyEnemiesOfType(MobileTypes.Knight_CityWatch, false, true) <= maxActiveGuardSpawns)
             {
                 // Handle indoor guard spawning
-                if (GameManager.Instance.PlayerEnterExit.IsPlayerInside && GameManager.Instance.PlayerEnterExit.IsPlayerInsideOpenShop)
+                var enterExit = GameManager.Instance.PlayerEnterExit;
+                if (enterExit.IsPlayerInside && (enterExit.IsPlayerInsideOpenShop || enterExit.IsPlayerInsideTavern || enterExit.IsPlayerInsideResidence))
                 {
-                    Vector3 lowestDoorPos;
-                    Vector3 lowestDoorNormal;
-                    if (GameManager.Instance.PlayerEnterExit.Interior.FindLowestInteriorDoor(out lowestDoorPos, out lowestDoorNormal))
+                    if (enterExit.Interior.FindLowestOuterInteriorDoor(out Vector3 lowestDoorPos, out Vector3 lowestDoorNormal))
                     {
                         lowestDoorPos += lowestDoorNormal * (GameManager.Instance.PlayerController.radius + 0.1f);
                         int guardCount = UnityEngine.Random.Range(2, 6);

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -1045,6 +1045,8 @@ namespace DaggerfallWorkshop.Game
             // Perform transition
             playerEnterExit.BuildingDiscoveryData = db;
             playerEnterExit.IsPlayerInsideOpenShop = RMBLayout.IsShop(db.buildingType) && IsBuildingOpen(db.buildingType);
+            playerEnterExit.IsPlayerInsideTavern = RMBLayout.IsTavern(db.buildingType);
+            playerEnterExit.IsPlayerInsideResidence = RMBLayout.IsResidence(db.buildingType);
             playerEnterExit.TransitionInterior(doorOwner, door, doFade, false);
         }
 

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -142,6 +142,18 @@ namespace DaggerfallWorkshop.Game
         }
 
         /// <summary>
+        /// True when player is inside a tavern.
+        /// Set upon entry.
+        /// </summary>
+        public bool IsPlayerInsideTavern { get; set; }
+
+        /// <summary>
+        /// True when player is inside a residence.
+        /// Set upon entry.
+        /// </summary>
+        public bool IsPlayerInsideResidence { get; set; }
+
+        /// <summary>
         /// True when player is swimming in water.
         /// </summary>
         public bool IsPlayerSwimming

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -232,6 +232,8 @@ namespace DaggerfallWorkshop.Game.Serialization
         public bool insideDungeon;
         public bool insideBuilding;
         public bool insideOpenShop;
+        public bool insideTavern;
+        public bool insideResidence;
         public string terrainSamplerName;
         public int terrainSamplerVersion;
         public StaticDoor[] exteriorDoors;

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -212,6 +212,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             playerPosition.insideDungeon = playerEnterExit.IsPlayerInsideDungeon;
             playerPosition.insideBuilding = playerEnterExit.IsPlayerInsideBuilding;
             playerPosition.insideOpenShop = playerEnterExit.IsPlayerInsideOpenShop;
+            playerPosition.insideTavern = playerEnterExit.IsPlayerInsideTavern;
+            playerPosition.insideResidence = playerEnterExit.IsPlayerInsideResidence;
             playerPosition.terrainSamplerName = DaggerfallUnity.Instance.TerrainSampler.ToString();
             playerPosition.terrainSamplerVersion = DaggerfallUnity.Instance.TerrainSampler.Version;
             playerPosition.weather = GameManager.Instance.WeatherManager.PlayerWeather.WeatherType;
@@ -386,6 +388,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             {
                 playerEnterExit.BuildingDiscoveryData = data.playerPosition.buildingDiscoveryData;
                 playerEnterExit.IsPlayerInsideOpenShop = data.playerPosition.insideOpenShop;
+                playerEnterExit.IsPlayerInsideTavern = data.playerPosition.insideTavern;
+                playerEnterExit.IsPlayerInsideResidence = data.playerPosition.insideResidence;
             }
 
             // Lower player position flag if inside with no doors

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -204,20 +204,19 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
-        /// Finds the interior door that is closest to ground level.
+        /// Finds the interior door that is closest to ground level and farthest from the center of the building.
         /// </summary>
         /// <param name="lowestDoorPositionOut">Position of lowest door in scene.</param>
         /// <param name="lowestDoorNormalOut">Normal vector of lowest door in scene.</param>
-        /// <returns>True if successful.</returns>
-        public bool FindLowestInteriorDoor(out Vector3 lowestDoorPositionOut, out Vector3 lowestDoorNormalOut)
+        /// <returns>True if successful. False if no doors are found.</returns>
+        public bool FindLowestOuterInteriorDoor(out Vector3 lowestDoorPositionOut, out Vector3 lowestDoorNormalOut)
         {
             lowestDoorPositionOut = lowestDoorNormalOut = Vector3.zero;
             DaggerfallStaticDoors interiorDoors = GetComponent<DaggerfallStaticDoors>();
             if (!interiorDoors)
                 return false;
 
-            int doorIndex;
-            if (interiorDoors.FindLowestDoor(-1, out lowestDoorPositionOut, out doorIndex))
+            if (interiorDoors.FindLowestOutermostDoor(-1, out lowestDoorPositionOut, out int doorIndex))
             {
                 lowestDoorNormalOut = interiorDoors.GetDoorNormal(doorIndex);
                 return true;

--- a/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
+++ b/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
@@ -190,13 +190,13 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
-        /// Find lowest door position in world space.
+        /// Find the lowest, farthest from building origin door position in world space.
         /// </summary>
         /// <param name="record">Door record index.</param>
         /// <param name="doorPosOut">Position of closest door in world space.</param>
         /// <param name="doorIndexOut">Door index in Doors array of closest door.</param>
         /// <returns>Whether or not we found a door</returns>
-        public bool FindLowestDoor(int record, out Vector3 doorPosOut, out int doorIndexOut)
+        public bool FindLowestOutermostDoor(int record, out Vector3 doorPosOut, out int doorIndexOut)
         {
             doorPosOut = Vector3.zero;
             doorIndexOut = -1;
@@ -204,8 +204,9 @@ namespace DaggerfallWorkshop
             if (Doors == null)
                 return false;
 
-            // Find lowest door in interior
+            // Find lowest (and outermost) door in interior
             float lowestY = float.MaxValue;
+            double farthestDist = 0d;
             for (int i = 0; i < Doors.Length; i++)
             {
                 // Get this door centre in world space
@@ -214,12 +215,15 @@ namespace DaggerfallWorkshop
                 // Check if door belongs to same building record or accept any record
                 if (Doors[i].recordIndex == record || record == -1)
                 {
+                    var interiorPos = GameObjectHelper.GetSpawnParentTransform().position;
                     float y = centre.y;
-                    if (y < lowestY)
+                    var dist = Vector2.Distance(new Vector2(interiorPos.x, interiorPos.z), new Vector2(centre.x, centre.z));
+                    if (y <= lowestY && dist > farthestDist)
                     {
                         doorPosOut = centre;
                         doorIndexOut = i;
                         lowestY = y;
+                        farthestDist = dist;
                     }
                 }
             }

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -693,6 +693,11 @@ namespace DaggerfallWorkshop.Utility
             }
         }
 
+        /// <summary>
+        /// Checks if building is a tavern.
+        /// </summary>
+        public static bool IsTavern(DFLocation.BuildingTypes buildingType) => buildingType == DFLocation.BuildingTypes.Tavern;
+
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
Guards now spawn at the ground-level door in taverns and residences. The door farthest from the building's origin is chosen to prevent guards entering from the building's courtyard.
Note that guards can still spawn in an unreachable place in disconnected interiors. This PR does not cover that issue.