### PR TITLE
Adding a FormulaHelper hook "CalculateCasterLevel"

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -840,6 +840,15 @@ namespace DaggerfallWorkshop.Game.Formulas
             return cooldown / classicFrameUpdate;
         }
 
+        public static int CalculateCasterLevel(DaggerfallEntity caster, IEntityEffect effect)
+        {
+            Func<DaggerfallEntity, IEntityEffect, int> del;
+            if (TryGetOverride("CalculateCasterLevel", out del))
+                return del(caster, effect);
+
+            return caster != null ? caster.Level : 1;
+        }
+
         #endregion
 
         #region Combat & Damage: component sub-formula

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffect.cs
@@ -739,7 +739,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// <returns>Chance value.</returns>
         public int ChanceValue()
         {
-            int casterLevel = (caster) ? caster.Entity.Level : 1;
+            int casterLevel = (caster) ? FormulaHelper.CalculateCasterLevel(caster.Entity, this) : 1;
             //Debug.LogFormat("{5} ChanceValue {0} = base + plus * (level/chancePerLevel) = {1} + {2} * ({3}/{4})", settings.ChanceBase + settings.ChancePlus * (int)Mathf.Floor(casterLevel / settings.ChancePerLevel), settings.ChanceBase, settings.ChancePlus, casterLevel, settings.ChancePerLevel, Key);
             return settings.ChanceBase + settings.ChancePlus * (int)Mathf.Floor(casterLevel / settings.ChancePerLevel);
         }
@@ -784,7 +784,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             int magnitude = 0;
             if (Properties.SupportMagnitude)
             {
-                int casterLevel = (caster) ? caster.Entity.Level : 1;
+                int casterLevel = (caster) ? FormulaHelper.CalculateCasterLevel(caster.Entity, this) : 1;
                 int baseMagnitude = UnityEngine.Random.Range(settings.MagnitudeBaseMin, settings.MagnitudeBaseMax + 1);
                 int plusMagnitude = UnityEngine.Random.Range(settings.MagnitudePlusMin, settings.MagnitudePlusMax + 1);
                 int multiplier = (int)Mathf.Floor(casterLevel / settings.MagnitudePerLevel);
@@ -909,7 +909,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
         void SetDuration()
         {
-            int casterLevel = (caster) ? caster.Entity.Level : 1;
+            int casterLevel = (caster) ? FormulaHelper.CalculateCasterLevel(caster.Entity, this) : 1;
             if (Properties.SupportDuration)
             {
                 // Multiplier clamped at 1 or player can lose a round depending on spell settings and level


### PR DESCRIPTION
Caster level is a core feature of Daggerfall spell effects. The 3 ways effects change in effectiveness is in their duration, their cast chance, and their magnitude. All three properties scale based on caster level, and this is the main way a spell gets better as the player progresses (aside from casting cost). The SpellMaker interface deals with caster levels, and a spell's information will also feature this level scaling.

Therefore, a mod that wants to modify existing or add new spell effects to the game will also most likely deal in terms of caster level. Currently, the caster level is always equal to the entity's level. But what if mods wanted to change that?

In my research, I've found one mod that tries to change the caster level: Unleveled Spells (https://www.nexusmods.com/daggerfallunity/mods/84). This mod works by basically recreating every spell effect in MagicAndEffects, and simply using the new formula for determining the caster level. This approach has drawbacks

- It's a lot of work
- This will override or be overriden by other mods that touch spell effects
- This will not affect new spell effects (if that's even possible in the current code? It will happen eventually, though)

It is my opinion that everyone would benefit from a more orthogonal approach, where certain mods focus on tweaking formulas, and other mods modify or create new spell effects. This way, we ensure more mod compatibility and consistency at large.

This is why I've introduced a new FormulaHelper hook "CalculateCasterLevel". When a spell effect needs to know the caster level, it calls this formula with the caster and the effect itself as input. The formula, as usual, checks for a formula override and invokes it if existing. Otherwise, it simply falls back to the existing behavior of using the caster's level.

With Unleveled Spells as inspiration, I've determined that the most common immediate information that a mod override formula would want to know if what spell is being cast. For example, if caster is the player, Unleveled Spells uses the effect's Properties.MagicSkill to get the player's LiveSkillValue, and determines a caster level proportional to that value (actual formula more complicated, but irrelevant here).

I hope you can see value in my proposed solution. If you have any questions, I can be reached on the official Discord server @kaboissonneault