### PR TITLE
Fixed some editor warnings

### DIFF
--- a/Assets/Scripts/Terrain/DaggerfallTerrain.cs
+++ b/Assets/Scripts/Terrain/DaggerfallTerrain.cs
@@ -341,7 +341,6 @@ namespace DaggerfallWorkshop
 
             // Promote material
             terrain.materialTemplate = terrainMaterial;
-            terrain.materialType = Terrain.MaterialType.Custom; // TODO: Terrain.MaterialType is now obsolete
 
             // Promote heights
             Vector3 size = terrain.terrainData.size;

--- a/Assets/Scripts/Utility/ViewportChanger.cs
+++ b/Assets/Scripts/Utility/ViewportChanger.cs
@@ -24,7 +24,7 @@ namespace DaggerfallWorkshop.Utility
 
         Rect standardViewportRect = new Rect(0, 0, 1, 1);
         Rect lastViewportRect;
-        Camera camera;
+        new Camera camera;
 
         private void Start()
         {


### PR DESCRIPTION
This fixes three of the warnings that appear in the editor every time scripts are re-compiled by:

- Adding "new" keyword to ViewportChanger's Camera variable.
- Deleting line in DaggerfallTerrain that sets materialType as materialTemplate is now set directly.

The warnings related to WWW being obsolete are still present because, [as I discovered](https://forums.dfworkshop.net/viewtopic.php?p=52520#p52520), UnityWebRequest is not a straight drop-in replacement for DFU's current code.