### PR TITLE
Added more "protected" and "virtual" in DaggerfallInventoryWindow

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -331,6 +331,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             UpdateRemoteTargetIcon();
 
             // Store toggle closed binding for this window
+            SetupClosedBinding();
+        }
+
+        protected void SetupClosedBinding()
+        {
             toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Inventory);
         }
 
@@ -807,7 +812,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             localItemListScroller.Items = localItemsFiltered;
         }
 
-        void SelectActionMode(ActionModes mode)
+        protected void SelectActionMode(ActionModes mode)
         {
             selectedActionMode = mode;
 
@@ -1061,7 +1066,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             Refresh(false);
         }
 
-        private void CheckWagonAccess()
+        protected void CheckWagonAccess()
         {
             if (allowDungeonWagonAccess)
             {
@@ -1108,7 +1113,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             return false;
         }
 
-        void UpdateItemInfoPanel(DaggerfallUnityItem item)
+        protected virtual void UpdateItemInfoPanel(DaggerfallUnityItem item)
         {
             // Display info in local target icon panel, replacing justification tokens
             TextFile.Token[] tokens = ItemHelper.GetItemInfo(item, DaggerfallUnity.TextProvider);
@@ -1121,7 +1126,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             UpdateItemInfoPanel(tokens);
         }
 
-        private void UpdateItemInfoPanel(TextFile.Token[] tokens)
+        protected void UpdateItemInfoPanel(TextFile.Token[] tokens)
         {
             for (int tokenIdx = 0; tokenIdx < tokens.Length; tokenIdx++)
             {
@@ -2088,7 +2093,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Hover & StartGame Event Handlers
 
-        private void PaperDoll_OnMouseMove(int x, int y)
+        protected virtual void PaperDoll_OnMouseMove(int x, int y)
         {
             byte value = paperDoll.GetEquipIndex(x, y);
             if (value != 0xff)


### PR DESCRIPTION
- Every operation in Setup had "protected" access in case a derived class felt like overriding it entirely, except for SelectActionMode and the "toggleClosedBinding" part, which require private access. Added "protected" to SelectActionMode, and exposed the toggleClosedBinding operation as a protected method
- Added a virtual to "UpdateItemInfoPanel(item)" in case a derived window wants to change how an item's info is displayed without changing all the other functions
- Added a virtual to PaperDoll_OnMouseMove since the other "OnMouseMove" functions had it (I actually need this for my mod)