### PR TITLE
Change NPC knowledge in Talk Manager to match classic

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1744,7 +1744,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                     !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy1, random.id) &&
                                     !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy2, random.id) &&
                                     !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy3, random.id) &&
-                                    factionData.GetFaction2ARelationToFaction1(factionData.FactionDict[key].id, random.id) == -1)
+                                    factionData.GetFaction2RelationToFaction1(factionData.FactionDict[key].id, random.id) == -1)
                                 {
                                     int powerSum = factionPowerMod + factionData.FactionDict[key].rulerPowerBonus;
                                     if (Dice100.SuccessRoll((powerSum + factionData.GetNumberOfCommonAlliesAndEnemies(factionData.FactionDict[key].id, random.id) * 3) / 5))
@@ -1878,7 +1878,7 @@ namespace DaggerfallWorkshop.Game.Entity
                                     !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy2, random.id) &&
                                     !factionData.IsFaction2AnAllyOfFaction1(factionData.FactionDict[key].enemy3, random.id))
                                 {
-                                    int relation = factionData.GetFaction2ARelationToFaction1(factionData.FactionDict[key].id, random.id);
+                                    int relation = factionData.GetFaction2RelationToFaction1(factionData.FactionDict[key].id, random.id);
                                     if (relation == -1 || relation == 2)
                                     {
                                         int mod = 0;

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1781,29 +1781,6 @@ namespace DaggerfallWorkshop.Game.Formulas
             return 0;
         }
 
-        public static float BonusChanceToKnowWhereIs(float bonusPerBlockLess = 0.0078f)
-        {
-            const int maxArea = 64;
-
-            // Must be in a location
-            if (!GameManager.Instance.PlayerGPS.HasCurrentLocation)
-                return 0;
-
-            // Get area of current location
-            DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
-            int locationArea = location.Exterior.ExteriorData.Width * location.Exterior.ExteriorData.Height;
-
-            // The largest possible location has an area of 64 (e.g. Daggerfall/Wayrest/Sentinel)
-            // The smallest possible location has an area of 1 (e.g. a tavern town)
-            // In a big city NPCs could be ignorant of all buildings, but in a small town it's unlikely they don't know the local tavern or smith
-            // So we apply a bonus that INCREASES the more city area size DECREASES
-            // With default inputs, a tiny 1x1 town NPC will get a +0.4914 to the default 0.5 chance for a total of 0.9914 chance to know building
-            // This is a big help as small towns also have less NPCs, and it gets frustrating when multiple NPCs don't knows where something is
-            float bonus = (maxArea - locationArea) * bonusPerBlockLess;
-
-            return bonus;
-        }
-
         #endregion
 
         #region Commerce

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -161,6 +161,7 @@ namespace DaggerfallWorkshop.Game
             public ListItemType type = ListItemType.Item; // list item can be either a normal item, a navigation item (to get to parent list) or an item group (contains list of child items)
             public string caption = "undefined"; // the caption text that is displayed for this topic in the left sub window of the talk window
             public string key = String.Empty; // the key used for entries belonging to quest resources, is String.Empty if the entry is not a quest resource
+            public int factionID = -1; // the faction ID of the organization if asking about this
             public QuestionType questionType = QuestionType.NoQuestion; // the question type of the entry (see description of QuestionType)
             public NPCKnowledgeAboutItem npcKnowledgeAboutItem = NPCKnowledgeAboutItem.NotSet; // the knowledge of the current npc talk partner about this topic
             public int buildingKey = -1; // used for listitems that are buildings to identify buildings
@@ -530,6 +531,13 @@ namespace DaggerfallWorkshop.Game
 
             if (CheckNPCisInSameBuildingAsTopic(listItem) || npcData.isSpyMaster || consoleCommandFlag_npcsKnowEverything)
                 return NPCKnowledgeAboutItem.KnowsAboutItem;
+
+            // Fixed from classic: an NPC belonging to an organization obviously knows about it
+            if (listItem.questionType == QuestionType.OrganizationInfo &&
+                GameManager.Instance.PlayerEntity.FactionData.IsFaction2RelatedToFaction1(npcData.factionData.id, listItem.factionID))
+            {
+                return NPCKnowledgeAboutItem.KnowsAboutItem;
+            }
 
             // Make roll result be the same every time for a given NPC
             if (currentNPCType == NPCType.Mobile)
@@ -3079,11 +3087,10 @@ namespace DaggerfallWorkshop.Game
             for (int i = 0; i < infoFactionIDs.Length; i++)
             {
                 ListItem itemOrganizationInfo = new ListItem();
-                FactionFile.FactionData factionData;
                 itemOrganizationInfo.type = ListItemType.Item;
                 itemOrganizationInfo.questionType = QuestionType.OrganizationInfo;
-                DaggerfallUnity.Instance.ContentReader.FactionFileReader.GetFactionData(infoFactionIDs[i], out factionData);
-                itemOrganizationInfo.caption = factionData.name;
+                itemOrganizationInfo.factionID = infoFactionIDs[i];
+                itemOrganizationInfo.caption = GameManager.Instance.PlayerEntity.FactionData.GetFactionName(infoFactionIDs[i]);
                 itemOrganizationInfo.index = i;
                 listTopicTellMeAbout.Add(itemOrganizationInfo);
             }

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -109,16 +109,17 @@ namespace DaggerfallWorkshop.Game
         readonly ushort[] answersToNonDirections =  { 7251, 7266, 7281, 7250, 7265, 7280, 7252, 7267, 7282, 7253, 7268, 7283, 7304, 7269, 7284,
                                                       7261, 7276, 7291, 7260, 7275, 7290, 7262, 7277, 7292, 7263, 7278, 7293, 7264, 7279, 7294};
 
+        // Knowledge modifiers extracted from FALL.EXE. There are 40 modifiers corresponding to 8 question types and 5 social groups.
+        // And as above, data has been fixed to restore the correct order between sgroup 0 (commoners) and sgroup 1 (merchants).
+        readonly short[] knowledgeModifiers = { 5,  7,  0,  0,  4,  1,  2, -2,  3,  7, -3,  0,  7,  2,  4,  4,  3, -2, -4, -3,
+                                                0,  3,  5,  2,  0, -4, -3, -6, -3,  4, -7, -5,  7,  0,  1, -1,  1,  6,  4,  2 };
+
         // Greeting records extracted from FALL.EXE.
         readonly ushort[] greetings =               { 8550, 8551, 8552, 8553, 8554, 8555, 8556, 8557, 8558, 8559, 8560, 8561, 8562, 8562,
                                                       8563, 8564, 8564, 8565, 8566, 8566, 8567, 8568, 8568, 8569, 8570, 8570, 8571 };
 
         readonly ushort[] allowedBulletinTextIds =  { 1475, 1476, 1477, 1478, 1479, 1482, 1483 };
 
-        const float DefaultChanceKnowsSomethingAboutWhereIs = 0.6f; // Chances unknown
-        const float DefaultChanceKnowsSomethingAboutQuest = 0.8f; // Chances unknown
-        const float DefaultChanceKnowsSomethingAboutOrganizationsStaticNPC = 0.8f; // Chances unknown
-        const float DefaultChanceKnowsSomethingAboutOrganizationsMobileNPC = 0.8f; // Chances unknown
         const float ChanceToRevealLocationOnMap = 0.35f; // Chances unknown
 
         const int maxNumAnswersNpcGivesTellMeAboutOrRumors = 1; // Maximum number of answers npc gives about "tell me about" questions or rumors
@@ -184,9 +185,6 @@ namespace DaggerfallWorkshop.Game
             public string pcFactionName; // kept for guild related greetings
             public string allyFactionName; // kept for guild related greetings
             public string enemyFactionName; // kept for guild related greetings
-            public float chanceKnowsSomethingAboutWhereIs; // the general chance that the current npc knows the answer to pc's "where is" question
-            public float chanceKnowsSomethingAboutQuest; // the general chance that the current npc knows the answer to pc's quest related question
-            public float chanceKnowsSomethingAboutOrganizations; // the general chance that the current npc knows the answer to pc's question about organizations
             public int numAnswersGivenTellMeAboutOrRumors; // the number of (successful) answers to a "tell me about" question or rumors given by the npc (answers about npc knew something)
             public bool isSpyMaster;
             public bool allowGuildResponse = true;
@@ -524,6 +522,39 @@ namespace DaggerfallWorkshop.Game
             return reaction;
         }
 
