### PR TITLE
Move Stealth skillcheck to FormulaHelper

### DIFF
--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -617,7 +617,7 @@ namespace DaggerfallWorkshop.Game
 
             timeOfLastStealthCheck = gameMinutes;
 
-            int stealthChance = FormulaHelper.CalculateStealthChance(distanceToTarget, MeshReader.GlobalScale, target);
+            int stealthChance = FormulaHelper.CalculateStealthChance(distanceToTarget, target);
 
             return Dice100.FailedRoll(stealthChance);
         }

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -277,7 +277,7 @@ namespace DaggerfallWorkshop.Game.Formulas
         }
         
         // Calculate chance of stealth skill hiding the user.
-        public static int CalculateStealthChance(float distanceToTarget, float globalScale, DaggerfallEntityBehaviour target)
+        public static int CalculateStealthChance(float distanceToTarget, DaggerfallEntityBehaviour target)
         {
             Func<float, float, DaggerfallEntityBehaviour, int> del;
             if (TryGetOverride("CalculateStealthChance", out del))

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -279,11 +279,11 @@ namespace DaggerfallWorkshop.Game.Formulas
         // Calculate chance of stealth skill hiding the user.
         public static int CalculateStealthChance(float distanceToTarget, DaggerfallEntityBehaviour target)
         {
-            Func<float, float, DaggerfallEntityBehaviour, int> del;
+            Func<float, DaggerfallEntityBehaviour, int> del;
             if (TryGetOverride("CalculateStealthChance", out del))
-                return del(distanceToTarget, globalScale, target);
+                return del(distanceToTarget, target);
 
-            int chance = 2 * ((int)(distanceToTarget / globalScale) * target.Entity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth) >> 10);
+            int chance = 2 * ((int)(distanceToTarget / MeshReader.GlobalScale) * target.Entity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth) >> 10);
             return chance;
         }
 


### PR DESCRIPTION
I am working on a Thief overhaul mod and to make any headway I need the ability to override the stealth check.

As far as I can see, only EnemySenses.cs checks this, so I have made a PR that moves this calculation to FormulaHelper, making it possible for mods to easily change how stealth is checked.