### PR TITLE
Fix some naming macros

### DIFF
--- a/Assets/Scripts/API/BiogFileMCP.cs
+++ b/Assets/Scripts/API/BiogFileMCP.cs
@@ -142,10 +142,9 @@ namespace DaggerfallConnect.Arena2
 
             public override string Name()
             {   // %bn
-                System.Random random = new System.Random();
-                DFRandom.Seed = (uint)random.Next();
-                NameHelper.BankTypes race = MacroHelper.GetNameBank((Races)parent.characterDocument.raceTemplate.ID);
-                return DaggerfallUnity.Instance.NameHelper.FullName(race, Genders.Male);
+                DFRandom.Seed = (uint)parent.GetHashCode();
+                NameHelper.BankTypes nameBank = MacroHelper.GetNameBank((Races)parent.characterDocument.raceTemplate.ID);
+                return DaggerfallUnity.Instance.NameHelper.FullName(nameBank, Genders.Male);
             }
 
             public override string Q1()
@@ -619,10 +618,23 @@ namespace DaggerfallConnect.Arena2
             public override string ImperialName()
             {   // %imp
                 string[] names = { "Pelagius", "Cephorus", "Uriel", "Cassynder", "Voragiel", "Trabbatus" };
-                System.Random random = new System.Random();
-                DFRandom.Seed = (uint)random.Next();
+                DFRandom.Seed = (uint)parent.GetHashCode();
                 uint rand = DFRandom.rand() % 6;
                 return names[rand];
+            }
+
+            public override string FemaleName()
+            {   // %fn
+                DFRandom.Seed = (uint)parent.GetHashCode() + 123;
+                NameHelper.BankTypes nameBank = MacroHelper.GetNameBank((Races)parent.characterDocument.raceTemplate.ID);
+                return DaggerfallUnity.Instance.NameHelper.FullName(nameBank, Genders.Female);
+            }
+
+            public override string MaleName()
+            {   // %mn
+                DFRandom.Seed = (uint)parent.GetHashCode() + 9543;
+                NameHelper.BankTypes nameBank = MacroHelper.GetNameBank((Races)parent.characterDocument.raceTemplate.ID);
+                return DaggerfallUnity.Instance.NameHelper.FullName(nameBank, Genders.Male);
             }
         }
     }

--- a/Assets/Scripts/Game/Questing/QuestMCP.cs
+++ b/Assets/Scripts/Game/Questing/QuestMCP.cs
@@ -11,6 +11,7 @@ using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Guilds;
+using DaggerfallWorkshop.Game.Utility;
 
 namespace DaggerfallWorkshop.Game.Questing
 {
@@ -33,10 +34,23 @@ namespace DaggerfallWorkshop.Game.Questing
             }
 
             public override string Name()
-            {
-                // Set seed to the quest UID before falling through to random name generation. (See t=2108)
-                DFRandom.srand((int) parent.UID);
-                return null;
+            {   // %n %nam
+                DFRandom.Seed = (uint)parent.UID;
+                return MacroHelper.GetRandomFullName();
+            }
+
+            public override string FemaleName()
+            {   // %fn
+                DFRandom.Seed = (uint)parent.UID;
+                NameHelper.BankTypes nameBank = (NameHelper.BankTypes)MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
+                return DaggerfallUnity.Instance.NameHelper.FullName(nameBank, Genders.Female);
+            }
+
+            public override string MaleName()
+            {   // %mn
+                DFRandom.Seed = (uint)parent.UID + 3457;
+                NameHelper.BankTypes nameBank = (NameHelper.BankTypes)MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
+                return DaggerfallUnity.Instance.NameHelper.FullName(nameBank, Genders.Male);
             }
 
             public override string FactionOrderName()

--- a/Assets/Scripts/Game/TalkManagerMCP.cs
+++ b/Assets/Scripts/Game/TalkManagerMCP.cs
@@ -51,8 +51,8 @@ namespace DaggerfallWorkshop.Game
                 // Used for greeting messages only: 7215, 7216, 7217
                 if (!string.IsNullOrEmpty(GameManager.Instance.TalkManager.GreetingNameNPC))
                     return GameManager.Instance.TalkManager.GreetingNameNPC;
-                else
-                    return null;
+
+                return MacroHelper.GetRandomFullName();
             }
 
             public override string Direction()

