### PR TITLE
Automap: Add support for the discovery state of OBJ models to be saved and loaded

### DIFF
--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -2264,16 +2264,20 @@ namespace DaggerfallWorkshop.Game
                     foreach (Transform currentTransformMesh in currentTransformModel.transform)
                     {
                         AutomapGeometryModelState model = new AutomapGeometryModelState();
-                        MeshRenderer meshRenderer = currentTransformMesh.GetComponent<MeshRenderer>();
-                        if ((meshRenderer) && (meshRenderer.enabled))
+                        MeshRenderer[] meshRenderers = currentTransformMesh.GetComponentsInChildren<MeshRenderer>();
+                        for (int i = 0; i < meshRenderers.Length; i++)
                         {
-                            model.discovered = true;
-                            model.visitedInThisRun = !meshRenderer.materials[0].IsKeywordEnabled("RENDER_IN_GRAYSCALE"); // all materials of model have the same setting - so just material[0] is tested
-                        }
-                        else
-                        {
-                            model.discovered = false;
-                            model.visitedInThisRun = false;
+                            if ((meshRenderers[i]) && (meshRenderers[i].enabled))
+                            {
+                                model.discovered = true;
+                                model.visitedInThisRun = !meshRenderers[i].materials[0].IsKeywordEnabled("RENDER_IN_GRAYSCALE"); // all materials of model have the same setting - so just material[0] is tested
+                                break;
+                            }
+                            else
+                            {
+                                model.discovered = false;
+                                model.visitedInThisRun = false;
+                            }
                         }
                         models.Add(model);
                     }
@@ -2481,10 +2485,13 @@ namespace DaggerfallWorkshop.Game
                     {
                         Transform currentTransformModel = currentTransformElement.GetChild(indexModel);
 
-                        MeshRenderer meshRenderer = currentTransformModel.GetComponent<MeshRenderer>();
-                        if (meshRenderer)
+                        MeshRenderer[] meshRenderers = currentTransformModel.GetComponentsInChildren<MeshRenderer>();
+                        for (int i = 0; i < meshRenderers.Length; i++)
                         {
-                            UpdateMeshRendererDungeonState(ref meshRenderer, automapDungeonState, indexBlock, indexElement, indexModel, forceNotVisitedInThisRun);
+                            if (meshRenderers[i])
+                            {
+                                UpdateMeshRendererDungeonState(meshRenderers[i], automapDungeonState, indexBlock, indexElement, indexModel, forceNotVisitedInThisRun);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This does two things:
1. Makes the UpdateMeshRendererDungeonState() function be called on all components of all children of the current transform model instead of only the first component in it's root. This fixes an issue where already discovered models on the dungeon map are not revealed after loading a save game if an OBJ file has been used to replace the model.
2. Solves an issue where the SaveStateAutomapDungeon function doesn't properly save the discovery state of OBJ models because it only checked the MeshRenderer component attached to the model's root and not those attached to children.

This PR is identical to #2002, just with all of my changes moved to a new branch. This PR fixes #1995.