### PR TITLE
Quest and enchanted items exclusions

### DIFF
--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -281,7 +281,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Handle bow with no arrows
-            if (!GameManager.Instance.WeaponManager.Sheathed && WeaponType == WeaponTypes.Bow && GameManager.Instance.PlayerEntity.Items.GetItem(Items.ItemGroups.Weapons, (int)Items.Weapons.Arrow) == null)
+            if (!GameManager.Instance.WeaponManager.Sheathed && WeaponType == WeaponTypes.Bow && GameManager.Instance.PlayerEntity.Items.GetItem(Items.ItemGroups.Weapons, (int)Items.Weapons.Arrow, allowQuestItem: false) == null)
             {
                 GameManager.Instance.WeaponManager.SheathWeapons();
                 DaggerfallUI.SetMidScreenText(TextManager.Instance.GetLocalizedText("youHaveNoArrows"));

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -348,14 +348,33 @@ namespace DaggerfallWorkshop.Game.Items
         /// </summary>
         /// <param name="itemGroup">Item group.</param>
         /// <param name="itemIndex">Template index.</param>
-        /// <param name="allowEnchantedItem">Include enchanted items.</param>
-        /// <param name="allowQuestItem">Include quest items.</param>
-        /// <param name="preferConjured">Prefer (short lived) conjured items.</param>
         /// <returns>An item of this type, or null if none found.</returns>
-        public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex, bool allowEnchantedItem = true, bool allowQuestItem = true, bool preferConjured = false)
+
+        public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex)
         {
             int groupIndex = DaggerfallUnity.Instance.ItemHelper.GetGroupIndex(itemGroup, itemIndex);
-            if (!preferConjured)
+            foreach (DaggerfallUnityItem item in items.Values)
+            {
+                if (item.ItemGroup == itemGroup && item.GroupIndex == groupIndex)
+                    return item;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Get the first of an item type from this collection that satisfies extra conditions.
+        /// </summary>
+        /// <param name="itemGroup">Item group.</param>
+        /// <param name="itemIndex">Template index.</param>
+        /// <param name="allowEnchantedItem">Include enchanted items.</param>
+        /// <param name="allowQuestItem">Include quest items.</param>
+        /// <param name="priorityToConjured">Prefer (short lived) conjured items.</param>
+        /// <returns>An item of this type, or null if none found.</returns>
+
+        public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex, bool allowEnchantedItem = true, bool allowQuestItem = true, bool priorityToConjured = false)
+        {
+            int groupIndex = DaggerfallUnity.Instance.ItemHelper.GetGroupIndex(itemGroup, itemIndex);
+            if (!priorityToConjured)
             {
                 foreach (DaggerfallUnityItem item in items.Values)
                 {

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -348,6 +348,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// </summary>
         /// <param name="itemGroup">Item group.</param>
         /// <param name="itemIndex">Template index.</param>
+        /// <param name="allowEnchantedItem">Include enchanted items.</param>
         /// <param name="allowQuestItem">Include quest items.</param>
         /// <param name="preferConjured">Prefer (short lived) conjured items.</param>
         /// <returns>An item of this type, or null if none found.</returns>

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -348,17 +348,12 @@ namespace DaggerfallWorkshop.Game.Items
         /// </summary>
         /// <param name="itemGroup">Item group.</param>
         /// <param name="itemIndex">Template index.</param>
+        /// <param name="priorityToConjured">Prefer (short lived) conjured items.</param>
         /// <returns>An item of this type, or null if none found.</returns>
 
-        public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex)
+        public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex, bool priorityToConjured)
         {
-            int groupIndex = DaggerfallUnity.Instance.ItemHelper.GetGroupIndex(itemGroup, itemIndex);
-            foreach (DaggerfallUnityItem item in items.Values)
-            {
-                if (item.ItemGroup == itemGroup && item.GroupIndex == groupIndex)
-                    return item;
-            }
-            return null;
+            return GetItem(itemGroup, itemIndex, true, true, priorityToConjured);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -348,16 +348,17 @@ namespace DaggerfallWorkshop.Game.Items
         /// </summary>
         /// <param name="itemGroup">Item group.</param>
         /// <param name="itemIndex">Template index.</param>
-        /// <param name="priorityToConjured">Prefer (short lived) conjured items.</param>
+        /// <param name="allowQuestItem">Include quest items.</param>
+        /// <param name="preferConjured">Prefer (short lived) conjured items.</param>
         /// <returns>An item of this type, or null if none found.</returns>
-        public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex, bool priorityToConjured = false)
+        public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex, bool allowEnchantedItem = true, bool allowQuestItem = true, bool preferConjured = false)
         {
             int groupIndex = DaggerfallUnity.Instance.ItemHelper.GetGroupIndex(itemGroup, itemIndex);
-            if (!priorityToConjured)
+            if (!preferConjured)
             {
                 foreach (DaggerfallUnityItem item in items.Values)
                 {
-                    if (item.ItemGroup == itemGroup && item.GroupIndex == groupIndex)
+                    if (item.ItemGroup == itemGroup && item.GroupIndex == groupIndex && (allowEnchantedItem || !item.IsEnchanted) && (allowQuestItem || !item.IsQuestItem))
                         return item;
                 }
                 return null;
@@ -368,7 +369,7 @@ namespace DaggerfallWorkshop.Game.Items
 
                 foreach (DaggerfallUnityItem item in items.Values)
                 {
-                    if (item.ItemGroup == itemGroup && item.GroupIndex == groupIndex)
+                    if (item.ItemGroup == itemGroup && item.GroupIndex == groupIndex && (allowEnchantedItem || !item.IsEnchanted) && (allowQuestItem || !item.IsQuestItem))
                     {
                         if (item.IsSummoned)
                         {

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -1188,7 +1188,7 @@ namespace DaggerfallWorkshop.Game.Items
         public bool AddSpellbookItem(PlayerEntity playerEntity)
         {
             ItemCollection items = playerEntity.Items;
-            DaggerfallUnityItem spellbook = items.GetItem(ItemGroups.MiscItems, (int)MiscItems.Spellbook);
+            DaggerfallUnityItem spellbook = items.GetItem(ItemGroups.MiscItems, (int)MiscItems.Spellbook, allowQuestItem: false);
             if (spellbook == null)
             {
                 items.AddItem(ItemBuilder.CreateItem(ItemGroups.MiscItems, (int)MiscItems.Spellbook));

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -253,7 +253,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     arrowLabelPos.x -= arrowCountTextLabel.TextWidth;
                     arrowLabelPos.y += compass.Size.y / 2 - arrowCountTextLabel.TextHeight / 2;
 
-                    DaggerfallUnityItem arrows = GameManager.Instance.PlayerEntity.Items.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, priorityToConjured: true);
+                    DaggerfallUnityItem arrows = GameManager.Instance.PlayerEntity.Items.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, allowQuestItem: false, preferConjured: true);
                     arrowCountTextLabel.Text = (arrows != null) ? arrows.stackCount.ToString() : "0";
                     arrowCountTextLabel.TextColor = (arrows != null && arrows.IsSummoned) ? conjuredArrowsColor : realArrowsColor;
                     arrowCountTextLabel.TextScale = NativePanel.LocalScale.x;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -253,7 +253,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     arrowLabelPos.x -= arrowCountTextLabel.TextWidth;
                     arrowLabelPos.y += compass.Size.y / 2 - arrowCountTextLabel.TextHeight / 2;
 
-                    DaggerfallUnityItem arrows = GameManager.Instance.PlayerEntity.Items.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, allowQuestItem: false, preferConjured: true);
+                    DaggerfallUnityItem arrows = GameManager.Instance.PlayerEntity.Items.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, allowQuestItem: false, priorityToConjured: true);
                     arrowCountTextLabel.Text = (arrows != null) ? arrows.stackCount.ToString() : "0";
                     arrowCountTextLabel.TextColor = (arrows != null && arrows.IsSummoned) ? conjuredArrowsColor : realArrowsColor;
                     arrowCountTextLabel.TextScale = NativePanel.LocalScale.x;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1771,7 +1771,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
             else if (item.ItemGroup == ItemGroups.UselessItems2 && item.TemplateIndex == (int)UselessItems2.Oil && collection != null)
             {
-                DaggerfallUnityItem lantern = localItems.GetItem(ItemGroups.UselessItems2, (int)UselessItems2.Lantern);
+                DaggerfallUnityItem lantern = localItems.GetItem(ItemGroups.UselessItems2, (int)UselessItems2.Lantern, allowQuestItem: false);
                 if (lantern != null && lantern.currentCondition <= lantern.maxCondition - item.currentCondition)
                 {   // Re-fuel lantern with the oil.
                     lantern.currentCondition += item.currentCondition;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPotionMakerWindow.cs
@@ -335,14 +335,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Remove item from player inventory unless a stack remains.
             foreach (DaggerfallUnityItem item in cauldron)
             {
-                DaggerfallUnityItem playerItem = GameManager.Instance.PlayerEntity.Items.GetItem(item.ItemGroup, item.TemplateIndex);
+                DaggerfallUnityItem playerItem = GameManager.Instance.PlayerEntity.Items.GetItem(item.ItemGroup, item.TemplateIndex, allowEnchantedItem: false);
                 if (playerItem != null)
                 {
                     GameManager.Instance.PlayerEntity.Items.RemoveOne(playerItem);
                 }
                 else
                 {
-                    DaggerfallUnityItem wagonItem = GameManager.Instance.PlayerEntity.WagonItems.GetItem(item.ItemGroup, item.TemplateIndex);
+                    DaggerfallUnityItem wagonItem = GameManager.Instance.PlayerEntity.WagonItems.GetItem(item.ItemGroup, item.TemplateIndex, allowEnchantedItem: false);
                     if (wagonItem != null)
                     {
                         GameManager.Instance.PlayerEntity.WagonItems.RemoveOne(wagonItem);

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -395,7 +395,7 @@ namespace DaggerfallWorkshop.Game
                     {
                         // Remove arrow
                         ItemCollection playerItems = playerEntity.Items;
-                        DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, priorityToConjured: true);
+                        DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, allowQuestItem: false, preferConjured: true);
                         bool isArrowSummoned = arrow.IsSummoned;
                         playerItems.RemoveOne(arrow);
 

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -395,7 +395,7 @@ namespace DaggerfallWorkshop.Game
                     {
                         // Remove arrow
                         ItemCollection playerItems = playerEntity.Items;
-                        DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, allowQuestItem: false, preferConjured: true);
+                        DaggerfallUnityItem arrow = playerItems.GetItem(ItemGroups.Weapons, (int)Weapons.Arrow, allowQuestItem: false, priorityToConjured: true);
                         bool isArrowSummoned = arrow.IsSummoned;
                         playerItems.RemoveOne(arrow);
 


### PR DESCRIPTION
Sometimes quest items and enchanted items deserve to not be used as standard items:
- (subreddit below) arrow quest item should not be picked as missile;
- enchanted ingredients should not be used to mix potions (regression in my refactoring of potion maker);
- I assume quest spell books could exist, and should be given a normal one as needed;
- I assume quest lanterns could exist, and should be excluded;
- I assume no quest or enchanted wagon/horse, sounds silly;
- I didn't consider quest or enchanted currency either. Currencies are hard enough (and a bit of a mess already), and also currencies are a good example of commodity so I don't think quest or enchanted money would make a great feature.

I also considered using a predicate parameter instead of flags to filter the result of GetItem() search, it'd be more general but it's also a matter of taste.

There may be other places where quest and enchanted items could benefit from exclusions, so I consider this a RFC for the moment.

Subreddit:
https://www.reddit.com/r/daggerfallunity/comments/n07718/til_that_if_your_quest_item_is_an_arrow_using/