### PR TITLE
fix potion maker's stackCounts

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -78,7 +78,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         List<DaggerfallUnityItem> ingredients = new List<DaggerfallUnityItem>();
         // Keep track of parent stack for splitted off ingredients
-        // invariant: if parent is in cauldron, no children is in ingredients
+        // invariant: if parent is in cauldron, no children are in ingredients
         Dictionary<DaggerfallUnityItem, DaggerfallUnityItem> parentStacks = new Dictionary<DaggerfallUnityItem, DaggerfallUnityItem>();
         List<DaggerfallUnityItem> cauldron = new List<DaggerfallUnityItem>();
         List<PotionRecipe> recipes = new List<PotionRecipe>();


### PR DESCRIPTION
Keep track of parent stack of splitted stacks;

Use it to enforce a new invariant: if a parent stack is in cauldron, none of its children must be in the ingredients 
(=> move parent to cauldron last, but also move parent to ingredients first).

Forums: https://forums.dfworkshop.net/viewtopic.php?f=31&t=4507