### PR TITLE
Return to using baseSpeed if riding

### DIFF
--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -177,7 +177,7 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-                float baseRunSpeed = (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
+                float baseRunSpeed = playerMotor.IsRiding ? baseSpeed : (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
                 return baseRunSpeed * (1.35f + (player.Skills.GetLiveSkillValue(DFCareer.Skills.Running) / 200f));
             }
         }


### PR DESCRIPTION
This makes no change to vanilla DFU, but allows mods to allow sprint riding. This will fix the Roleplay & Realism mod exhanced riding sprint function to be faster rather than slower as it currently is.

I can take a different approach if this change is a problem.