### PR TITLE
Publicize CurrentRestMode

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -144,6 +144,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public bool PreventNormalizingReputations { get { return preventNormalizingReputations; } set { preventNormalizingReputations = value; } }
         public bool IsResting { get { return isResting; } set { isResting = value; } }
         public bool IsLoitering { get; set; }
+        public DaggerfallRestWindow.RestModes CurrentRestMode { get; set; }
         public Races Race { get { return (Races)RaceTemplate.ID; } }
         public RaceTemplate RaceTemplate { get { return GetLiveRaceTemplate(); } }
         public RaceTemplate BirthRaceTemplate { get { return raceTemplate; } set { raceTemplate = value; } }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -68,7 +68,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected const float loiterWaitTimePerHour = 1.25f;
         protected const int cityCampingIllegal = 17;
 
-        protected RestModes currentRestMode = RestModes.Selection;
         protected int minutesOfHour = 0;
         protected int hoursRemaining = 0;
         protected int totalHours = 0;
@@ -89,9 +88,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #endregion
 
+        #region Properties
+
+        protected RestModes currentRestMode
+        {
+            get { return GameManager.Instance.PlayerEntity.CurrentRestMode; }
+            set { GameManager.Instance.PlayerEntity.CurrentRestMode = value; }
+        }
+
+        #endregion
+
         #region Enums
 
-        protected enum RestModes
+        public enum RestModes
         {
             Selection,
             TimedRest,


### PR DESCRIPTION
This is for issue #1962.

This PR essentially would replace the utility of `PlayerEntity.IsLoitering` and `PlayerEntity.IsResting`, but may be kept for mod compatibility reasons. I also have no problem with removing them if requested. :)

I publicized the `RestModes` enum and kept it in `DaggerfallRestWindow`, but I can move it elsewhere to `DaggerfallUnityEnums` if mod compatibility is also not an issue.