### PR TITLE
Added the ability for mods to add new Biography templates

### DIFF
--- a/Assets/Scripts/Game/Player/CharacterDocument.cs
+++ b/Assets/Scripts/Game/Player/CharacterDocument.cs
@@ -58,6 +58,7 @@ namespace DaggerfallWorkshop.Game.Player
         public sbyte biographyReactionMod;
         public List<string> biographyEffects;
         public int classIndex;
+        public int biographyIndex;
         public List<string> backStory;
         public bool isCustom = false;
         public Races classicTransformedRace = Races.None;

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharBiography.cs
@@ -144,7 +144,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
 
                 // Create text biography
-                BackStory = biogFile.GenerateBackstory(Document.classIndex);
+                BackStory = biogFile.GenerateBackstory();
 
                 // Show reputation changes
                 biogFile.DigestRepChanges();

--- a/Assets/StreamingAssets/BIOGs/readme.txt
+++ b/Assets/StreamingAssets/BIOGs/readme.txt
@@ -1,7 +1,21 @@
-Place replacement BIOG*.txt files in this folder. Valid range is BIOG00T0.TXT to BIOG17T0.TXT.
+Place replacement BIOG*.txt files in this folder.
+
+The name format is BIOG[class]T[index].txt
+Class is a value between 0 and 17, inclusively. They correspond to the same list the player chooses when starting a new character.
+Index is any number. The classic biographies use 0, and mods are free to use any other number they want.
+
+For example, BIOG10T2.txt would be a valid alternative biography for a Thief, or Thief-adjacent custom class.
+
+To allow mods to have a custom backstory to go with the biography, BIOG files may optionally start with the following line:
+
+#12345
+
+This will make the game use the specified string id (here, 12345) for the History text found in the character sheet. By default, the string id is 4116 + class. Classic strings stop at 9999, so mods can use a custom ITextProvider to have custom strings above this value.
 
 Note that BIOG text is not currently included in core localization string tables.
 It's necessary to copy correct language version of files into BIOGs folder.
 English BIOG files are used by default, DE and FR versions are also provided for convenience.
+
+The T0 templates are not exactly the original Arena2 BIOG files. Some bugfixes and minor balance changes have been made.
 
 Credit for fixed files to Frank 'Deepfighter' Schwalb. Please see "readme-deepfighter.txt" for more information.


### PR DESCRIPTION
I felt like investigating the biography and History system in Daggerfall, and noticed that it wouldn't be too hard for DFU to give mods the ability to introduce alternative biographies for character.

With these changes, after choosing a class (ex: Mage aka 0), the game looks for all files that match BIOG00T([0-9]+).txt in the BIOG source folder. If multiple files are found, one is selected at random (note: could be extended later to offer a list to choose from).

In addition, an extension was added to the BIOG file format. Before the first question, if a line starts with #, the rest of the line will be interpreted as a string id, and will be used for the backstory. With a custom ITextProvider, mods can make use of unused string values to provide new backstory text.

For example, if a mod adds a BIOG00T1.txt file, when a player creates a Mage (or similar custom class), the game will randomly pick between BIOG00T0 and BIOG00T1, with possibility for a new set of questions and/or a different backstory.

I've asked around, and it seems like it would be a popular feature.
