### PR TITLE
Ensure that the last location is set to current loc when entering a building.

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -21,6 +21,7 @@ using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.MagicAndEffects;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -666,6 +667,9 @@ namespace DaggerfallWorkshop.Game
                 // Clear all stateful objects from world loose object tracking
                 world.ClearStatefulLooseObjects();
             }
+
+            // Ensure building variant checks use this location.
+            WorldDataVariants.SetLastLocationKeyTo(playerGPS.CurrentRegionIndex, playerGPS.CurrentLocationIndex);
 
             // Raise event
             RaiseOnPreTransitionEvent(TransitionType.ToBuildingInterior, door);

--- a/Assets/Scripts/Terrain/TerrainNature.cs
+++ b/Assets/Scripts/Terrain/TerrainNature.cs
@@ -21,8 +21,21 @@ namespace DaggerfallWorkshop
     /// </summary>
     public interface ITerrainNature
     {
+        /// <summary>
+        /// This should return true if any nature flat is replaced by a 3d model.
+        /// 
+        /// It's used by DFU streaming world to trigger nature layout for map pixels moving between distance 1 and 2 when
+        /// 3d models are used. Distance 1 use models, but map pixels at distance 2+ still use billboards for performance.
+        /// </summary>
         bool NatureMeshUsed { get; }
 
+        /// <summary>
+        /// Layout nature flats for a map pixel.
+        /// </summary>
+        /// <param name="dfTerrain">The terrain object for the map pixel</param>
+        /// <param name="dfBillboardBatch">Daggerfall billboard batcher object to add flats to</param>
+        /// <param name="terrainScale">Terrain scale being used by streaming world</param>
+        /// <param name="terrainDist">Distance of this map pixel from the one the player is currently in</param>
         void LayoutNature(DaggerfallTerrain dfTerrain, DaggerfallBillboardBatch dfBillboardBatch, float terrainScale, int terrainDist);
     }
 

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataVariants.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataVariants.cs
@@ -57,6 +57,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
         static Dictionary<VariantBuildingKey, string> buildingVariants = new Dictionary<VariantBuildingKey, string>();
 
+        /// <summary>
+        /// Sets the last location key to specified location in region. Used before entering buildings to
+        /// ensure that the correct location specific variant can be found.
+        /// </summary>
+        public static void SetLastLocationKeyTo(int regionIndex, int locationIndex)
+        {
+            lastLocationKey = WorldDataReplacement.MakeLocationKey(regionIndex, locationIndex);
+        }
+
         #region Setters for variants
 
         /// <summary>

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataVariants.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataVariants.cs
@@ -214,6 +214,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return NoVariant;
         }
 
+        public static string GetBuildingVariant(int regionIndex, int locationIndex, string blockName, int recordIndex)
+        {
+            int locationKey = WorldDataReplacement.MakeLocationKey(regionIndex, locationIndex);
+            VariantBuildingKey buildingKey = new VariantBuildingKey(lastLocationKey, blockName, recordIndex);
+            return buildingVariants[buildingKey];
+        }
+
 
         #endregion
 


### PR DESCRIPTION
Turns out that live builds can sometimes update locations in a different order leaving the last location set to someplace other than current which breaks building variants for first entry.

Also added some docs for the terrain nature interface.
