### PR TITLE
Added two event handlers for loot spawning

### DIFF
--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -22,11 +22,34 @@ using DaggerfallWorkshop.Game.Items;
 namespace DaggerfallWorkshop.Game.Entity
 {
     /// <summary>
+    /// The parameters involved in creating an enemy loot pile
+    /// </summary>
+    public class EnemyLootSpawnedEventArgs : System.EventArgs
+    {
+        /// <summary>
+        /// The Mobile object used for the enemy
+        /// </summary>
+        public MobileEnemy MobileEnemy { get; set; }
+
+        /// <summary>
+        /// The Career template of the enemy
+        /// </summary>
+        public DFCareer EnemyCareer { get; set; }
+
+        /// <summary>
+        /// The collection containing all the items of the loot pile. New items can be added
+        /// </summary>
+        public ItemCollection Items { get; set; }
+    }
+
+    /// <summary>
     /// Implements DaggerfallEntity with properties specific to enemies.
     /// </summary>
     public class EnemyEntity : DaggerfallEntity
     {
         #region Fields
+
+        public static System.EventHandler<EnemyLootSpawnedEventArgs> OnLootSpawned;
 
         int careerIndex = -1;
         EntityTypes entityType = EntityTypes.None;
@@ -345,6 +368,8 @@ namespace DaggerfallWorkshop.Game.Entity
                 // Chance of adding potion recipe
                 DaggerfallLoot.RandomlyAddPotionRecipe(2, items);
             }
+
+            OnLootSpawned?.Invoke(this, new EnemyLootSpawnedEventArgs { MobileEnemy = mobileEnemy, EnemyCareer = career, Items = items });
 
             FillVitalSigns();
         }

--- a/Assets/Scripts/Game/Items/LootTables.cs
+++ b/Assets/Scripts/Game/Items/LootTables.cs
@@ -17,6 +17,29 @@ using DaggerfallWorkshop.Game.Utility;
 namespace DaggerfallWorkshop.Game.Items
 {
     /// <summary>
+    /// The parameters involved in creating a loot pile from a loot table.
+    /// </summary>
+    public class TabledLootSpawnedEventArgs : System.EventArgs
+    {
+        /// <summary>
+        /// The index of the location.
+        /// For Dungeons, this corresponds to DFRegion.DungeonTypes.
+        /// For Interiors, this corresponds to DFRegion.LocationTypes.
+        /// </summary>
+        public int LocationIndex { get; set; }
+
+        /// <summary>
+        /// The Key used to spawn the loot pile (ex: "K" for Crypt loot).
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// The collection containing all the items of the loot pile. New items can be added.
+        /// </summary>
+        public ItemCollection Items { get; set; }
+    }
+
+    /// <summary>
     /// Built-in loot tables.
     /// Currently just for testing during early implementation.
     /// These approximate the loot tables on page 156 of Daggerfall Chronicles but are
@@ -25,6 +48,9 @@ namespace DaggerfallWorkshop.Game.Items
     /// </summary>
     public static class LootTables
     {
+        // When a Loot pile is generated from a loot table
+        public static System.EventHandler<TabledLootSpawnedEventArgs> OnLootSpawned;
+
         /// <summary>
         /// Default loot table chance matrices.
         /// Note: Temporary implementation. Will eventually be moved to an external file and loaded as keyed dict.
@@ -133,6 +159,9 @@ namespace DaggerfallWorkshop.Game.Items
                     DaggerfallLoot.RandomlyAddPotion(4, loot.Items);
                     DaggerfallLoot.RandomlyAddPotionRecipe(2, loot.Items);
                 }
+
+                OnLootSpawned?.Invoke(null, new TabledLootSpawnedEventArgs { LocationIndex = locationIndex, Key = lootTableKeys[locationIndex], Items = loot.Items });
+
                 return true;
             }
             return false;


### PR DESCRIPTION
There's currently many ways to modify what loot is found in enemy loot piles, and the loot piles found in dungeons and interiors.

When mods register custom items in a given category, it can replace the default loot of that category. 
Mods can replace the default loot tables found in LootTables.
Mods can use the "ModifyFoundLootItems" formula, now fixed for 0.11.3
Mods can also register to the EnemyDeath.OnEnemyDeath event handler and modify the entity's items just before it creates the loot pile.

For some situations, all these solutions have issues.

First, the loot tables in LootTables and the "ModifyFoundLootItems" formula can only be changed by one mod. If multiple mods take this approach, they will conflict.
Second, registering items in a category used by loot tables does not work if you want to add a new kind of drop entirely. For example, a hunting mod might want to add meat on beast enemies. 

For the EnemyDeath approach, it just doesn't feel right. You need to do a lot of work to access the data you need (ex: [Climate&Calories](https://github.com/Ralzar81/Climates-Calories/blob/034ca75f4a9ef9d2ebf23ff25d01d8aa6e4af1bc/Climates%20%26%20Calories/Hunting.cs#L41)). Also, unlike the rest of the loot, this is generated only when the enemy dies, and won't remain consistent if the player reloads the game and kills the same enemy.

This PR therefore adds two new event handlers for enemy loot piles and "location" piles, each with all the information a mod could need, and called as soon as loot is generated. Event handlers can be registered by multiple mods without issues.

I have an example of how this would be used [here](https://github.com/KABoissonneault/DFU-Mod_Repair-Tools/blob/feat/leveled-repairs/Scripts/RepairTools.cs#L222).