### PR TITLE
Added Forward Thrust as an option

### DIFF
--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -172,6 +172,8 @@ namespace DaggerfallWorkshop.Game
                     state = WeaponStates.StrikeDownRight;
                     break;
                 case WeaponManager.MouseDirections.Up:
+                case WeaponManager.MouseDirections.UpLeft:
+                case WeaponManager.MouseDirections.UpRight:
                     state = WeaponStates.StrikeUp;
                     break;
                 default:

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -335,7 +335,7 @@ namespace DaggerfallWorkshop.Game
                 }
                 else if (isClickAttack)
                 {
-                    attackDirection = (MouseDirections)UnityEngine.Random.Range((int)MouseDirections.Left, (int)MouseDirections.DownRight + 1);
+                    attackDirection = (MouseDirections)UnityEngine.Random.Range((int)MouseDirections.UpRight, (int)MouseDirections.DownRight + 1);
                     isClickAttack = false;
                 }
                 else


### PR DESCRIPTION
Hi all,
I saw this as a bug, but it may have been intentional. If so, please reject this PR.
I noticed that the click to attack never selects Thrust forward. It turns out that the random selection doesn't have thrust as an option. I changed it to now include upRight (enum #3 instead of starting with Left Enum #4).

I did have to change FPSWeapon as OnAttackDirection was only looking for Up instead of also looking for UpLeft and UpRight.

Thanks
a