### PR TITLE
Fix spurious "can't carry any more" when picking maps

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -640,10 +640,11 @@ namespace DaggerfallWorkshop.Game.Items
             return (TemplateIndex == templateIndex);
         }
 
-        // Horses, carts and arrows are not counted against encumbrance.
+        // Horses, carts, arrows and maps are not counted against encumbrance.
         public float EffectiveUnitWeightInKg()
         {
-            if (ItemGroup == ItemGroups.Transportation || TemplateIndex == (int)Weapons.Arrow)
+            if (ItemGroup == ItemGroups.Transportation || TemplateIndex == (int)Weapons.Arrow ||
+                IsOfTemplate(ItemGroups.MiscItems, (int)MiscItems.Map))
                 return 0f;
             return weightInKg;
         }


### PR DESCRIPTION
If you encumbrance is maxed out, picking maps will work but be followed by a "can't carry any more" message that was stacked below by the call to CanCarryAmount().

This doesn't happen with arrows because their effective weight is 0.
Extend this to maps, which is the simplest fix.