### PR TITLE
Fixed date lines in journal entries of quests

### DIFF
--- a/Assets/StreamingAssets/Quests/A0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y06.txt
@@ -32,8 +32,9 @@ AcceptQuest:  [1002]
 <ce>                                master.
 
 QuestLogEntry:  [1010]
-%qdt: I met
- _qgiver_ in ___qgiver_,
+%qdt:
+ I met _qgiver_
+ in ___qgiver_,
  who told me %g3 master in
  _meetingplace_ would
  pay _gold_ gold pieces for
@@ -41,9 +42,9 @@ QuestLogEntry:  [1010]
  dangerous task.
 
 Message:  1011
-%qdt: The traitor
- _traitor_ magicked me
- to __dungeon_.
+%qdt:
+ The traitor _traitor_
+ magicked me to __dungeon_.
  If I ever get out, we will meet again.
 
 Message:  1012

--- a/Assets/StreamingAssets/Quests/A0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y10.txt
@@ -47,7 +47,7 @@ AcceptQuest:  [1002]
 <ce>          So that's the way you want it! I'm game to any %ra!
 
 QuestFail:  [1003]
-%qdt
+%qdt:
  I have agreed to duel with _giver_ at
  _inn_ in ___giver_ in six hours.
 

--- a/Assets/StreamingAssets/Quests/A0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y12.txt
@@ -60,7 +60,7 @@ QuestorPostfailure:  [1009]
 <ce>                        wish to speak with you.
 
 QuestLogEntry:  [1010]
-%qdt
+%qdt:
  _giver_ of ___giver_ has offered me _gold_
  gold to find %g3 book, _book_.
 

--- a/Assets/StreamingAssets/Quests/A0C00Y14.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y14.txt
@@ -75,7 +75,8 @@ QuestorPostfailure:  [1009]
 <ce>                        I would never help you.
 
 QuestLogEntry:  [1010]
-%qdt: _questgiver_ of
+%qdt:
+ _questgiver_ of
  ___questgiver_ has charged
  me with the task of delivering
  a package to _pickuplocal_,

--- a/Assets/StreamingAssets/Quests/A0C01Y09.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y09.txt
@@ -79,7 +79,7 @@ Message:  1013
 <ce>                               _questg_?
 
 Message:  1025
-%qdt
+%qdt:
  I have promised _questg_ of ___questg_
  that I will obtain some _item_ from
  _merchant_ at _store_

--- a/Assets/StreamingAssets/Quests/C0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y11.txt
@@ -60,7 +60,7 @@ I gave thee a chance before, and it was a waste of breath.
 Do you think that I forgot _house_ already, %pct?
 
 QuestLogEntry:  [1010]
-%qdt
+%qdt:
  _qgiver_ of __qgiver_,
  in ___qgiver_ has given
  me the chance to rid _house_

--- a/Assets/StreamingAssets/Quests/M0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/M0B20Y02.txt
@@ -79,7 +79,8 @@ Message:  1020
 <ce>                      Smash you! Smash you flat!
 
 Message:  1030
-%qdt: The Fighters Guild of
+%qdt:
+ The Fighters Guild of
  ___questgiver_ has hired me
  to kill a tribe of six giants in
  their hideout, ___mondung_. I

--- a/Assets/StreamingAssets/Quests/M0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y12.txt
@@ -62,10 +62,11 @@ QuestorPostfailure:  [1009]
 <ce>                         might want you to do?
 
 QuestLogEntry:  [1010]
-%qdt: The Fighters
- Guild of ___qgiver_ has
- offered to let me to kill a
- giant spider which hatched
+%qdt:
+ The Fighters Guild of
+ ___qgiver_ has
+ offered to let me to kill
+ a giant spider which hatched
  in _house_.
  It's got be done today.
 

--- a/Assets/StreamingAssets/Quests/M0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y13.txt
@@ -60,8 +60,9 @@ QuestorPostfailure:  [1009]
 <ce>                        someone else to do it.
 
 QuestLogEntry:  [1010]
-%qdt: The Fighters
- Guild of ___qgiver_ has
+%qdt:
+ The Fighters Guild of
+ ___qgiver_ has
  offered to let me to take
  care of some barbarian
  marauding _house_.

--- a/Assets/StreamingAssets/Quests/M0C00Y14.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y14.txt
@@ -64,8 +64,9 @@ QuestorPostfailure:  [1009]
 <ce>                     rats. You are hopeless %pcn.
 
 QuestLogEntry:  [1010]
