### PR TITLE
PlayerEnterExit: Reduce delay filling Dungeon variable

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -887,9 +887,10 @@ namespace DaggerfallWorkshop.Game
             RaiseOnPreTransitionEvent(TransitionType.ToDungeonInterior, door);
 
             // Layout dungeon
-            GameObject newDungeon = GameObjectHelper.CreateDaggerfallDungeonGameObject(location, DungeonParent.transform);
+            GameObject newDungeon;
+            dungeon = GameObjectHelper.CreateDaggerfallDungeonGameObject(location, DungeonParent.transform, out newDungeon);
+            dungeon.SetDungeon(location);
             newDungeon.hideFlags = defaultHideFlags;
-            dungeon = newDungeon.GetComponent<DaggerfallDungeon>();
 
             // Find start marker to position player
             if (!dungeon.StartMarker)
@@ -947,9 +948,10 @@ namespace DaggerfallWorkshop.Game
             RaiseOnPreTransitionEvent(TransitionType.ToDungeonInterior);
 
             // Layout dungeon
-            GameObject newDungeon = GameObjectHelper.CreateDaggerfallDungeonGameObject(location, DungeonParent.transform, importEnemies);
+            GameObject newDungeon;
+            dungeon = GameObjectHelper.CreateDaggerfallDungeonGameObject(location, DungeonParent.transform, out newDungeon);
+            dungeon.SetDungeon(location, importEnemies);
             newDungeon.hideFlags = defaultHideFlags;
-            dungeon = newDungeon.GetComponent<DaggerfallDungeon>();
 
             GameObject marker = null;
             if (preferEnterMarker && dungeon.EnterMarker != null)

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -1338,18 +1338,24 @@ namespace DaggerfallWorkshop.Utility
             return go;
         }
 
-        public static GameObject CreateDaggerfallDungeonGameObject(string multiName, Transform parent)
+        public static GameObject CreateDaggerfallDungeonGameObject(string multiName, Transform parent, bool importEnemies = true)
         {
             // Get dungeon
+            DaggerfallDungeon daggerfallDungeon = null;
             DFLocation location;
             if (!FindMultiNameLocation(multiName, out location))
                 return null;
+            
+            GameObject daggerfallDungeonObject;
+            daggerfallDungeon = CreateDaggerfallDungeonGameObject(location, parent, out daggerfallDungeonObject);
+            daggerfallDungeon.SetDungeon(location, importEnemies);
 
-            return CreateDaggerfallDungeonGameObject(location, parent);
+            return daggerfallDungeonObject;
         }
 
-        public static GameObject CreateDaggerfallDungeonGameObject(DFLocation location, Transform parent, bool importEnemies = true)
+        public static DaggerfallDungeon CreateDaggerfallDungeonGameObject(DFLocation location, Transform parent, out GameObject go)
         {
+            go = null;
             if (!location.HasDungeon)
             {
                 string multiName = string.Format("{0}/{1}", location.RegionName, location.Name);
@@ -1357,12 +1363,12 @@ namespace DaggerfallWorkshop.Utility
                 return null;
             }
 
-            GameObject go = new GameObject(DaggerfallDungeon.GetSceneName(location));
-            if (parent) go.transform.parent = parent;
-            DaggerfallDungeon c = go.AddComponent<DaggerfallDungeon>();
-            c.SetDungeon(location, importEnemies);
+            go = new GameObject(DaggerfallDungeon.GetSceneName(location));
+            if (parent)
+                go.transform.parent = parent;
+            DaggerfallDungeon daggerfallDungeon = go.AddComponent<DaggerfallDungeon>();
 
-            return go;
+            return daggerfallDungeon;
         }
 
         public static GameObject CreateDaggerfallTerrainGameObject(Transform parent)


### PR DESCRIPTION
Previously, GameObjectHelper ran the SetDungeon function in DaggerfallDungeon before returning it's results. Since PlayerEnterExit uses the value of this returned result to fill it's Dungeon variable, this meant that there was a short period where Dungeon was equal to Null even though the DaggerfallDungeon object existed. This moves the SetDungeon function so that it runs after the Dungeon variable is filled.

I encountered this problem while working on PR #2026 where I couldn't retrieve the value of the dungeon's ID because Dungeon was still Null while the ApplyMaterials function in RuntimeMaterials was running.