### PR TITLE
Fix dungeon FM songs (related to #1953)

### DIFF
--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -768,6 +768,7 @@ namespace DaggerfallWorkshop.Game
         static SongFiles[] _dungeonSongsFM = new SongFiles[]
         {
             SongFiles.song_fm_dngn1,
+            SongFiles.song_fm_dngn1,
             SongFiles.song_fm_dngn2,
             SongFiles.song_fm_dngn3,
             SongFiles.song_fm_dngn4,
@@ -779,6 +780,7 @@ namespace DaggerfallWorkshop.Game
             SongFiles.song_04fm,
             SongFiles.song_05fm,
             SongFiles.song_07fm,
+            SongFiles.song_15fm,
             SongFiles.song_15fm,
         };
 

--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -332,7 +332,7 @@ namespace DaggerfallWorkshop.Game
                     }
                     DFRandom.srand(unknown2 ^ ((byte)region << 8));
                     random = DFRandom.rand();
-                    index = (int)(random % 15);
+                    index = (int)(random % DungeonInteriorSongs.Length);
                 }
                 else if (currentPlaylist == SneakingSongs)
                 {


### PR DESCRIPTION
Makes sure they're 15 dungeon FM songs, like the 15 dungeon GM songs, so that songs stay in sync.

In classic Daggerfall configured for SoundBlaster 16,  
- fm_dngn1 plays in The Convocation of Elona, Daggerfall
- 15fm plays in The Ruins of Copperhart Orchard, Daggerfall

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=4401