-%qdt: The Fighters
- Guild of ___qgiver_ has
+%qdt:
+ The Fighters Guild of
+ ___qgiver_ has
  offered to let me rid _house_
  of a giant rat infestation.
  I have one day to get it done.

--- a/Assets/StreamingAssets/Quests/N0B10Y01.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y01.txt
@@ -96,9 +96,10 @@ QuestLogEntry:  [1010]
 <ce>                       from the atronach's eyes.
 
 Message:  1020
-%qdt: The Mages Guild of
- ___questgiver_ has hired me to find an
- atronach that escaped from their laboratory.
+%qdt:
+ The Mages Guild of ___questgiver_
+ has hired me to find an atronach
+ that escaped from their laboratory.
  It has laired in ___mondung_.
  I need to have the creature dead and be back
  in ___questgiver_ in =1stparton_ days.

--- a/Assets/StreamingAssets/Quests/N0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y03.txt
@@ -58,7 +58,7 @@ The Mages Guild should've got real guards. That's why they lost the _treasure_
 RumorsPostsuccess:  [1007]
 Those thieves aren't going to try to get that _treasure_ again, I bet.
 <--->
-The thieves who tried to get that _treasure_ didn't expect a real guard, I bet
+The thieves who tried to get that _treasure_ didn't expect a real guard, I bet.
 
 QuestorPostsuccess:  [1008]
 How are you, %pcf? Found any use for that _potion_ yet?
@@ -71,8 +71,8 @@ QuestorPostfailure:  [1009]
 
 QuestLogEntry:  [1010]
 %qdt:
- I agreed
- to guard a magic _treasure_
+ I agreed to guard a
+ magic _treasure_
  at the Mages Guild of
  ___qgiver_. I have
  to be there between midnight

--- a/Assets/StreamingAssets/Quests/N0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/N0B20Y02.txt
@@ -88,12 +88,15 @@ QuestorPostfailure:  [1009]
 <ce>                        At least, nothing nice.
 
 QuestLogEntry:  [1010]
-%qdt: I agreed to
- protect _sleepingmage_ at
+%qdt: 
+ I agreed to protect
+ _sleepingmage_ at
  the _magesguild_ while
  %g lies helpless in a trance.
  I must guard %g2 for 3 hours
  starting immediately.
+
+-moved line down from %qdt line.
 
 Message:  1011
 <ce>                    Stand aside, apprentice whelp!

--- a/Assets/StreamingAssets/Quests/N0B21Y14.txt
+++ b/Assets/StreamingAssets/Quests/N0B21Y14.txt
@@ -90,8 +90,9 @@ The Oracle knew that Sentinel would lose the war with Daggerfall.
 If Camaron of Sentinel had listened to the Oracle, he'd be alive today.
 
 Message:  1014
-%qdt: I got a letter
- from The Acolyte asking for a meeting.
+%qdt:
+ I got a letter from The Acolyte 
+ asking for a meeting.
  He is staying at _temple_
  in __temple_.
 

--- a/Assets/StreamingAssets/Quests/N0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y10.txt
@@ -35,7 +35,7 @@ AcceptQuest:  [1002]
 <ce>                      back to me if you find it.
 
 QuestFail:  [1003]
-%qdt
+%qdt:
  I have agreed to find the book _book_
  for the Mages Guild of ___giver_.
  If I find it, I need to get it back to

--- a/Assets/StreamingAssets/Quests/N0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y11.txt
@@ -124,10 +124,10 @@ QuestorPostfailure:  [1009]
 <ce>                             breath on you?
 
 QuestLogEntry:  [1010]
-%qdt, I was
- asked to find a sample of
- _ingredient_ that is
- supposed to be hidden away
+%qdt:
+ I was asked to find a sample
+ of _ingredient_ that
+ is supposed to be hidden away
  in ___dungeon_.
  _qgiver_ of the Mages
  Guild of ___qgiver_

--- a/Assets/StreamingAssets/Quests/N0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y11.txt
@@ -53,7 +53,7 @@ QuestComplete:  [1004]
 <ce>                     with favor in the guild halls.
 
 RumorsDuringQuest:  [1005]
-That crazy mage at the Guild insists that ___dungeon_ has the best _ingredient_
+That crazy mage at the Guild insists that ___dungeon_ has the best _ingredient_.
 
 RumorsPostfailure:  [1006]
 I got a boil the other day ... but it healed.