+        NPCKnowledgeAboutItem GetNPCKnowledgeAboutItem(ListItem listItem)
+        {
+            // This check prevents NPCs from answering for quest resources outside the current region
+            if (!CheckNPCcanKnowAboutTellMeAboutTopic(listItem))
+                return NPCKnowledgeAboutItem.DoesNotKnowAboutItem;
+
+            if (CheckNPCisInSameBuildingAsTopic(listItem) || npcData.isSpyMaster || consoleCommandFlag_npcsKnowEverything)
+                return NPCKnowledgeAboutItem.KnowsAboutItem;
+
+            // Make roll result be the same every time for a given NPC
+            if (currentNPCType == NPCType.Mobile)
+                DFRandom.Seed = (uint)lastTargetMobileNPC.GetHashCode();
+            else if (currentNPCType == NPCType.Static)
+                DFRandom.Seed = (uint)lastTargetStaticNPC.GetHashCode();
+
+            if (listItem.buildingKey != -1)
+                DFRandom.Seed += (uint)listItem.buildingKey;
+            else if (listItem.key != String.Empty)
+                DFRandom.Seed += (uint)listItem.key.GetHashCode();
+            else
+                DFRandom.Seed += (uint)listItem.caption.GetHashCode();
+
+            // Convert question type to classic index to use the knowledge modifiers array
+            int classicQuestionIndex = GetClassicQuestionIndex(listItem.questionType);
+            int rollToBeat = knowledgeModifiers[classicQuestionIndex * 5 + (int)npcData.socialGroup] + 10;
+
+            int rand = DFRandom.random_range_inclusive(1, 20);
+            if (rand <= rollToBeat)
+                return NPCKnowledgeAboutItem.KnowsAboutItem;
+
+            return NPCKnowledgeAboutItem.DoesNotKnowAboutItem;
+        }
+
         int GetReactionToPlayer_0_1_2(QuestionType qt, FactionFile.SocialGroups npcSocialGroup)
         {
             int socialGroup = (int)npcSocialGroup;
@@ -554,39 +585,9 @@ namespace DaggerfallWorkshop.Game
                 toneModifier += Dice100.FailedRoll(skillValue) ? -10 : 5;
 
             // Convert question type to index to classic data
-            int classicDataIndex = 2; // Using as default, as this gives no bonus or penalty.
-
-            switch (qt)
-            {
-                case QuestionType.LocalBuilding:
-                case QuestionType.Regional:
-                    classicDataIndex = 0; // == Where is Location
-                    break;
-                case QuestionType.Person:
-                    classicDataIndex = 1; // == Where is Person
-                    break;
-                case QuestionType.Thing: // Not used
-                    classicDataIndex = 2; // == Where is Thing
-                    break;
-                case QuestionType.Work:
-                    classicDataIndex = 3; // == Where is Work
-                    break;
-                case QuestionType.QuestLocation:
-                case QuestionType.OrganizationInfo:
-                    classicDataIndex = 4; // == Tell me about Location (Also sticking OrganizationInfo here. In classic I think "OrganizationInfo" might just
-                                          // take whichever of location, person, item or work buttons you've last clicked on for the reaction roll.)
-                    break;
-                case QuestionType.QuestPerson:
-                    classicDataIndex = 5; // == Tell me about Person
-                    break;
-                case QuestionType.QuestItem:
-                    classicDataIndex = 6; // == Tell me about Thing
-                    break;
-                    // 7 == Tell me about Work (not used)
-            }
-
+            int classicQuestionIndex = GetClassicQuestionIndex(qt);
             int reaction = player.Stats.LivePersonality / 5
-               + questionTypeReactionMods[classicDataIndex]
+               + questionTypeReactionMods[classicQuestionIndex]
                + toneModifier;
 
             // Make roll result be the same every time for a given NPC
@@ -609,6 +610,41 @@ namespace DaggerfallWorkshop.Game
             if (reaction < rollToBeat + 20) // Lowered from classic to be less difficult (classic uses +30)
                 return 1;
             return 2;
+        }
+
+        private static int GetClassicQuestionIndex(QuestionType qt)
+        {
+            int index = 2; // Using as default, as this gives no bonus or penalty.
+            switch (qt)
+            {
+                case QuestionType.LocalBuilding:
+                case QuestionType.Regional:
+                    index = 0; // == Where is Location
+                    break;
+                case QuestionType.Person:
+                    index = 1; // == Where is Person
+                    break;
+                case QuestionType.Thing: // Not used
+                    index = 2; // == Where is Thing
+                    break;
+                case QuestionType.Work:
+                    index = 3; // == Where is Work
+                    break;
+                case QuestionType.QuestLocation:
+                case QuestionType.OrganizationInfo:
+                    index = 4; // == Tell me about Location (Also sticking OrganizationInfo here. In classic I think "OrganizationInfo" might just
+                               // take whichever of location, person, item or work buttons you've last clicked on for the reaction roll.)
+                    break;
+                case QuestionType.QuestPerson:
+                    index = 5; // == Tell me about Person
+                    break;
+                case QuestionType.QuestItem:
+                    index = 6; // == Tell me about Thing
+                    break;
+                    // 7 == Tell me about Work (not used)
+            }
+
+            return index;
         }
 
         // Player has clicked on a mobile talk target
