### PR TITLE
Fix issues where dungeon Automap models are created using the wrong texture table

### DIFF
--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -2041,6 +2041,8 @@ namespace DaggerfallWorkshop.Game
 
                         DFBlock blockData;
                         int[] textureTable = null;
+                        if (GameManager.Instance.PlayerEnterExit.Dungeon != null)
+                            textureTable = GameManager.Instance.PlayerEnterExit.Dungeon.DungeonTextureTable;
                         GameObject gameobjectBlock = RDBLayout.CreateBaseGameObject(block.BlockName, null, out blockData, textureTable, true, null, false);
                         gameobjectBlock.transform.position = new Vector3(block.X * RDBLayout.RDBSide, 0, block.Z * RDBLayout.RDBSide);
 

--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -2047,9 +2047,7 @@ namespace DaggerfallWorkshop.Game
                         }
 
                         DFBlock blockData;
-                        int[] textureTable = null;
-                        if (GameManager.Instance.PlayerEnterExit.Dungeon != null)
-                            textureTable = GameManager.Instance.PlayerEnterExit.Dungeon.DungeonTextureTable;
+                        int[] textureTable = GameManager.Instance.PlayerEnterExit?.Dungeon?.DungeonTextureTable;
 
                         Automap.isCreatingDungeonAutomapBaseGameObjects = true;
                         GameObject gameobjectBlock = RDBLayout.CreateBaseGameObject(block.BlockName, null, out blockData, textureTable, true, null, false);

--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -269,6 +269,8 @@ namespace DaggerfallWorkshop.Game
 
         bool iTweenCameraAnimationIsRunning = false; // indicates if iTween camera animation is running (i.e. teleporter portal jump animation plays)
 
+        static bool isCreatingDungeonAutomapBaseGameObjects = false; // Indicates that the Automap is creating the models for a Castle's or Dungeon's Automap
+
         #endregion
 
         #region Properties
@@ -359,6 +361,11 @@ namespace DaggerfallWorkshop.Game
         public bool ITweenCameraAnimationIsRunning
         {
             get { return iTweenCameraAnimationIsRunning; }
+        }
+
+        public static bool IsCreatingDungeonAutomapBaseGameObjects
+        {
+            get { return isCreatingDungeonAutomapBaseGameObjects; }
         }
 
         #endregion
@@ -2043,7 +2050,11 @@ namespace DaggerfallWorkshop.Game
                         int[] textureTable = null;
                         if (GameManager.Instance.PlayerEnterExit.Dungeon != null)
                             textureTable = GameManager.Instance.PlayerEnterExit.Dungeon.DungeonTextureTable;
+
+                        Automap.isCreatingDungeonAutomapBaseGameObjects = true;
                         GameObject gameobjectBlock = RDBLayout.CreateBaseGameObject(block.BlockName, null, out blockData, textureTable, true, null, false);
+                        Automap.isCreatingDungeonAutomapBaseGameObjects = false;
+
                         gameobjectBlock.transform.position = new Vector3(block.X * RDBLayout.RDBSide, 0, block.Z * RDBLayout.RDBSide);
 
                         gameobjectBlock.transform.SetParent(gameobjectDungeon.transform);

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -35,6 +35,7 @@ namespace DaggerfallWorkshop.Game
         UnderwaterFog underwaterFog;
         DaggerfallUnity dfUnity;
         CharacterController controller;
+        bool isCreatingDungeonBaseGameObjects = false;
         bool isPlayerInside = false;
         bool isPlayerInsideDungeon = false;
         bool isPlayerInsideDungeonCastle = false;