--- a/Assets/StreamingAssets/Quests/N0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y13.txt
@@ -140,7 +140,8 @@ QuestorPostfailure:  [1009]
 <ce>                    I should keeping talking to you.
 
 QuestLogEntry:  [1010]
-%qdt: I met _questgiver_
+%qdt:
+ I met _questgiver_
  of the Mages Guild of ___questgiver_
  who sent me on a quest to find an
  ancient text hidden in ___dungeon_.

--- a/Assets/StreamingAssets/Quests/P0A01L00.txt
+++ b/Assets/StreamingAssets/Quests/P0A01L00.txt
@@ -87,8 +87,9 @@ That =questgiver_ is a mentor of the vampiric bloodline, %vam.
 _questgiver_ is a proud and capable member of %vam bloodline.
 
 Message:  1015
-%qdt: I received a
- letter from a member of my "family."
+%qdt:
+ I received a letter from
+ a member of my "family."
  I have been told to slay a "member
  of a lesser bloodline," presumably
  not one of %vam, in a

--- a/Assets/StreamingAssets/Quests/P0B00L06.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L06.txt
@@ -77,8 +77,9 @@ QuestLogEntry:  [1010]
                       _vamp_
 
 Message:  1011
-%qdt: I received a
- letter from _vamp_ of
+%qdt:
+ I received a letter
+ from _vamp_ of
  %vam in ___vamp_.
  I am to meet %g2 in a place
  called __vamp_ as
@@ -164,7 +165,8 @@ Message:  1018
 <ce>                       vampires could be anyone.
 
 Message:  1019
-%qdt: _mg_ of
+%qdt:
+ _mg_ of
  __mg_ in ___mg_
  wants me to go to ___mondung_
  to take _mage_'s
@@ -206,9 +208,10 @@ Message:  1020
  about increasing funding. Going nowhere.
 
 Message:  1021
-%qdt: A sorcerer named
- _mage_ has come close
- to major discoveries about %vam
+%qdt:
+ A sorcerer named _mage_
+ has come close to major
+ discoveries about %vam
  and _vamp_ has sent me
  to the laboratory, ___mondung_
  to retrieve the notes. It is likely that

--- a/Assets/StreamingAssets/Quests/P0B10L07.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L07.txt
@@ -91,8 +91,9 @@ Message:  1012
  as soon as possible.
 
 Message:  1013
-%qdt: _vamp_
- wants me to go to ___mondung_
+%qdt:
+ _vamp_ wants me
+ to go to ___mondung_
  and throttle _knight_,
  a knight who refuses to bend to the
  will of %vam. I am

--- a/Assets/StreamingAssets/Quests/Q0C00Y04.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y04.txt
@@ -71,7 +71,8 @@ QuestorPostfailure:  [1009]
 <ce>                         stand to look on thee.
 
 QuestLogEntry:  [1010]
-%qdt: ==qgiver_ has
+%qdt:
+ ==qgiver_ has
  sent me to the Mages Guild of
  ___mguild_ with a
  mysterious potion. I am to look

--- a/Assets/StreamingAssets/Quests/Q0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y06.txt
@@ -86,7 +86,8 @@ _witch_ is a witch of ___witch_.
 _witch_ is a ___witch_ witch, a =witch_.
 
 Message:  1015
-%qdt: _witch_ of
+%qdt:
+ _witch_ of
  ___witch_ has sent me to slay
  a vampire ancient bent on the destruction
  of the witches of %reg. I

--- a/Assets/StreamingAssets/Quests/R0C10Y18.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y18.txt
@@ -94,8 +94,9 @@ _questgiver_
  less.
 
 Message:  1016
-%qdt: There was a
- _item2_ hidden in the _item1_. For the
+%qdt:
+ There was a _item2_ hidden
+ in the _item1_. For the
  _reward_ gold I was promised, I have to
  deliver the _item2_ to a third party
  in ___npc2_, _npc2_ of

--- a/Assets/StreamingAssets/Quests/R0C11Y03.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y03.txt
@@ -108,8 +108,9 @@ A daedra's heart. It never spoils, but some recipes call for it to be fresh.
 The heart of a daedra. Not the sort of thing daedras like in mortals' hands.
 
 Message:  1015
