### PR TITLE
BookFile: Added try-catch check to BinaryReader portion

### DIFF
--- a/Assets/Scripts/API/BookFile.cs
+++ b/Assets/Scripts/API/BookFile.cs
@@ -136,21 +136,39 @@ namespace DaggerfallConnect.Arena2
             BinaryReader reader = bookFile.GetReader();
 
             header = new BookHeader();
-            header.Title = FileProxy.ReadCStringSkip(reader, 0, 64);
-            header.Author = FileProxy.ReadCStringSkip(reader, 0, 64);
-            header.IsNaughty = (FileProxy.ReadCStringSkip(reader, 0, 8) == naughty);
-            header.NullValues = reader.ReadBytes(88);
-            header.Price = reader.ReadUInt32();
-            header.Unknown1 = reader.ReadUInt16();
-            header.Unknown2 = reader.ReadUInt16();
-            header.Unknown3 = reader.ReadUInt16();
-            header.PageCount = reader.ReadUInt16();
+            try
+            {
+                header.Title = FileProxy.ReadCStringSkip(reader, 0, 64);
+                header.Author = FileProxy.ReadCStringSkip(reader, 0, 64);
+                header.IsNaughty = (FileProxy.ReadCStringSkip(reader, 0, 8) == naughty);
+                header.NullValues = reader.ReadBytes(88);
+                header.Price = reader.ReadUInt32();
+                header.Unknown1 = reader.ReadUInt16();
+                header.Unknown2 = reader.ReadUInt16();
+                header.Unknown3 = reader.ReadUInt16();
+                header.PageCount = reader.ReadUInt16();
+            }
+            catch (EndOfStreamException e)
+            {
+                if (header.Title != null)
+                    Debug.LogErrorFormat($"EndOfStreamException encountered for book {header.Title}.\n{e}");
+                else
+                    Debug.LogErrorFormat($"EndOfStreamException encountered for last book whose title couldn't be retrieved.\n{e}");
+            }
             header.PageOffsets = new UInt32[header.PageCount];
             for (int i = 0; i < header.PageCount; i++)
             {
-                header.PageOffsets[i] = reader.ReadUInt32();
+                try
+                {
+                    header.PageOffsets[i] = reader.ReadUInt32();
+                }
+                catch (EndOfStreamException e)
+                {
+                    Debug.LogErrorFormat($"EndOfStreamException encountered for book {header.Title} at position {i} of {header.PageCount}.\n{e}");
+                    break;
+                }
             }
-            
+
             if (randomPrice)
             {
                 // Overwrite price field using random seeded with first 4 bytes.

--- a/Assets/Scripts/Utility/AssetInjection/BookReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/BookReplacement.cs
@@ -167,16 +167,16 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 string path = Path.Combine(booksPath, name);
                 if (File.Exists(path))
                 {
-                    book.OpenBook(File.ReadAllBytes(path), name);
-                    return true;
+                    if (book.OpenBook(File.ReadAllBytes(path), name))
+                        return true;
                 }
 
                 // Seek from mods
                 TextAsset textAsset;
                 if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(name, false, out textAsset))
                 {
-                    book.OpenBook(textAsset.bytes, name);
-                    return true;
+                    if (book.OpenBook(textAsset.bytes, name))
+                        return true;
                 }
             }
 


### PR DESCRIPTION
On a few occassions, I've loaded a save only to get the HUD overlaying a black screen. The game still appeared to be running but the game didn't seem to react to my inputs. I couldn't open the main menu either and had to kill the game. On this occasion, I caught this happening in the editor which reported an `EndOfStreamException` in the line `header.PageOffsets[i] = reader.ReadUInt32()`. As a result, I added a try-catch check to gracefully handle this exception in future for any part of the BookFile's BinaryReader code.