### PR TITLE
Update paymoney quest action to allow only gold to be accepted if desired

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/PayMoney.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PayMoney.cs
@@ -21,10 +21,11 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
         Symbol paidTaskSymbol;
         Symbol notTaskSymbol;
         int amount;
+        bool goldOnly;
 
         public override string Pattern
         {
-            get { return @"pay (?<amount>\d+) money do (?<paidTaskName>[a-zA-Z0-9_.]+) otherwise do (?<notTaskName>[a-zA-Z0-9_.]+)"; }
+            get { return @"pay (?<amount>\d+) (?<type>money|gold) do (?<paidTaskName>[a-zA-Z0-9_.]+) otherwise do (?<notTaskName>[a-zA-Z0-9_.]+)"; }
         }
 
         public PayMoney(Quest parentQuest)
@@ -43,6 +44,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             // Factory new action
             PayMoney action = new PayMoney(parentQuest);
             action.amount = Parser.ParseInt(match.Groups["amount"].Value);
+            action.goldOnly = match.Groups["type"].Value == "gold";
             action.paidTaskSymbol = new Symbol(match.Groups["paidTaskName"].Value);
             action.notTaskSymbol = new Symbol(match.Groups["notTaskName"].Value);
 
@@ -56,21 +58,37 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             // When an amount is specified
             if (amount > 0)
             {
-                // Does player have enough gold?
-                if (GameManager.Instance.PlayerEntity.GetGoldAmount() >= amount)
+                if (goldOnly)
                 {
-                    // Then deduct gold
-                    GameManager.Instance.PlayerEntity.DeductGoldAmount(amount);
-                    ParentQuest.StartTask(paidTaskSymbol);
+                    // Does player have enough gold?
+                    if (GameManager.Instance.PlayerEntity.GoldPieces >= amount)
+                    {
+                        // Then deduct gold and start paid task
+                        GameManager.Instance.PlayerEntity.GoldPieces -= amount;
+                        ParentQuest.StartTask(paidTaskSymbol);
+                    }
+                    else
+                    {
+                        // Otherwise trigger secondary task and exit
+                        ParentQuest.StartTask(notTaskSymbol);
+                    }
                 }
                 else
                 {
-                    // Otherwise trigger secondary task and exit
-                    ParentQuest.StartTask(notTaskSymbol);
+                    // Does player have enough money?
+                    if (GameManager.Instance.PlayerEntity.GetGoldAmount() >= amount)
+                    {
+                        // Then deduct money and start paid task
+                        GameManager.Instance.PlayerEntity.DeductGoldAmount(amount);
+                        ParentQuest.StartTask(paidTaskSymbol);
+                    }
+                    else
+                    {
+                        // Otherwise trigger secondary task and exit
+                        ParentQuest.StartTask(notTaskSymbol);
+                    }
                 }
             }
-
-            SetComplete();
         }
 
         #region Serialization
@@ -81,6 +99,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             public Symbol paidTaskSymbol;
             public Symbol notTaskSymbol;
             public int amount;
+            public bool goldOnly;
         }
 
         public override object GetSaveData()
@@ -89,6 +108,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             data.paidTaskSymbol = paidTaskSymbol;
             data.notTaskSymbol = notTaskSymbol;
             data.amount = amount;
+            data.goldOnly = goldOnly;
 
             return data;
         }
@@ -102,6 +122,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             paidTaskSymbol = data.paidTaskSymbol;
             notTaskSymbol = data.notTaskSymbol;
             amount = data.amount;
+            goldOnly = data.goldOnly;
         }
 
         #endregion


### PR DESCRIPTION
This action was added for my R&R quest Mountain Rumors. With the latest quest machine changes I needed pay money to be able to limit to just real gold pieces. SHould be backwards compatible with saves, and it worked for me.