### PR TITLE
Add %mn and %fn macros support to TalkManagerMCP

### DIFF
--- a/Assets/Scripts/Game/TalkManagerMCP.cs
+++ b/Assets/Scripts/Game/TalkManagerMCP.cs
@@ -9,6 +9,8 @@
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
+using DaggerfallWorkshop.Game.Utility;
+using DaggerfallConnect.Arena2;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -53,6 +55,21 @@ namespace DaggerfallWorkshop.Game
                     return GameManager.Instance.TalkManager.GreetingNameNPC;
 
                 return MacroHelper.GetRandomFullName();
+            }
+
+            public override string FemaleName()
+            {
+                NameHelper.BankTypes nameBank = (NameHelper.BankTypes)MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
+                return DaggerfallUnity.Instance.NameHelper.FullName(nameBank, Genders.Female);
+            }
+
+            public override string MaleName()
+            {
+                DFRandom.Seed += 3547;
+                NameHelper.BankTypes nameBank = (NameHelper.BankTypes)MapsFile.RegionRaces[GameManager.Instance.PlayerGPS.CurrentRegionIndex];
+                string name= DaggerfallUnity.Instance.NameHelper.FullName(nameBank, Genders.Male);
+                DFRandom.Seed -= 3547;
+                return name;
             }
 
             public override string Direction()


### PR DESCRIPTION
This PR fixes this:

![bad_%fn_expansion](https://user-images.githubusercontent.com/46795115/115914441-3b1e4a80-a472-11eb-8e1d-b8101385e402.jpg)

The %mn macro is not used in conversations but I added it for the sake of consistency. Note that the random seed for an NPC is not fixed for now so what I do in `MaleName` to differentiate the male name random seed from the female name one is uselesss until PR #2085 is merged.

