### PR TITLE
Modding the character sheet's Skills dialog

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -270,63 +270,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             button.OnMouseClick += StatButton_OnMouseClick;
         }
 
-        // Creates formatting tokens for skill popups
-        TextFile.Token[] CreateSkillTokens(DFCareer.Skills skill, bool twoColumn = false, int startPosition = 0)
-        {
-            bool highlight = playerEntity.GetSkillRecentlyIncreased(skill);
-
-            List<TextFile.Token> tokens = new List<TextFile.Token>();
-            TextFile.Formatting formatting = highlight ? TextFile.Formatting.TextHighlight : TextFile.Formatting.Text;
-
-            TextFile.Token skillNameToken = new TextFile.Token();
-            skillNameToken.formatting = formatting;
-            skillNameToken.text = DaggerfallUnity.Instance.TextProvider.GetSkillName(skill);
-
-            TextFile.Token skillValueToken = new TextFile.Token();
-            skillValueToken.formatting = formatting;
-            skillValueToken.text = string.Format("{0}%", playerEntity.Skills.GetLiveSkillValue(skill));
-
-            DFCareer.Stats primaryStat = DaggerfallSkills.GetPrimaryStat(skill);
-            TextFile.Token skillPrimaryStatToken = new TextFile.Token();
-            skillPrimaryStatToken.formatting = formatting;
-            skillPrimaryStatToken.text = DaggerfallUnity.Instance.TextProvider.GetAbbreviatedStatName(primaryStat);
-
-            TextFile.Token positioningToken = new TextFile.Token();
-            positioningToken.formatting = TextFile.Formatting.PositionPrefix;
-
-            TextFile.Token tabToken = new TextFile.Token();
-            tabToken.formatting = TextFile.Formatting.PositionPrefix;
-
-            // Add tokens in order
-            if (!twoColumn)
-            {
-                tokens.Add(skillNameToken);
-                tokens.Add(tabToken);
-                tokens.Add(tabToken);
-                tokens.Add(tabToken);
-                tokens.Add(skillValueToken);
-                tokens.Add(tabToken);
-                tokens.Add(skillPrimaryStatToken);
-            }
-            else // miscellaneous skills
-            {
-                if (startPosition != 0) // if this is the second column
-                {
-                    positioningToken.x = startPosition;
-                    tokens.Add(positioningToken);
-                }
-                tokens.Add(skillNameToken);
-                positioningToken.x = startPosition + 85;
-                tokens.Add(positioningToken);
-                tokens.Add(skillValueToken);
-                positioningToken.x = startPosition + 112;
-                tokens.Add(positioningToken);
-                tokens.Add(skillPrimaryStatToken);
-            }
-
-            return tokens.ToArray();
-        }
-
         void ShowSkillsDialog(List<DFCareer.Skills> skills, bool twoColumn = false)
         {
             bool secondColumn = false;
@@ -339,7 +282,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 if (!twoColumn)
                 {
-                    tokens.AddRange(CreateSkillTokens(skills[i]));
+                    tokens.AddRange(DaggerfallUnity.TextProvider.GetSkillSummary(skills[i], 0));
                     if (i < skills.Count - 1)
                         tokens.Add(TextFile.NewLineToken);
                 }
@@ -347,12 +290,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     if (!secondColumn)
                     {
-                        tokens.AddRange(CreateSkillTokens(skills[i], true));
+                        tokens.AddRange(DaggerfallUnity.TextProvider.GetSkillSummary(skills[i], 0));
                         secondColumn = !secondColumn;
                     }
                     else
                     {
-                        tokens.AddRange(CreateSkillTokens(skills[i], true, 136));
+                        tokens.AddRange(DaggerfallUnity.TextProvider.GetSkillSummary(skills[i], 136));
                         secondColumn = !secondColumn;
                         if (i < skills.Count - 1)
                             tokens.Add(TextFile.NewLineToken);

--- a/Assets/Scripts/Utility/FallbackTextProvider.cs
+++ b/Assets/Scripts/Utility/FallbackTextProvider.cs
@@ -1,0 +1,214 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: kaboissonneault (kaboissonneault@gmail.com)
+// Contributors:    
+// 
+// Notes:
+//
+
+using DaggerfallConnect;
+using DaggerfallConnect.Arena2;
+using DaggerfallWorkshop.Game.Items;
+
+namespace DaggerfallWorkshop.Utility
+{
+    /// <summary>
+    /// Base class that allows derived implementations to only override certain text functionality,
+    /// while having the another implementation as a "fallback" for the cases it's not interested in
+    /// For mods, this usually means taking the previous DaggerfallUnity.Instance.TextProvider as the fallback,
+    /// then replacing the game's text provider with their own implementation based on FallbackTextProvider
+    ///
+    /// Ex:
+    ///
+    /// class MyModTextProvider : FallbackTextProvider
+    /// {
+    ///   public string GetSkillName(DFCareer.Skills skill)
+    ///   {
+    ///     if(skill == DFCareer.Skills.Mercantile)
+    ///         return "Commerce";
+    ///     else
+    ///         return FallbackProvider.GetSkillName(skill);
+    ///   }
+    /// }
+    ///
+    /// public void Awake()
+    /// {
+    ///     DaggerfallUnity.Instance.TextProvider = new MyModProvider(DaggerfallUnity.Instance.TextProvider);
+    /// }
+    ///
+    /// This pattern allows multiple mods to add their own functionality to the text provider without conflicting
+    /// </summary>
+    public abstract class FallbackTextProvider : ITextProvider
+    {
+        ITextProvider fallback;
+
+        protected ITextProvider FallbackProvider
+        {
+            get { return fallback; }
+        }
+
+        public FallbackTextProvider(ITextProvider Fallback)
+        {
+            fallback = Fallback;
+        }
+
+        /// <summary>
+        /// Gets tokens from a TEXT.RSC record.
+        /// </summary>
+        /// <param name="id">Text resource ID.</param>
+        /// <returns>Text resource tokens.</returns>
+        public virtual TextFile.Token[] GetRSCTokens(int id)
+        {
+            return fallback.GetRSCTokens(id);
+        }
+
+        /// <summary>
+        /// Gets tokens from RSC localization table with custom string ID and conversion back to RSC tokens.
+        /// Does not support fallback to classic TEXT.RSC. Record key must exist in RSC localization table.
+        /// </summary>
+        /// <param name="id">String table key.</param>
+        /// <returns>Text resource tokens.</returns>
+        public virtual TextFile.Token[] GetRSCTokens(string id)
+        {
+            return fallback.GetRSCTokens(id);
+        }
+
+        /// <summary>
+        /// Gets tokens from a randomly selected subrecord.
+        /// </summary>
+        /// <param name="id">Text resource ID.</param>
+        /// <param name="dfRand">Use Daggerfall rand() for random selection.</param>
+        /// <returns>Text resource tokens.</returns>
+        public virtual TextFile.Token[] GetRandomTokens(int id, bool dfRand = false)
+        {
+            return fallback.GetRandomTokens(id, dfRand);
+        }
+
+        /// <summary>
+        /// Creates a custom token array.
+        /// </summary>
+        /// <param name="formatting">Formatting of each line.</param>
+        /// <param name="lines">All text lines.</param>
+        /// <returns>Token array.</returns>
+        public virtual TextFile.Token[] CreateTokens(TextFile.Formatting formatting, params string[] lines)
+        {
+            return fallback.CreateTokens(formatting, lines);
+        }
+
+        /// <summary>
+        /// Gets string from token array.
+        /// </summary>
+        /// <param name="id">Text resource ID.</param>
+        /// <returns>String from text resource.</returns>
+        public virtual string GetText(int id)
+        {
+            return fallback.GetText(id);
+        }
+
+        /// <summary>
+        /// Gets random string from separated token array.
+        /// Example would be flavour text variants when finding dungeon exterior.
+        /// </summary>
+        /// <param name="id">Text resource ID.</param>
+        /// <returns>String randomly selected from variants.</returns>
+        public virtual string GetRandomText(int id)
+        {
+            return fallback.GetRandomText(id);
+        }
+
+        /// <summary>
+        /// Gets name of weapon material type.
+        /// </summary>
+        /// <param name="material">Material type of weapon.</param>
+        /// <returns>String for weapon material name.</returns>
+        public virtual string GetWeaponMaterialName(WeaponMaterialTypes material)
+        {
+            return fallback.GetWeaponMaterialName(material);
+        }
+
+        /// <summary>
+        /// Gets name of armor material type.
+        /// </summary>
+        /// <param name="material">Material type of armor.</param>
+        /// <returns>String for armor material name.</returns>
+        public virtual string GetArmorMaterialName(ArmorMaterialTypes material)
+        {
+            return fallback.GetArmorMaterialName(material);
+        }
+
+        /// <summary>
+        /// Gets text for skill name.
+        /// </summary>
+        /// <param name="skill">Skill.</param>
+        /// <returns>Text for this skill.</returns>
+        public virtual string GetSkillName(DFCareer.Skills skill)
+        {
+            return fallback.GetSkillName(skill);
+        }
+
+        /// <summary>
+        /// Gets text to be shown in the Skill summary popup
+        /// </summary>
+        /// <param name="skill">Skill.s</param>
+        /// <param name="startPosition">Position in pixel of the first positioning token</param>
+        /// <returns>Tokens for the skill.</returns>
+        public virtual TextFile.Token[] GetSkillSummary(DFCareer.Skills skill, int startPosition)
+        {
+            return fallback.GetSkillSummary(skill, startPosition);
+        }
+
+        /// <summary>
+        /// Gets text for stat name.
+        /// </summary>
+        /// <param name="stat">Stat.</param>
+        /// <returns>Text for this stat.</returns>
+        public virtual string GetStatName(DFCareer.Stats stat)
+        {
+            return fallback.GetStatName(stat);
+        }
+
+        /// <summary>
+        /// Gets abbreviated text for stat name.
+        /// </summary>
+        /// <param name="stat">Stat.</param>
+        /// <returns>Abbreviated text for this stat.</returns>
+        public virtual string GetAbbreviatedStatName(DFCareer.Stats stat)
+        {
+            return fallback.GetAbbreviatedStatName(stat);
+        }
+
+        /// <summary>
+        /// Gets text resource ID of stat description.
+        /// </summary>
+        /// <param name="stat">Stat.</param>
+        /// <returns>Text resource ID.</returns>
+        public virtual int GetStatDescriptionTextID(DFCareer.Stats stat)
+        {
+            return fallback.GetStatDescriptionTextID(stat);
+        }
+
+        /// <summary>
+        /// Attempts to read a localized string from a named table collection.
+        /// </summary>
+        /// <param name="collection">Name of table collection.</param>
+        /// <param name="id">ID of string to get.</param>
+        /// <param name="result">Localized string result or null/empty.</param>
+        /// <returns>True if string found, otherwise false.</returns>
+        public virtual bool GetLocalizedString(string collection, string id, out string result)
+        {
+            return fallback.GetLocalizedString(collection, id, out result);
+        }
+
+        /// <summary>
+        /// Enable or disable verbose localized string debug in player log.
+        /// </summary>
+        /// <param name="enable">True to enable, false to disable.</param>
+        public virtual void EnableLocalizedStringDebug(bool enable)
+        {
+            fallback.EnableLocalizedStringDebug(enable);
+        }
+    }
+}

--- a/Assets/Scripts/Utility/FallbackTextProvider.cs.meta
+++ b/Assets/Scripts/Utility/FallbackTextProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0843660ab216c344eb80eac806255ba5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/TextProvider.cs
+++ b/Assets/Scripts/Utility/TextProvider.cs
@@ -19,6 +19,7 @@ using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Localization;
 using UnityEngine.Localization.Tables;
 using DaggerfallWorkshop.Game;
+using DaggerfallWorkshop.Game.Entity;
 
 namespace DaggerfallWorkshop.Utility
 {
@@ -94,6 +95,14 @@ namespace DaggerfallWorkshop.Utility
         /// <param name="skill">Skill.</param>
         /// <returns>Text for this skill.</returns>
         string GetSkillName(DFCareer.Skills skill);
+
+        /// <summary>
+        /// Gets text to be shown in the Skill summary popup
+        /// </summary>
+        /// <param name="skill">Skill.s</param>
+        /// <param name="startPosition">Position in pixel of the first positioning token</param>
+        /// <returns>Tokens for the skill.</returns>
+        TextFile.Token[] GetSkillSummary(DFCareer.Skills skill, int startPosition);
 
         /// <summary>
         /// Gets text for stat name.
@@ -465,6 +474,49 @@ namespace DaggerfallWorkshop.Utility
                 default:
                     return string.Empty;
             }
+        }
+
+        public TextFile.Token[] GetSkillSummary(DFCareer.Skills skill, int startPosition)
+        {
+            PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+            bool highlight = playerEntity.GetSkillRecentlyIncreased(skill);
+
+            List<TextFile.Token> tokens = new List<TextFile.Token>();
+            TextFile.Formatting formatting = highlight ? TextFile.Formatting.TextHighlight : TextFile.Formatting.Text;
+
+            TextFile.Token skillNameToken = new TextFile.Token();
+            skillNameToken.formatting = formatting;
+            skillNameToken.text = DaggerfallUnity.Instance.TextProvider.GetSkillName(skill);
+
+            TextFile.Token skillValueToken = new TextFile.Token();
+            skillValueToken.formatting = formatting;
+            skillValueToken.text = string.Format("{0}%", playerEntity.Skills.GetLiveSkillValue(skill));
+
+            DFCareer.Stats primaryStat = DaggerfallSkills.GetPrimaryStat(skill);
+            TextFile.Token skillPrimaryStatToken = new TextFile.Token();
+            skillPrimaryStatToken.formatting = formatting;
+            skillPrimaryStatToken.text = DaggerfallUnity.Instance.TextProvider.GetAbbreviatedStatName(primaryStat);
+
+            TextFile.Token positioningToken = new TextFile.Token();
+            positioningToken.formatting = TextFile.Formatting.PositionPrefix;
+
+            TextFile.Token tabToken = new TextFile.Token();
+            tabToken.formatting = TextFile.Formatting.PositionPrefix;
+
+            if (startPosition != 0) // if this is the second column
+            {
+                positioningToken.x = startPosition;
+                tokens.Add(positioningToken);
+            }
+            tokens.Add(skillNameToken);
+            positioningToken.x = startPosition + 85;
+            tokens.Add(positioningToken);
+            tokens.Add(skillValueToken);
+            positioningToken.x = startPosition + 112;
+            tokens.Add(positioningToken);
+            tokens.Add(skillPrimaryStatToken);
+
+            return tokens.ToArray();
         }
 
         public string GetStatName(DFCareer.Stats stat)


### PR DESCRIPTION
Mods may add new benefits to skills. For example, my [Skilled Spells](https://www.nexusmods.com/daggerfallunity/mods/186) mod bases the caster level for a magical effect on the skill associated with the effect.

This is currently hard to communicate to the player, without telling them to just enter console commands. 

I found that having a mod replacing the entire character sheet window just to change the skills dialog was too prone to conflicts, so I took another approach.

The skill summary code in DaggerfallCharacterSheetWindow.cs was simplified - without changing how it looks - and moved to TextProvider, in a new GetSkillSummary method. The text provider only has to handle the "starting position" for the tokens due to the Misc skills window's two columns. Otherwise, it can show whatever it wants.

Here's an example of a mod overriding the skill summary string with these changes: https://github.com/KABoissonneault/DFU-SkilledSpells/blob/feat/skill-summary-level/Scripts/SkillsSpellsTextProvider.cs

Which results in
![image](https://user-images.githubusercontent.com/5789925/116640517-cbf49a80-a938-11eb-8a30-65e902ebb14b.png)

Again, without any mods, the appearance does not change from the existing implementation.

As a bonus, while dealing with mods that replace text providers, I found having a "fallback" text provider base implementation useful for ensuring no conflicts between mods, and avoiding redundant work. I thought it would be better to provide this class in DFU itself, so all mods can use this approach. See the comments in the code itself, and consult the reference implementation linked above.