### PR TITLE
Fixed spells with multiple effects ending too early

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1700,8 +1700,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                 foreach (IEntityEffect effect in bundle.liveEffects)
                 {
                     // Update effects with remaining rounds, item effects are always ticked
-                    hasRemainingEffectRounds = effect.RoundsRemaining > 0;
-                    if (hasRemainingEffectRounds || bundle.fromEquippedItem != null)
+                    hasRemainingEffectRounds = hasRemainingEffectRounds || effect.RoundsRemaining > 0;
+                    if (effect.RoundsRemaining > 0 || bundle.fromEquippedItem != null)
                         effect.MagicRound();
                 }
 


### PR DESCRIPTION
If a spell has multiple effects, the entity effect manager will remove its bundle when the last effect expires, rather than when all effects expire.

To reproduce:
1. Create a spell with at least two effects. Make the first effect last at least 2 rounds, and make the last effect last 1 round (instant counts as 1)
2. Cast spell
3. Wait 1 round
4. See spell being immediately removed, even though the first effect still had another round

The bug still occurs even if the first effect has 10+ rounds remaining.

I'm not sure if this is a classic issue, but even if it is, it's worth fixing in my opinion. The bug can be worked around by having the longest effect be the last in the list.