### PR TITLE
Add NameSeed to building overrides

### DIFF
--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -720,6 +720,10 @@ namespace DaggerfallConnect.Arena2
                     blocks[block].DFBlock.RmbBlock.SubRecords[i] = buildingReplacementData.RmbSubRecord;
                     blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].FactionId = buildingReplacementData.FactionId;
                     blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.BuildingType;
+                    if (buildingReplacementData.Quality > 0)
+                        blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].Quality = buildingReplacementData.Quality;
+                    if (buildingReplacementData.NameSeed > 0)
+                        blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].NameSeed = buildingReplacementData.NameSeed;
                     if (buildingReplacementData.AutoMapData != null && buildingReplacementData.AutoMapData.Length == 64 * 64)
                         blocks[block].DFBlock.RmbBlock.FldHeader.AutoMapData = buildingReplacementData.AutoMapData;
                 }

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -29,6 +29,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         public ushort FactionId;
         public int BuildingType;
         public byte Quality;
+        public ushort NameSeed;
         public DFBlock.RmbSubRecord RmbSubRecord;
         public byte[] AutoMapData;      // for coloured map (optional)
     }

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -565,13 +565,14 @@ namespace DaggerfallWorkshop.Utility
                                 // Use custom building values from replacement data, but only use up pool item if factionId is zero
                                 if (buildingReplacementData.FactionId != 0)
                                 {
-                                    // Don't use up pool item and set factionId from replacement data
+                                    // Don't use up pool item and set factionId, NameSeed, Quality from replacement data
                                     item.used = false;
                                     building.FactionId = buildingReplacementData.FactionId;
+                                    building.Quality = buildingReplacementData.Quality;
+                                    building.NameSeed = buildingReplacementData.NameSeed;
                                 }
-                                // Always override type and quality
+                                // Always override type
                                 building.BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.BuildingType;
-                                building.Quality = buildingReplacementData.Quality;
                             }
 
                             // Matched to classic: special handling for some Order of the Raven buildings

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -569,7 +569,7 @@ namespace DaggerfallWorkshop.Utility
                                     item.used = false;
                                     building.FactionId = buildingReplacementData.FactionId;
                                     building.Quality = buildingReplacementData.Quality;
-                                    building.NameSeed = buildingReplacementData.NameSeed;
+                                    building.NameSeed = (ushort)(buildingReplacementData.NameSeed + location.LocationIndex);    // Vary name seed by location
                                 }
                                 // Always override type
                                 building.BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.BuildingType;


### PR DESCRIPTION
Missed this before because I was doing a guild and they don't use a seed for the name. Have already updated documentation accordingly here https://forums.dfworkshop.net/viewtopic.php?p=32886#p32886