### PR TITLE
Prevent backstabbing daedra seducers during transformations

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -240,7 +240,7 @@ namespace DaggerfallWorkshop.Game
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
 
             // Calculate damage
-            damage = FormulaHelper.CalculateAttackDamage(entity, playerEntity, -1, 0, weapon);
+            damage = FormulaHelper.CalculateAttackDamage(entity, playerEntity, false, 0, weapon);
 
             // Break any "normal power" concealment effects on enemy
             if (entity.IsMagicallyConcealedNormalPower && damage > 0)
@@ -301,7 +301,7 @@ namespace DaggerfallWorkshop.Game
             EnemyMotor targetMotor = senses.Target.transform.GetComponent<EnemyMotor>();
 
             // Calculate damage
-            damage = FormulaHelper.CalculateAttackDamage(entity, targetEntity, -1, 0, weapon);
+            damage = FormulaHelper.CalculateAttackDamage(entity, targetEntity, false, 0, weapon);
 
             // Break any "normal power" concealment effects on enemy
             if (entity.IsMagicallyConcealedNormalPower && damage > 0)

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -23,6 +23,7 @@ using DaggerfallWorkshop.Utility;
 using DaggerfallConnect.Save;
 using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.Utility.ModSupport;
+using static DaggerfallWorkshop.DaggerfallMobileUnit;
 
 namespace DaggerfallWorkshop.Game.Formulas
 {
@@ -513,18 +514,18 @@ namespace DaggerfallWorkshop.Game.Formulas
         /// </summary>
         /// <param name="attacker">Attacking entity</param>
         /// <param name="target">Target entity</param>
-        /// <param name="enemyAnimStateRecord">Record # of the target, used for backstabbing</param>
+        /// <param name="isEnemyFacingAwayFromPlayer">Whether enemy is facing away from player, used for backstabbing</param>
         /// <param name="weaponAnimTime">Time the weapon animation lasted before the attack in ms, used for bow drawing </param>
         /// <param name="weapon">The weapon item being used</param>
         /// <returns>Damage inflicted to target, can be 0 for a miss or ineffective hit</returns>
-        public static int CalculateAttackDamage(DaggerfallEntity attacker, DaggerfallEntity target, int enemyAnimStateRecord, int weaponAnimTime, DaggerfallUnityItem weapon)
+        public static int CalculateAttackDamage(DaggerfallEntity attacker, DaggerfallEntity target, bool isEnemyFacingAwayFromPlayer, int weaponAnimTime, DaggerfallUnityItem weapon)
         {
             if (attacker == null || target == null)
                 return 0;
 
-            Func<DaggerfallEntity, DaggerfallEntity, int, int, DaggerfallUnityItem, int> del;
+            Func<DaggerfallEntity, DaggerfallEntity, bool, int, DaggerfallUnityItem, int> del;
             if (TryGetOverride("CalculateAttackDamage", out del))
-                return del(attacker, target, enemyAnimStateRecord, weaponAnimTime, weapon);
+                return del(attacker, target, isEnemyFacingAwayFromPlayer, weaponAnimTime, weapon);
 
             int damageModifiers = 0;
             int damage = 0;
@@ -590,7 +591,7 @@ namespace DaggerfallWorkshop.Game.Formulas
                 damageModifiers += racialMods.damageMod;
                 chanceToHitMod += racialMods.toHitMod;
 
-                backstabChance = CalculateBackstabChance(player, null, enemyAnimStateRecord);
+                backstabChance = CalculateBackstabChance(player, null, isEnemyFacingAwayFromPlayer);
                 chanceToHitMod += backstabChance;
             }
 
@@ -930,14 +931,13 @@ namespace DaggerfallWorkshop.Game.Formulas
             return mods;
         }
 
-        public static int CalculateBackstabChance(PlayerEntity player, DaggerfallEntity target, int enemyAnimStateRecord)
+        public static int CalculateBackstabChance(PlayerEntity player, DaggerfallEntity target, bool isEnemyFacingAwayFromPlayer)
         {
-            Func<PlayerEntity, DaggerfallEntity, int, int> del;
+            Func<PlayerEntity, DaggerfallEntity, bool, int> del;
             if (TryGetOverride("CalculateBackstabChance", out del))
-                return del(player, target, enemyAnimStateRecord);
+                return del(player, target, isEnemyFacingAwayFromPlayer);
 
-            // If enemy is facing away from player
-            if (enemyAnimStateRecord % 5 > 2)
+            if (isEnemyFacingAwayFromPlayer)
             {
                 player.TallySkill(DFCareer.Skills.Backstabbing, 1);
                 return player.Skills.GetLiveSkillValue(DFCareer.Skills.Backstabbing);

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -23,7 +23,6 @@ using DaggerfallWorkshop.Utility;
 using DaggerfallConnect.Save;
 using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.Utility.ModSupport;
-using static DaggerfallWorkshop.DaggerfallMobileUnit;
 
 namespace DaggerfallWorkshop.Game.Formulas
 {

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -532,7 +532,10 @@ namespace DaggerfallWorkshop.Game
 
                     // Calculate damage
                     int animTime = (int)(ScreenWeapon.GetAnimTime() * 1000);    // Get animation time, converted to ms.
-                    int damage = FormulaHelper.CalculateAttackDamage(playerEntity, enemyEntity, entityMobileUnit.Summary.AnimStateRecord, animTime, strikingWeapon);
+                    bool isEnemyFacingAwayFromPlayer = entityMobileUnit.Summary.AnimStateRecord % 5 > 2 &&
+                        entityMobileUnit.Summary.EnemyState != MobileStates.SeducerTransform1 &&
+                        entityMobileUnit.Summary.EnemyState != MobileStates.SeducerTransform2;
+                    int damage = FormulaHelper.CalculateAttackDamage(playerEntity, enemyEntity, isEnemyFacingAwayFromPlayer, animTime, strikingWeapon);
 
                     // Break any "normal power" concealment effects on player
                     if (playerEntity.IsMagicallyConcealedNormalPower && damage > 0)


### PR DESCRIPTION
Note: Changes the signatures of CalculateAttackDamage and CalculateBackstabChance delegates.
It seemed weird to pass around a frame record number that's tied to current enemies animation.
