### PR TITLE
Allow mods to add as well as modify loot items

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -2028,16 +2028,16 @@ namespace DaggerfallWorkshop.Game.Formulas
         /// <summary>
         /// Allows loot found in containers and enemy corpses to be modified.
         /// </summary>
-        /// <param name="lootItems">An array of the loot items</param>
-        /// <returns>The number of items modified.</returns>
-        public static int ModifyFoundLootItems(ref DaggerfallUnityItem[] lootItems)
+        /// <param name="lootItems">An array of the loot items to modify</param>
+        /// <returns>The array of modified loot items</returns>
+        public static DaggerfallUnityItem[] ModifyFoundLootItems(ref DaggerfallUnityItem[] lootItems)
         {
-            Func<DaggerfallUnityItem[], int> del;
+            Func<DaggerfallUnityItem[], DaggerfallUnityItem[]> del;
             if (TryGetOverride("ModifyFoundLootItems", out del))
                 return del(lootItems);
 
-            // DFU does no post-processing of loot items hence report zero changes, this is solely for mods to override.
-            return 0;
+            // DFU does no post-processing of loot items hence return array unchanged. This function is solely for mods to override.
+            return lootItems;
         }
 
         /// <summary>

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -71,9 +71,9 @@ namespace DaggerfallWorkshop
             LootChanceMatrix matrix = LootTables.GetMatrix(LootTableKey);
             DaggerfallUnityItem[] newitems = LootTables.GenerateRandomLoot(matrix, GameManager.Instance.PlayerEntity);
 
-            FormulaHelper.ModifyFoundLootItems(ref newitems);
+            DaggerfallUnityItem[] modifieditems = FormulaHelper.ModifyFoundLootItems(ref newitems);
 
-            collection.Import(newitems);
+            collection.Import(modifieditems);
         }
 
         /// <summary>


### PR DESCRIPTION
Unfortunately System.Func doesn't allow for passing by ref so returning the array allows new loot to be added by mods.