### PR TITLE
Fixed torch burning ticks progressing while the game is paused

### DIFF
--- a/Assets/Scripts/Game/EnablePlayerTorch.cs
+++ b/Assets/Scripts/Game/EnablePlayerTorch.cs
@@ -29,7 +29,7 @@ namespace DaggerfallWorkshop.Game
         Light torchLight;
         float torchIntensity;
         float intensityMod = 1f;
-        float lastTickTime;
+        float tickTimeBuffer = 0f;
         float tickTimeInterval = 20f;
         float guttering = 0;
 
@@ -65,12 +65,13 @@ namespace DaggerfallWorkshop.Game
                 DaggerfallUnityItem lightSource = playerEntity.LightSource;
                 if (lightSource != null)
                 {
+                    tickTimeBuffer += Time.deltaTime;
                     enableTorch = true;
                     torchLight.range = lightSource.ItemTemplate.capacityOrTarget;
                     // Consume durability / fuel
-                    if (Time.realtimeSinceStartup > lastTickTime + tickTimeInterval)
+                    if (tickTimeBuffer > tickTimeInterval)
                     {
-                        lastTickTime = Time.realtimeSinceStartup;
+                        tickTimeBuffer = 0f;
                         if (lightSource.currentCondition > 0)
                             lightSource.currentCondition--;
 


### PR DESCRIPTION
Every frame, if the game is not paused, the torch checks if more than 20 seconds has elapsed since the last tick, and if so, reduces condition. This check is based on real time­. Therefore, if a tick occurs and the player pauses immediately for at least 20 seconds, once they come back to gameplay, the torch will burn again immediately. No game mechanic should progress while the game is paused.

This implementation instead uses a time buffer that increases in time only while the game is not paused (and the torch is active of course). One potential issue is that the timer does not reset when unequipping the torch, but it might be a good thing, since it prevents "exploits" based on unequipping the torch every 19 seconds.