### PR TITLE
Automap: Move Mesh and Material update to separate script

### DIFF
--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -1296,115 +1296,6 @@ namespace DaggerfallWorkshop.Game
             Shader.SetGlobalFloat("_SclicingPositionY", slicingPositionY);
         }
 
-        private void UpdateMaterialsOfMeshRenderer(MeshRenderer meshRenderer, bool visitedInThisEntering = false)
-        {
-            Vector3 playerAdvancedPos = gameObjectPlayerAdvanced.transform.position;
-            Material[] newMaterials = new Material[meshRenderer.materials.Length];
-            for (int i = 0; i < meshRenderer.materials.Length; i++)
-            {
-                Material material = meshRenderer.materials[i];
-                Material newMaterial = newMaterials[i];
-
-                newMaterial = new Material(Shader.Find("Daggerfall/Automap"));
-                //newMaterial.CopyPropertiesFromMaterial(material);
-                newMaterial.name = "AutomapBelowSclicePlane injected for: " + material.name;
-                if (material.HasProperty(Uniforms.MainTex))
-                    newMaterial.SetTexture(Uniforms.MainTex, material.GetTexture(Uniforms.MainTex));
-                if (material.HasProperty(Uniforms.BumpMap))
-                    newMaterial.SetTexture(Uniforms.BumpMap, material.GetTexture(Uniforms.BumpMap));
-                if (material.HasProperty(Uniforms.EmissionMap))
-                    newMaterial.SetTexture(Uniforms.EmissionMap, material.GetTexture(Uniforms.EmissionMap));
-                if (material.HasProperty(Uniforms.EmissionColor))
-                    newMaterial.SetColor(Uniforms.EmissionColor, material.GetColor(Uniforms.EmissionColor));
-                Vector4 playerPosition = new Vector4(playerAdvancedPos.x, playerAdvancedPos.y + Camera.main.transform.localPosition.y, playerAdvancedPos.z, 0.0f);
-                newMaterial.SetVector("_PlayerPosition", playerPosition);
-                if (visitedInThisEntering == true)
-                    newMaterial.DisableKeyword("RENDER_IN_GRAYSCALE");
-                else
-                    newMaterial.EnableKeyword("RENDER_IN_GRAYSCALE");
-                newMaterials[i] = newMaterial;
-            }
-            meshRenderer.materials = newMaterials;
-        }     
-
-        /// <summary>
-        /// will inject materials and properties to MeshRenderer in the proper hierarchy level of automap level geometry GameObject
-        /// note: the proper hierarchy level differs between an "Interior" and a "Dungeon" geometry GameObject
-        /// </summary>
-        /// <param name="resetDiscoveryState"> if true resets the discovery state for geometry that needs to be discovered (when inside dungeons or castles) </param>
-        private void InjectMeshAndMaterialProperties(bool resetDiscoveryState = true)
-        {
-            if (GameManager.Instance.IsPlayerInsideBuilding)
-            {
-                // find all MeshRenderers in 3rd hierarchy level
-                foreach (Transform elem in gameobjectGeometry.transform)
-                {
-                    foreach (Transform innerElem in elem.gameObject.transform)
-                    {
-                        foreach (Transform inner2Elem in innerElem.gameObject.transform)
-                        {
-                            // get rid of animated materials (will not break automap rendering but is not necessary)
-                            AnimatedMaterial[] animatedMaterials = inner2Elem.gameObject.GetComponents<AnimatedMaterial>();                            
-                            foreach (AnimatedMaterial animatedMaterial in animatedMaterials)
-                            {
-                                UnityEngine.Object.Destroy(animatedMaterial);
-                            }
-
-                            MeshRenderer[] meshRenderers = inner2Elem.gameObject.GetComponentsInChildren<MeshRenderer>();
-                            if (meshRenderers == null)
-                                continue;
-
-                            // update materials and set meshes as visited in this run (so "Interior" geometry always is colored
-                            // (since we don't disable the mesh, it is also discovered - which is a precondition for being rendered))
-                            foreach (MeshRenderer meshRenderer in meshRenderers)
-                            {
-                                UpdateMaterialsOfMeshRenderer(meshRenderer, true);
-                            }
-                        }
-                    }
-                }
-            }
-            else if ((GameManager.Instance.IsPlayerInsideDungeon)||(GameManager.Instance.IsPlayerInsideCastle))
-            {
-                // find all MeshRenderers in 4th hierarchy level
-                foreach (Transform elem in gameobjectGeometry.transform)
-                {
-                    foreach (Transform innerElem in elem.gameObject.transform)
-                    {
-                        foreach (Transform inner2Elem in innerElem.gameObject.transform)
-                        {
-                            foreach (Transform inner3Elem in inner2Elem.gameObject.transform)
-                            {
-                                // get rid of animated materials (will not break automap rendering but is not necessary)
-                                AnimatedMaterial[] animatedMaterials = inner3Elem.gameObject.GetComponents<AnimatedMaterial>();
-                                foreach (AnimatedMaterial animatedMaterial in animatedMaterials)
-                                {
-                                    UnityEngine.Object.Destroy(animatedMaterial);
-                                }
-
-                                MeshRenderer[] meshRenderers = inner3Elem.gameObject.GetComponentsInChildren<MeshRenderer>();
-                                if (meshRenderers == null)
-                                    continue;
-
-                                // update materials (omit 2nd parameter so default behavior is initiated which is:
-                                // meshes are marked as not visited in this run (so "Dungeon" geometry that has been discovered in a previous dungeon run is rendered in grayscale)
-                                foreach (MeshRenderer meshRenderer in meshRenderers)
-                                {
-                                    UpdateMaterialsOfMeshRenderer(meshRenderer);
-
-                                    if (resetDiscoveryState) // if forced reset of discovery state
-                                    {
-                                        // mark meshRenderer as undiscovered
-                                        meshRenderer.enabled = false;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         //private void SetMaterialTransparency(Material material)
         //{
         //    material.SetOverrideTag("RenderType", "Transparent");
@@ -1996,7 +1887,7 @@ namespace DaggerfallWorkshop.Game
             gameobjectGeometry.transform.SetParent(gameobjectAutomap.transform);
 
             // inject all materials of automap geometry with automap shader and reset MeshRenderer enabled state (this is used for the discovery mechanism)
-            InjectMeshAndMaterialProperties();
+            RaiseOnInjectMeshAndMaterialPropertiesEvent();
 
             //oldGeometryName = newGeometryName;
         }
@@ -2041,7 +1932,7 @@ namespace DaggerfallWorkshop.Game
 
                         DFBlock blockData;
                         int[] textureTable = null;
-                        GameObject gameobjectBlock = RDBLayout.CreateBaseGameObject(block.BlockName, null, out blockData, textureTable, true, null, false);
+                        GameObject gameobjectBlock = RDBLayout.CreateBaseGameObject(block.BlockName, null, out blockData, textureTable, true, null, false, true);
                         gameobjectBlock.transform.position = new Vector3(block.X * RDBLayout.RDBSide, 0, block.Z * RDBLayout.RDBSide);
 
                         gameobjectBlock.transform.SetParent(gameobjectDungeon.transform);
@@ -2067,10 +1958,10 @@ namespace DaggerfallWorkshop.Game
 
             // put all objects inside gameobjectGeometry in layer "Automap"
             SetLayerRecursively(gameobjectGeometry, layerAutomap);
-            gameobjectGeometry.transform.SetParent(gameobjectAutomap.transform);            
+            gameobjectGeometry.transform.SetParent(gameobjectAutomap.transform);
 
             // inject all materials of automap geometry with automap shader and reset MeshRenderer enabled state (this is used for the discovery mechanism)
-            InjectMeshAndMaterialProperties();
+            RaiseOnInjectMeshAndMaterialPropertiesEvent();
 
             //oldGeometryName = newGeometryName;
         }
@@ -2658,6 +2549,26 @@ namespace DaggerfallWorkshop.Game
                 dictTeleporterConnections.Add(connection.ToString(), connection);
         }
 
+        /// <summary>
+        /// Send an event instructing all Automap models to apply Automap materials and properties to their MeshRenderers.
+        /// </summary>
+        /// <param name="resetDiscoveryState"> if true resets the discovery state for geometry that needs to be discovered (when inside dungeons or castles) </param>
+        public delegate void OnInjectMeshAndMaterialPropertiesEventHandler(bool playerIsInsideBuilding, Vector3 playerAdvancedPos, Material automapMaterial, bool resetDiscoveryState);
+        public static event OnInjectMeshAndMaterialPropertiesEventHandler OnInjectMeshAndMaterialProperties;
+        private void RaiseOnInjectMeshAndMaterialPropertiesEvent(bool resetDiscoveryState = true)
+        {
+            if (OnInjectMeshAndMaterialProperties != null)
+            {
+                bool playerIsInsideBuilding = false;
+                if (GameManager.Instance.IsPlayerInsideBuilding)
+                    playerIsInsideBuilding = true;
+
+                Vector3 playerAdvancedPos = gameObjectPlayerAdvanced.transform.position;
+                Material automapMaterial = new Material(Shader.Find("Daggerfall/Automap"));
+
+                OnInjectMeshAndMaterialProperties(playerIsInsideBuilding, playerAdvancedPos, automapMaterial, resetDiscoveryState);
+            }
+        }
         #endregion
 
         #region console_commands

--- a/Assets/Scripts/Game/AutomapModel.cs
+++ b/Assets/Scripts/Game/AutomapModel.cs
@@ -1,0 +1,106 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: XJDHDR
+// Contributors:     
+// 
+// Notes:
+//
+
+using DaggerfallWorkshop;
+using DaggerfallWorkshop.Game;
+using DaggerfallWorkshop.Utility;
+using UnityEngine;
+
+namespace DaggerfallWorkshop
+{
+    /// <summary>
+    /// Attached to all Automap models to perform various functions specific to them.
+    /// </summary>
+    public sealed class AutomapModel : MonoBehaviour
+    {
+        [SerializeField]
+        [HideInInspector]
+        private bool subscribedToEvents = false;
+
+        void Awake()
+        {
+            if (!subscribedToEvents)
+            {
+                Automap.OnInjectMeshAndMaterialProperties += Automap_OnInjectMeshAndMaterialProperties;
+                subscribedToEvents = true;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (subscribedToEvents)
+            {
+                Automap.OnInjectMeshAndMaterialProperties -= Automap_OnInjectMeshAndMaterialProperties;
+                subscribedToEvents = false;
+            }
+        }
+
+        private void Automap_OnInjectMeshAndMaterialProperties(bool playerIsInsideBuilding, Vector3 playerAdvancedPos, Material automapMaterial, bool resetDiscoveryState = true)
+        {
+            Automap.OnInjectMeshAndMaterialProperties -= Automap_OnInjectMeshAndMaterialProperties;
+            subscribedToEvents = false;
+
+            // get rid of animated materials (will not break automap rendering but is not necessary)
+            AnimatedMaterial[] animatedMaterials = gameObject.GetComponentsInChildren<AnimatedMaterial>();
+            foreach (AnimatedMaterial animatedMaterial in animatedMaterials)
+            {
+                UnityEngine.Object.Destroy(animatedMaterial);
+            }
+
+            MeshRenderer[] meshRenderers = gameObject.GetComponentsInChildren<MeshRenderer>();
+            if (meshRenderers == null)
+                return;
+
+            // Update materials. If inside an interior, set visitedInThisEntering parameter to True so that they are always coloured.
+            // Otherwise, mark meshes as not visited in this run (so "Dungeon" geometry that has been discovered in a previous dungeon run is rendered in grayscale)
+            foreach (MeshRenderer meshRenderer in meshRenderers)
+            {
+                UpdateMaterialsOfMeshRenderer(playerAdvancedPos, automapMaterial, meshRenderer, playerIsInsideBuilding);
+
+                // if player is inside dungeon or castle and forced reset of discovery state.
+                if ((!playerIsInsideBuilding) && (resetDiscoveryState))
+                {
+                    // mark meshRenderer as undiscovered
+                    meshRenderer.enabled = false;
+                }
+            }
+        }
+
+        private void UpdateMaterialsOfMeshRenderer(Vector3 playerAdvancedPos, Material automapMaterial, MeshRenderer meshRenderer, bool visitedInThisEntering = false)
+        {
+            Material[] newMaterials = new Material[meshRenderer.materials.Length];
+            for (int i = 0; i < meshRenderer.materials.Length; i++)
+            {
+                Material curMaterial = meshRenderer.materials[i];
+                Material newMaterial = Instantiate(automapMaterial);
+
+                //newMaterial.CopyPropertiesFromMaterial(material);
+                newMaterial.name = "AutomapBelowSclicePlane injected for: " + curMaterial.name;
+                if (curMaterial.HasProperty(Uniforms.MainTex))
+                    newMaterial.SetTexture(Uniforms.MainTex, curMaterial.GetTexture(Uniforms.MainTex));
+                if (curMaterial.HasProperty(Uniforms.BumpMap))
+                    newMaterial.SetTexture(Uniforms.BumpMap, curMaterial.GetTexture(Uniforms.BumpMap));
+                if (curMaterial.HasProperty(Uniforms.EmissionMap))
+                    newMaterial.SetTexture(Uniforms.EmissionMap, curMaterial.GetTexture(Uniforms.EmissionMap));
+                if (curMaterial.HasProperty(Uniforms.EmissionColor))
+                    newMaterial.SetColor(Uniforms.EmissionColor, curMaterial.GetColor(Uniforms.EmissionColor));
+                Vector4 playerPosition = new Vector4(playerAdvancedPos.x, playerAdvancedPos.y + Camera.main.transform.localPosition.y, playerAdvancedPos.z, 0.0f);
+                newMaterial.SetVector("_PlayerPosition", playerPosition);
+                if (visitedInThisEntering == true)
+                    newMaterial.DisableKeyword("RENDER_IN_GRAYSCALE");
+                else
+                    newMaterial.EnableKeyword("RENDER_IN_GRAYSCALE");
+                newMaterials[i] = newMaterial;
+            }
+            meshRenderer.materials = newMaterials;
+        }
+    }
+}

--- a/Assets/Scripts/Game/AutomapModel.cs.meta
+++ b/Assets/Scripts/Game/AutomapModel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f140da8322f157a4ba5094186c3bbb3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -97,7 +97,8 @@ namespace DaggerfallWorkshop.Utility
             int[] textureTable = null,
             bool allowExitDoors = true,
             DaggerfallRDBBlock cloneFrom = null,
-            bool serialize = true)
+            bool serialize = true,
+            bool isAutomapRun = false)
         {
             blockDataOut = new DFBlock();
 
@@ -113,7 +114,7 @@ namespace DaggerfallWorkshop.Utility
             // Get block data
             blockDataOut = dfUnity.ContentReader.BlockFileReader.GetBlock(blockName);
 
-            return CreateBaseGameObject(ref blockDataOut, actionLinkDict, textureTable, allowExitDoors, cloneFrom, serialize);
+            return CreateBaseGameObject(ref blockDataOut, actionLinkDict, textureTable, allowExitDoors, cloneFrom, serialize, isAutomapRun);
         }
 
         /// <summary>
@@ -131,7 +132,8 @@ namespace DaggerfallWorkshop.Utility
             int[] textureTable = null,
             bool allowExitDoors = true,
             DaggerfallRDBBlock cloneFrom = null,
-            bool serialize = true)
+            bool serialize = true,
+            bool isAutomapRun = false)
         {
             DaggerfallUnity dfUnity = DaggerfallUnity.Instance;
             if (!dfUnity.IsReady)
@@ -142,16 +144,16 @@ namespace DaggerfallWorkshop.Utility
                 textureTable = DungeonTextureTables.DefaultTextureTable;
 
             // Create gameobject
-            GameObject go;
+            GameObject daggerfallBlockGO;
             string name = string.Format("DaggerfallBlock [{0}]", blockData.Name);
             if (cloneFrom != null)
             {
-                go = GameObjectHelper.InstantiatePrefab(cloneFrom.gameObject, name, null, Vector3.zero);
+                daggerfallBlockGO = GameObjectHelper.InstantiatePrefab(cloneFrom.gameObject, name, null, Vector3.zero);
             }
             else
             {
-                go = new GameObject(name);
-                go.AddComponent<DaggerfallRDBBlock>();
+                daggerfallBlockGO = new GameObject(name);
+                daggerfallBlockGO.AddComponent<DaggerfallRDBBlock>();
             }
 
             // Setup combiner
@@ -162,8 +164,8 @@ namespace DaggerfallWorkshop.Utility
             // Add parent node
             GameObject modelsNode = new GameObject("Models");
             GameObject actionModelsNode = new GameObject("Action Models");
-            modelsNode.transform.parent = go.transform;
-            actionModelsNode.transform.parent = go.transform;
+            modelsNode.transform.parent = daggerfallBlockGO.transform;
+            actionModelsNode.transform.parent = daggerfallBlockGO.transform;
 
             // Add models
             List<StaticDoor> exitDoors;
@@ -177,7 +179,8 @@ namespace DaggerfallWorkshop.Utility
                 serialize,
                 combiner,
                 modelsNode.transform,
-                actionModelsNode.transform);
+                actionModelsNode.transform,
+                isAutomapRun);
 
             // Apply combiner
             if (combiner != null)
@@ -197,11 +200,11 @@ namespace DaggerfallWorkshop.Utility
             // Add exit doors
             if (exitDoors.Count > 0)
             {
-                DaggerfallStaticDoors c = go.AddComponent<DaggerfallStaticDoors>();
+                DaggerfallStaticDoors c = daggerfallBlockGO.AddComponent<DaggerfallStaticDoors>();
                 c.Doors = exitDoors.ToArray();
             }
 
-            return go;
+            return daggerfallBlockGO;
         }
 
         /// <summary>
