### PR TITLE
Call UpdateMeshRendererDungeonState() on all children of Transform Models

### DIFF
--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -2264,16 +2264,20 @@ namespace DaggerfallWorkshop.Game
                     foreach (Transform currentTransformMesh in currentTransformModel.transform)
                     {
                         AutomapGeometryModelState model = new AutomapGeometryModelState();
-                        MeshRenderer meshRenderer = currentTransformMesh.GetComponent<MeshRenderer>();
-                        if ((meshRenderer) && (meshRenderer.enabled))
+                        MeshRenderer[] meshRenderers = currentTransformMesh.GetComponentsInChildren<MeshRenderer>();
+                        for (int i = 0; i < meshRenderers.Length; i++)
                         {
-                            model.discovered = true;
-                            model.visitedInThisRun = !meshRenderer.materials[0].IsKeywordEnabled("RENDER_IN_GRAYSCALE"); // all materials of model have the same setting - so just material[0] is tested
-                        }
-                        else
-                        {
-                            model.discovered = false;
-                            model.visitedInThisRun = false;
+                            if ((meshRenderers[i]) && (meshRenderers[i].enabled))
+                            {
+                                model.discovered = true;
+                                model.visitedInThisRun = !meshRenderers[i].materials[0].IsKeywordEnabled("RENDER_IN_GRAYSCALE"); // all materials of model have the same setting - so just material[0] is tested
+                                break;
+                            }
+                            else
+                            {
+                                model.discovered = false;
+                                model.visitedInThisRun = false;
+                            }
                         }
                         models.Add(model);
                     }

--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -2397,7 +2397,7 @@ namespace DaggerfallWorkshop.Game
             DestroyTeleporterMarkers();
         }
 
-        void UpdateMeshRendererDungeonState(ref MeshRenderer meshRenderer, AutomapDungeonState automapDungeonState, int indexBlock, int indexElement, int indexModel, bool forceNotVisitedInThisRun)
+        void UpdateMeshRendererDungeonState(MeshRenderer meshRenderer, AutomapDungeonState automapDungeonState, int indexBlock, int indexElement, int indexModel, bool forceNotVisitedInThisRun)
         {
             if (automapDungeonState.blocks[indexBlock].blockElements[indexElement].models[indexModel].discovered == true)
             {
@@ -2481,10 +2481,13 @@ namespace DaggerfallWorkshop.Game
                     {
                         Transform currentTransformModel = currentTransformElement.GetChild(indexModel);
 
-                        MeshRenderer meshRenderer = currentTransformModel.GetComponent<MeshRenderer>();
-                        if (meshRenderer)
+                        MeshRenderer[] meshRenderers = currentTransformModel.GetComponentsInChildren<MeshRenderer>();
+                        for (int i = 0; i < meshRenderers.Length; i++)
                         {
-                            UpdateMeshRendererDungeonState(ref meshRenderer, automapDungeonState, indexBlock, indexElement, indexModel, forceNotVisitedInThisRun);
+                            if (meshRenderers[i])
+                            {
+                                UpdateMeshRendererDungeonState(meshRenderers[i], automapDungeonState, indexBlock, indexElement, indexModel, forceNotVisitedInThisRun);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This change makes the UpdateMeshRendererDungeonState() function be called on all MeshRenderer components of all children of the current transform model instead of only the first one in it's root. 

This fixes an issue where already discovered models on the dungeon map are not revealed after loading a save game if an OBJ file has been used to replace the model. This change was adapted from pull request #1988 . Without my changes, the dungeon map looks like the first screenshot attached to the issue. With my changes, the same corridor after loading the attached save looks like this, as it should. Don't worry about the wrong textures on my models, that's a separate issue I've reported elsewhere:
![Undiscovered models fixed](https://user-images.githubusercontent.com/7355441/105647826-0ea77080-5f0d-11eb-9e1b-76a26ca9b329.jpg)

If this PR is merged, it will fix #1995 

I'm leaving this as a draft because I would like some comments from the devs. 
On the one hand, Nystul said that this is the wrong way to fix this issue because he believes that if the model hierarchy is different to when the game was saved, it will break stuff.
On the other hand, other changes have been made to DFU in response to other OBJ related issues I've reported. One example is [this pull request](https://github.com/Interkarma/daggerfall-unity/pull/1988) by Pango which fixes it's issue in a similar way to this PR. 
That said, in [this forum post](https://forums.dfworkshop.net/viewtopic.php?p=47664#p47664) - even though TheLacus did change his script to work with OBJ's model hierarchy - he specifically mentioned avoiding GetComponentInChildren() for performance reasons.

I also had to create a new variable to make this work (Unity complained that I can't use a ForEach iteration variable as a ref). Does anyone feel I could have given it a better name? 

Otherwise, it is ready to go.