@@ -713,9 +749,6 @@ namespace DaggerfallWorkshop.Game
             npcData.guildGroup = FactionFile.GuildGroups.None;
             npcData.factionData = factionData;
             npcData.race = targetMobileNPC.Race;
-            npcData.chanceKnowsSomethingAboutWhereIs = DefaultChanceKnowsSomethingAboutWhereIs + FormulaHelper.BonusChanceToKnowWhereIs();
-            npcData.chanceKnowsSomethingAboutQuest = DefaultChanceKnowsSomethingAboutQuest;
-            npcData.chanceKnowsSomethingAboutOrganizations = DefaultChanceKnowsSomethingAboutOrganizationsMobileNPC;
             npcData.isSpyMaster = false;
 
             AssembleTopicListPerson(); // Update "Where Is" -> "Person" list since this list may hide the questor (if talking to the questor)
@@ -750,9 +783,6 @@ namespace DaggerfallWorkshop.Game
             npcData.guildGroup = (FactionFile.GuildGroups)factionData.ggroup;
             npcData.factionData = factionData;
             npcData.race = targetNPC.Data.race;
-            npcData.chanceKnowsSomethingAboutWhereIs = DefaultChanceKnowsSomethingAboutWhereIs + FormulaHelper.BonusChanceToKnowWhereIs();
-            npcData.chanceKnowsSomethingAboutQuest = DefaultChanceKnowsSomethingAboutQuest;
-            npcData.chanceKnowsSomethingAboutOrganizations = DefaultChanceKnowsSomethingAboutOrganizationsStaticNPC;
             npcData.isSpyMaster = false;
 
             AssembleTopicListPerson(); // Update "Where Is" -> "Person" list since this list may hide the questor (if talking to the questor)
