### PR TITLE
Prevent detecting accidental axis button "presses" from movement and camera axes

### DIFF
--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -930,6 +930,17 @@ namespace DaggerfallWorkshop.Game
             axisActionInvertDict[(int)axis] = invert;
         }
 
+        public bool IsUsedInAxisBinding(KeyCode code)
+        {
+            string axis = InputManager.Instance.AxisKeyCodeToInputAxis((int)code);
+
+            return (!string.IsNullOrEmpty(axis)
+                && (axis == movementAxisBindingCache[0]
+                || axis == movementAxisBindingCache[1]
+                || axis == cameraAxisBindingCache[0]
+                || axis == cameraAxisBindingCache[1]));
+        }
+
         // 'autofill' false: Forcefully set keybindings to defaults
         // 'autofill' true: Deploys default values if action missing from loaded keybinds
         public void ResetDefaults(bool autofill = false)
@@ -1061,22 +1072,60 @@ namespace DaggerfallWorkshop.Game
 
         public bool AnyKeyDown
         {
-            get
-            {
-                foreach (KeyCode k in KeyCodeList)
-                    if (GetUnaryKey(k, getKeyDownMethod, true, false)) return true;
-                return false;
-            }
+            get => GetAnyKeyDown() != KeyCode.None;
         }
 
         public bool AnyKeyUp
         {
-            get
-            {
-                foreach (KeyCode k in KeyCodeList)
-                    if (GetUnaryKey(k, getKeyUpMethod, false, false)) return true;
-                return false;
-            }
+            get => GetAnyKeyUp() != KeyCode.None;
+        }
+
+        public bool AnyKeyDownIgnoreAxisBinds
+        {
+            get => GetAnyKeyDownIgnoreAxisBinds() != KeyCode.None;
+        }
+
+
+        public bool AnyKeyUpIgnoreAxisBinds
+        {
+            get => GetAnyKeyUpIgnoreAxisBinds() != KeyCode.None;
+        }
+
+        public KeyCode GetAnyKeyDown()
+        {
+            foreach (KeyCode k in KeyCodeList)
+                if (GetUnaryKey(k, getKeyDownMethod, true, false))
+                    return k;
+
+            return KeyCode.None;
+        }
+
+        public KeyCode GetAnyKeyUp()
+        {
+            foreach (KeyCode k in KeyCodeList)
+                if (GetUnaryKey(k, getKeyUpMethod, false, false))
+                    return k;
+
+            return KeyCode.None;
+        }
+
+        public KeyCode GetAnyKeyDownIgnoreAxisBinds()
+        {
+            foreach (KeyCode k in KeyCodeList)
+                if (!IsUsedInAxisBinding(k) && GetUnaryKey(k, getKeyDownMethod, true, false)) 
+                    return k;
+
+            return KeyCode.None;
+        }
+
+
+        public KeyCode GetAnyKeyUpIgnoreAxisBinds()
+        {
+            foreach (KeyCode k in KeyCodeList)
+                if (!IsUsedInAxisBinding(k) && GetUnaryKey(k, getKeyUpMethod, false, false))
+                    return k;
+
+            return KeyCode.None;
         }
 
         public KeyCode GetComboCode(KeyCode a, KeyCode b)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -383,23 +383,23 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public static IEnumerator WaitForKeyPress(Button button, System.Action checkDuplicates, System.Action<bool> setWaitingForInput)
         {
             string currentLabel = button.Label.Text;
+            KeyCode code1;
+            KeyCode code2;
 
             button.Label.Text = "";
             yield return new WaitForSecondsRealtime(0.05f);
 
-            while (!InputManager.Instance.AnyKeyDown)
+            while ((code1 = InputManager.Instance.GetAnyKeyDownIgnoreAxisBinds()) == KeyCode.None)
             {
                 setWaitingForInput(true);
                 yield return null;
             }
 
-            KeyCode code1 = InputManager.Instance.LastSingleKeyDown;
-
             yield return new WaitForSecondsRealtime(0.05f);
 
-            while (!InputManager.Instance.AnyKeyDown)
+            while ((code2 = InputManager.Instance.GetAnyKeyDownIgnoreAxisBinds()) == KeyCode.None)
             {
-                if (InputManager.Instance.AnyKeyUp)
+                if (InputManager.Instance.GetAnyKeyUpIgnoreAxisBinds() != KeyCode.None)
                     break;
 
                 setWaitingForInput(true);
@@ -408,8 +408,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             setWaitingForInput(false);
 
-            KeyCode code2 = InputManager.Instance.LastSingleKeyDown;
-            KeyCode code = code1 == code2 ? code1 : InputManager.Instance.GetComboCode(code1, code2);
+            KeyCode code = code1 == code2 || code2 == KeyCode.None ? code1 : InputManager.Instance.GetComboCode(code1, code2);
 
             if (code != KeyCode.None && InputManager.Instance.ReservedKeys.FirstOrDefault(x => x == code) == KeyCode.None)
             {

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
@@ -537,11 +537,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         IEnumerator WaitForKeyPress(Button button, bool isAxisAction)
         {
             string currentLabel = button.Label.Text;
+            KeyCode code = KeyCode.None;
 
             button.Label.Text = "";
             yield return new WaitForSecondsRealtime(0.05f);
 
-            while (!InputManager.Instance.AnyKeyDown)
+            while ((!isAxisAction && (code = InputManager.Instance.GetAnyKeyDownIgnoreAxisBinds()) == KeyCode.None)
+                || (isAxisAction && (code = InputManager.Instance.GetAnyKeyDown()) == KeyCode.None))
             {
                 SetWaitingForInput(true);
                 yield return null;
@@ -549,13 +551,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             SetWaitingForInput(false);
 
-            KeyCode code = InputManager.Instance.LastSingleKeyDown;
-
             if (code != KeyCode.None)
             {
-                if(InputManager.Instance.ReservedKeys.FirstOrDefault(x => x == code) == KeyCode.None)
+                if (InputManager.Instance.ReservedKeys.FirstOrDefault(x => x == code) == KeyCode.None)
                 {
-                    if(isAxisAction)
+                    if (isAxisAction)
                     {
                         var text = InputManager.Instance.AxisKeyCodeToInputAxis((int)code);
                         if (!string.IsNullOrEmpty(text))

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallVidPlayerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallVidPlayerWindow.cs
@@ -114,7 +114,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Handle exit any key or end of video
             if (useCustomVideo)
             {
-                if (endOnAnyKey && InputManager.Instance.AnyKeyDown ||
+                if (endOnAnyKey && InputManager.Instance.AnyKeyDownIgnoreAxisBinds ||
                     Input.GetKeyDown(KeyCode.Escape) ||
                     !customVideo.IsPlaying)
                 {
@@ -130,7 +130,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else
             {
-                if (endOnAnyKey && InputManager.Instance.AnyKeyDown ||
+                if (endOnAnyKey && InputManager.Instance.AnyKeyDownIgnoreAxisBinds ||
                     Input.GetKeyDown(KeyCode.Escape) ||
                     video.VidFile.EndOfFile && video.Playing)
                 {


### PR DESCRIPTION
If the player accidentally moves their movement or camera axis in a cutscene sequence, it will recognize it as a button press in the direction it went and skip the video, since it was looking for "any key down". Similarly, a player might accidentally bind either axis while the control window is waiting for a key press (especially when trying to bind the controller buttons commonly known as L3 and R3, where you press down on the joysticks.) Those axis buttons are not needed for any practical reason since they are already in use for moving the character and camera.

These changes will simply ignore those detected axis buttons if they are a part of the movement or camera axes. I also added two new boolean property getters `AnyKey(Down/Up)IgnoreAxisBinds` and four new public `KeyCode` methods to return the specific key of the `AnyKey` methods. Some of these might be unused in the codebase, but they can be helpful for modding.