### PR TITLE
Change HotKeySequenceProcessed From Bool To Enum

### DIFF
--- a/Assets/Scripts/Game/HotkeySequence.cs
+++ b/Assets/Scripts/Game/HotkeySequence.cs
@@ -23,6 +23,13 @@ namespace DaggerfallWorkshop.Game
             Alt = 256,
         };
 
+        public enum HotkeySequenceProcessStatus
+        {
+            NotFound,
+            Handled,
+            Disabled,
+        };
+
         public const KeyModifiers virtualKeys = KeyModifiers.Ctrl | KeyModifiers.Shift | KeyModifiers.Alt;
 
         private readonly KeyCode keyCode;

--- a/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
+++ b/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -62,7 +62,7 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         void Update ()
         {
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 if (InputManager.Instance.GetKeyUp(prtscrBinding))
                     StartCoroutine(TakeScreenshot());

--- a/Assets/Scripts/Game/UserInterface/Panel.cs
+++ b/Assets/Scripts/Game/UserInterface/Panel.cs
@@ -212,7 +212,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             }
         }
 
-        public bool ProcessHotkeySequences(HotkeySequence.KeyModifiers keyModifiers)
+        public HotkeySequence.HotkeySequenceProcessStatus ProcessHotkeySequences(HotkeySequence.KeyModifiers keyModifiers)
         {
             foreach (BaseScreenComponent component in components)
             {
@@ -220,7 +220,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 {
                     Button buttonComponent = (Button)component;
                     if (buttonComponent.ProcessHotkeySequences(keyModifiers))
-                        return true;
+                        return HotkeySequence.HotkeySequenceProcessStatus.Handled;
                 }
             }
             foreach (BaseScreenComponent component in components)
@@ -228,11 +228,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 if (component.Enabled && component is Panel)
                 {
                     Panel panelComponent = (Panel)component;
-                    if (panelComponent.ProcessHotkeySequences(keyModifiers))
-                        return true;
+                    if (panelComponent.ProcessHotkeySequences(keyModifiers) == HotkeySequence.HotkeySequenceProcessStatus.Handled)
+                        return HotkeySequence.HotkeySequenceProcessStatus.Handled;
                 }
             }
-            return false;
+            return HotkeySequence.HotkeySequenceProcessStatus.NotFound;
         }
 
         #region Private Methods

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -206,7 +206,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 if (Input.GetKeyDown(KeyCode.Tab))
                     NextPage();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -231,7 +231,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed  == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 // Toggle window closed with same hotkey used to open it
                 if (InputManager.Instance.GetKeyUp(toggleClosedBinding))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -338,7 +338,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 // Toggle window closed with same hotkey used to open it
                 if (InputManager.Instance.GetKeyUp(toggleClosedBinding))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -290,7 +290,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || InputManager.Instance.GetKeyDown(extraProceedBinding))
                     isNextMessageDeferred = true;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
@@ -171,7 +171,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Scale version text based on native panel scaling
             versionTextLabel.TextScale = NativePanel.LocalScale.x * 0.75f;
 
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 // Toggle window closed with same hotkey used to open it
                 if (InputManager.Instance.GetKeyUp(toggleClosedBinding))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
@@ -67,7 +67,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             base.Update();
 
             cancelled = false;
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 if (allowCancel && Input.GetKeyUp(exitKey))
                     CancelWindow();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestJournalWindow.cs
@@ -211,7 +211,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 // Toggle window closed with same hotkey used to open it
                 if (InputManager.Instance.GetKeyUp(toggleClosedBinding1) || InputManager.Instance.GetKeyUp(toggleClosedBinding2))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -184,7 +184,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 // Toggle window closed with same hotkey used to open it, or the DaggerfallBaseWindow's exitKey
                 // Window will properly end the rest if the player was currently resting

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -204,7 +204,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 // Toggle window closed with same hotkey used to open it
                 if (InputManager.Instance.GetKeyUp(toggleClosedBinding))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -149,7 +149,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (!DaggerfallUI.Instance.HotkeySequenceProcessed)
+            if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
                 // Toggle window closed with same hotkey used to open it
                 if (InputManager.Instance.GetKeyUp(toggleClosedBinding))


### PR DESCRIPTION
Hi all,
This PR is in response to a bug report from agris in Inventory Filter; the bug report can be found at https://forums.dfworkshop.net/viewtopic.php?f=27&t=3224&start=30

the approach used to resolve the issue was proposed by @petchema at https://forums.dfworkshop.net/viewtopic.php?f=23&t=4612

This approach is to change the data type of HotKeySequenceProcessed from a bool to an enum in order to support a third state: Disabled

If a window control has focus and is set to overrideHotKeys then HotKeySequenceProcessed = disabled.
If not, then if hotKeysequence recognized, HotKeySequenceProcessed = Handled
otherwise, HotKeySequenceProcessed = NotFound

@petchema, If you wouldn't mind taking a quick peek at the code, I would really appreciate it.  It seems to be working, but I just want to make sure. 

Thank you so much for you continued help!

thanks
a