### PR TITLE
Extra features for the CustomDoor script

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -470,7 +470,7 @@ namespace DaggerfallWorkshop.Game
             Transform doorOwner)
         {
             StaticDoor door;
-            if (CustomDoor.HasHit(hit, out door) || (doors && doors.HasHit(hit.point, out door))
+            if (CustomDoor.HasHit(hit, out door) || (doors && doors.HasHit(hit.point, out door)))
             {
                 // Check if close enough to activate
                 if (hit.distance > DoorActivationDistance)

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -469,9 +469,8 @@ namespace DaggerfallWorkshop.Game
             int buildingLockValue,
             Transform doorOwner)
         {
-            bool noCustomDoorFound;
             StaticDoor door;
-            if (CustomDoor.HasHit(hit, out door, out noCustomDoorFound) || (doors && noCustomDoorFound && doors.HasHit(hit.point, out door)))
+            if (CustomDoor.HasHit(hit, out door) || doors.HasHit(hit.point, out door))
             {
                 // Check if close enough to activate
                 if (hit.distance > DoorActivationDistance)
@@ -1004,8 +1003,7 @@ namespace DaggerfallWorkshop.Game
             Transform doorOwner;
             DaggerfallStaticDoors doors = GetDoors(hit.transform, out doorOwner);
             StaticDoor door;
-            bool noCustomDoorFound;
-            if (CustomDoor.HasHit(hit, out door, out noCustomDoorFound) || (doors && noCustomDoorFound && doors.HasHit(hit.point, out door)))
+            if (CustomDoor.HasHit(hit, out door) || (doors && doors.HasHit(hit.point, out door)))
             {
                 // Discover building - this is needed to check lock level and transition to interior
                 GameManager.Instance.PlayerGPS.DiscoverBuilding(door.buildingKey);

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -470,7 +470,7 @@ namespace DaggerfallWorkshop.Game
             Transform doorOwner)
         {
             StaticDoor door;
-            if (CustomDoor.HasHit(hit, out door) || doors.HasHit(hit.point, out door))
+            if (CustomDoor.HasHit(hit, out door) || (doors && doors.HasHit(hit.point, out door))
             {
                 // Check if close enough to activate
                 if (hit.distance > DoorActivationDistance)

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -470,7 +470,7 @@ namespace DaggerfallWorkshop.Game
             Transform doorOwner)
         {
             StaticDoor door;
-            if (doors.HasHit(hit.point, out door) || CustomDoor.HasHit(hit, out door))
+            if (CustomDoor.HasHit(hit, out door) || doors.HasHit(hit.point, out door))
             {
                 // Check if close enough to activate
                 if (hit.distance > DoorActivationDistance)

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -469,8 +469,9 @@ namespace DaggerfallWorkshop.Game
             int buildingLockValue,
             Transform doorOwner)
         {
+            bool noCustomDoorFound;
             StaticDoor door;
-            if (CustomDoor.HasHit(hit, out door) || doors.HasHit(hit.point, out door))
+            if (CustomDoor.HasHit(hit, out door, out noCustomDoorFound) || (doors && noCustomDoorFound && doors.HasHit(hit.point, out door)))
             {
                 // Check if close enough to activate
                 if (hit.distance > DoorActivationDistance)
@@ -1003,7 +1004,8 @@ namespace DaggerfallWorkshop.Game
             Transform doorOwner;
             DaggerfallStaticDoors doors = GetDoors(hit.transform, out doorOwner);
             StaticDoor door;
-            if (doors && doors.HasHit(hit.point, out door) || CustomDoor.HasHit(hit, out door))
+            bool noCustomDoorFound;
+            if (CustomDoor.HasHit(hit, out door, out noCustomDoorFound) || (doors && noCustomDoorFound && doors.HasHit(hit.point, out door)))
             {
                 // Discover building - this is needed to check lock level and transition to interior
                 GameManager.Instance.PlayerGPS.DiscoverBuilding(door.buildingKey);

--- a/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
@@ -26,10 +26,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     {
         private StaticDoor? staticDoor;
 
+        [Tooltip("Type of door that is being defined. None means building textures are used to determine this.")]
+        public DoorTypes DoorType = DoorTypes.None;
+        
         /// <summary>
-        /// The trigger for this door.
+        /// The triggers for the doors.
         /// </summary>
-        [Tooltip("The trigger for this door.")]
+        [Tooltip("The triggers for the doors.")]
         public BoxCollider DoorTrigger;
 
         private void Awake()
@@ -53,9 +56,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             staticDoor.buildingKey = buildingKey;
 
             // Set data to all doors in the building
-            var doors = building.GetComponentsInChildren<CustomDoor>();
-            for (int i = 0; i < doors.Length; i++)
-                doors[i].staticDoor = staticDoor;
+            CustomDoor[] allCustomDoors = building.GetComponentsInChildren<CustomDoor>();
+            for (int i = 0; i < allCustomDoors.Length; i++)
+            {
+                if ((allCustomDoors[i].DoorType != null) && (allCustomDoors[i].DoorType != DoorTypes.None))
+                    staticDoor.DoorType = allCustomDoors[i].DoorType;
+                allCustomDoors[i].staticDoor = staticDoor;
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
@@ -26,8 +26,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     {
         private StaticDoor? staticDoor;
         
-        [Tooltip("If ticked, tells the game not to check for a static door hit after checking for custom doors. NOTE: This is enabled per model, not per script.")]
-        public bool NoStaticDoorCheck = false;
+        [Tooltip("Disables all classic doors on this building (not only on the gameobject where this component is added).")]
+        public bool DisableClassicDoors = false;
         
         [Tooltip("Choose which of the doors in this model's Static Door array will be copied for this custom door.")]
         public int StaticDoorCopied = 0;
@@ -35,7 +35,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <summary>
         /// The trigger for this door.
         /// </summary>
-        [Tooltip("The trigger for this door. Drag and drop your Box Collider here.")]
+        [Tooltip("The trigger for this door. If unset, uses the first box collider found on gameobject.")]
         public BoxCollider DoorTrigger;
 
         private void Awake()
@@ -59,7 +59,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             CustomDoor[] allCustomDoors = building.GetComponentsInChildren<CustomDoor>();
             for (int i = 0; i < allCustomDoors.Length; i++)
             {
-                if (allCustomDoors[i].NoStaticDoorCheck == true)
+                if (allCustomDoors[i].DisableClassicDoors == true)
                     dontCreateStaticDoors = true;
 
                 if ((allCustomDoors[i].StaticDoorCopied < 0) || (allCustomDoors[i].StaticDoorCopied > staticDoors.Length))

--- a/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
@@ -51,6 +51,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="building">The imported gameobject which provides building and doors.</param>
         /// <param name="staticDoors">The list of static doors for the vanilla building.</param>
         /// <param name="buildingKey">The key of the building that owns the doors.</param>
+        /// <param name="dontCreateStaticDoors">If true, custom door components request to suppress classic doors.</param>
         public static void InitDoors(GameObject building, StaticDoor[] staticDoors, int buildingKey, out bool dontCreateStaticDoors)
         {
             dontCreateStaticDoors = false;

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -153,20 +153,23 @@ namespace DaggerfallWorkshop.Utility
             // Add models and static props
             GameObject modelsNode = new GameObject("Models");
             modelsNode.transform.parent = go.transform;
-            AddModels(dfUnity, layoutX, layoutY, ref blockData, out modelDoors, out modelBuildings, combiner, modelsNode.transform);
+            AddModels(dfUnity, layoutX, layoutY, ref blockData, out modelDoors, out modelBuildings, out bool dontCreateStaticDoors, combiner, modelsNode.transform);
             AddProps(dfUnity, ref blockData, out propDoors, combiner, modelsNode.transform);
 
             // Combine list of doors found in models and props
             List<StaticDoor> allDoors = new List<StaticDoor>();
-            if (modelDoors.Count > 0) allDoors.AddRange(modelDoors);
-            if (propDoors.Count > 0) allDoors.AddRange(propDoors);
-
-            // Assign building key to each door
-            for (int i = 0; i < allDoors.Count; i++)
+            if (dontCreateStaticDoors != true)
             {
-                StaticDoor door = allDoors[i];
-                door.buildingKey = BuildingDirectory.MakeBuildingKey((byte)layoutX, (byte)layoutY, (byte)door.recordIndex);
-                allDoors[i] = door;
+                if (modelDoors.Count > 0) allDoors.AddRange(modelDoors);
+                if (propDoors.Count > 0) allDoors.AddRange(propDoors);
+
+                // Assign building key to each door
+                for (int i = 0; i < allDoors.Count; i++)
+                {
+                    StaticDoor door = allDoors[i];
+                    door.buildingKey = BuildingDirectory.MakeBuildingKey((byte)layoutX, (byte)layoutY, (byte)door.recordIndex);
+                    allDoors[i] = door;
+                }
             }
 
             // Assign building key to each building
@@ -710,11 +713,13 @@ namespace DaggerfallWorkshop.Utility
             ref DFBlock blockData,
             out List<StaticDoor> doorsOut,
             out List<StaticBuilding> buildingsOut,
+            out bool dontCreateStaticDoors,
             ModelCombiner combiner = null,
             Transform parent = null)
         {
             doorsOut = new List<StaticDoor>();
             buildingsOut = new List<StaticBuilding>();
+            dontCreateStaticDoors = false;
 
             // Iterate through all subrecords
             int recordCount = 0;
@@ -771,7 +776,7 @@ namespace DaggerfallWorkshop.Utility
                     {
                         // Find doors
                         if (staticDoors != null && staticDoors.Length > 0)
-                            CustomDoor.InitDoors(go, staticDoors, buildingKey);
+                            CustomDoor.InitDoors(go, staticDoors, buildingKey, out dontCreateStaticDoors);
 
                         continue;
                     }


### PR DESCRIPTION
My changes here add two additional functions to the CustomDoor script:
- You can specify what DoorType the doors created by this script will be in the Editor's Inspector, giving a modder the ability to override the DoorType set by analysing the textures.
- ~~You can add multiple BoxColliders to the model and allow more than one of them to be treated as a door by this script.~~ Edit: Original code already did this.

I've marked this as a draft to get the opinions of the DFU devs and see if this is something you are willing to add to the base game. Especially @TheLacus since this was originally his work.