### PR TITLE
RuntimeMaterial: Take RandomDungeonTextures setting into account

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallDungeon.cs
+++ b/Assets/Scripts/Internal/DaggerfallDungeon.cs
@@ -567,11 +567,16 @@ namespace DaggerfallWorkshop
         /// <summary>
         /// An event raised after a dungeon has been set and its layout has been performed.
         /// </summary>
-        public static event Action<DaggerfallDungeon> OnSetDungeon;
+        public delegate void OnSetDungeonEventHandler(DaggerfallDungeon daggerfallDungeon, int[] dungeonTextureTable, int dungeonID);
+        public static event OnSetDungeonEventHandler OnSetDungeon;
         private void RaiseOnSetDungeonEvent()
         {
             if (OnSetDungeon != null)
-                OnSetDungeon(this);
+            {
+                int[] dungeonTextureTable = DungeonTextureTable;
+                int dungeonID = summary.ID;
+                OnSetDungeon(this, dungeonTextureTable, dungeonID);
+            }
         }
     }
 }

--- a/Assets/Scripts/Internal/DaggerfallDungeon.cs
+++ b/Assets/Scripts/Internal/DaggerfallDungeon.cs
@@ -567,16 +567,11 @@ namespace DaggerfallWorkshop
         /// <summary>
         /// An event raised after a dungeon has been set and its layout has been performed.
         /// </summary>
-        public delegate void OnSetDungeonEventHandler(DaggerfallDungeon daggerfallDungeon, int[] dungeonTextureTable, int dungeonID);
-        public static event OnSetDungeonEventHandler OnSetDungeon;
+        public static event Action<DaggerfallDungeon> OnSetDungeon;
         private void RaiseOnSetDungeonEvent()
         {
             if (OnSetDungeon != null)
-            {
-                int[] dungeonTextureTable = DungeonTextureTable;
-                int dungeonID = summary.ID;
-                OnSetDungeon(this, dungeonTextureTable, dungeonID);
-            }
+                OnSetDungeon(this);
         }
     }
 }

--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
@@ -234,13 +234,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 #endif
 
-        private void DaggerfallDungeon_OnSetDungeon(DaggerfallDungeon daggerfallDungeon, int[] dungeonTextureTable, int dungeonID)
+        private void DaggerfallDungeon_OnSetDungeon(DaggerfallDungeon daggerfallDungeon)
         {
             if (transform.IsChildOf(daggerfallDungeon.transform))
             {
                 DaggerfallDungeon.OnSetDungeon -= DaggerfallDungeon_OnSetDungeon;
                 subscribedToOnSetDungeon = false;
-                ApplyMaterials(true, dungeonTextureTable, dungeonID);
+                ApplyMaterials(true, daggerfallDungeon.DungeonTextureTable, daggerfallDungeon.Summary.ID);
             }
         }
     }

--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
@@ -146,8 +146,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 ClimateSeason season;
                 if (dungeonTextureTable != null)
                 {
-                    if ((dungeonID == -1) && (GameManager.Instance.PlayerEnterExit?.Dungeon?.Summary != null))
-                        dungeonID = GameManager.Instance.PlayerEnterExit.Dungeon.Summary.ID;
+                    if (dungeonID == -1)
+                    {
+                        DaggerfallDungeon daggerfallDungeon = GameManager.Instance.PlayerEnterExit.Dungeon;
+                        if (daggerfallDungeon != null)
+                            dungeonID = daggerfallDungeon.Summary.ID;
+                    }
 
                     // This model is inside a dungeon
                     int randomDungeonTextures = DaggerfallUnity.Settings.RandomDungeonTextures;

--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
@@ -123,11 +123,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 if (materials != null)
                     Materials = materials;
                 UseDungeonTextureTable = true;
-//                ApplyMaterials(true, dungeonTextureTable);
+                ApplyMaterials(true, dungeonTextureTable);
             }
         }
 
-        private void ApplyMaterials(bool force, DaggerfallDungeon daggerfallDungeon = null)
+        private void ApplyMaterials(bool force, int[] dungeonTextureTable = null)
         {
             if (Materials == null || Materials.Length == 0)
                 return;
@@ -142,25 +142,22 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 }
 
                 DFLocation.ClimateBaseType climateBaseType = GameManager.Instance.PlayerGPS.ClimateSettings.ClimateType;
-                int[] dungeonTextureTable = null;
                 ClimateBases climate;
                 ClimateSeason season;
