### PR TITLE
Bugfix of wrong choice for Nature Billboards at Climate borders

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -1250,7 +1250,8 @@ namespace DaggerfallWorkshop
             if (dfTerrain && dfBillboardBatch)
             {
                 // Get current climate and nature archive and terrain distance
-                int natureArchive = ClimateSwaps.GetNatureArchive(dfTerrain.MapData.worldClimate, dfUnity.WorldTime.Now.SeasonValue);
+                DFLocation.ClimateSettings worldClimateSettings = MapsFile.GetWorldClimateSettings(dfTerrain.MapData.worldClimate);
+                int natureArchive = ClimateSwaps.GetNatureArchive(worldClimateSettings.NatureSet, dfUnity.WorldTime.Now.SeasonValue);
                 dfBillboardBatch.SetMaterial(natureArchive);
                 int terrainDist = GetTerrainDist(LocalPlayerGPS.CurrentMapPixel, dfTerrain.MapPixelX, dfTerrain.MapPixelY);
                 dfUnity.TerrainNature.LayoutNature(dfTerrain, dfBillboardBatch, TerrainScale, terrainDist);

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -1250,7 +1250,7 @@ namespace DaggerfallWorkshop
             if (dfTerrain && dfBillboardBatch)
             {
                 // Get current climate and nature archive and terrain distance
-                int natureArchive = ClimateSwaps.GetNatureArchive(LocalPlayerGPS.ClimateSettings.NatureSet, dfUnity.WorldTime.Now.SeasonValue);
+                int natureArchive = ClimateSwaps.GetNatureArchive(dfTerrain.MapData.worldClimate, dfUnity.WorldTime.Now.SeasonValue);
                 dfBillboardBatch.SetMaterial(natureArchive);
                 int terrainDist = GetTerrainDist(LocalPlayerGPS.CurrentMapPixel, dfTerrain.MapPixelX, dfTerrain.MapPixelY);
                 dfUnity.TerrainNature.LayoutNature(dfTerrain, dfBillboardBatch, TerrainScale, terrainDist);

--- a/Assets/Scripts/Utility/ClimateSwaps.cs
+++ b/Assets/Scripts/Utility/ClimateSwaps.cs
@@ -383,6 +383,48 @@ namespace DaggerfallWorkshop.Utility
             return GetNatureArchive(natureSet, climateSeason);
         }
 
+        public static int GetNatureArchive(int climate, DaggerfallDateTime.Seasons worldSeason)
+        {
+            ClimateNatureSets natureSet;
+            ClimateSeason climateSeason = ClimateSeason.Summer;
+            if (worldSeason == DaggerfallDateTime.Seasons.Winter)
+                climateSeason = ClimateSeason.Winter;
+
+            switch (climate)
+            {
+                case 227:
+                    natureSet = ClimateNatureSets.RainForest;
+                    break;
+                case 229:
+                    natureSet = ClimateNatureSets.SubTropical;
+                    break;
+                case 228:
+                    natureSet = ClimateNatureSets.Swamp;
+                    break;
+                case 224:
+                case 225:
+                    natureSet = ClimateNatureSets.Desert;
+                    break;
+                case 231:
+                    natureSet = ClimateNatureSets.TemperateWoodland;
+                    break;
+                case 230:
+                    natureSet = ClimateNatureSets.WoodlandHills;
+                    break;
+                case 232:
+                    natureSet = ClimateNatureSets.HauntedWoodlands;
+                    break;
+                case 226:
+                    natureSet = ClimateNatureSets.Mountains;
+                    break;
+                default:
+                    natureSet = ClimateNatureSets.TemperateWoodland;
+                    break;
+            }
+
+            return GetNatureArchive(natureSet, climateSeason);
+        }
+
         public static int GetNatureArchive(ClimateNatureSets natureSet, ClimateSeason climateSeason)
         {
             // Get base set

--- a/Assets/Scripts/Utility/ClimateSwaps.cs
+++ b/Assets/Scripts/Utility/ClimateSwaps.cs
@@ -383,48 +383,6 @@ namespace DaggerfallWorkshop.Utility
             return GetNatureArchive(natureSet, climateSeason);
         }
 
-        public static int GetNatureArchive(int climate, DaggerfallDateTime.Seasons worldSeason)
-        {
-            ClimateNatureSets natureSet;
-            ClimateSeason climateSeason = ClimateSeason.Summer;
-            if (worldSeason == DaggerfallDateTime.Seasons.Winter)
-                climateSeason = ClimateSeason.Winter;
-
-            switch (climate)
-            {
-                case 227:
-                    natureSet = ClimateNatureSets.RainForest;
-                    break;
-                case 229:
-                    natureSet = ClimateNatureSets.SubTropical;
-                    break;
-                case 228:
-                    natureSet = ClimateNatureSets.Swamp;
-                    break;
-                case 224:
-                case 225:
-                    natureSet = ClimateNatureSets.Desert;
-                    break;
-                case 231:
-                    natureSet = ClimateNatureSets.TemperateWoodland;
-                    break;
-                case 230:
-                    natureSet = ClimateNatureSets.WoodlandHills;
-                    break;
-                case 232:
-                    natureSet = ClimateNatureSets.HauntedWoodlands;
-                    break;
-                case 226:
-                    natureSet = ClimateNatureSets.Mountains;
-                    break;
-                default:
-                    natureSet = ClimateNatureSets.TemperateWoodland;
-                    break;
-            }
-
-            return GetNatureArchive(natureSet, climateSeason);
-        }
-
         public static int GetNatureArchive(ClimateNatureSets natureSet, ClimateSeason climateSeason)
         {
             // Get base set


### PR DESCRIPTION
Solved a bug where the PlayerGPS climate was used when picking nature billboards for new terrains instead of the terrains climate itself. This solves the bug at climate transitions, where terrains got nature billboards assigned, that were based on the players current climate location, not their actual climate.