### PR TITLE
Set mod warning MessageBox's default button to 'yes'

### DIFF
--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -484,8 +484,8 @@ namespace DaggerfallWorkshop.Game.Serialization
 
                 modBox.EnableVerticalScrolling(80);
                 modBox.SetText(modMessage);
-                modBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
-                modBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No, true);
+                modBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes, true);
+                modBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No);
                 modBox.PauseWhileOpen = true;
 
                 modBox.OnButtonClick += ((s, messageBoxButton) =>


### PR DESCRIPTION
Pressing the enter key while on the mod warning message will default to 'yes', meaning it will proceed to load the save. It feels more natural to press the enter key as a confirmation than a cancellation.