### PR TITLE
Resynchronize vital indicators after toggling large HUD

### DIFF
--- a/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
+++ b/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
@@ -58,6 +58,7 @@ namespace DaggerfallWorkshop.Game
             StreamingWorld.OnInitWorld += StreamingWorld_OnInitWorld;
             SaveLoadManager.OnLoad += SaveLoadManager_OnLoad;
             DaggerfallCourtWindow.OnCourtScreen += DaggerfallCourtWindow_OnCourtScreen;
+            DaggerfallHUD.OnLargeHUDToggle += DaggerfallHUD_OnLargeHUDToggle;
         }
 
         void Update()
@@ -134,6 +135,12 @@ namespace DaggerfallWorkshop.Game
         private void DaggerfallCourtWindow_OnCourtScreen()
         {
             // Clear when player goes to court screen
+            ResetVitals();
+        }
+
+        private void DaggerfallHUD_OnLargeHUDToggle()
+        {
+            // Resynchronize indicators that were disabled
             ResetVitals();
         }
     }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -203,15 +203,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (largeHUD.HorizontalAlignment == HorizontalAlignment.None)
                         largeHUD.HorizontalAlignment = HorizontalAlignment.Center;
                 }
-                if (!largeHUDwasEnabled)
-                    RaiseOnLargeHUDToggleEvent();
             }
             else
             {
                 largeHUD.Enabled = false;
-                if (largeHUDwasEnabled)
-                    RaiseOnLargeHUDToggleEvent();
             }
+
+            if (largeHUDEnabled != largeHUDwasEnabled)
+                RaiseOnLargeHUDToggleEvent();
 
             // Scale large HUD
             largeHUD.CustomScale = NativePanel.LocalScale;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallHUD.cs
@@ -184,6 +184,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             activeSpells.Enabled = ShowActiveSpells;
 
             // Large HUD will force certain other HUD elements off as they conflict in space or utility
+            bool largeHUDwasEnabled = largeHUD.Enabled;
             bool largeHUDEnabled = DaggerfallUnity.Settings.LargeHUD;
             if (largeHUDEnabled)
             {
@@ -202,10 +203,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (largeHUD.HorizontalAlignment == HorizontalAlignment.None)
                         largeHUD.HorizontalAlignment = HorizontalAlignment.Center;
                 }
+                if (!largeHUDwasEnabled)
+                    RaiseOnLargeHUDToggleEvent();
             }
             else
             {
                 largeHUD.Enabled = false;
+                if (largeHUDwasEnabled)
+                    RaiseOnLargeHUDToggleEvent();
             }
 
             // Scale large HUD
@@ -340,5 +345,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             midScreenTextDelay = delay;
             GameManager.Instance.PlayerEntity.Notebook.AddMessage(message);
         }
+
+        #region Events
+
+        // OnLargeHUDToggleEvent
+        public delegate void OnLargeHUDToggleHandler();
+        public static event OnLargeHUDToggleHandler OnLargeHUDToggle;
+        protected virtual void RaiseOnLargeHUDToggleEvent()
+        {
+            if (OnLargeHUDToggle != null)
+                OnLargeHUDToggle();
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Fix for issue #2096

Vital indicators logic is already split in two parts:
- update methods deal with the inertia/convergence usual behavior;
- events can force an immediate adjustment of indicators to current value

This PR add an event triggered right after the large HUD is toggled, and then subscribe to that event to force an immediate update of the indicators.