@@ -93,6 +94,15 @@ namespace DaggerfallWorkshop.Game
         public bool LastInteriorStartFlag
         {
             get { return lastInteriorStartFlag; }
+        }
+
+        /// <summary>
+        /// True when GameObjectHelper is creating the RDB Base Game Objects
+        /// </summary>
+        public bool IsCreatingDungeonBaseGameObjects
+        {
+            get { return isCreatingDungeonBaseGameObjects; }
+            set { isCreatingDungeonBaseGameObjects = value; }
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
@@ -62,13 +62,28 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             // Apply materials when the gameobject is first instantiated (not when cloned).
             if (!hasAppliedMaterials)
             {
-                ApplyMaterials(false);
-
                 if (UseDungeonTextureTable)
                 {
-                    DaggerfallDungeon.OnSetDungeon += DaggerfallDungeon_OnSetDungeon;
-                    subscribedToOnSetDungeon = true;
+                    // Modder has enabled the use of the Dungeon Texture Table for this model.
+                    if (Automap.IsCreatingDungeonAutomapBaseGameObjects)
+                    {
+                        // This model's GameObject was created for a location interior's Automap. Immediately create materials and get texture table from DaggerfallDungeon.
+                        ApplyMaterials(false, GameManager.Instance.PlayerEnterExit.Dungeon.DungeonTextureTable);
+                    }
+                    else if (GameManager.Instance.PlayerEnterExit.IsCreatingDungeonBaseGameObjects == true)
+                    {
+                        // This model's GameObject was created for a dungeon's or castle's interior. Register for the OnSetDungeon event as the texture table is not available yet.
+                        DaggerfallDungeon.OnSetDungeon += DaggerfallDungeon_OnSetDungeon;
+                        subscribedToOnSetDungeon = true;
+                    }
+                    else
+                    {
+                        // Otherwise, this model's GameObject is in a location that doesn't need a dungeon texture table.
+                        ApplyMaterials(false);
+                    }
                 }
+                else
+                    ApplyMaterials(false);
             }
         }
 

--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
@@ -67,8 +67,16 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     // Modder has enabled the use of the Dungeon Texture Table for this model.
                     if (Automap.IsCreatingDungeonAutomapBaseGameObjects)
                     {
-                        // This model's GameObject was created for a location interior's Automap. Immediately create materials and get texture table from DaggerfallDungeon.
-                        ApplyMaterials(false, GameManager.Instance.PlayerEnterExit.Dungeon.DungeonTextureTable);
+                        if (GameManager.Instance.IsPlayerInsideBuilding)
+                        {
+                            // This model was created for a settlement interior's Automap. Immediately create materials without texture table.
+                            ApplyMaterials(false);
+                        }
+                        else
+                        {
+                            // This model's GameObject was created for a dungeon or castle Automap. Immediately create materials and get texture table from DaggerfallDungeon.
+                            ApplyMaterials(false, GameManager.Instance.PlayerEnterExit.Dungeon.DungeonTextureTable);
+                        }
                     }
                     else if (GameManager.Instance.PlayerEnterExit.IsCreatingDungeonBaseGameObjects == true)
                     {
@@ -227,7 +235,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             {
                 DaggerfallDungeon.OnSetDungeon -= DaggerfallDungeon_OnSetDungeon;
                 subscribedToOnSetDungeon = false;
-                ApplyMaterials(true, daggerfallDungeon.DungeonTextureTable);
+                ApplyMaterials(false, daggerfallDungeon.DungeonTextureTable);
             }
         }
     }

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -558,7 +558,10 @@ namespace DaggerfallWorkshop.Utility
 
             // Create base object
             DFBlock blockData;
+            GameManager.Instance.PlayerEnterExit.IsCreatingDungeonBaseGameObjects = true;
             GameObject go = RDBLayout.CreateBaseGameObject(blockName, actionLinkDict, out blockData, textureTable, allowExitDoors, cloneFrom);
+            GameManager.Instance.PlayerEnterExit.IsCreatingDungeonBaseGameObjects = false;
+
             // Add action doors
             RDBLayout.AddActionDoors(go, actionLinkDict, ref blockData, textureTable);
 


### PR DESCRIPTION
I noticed some issues with the way dungeon Automap models are created which caused them to use the wrong texture tables when creating their materials. Both the vanilla models and RuntimeMaterials had this problem.

For the vanilla models, the script was passing a null reference for the texture table, causing the CreateBaseGameObject method to just use the default table. For RuntimeMaterials, the script was getting the texture table from an event that never fired.

It has been reported in the forum [here](https://forums.dfworkshop.net/viewtopic.php?f=31&t=4412).

If merged, this PR will fix the second problem mentioned in issue #1990.

@TheLacus - Maybe you should review the RuntimeMaterials portion of this PR?

Edit: Merging this PR will fix #1990 as this is the last part of that issue that needs to be fixed.