### PR TITLE
Fixed issues while parsing Deepfighter's BIOG files

### DIFF
--- a/Assets/Scripts/API/BiogFile.cs
+++ b/Assets/Scripts/API/BiogFile.cs
@@ -223,7 +223,7 @@ namespace DaggerfallConnect.Arena2
 
         private static void ApplyPlayerEffect(PlayerEntity playerEntity, string effect)
         {
-            string[] tokens = effect.Split(' ');
+            string[] tokens = effect.Split(null);
             int parseResult;
 
             // Skill modifier effect

--- a/Assets/StreamingAssets/BIOGs/BIOG01T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG01T0.TXT
@@ -215,7 +215,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG02T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG02T0.TXT
@@ -200,7 +200,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG03T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG03T0.TXT
@@ -207,7 +207,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG05T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG05T0.TXT
@@ -235,7 +235,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG06T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG06T0.TXT
@@ -177,7 +177,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG10T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG10T0.TXT
@@ -202,7 +202,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG12T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG12T0.TXT
@@ -138,7 +138,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG13T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG13T0.TXT
@@ -125,7 +125,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG14T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG14T0.TXT
@@ -132,7 +132,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG15T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG15T0.TXT
@@ -137,7 +137,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG16T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG16T0.TXT
@@ -128,7 +128,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/BIOG17T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/BIOG17T0.TXT
@@ -128,7 +128,6 @@ a.	Resisting poisons
 b.	Staying awake and alert
 	FT -5
 c.	Getting along with others
-	&
 	RR -5
 d.	Avoiding diseases
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG01T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG01T0.TXT
@@ -215,7 +215,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG02T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG02T0.TXT
@@ -200,7 +200,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG03T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG03T0.TXT
@@ -206,7 +206,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG05T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG05T0.TXT
@@ -233,7 +233,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG06T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG06T0.TXT
@@ -173,7 +173,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG10T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG10T0.TXT
@@ -201,7 +201,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert 
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG12T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG12T0.TXT
@@ -137,7 +137,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG13T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG13T0.TXT
@@ -124,7 +124,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert 
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG14T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG14T0.TXT
@@ -132,7 +132,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG15T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG15T0.TXT
@@ -137,7 +137,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG16T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG16T0.TXT
@@ -128,7 +128,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Deutsch/BIOG17T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Deutsch/BIOG17T0.TXT
@@ -128,7 +128,6 @@ a.	Giften zu widerstehen
 b.	wach und alarmiert zu bleiben
 	FT -5
 c.	Kontakte zu kn}pfen
-	&
 	RR -5
 d.	Krankheiten zu verhindern
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG01T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG01T0.TXT
@@ -215,7 +215,6 @@ a.	resister au poison
 b.	rester eveille et alerte 
 	FT -5
 c.	etre sociable
-	&
 	RR -5
 d.	resister aux maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG02T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG02T0.TXT
@@ -200,7 +200,6 @@ a.	resister au poison
 b.	rester eveille et alerte 
 	FT -5
 c.	etre sociable
-	&
 	RR -5
 d.	resister aux maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG03T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG03T0.TXT
@@ -206,7 +206,6 @@ a.	resister au poison
 b.	rester eveille et alerte 
 	FT -5
 c.	etre sociable
-	&
 	RR -5
 d.	resister aux maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG06T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG06T0.TXT
@@ -174,7 +174,6 @@ a.	resister au poison
 b.	rester eveille et alerte 
 	FT -5
 c.	etre sociable
-	&
 	RR -5
 d.	resister au maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG10T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG10T0.TXT
@@ -201,7 +201,6 @@ a.	resister aux poisons
 b.	rester eveille et alerte
 	FT -5
 c.	vous entendre avec les autres
-	&
 	RR -5
 d.	eviter les maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG12T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG12T0.TXT
@@ -137,7 +137,6 @@ a.	resister aux poisons
 b.	rester eveille et alerte
 	FT -5
 c.	vous entendre avec les autres
-	&
 	RR -5
 d.	eviter les maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG13T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG13T0.TXT
@@ -125,7 +125,6 @@ a.	resister aux poisons
 b.	rester eveille et alerte
 	FT -5
 c.	vous entendre avec les autres
-	&
 	RR -5
 d.	eviter les maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG14T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG14T0.TXT
@@ -132,7 +132,6 @@ a.	resister aux poisons
 b.	rester eveille et alerte
 	FT -5
 c.	vous entendre avec les autres
-	&
 	RR -5
 d.	eviter les maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG15T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG15T0.TXT
@@ -138,7 +138,6 @@ a.	resister aux poisons
 b.	rester eveille et alerte
 	FT -5
 c.	vous entendre avec les autres
-	&
 	RR -5
 d.	resister aux maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG16T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG16T0.TXT
@@ -127,7 +127,6 @@ a.	resister aux poisons
 b.	rester eveille et alerte
 	FT -5
 c.	vous entendre avec les autres
-	&
 	RR -5
 d.	eviter les maladies
 	RD -5

--- a/Assets/StreamingAssets/BIOGs/Francais/BIOG17T0.TXT
+++ b/Assets/StreamingAssets/BIOGs/Francais/BIOG17T0.TXT
@@ -128,7 +128,6 @@ a.	resister aux poisons
 b.	rester eveille et alerte
 	FT -5
 c.	vous entendre avec les autres
-	&
 	RR -5
 d.	resister aux maladies
 	RD -5


### PR DESCRIPTION
1) Some lines (mostly the ones with IT) use tabs instead of spaces to split token­. This caused BiogFile.cs to fail parsing those lines, failing to give the character the intended item. BiogFile.cs now splits tokens with any whitespace
2) Almost all BIOG files had the same copy-pasted "&" line, which caused BiogFile.cs to throw an error on invalid command. Removed that line from all BIOG files, as this was likely not intended

Repro case:
1. Start DFU without any mods
2. Start New Game
3. Create a Warrior character, and answer "Axe fighting" to the first question. The rest can be answered randomly
4. Open Inventory

Expected:
In BIOG16T0.txt, "Axe fighting" to question 1 should give you IT 3 15 0, aka Iron War-axe

Actual result:
No axe in inventory

The error logs can be seen when creating the character from the Unity Editor