### PR TITLE
Fix: Show biography skill bonuses during character creation

### DIFF
--- a/Assets/Scripts/API/BiogFile.cs
+++ b/Assets/Scripts/API/BiogFile.cs
@@ -444,7 +444,7 @@ namespace DaggerfallConnect.Arena2
             }
         }
 
-        public static void ApplyEffects(List<string> effects, PlayerEntity playerEntity)
+        public static void ApplyEffects(IEnumerable<string> effects, PlayerEntity playerEntity)
         {
             if (effects == null)
                 return;
@@ -453,6 +453,38 @@ namespace DaggerfallConnect.Arena2
             {
                 ApplyPlayerEffect(playerEntity, effect);
             }
+        }
+
+        public static int[] GetSkillEffects(IEnumerable<string> effects)
+        {
+            if (effects == null)
+                return null;
+
+            int skillCount = (int)DFCareer.Skills.Count;
+            int[] skills = new int[skillCount];
+
+            // Apply only skill effects
+            foreach(string effect in effects)
+            {
+                string[] tokens = effect.Split(null);
+                int parseResult;
+
+                // Skill modifier effect
+                if (int.TryParse(tokens[0], out parseResult) && parseResult >= 0 && parseResult < skillCount)
+                {
+                    short modValue;
+                    if (short.TryParse(tokens[1], out modValue))
+                    {
+                        skills[parseResult] += modValue;
+                    }
+                    else
+                    {
+                        Debug.LogError("CreateCharBiography: Invalid skill adjustment value.");
+                    }
+                }
+            }
+
+            return skills;
         }
 
         private static ArmorMaterialTypes WeaponToArmorMaterialType(WeaponMaterialTypes materialType)

--- a/Assets/Scripts/API/DFCareer.cs
+++ b/Assets/Scripts/API/DFCareer.cs
@@ -483,6 +483,7 @@ namespace DaggerfallConnect
             BluntWeapon = 32,
             Archery = 33,
             CriticalStrike = 34,