@@ -582,12 +585,13 @@ namespace DaggerfallWorkshop.Utility
             bool serialize,
             ModelCombiner combiner = null,
             Transform modelsParent = null,
-            Transform actionModelsParent = null)
+            Transform actionModelsParent = null,
+            bool isAutomapRun = false)
         {
             exitDoorsOut = new List<StaticDoor>();
 
             // Iterate object groups
-            foreach (DFBlock.RdbObjectRoot group in blockData.RdbBlock.ObjectRootList)
+            foreach (DFBlock.RdbObjectRoot group in blockData.RdbBlock.ObjectRootList)      // XJDHDR - Test Parallel.ForEach
             {
                 // Skip empty object groups
                 if (null == group.RdbObjects)
@@ -596,7 +600,7 @@ namespace DaggerfallWorkshop.Utility
                 }
 
                 // Iterate objects in this group
-                foreach (DFBlock.RdbObject obj in group.RdbObjects)
+                foreach (DFBlock.RdbObject obj in group.RdbObjects)      // XJDHDR - Test Parallel.ForEach
                 {
                     // Add models
                     if (obj.Type == DFBlock.RdbResourceTypes.Model)
@@ -636,7 +640,7 @@ namespace DaggerfallWorkshop.Utility
                             // Special handling for dungeon exits - collider handled as a special case in DaggerfallStaticDoors startup
                             if (modelId == exitDoorModelID)
                             {
-                                AddStandaloneModel(dfUnity, ref modelData, modelMatrix, modelsParent, hasAction, true);
+                                AddStandaloneModel(dfUnity, ref modelData, modelMatrix, modelsParent, isAutomapRun, hasAction, true);
                                 continue;
                             }
 
@@ -646,14 +650,14 @@ namespace DaggerfallWorkshop.Utility
                             // Not sure if these object ever actions, but bypass this hack if they do
                             if (modelId >= minTapestryID && modelId <= maxTapestryID && !hasAction)
                             {
-                                AddStandaloneModel(dfUnity, ref modelData, modelMatrix, modelsParent, hasAction, true);
+                                AddStandaloneModel(dfUnity, ref modelData, modelMatrix, modelsParent, isAutomapRun, hasAction, true);
                                 continue;
                             }
 
                             // Add or combine
                             if (combiner == null || hasAction || PlayerActivate.HasCustomActivation(modelId))
                             {
-                                standaloneObject = AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent, hasAction);
+                                standaloneObject = AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent, isAutomapRun, hasAction);
                                 standaloneObject.GetComponent<DaggerfallMesh>().SetDungeonTextures(textureTable);
                             }
                             else