@@ -1710,32 +1740,7 @@ namespace DaggerfallWorkshop.Game
         public string GetAnswerWhereIs(ListItem listItem)
         {
             if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.NotSet)
-            {
-                // Decide here if npcs knows question's answer (spymaster always knows)
-                float randomFloat = UnityEngine.Random.Range(0.0f, 1.0f);
-                if (CheckNPCisInSameBuildingAsTopic(listItem, QuestionType.Person) || randomFloat < npcData.chanceKnowsSomethingAboutWhereIs || npcData.isSpyMaster || consoleCommandFlag_npcsKnowEverything)
-                    listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.KnowsAboutItem;
-                else
-                    listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.DoesNotKnowAboutItem;
-            }
-
-            // Test if player is inside dungeon and retrieve dungeon name in this case
-            string dungeonName = "";
-            if (GameManager.Instance.IsPlayerInsideCastle || GameManager.Instance.IsPlayerInsideDungeon)
-            {
-                dungeonName = GameManager.Instance.PlayerEnterExit.Dungeon.GetSpecialDungeonName();
-            }
-
-            // Test if npc is asked about building and is in the same building (also for quest persons) -> then he/she should know about building
-            if (listItem.questionType == QuestionType.LocalBuilding || listItem.questionType == QuestionType.QuestLocation && GameManager.Instance.IsPlayerInside)
-            {
-                if (GameManager.Instance.PlayerEnterExit.ExteriorDoors.Length > 0 && listItem.buildingKey == GameManager.Instance.PlayerEnterExit.ExteriorDoors[0].buildingKey ||
-                    dungeonName == listItem.caption)
-                {
-                    listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.KnowsAboutItem;
-                    listItem.npcInSameBuildingAsTopic = true;
-                }
-            }
+                listItem.npcKnowledgeAboutItem = GetNPCKnowledgeAboutItem(listItem);
 
             if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)
             {
@@ -1743,55 +1748,25 @@ namespace DaggerfallWorkshop.Game
                 return ExpandRandomTextRecord(answersToDirections[3 * (int)npcData.socialGroup + reactionToPlayer_0_1_2]);
             }
 
