### PR TITLE
Fix several issues with conjured arrows

### DIFF
--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -83,6 +83,7 @@ namespace DaggerfallWorkshop.Game
         float initialIntensity;
         EntityEffectBundle payload;
         bool isArrow = false;
+        bool isArrowSummoned = false;
         GameObject goModel = null;
         EnemySenses enemySenses;
 
@@ -139,6 +140,11 @@ namespace DaggerfallWorkshop.Game
         {
             get { return isArrow; }
             set { isArrow = value; }
+        }
+        public bool IsArrowSummoned
+        {
+            get { return isArrowSummoned; }
+            set { isArrowSummoned = value; }
         }
 
         /// <summary>
@@ -595,7 +601,7 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 Transform hitTransform = arrowHitCollider.gameObject.transform;
-                GameManager.Instance.WeaponManager.WeaponDamage(GameManager.Instance.WeaponManager.LastBowUsed, true, hitTransform, hitTransform.position, goModel.transform.forward);
+                GameManager.Instance.WeaponManager.WeaponDamage(GameManager.Instance.WeaponManager.LastBowUsed, true, isArrowSummoned, hitTransform, hitTransform.position, goModel.transform.forward);
             }
         }
 

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -348,16 +348,41 @@ namespace DaggerfallWorkshop.Game.Items
         /// </summary>
         /// <param name="itemGroup">Item group.</param>
         /// <param name="itemIndex">Template index.</param>
+        /// <param name="priorityToConjured">Prefer (short lived) conjured items.</param>
         /// <returns>An item of this type, or null if none found.</returns>
-        public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex)
+        public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex, bool priorityToConjured = false)
         {
             int groupIndex = DaggerfallUnity.Instance.ItemHelper.GetGroupIndex(itemGroup, itemIndex);
-            foreach (DaggerfallUnityItem item in items.Values)
+            if (!priorityToConjured)
             {
-                if (item.ItemGroup == itemGroup && item.GroupIndex == groupIndex)
-                    return item;
+                foreach (DaggerfallUnityItem item in items.Values)
+                {
+                    if (item.ItemGroup == itemGroup && item.GroupIndex == groupIndex)
+                        return item;
+                }
+                return null;
             }
-            return null;
+            else
+            {
+                DaggerfallUnityItem selectedItem = null;
+
+                foreach (DaggerfallUnityItem item in items.Values)
+                {
+                    if (item.ItemGroup == itemGroup && item.GroupIndex == groupIndex)
+                    {
+                        if (item.IsSummoned)
+                        {
+                            // pick conjured items with shortest life
+                            if (selectedItem == null || !selectedItem.IsSummoned || selectedItem.TimeForItemToDisappear > item.TimeForItemToDisappear)
+                                selectedItem = item;
+                        }
+                        else // real item
+                            if (selectedItem == null)
+                                selectedItem = item;
+                    }
+                }
+                return selectedItem;
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -666,7 +666,7 @@ namespace DaggerfallWorkshop.Game.Items
                 if (checkItem != item && 
                     checkItem.ItemGroup == itemGroup && checkItem.GroupIndex == groupIndex &&
                     checkItem.PotionRecipeKey == item.PotionRecipeKey &&
-                    checkItem.IsSummoned == item.IsSummoned &&
+                    checkItem.TimeForItemToDisappear == item.TimeForItemToDisappear &&
                     checkItem.IsStackable())
                     return checkItem;
             }

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/CreateItem.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/CreateItem.cs
@@ -26,6 +26,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         public static readonly string EffectKey = "CreateItem";
 
         DaggerfallListPickerWindow itemPicker;
+        static int lastSelectedIndex = 0;
 
         enum CreateItemSelection
         {
@@ -71,6 +72,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             {
                 itemPicker.ListBox.AddItem(TextManager.Instance.GetLocalizedText(item.ToString()));
             }
+            itemPicker.ListBox.SelectIndex(lastSelectedIndex);
+            itemPicker.ListBox.ScrollToSelected();
         }
 
         public override void SetProperties()
@@ -115,6 +118,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 
         private void ItemPicker_OnItemPicked(int index, string itemString)
         {
+            lastSelectedIndex = index;
             //Add selected item to inventory with time limit
             DaggerfallUnityItem item = CreateTempItem((CreateItemSelection)index);
             if (item != null)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -24,6 +24,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     {
         const int midScreenTextDefaultY = 146;
 
+        Color realArrowsColor = new Color(0.6f, 0.6f, 0.6f);
+        Color conjuredArrowsColor = new Color(0.18f, 0.32f, 0.48f, 0.5f);
+
         float crosshairScale = 0.75f;
 
         PopupText popupText = new PopupText();
@@ -160,7 +163,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             questDebugger.AutoSize = AutoSizeModes.ScaleToFit;
             ParentPanel.Components.Add(questDebugger);
 
-            arrowCountTextLabel.TextColor = new Color(0.6f, 0.6f, 0.6f);
+            arrowCountTextLabel.TextColor = realArrowsColor;
             arrowCountTextLabel.ShadowPosition = Vector2.zero;
             ParentPanel.Components.Add(arrowCountTextLabel);
         }
@@ -250,8 +253,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     arrowLabelPos.x -= arrowCountTextLabel.TextWidth;
                     arrowLabelPos.y += compass.Size.y / 2 - arrowCountTextLabel.TextHeight / 2;
 
-                    DaggerfallUnityItem arrows = GameManager.Instance.PlayerEntity.Items.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow);
+                    DaggerfallUnityItem arrows = GameManager.Instance.PlayerEntity.Items.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, priorityToConjured: true);
                     arrowCountTextLabel.Text = (arrows != null) ? arrows.stackCount.ToString() : "0";
