### PR TITLE
Fix regression in PR 2051

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -94,24 +94,29 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="modelID">Daggerfall model ID.</param>
         /// <param name="parent">Parent to assign to GameObject.</param>
         /// <param name="matrix">Matrix with position and rotation of GameObject.</param>
+        /// <param name="isAutomapRun">True if current model is being created for an Automap?</param>
         /// <returns>Returns the imported model or null if not found.</returns>
-        public static GameObject ImportCustomGameobject (uint modelID, Transform parent, Matrix4x4 matrix)
+        public static GameObject ImportCustomGameobject (uint modelID, Transform parent, Matrix4x4 matrix, bool isAutomapRun = false)
         {
-            GameObject go;
-            if (!TryImportGameObject(modelID, true, out go))
+            GameObject modelGO;
+            if (!TryImportGameObject(modelID, true, out modelGO))
                 return null;
 
-            go.name = GameObjectHelper.GetGoModelName(modelID) + " [Replacement]";
-            go.transform.parent = parent;
-            go.transform.position = matrix.GetColumn(3);
-            go.transform.rotation = matrix.rotation;
+            modelGO.name = GameObjectHelper.GetGoModelName(modelID) + " [Replacement]";
+            modelGO.transform.parent = parent;
+            modelGO.transform.position = matrix.GetColumn(3);
+            modelGO.transform.rotation = matrix.rotation;
 
             //Multiply the scale instead of applying it, since custom 3D models doesn't necessary have (1,1,1) scale
-            go.transform.localScale = Vector3.Scale(go.transform.localScale, matrix.lossyScale);
+            modelGO.transform.localScale = Vector3.Scale(modelGO.transform.localScale, matrix.lossyScale);
 
             // Finalise gameobject
-            FinaliseMaterials(go);
-            return go;
+            FinaliseMaterials(modelGO);
+
+            if (isAutomapRun)
+                modelGO.AddComponent<AutomapModel>();
+
+            return modelGO;
         }
 
         public static string GetFlatReplacementName (int archive, int record)

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -591,7 +591,7 @@ namespace DaggerfallWorkshop.Utility
             exitDoorsOut = new List<StaticDoor>();
 
             // Iterate object groups
-            foreach (DFBlock.RdbObjectRoot group in blockData.RdbBlock.ObjectRootList)      // XJDHDR - Test Parallel.ForEach
+            foreach (DFBlock.RdbObjectRoot group in blockData.RdbBlock.ObjectRootList)
             {
                 // Skip empty object groups
                 if (null == group.RdbObjects)
@@ -600,7 +600,7 @@ namespace DaggerfallWorkshop.Utility
                 }
 
                 // Iterate objects in this group
-                foreach (DFBlock.RdbObject obj in group.RdbObjects)      // XJDHDR - Test Parallel.ForEach
+                foreach (DFBlock.RdbObject obj in group.RdbObjects)
                 {
                     // Add models
                     if (obj.Type == DFBlock.RdbResourceTypes.Model)
@@ -634,7 +634,7 @@ namespace DaggerfallWorkshop.Utility
 
                         // Get GameObject
                         Transform parent = (hasAction) ? actionModelsParent : modelsParent;
-                        GameObject standaloneObject = MeshReplacement.ImportCustomGameobject(modelId, parent, modelMatrix);
+                        GameObject standaloneObject = MeshReplacement.ImportCustomGameobject(modelId, parent, modelMatrix, isAutomapRun);
                         if (standaloneObject == null)
                         {
                             // Special handling for dungeon exits - collider handled as a special case in DaggerfallStaticDoors startup


### PR DESCRIPTION
When I moved the InjectMeshAndMaterialProperties and UpdateMaterialsOfMeshRenderer functions into a separate script, the intention was for each of these scripts to do the same thing as the previous code. However, PR #2051 has a regression in it where this script is only added to vanilla models generated from Arch3D.bsa and is not applied to mod added models. This PR fixes this so that mod added models will now also receive the script and have the Automap shader and textures applied.

At the same time, I also removed some comments I accidentally left in RDBLayout in one of my other PRs. Unfortunately, Unity does not allow manipulating a Game Object's Transform from anything except the main thread.