-            // Check if npc is in same building if topic is building
-            if (currentQuestionListItem.questionType == QuestionType.LocalBuilding && currentQuestionListItem.npcInSameBuildingAsTopic)
-                return string.Format(TextManager.Instance.GetLocalizedText("YouAreInSameBuilding"), currentQuestionListItem.caption);
+            // Check if NPC is in same building if topic is building
+            if (listItem.questionType == QuestionType.LocalBuilding && listItem.npcInSameBuildingAsTopic)
+                return string.Format(TextManager.Instance.GetLocalizedText("YouAreInSameBuilding"), listItem.caption);
 
-            // Check if npc is in same building as quest person when asking about quest person via "Where is"->"Person"
-            if (currentQuestionListItem.questionType == QuestionType.Person)
+            // Check if NPC is in same building as quest person when asking about quest person via "Where is"->"Person"
+            if (listItem.questionType == QuestionType.Person && listItem.npcInSameBuildingAsTopic)
             {
-                int buildingKey;
-                string buildingName = "";
+                BuildingInfo building = GetBuildingInfoCurrentBuildingOrPalace();
+                if (building.name != string.Empty)
+                    return string.Format(TextManager.Instance.GetLocalizedText("NpcInSameBuilding"), listItem.caption, building.name);
 
-                string key = currentQuestionListItem.key;
-                Person person;
-                GetPersonResource(currentQuestionListItem.questID, key, out person);
-                if (person.IsQuestor)
-                {
-                    buildingKey = GetPersonBuildingKey(ref person);
-                    if (buildingKey != 0)
-                        buildingName = GetBuildingNameForBuildingKey(buildingKey);
-                }
-                else
-                {
-                    SiteDetails siteDetails = GetPersonSiteDetails(ref person);
-                    buildingKey = siteDetails.buildingKey;
-                    buildingName = siteDetails.buildingName;
-                }
-
-                // in case building name could not be resolved correctly
-                if (string.IsNullOrEmpty(buildingName) || buildingName == TextManager.Instance.GetLocalizedText("residence"))
-                    // Default to person home
-                    buildingName = person.HomeBuildingName;
-
-                if (GameManager.Instance.IsPlayerInside &&
-                    (GameManager.Instance.PlayerEnterExit.ExteriorDoors.Length > 0 && buildingKey == GameManager.Instance.PlayerEnterExit.ExteriorDoors[0].buildingKey) ||
-                    dungeonName == buildingName)
-                {
-                    currentQuestionListItem.npcInSameBuildingAsTopic = true;
-
-                    if (buildingName != string.Empty)
-                        return string.Format(TextManager.Instance.GetLocalizedText("NpcInSameBuilding"), currentQuestionListItem.caption, buildingName);
-
-                    return TextManager.Instance.GetLocalizedText("resolvingError");
-                }
+                return TextManager.Instance.GetLocalizedText("resolvingError");
             }
 
             // Messages if NPC does know answer to give directions
             return ExpandRandomTextRecord(answersToDirections[15 + 3 * (int)npcData.socialGroup + reactionToPlayer_0_1_2]);
         }
 
