### PR TITLE
Fixed misnamed formula overrides

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -207,7 +207,7 @@ namespace DaggerfallWorkshop.Game.Formulas
         public static int CalculateFatigueRecoveryRate(int maxFatigue)
         {
             Func<int, int> del;
-            if (TryGetOverride("HealingRateModifier", out del))
+            if (TryGetOverride("CalculateFatigueRecoveryRate", out del))
                 return del(maxFatigue);
 
             return Mathf.Max((int)Mathf.Floor(maxFatigue / 8), 1);
@@ -217,7 +217,7 @@ namespace DaggerfallWorkshop.Game.Formulas
         public static int CalculateSpellPointRecoveryRate(PlayerEntity player)
         {
             Func<PlayerEntity, int> del;
-            if (TryGetOverride("HealingRateModifier", out del))
+            if (TryGetOverride("CalculateSpellPointRecoveryRate", out del))
                 return del(player);
 
             if (player.Career.NoRegenSpellPoints)


### PR DESCRIPTION
Fixed misnamed formula overrides for CalculateFatigueRecoveryRate and CalculateSpellPointsRecoveryRate

Every other formula in that file has an override named after the function name. These two seem to be a copy-paste error. The function signature is not even consistent, so it wouldn't work as intentional design.