### PR TITLE
Implement right clicks as described in Daggerfall manual

### DIFF
--- a/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
+++ b/Assets/Scripts/Game/UserInterface/ItemListScroller.cs
@@ -129,6 +129,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public delegate void OnItemRightClickHandler(DaggerfallUnityItem item);
         public event OnItemRightClickHandler OnItemRightClick;
 
+        public delegate void OnItemMiddleClickHandler(DaggerfallUnityItem item);
+        public event OnItemMiddleClickHandler OnItemMiddleClick;
+
         public delegate void OnItemHoverHandler(DaggerfallUnityItem item);
         public event OnItemHoverHandler OnItemHover;
 
@@ -338,6 +341,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 itemButtons[i].Tag = i;
                 itemButtons[i].OnMouseClick += ItemButton_OnMouseClick;
                 itemButtons[i].OnRightMouseClick += ItemButton_OnRightMouseClick;
+                itemButtons[i].OnMiddleMouseClick += ItemButton_OnMiddleMouseClick;
                 itemButtons[i].OnMouseEnter += ItemButton_OnMouseEnter;
                 itemButtons[i].OnMouseScrollUp += ItemButton_OnMouseEnter;
                 itemButtons[i].OnMouseScrollDown += ItemButton_OnMouseEnter;
@@ -528,7 +532,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #region Event handlers
 
-        void ItemButton_OnClick(BaseScreenComponent sender, Vector2 position, bool rightClick)
+        void ItemButton_OnClick(BaseScreenComponent sender, Vector2 position, bool rightClick, bool middleClick = false)
         {
             // Get index
             int index = (GetScrollIndex() * listWidth) + (int)sender.Tag;
@@ -538,10 +542,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // Get item and raise item click event
             DaggerfallUnityItem item = items[index];
 
-            if (!rightClick && item != null && OnItemClick != null)
-                    OnItemClick(item);
-            else if (item != null && OnItemRightClick != null)
-                    OnItemRightClick(item);
+            if (middleClick && item != null && OnItemMiddleClick != null)
+                OnItemMiddleClick(item);
+            else if (rightClick && item != null && OnItemRightClick != null)
+                OnItemRightClick(item);
+            else if (item != null && OnItemClick != null)
+                OnItemClick(item);
 
             ItemButton_OnMouseEnter(sender);
         }
@@ -554,6 +560,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
         void ItemButton_OnRightMouseClick(BaseScreenComponent sender, Vector2 position)
         {
             ItemButton_OnClick(sender, position, true);
+        }
+
+        void ItemButton_OnMiddleMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            ItemButton_OnClick(sender, position, false, true);
         }
 
         void ItemButton_OnMouseEnter(BaseScreenComponent sender)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -767,10 +767,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Item Click Event Handlers
 
-        protected override void LocalItemListScroller_OnItemClick(DaggerfallUnityItem item)
+        protected override void LocalItemListScroller_OnItemClick(DaggerfallUnityItem item, ActionModes actionMode)
         {
             // Handle click based on action & mode
-            if (selectedActionMode == ActionModes.Select)
+            if (actionMode == ActionModes.Select || actionMode == ActionModes.Remove)
             {
                 switch (WindowMode)
                 {
@@ -790,9 +790,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         break;
 
                     case WindowModes.Buy:
-                        if (UsingWagon)     // Allows player to get & equip stuff from cart while purchasing.
+                        if (UsingWagon)                             // Allows player to get & equip stuff from cart while purchasing.
                             TransferItem(item, localItems, PlayerEntity.Items, CanCarryAmount(item), equip: !item.IsAStack());
-                        else                // Allows player to equip and unequip while purchasing.
+                        else if (actionMode == ActionModes.Remove && basketItems.Contains(item))    // Allows clearing individual items
+                            TransferItem(item, basketItems, remoteItems);
+                        else if (actionMode == ActionModes.Select)  // Allows player to equip and unequip while purchasing.
                             EquipItem(item);
                         break;
 
@@ -818,19 +820,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         break;
                 }
             }
-            else if (selectedActionMode == ActionModes.Info)
+            else if (actionMode == ActionModes.Info)
             {
                 ShowInfoPopup(item);
             }
         }
 
-        protected override void RemoteItemListScroller_OnItemClick(DaggerfallUnityItem item)
+        protected override void RemoteItemListScroller_OnItemClick(DaggerfallUnityItem item, ActionModes actionMode)
         {
             // Handle click based on action
-            if (selectedActionMode == ActionModes.Select)
+            if (actionMode == ActionModes.Select || actionMode == ActionModes.Remove)
             {
                 if (WindowMode == WindowModes.Buy)
-                    TransferItem(item, remoteItems, basketItems, CanCarryAmount(item), equip: !item.IsAStack());
+                    TransferItem(item, remoteItems, basketItems, CanCarryAmount(item), equip: !item.IsAStack() && actionMode == ActionModes.Select);
                 else if (WindowMode == WindowModes.Repair)
                 {
                     if (item.RepairData.IsBeingRepaired() && !item.RepairData.IsRepairFinished())
@@ -847,7 +849,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 else
                     TransferItem(item, remoteItems, localItems, UsingWagon ? WagonCanHoldAmount(item) : CanCarryAmount(item), blockTransport: UsingWagon);
             }
-            else if (selectedActionMode == ActionModes.Info)
+            else if (actionMode == ActionModes.Info)
             {
                 ShowInfoPopup(item);
             }


### PR DESCRIPTION
See page 53 of the original Daggerfall manual. Variant changing was added to right clicks, this is now on middle mouse click.

As discussed here: https://forums.dfworkshop.net/viewtopic.php?p=52256#p52256

@Interkarma This is a candidate change which you can veto if you wish. 

Note that it may break mods that override inventory or trade UI windows until they are updated.

@petchema Would you mind casting your eye for detail over this one and test it to see if I missed any interactions.