-        public string GetAnswerAboutRegionalBuilding(ListItem listItem)
+        public string GetAnswerWhereIsRegionalBuilding(ListItem listItem)
         {
             if (GetRegionalLocationCityName(listItem))
                 return ExpandRandomTextRecord(10);
@@ -1928,25 +1903,19 @@ namespace DaggerfallWorkshop.Game
                 case QuestionType.WhereAmI:
                     answer = GetAnswerWhereAmI();
                     break;
-                case QuestionType.OrganizationInfo:
-                    answer = GetAnswerTellMeAboutTopic(listItem, npcData.chanceKnowsSomethingAboutOrganizations);
-                    break;
                 case QuestionType.LocalBuilding:
-                    answer = GetAnswerWhereIs(listItem);
-                    break;
                 case QuestionType.Person:
+                case QuestionType.Thing: // Never reached since there are no "where is"-type questions for things in classic
                     answer = GetAnswerWhereIs(listItem);
-                    break;
-                case QuestionType.Thing:
-                    answer = GetAnswerWhereIs(listItem); // Never reached since there are no "where is"-type questions for things in classic
                     break;
                 case QuestionType.Regional:
-                    answer = GetAnswerAboutRegionalBuilding(listItem);
+                    answer = GetAnswerWhereIsRegionalBuilding(listItem);
                     break;
+                case QuestionType.OrganizationInfo:
                 case QuestionType.QuestLocation:
                 case QuestionType.QuestPerson:
                 case QuestionType.QuestItem:
-                    answer = GetAnswerTellMeAboutTopic(listItem, npcData.chanceKnowsSomethingAboutQuest);
+                    answer = GetAnswerTellMeAboutTopic(listItem);
                     break;
                 case QuestionType.Work:
                     if (!WorkAvailable)
@@ -1972,32 +1941,24 @@ namespace DaggerfallWorkshop.Game
             return answer;
         }
 
-        public string GetAnswerTellMeAboutTopic(ListItem listItem, float chanceNPCknowsSomething)
+        public string GetAnswerTellMeAboutTopic(ListItem listItem)
         {
             if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.NotSet)
-            {
-                // Decide here if npcs knows question's answer (spymaster always knows)
-                float randomFloat = UnityEngine.Random.Range(0.0f, 1.0f);
-                if ((CheckNPCisInSameBuildingAsTopic(listItem, QuestionType.QuestPerson) || randomFloat < chanceNPCknowsSomething || npcData.isSpyMaster || consoleCommandFlag_npcsKnowEverything) && CheckNPCcanKnowAboutTellMeAboutTopic(listItem))
-                    listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.KnowsAboutItem;
-                else
-                    listItem.npcKnowledgeAboutItem = NPCKnowledgeAboutItem.DoesNotKnowAboutItem;
-            }
+                listItem.npcKnowledgeAboutItem = GetNPCKnowledgeAboutItem(listItem);
 
-            if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem || (npcData.numAnswersGivenTellMeAboutOrRumors >= maxNumAnswersNpcGivesTellMeAboutOrRumors && !CheckNPCisInSameBuildingAsTopic(listItem, QuestionType.QuestPerson) && !npcData.isSpyMaster && !consoleCommandFlag_npcsKnowEverything))
+            if (listItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem ||
+                (npcData.numAnswersGivenTellMeAboutOrRumors >= maxNumAnswersNpcGivesTellMeAboutOrRumors &&
+                !CheckNPCisInSameBuildingAsTopic(listItem) && !npcData.isSpyMaster && !consoleCommandFlag_npcsKnowEverything))
             {
                 // Messages if NPC doesn't know answer to non-directions question
                 return ExpandRandomTextRecord(answersToNonDirections[3 * (int)npcData.socialGroup + reactionToPlayer_0_1_2]);
             }
