### PR TITLE
Adding formula overrides for spell effect cost formulas

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -743,8 +743,7 @@ namespace DaggerfallWorkshop.Game.Entity
             List<EffectBundleSettings> sortedSpellbook = spellbook
                 .OrderBy((EffectBundleSettings spell) =>
                 {
-                    int goldCost, spellPointCost;
-                    FormulaHelper.CalculateTotalEffectCosts(spell.Effects, spell.TargetType, out goldCost, out spellPointCost, null, spell.MinimumCastingCost);
+                    (int _, int spellPointCost) = FormulaHelper.CalculateTotalEffectCosts(spell.Effects, spell.TargetType, null, spell.MinimumCastingCost);
                     return spellPointCost;
                 })
             .ToList();

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -2132,6 +2132,10 @@ namespace DaggerfallWorkshop.Game.Formulas
         /// <param name="minimumCastingCost">Spell point always costs minimum (e.g. from vampirism). Do not set true for reflection/absorption cost calculations.</param>
         public static SpellCost CalculateTotalEffectCosts(EffectEntry[] effectEntries, TargetTypes targetType, DaggerfallEntity casterEntity = null, bool minimumCastingCost = false)
         {
+            Func<EffectEntry[], TargetTypes, DaggerfallEntity, bool, SpellCost> del;
+            if (TryGetOverride("CalculateTotalEffectCosts", out del))
+                return del(effectEntries, targetType, casterEntity, minimumCastingCost);
+
             const int castCostFloor = 5;
 
             SpellCost totalCost;
@@ -2186,6 +2190,10 @@ namespace DaggerfallWorkshop.Game.Formulas
         /// </summary>
         public static SpellCost CalculateEffectCosts(IEntityEffect effect, EffectSettings settings, DaggerfallEntity casterEntity = null)
         {
+            Func<IEntityEffect, EffectSettings, DaggerfallEntity, SpellCost> del;
+            if(TryGetOverride("CalculateEffectCosts", out del))
+                return del(effect, settings, casterEntity);
+
             bool activeComponents = false;            
 
             // Get related skill
@@ -2266,6 +2274,10 @@ namespace DaggerfallWorkshop.Game.Formulas
 
         public static int ApplyTargetCostMultiplier(int cost, TargetTypes targetType)
         {
+            Func<int, TargetTypes, int> del;
+            if (TryGetOverride("ApplyTargetCostMultiplier", out del))
+                return del(cost, targetType);
+
             switch (targetType)
             {
                 default:

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -316,8 +316,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                 return false;
 
             // Get spellpoint costs of this spell
-            int totalGoldCostUnused;
-            FormulaHelper.CalculateTotalEffectCosts(spell.Settings.Effects, spell.Settings.TargetType, out totalGoldCostUnused, out readySpellCastingCost, null, spell.Settings.MinimumCastingCost);
+            (int _, int spellPointCost) = FormulaHelper.CalculateTotalEffectCosts(spell.Settings.Effects, spell.Settings.TargetType, null, spell.Settings.MinimumCastingCost);
+            readySpellCastingCost = spellPointCost;
 
             // Allow casting spells of any cost if entity is player and godmode enabled
             bool godModeCast = (IsPlayerEntity && GameManager.Instance.PlayerEntity.GodMode);
@@ -1242,9 +1242,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         }
 
         int GetEffectCastingCost(IEntityEffect effect, TargetTypes targetType, DaggerfallEntity casterEntity)
-        {
-            int goldCost, spellPointCost;
-            FormulaHelper.CalculateEffectCosts(effect, effect.Settings, out goldCost, out spellPointCost, casterEntity);
+        {            
+            (int _, int spellPointCost) = FormulaHelper.CalculateEffectCosts(effect, effect.Settings, casterEntity);
             spellPointCost = FormulaHelper.ApplyTargetCostMultiplier(spellPointCost, targetType);
 
             // Spells always cost at least 5 spell points

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallEffectSettingsEditorWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallEffectSettingsEditorWindow.cs
@@ -395,8 +395,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 OnSettingsChanged();
 
             // Get spell cost
-            int goldCost, spellPointCost;
-            FormulaHelper.CalculateEffectCosts(EffectEntry, out goldCost, out spellPointCost);
+            (int _, int spellPointCost) = FormulaHelper.CalculateEffectCosts(EffectEntry);
             spellCostLabel.Text = spellPointCost.ToString();
         }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -257,8 +257,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 // Get spell costs
                 // Costs can change based on player skills and stats so must be calculated each time
-                int goldCost, spellPointCost;
-                FormulaHelper.CalculateTotalEffectCosts(spell.Effects, spell.TargetType, out goldCost, out spellPointCost, null, spell.MinimumCastingCost);
+                (int _, int spellPointCost) = FormulaHelper.CalculateTotalEffectCosts(spell.Effects, spell.TargetType, null, spell.MinimumCastingCost);
 
                 // Lycanthropy is a free spell, even though it shows a cost in classic
                 // Setting cost to 0 so it displays correctly in spellbook
@@ -511,9 +510,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 spellSettings = offeredSpells[spellsListBox.SelectedIndex];
 
-                // The price shown in buy mode is the player casting cost * 4
-                int goldCost, spellPointCost;
-                FormulaHelper.CalculateTotalEffectCosts(spellSettings.Effects, spellSettings.TargetType, out goldCost, out spellPointCost);
+                // The price shown in buy mode is the player casting cost * 4                
+                (int _, int spellPointCost) = FormulaHelper.CalculateTotalEffectCosts(spellSettings.Effects, spellSettings.TargetType);
                 presentedCost = spellPointCost * 4;
 
                 // Presented cost is halved on Witches Festival holiday

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellMakerWindow.cs
@@ -687,7 +687,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 effectEntries[editOrDeleteSlot] = effectEditor.EffectEntry;
 
             // Get total costs
-            FormulaHelper.CalculateTotalEffectCosts(effectEntries, selectedTarget, out totalGoldCost, out totalSpellPointCost);
+            (totalGoldCost, totalSpellPointCost) = FormulaHelper.CalculateTotalEffectCosts(effectEntries, selectedTarget);
             SetStatusLabels();
         }
 


### PR DESCRIPTION
This pull request is for overriding CalculateTotalEffectCosts, CalculateEffectCosts, ApplyTargetCostMultiplier. Since C#'s `System.Func` does not handle `out` parameters, I've replaced the gold cost and spell point cost out parameters with a single return type containing both values, a struct inside `FormulaHelper` called `SpellCost`. I thought it would be preferable to having a generic `Tuple<int, int>`. Tell me if there's a better place to put this structure.

The branch has no impact on gameplay, but allows mods to change how spell effect costs are calculated. 
Example: https://github.com/KABoissonneault/DFU-BalancedSpellCosts/blob/main/Scripts/BalancedSpellCostsMod.cs#L41
This mod keeps the same overall formula, but removes the truncating in the "Per-level" cost calculate and in the average magnitude calculation

In the future, I plan to use this to plug new spell effect settings inside the formula to change spell costs without having to replace all the spell effects.