+            Count = 35, // Not a valid skill
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallSkills.cs
@@ -23,7 +23,7 @@ namespace DaggerfallWorkshop.Game.Entity
     {
         #region Fields
 
-        public const int Count = 35;
+        public const int Count = (int)DFCareer.Skills.Count;
         public const int PrimarySkillsCount = 3;
         public const int MajorSkillsCount = 3;
         public const int MinorSkillsCount = 6;

--- a/Assets/Scripts/Game/UserInterface/SkillsRollout.cs
+++ b/Assets/Scripts/Game/UserInterface/SkillsRollout.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -10,13 +10,9 @@
 //
 
 using UnityEngine;
-using System;
 using System.Collections.Generic;
-using System.Text;
-using System.IO;
+using System.Linq;
 using DaggerfallConnect;
-using DaggerfallConnect.Arena2;
-using DaggerfallWorkshop;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Entity;
 
@@ -65,6 +61,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
         TextLabel[] majorSkillValueLabels = new TextLabel[DaggerfallSkills.MajorSkillsCount];
         TextLabel[] minorSkillValueLabels = new TextLabel[DaggerfallSkills.MinorSkillsCount];
 
+        IEnumerable<int> skillBonuses;
+
         public DaggerfallSkills StartingSkills
         {
             get { return startingSkills; }
@@ -75,6 +73,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             get { return workingSkills; }
             set { SetSkills(startingSkills, value); }
+        }
+
+        public IEnumerable<int> SkillBonuses
+        {
+            get { return skillBonuses; }
+            set { skillBonuses = value; UpdateSkillValueLabels(); }
         }
 
         public int PrimarySkillBonusPoints
@@ -282,7 +286,16 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 int startingSkill = startingSkills.GetPermanentSkillValue(primarySkills[i]);
                 int workingSkill = workingSkills.GetPermanentSkillValue(primarySkills[i]);
 
-                primarySkillValueLabels[i].Text = workingSkill.ToString();
+                if (skillBonuses != null)
+                {
+                    int bonusSkill = skillBonuses.ElementAt((int)primarySkills[i]);
+                    primarySkillValueLabels[i].Text = (workingSkill + bonusSkill).ToString();
+                }
+                else
+                {
+                    primarySkillValueLabels[i].Text = workingSkill.ToString();
+                }
+
                 if (workingSkill != startingSkill)
                     primarySkillValueLabels[i].TextColor = modifiedStatTextColor;
                 else
@@ -295,7 +308,16 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 int startingSkill = startingSkills.GetPermanentSkillValue(majorSkills[i]);
                 int workingSkill = workingSkills.GetPermanentSkillValue(majorSkills[i]);
 
-                majorSkillValueLabels[i].Text = workingSkill.ToString();
+                if (skillBonuses != null)
+                {
+                    int bonusSkill = skillBonuses.ElementAt((int)majorSkills[i]);
+                    majorSkillValueLabels[i].Text = (workingSkill + bonusSkill).ToString();
+                }
+                else
+                {
+                    majorSkillValueLabels[i].Text = workingSkill.ToString();
+                }
+
                 if (workingSkill != startingSkill)
                     majorSkillValueLabels[i].TextColor = modifiedStatTextColor;
                 else
@@ -308,7 +330,16 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 int startingSkill = startingSkills.GetPermanentSkillValue(minorSkills[i]);
                 int workingSkill = workingSkills.GetPermanentSkillValue(minorSkills[i]);
 
-                minorSkillValueLabels[i].Text = workingSkill.ToString();
+                if (skillBonuses != null)
+                {
+                    int bonusSkill = skillBonuses.ElementAt((int)minorSkills[i]);
+                    minorSkillValueLabels[i].Text = (workingSkill + bonusSkill).ToString();
+                }
+                else
+                {
+                    minorSkillValueLabels[i].Text = workingSkill.ToString();
+                }
+
                 if (workingSkill != startingSkill)
                     minorSkillValueLabels[i].TextColor = modifiedStatTextColor;
                 else

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharAddBonusSkills.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharAddBonusSkills.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -50,6 +50,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         public DaggerfallSkills WorkingSkills
         {
             get { return skillsRollout.WorkingSkills; }
+        }
+
+        public IEnumerable<int> SkillBonuses
+        {
+            get { return skillsRollout.SkillBonuses; }
+            set { skillsRollout.SkillBonuses = value; }
         }
 
         public CreateCharAddBonusSkills(IUserInterfaceManager uiManager)

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharCustomClass.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharCustomClass.cs
@@ -185,9 +185,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             skillsDict = new Dictionary<string, DFCareer.Skills>();
             foreach (DFCareer.Skills skill in Enum.GetValues(typeof(DFCareer.Skills)))
             {
-                skillsDict.Add(DaggerfallUnity.Instance.TextProvider.GetSkillName(skill), skill);
+                string name = DaggerfallUnity.Instance.TextProvider.GetSkillName(skill);
+                if(!string.IsNullOrEmpty(name))
+                    skillsDict.Add(name, skill);
             }
-            skillsDict.Remove(string.Empty); // Don't include "none" skill value.
             skillsList = new List<string>(skillsDict.Keys);
             skillsList.Sort(); // Sort skills alphabetically a la classic.
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharSummary.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharSummary.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -100,6 +100,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             this.skillsRollout.SetClassSkills(characterDocument.career);
             this.skillsRollout.StartingSkills = characterDocument.startingSkills;
             this.skillsRollout.WorkingSkills = characterDocument.workingSkills;
+            this.skillsRollout.SkillBonuses = BiogFile.GetSkillEffects(characterDocument.biographyEffects);
             this.skillsRollout.PrimarySkillBonusPoints = 0;
             this.skillsRollout.MajorSkillBonusPoints = 0;
             this.skillsRollout.MinorSkillBonusPoints = 0;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallStartNewGameWizard.cs
@@ -249,6 +249,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 createCharAddBonusSkillsWindow = new CreateCharAddBonusSkills(uiManager);
                 createCharAddBonusSkillsWindow.OnClose += AddBonusSkillsWindow_OnClose;
                 createCharAddBonusSkillsWindow.DFClass = characterDocument.career;
+                createCharAddBonusSkillsWindow.SkillBonuses = BiogFile.GetSkillEffects(characterDocument.biographyEffects);
             }
 
             // Update class if player changes class selection


### PR DESCRIPTION
I noticed the original TES2 shows the Biography skill bonuses during the "Add Bonus Skills" and "Summary" phase of character creation. The bonuses themselves are bugged in TES2, but the ones you see during creation are the ones you get when you start the game.

So, I did this for consistency