+                    arrowCountTextLabel.TextColor = (arrows != null && arrows.IsSummoned) ? conjuredArrowsColor : realArrowsColor;
                     arrowCountTextLabel.TextScale = NativePanel.LocalScale.x;
                     arrowCountTextLabel.Position = arrowLabelPos;
                     arrowCountTextLabel.Enabled = true;

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -76,7 +76,6 @@ namespace DaggerfallWorkshop.Game
         DaggerfallUnityItem currentRightHandWeapon = null;
         DaggerfallUnityItem currentLeftHandWeapon = null;
         DaggerfallUnityItem lastBowUsed = null;
-        bool isLastArrowSummoned = false;
 
         public float EquipCountdownRightHand;
         public float EquipCountdownLeftHand;
@@ -371,12 +370,6 @@ namespace DaggerfallWorkshop.Game
             {
                 ScreenWeapon.PlaySwingSound();
                 isBowSoundFinished = true;
-
-                // Remove arrow
-                ItemCollection playerItems = playerEntity.Items;
-                DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, priorityToConjured: true);
-                isLastArrowSummoned = arrow.IsSummoned;
-                playerItems.RemoveOne(arrow);
             }
             else if (!isDamageFinished && ScreenWeapon.GetCurrentFrame() == ScreenWeapon.GetHitFrame())
             {
@@ -400,11 +393,17 @@ namespace DaggerfallWorkshop.Game
                     DaggerfallMissile missile = Instantiate(ArrowMissilePrefab);
                     if (missile)
                     {
+                        // Remove arrow
+                        ItemCollection playerItems = playerEntity.Items;
+                        DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, priorityToConjured: true);
+                        bool isArrowSummoned = arrow.IsSummoned;
+                        playerItems.RemoveOne(arrow);
+
                         missile.Caster = GameManager.Instance.PlayerEntityBehaviour;
                         missile.TargetType = TargetTypes.SingleTargetAtRange;
                         missile.ElementType = ElementTypes.None;
                         missile.IsArrow = true;
-                        missile.IsArrowSummoned = isLastArrowSummoned;
+                        missile.IsArrowSummoned = isArrowSummoned;
 
                         lastBowUsed = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;;
                     }

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -373,7 +373,7 @@ namespace DaggerfallWorkshop.Game
 
                 // Remove arrow
                 ItemCollection playerItems = playerEntity.Items;
