### PR TITLE
Automap: Check CombineRDB state before resetting

### DIFF
--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -2020,6 +2020,7 @@ namespace DaggerfallWorkshop.Game
             gameobjectGeometry = new GameObject("GeometryAutomap (Dungeon)");
 
             // disable this option to get all small dungeon parts as individual models
+            bool combineRdbOptionState = DaggerfallUnity.Instance.Option_CombineRDB;
             DaggerfallUnity.Instance.Option_CombineRDB = false;
 
             foreach (Transform elem in GameManager.Instance.DungeonParent.transform)
@@ -2060,8 +2061,9 @@ namespace DaggerfallWorkshop.Game
                 }
             }
 
-            // enable this option (to reset to normal behavior)
-            DaggerfallUnity.Instance.Option_CombineRDB = true;
+            // set this option back to previous state (to reset to previous behavior)
+            if (combineRdbOptionState)
+                DaggerfallUnity.Instance.Option_CombineRDB = true;
 
             // put all objects inside gameobjectGeometry in layer "Automap"
             SetLayerRecursively(gameobjectGeometry, layerAutomap);


### PR DESCRIPTION
While building the dungeon's Automap, the script's CreateDungeonGeometryForAutomap function disables the CombineRDB option to create individual models in the map instead of a combined model. After generating these models, it then re-enables this option. The problem is that if the user has disabled this option through the Unity Editor, this script re-enables it after generating the automap, forcing the user to re-disable it every time they load or enter a dungeon.

This commit adds a check to the setting manipulation so that at the end of automap generation, the CombineRDB option will only be re-enabled if it was originally enabled at the start of generation.