@@ -704,6 +708,7 @@ namespace DaggerfallWorkshop.Utility
             ref ModelData modelData,
             Matrix4x4 matrix,
             Transform parent,
+            bool isAutomapRun = false,
             bool overrideStatic = false,
             bool ignoreCollider = false,
             bool convexCollider = false)
@@ -713,12 +718,15 @@ namespace DaggerfallWorkshop.Utility
 
             // Add GameObject
             uint modelID = (uint)modelData.DFMesh.ObjectId;
-            GameObject go = GameObjectHelper.CreateDaggerfallMeshGameObject(modelID, parent, makeStatic, null, ignoreCollider, convexCollider);
-            go.transform.position = matrix.GetColumn(3);
-            go.transform.rotation = matrix.rotation;
-            go.transform.localScale = matrix.lossyScale;
+            GameObject modelGO = GameObjectHelper.CreateDaggerfallMeshGameObject(modelID, parent, makeStatic, null, ignoreCollider, convexCollider);
+            modelGO.transform.position = matrix.GetColumn(3);
+            modelGO.transform.rotation = matrix.rotation;
+            modelGO.transform.localScale = matrix.lossyScale;
 
-            return go;
+            if (isAutomapRun)
+                modelGO.AddComponent<AutomapModel>();
+
+            return modelGO;
         }
 
         /// <summary>


