### PR TITLE
Some fixes for Action Doors with child objects

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableActionDoor.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableActionDoor.cs
@@ -24,7 +24,7 @@ namespace DaggerfallWorkshop.Game.Serialization
     {
         #region Fields
 
-        DaggerfallActionDoor actionDoor;
+        DaggerfallActionDoor[] allActionDoors;
 
         #endregion
 
@@ -32,8 +32,8 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         void Awake()
         {
-            actionDoor = GetComponent<DaggerfallActionDoor>();
-            if (!actionDoor)
+            allActionDoors = GetComponentsInChildren<DaggerfallActionDoor>();
+            if (!allActionDoors[0])
                 throw new Exception("DaggerfallActionDoor not found.");
         }
 
@@ -42,10 +42,10 @@ namespace DaggerfallWorkshop.Game.Serialization
             if (LoadID != 0)
             {
                 // Using same hack ID fix as SerializableEnemy
-                if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && actionDoor)
+                if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideDungeon && allActionDoors[0])
                 {
-                    while (SaveLoadManager.StateManager.ContainsActionDoor(actionDoor.LoadID))
-                        actionDoor.LoadID++;
+                    while (SaveLoadManager.StateManager.ContainsActionDoor(allActionDoors[0].LoadID))
+                        allActionDoors[0].LoadID++;
                 }
 
                 SaveLoadManager.RegisterSerializableGameObject(this);
@@ -67,17 +67,17 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         public object GetSaveData()
         {
-            if (!actionDoor)
+            if (!allActionDoors[0])
                 return null;
 
             ActionDoorData_v1 data = new ActionDoorData_v1();
             data.loadID = LoadID;
-            data.currentLockValue = actionDoor.CurrentLockValue;
+            data.currentLockValue = allActionDoors[0].CurrentLockValue;
             data.currentRotation = transform.rotation;
-            data.currentState = actionDoor.CurrentState;
-            data.lockpickFailedSkillLevel = actionDoor.FailedSkillLevel;
+            data.currentState = allActionDoors[0].CurrentState;
+            data.lockpickFailedSkillLevel = allActionDoors[0].FailedSkillLevel;
 
-            if (actionDoor.IsMoving)
+            if (allActionDoors[0].IsMoving)
             {
                 __ExternalAssets.iTween tween = GetComponent<__ExternalAssets.iTween>();
                 if (tween)
@@ -94,11 +94,11 @@ namespace DaggerfallWorkshop.Game.Serialization
             ActionDoorData_v1 data = (ActionDoorData_v1)dataIn;
             if (data.loadID == LoadID)
             {
-                actionDoor.CurrentLockValue = data.currentLockValue;
-                actionDoor.transform.rotation = data.currentRotation;
-                actionDoor.CurrentState = data.currentState;
-                actionDoor.RestartTween(1 - data.actionPercentage);
-                actionDoor.FailedSkillLevel = data.lockpickFailedSkillLevel;
+                allActionDoors[0].CurrentLockValue = data.currentLockValue;
+                allActionDoors[0].transform.rotation = data.currentRotation;
+                allActionDoors[0].CurrentState = data.currentState;
+                allActionDoors[0].RestartTween(1 - data.actionPercentage);
+                allActionDoors[0].FailedSkillLevel = data.lockpickFailedSkillLevel;
             }
         }
 
@@ -108,12 +108,12 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         bool HasChanged()
         {
-            if (!actionDoor)
+            if (!allActionDoors[0])
                 return false;
 
             // Save when door not closed or lock value has changed
             // Door is otherwise in starting closed position with initial lock value
-            if (actionDoor.CurrentState != ActionState.Start || actionDoor.CurrentLockValue != actionDoor.StartingLockValue)
+            if (allActionDoors[0].CurrentState != ActionState.Start || allActionDoors[0].CurrentLockValue != allActionDoors[0].StartingLockValue)
                 return true;
 
             return false;
@@ -121,10 +121,10 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         ulong GetLoadID()
         {
-            if (!actionDoor)
+            if (!allActionDoors[0])
                 return 0;
 
-            return actionDoor.LoadID;
+            return allActionDoors[0].LoadID;
         }
 
         #endregion

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -1010,9 +1010,9 @@ namespace DaggerfallWorkshop
                 go.transform.position = modelPosition;
 
                 // Get action door script and assign loadID
-                DaggerfallActionDoor actionDoor = go.GetComponent<DaggerfallActionDoor>();
-                if (actionDoor)
-                    actionDoor.LoadID = loadID;
+                DaggerfallActionDoor[] allActionDoors = go.GetComponentsInChildren<DaggerfallActionDoor>();
+                if (allActionDoors[0])
+                    allActionDoors[0].LoadID = loadID;
                 else
                     Debug.LogError($"Failed to get DaggerfallActionDoor on {modelId}. Make sure is added to door prefab.");
 

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1144,19 +1144,22 @@ namespace DaggerfallWorkshop.Utility
             go.transform.localPosition = modelMatrix.GetColumn(3);
 
             // Get action door script
-            DaggerfallActionDoor actionDoor = go.GetComponent<DaggerfallActionDoor>();
-            if (actionDoor)
+            DaggerfallActionDoor[] actionDoors = go.GetComponentsInChildren<DaggerfallActionDoor>();
+            for (int i = 0; i < actionDoors.Length; i++)
             {
-                // Set starting lock value
-                byte[] lockValues = { 0x00, 0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C, 0x0E, 0x10, 0x12, 0x14, 0x19, 0x1E, 0x32, 0x80, 0xFF };
-                actionDoor.StartingLockValue = lockValues[obj.Resources.ModelResource.TriggerFlag_StartingLock >> 4];
+                if (actionDoors[i])
+                {
+                    // Set starting lock value
+                    byte[] lockValues = { 0x00, 0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C, 0x0E, 0x10, 0x12, 0x14, 0x19, 0x1E, 0x32, 0x80, 0xFF };
+                    actionDoors[i].StartingLockValue = lockValues[obj.Resources.ModelResource.TriggerFlag_StartingLock >> 4];
 
-                // Set LoadID
-                actionDoor.LoadID = loadID;
-            }
-            else
-            {
-                Debug.LogError($"Failed to get DaggerfallActionDoor on {modelId}. Make sure is added to door prefab.");
+                    // Set LoadID
+                    actionDoors[i].LoadID = loadID;
+                }
+                else
+                {
+                    Debug.LogError($"Failed to get DaggerfallActionDoor on {modelId}. Make sure is added to door prefab.");
+                }
             }
 
             return go;


### PR DESCRIPTION
This change fixes a bug I found where the Action Doors in a Block don't have their Starting Lock Level (and presumably other variables) set to the block's defined values if the Action Door script is attached to a child of the model's prefab. An example of this is if the door has been replaced by an OBJ model.

I reported this bug on the forum [here](https://forums.dfworkshop.net/viewtopic.php?p=51629#p51629).