### PR TITLE
SpeedChanger Updates

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -658,7 +658,7 @@ namespace Wenzil.Console
                 {
                     try
                     {
-                        Console.Log(string.Format("Current Walk Speed: ", speedChanger.currentWalkSpeed));
+                        Console.Log(string.Format("Current Walk Speed: ", speedChanger.RefreshWalkSpeed().ToString()));
                         return HelpCommand.Execute(SetWalkSpeed.name);
 
                     }
@@ -718,7 +718,7 @@ namespace Wenzil.Console
                 {
                     try
                     {
-                        Console.Log(string.Format("Current Run Speed: {0}", speedChanger.currentRunSpeed.ToString()));
+                        Console.Log(string.Format("Current Run Speed: {0}", speedChanger.RefreshRunSpeed().ToString()));
                         return HelpCommand.Execute(SetRunSpeed.name);
 
                     }
@@ -734,7 +734,7 @@ namespace Wenzil.Console
                     if (speedChanger.RemoveSpeedMod(args[0].ToString(), true))
                         return string.Format("Run speed modifier " + args[0].ToString() + " removed");
                     else
-                        return error + " Run speed is " + speedChanger.RefreshRunspeed().ToString();
+                        return error + " Run speed is " + speedChanger.RefreshRunSpeed().ToString();
                 }
                 else if (speed != -1 && speed != -2 && speed < 0)
                 {
@@ -748,12 +748,12 @@ namespace Wenzil.Console
                 else if (speed == -2)
                 {
                     speedChanger.ResetSpeed(false, true);
-                    return string.Format("Run speed modifiers cleared. Run speed is " + speedChanger.RefreshRunspeed().ToString());
+                    return string.Format("Run speed modifiers cleared. Run speed is " + speedChanger.RefreshRunSpeed().ToString());
                 }
                 else
                 {
                     speedChanger.AddRunSpeedMod(out UID, speed);
-                    return string.Format("Run speed Modifier added (UID: " + UID + "). Run speed is " + speedChanger.RefreshRunspeed().ToString());
+                    return string.Format("Run speed Modifier added (UID: " + UID + "). Run speed is " + speedChanger.RefreshRunSpeed().ToString());
                 }
             }
         }

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -642,7 +642,7 @@ namespace Wenzil.Console
         {
             public static readonly string name = "set_walkspeed";
             public static readonly string error = "Failed to set walk speed - invalid setting or PlayerMotor object not found";
-            public static readonly string description = "Set walk speed by multiplying current walk speed by inserted percentage. Set to -1 to disable speed modifiers. Set to -2 to clear out all speed modifiers";
+            public static readonly string description = "Set walk speed by multiplying current walk speed by inserted percentage. Set to -1 to disable or enable speed overrides. Set to -2 to clear out all speed modifiers";
             public static readonly string usage = "set_walkspeed [#]";
 
             public static string Execute(params string[] args)
@@ -658,7 +658,7 @@ namespace Wenzil.Console
                 {
                     try
                     {
-                        Console.Log(string.Format("Current Walk Speed: {0}", speedChanger.currentWalkSpeed));
+                        Console.Log(string.Format("Current Walk Speed: ", speedChanger.currentWalkSpeed));
                         return HelpCommand.Execute(SetWalkSpeed.name);
 
                     }
@@ -682,17 +682,17 @@ namespace Wenzil.Console
                 else if (speed == -1)
                 {
                     speedChanger.walkSpeedOverride = !speedChanger.walkSpeedOverride;
-                    return string.Format("Walk speed override set to: {0}", speedChanger.walkSpeedOverride);
+                    return string.Format("Walk speed override set to: " + speedChanger.walkSpeedOverride);
                 }
                 else if (speed == -2)
                 {
                     speedChanger.ResetSpeed(true, false);
-                    return string.Format("Walk speed modifiers cleared.");
+                    return string.Format("Walk speed modifiers cleared. Walk speed is " + speedChanger.currentWalkSpeed); 
                 }
                 else
                 {
                     speedChanger.AddWalkSpeedMod(out UID, speed);
-                    return string.Format("{0} Walk speed Modifier added (UID: " + UID + "). Walk speed is" + speedChanger.walkSpeedOverride);
+                    return string.Format("Walk speed Modifier added (UID: " + UID + "). Walk speed is " + speedChanger.currentWalkSpeed);
                 }
 
             }
@@ -702,7 +702,7 @@ namespace Wenzil.Console
         {
             public static readonly string name = "set_runspeed";
             public static readonly string error = "Failed to set run speed - invalid setting or PlayerMotor object not found";
-            public static readonly string description = "Set run speed by multiplying current run speed by inserted percentage. Set to -1 to return to default speed/clear run speed modifiers.";
+            public static readonly string description = "Set run speed by multiplying current run speed by inserted percentage. Set to -1 to disable or enable speed overrides. Set to -2 to clear out all speed modifiers";
             public static readonly string usage = "set_runspeed [#]";
 
             public static string Execute(params string[] args)
@@ -718,7 +718,7 @@ namespace Wenzil.Console
                 {
                     try
                     {
-                        Console.Log(string.Format("Current Run Speed: {0}", speedChanger.currentRunSpeed));
+                        Console.Log(string.Format("Current Run Speed: {0}", speedChanger.currentRunSpeed.ToString()));
                         return HelpCommand.Execute(SetRunSpeed.name);
 
                     }
@@ -743,17 +743,17 @@ namespace Wenzil.Console
                 else if (speed == -1)
                 {
                     speedChanger.runSpeedOverride = !speedChanger.runSpeedOverride;
-                    return string.Format("Run speed override set to: {0}", speedChanger.runSpeedOverride);
+                    return string.Format("Run speed override set to: " + speedChanger.runSpeedOverride);
                 }
                 else if (speed == -2)
                 {
                     speedChanger.ResetSpeed(false, true);
-                    return string.Format("Run speed modifiers cleared.");
+                    return string.Format("Run speed modifiers cleared. Run speed is " + speedChanger.currentRunSpeed);
                 }
                 else
                 {
                     speedChanger.AddRunSpeedMod(out UID, speed);
-                    return string.Format("{0} Run speed Modifier added (UID: " + UID + "). Run speed is" + speedChanger.runSpeedOverride);
+                    return string.Format("Run speed Modifier added (UID: " + UID + "). Run speed is " + speedChanger.currentRunSpeed);
                 }
             }
         }

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -642,12 +642,13 @@ namespace Wenzil.Console
         {
             public static readonly string name = "set_walkspeed";
             public static readonly string error = "Failed to set walk speed - invalid setting or PlayerMotor object not found";
-            public static readonly string description = "Set walk speed. Set to -1 to return to default speed.";
+            public static readonly string description = "Set walk speed by multiplying current walk speed by inserted percentage. Set to -1 to disable speed modifiers. Set to -2 to clear out all speed modifiers";
             public static readonly string usage = "set_walkspeed [#]";
 
             public static string Execute(params string[] args)
             {
-                int speed;
+                float speed;
+                string UID;
                 PlayerSpeedChanger speedChanger = GameManager.Instance.SpeedChanger;
 
                 if (speedChanger == null)
@@ -657,7 +658,7 @@ namespace Wenzil.Console
                 {
                     try
                     {
-                        Console.Log(string.Format("Current Walk Speed: {0}", speedChanger.GetWalkSpeed(GameManager.Instance.PlayerEntity)));
+                        Console.Log(string.Format("Current Walk Speed: {0}", speedChanger.currentWalkSpeed));
                         return HelpCommand.Execute(SetWalkSpeed.name);
 
                     }
@@ -667,18 +668,31 @@ namespace Wenzil.Console
                     }
 
                 }
-                else if (!int.TryParse(args[0], out speed))
+                else if (!float.TryParse(args[0], out speed))
+                {
+                    if (speedChanger.RemoveSpeedMod(args[0].ToString()))
+                        return string.Format("Walk speed modifier " + args[0].ToString() + " removed");
+                    else
+                        return error;
+                }
+                else if (speed != -1 && speed != -2 && speed < 0)
+                {
                     return error;
+                }
                 else if (speed == -1)
                 {
-                    speedChanger.useWalkSpeedOverride = false;
-                    return string.Format("Walk speed set to default.");
+                    speedChanger.walkSpeedOverride = !speedChanger.walkSpeedOverride;
+                    return string.Format("Walk speed override set to: {0}", speedChanger.walkSpeedOverride);
+                }
+                else if (speed == -2)
+                {
+                    speedChanger.ResetSpeed(true, false);
+                    return string.Format("Walk speed modifiers cleared.");
                 }
                 else
                 {
-                    speedChanger.useWalkSpeedOverride = true;
-                    speedChanger.walkSpeedOverride = speed;
-                    return string.Format("Walk speed set to: {0}", speed);
+                    speedChanger.AddWalkSpeedMod(out UID, speed);
+                    return string.Format("{0} Walk speed Modifier added (UID: " + UID + "). Walk speed is" + speedChanger.walkSpeedOverride);
                 }
 
             }
@@ -688,13 +702,14 @@ namespace Wenzil.Console
         {
             public static readonly string name = "set_runspeed";
             public static readonly string error = "Failed to set run speed - invalid setting or PlayerMotor object not found";
-            public static readonly string description = "Set run speed. Set to -1 to return to default speed.";
+            public static readonly string description = "Set run speed by multiplying current run speed by inserted percentage. Set to -1 to return to default speed/clear run speed modifiers.";
             public static readonly string usage = "set_runspeed [#]";
 
             public static string Execute(params string[] args)
             {
-                int speed;
-                PlayerSpeedChanger speedChanger = GameManager.Instance.SpeedChanger;//GameObject.FindObjectOfType<PlayerMotor>();
+                float speed;
+                string UID;
+                PlayerSpeedChanger speedChanger = GameManager.Instance.SpeedChanger;
 
                 if (speedChanger == null)
                     return error;
@@ -703,7 +718,7 @@ namespace Wenzil.Console
                 {
                     try
                     {
-                        Console.Log(string.Format("Current RunSpeed: {0}", speedChanger.GetRunSpeed(speedChanger.GetWalkSpeed(GameManager.Instance.PlayerEntity))));
+                        Console.Log(string.Format("Current Run Speed: {0}", speedChanger.currentRunSpeed));
                         return HelpCommand.Execute(SetRunSpeed.name);
 
                     }
@@ -714,20 +729,31 @@ namespace Wenzil.Console
 
 
                 }
-                else if (!int.TryParse(args[0], out speed))
+                else if (!float.TryParse(args[0], out speed))
+                {
+                    if (speedChanger.RemoveSpeedMod(args[0].ToString(), true))
+                        return string.Format("Run speed modifier " + args[0].ToString() + " removed");
+                    else
+                        return error;
+                }
+                else if (speed != -1 && speed != -2 && speed < 0)
                 {
                     return error;
                 }
                 else if (speed == -1)
                 {
-                    speedChanger.useRunSpeedOverride = false;
-                    return string.Format("Run speed set to default.");
+                    speedChanger.runSpeedOverride = !speedChanger.runSpeedOverride;
+                    return string.Format("Run speed override set to: {0}", speedChanger.runSpeedOverride);
+                }
+                else if (speed == -2)
+                {
+                    speedChanger.ResetSpeed(false, true);
+                    return string.Format("Run speed modifiers cleared.");
                 }
                 else
                 {
-                    speedChanger.runSpeedOverride = speed;
-                    speedChanger.useRunSpeedOverride = true;
-                    return string.Format("Run speed set to: {0}", speed);
+                    speedChanger.AddRunSpeedMod(out UID, speed);
+                    return string.Format("{0} Run speed Modifier added (UID: " + UID + "). Run speed is" + speedChanger.runSpeedOverride);
                 }
             }
         }
@@ -2097,10 +2123,11 @@ namespace Wenzil.Console
                         foreach (WeaponMaterialTypes material in weaponMaterials)
                         {
                             Array enumArray = itemHelper.GetEnumArray(ItemGroups.Weapons);
-                            for (int i = 0; i < enumArray.Length-1; i++)
+                            for (int i = 0; i < enumArray.Length - 1; i++)
                             {
                                 newItem = ItemBuilder.CreateWeapon((Weapons)enumArray.GetValue(i), material);
-                                if (args[0] == "magicWeapons") {
+                                if (args[0] == "magicWeapons")
+                                {
                                     newItem.legacyMagic = new DaggerfallEnchantment[] { new DaggerfallEnchantment() { type = EnchantmentTypes.CastWhenUsed, param = 5 } };
                                     newItem.IdentifyItem();
                                 }

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -673,11 +673,11 @@ namespace Wenzil.Console
                     if (speedChanger.RemoveSpeedMod(args[0].ToString()))
                         return string.Format("Walk speed modifier " + args[0].ToString() + " removed");
                     else
-                        return error;
+                        return error + " Walk speed: " + speedChanger.RefreshWalkSpeed().ToString();
                 }
                 else if (speed != -1 && speed != -2 && speed < 0)
                 {
-                    return error;
+                    return error + " Walk speed: " + speedChanger.RefreshWalkSpeed().ToString();
                 }
                 else if (speed == -1)
                 {
@@ -687,12 +687,12 @@ namespace Wenzil.Console
                 else if (speed == -2)
                 {
                     speedChanger.ResetSpeed(true, false);
-                    return string.Format("Walk speed modifiers cleared. Walk speed is " + speedChanger.currentWalkSpeed); 
+                    return string.Format("Walk speed modifiers cleared. Walk speed is " + speedChanger.RefreshWalkSpeed().ToString()); 
                 }
                 else
                 {
                     speedChanger.AddWalkSpeedMod(out UID, speed);
-                    return string.Format("Walk speed Modifier added (UID: " + UID + "). Walk speed is " + speedChanger.currentWalkSpeed);
+                    return string.Format("Walk speed Modifier added (UID: " + UID + "). Walk speed is " + speedChanger.RefreshWalkSpeed().ToString());
                 }
 
             }
@@ -701,7 +701,7 @@ namespace Wenzil.Console
         private static class SetRunSpeed
         {
             public static readonly string name = "set_runspeed";
-            public static readonly string error = "Failed to set run speed - invalid setting or PlayerMotor object not found";
+            public static readonly string error = "Failed to set run speed - invalid setting or PlayerMotor object not found.";
             public static readonly string description = "Set run speed by multiplying current run speed by inserted percentage. Set to -1 to disable or enable speed overrides. Set to -2 to clear out all speed modifiers";
             public static readonly string usage = "set_runspeed [#]";
 
@@ -734,7 +734,7 @@ namespace Wenzil.Console
                     if (speedChanger.RemoveSpeedMod(args[0].ToString(), true))
                         return string.Format("Run speed modifier " + args[0].ToString() + " removed");
                     else
-                        return error;
+                        return error + " Run speed is " + speedChanger.RefreshRunspeed().ToString();
                 }
                 else if (speed != -1 && speed != -2 && speed < 0)
                 {
@@ -743,17 +743,17 @@ namespace Wenzil.Console
                 else if (speed == -1)
                 {
                     speedChanger.runSpeedOverride = !speedChanger.runSpeedOverride;
-                    return string.Format("Run speed override set to: " + speedChanger.runSpeedOverride);
+                    return string.Format("Run speed override set to: " + speedChanger.runSpeedOverride.ToString());
                 }
                 else if (speed == -2)
                 {
                     speedChanger.ResetSpeed(false, true);
-                    return string.Format("Run speed modifiers cleared. Run speed is " + speedChanger.currentRunSpeed);
+                    return string.Format("Run speed modifiers cleared. Run speed is " + speedChanger.RefreshRunspeed().ToString());
                 }
                 else
                 {
                     speedChanger.AddRunSpeedMod(out UID, speed);
-                    return string.Format("Run speed Modifier added (UID: " + UID + "). Run speed is " + speedChanger.currentRunSpeed);
+                    return string.Format("Run speed Modifier added (UID: " + UID + "). Run speed is " + speedChanger.RefreshRunspeed().ToString());
                 }
             }
         }

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -34,11 +34,11 @@ namespace DaggerfallWorkshop.Game
         private const float dfCartBase = dfWalkBase + 100f;
 
         public bool walkSpeedOverride = true;
-        public float currentWalkSpeed { get; private set; } = 0;
+        private float currentWalkSpeed = 0;
         private Dictionary<string, float> walkSpeedModifierList = new Dictionary<string, float>();
 
         public bool runSpeedOverride = true;
-        public float currentRunSpeed { get; private set; } = 0;
+        private float currentRunSpeed = 0;
         private Dictionary<string, float> runSpeedModifierList = new Dictionary<string, float>();
 
         public delegate bool CanPlayerRun();
@@ -115,7 +115,7 @@ namespace DaggerfallWorkshop.Game
 
             if (isRunning)
             {
-                speed = RefreshRunspeed();
+                speed = RefreshRunSpeed();
 
                 //switch sneaking off if was previously sneaking
                 sneakingMode = false;

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -281,7 +281,7 @@ namespace DaggerfallWorkshop.Game
         /// Updates the players walk speed using for loop and dictionary values to ensure proper sequential processing to get proper end speed.
         /// Processing of modifiers is processed by their addition order. First added by modder is multiplied first, and so on.
         /// </summary>
-        private float RefreshWalkSpeed()
+        public float RefreshWalkSpeed()
         {
             //setup and grab needed base values for computing end speed.
             float baseWalkSpeed = GetWalkSpeed(GameManager.Instance.PlayerEntity);
@@ -331,7 +331,7 @@ namespace DaggerfallWorkshop.Game
         /// Updates the players walk speed using for loop and dictionary values to ensure proper sequential processing to get proper end speed.
         /// Processing of modifiers is processed by their addition order. First added by modder is multiplied first, and so on.
         /// </summary>
-        private float RefreshRunspeed()
+        public float RefreshRunSpeed()
         {
             //setup and grab needed base values for computing end speed.
             float baseRunSpeed = GetRunSpeed();

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -53,7 +53,6 @@ namespace DaggerfallWorkshop.Game
         public bool updateRunSpeed;
         private float previousBaseWalkSpeed;
         private float previousBaseRunSpeed;
-        private float baseSpeed = 0;
 
         private void Start()
         {
@@ -143,6 +142,7 @@ namespace DaggerfallWorkshop.Game
         public float GetBaseSpeed()
         {
             Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            float baseSpeed = 0;
             float playerSpeed = player.Stats.LiveSpeed;
             if (playerMotor == null) // fixes null reference bug.
                 playerMotor = GameManager.Instance.PlayerMotor;
@@ -165,18 +165,19 @@ namespace DaggerfallWorkshop.Game
         /// Add custom walk speed modifier to speed modifer dictionary. Returns unique ID for referencing of custom speedModifier for future manipulation.
         /// </summary>
         /// <param name="speedModifier">the amount to change players base walk speed by percentages. AKA, .75 will lower player movement by 25%. Using 0 or negatives will do nothing but return null.</param>
+        /// <param name="UID">The Unique Universal ID created and provided when original value was added to dictionary. Store this value to reference your speed modifier later.</param>
         /// <param name="refreshWalkSpeed">will cause routine to also update the player speed using the list to sequentially multiply the current base value by the list modifier values.</param>
         /// <returns></returns>        
-        public bool AddWalkSpeedMod(out string UUID, float walkSpeedModifier = 0, bool refreshWalkSpeed = true)
+        public bool AddWalkSpeedMod(out string UID, float walkSpeedModifier = 0, bool refreshWalkSpeed = true)
         {
             bool added = false;
-            UUID = null;
+            UID = null;
 
             //if they set a speed modifier greater than 0, grab the list index using count, and add item (which will be at the lastID index spot).
             if (walkSpeedModifier > 0)
             {
-                UUID = System.Guid.NewGuid().ToString();
-                walkSpeedModifierList.Add(UUID, walkSpeedModifier);
+                UID = System.Guid.NewGuid().ToString();
+                walkSpeedModifierList.Add(UID, walkSpeedModifier);
                 added = true;
             }
             //trigger an update to the walk speed loop to push updated walk speed value.
@@ -189,18 +190,19 @@ namespace DaggerfallWorkshop.Game
         /// Add custom walk speed modifier to speed modifer dictionary. Returns unique ID for referencing of custom speedModifier for future manipulation.
         /// </summary>
         /// <param name="speedModifier">the amount to change players base walk speed by percentages. AKA, .75 will lower player movement by 25%. Using 0 or negatives will do nothing but return null.</param>
+        /// <param name="UID">The Unique Universal ID created and provided when original value was added to dictionary. Store this value to reference your speed modifier later.</param>
         /// <param name="refreshWalkSpeed">will cause routine to also update the player speed using the list to sequentially multiply the current base value by the list modifier values.</param>
         /// <returns></returns>        
-        public bool AddRunSpeedMod(out string UUID, float speedModifier = 0, bool refreshRunSpeed = true)
+        public bool AddRunSpeedMod(out string UID, float speedModifier = 0, bool refreshRunSpeed = true)
         {
             bool added = false;
-            UUID = null;
+            UID = null;
 
             //if they set a speed modifier greater than 0, grab the list index using count, and add item (which will be at the lastID index spot).
             if (speedModifier > 0)
             {
-                UUID = System.Guid.NewGuid().ToString();
-                runSpeedModifierList.Add(UUID, speedModifier);
+                UID = System.Guid.NewGuid().ToString();
+                runSpeedModifierList.Add(UID, speedModifier);
                 added = true;
             }
 
@@ -211,37 +213,38 @@ namespace DaggerfallWorkshop.Game
         }
 
         /// <summary>
-        /// remove custom speed modifier from speed modifer dictionary using stored UID. Returns true if removed, false if not found. Ensure to set if it is a run or walk speed modifier being removed.
+        /// Remove custom speed modifier from speed modifer dictionary using stored UID. Returns true if removed, false if not found. Ensure to set if it is a run or walk speed modifier being removed.
         /// </summary>
-        /// <param name="UUID">The Unique Universal ID created and provided when original value was added to dictionary.</param>
+        /// <param name="speedModifier">the amount to change players base walk speed by percentages. AKA, .75 will lower player movement by 25%. Using 0 or negatives will do nothing but return null.</param>
+        /// <param name="UID">The Unique Universal ID created and provided when original value was added to dictionary. Store this value to reference your speed modifier later.</param>
         /// <param name="refreshWalkSpeed">will cause routine to also update the player speed using the list to sequentially multiply the current base value by the list modifier values.</param>
         /// <returns></returns>   
-        public bool RemoveSpeedMod(string UUID, bool removeRunSpeed = false, bool refresSpeed = true)
+        public bool RemoveSpeedMod(string UID, bool removeRunSpeed = false, bool refreshSpeed = true)
         {
             //setup false bool for manipulation.
             bool removed = false;
 
-            //if there is no uuid put in, return false as error catching.
-            if (UUID == "" || UUID == null)
+            //if there is no uid put in, return false as error catching.
+            if (UID == "" || UID == null)
                 return removed;
 
             //if there is a modifier put in, see if dictionary contains it in the unique keys, and then remove and return true.
-            if (!removeRunSpeed && walkSpeedModifierList.ContainsKey(UUID))
+            if (!removeRunSpeed && walkSpeedModifierList.ContainsKey(UID))
             {
-                walkSpeedModifierList.Remove(UUID);
+                walkSpeedModifierList.Remove(UID);
                 removed = true;
             }
 
             //if there is a modifier put in, see if dictionary contains it in the unique keys, and then remove and return true.
-            if (removeRunSpeed && runSpeedModifierList.ContainsKey(UUID))
+            if (removeRunSpeed && runSpeedModifierList.ContainsKey(UID))
             {
-                runSpeedModifierList.Remove(UUID);
+                runSpeedModifierList.Remove(UID);
                 removed = true;
             }
 
             //trigger an update to the walk speed loop to push updated walk speed value.
-            updateWalkSpeed = refresSpeed;
-            updateRunSpeed = refresSpeed;
+            updateWalkSpeed = refreshSpeed;
+            updateRunSpeed = refreshSpeed;
 
             return removed;
         }
@@ -271,7 +274,6 @@ namespace DaggerfallWorkshop.Game
                 updateRunSpeed = true;
             }
 
-            updateRunSpeed = true;
             return reset;
         }
 
@@ -285,7 +287,7 @@ namespace DaggerfallWorkshop.Game
             float baseWalkSpeed = GetWalkSpeed(GameManager.Instance.PlayerEntity);
             float overrideSpeed = 0;
 
-            //if there are no modifiers in the dictionary, return the base walk speed.
+            //if there are no modifiers in the dictionary, return the base walk speed before modifying it.
             if (walkSpeedModifierList.Count == 0 || walkSpeedOverride == false)
                 return baseWalkSpeed;
 
@@ -335,7 +337,7 @@ namespace DaggerfallWorkshop.Game
             float baseRunSpeed = GetRunSpeed();
             float overrideSpeed = 0;
 
-            //if there are no modifiers in the dictionary, return the base walk speed.
+            //if there are no modifiers in the dictionary, return the base walk speed before modifying it.
             if (runSpeedModifierList.Count == 0 || runSpeedOverride == false)
                 return baseRunSpeed;
 
@@ -394,7 +396,7 @@ namespace DaggerfallWorkshop.Game
         public float GetRunSpeed()
         {
             Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-            float baseRunSpeed = playerMotor.IsRiding ? baseSpeed : (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
+            float baseRunSpeed = (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
             return baseRunSpeed * (1.35f + (player.Skills.GetLiveSkillValue(DFCareer.Skills.Running) / 200f));
         }
 

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -10,6 +10,7 @@
 //
 
 using DaggerfallConnect;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace DaggerfallWorkshop.Game
@@ -32,11 +33,13 @@ namespace DaggerfallWorkshop.Game
         private const float dfRideBase = dfWalkBase + 225f;
         private const float dfCartBase = dfWalkBase + 100f;
 
-        public float walkSpeedOverride = 6.0f;
-        public bool useWalkSpeedOverride = false;
+        public bool walkSpeedOverride = true;
+        public float currentWalkSpeed { get; private set; } = 0;
+        private Dictionary<string, float> walkSpeedModifierList = new Dictionary<string, float>();
 
-        public float runSpeedOverride = 11.0f;
-        public bool useRunSpeedOverride = false;
+        public bool runSpeedOverride = true;
+        public float currentRunSpeed { get; private set; } = 0;
+        private Dictionary<string, float> runSpeedModifierList = new Dictionary<string, float>();
 
         public delegate bool CanPlayerRun();
         public CanPlayerRun CanRun { get; set; }
@@ -46,11 +49,18 @@ namespace DaggerfallWorkshop.Game
         public bool isRunning = false;
         public bool isSneaking = false;
 
+        public bool updateWalkSpeed;
+        public bool updateRunSpeed;
+        private float previousBaseWalkSpeed;
+        private float previousBaseRunSpeed;
+
         private void Start()
         {
             playerMotor = GameManager.Instance.PlayerMotor;
             levitateMotor = GetComponent<LevitateMotor>();
             CanRun = CanRunUnlessRiding;
+            currentWalkSpeed = GetWalkSpeed(GameManager.Instance.PlayerEntity);
+            currentRunSpeed = GetRunSpeed();
         }
 
 
@@ -104,7 +114,7 @@ namespace DaggerfallWorkshop.Game
 
             if (isRunning)
             {
-                speed = GetRunSpeed(speed);
+                speed = RefreshRunspeed();
 
                 //switch sneaking off if was previously sneaking
                 sneakingMode = false;
@@ -145,8 +155,224 @@ namespace DaggerfallWorkshop.Game
                 baseSpeed = (playerSpeed + rideSpeed) / classicToUnitySpeedUnitRatio;
             }
             else
-                baseSpeed = GetWalkSpeed(player);
+            {
+                baseSpeed = RefreshWalkSpeed();
+            }
             return baseSpeed;
+        }
+
+        /// <summary>
+        /// Add custom walk speed modifier to speed modifer dictionary. Returns unique ID for referencing of custom speedModifier for future manipulation.
+        /// </summary>
+        /// <param name="speedModifier">the amount to change players base walk speed by percentages. AKA, .75 will lower player movement by 25%. Using 0 or negatives will do nothing but return null.</param>
+        /// <param name="refreshWalkSpeed">will cause routine to also update the player speed using the list to sequentially multiply the current base value by the list modifier values.</param>
+        /// <returns></returns>        
+        public bool AddWalkSpeedMod(out string UUID, float walkSpeedModifier = 0, bool refreshWalkSpeed = true)
+        {
+            bool added = false;
+            UUID = null;
+
+            //if they set a speed modifier greater than 0, grab the list index using count, and add item (which will be at the lastID index spot).
+            if (walkSpeedModifier > 0)
+            {
+                UUID = System.Guid.NewGuid().ToString();
+                walkSpeedModifierList.Add(UUID, walkSpeedModifier);
+                added = true;
+            }
+            //trigger an update to the walk speed loop to push updated walk speed value.
+            updateWalkSpeed = refreshWalkSpeed;
+
+            return added;
+        }
+
+        /// <summary>
+        /// Add custom walk speed modifier to speed modifer dictionary. Returns unique ID for referencing of custom speedModifier for future manipulation.
+        /// </summary>
+        /// <param name="speedModifier">the amount to change players base walk speed by percentages. AKA, .75 will lower player movement by 25%. Using 0 or negatives will do nothing but return null.</param>
+        /// <param name="refreshWalkSpeed">will cause routine to also update the player speed using the list to sequentially multiply the current base value by the list modifier values.</param>
+        /// <returns></returns>        
+        public bool AddRunSpeedMod(out string UUID, float speedModifier = 0, bool refreshRunSpeed = true)
+        {
+            bool added = false;
+            UUID = null;
+
+            //if they set a speed modifier greater than 0, grab the list index using count, and add item (which will be at the lastID index spot).
+            if (speedModifier > 0)
+            {
+                UUID = System.Guid.NewGuid().ToString();
+                runSpeedModifierList.Add(UUID, speedModifier);
+                added = true;
+            }
+
+            //trigger an update to the walk speed loop to push updated walk speed value.
+            updateRunSpeed = refreshRunSpeed;
+
+            return added;
+        }
+
+        /// <summary>
+        /// remove custom speed modifier from speed modifer dictionary using stored UID. Returns true if removed, false if not found. Ensure to set if it is a run or walk speed modifier being removed.
+        /// </summary>
+        /// <param name="UUID">The Unique Universal ID created and provided when original value was added to dictionary.</param>
+        /// <param name="refreshWalkSpeed">will cause routine to also update the player speed using the list to sequentially multiply the current base value by the list modifier values.</param>
+        /// <returns></returns>   
+        public bool RemoveSpeedMod(string UUID, bool removeRunSpeed = false, bool refresSpeed = true)
+        {
+            //setup false bool for manipulation.
+            bool removed = false;
+
+            //if there is no uuid put in, return false as error catching.
+            if (UUID == "" || UUID == null)
+                return removed;
+
+            //if there is a modifier put in, see if dictionary contains it in the unique keys, and then remove and return true.
+            if (!removeRunSpeed && walkSpeedModifierList.ContainsKey(UUID))
+            {
+                walkSpeedModifierList.Remove(UUID);
+                removed = true;
+            }
+
+            //if there is a modifier put in, see if dictionary contains it in the unique keys, and then remove and return true.
+            if (removeRunSpeed && runSpeedModifierList.ContainsKey(UUID))
+            {
+                runSpeedModifierList.Remove(UUID);
+                removed = true;
+            }
+
+            //trigger an update to the walk speed loop to push updated walk speed value.
+            updateWalkSpeed = refresSpeed;
+            updateRunSpeed = refresSpeed;
+
+            return removed;
+        }
+
+        /// <summary>
+        /// Clears our associated modifier list of all values. default to clearing out both run and walk speed modifier list.
+        /// </summary>
+        /// <param name="walkSpeedReset">clear out walk speed modifier list.</param>
+        /// <param name="runSpeedReset">clear out run speed modifier list</param>
+        public bool ResetSpeed(bool walkSpeedReset = true, bool runSpeedReset = true)
+        {
+            bool reset = false;
+
+            //if walk speed is reset, reset all needed properties to reset walk speed.
+            if (walkSpeedReset)
+            {
+                walkSpeedModifierList.Clear();
+                reset = true;
+                updateWalkSpeed = true;
+            }
+
+            //if run speed is reset, reset all needed properties to reset run speed.
+            if (runSpeedReset)
+            {
+                runSpeedModifierList.Clear();
+                reset = true;
+                updateRunSpeed = true;
+            }
+
+            updateRunSpeed = true;
+            return reset;
+        }
+
+        /// <summary>
+        /// Updates the players walk speed using for loop and dictionary values to ensure proper sequential processing to get proper end speed.
+        /// Processing of modifiers is processed by their addition order. First added by modder is multiplied first, and so on.
+        /// </summary>
+        private float RefreshWalkSpeed()
+        {
+            //setup and grab needed base values for computing end speed.
+            float baseWalkSpeed = GetWalkSpeed(GameManager.Instance.PlayerEntity);
+            float overrideSpeed = 0;
+
+            //if there are no modifiers in the dictionary, return the base walk speed.
+            if (walkSpeedModifierList.Count == 0 || walkSpeedOverride == false)
+                return baseWalkSpeed;
+
+            //checks to see if players base run speed updated, and if so, triggers new speed update loop below.
+            if (previousBaseWalkSpeed != baseWalkSpeed)
+            {
+                previousBaseWalkSpeed = baseWalkSpeed;
+                updateWalkSpeed = true;
+            }
+
+            //if updateWalkSpeed switch is turned to true, update walk speed using an if then and while loop.
+            if (updateWalkSpeed)
+            {
+                //shunt collection as a numerator into a object var to be used.
+                using (var modifierValue = walkSpeedModifierList.GetEnumerator())
+                {
+                    //if the first item is moved do this, calculate speed using base speed as the starting point.
+                    if (modifierValue.MoveNext())
+                    {
+                        overrideSpeed = baseWalkSpeed * modifierValue.Current.Value;
+
+                        //once first move next is done to get speed from base value, start while loop to sequentally calculate subsequent values.
+                        while (modifierValue.MoveNext())
+                        {
+                            overrideSpeed = overrideSpeed * modifierValue.Current.Value;
+                        }
+                    }
+                }
+
+                //assign override speed and switch updateWalkSpeed to false to stop it from looping every time it is called.
+                //only want it to loop when collection changes - AKA, add, remove, ect - or modder forces switch flip.
+                currentWalkSpeed = overrideSpeed;
+                updateWalkSpeed = false;
+            }
+
+            //return the final modified walk speed.
+            return currentWalkSpeed;
+        }
+
+        /// <summary>
+        /// Updates the players walk speed using for loop and dictionary values to ensure proper sequential processing to get proper end speed.
+        /// Processing of modifiers is processed by their addition order. First added by modder is multiplied first, and so on.
+        /// </summary>
+        private float RefreshRunspeed()
+        {
+            //setup and grab needed base values for computing end speed.
+            float baseRunSpeed = GetRunSpeed();
+            float overrideSpeed = 0;
+
+            //if there are no modifiers in the dictionary, return the base walk speed.
+            if (runSpeedModifierList.Count == 0 || runSpeedOverride == false)
+                return baseRunSpeed;
+
+            //checks to see if players base run speed updated, and if so, triggers new speed update loop below.
+            if (previousBaseRunSpeed != baseRunSpeed)
+            {
+                previousBaseRunSpeed = baseRunSpeed;
+                updateRunSpeed = true;
+            }
+
+            //if updateWalkSpeed switch is turned to true, update walk speed using an if then and while loop.
+            if (updateRunSpeed)
+            {
+                //shunt collection as a numerator into a object var to be used.
+                using (var modifierValue = runSpeedModifierList.GetEnumerator())
+                {
+                    //if the first item is moved do this, calculate speed using base speed as the starting point.
+                    if (modifierValue.MoveNext())
+                    {
+                        overrideSpeed = baseRunSpeed * modifierValue.Current.Value;
+
+                        //once first move next is done to get speed from base value, start while loop to sequentally calculate subsequent values.
+                        while (modifierValue.MoveNext())
+                        {
+                            overrideSpeed = overrideSpeed * modifierValue.Current.Value;
+                        }
+                    }
+                }
+
+                //assign override speed and switch updateWalkSpeed to false to stop it from looping every time it is called.
+                //only want it to loop when collection changes - AKA, add, remove, ect - or modder forces switch flip.
+                currentRunSpeed = overrideSpeed;
+                updateRunSpeed = false;
+            }
+
+            //return the final modified walk speed.
+            return currentRunSpeed;
         }
 
         /// <summary>
@@ -156,13 +382,8 @@ namespace DaggerfallWorkshop.Game
         /// <returns></returns>
         public float GetWalkSpeed(Entity.PlayerEntity player)
         {
-            if (useWalkSpeedOverride)
-                return walkSpeedOverride;
-            else
-            {
-                float drag = 0.5f * (100 - (player.Stats.LiveSpeed >= 30 ? player.Stats.LiveSpeed : 30));
-                return (player.Stats.LiveSpeed + dfWalkBase - drag) / classicToUnitySpeedUnitRatio;
-            }
+            float drag = 0.5f * (100 - (player.Stats.LiveSpeed >= 30 ? player.Stats.LiveSpeed : 30));
+            return (player.Stats.LiveSpeed + dfWalkBase - drag) / classicToUnitySpeedUnitRatio;
         }
 
         /// <summary>
@@ -170,16 +391,11 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         /// <param name="baseSpeed"></param>
         /// <returns></returns>
-        public float GetRunSpeed(float baseSpeed)
+        public float GetRunSpeed()
         {
-            if (useRunSpeedOverride)
-                return runSpeedOverride;
-            else
-            {
-                Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-                float baseRunSpeed = playerMotor.IsRiding ? baseSpeed : (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
-                return baseRunSpeed * (1.35f + (player.Skills.GetLiveSkillValue(DFCareer.Skills.Running) / 200f));
-            }
+            Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
+            float baseRunSpeed = playerMotor.IsRiding ? baseSpeed : (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
+            return baseRunSpeed * (1.35f + (player.Skills.GetLiveSkillValue(DFCareer.Skills.Running) / 200f));
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -53,6 +53,7 @@ namespace DaggerfallWorkshop.Game
         public bool updateRunSpeed;
         private float previousBaseWalkSpeed;
         private float previousBaseRunSpeed;
+        private float baseSpeed = 0;
 
         private void Start()
         {
@@ -142,7 +143,6 @@ namespace DaggerfallWorkshop.Game
         public float GetBaseSpeed()
         {
             Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-            float baseSpeed = 0;
             float playerSpeed = player.Stats.LiveSpeed;
             if (playerMotor == null) // fixes null reference bug.
                 playerMotor = GameManager.Instance.PlayerMotor;

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -463,7 +463,7 @@ namespace DaggerfallWorkshop.Game
             if (smoothFollower != null && controller != null)
             {
                 float distanceMoved = Vector3.Distance(smoothFollowerPrevWorldPos, smoothFollower.position);        // Assuming the follower is a child of this motor transform we can get the distance travelled.
-                float distanceThreshold = speedChanger.GetRunSpeed(speed) * Time.deltaTime;         // Without question any distance travelled less than the running speed is legal.
+                float distanceThreshold = speedChanger.currentRunSpeed * Time.deltaTime;         // Without question any distance travelled less than the running speed is legal.
                 float motorVelocity = controller.velocity.magnitude / Time.fixedDeltaTime;
                 float maxPossibleDistanceByMotorVelocity = motorVelocity * Time.deltaTime * 2.0f;   // Theoretically the max distance the motor can carry the player with a generous margin.
 

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -463,7 +463,7 @@ namespace DaggerfallWorkshop.Game
             if (smoothFollower != null && controller != null)
             {
                 float distanceMoved = Vector3.Distance(smoothFollowerPrevWorldPos, smoothFollower.position);        // Assuming the follower is a child of this motor transform we can get the distance travelled.
-                float distanceThreshold = speedChanger.currentRunSpeed * Time.deltaTime;         // Without question any distance travelled less than the running speed is legal.
+                float distanceThreshold = speedChanger.RefreshRunSpeed() * Time.deltaTime;         // Without question any distance travelled less than the running speed is legal.
                 float motorVelocity = controller.velocity.magnitude / Time.fixedDeltaTime;
                 float maxPossibleDistanceByMotorVelocity = motorVelocity * Time.deltaTime * 2.0f;   // Theoretically the max distance the motor can carry the player with a generous margin.
 

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -490,6 +490,10 @@ namespace DaggerfallWorkshop.Game
             // This prevents levitation flag carrying over and effect system can still restore it if needed
             if (levitateMotor)
                 levitateMotor.IsLevitating = false;
+
+            //reset speed modifiers.
+            //ensures speed modifiers from previous game does not carry over into new game.
+            speedChanger.ResetSpeed();
         }
 
         /// <summary>


### PR DESCRIPTION
Developers can now hook into and update player walk and run speed using the player speed changer. This is done by sequentially adding the change values to a dictionary and tying them to a UID out string property. The developer stores the UID out so they can remove/manipulate their speed changes at a later time in code execution.

**Currently we have these public properties:**

- Bool walkSpeedOverride: turns on and off using walk modifier list to change player movement speed. Does not clear list, merely ignores it.
- Bool runSpeedOverride: turns on and off using run modifier list to change player movement speed. Does not clear list, merely ignores it.
- Bool updateWalkSpeed: turn true to recompute the walk speed; will flip false once done on next frame.
- Bool updateRunSpeed: turn true to recompute the run speed; will flip false once done on next frame.

**Currently we have these public routines:**

- Bool AddWalkSpeedMod(out string UID, float walkSpeedModifier = 0, bool refreshWalkSpeed = true): Add a percentage multiplier to the walk speed modifier list. Returns true if the unique ID is output as an out string value to refer to/manipulate modifier. Returns false if it couldn't add it.
- Bool AddRunSpeedMod(out string UID, float speedModifier = 0, bool refreshRunSpeed = true): Add a percentage multiplier to the runspeed modifier list. Returns true if the unique ID is output as an out string value to refer to/manipulate modifier. Returns false if it couldn't add it.
- Bool RemoveSpeedMod(string UID, bool removeRunSpeed = false, bool refresSpeed = true): Remove a speed modifier using previously generated unique ID string value. Allows you to select if your removing running or walking speed modifiers. Returns true or false based on if modifier was removed or not.
- Bool ResetSpeed(bool walkSpeedReset = true, bool runSpeedReset = true): Remove a speed modifier using previously generated unique ID string value. Allows you to select if your removing running or walking speed modifiers. Returns true or false based on if modifier was removed or not.
- Float RefreshWalkSpeed(): Updates the players walk speed using for loop and dictionary values to ensure proper sequential processing to get proper end speed and returns updated walk speed value. Processing of modifiers is processed by their addition order. First added by modder is multiplied first, and so on.
- Float RefreshRunSpeed(): Updates the players run speed using for loop and dictionary values to ensure proper sequential processing to get proper end speed and returns updated run speed value. Processing of modifiers is processed by their addition order. First added by modder is multiplied first, and so on.

**Current console command settings are. These apply the same to set_walkspeed console command:**

- Set_runspeed -1: Enable/Disable run speed sequential modifier. Does not clear modifier list, just ignores it and returns base run speed. Returns current run speed value based on if sequential modifier is enabled or not.
- Set_runspeed -2: Run speed modifiers cleared. Clears out current run speed modifier list. Returns run speed value after all modifers have been removed from modifier list.
- Set_runspeed #: Adds percentage multiplier to run speed modifier list for sequential calculation; tells user UID for added modifier so they can remove it without clearing list if they want. Users cannot insert negative numbers, other than -1 and -2. Returns run speed after addition of modifer value.
- Set_runspeed UID: Checks to see if dictionary modifier list contains UID modifer. If it does, will remove the added modifier. If not will return normal error message saying invalid input. Returns run speed after removal of modifier.
- Set_runspeed : Returns basic error and current updated run speed.