### PR TITLE
Fix Castle Wayrest backroom door messages not showing up (issue #1974)

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -255,7 +255,9 @@ namespace DaggerfallWorkshop
             DaggerfallAction action = GetComponent<DaggerfallAction>();
             if (action != null
                 && action.ActionFlag == DFBlock.RdbActionFlags.DoorText
-                && (action.TriggerFlag == DFBlock.RdbTriggerFlags.Door || action.TriggerFlag == DFBlock.RdbTriggerFlags.Direct) // Door to Mynisera's room has a "Direct" trigger flag
+                && action.Index > 0
+                && (action.TriggerFlag == DFBlock.RdbTriggerFlags.Door || action.TriggerFlag == DFBlock.RdbTriggerFlags.Direct // Door to Mynisera's room has a "Direct" trigger flagged
+                    || action.TriggerFlag == DFBlock.RdbTriggerFlags.MultiTrigger) // Some Castle Wayrest doors have "MultiTrigger" trigger flag
                 && action.activationCount == 0
                 && activatedByPlayer)
             {


### PR DESCRIPTION
Some doors in Castle Wayrest do not show their "warning" messages on first click because their actions are flagged MultiTrigger and only Door and Direct flags were handled in DaggerfallActionDoor.Open().

However, I noticed that some MultiTrigger doors (like the large double doors of Castle Wayrest, no need to search very far) are flagged as having some DoorText yet have no text to display, so if I just add MultiTrigger to the handled cases, those doors suddenly require 2 clicks to open.
So, I also added an action.Index > 0 check to try to make sure the DoorText flag is legit (I assume there's no text with index TYPE_11_TEXT_INDEX aka 8600?)

Fixes issue #1974 