### PR TITLE
Bugfix for PR 2053

### DIFF
--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -35,7 +35,7 @@ namespace DaggerfallWorkshop.Game
         UnderwaterFog underwaterFog;
         DaggerfallUnity dfUnity;
         CharacterController controller;
-        bool isCreatingDungeonBaseGameObjects = false;
+        bool isCreatingDungeonObjects = false;
         bool isPlayerInside = false;
         bool isPlayerInsideDungeon = false;
         bool isPlayerInsideDungeonCastle = false;
@@ -99,10 +99,10 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// True when GameObjectHelper is creating the RDB Base Game Objects
         /// </summary>
-        public bool IsCreatingDungeonBaseGameObjects
+        public bool IsCreatingDungeonObjects
         {
-            get { return isCreatingDungeonBaseGameObjects; }
-            set { isCreatingDungeonBaseGameObjects = value; }
+            get { return isCreatingDungeonObjects; }
+            set { isCreatingDungeonObjects = value; }
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
@@ -78,7 +78,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                             ApplyMaterials(false, GameManager.Instance.PlayerEnterExit.Dungeon.DungeonTextureTable);
                         }
                     }
-                    else if (GameManager.Instance.PlayerEnterExit.IsCreatingDungeonBaseGameObjects == true)
+                    else if (GameManager.Instance.PlayerEnterExit.IsCreatingDungeonObjects == true)
                     {
                         // This model's GameObject was created for a dungeon's or castle's interior. Register for the OnSetDungeon event as the texture table is not available yet.
                         DaggerfallDungeon.OnSetDungeon += DaggerfallDungeon_OnSetDungeon;

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -558,9 +558,8 @@ namespace DaggerfallWorkshop.Utility
 
             // Create base object
             DFBlock blockData;
-            GameManager.Instance.PlayerEnterExit.IsCreatingDungeonBaseGameObjects = true;
+            GameManager.Instance.PlayerEnterExit.IsCreatingDungeonObjects = true;
             GameObject go = RDBLayout.CreateBaseGameObject(blockName, actionLinkDict, out blockData, textureTable, allowExitDoors, cloneFrom);
-            GameManager.Instance.PlayerEnterExit.IsCreatingDungeonBaseGameObjects = false;
 
             // Add action doors
             RDBLayout.AddActionDoors(go, actionLinkDict, ref blockData, textureTable);
@@ -588,6 +587,7 @@ namespace DaggerfallWorkshop.Utility
 
             // Link action nodes
             RDBLayout.LinkActionNodes(actionLinkDict);
+            GameManager.Instance.PlayerEnterExit.IsCreatingDungeonObjects = false;
 
             return go;
         }


### PR DESCRIPTION
This fixes a bug in PR #2053 where Runtime Materials only detected that it was being created for a dungeon's or castle's interior if attached to a Base Game Object and not if attached to anything else that is inside a dungeon, such as Action Doors. This meant that modded secret doors received the wrong textures. The script will now correctly detect a dungeon/castle interior creation if attached to other objects.

To test this PR, you can download my mod [Unofficial Block Location and Model fixes](https://www.nexusmods.com/daggerfallunity/mods/100?tab=files) then load the attached save game. Without this PR, the secret door in front of you will have the wrong texture. With this PR, the texture will be correct.
[Secret door test.zip](https://github.com/Interkarma/daggerfall-unity/files/6209795/Secret.door.test.zip)