-%qdt: _questgiver_
- of ___questgiver_ asked me
+%qdt:
+ _questgiver_ of
+ ___questgiver_ asked me
  to bring the heart of a daedra to
  %g3 alchemist in __chemist_ of
  ___chemist_. This alchemist

--- a/Assets/StreamingAssets/Quests/R0C11Y16.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y16.txt
@@ -93,8 +93,9 @@ QuestLogEntry:  [1010]
 <ce>                 expects you there in =2ndparton_ days.
 
 Message:  1015
-%qdt: A spy in the employ
- of _questgiver_ of ___questgiver_
+%qdt:
+ A spy in the employ of
+ _questgiver_ of ___questgiver_
  needs a telescope and I have been asked
  to deliver it. I have =1stparton_ days
  to get to _npc1_ in
@@ -103,7 +104,8 @@ Message:  1015
  instructions.
 
 Message:  1016
-%qdt: I gave _npc1_ %g3
+%qdt:
+ I gave _npc1_ %g3
  telescope and %g sent me on to someone named
  _npc2_ of ___npc2_ with
  a relic of some kind. I have =2ndparton_

--- a/Assets/StreamingAssets/Quests/R0C11Y27.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y27.txt
@@ -82,8 +82,9 @@ QuestorPostfailure:  [1009]
 <ce>                             with you now.
 
 QuestLogEntry:  [1010]
-%qdt: I am bringing
- _npc1_ of __npc1_,
+%qdt:
+ I am bringing _npc1_
+ of __npc1_,
  ___npc1_ a _item1_ in
  exchange for some item that
  _questgiver_ wants to be
@@ -92,7 +93,8 @@ QuestLogEntry:  [1010]
  the first part of this delivery.
 
 Message:  1011
-%qdt: _npc1_ sent
+%qdt:
+ _npc1_ sent
  me on to _npc2_, the third
  party in ___npc2_, with some
  _item2_. I will recognize

--- a/Assets/StreamingAssets/Quests/R0C20Y07.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y07.txt
@@ -78,8 +78,9 @@ QuestorPostfailure:  [1009]
 <ce>                               sapphire.
 
 QuestLogEntry:  [1010]
-%qdt: _questgiver_
- of ___questgiver_ has sent me
+%qdt:
+ _questgiver_ of
+ ___questgiver_ has sent me
  on a mission to find a sapphire stolen from
  %g3 friend, _qgfriend_ of
  __qgfriend_, ___qgfriend_.

--- a/Assets/StreamingAssets/Quests/R0C20Y22.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y22.txt
@@ -74,8 +74,9 @@ QuestorPostfailure:  [1009]
 <ce>                         question, by the way.
 
 QuestLogEntry:  [1010]
-%qdt: _questgiver_ has
- hired me to deliver a _item_ to someone
+%qdt: 
+ _questgiver_ has hired me
+ to deliver a _item_ to someone
  in ___contact_ named _contact_.
  %g will meet me at __contact_
  in =queston_ days to reward me if I have not

--- a/Assets/StreamingAssets/Quests/S0000001.txt
+++ b/Assets/StreamingAssets/Quests/S0000001.txt
@@ -227,10 +227,11 @@ Message:  1018
 <ce>            years ago. Why can't you let him rest in peace?
 
 Message:  1019
-%qdt: Prince Lhotun of
- Sentinel has asked me to investigate the death of
- his brother, _brother_, who was supposedly kidnapped
- by the Underking years ago.
+%qdt:
+ Prince Lhotun of Sentinel has asked
+ me to investigate the death of his
+ brother, _brother_, who was supposedly
+ kidnapped by the Underking years ago.
 
 Message:  1020
 <ce>                You pick up a death certificate.

--- a/Assets/StreamingAssets/Quests/Y0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/Y0C00Y00.txt
@@ -88,8 +88,9 @@ Message:  1013
 <ce>                 I have no idea what _artifact_ does.
 
 Message:  1020
-%qdt: The Daedric Prince
- Mehrunes Dagon wants me to slay a frost daedra in
+%qdt: 
+ The Daedric Prince Mehrunes Dagon
+ wants me to slay a frost daedra in
  ___mondung_.  After the extermination
  is complete, I have =1stparton_ days
  to meet with _contact_ and receive


### PR DESCRIPTION
In some quests the text of the journal entry starts directly after the variable _%qdt:_. 

I changed those entries and reformatted them, so that now all the text is on a new line, which is the preferred way, as seen in all the other instances.

(btw. first pull request (ever)! :))