### PR TITLE
GameObjectHelper: Set static flags while tagging Static Geometry

### DIFF
--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -393,6 +393,7 @@ namespace DaggerfallWorkshop.Utility
             if (go)
             {
                 go.tag = DaggerfallUnity.staticGeometryTag;
+                go.isStatic = true;
             }
         }
 


### PR DESCRIPTION
In addition to adding the staticGeometryTag to any GameObject run through the TagStaticGeometry function, this PR makes it also enable all of the [StaticEditorFlags](https://docs.unity3d.com/Manual/StaticObjects.html) for that object. This might help with performance.