-            else
-            {
-                npcData.numAnswersGivenTellMeAboutOrRumors++;
 
-                // Messages if NPC does know answer to non-directions question
-                return ExpandRandomTextRecord(answersToNonDirections[15 + 3 * (int)npcData.socialGroup + reactionToPlayer_0_1_2]);
-            }
+            npcData.numAnswersGivenTellMeAboutOrRumors++;
+
+            // Messages if NPC does know answer to non-directions question
+            return ExpandRandomTextRecord(answersToNonDirections[15 + 3 * (int)npcData.socialGroup + reactionToPlayer_0_1_2]);
         }
-
 
         public void ForceTopicListsUpdate()
         {
@@ -2587,8 +2548,7 @@ namespace DaggerfallWorkshop.Game
                 npcGreetingText = ExpandRandomTextRecord(npcGreetingRecord);
             }
 
-            // Reset NPC knowledge, for now it resets every time the NPC has changed (player talked to new NPC)
-            // TODO: Match classic daggerfall - in classic NPC remembers their knowledge about topics for their time of existence
+            // Reset NPC knowledge if not talking to the same NPC as before
             if (!sameTalkTargetAsBefore)
                 ResetNPCKnowledge();
 
@@ -2955,14 +2915,28 @@ namespace DaggerfallWorkshop.Game
             return true;
         }
 
-        private bool CheckNPCisInSameBuildingAsTopic(ListItem item, QuestionType questionType)
+        private bool CheckNPCisInSameBuildingAsTopic(ListItem item)
         {
-            if (item.questionType != questionType)
+            if (!GameManager.Instance.IsPlayerInside ||
+                item.questionType != QuestionType.LocalBuilding && item.questionType != QuestionType.Person &&
+                item.questionType != QuestionType.QuestPerson && item.questionType != QuestionType.QuestLocation)
                 return false;
 
-            if (!GameManager.Instance.IsPlayerInside) // only if player is inside it can be a building/palace person of interest is in
-                return false;
+            BuildingInfo buildingInfoCurrentBuilding = GetBuildingInfoCurrentBuildingOrPalace();
 
+            // First check if player is looking for a local building
+            if (item.questionType == QuestionType.LocalBuilding)
+            {
+                if (item.buildingKey == buildingInfoCurrentBuilding.buildingKey)
+                {
+                    item.npcInSameBuildingAsTopic = true;
+                    return true;
+                }
+
+                return false;
+            }
+
+            // If not looking for a local building, then player must be looking for a quest person or a quest location
             Quest quest = GameManager.Instance.QuestMachine.GetQuest(item.questID);
             QuestResource questResource = quest.GetResource(item.key);
             Person person = (Person)questResource;
@@ -2977,8 +2951,6 @@ namespace DaggerfallWorkshop.Game
             {
                 place = person.GetHomePlace(); // get home place if no assigned place was found
             }
-
-            BuildingInfo buildingInfoCurrentBuilding = GetBuildingInfoCurrentBuildingOrPalace();
 
             if (place.SiteDetails.regionName != GameManager.Instance.PlayerGPS.CurrentRegionName)
                 return false;
@@ -2997,6 +2969,7 @@ namespace DaggerfallWorkshop.Game
                     return false;
             }
 
+            item.npcInSameBuildingAsTopic = true;
             return true;
         }
 