--- a/Assets/Scripts/Utility/MacroDataSource.cs
+++ b/Assets/Scripts/Utility/MacroDataSource.cs
@@ -20,7 +20,7 @@ namespace DaggerfallWorkshop.Utility
     // TODO: extract interface when complete set of handlers done? : IMacroDataSource
     {
         public virtual string Name()
-        {   // %n %nam
+        {   // %n %nam %bn
             throw new NotImplementedException();
         }
 
@@ -643,6 +643,18 @@ namespace DaggerfallWorkshop.Utility
         public virtual string ImperialName()
         {
             // %imp
+            throw new NotImplementedException();
+        }
+
+        public virtual string FemaleName()
+        {
+            // %fn %fn2
+            throw new NotImplementedException();
+        }
+
+        public virtual string MaleName()
+        {
+            // %mn %mn2
             throw new NotImplementedException();
         }
     }

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -308,6 +308,17 @@ namespace DaggerfallWorkshop.Utility
             return DaggerfallUnity.Instance.NameHelper.FullName(GetNameBank(race), gender);
         }
 
+        public static string GetRandomFullName()
+        {
+            // Get appropriate nameBankType for this region and a random gender
+            NameHelper.BankTypes nameBankType = NameHelper.BankTypes.Breton;
+            if (GameManager.Instance.PlayerGPS.CurrentRegionIndex > -1)
+                nameBankType = (NameHelper.BankTypes)MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
+            Genders gender = (DFRandom.random_range_inclusive(0, 1) == 1) ? Genders.Female : Genders.Male;
+
+            return DaggerfallUnity.Instance.NameHelper.FullName(nameBankType, gender);
+        }
+
         public static NameHelper.BankTypes GetNameBank(Races race)
         {
             switch (race)
@@ -628,7 +639,7 @@ namespace DaggerfallWorkshop.Utility
                         return child.name;
             }
             // Use a random name if no defined individual ruler.
-            return Name(null);
+            return GetRandomFullName();
         }
 
         private static string Crime(IMacroContextProvider mcp)
@@ -995,13 +1006,15 @@ namespace DaggerfallWorkshop.Utility
         }
 
         private static string FemaleName(IMacroContextProvider mcp)
-        {   // %fn
-            return DaggerfallUnity.Instance.NameHelper.FullName(GetRandomNameBank(), Genders.Female);
+        {   // %fn %fn2
+            if (mcp == null) return null;
+            return mcp.GetMacroDataSource().FemaleName();
         }
 
         private static string MaleName(IMacroContextProvider mcp)
-        {   // %mn
-            return DaggerfallUnity.Instance.NameHelper.FullName(GetRandomNameBank(), Genders.Male);
+        {   // %mn %mn2
+            if (mcp == null) return null;
+            return mcp.GetMacroDataSource().MaleName();
         }
 
         private static string VampireClan(IMacroContextProvider mcp)
@@ -1021,24 +1034,9 @@ namespace DaggerfallWorkshop.Utility
         #region Contextual macro handlers
 
         private static string Name(IMacroContextProvider mcp)
-        {   // %n %nam
-            // Call the MCP first for context.
-            if (mcp != null)
-            {
-                try {
-                    string name = mcp.GetMacroDataSource().Name();
-                    if (name != null)
-                        return name;
-                } catch (NotImplementedException) { }
-            }
-            
-            // Get appropriate nameBankType for this region and a random gender
-            NameHelper.BankTypes nameBankType = NameHelper.BankTypes.Breton;
-            if (GameManager.Instance.PlayerGPS.CurrentRegionIndex > -1)
-                nameBankType = (NameHelper.BankTypes)MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
-            Genders gender = (DFRandom.random_range_inclusive(0, 1) == 1) ? Genders.Female : Genders.Male;
-
-            return DaggerfallUnity.Instance.NameHelper.FullName(nameBankType, gender);
+        {   // %n %nam %bn
+            if (mcp == null) return null;
+            return mcp.GetMacroDataSource().Name();
         }
 
         private static string VampireNpcClan(IMacroContextProvider mcp)


### PR DESCRIPTION
Fix an issue reported on the forums regarding the %fn macro: http://forums.dfworkshop.net/viewtopic.php?f=31&t=4447&sid=26748510f65c64d9c1d3237b74cb59cb

This issue can be seen on character biography when creating a Warrior. The same bug also affects the %mn macro when creating a Knight.

There is also one affected noble quest using both macros, R0C11Y28, where names on the autopsy report are always changing without this fix.

I also took the time to refactor the `MacroHelper.Name` method as its current state was not satisfying.
 