### PR TITLE
Allow non-member quests to have rep requirements

### DIFF
--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -326,7 +326,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 foreach (QuestData quest in guildQuests)
                 {
                     if ((status == (MembershipStatus)quest.membership || tplMemb == (MembershipStatus)quest.membership) &&
-                        (status == MembershipStatus.Nonmember || (quest.minReq < 10 && quest.minReq <= rank) || (quest.minReq >= 10 && quest.minReq <= rep)))
+                        ((status == MembershipStatus.Nonmember && quest.minReq == 0) || (quest.minReq < 10 && quest.minReq <= rank) || (quest.minReq >= 10 && quest.minReq <= rep)))
                     {
                         if ((!quest.adult || DaggerfallUnity.Settings.PlayerNudity) && !(quest.oneTime && oneTimeQuestsAccepted.Contains(quest.name)))
                             pool.Add(quest);


### PR DESCRIPTION
This is for the Witch Coven guild that is not joinable, and leaves all non-member quests with 0 rank/rep defined in the quest list still able to be given to players with negative rep.