@@ -3030,10 +3003,6 @@ namespace DaggerfallWorkshop.Game
 
         private void AssembleTopiclistTellMeAbout()
         {
-            List<ListItem> oldTopicList = null;
-            if (listTopicTellMeAbout != null)
-                oldTopicList = listTopicTellMeAbout; // store old topic list to inject some of the info into new list
-
             listTopicTellMeAbout = new List<ListItem>();
             ListItem itemAnyNews = new ListItem();
             itemAnyNews.type = ListItemType.Item;
@@ -3118,26 +3087,10 @@ namespace DaggerfallWorkshop.Game
                 itemOrganizationInfo.index = i;
                 listTopicTellMeAbout.Add(itemOrganizationInfo);
             }
-
-            if (oldTopicList != null)
-            {
-                for (int i = 0; i < listTopicTellMeAbout.Count; i++)
-                {
-                    ListItem oldItem = oldTopicList.Find(x => x.caption == listTopicTellMeAbout[i].caption);
-                    if (oldItem != null)
-                    {
-                        listTopicTellMeAbout[i].npcKnowledgeAboutItem = oldItem.npcKnowledgeAboutItem;
-                    }
-                }
-            }
         }
 
         private void AssembleTopicListLocation()
         {
-            List<ListItem> oldTopicList = null;
-            if (listTopicLocation != null)
-                oldTopicList = listTopicLocation; // store old topic list to inject some of the info into new list
-
             listTopicLocation = new List<ListItem>();
 
             GetBuildingList();
@@ -3289,18 +3242,6 @@ namespace DaggerfallWorkshop.Game
 
             AddRegionalItems(ref itemBuildingTypeGroup);
             listTopicLocation.Add(itemBuildingTypeGroup);
-
-            if (oldTopicList != null)
-            {
-                for (int i = 0; i < listTopicLocation.Count; i++)
-                {
-                    ListItem oldItem = oldTopicList.Find(x => x.caption == listTopicLocation[i].caption);
-                    if (oldItem != null)
-                    {
-                        listTopicLocation[i].npcKnowledgeAboutItem = oldItem.npcKnowledgeAboutItem;
-                    }
-                }
-            }
         }
 
         private void AddRegionalItems(ref ListItem itemBuildingTypeGroup)
@@ -3366,10 +3307,6 @@ namespace DaggerfallWorkshop.Game
 
         private void AssembleTopicListPerson()
         {
-            List<ListItem> oldTopicList = null;
-            if (listTopicLocation != null)
-                oldTopicList = listTopicLocation; // Store old topic list to inject some of the info into new list
-
             listTopicPerson = new List<ListItem>();
 
             foreach (KeyValuePair<ulong, QuestResources> questInfo in dictQuestInfo)
@@ -3446,39 +3383,12 @@ namespace DaggerfallWorkshop.Game
 
                 }
             }
-
-            if (oldTopicList != null)
-            {
-                for (int i = 0; i < listTopicPerson.Count; i++)
-                {
-                    ListItem oldItem = oldTopicList.Find(x => x.caption == listTopicPerson[i].caption);
-                    if (oldItem != null)
-                    {
-                        listTopicPerson[i].npcKnowledgeAboutItem = oldItem.npcKnowledgeAboutItem;
-                    }
-                }
-            }
         }
 
         private void AssembleTopicListThing()
         {
-            List<ListItem> oldTopicList = null;
-            if (listTopicLocation != null)
-                oldTopicList = listTopicLocation; // Store old topic list to inject some of the info into a new list
-
+            // Just an empty list as this is never used
             listTopicThing = new List<ListItem>();
-
-            if (oldTopicList != null)
-            {
-                for (int i = 0; i < listTopicThing.Count; i++)
-                {
-                    ListItem oldItem = oldTopicList.Find(x => x.caption == listTopicThing[i].caption);
-                    if (oldItem != null)
-                    {
-                        listTopicThing[i].npcKnowledgeAboutItem = oldItem.npcKnowledgeAboutItem;
-                    }
-                }
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
Change made after having reverse engineered classic Daggerfall function used to check if an NPC is able to answer a question or not. NPCs will now use an array of modifiers corresponding to their social class and to the kind of question they are asked in order to get the roll to beat to check if they are able to answer or not.

This change also makes NPC keep their previous knowledge after closing the chat window, as in classic.