-                if (daggerfallDungeon != null)
+                if (dungeonTextureTable != null)
                 {
                     // This model is inside a dungeon
-                    dungeonTextureTable = daggerfallDungeon.DungeonTextureTable;
                     int randomDungeonTextures = DaggerfallUnity.Settings.RandomDungeonTextures;
-                    if ((randomDungeonTextures == 2) || (randomDungeonTextures == 4) || 
-                        ((!DaggerfallDungeon.IsMainStoryDungeon(daggerfallDungeon.Summary.ID)) && 
-                        (randomDungeonTextures == 1 || randomDungeonTextures == 3)))
+                    if ((randomDungeonTextures == 2) || ((!DaggerfallDungeon.IsMainStoryDungeon(GameManager.Instance.PlayerEnterExit.Dungeon.Summary.ID)) && (randomDungeonTextures == 3)))
                     {
-                        // Player either wants climate variations applied to all dungeons or to non-Main Quest dungeons, with this model not inside one.
+                        // Dungeon Textures is either set to "ClimateOnly" or set to "Climate" and model is not in a Main Quest dungeon.
                         climate = ClimateSwaps.FromAPIClimateBase(climateBaseType);
-                        season = DaggerfallUnity.Instance.WorldTime.Now.SeasonValue == DaggerfallDateTime.Seasons.Winter ? ClimateSeason.Winter : ClimateSeason.Summer;
+                        season = ClimateSeason.Summer;      // Dungeon interiors don't care about season.
                     }
                     else
                     {
-                        // Model is either in Main Quest dungeon or DungeonTextureTable is set to "Classic"
+                        // Any other Dungeon Textures configuration doesn't care about climate. 
+                        // Classic settings act as if the dungeon's climate is always "Desert". Random has the climate variations already integrated into the DungeonTextureTable.
                         climate = ClimateBases.Desert;
                         season = ClimateSeason.Summer;
                     }
@@ -240,7 +237,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             {
                 DaggerfallDungeon.OnSetDungeon -= DaggerfallDungeon_OnSetDungeon;
                 subscribedToOnSetDungeon = false;
-                ApplyMaterials(true, daggerfallDungeon);
+                ApplyMaterials(true, daggerfallDungeon.DungeonTextureTable);
             }
         }
     }

--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
@@ -127,7 +127,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             }
         }
 
-        private void ApplyMaterials(bool force, int[] dungeonTextureTable = null)
+        private void ApplyMaterials(bool force, int[] dungeonTextureTable = null, int dungeonID = -1)
         {
             if (Materials == null || Materials.Length == 0)
                 return;
@@ -146,9 +146,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 ClimateSeason season;
                 if (dungeonTextureTable != null)
                 {
+                    if ((dungeonID == -1) && (GameManager.Instance.PlayerEnterExit?.Dungeon?.Summary != null))
+                        dungeonID = GameManager.Instance.PlayerEnterExit.Dungeon.Summary.ID;
+
                     // This model is inside a dungeon
                     int randomDungeonTextures = DaggerfallUnity.Settings.RandomDungeonTextures;
-                    if ((randomDungeonTextures == 2) || ((!DaggerfallDungeon.IsMainStoryDungeon(GameManager.Instance.PlayerEnterExit.Dungeon.Summary.ID)) && (randomDungeonTextures == 3)))
+                    if ((randomDungeonTextures == 2) || ((dungeonID != -1) && (!DaggerfallDungeon.IsMainStoryDungeon(dungeonID)) && (randomDungeonTextures == 3)))
                     {
                         // Dungeon Textures is either set to "ClimateOnly" or set to "Climate" and model is not in a Main Quest dungeon.
                         climate = ClimateSwaps.FromAPIClimateBase(climateBaseType);
@@ -231,13 +234,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 #endif
 
-        private void DaggerfallDungeon_OnSetDungeon(DaggerfallDungeon daggerfallDungeon)
+        private void DaggerfallDungeon_OnSetDungeon(DaggerfallDungeon daggerfallDungeon, int[] dungeonTextureTable, int dungeonID)
         {
             if (transform.IsChildOf(daggerfallDungeon.transform))
             {
                 DaggerfallDungeon.OnSetDungeon -= DaggerfallDungeon_OnSetDungeon;
                 subscribedToOnSetDungeon = false;
-                ApplyMaterials(true, daggerfallDungeon.DungeonTextureTable);
+                ApplyMaterials(true, dungeonTextureTable, dungeonID);
             }
         }
     }


### PR DESCRIPTION
RuntimeMaterials previously didn't take the game's RandomDungeonTextures setting into account when it decided to apply climate variations to dungeon models. This meant that dungeon models using RuntimeMaterials looked noticeably different next to vanilla models. This PR integrates the same logic that DaggerfallDungeon uses to decide what textures vanilla models use. 

The texture assignment abilities of RuntimeMaterials now ~almost~ matches that of the vanilla logic. The only thing I still need to sort out is that when the RandomDungeonTextures setting was set to "Random", I found a dungeon (Castle Buckington - Ilessan Hills in this case) where the vanilla models were using textures from the "Swamp" climate set whereas RuntimeMaterials used the "Temperate" set. Edit: This no longer applies.

In particular, I would like @TheLacus to take a look at this since RuntimeMaterials was his work.

If merged, this PR will ~mostly~ fix the third problem described in issue #1990. 

RuntimeMaterials - Temperate textures:
![RunMat - Temperate climate](https://user-images.githubusercontent.com/7355441/107337474-46bece00-6b1f-11eb-89ef-87d36a4a5b37.jpg)
Vanilla model - Swamp textures:
![DagMesh - Swamp climate](https://user-images.githubusercontent.com/7355441/107337479-47effb00-6b1f-11eb-913d-7358d02af3f7.jpg)