### PR DESCRIPTION
This moves the contents of the InjectMeshAndMaterialProperties and UpdateMaterialsOfMeshRenderer functions into the AutomapModel script. This script is attached to every model that is used to construct the Automap. Then, instead of the Automap script iterating through the Automap tree to run these function on every model it finds, it raises an event that causes each model to run it's copy of the AutomapModel script functions.

I also made one or two optimisations to the existing code, resulting in a 55-60% reduction in the time it takes. Here are some numbers I got for the time taken for the InjectMeshAndMaterialProperties loop/event to run on loading or entering these locations on my desktop PC. For some reason, the function appears to run twice for dungeons and once for castles. I included both times for the dungeons:

Current code:
- Daggerfall Castle:
	- 543.5694ms
- Privateers Hold:
	- 161.139ms and 160.9252ms
- Castle Buckington:
 	- 351.8485ms and 348.7866ms
	
My PR:
- Daggerfall Castle:
	- 226.1401ms
- Privateers Hold:
	- 65.6735ms and 66.3357ms
- Castle Buckington:
	- 146.2152ms and 143.3541ms

I'm not sure if you would be interested in this PR. I was working on this while doing some experiments with multithreading Automap creation. Unfortunately, Unity has blocked the ability to run any part of these functions in anything but the main thread. Maybe what did work will be useful though? I think this event format makes the code look a bit neater.