### PR TITLE
Ensure that both Mages Guild songs can be played

### DIFF
--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -334,9 +334,9 @@ namespace DaggerfallWorkshop.Game
                     random = DFRandom.rand();
                     index = (int)(random % 15);
                 }
-                else if (currentPlaylist == SneakingSongs)
+                else if (currentPlaylist == SneakingSongs || currentPlaylist == MagesGuildSongs)
                 {
-                    index = UnityEngine.Random.Range(0, SneakingSongs.Length);
+                    index = UnityEngine.Random.Range(0, currentPlaylist.Length);
                 }
             }
             currentSong = currentPlaylist[index];
@@ -738,7 +738,6 @@ namespace DaggerfallWorkshop.Game
             SongFiles.song_gbad,
             SongFiles.song_ggood,
             SongFiles.song_gbad,
-            SongFiles.song_gneut,
             SongFiles.song_gneut,
         };
 


### PR DESCRIPTION
Fix the bug reported on the forums: http://forums.dfworkshop.net/viewtopic.php?f=5&t=4446&sid=1f23cb27abe1fc66bb5e39698055c153. This is similar to what classic does.

I also removed a temple song as there should be only 8 of them, corresponding to the 8 deities.