### PR TITLE
Refresh cursor on game start

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -398,7 +398,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <returns>True if asset is found and loaded sucessfully.</returns>
         public bool TryGetAsset<T>(string name, bool? clone, out T asset) where T : UnityEngine.Object
         {
-            var query = from mod in EnumerateModsReverse()
+            var query = from mod in EnumerateEnabledModsReverse()
 #if UNITY_EDITOR
                         where (mod.AssetBundle != null && mod.AssetBundle.Contains(name)) || (mod.IsVirtual && mod.HasAsset(name))
 #else
@@ -423,7 +423,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// <returns>True if asset is found and loaded sucessfully.</returns>
         public bool TryGetAsset<T>(string[] names, bool? clone, out T asset) where T : UnityEngine.Object
         {
-            var query = from mod in EnumerateModsReverse()
+            var query = from mod in EnumerateEnabledModsReverse()
 #if UNITY_EDITOR
                         where mod.AssetBundle != null || mod.IsVirtual
                         from name in names where mod.IsVirtual ? mod.HasAsset(name) : mod.AssetBundle.Contains(name)
@@ -1032,6 +1032,20 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Enumerates all enabled mods with reverse load order, for internal use only. Mods are always launched
+        /// at a later time (after disabled mods are unloaded), so they can use <see cref="EnumerateModsReverse()"/> instead.
+        /// </summary>
+        /// <returns>An enumeration of enabled mods sorted by reverse load order.</returns>
+        internal IEnumerable<Mod> EnumerateEnabledModsReverse()
+        {
+            IEnumerable<Mod> query = EnumerateModsReverse();
+            if (alreadyAtStartMenuState)
+                return query;
+
+            return query.Where(x => x.Enabled);
         }
 
         internal Mod GetModFromName(string name)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -671,9 +671,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 Cursor.SetCursor(tex, Vector2.zero, cursorMode);
                 Debug.Log("Cursor texture overridden by mods.");
-
-                if (!refresh)
-                    StateManager.OnStateChange += StateManager_OnStateChange;
             }
             else
             {
@@ -682,6 +679,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             DaggerfallUnity.Settings.CursorWidth = cursorWidth;
             DaggerfallUnity.Settings.CursorHeight = cursorHeight;
+
+            if (!refresh)
+                StateManager.OnStateChange += StateManager_OnStateChange;
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -157,31 +157,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             moveNextStage = true;
 
-            int cursorWidth = 32;
-            int cursorHeight = 32;
-
             // Apply joystick settings to input manager to keep consistency between the setup wizard and the game
             InputManager.Instance.JoystickCursorSensitivity = DaggerfallUnity.Settings.JoystickCursorSensitivity;
             InputManager.Instance.JoystickDeadzone = DaggerfallUnity.Settings.JoystickDeadzone;
 
             // Override cursor
-            Texture2D tex;
-            if (TextureReplacement.TryImportTexture("Cursor", true, out tex))
-            {
-                CursorMode cursorMode = CursorMode.Auto;
-                cursorWidth = tex.width;
-                cursorHeight = tex.height;
-
-                // Cases when true cursor size cannot be achieved using hardware accelerated cursor
-                if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.Windows && (cursorWidth > 32 || cursorHeight > 32))
-                    cursorMode = CursorMode.ForceSoftware;
-
-                Cursor.SetCursor(tex, Vector2.zero, cursorMode);
-                Debug.Log("Cursor texture overridden by mods.");
-            }
-
-            DaggerfallUnity.Settings.CursorWidth = cursorWidth;
-            DaggerfallUnity.Settings.CursorHeight = cursorHeight;
+            SetCursor();
         }
 
         public override void Update()
@@ -673,6 +654,36 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             return TextManager.Instance.GetText("MainMenu", key);
         }
 
+        private void SetCursor(bool refresh = false)
+        {
+            int cursorWidth = 32;
+            int cursorHeight = 32;
+
+            if (TextureReplacement.TryImportTexture("Cursor", true, out Texture2D tex))
+            {
+                CursorMode cursorMode = CursorMode.Auto;
+                cursorWidth = tex.width;
+                cursorHeight = tex.height;
+
+                // Cases when true cursor size cannot be achieved using hardware accelerated cursor
+                if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.Windows && (cursorWidth > 32 || cursorHeight > 32))
+                    cursorMode = CursorMode.ForceSoftware;
+
+                Cursor.SetCursor(tex, Vector2.zero, cursorMode);
+                Debug.Log("Cursor texture overridden by mods.");
+
+                if (!refresh)
+                    StateManager.OnStateChange += StateManager_OnStateChange;
+            }
+            else
+            {
+                Cursor.SetCursor(null, Vector2.zero, CursorMode.Auto);
+            }
+
+            DaggerfallUnity.Settings.CursorWidth = cursorWidth;
+            DaggerfallUnity.Settings.CursorHeight = cursorHeight;
+        }
+
         #endregion
 
         #region Event Handlers
@@ -867,6 +878,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 AdvancedSettingsWindow advancedSettingsWindow = new AdvancedSettingsWindow(DaggerfallUI.UIManager);
                 DaggerfallUI.UIManager.PushWindow(advancedSettingsWindow);
+            }
+        }
+
+        private void StateManager_OnStateChange(StateManager.StateTypes state)
+        {
+            if (state == StateManager.StateTypes.Start)
+            {
+                StateManager.OnStateChange -= StateManager_OnStateChange;
+                SetCursor(true);
             }
         }
 


### PR DESCRIPTION
Custom assets are tipically only seeked in the Game scene. Cursor is a special case because is also needed in the Startup scene, so there was an issue where a mod providing the cursor, initially enabled, was disabled resulting in a missing cursor, as well as an issue where a custom cursor was provided by a disabled mod.

Cursor is now also seeked on game launch to ensure changes to mod configuration during setup (i.e mod enabled or disabled) are applied.