### PR TITLE
I found a bug in the code that I had submitted as part of PR 2056.

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -393,7 +393,7 @@ namespace DaggerfallWorkshop.Game
                 processHotkeys = false;
                 HotkeySequenceProcessed = ProcessHotKeySequences();
             }
-            else if (uiManager.TopWindow.FocusControl != null && uiManager.TopWindow.FocusControl.OverridesHotkeySequences)
+            else if (uiManager?.TopWindow?.FocusControl?.OverridesHotkeySequences == true)
                 HotkeySequenceProcessed = HotkeySequence.HotkeySequenceProcessStatus.Disabled;
             else
                 HotkeySequenceProcessed = HotkeySequence.HotkeySequenceProcessStatus.NotFound;


### PR DESCRIPTION
I found an issue in the code that I had submitted in PR # 2056.

In DaggerfallUI, I check for uiManager.TopWindow.FocusControl not to be null but I just hit a situation where uiManager.TopWindow was null so this failed on nullException.
I added a check for TopWindow as well now to correct that issue.
Sorry for this, the issue.

Thanks 
A