### PR TITLE
Fix mods window all on/off text color

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModLoaderInterfaceWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModLoaderInterfaceWindow.cs
@@ -663,6 +663,7 @@ public class ModLoaderInterfaceWindow : DaggerfallPopupWindow
         for (int i = 0; i < modSettings.Length; i++)
         {
             modSettings[i].enabled = true;
+            modList.GetItem(i).textColor = unselectedTextColor;
         }
         UpdateModPanel();
     }
@@ -675,6 +676,7 @@ public class ModLoaderInterfaceWindow : DaggerfallPopupWindow
         for (int i = 0; i < modSettings.Length; i++)
         {
             modSettings[i].enabled = false;
+            modList.GetItem(i).textColor = disabledModTextColor;
         }
 
         UpdateModPanel();


### PR DESCRIPTION
[[0.11.0] All On/Off buttons in mod management don't update mod name "ghosting"](https://forums.dfworkshop.net/viewtopic.php?f=31&t=4556)