-                DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow);
+                DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, priorityToConjured: true);
                 playerItems.RemoveOne(arrow);
             }
             else if (!isDamageFinished && ScreenWeapon.GetCurrentFrame() == ScreenWeapon.GetHitFrame())

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -76,6 +76,7 @@ namespace DaggerfallWorkshop.Game
         DaggerfallUnityItem currentRightHandWeapon = null;
         DaggerfallUnityItem currentLeftHandWeapon = null;
         DaggerfallUnityItem lastBowUsed = null;
+        bool isLastArrowSummoned = false;
 
         public float EquipCountdownRightHand;
         public float EquipCountdownLeftHand;
@@ -374,6 +375,7 @@ namespace DaggerfallWorkshop.Game
                 // Remove arrow
                 ItemCollection playerItems = playerEntity.Items;
                 DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, priorityToConjured: true);
+                isLastArrowSummoned = arrow.IsSummoned;
                 playerItems.RemoveOne(arrow);
             }
             else if (!isDamageFinished && ScreenWeapon.GetCurrentFrame() == ScreenWeapon.GetHitFrame())
@@ -402,6 +404,7 @@ namespace DaggerfallWorkshop.Game
                         missile.TargetType = TargetTypes.SingleTargetAtRange;
                         missile.ElementType = ElementTypes.None;
                         missile.IsArrow = true;
+                        missile.IsArrowSummoned = isLastArrowSummoned;
 
                         lastBowUsed = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;;
                     }
@@ -479,7 +482,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Returns true if hit an enemy entity
-        public bool WeaponDamage(DaggerfallUnityItem strikingWeapon, bool arrowHit, Transform hitTransform, Vector3 impactPosition, Vector3 direction)
+        public bool WeaponDamage(DaggerfallUnityItem strikingWeapon, bool arrowHit, bool arrowSummoned, Transform hitTransform, Vector3 impactPosition, Vector3 direction)
         {
             DaggerfallEntityBehaviour entityBehaviour = hitTransform.GetComponent<DaggerfallEntityBehaviour>();
             DaggerfallMobileUnit entityMobileUnit = hitTransform.GetComponentInChildren<DaggerfallMobileUnit>();
@@ -541,8 +544,8 @@ namespace DaggerfallWorkshop.Game
                     if (playerEntity.IsMagicallyConcealedNormalPower && damage > 0)
                         EntityEffectManager.BreakNormalPowerConcealmentEffects(GameManager.Instance.PlayerEntityBehaviour);
 
-                    // Play arrow sound and add arrow to target's inventory
-                    if (arrowHit)
+                    // Add arrow to target's inventory
+                    if (arrowHit && !arrowSummoned)
                     {
                         DaggerfallUnityItem arrow = ItemBuilder.CreateItem(ItemGroups.Weapons, (int)Weapons.Arrow);
                         enemyEntity.Items.AddItem(arrow);
@@ -893,7 +896,7 @@ namespace DaggerfallWorkshop.Game
                    // Fall back to simple ray for narrow cages https://forums.dfworkshop.net/viewtopic.php?f=5&t=2195#p39524
                    || Physics.Raycast(ray, out hit, weapon.Reach, playerLayerMask))
                 {
-                    hitEnemy = WeaponDamage(strikingWeapon, false, hit.transform, hit.point, mainCamera.transform.forward);
+                    hitEnemy = WeaponDamage(strikingWeapon, false, false, hit.transform, hit.point, mainCamera.transform.forward);
                 }
             }
         }


### PR DESCRIPTION
- don't stack conjured arrows with different TTLs;
- shoot conjured arrows first, starting with the ones with lowest TTL;
- change color of arrow counter to tell whether you're about to shoot a conjured or real arrow;
- prevent looting conjured arrows (currently they're converted to real arrows in enemies inventory).

Forums: https://forums.dfworkshop.net/viewtopic.php?f=5&t=4629