### PR TITLE
Cache RMB blocks

### DIFF
--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -419,19 +419,14 @@ namespace DaggerfallConnect.Arena2
         /// <summary>
         /// Gets block AutoMap by name.
         /// </summary>
-        /// <param name="name">Name of block.</param>
+        /// <param name="block">Reference to block.</param>
         /// <param name="removeGroundFlats">Filters ground flat "speckles" from the AutoMap.</param>
         /// <returns>DFBitmap object.</returns>
-        public DFBitmap GetBlockAutoMap(string name, bool removeGroundFlats)
+        static public DFBitmap GetBlockAutoMap(in DFBlock block, bool removeGroundFlats)
         {
-            // Test block is valid
-            DFBlock dfBlock = GetBlock(name);
-            if (string.IsNullOrEmpty(dfBlock.Name))
-                return new DFBitmap();
-
             // Create DFBitmap and copy data
             DFBitmap dfBitmap = new DFBitmap();
-            dfBitmap.Data = dfBlock.RmbBlock.FldHeader.AutoMapData;
+            dfBitmap.Data = block.RmbBlock.FldHeader.AutoMapData;
             dfBitmap.Width = 64;
             dfBitmap.Height = 64;
 

--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -724,13 +724,13 @@ namespace DaggerfallConnect.Arena2
             dfLocation.LocationIndex = location;
 
             // Generate smaller dungeon when possible
-            if (UseSmallerDungeon(ref dfLocation))
+            if (UseSmallerDungeon(dfLocation))
                 GenerateSmallerDungeon(ref dfLocation);
 
             return dfLocation;
         }
 
-        private bool UseSmallerDungeon(ref DFLocation dfLocation)
+        private bool UseSmallerDungeon(in DFLocation dfLocation)
         {
             // Do nothing if location has no dungeon or if a main story dungeon - these are never made smaller
             if (!dfLocation.HasDungeon || DaggerfallDungeon.IsMainStoryDungeon(dfLocation.MapTableData.MapId))
@@ -783,7 +783,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="x">Block X coordinate.</param>
         /// <param name="y">Block Y coordinate.</param>
         /// <returns>Block name.</returns>
-        public string GetRmbBlockName(ref DFLocation dfLocation, int x, int y)
+        public string GetRmbBlockName(in DFLocation dfLocation, int x, int y)
         {
             int index = y * dfLocation.Exterior.ExteriorData.Width + x;
             return dfLocation.Exterior.ExteriorData.BlockNames[index];
@@ -796,7 +796,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="x">Block X coordinate.</param>
         /// <param name="y">Block Y coordinate.</param>
         /// <returns>Block name.</returns>
-        public string ResolveRmbBlockName(ref DFLocation dfLocation, int x, int y)
+        public string ResolveRmbBlockName(in DFLocation dfLocation, int x, int y)
         {
             // Get indices
             int offset = y * dfLocation.Exterior.ExteriorData.Width + x;
@@ -804,7 +804,7 @@ namespace DaggerfallConnect.Arena2
             byte blockNumber = dfLocation.Exterior.ExteriorData.BlockNumber[offset];
             byte blockCharacter = dfLocation.Exterior.ExteriorData.BlockCharacter[offset];
 
-            return ResolveRmbBlockName(ref dfLocation, blockIndex, blockNumber, blockCharacter);
+            return ResolveRmbBlockName(dfLocation, blockIndex, blockNumber, blockCharacter);
         }
 
         /// <summary>
@@ -815,7 +815,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="blockNumber">Block number.</param>
         /// <param name="blockCharacter">Block character.</param>
         /// <returns>Block name.</returns>
-        public string ResolveRmbBlockName(ref DFLocation dfLocation, byte blockIndex, byte blockNumber, byte blockCharacter)
+        public string ResolveRmbBlockName(in DFLocation dfLocation, byte blockIndex, byte blockNumber, byte blockCharacter)
         {
             string letter1 = string.Empty;
             string letter2 = string.Empty;
@@ -1174,7 +1174,7 @@ namespace DaggerfallConnect.Arena2
             {
                 // Construct block name
                 dfLocation.Exterior.ExteriorData.BlockNames[i] = ResolveRmbBlockName(
-                    ref dfLocation,
+                    dfLocation,
                     dfLocation.Exterior.ExteriorData.BlockIndex[i],
                     dfLocation.Exterior.ExteriorData.BlockNumber[i],
                     dfLocation.Exterior.ExteriorData.BlockCharacter[i]);
@@ -1329,11 +1329,11 @@ namespace DaggerfallConnect.Arena2
 
             // Generate new dungeon layout with smallest viable dungeon (1x normal block surrounded by 4x border blocks)
             DFLocation.DungeonBlock[] layout = new DFLocation.DungeonBlock[5];
-            layout[0] = GenerateRDBBlock(0, 0, false, true, ref dfLocation);           // Central starting block
-            layout[1] = GenerateRDBBlock(0, -1, true, false, ref dfLocation);          // North border block
-            layout[2] = GenerateRDBBlock(-1, 0, true, false, ref dfLocation);          // West border block
-            layout[3] = GenerateRDBBlock(1, 0, true, false, ref dfLocation);           // East border block
-            layout[4] = GenerateRDBBlock(0, 1, true, false, ref dfLocation);           // South border block
+            layout[0] = GenerateRDBBlock(0, 0, false, true, dfLocation);           // Central starting block
+            layout[1] = GenerateRDBBlock(0, -1, true, false, dfLocation);          // North border block
+            layout[2] = GenerateRDBBlock(-1, 0, true, false, dfLocation);          // West border block
+            layout[3] = GenerateRDBBlock(1, 0, true, false, dfLocation);           // East border block
+            layout[4] = GenerateRDBBlock(0, 1, true, false, dfLocation);           // South border block
 
             // Inject new block array into location
             dfLocation.Dungeon.Blocks = layout;
@@ -1348,10 +1348,10 @@ namespace DaggerfallConnect.Arena2
         /// <param name="startingBlock">True to make this a starting block (must only be one).</param>
         /// <param name="dfLocation">Reference location to select a random block from.</param>
         /// <returns>DFLocation.DungeonBlock</returns>
-        DFLocation.DungeonBlock GenerateRDBBlock(sbyte x, sbyte z, bool borderBlock, bool startingBlock, ref DFLocation dfLocation)
+        DFLocation.DungeonBlock GenerateRDBBlock(sbyte x, sbyte z, bool borderBlock, bool startingBlock, in DFLocation dfLocation)
         {
             // Get random block from reference location and overwrite some properties
-            DFLocation.DungeonBlock block = GetRandomBlock(borderBlock, ref dfLocation);
+            DFLocation.DungeonBlock block = GetRandomBlock(borderBlock, dfLocation);
             block.X = x;
             block.Z = z;
             block.IsStartingBlock = startingBlock;
@@ -1365,7 +1365,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="borderBlock">True to select a border block, false to select an interior block.</param>
         /// <param name="dfLocation">Reference location to select a random block from.</param>
         /// <returns>DFLocation.DungeonBlock</returns>
-        DFLocation.DungeonBlock GetRandomBlock(bool borderBlock, ref DFLocation dfLocation)
+        DFLocation.DungeonBlock GetRandomBlock(bool borderBlock, in DFLocation dfLocation)
         {
             List<DFLocation.DungeonBlock> filteredBlocks = new List<DFLocation.DungeonBlock>();
             foreach (DFLocation.DungeonBlock block in dfLocation.Dungeon.Blocks)

--- a/Assets/Scripts/Game/BuildingDirectory.cs
+++ b/Assets/Scripts/Game/BuildingDirectory.cs
@@ -81,14 +81,14 @@ namespace DaggerfallWorkshop.Game
         /// Setup building directory from specified location.
         /// </summary>
         /// <param name="location">Source location data.</param>
-        public void SetLocation(DFLocation location)
+        /// <param name="blocks">Exterior blocks.</param>
+        public void SetLocation(in DFLocation location, out DFBlock[] blocks)
         {
             // Clear existing buildings
             buildingDict.Clear();
 
             // Get block data pre-populated with map building data.
-            DFBlock[] blocks;
-            RMBLayout.GetLocationBuildingData(location, out blocks);
+            blocks = RMBLayout.GetLocationBuildingData(location);
 
             // Construct building directory
             int width = location.Exterior.ExteriorData.Width;

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -1036,8 +1036,7 @@ namespace DaggerfallWorkshop.Game.Questing
             QuestResource[] parentQuestPlaceResources = ParentQuest.GetAllResources(typeof(Place));
 
             // Iterate through all blocks
-            DFBlock[] blocks;
-            RMBLayout.GetLocationBuildingData(location, out blocks);
+            DFBlock[] blocks = RMBLayout.GetLocationBuildingData(location);
             int width = location.Exterior.ExteriorData.Width;
             int height = location.Exterior.ExteriorData.Height;
             for (int y = 0; y < height; y++)

--- a/Assets/Scripts/Game/Utility/CityNavigation.cs
+++ b/Assets/Scripts/Game/Utility/CityNavigation.cs
@@ -208,7 +208,7 @@ namespace DaggerfallWorkshop.Game.Utility
         /// <param name="blockData">RMB block data.</param>
         /// <param name="xBlock">X block to set.</param>
         /// <param name="yBlock">Y block to set.</param>
-        public void SetRMBData(ref DFBlock blockData, int xBlock, int yBlock)
+        public void SetRMBData(in DFBlock blockData, int xBlock, int yBlock)
         {
             // Validate
             if (xBlock < 0 || xBlock >= cityWidth ||

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -368,8 +368,7 @@ namespace DaggerfallWorkshop
         {
             // Get block data
             DFLocation location = GameManager.Instance.PlayerGPS.CurrentLocation;
-            DFBlock[] blocks;
-            RMBLayout.GetLocationBuildingData(location, out blocks);
+            DFBlock[] blocks = RMBLayout.GetLocationBuildingData(location);
             bool foundBlock = false;
             for (int index = 0; index < blocks.Length && !foundBlock; ++index)
             {

--- a/Assets/Scripts/Internal/DaggerfallLocation.cs
+++ b/Assets/Scripts/Internal/DaggerfallLocation.cs
@@ -423,7 +423,7 @@ namespace DaggerfallWorkshop
                         //miscBillboardBatch.BlockOrigin = blockOrigin;
                     }
 
-                    string blockName = dfUnity.ContentReader.BlockFileReader.CheckName(dfUnity.ContentReader.MapFileReader.GetRmbBlockName(ref location, x, y));
+                    string blockName = dfUnity.ContentReader.BlockFileReader.CheckName(dfUnity.ContentReader.MapFileReader.GetRmbBlockName(location, x, y));
                     GameObject go = GameObjectHelper.CreateRMBBlockGameObject(
                         blockName,
                         x,

--- a/Assets/Scripts/Terrain/TerrainHelper.cs
+++ b/Assets/Scripts/Terrain/TerrainHelper.cs
@@ -145,7 +145,7 @@ namespace DaggerfallWorkshop
                 {
                     // Get block data
                     DFBlock block;
-                    string blockName = dfUnity.ContentReader.MapFileReader.GetRmbBlockName(ref location, blockX, blockY);
+                    string blockName = dfUnity.ContentReader.MapFileReader.GetRmbBlockName(location, blockX, blockY);
                     if (!dfUnity.ContentReader.GetBlock(blockName, out block))
                         continue;
 

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -16,6 +16,7 @@ using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game;
+using System.Linq;
 
 namespace DaggerfallWorkshop.Utility
 {
@@ -24,6 +25,9 @@ namespace DaggerfallWorkshop.Utility
     /// </summary>
     public static class RMBLayout
     {
+
+        #region Fields
+
         public const int RMBTilesPerBlock = 16;
         public const int RMBTilesPerTerrain = 128;
         public const float RMBSide = 4096f * MeshReader.GlobalScale;
@@ -35,6 +39,11 @@ namespace DaggerfallWorkshop.Utility
         public const uint CityGateOpenModelID = 446;
         public const uint CityGateClosedModelID = 447;
         public const uint BulletinBoardModelID = 41739;
+
+        private static int maxLocationCacheSize = 12;
+        private static List<KeyValuePair<int, DFBlock[]>> locationCache = new List<KeyValuePair<int, DFBlock[]>>();
+
+        #endregion
 
         // Animal sounds range. Matched to classic.
         const float animalSoundMaxDistance = 768 * MeshReader.GlobalScale;
@@ -452,7 +461,7 @@ namespace DaggerfallWorkshop.Utility
         /// <param name="layoutX">X coordindate in map layout used to generate building key.</param>
         /// <param name="layoutY">Y coordindate in map layout used to generate building key.</param>
         /// <returns>BuildingSummary.</returns>
-        public static BuildingSummary[] GetBuildingData(DFBlock blockData, int layoutX = -1, int layoutY = -1)
+        public static BuildingSummary[] GetBuildingData(in DFBlock blockData, int layoutX = -1, int layoutY = -1)
         {
             // Store building information
             int buildingCount = blockData.RmbBlock.SubRecords.Length;
@@ -463,7 +472,7 @@ namespace DaggerfallWorkshop.Utility
                 buildings[i] = new BuildingSummary();
 
                 // Set building data
-                DFLocation.BuildingData buildingData = blockData.RmbBlock.FldHeader.BuildingDataList[i];
+                ref readonly DFLocation.BuildingData buildingData = ref blockData.RmbBlock.FldHeader.BuildingDataList[i];
                 buildings[i].buildingKey = BuildingDirectory.MakeBuildingKey((byte)layoutX, (byte)layoutY, (byte)i);
                 buildings[i].NameSeed = buildingData.NameSeed;
                 buildings[i].FactionId = buildingData.FactionId;
@@ -471,7 +480,7 @@ namespace DaggerfallWorkshop.Utility
                 buildings[i].Quality = buildingData.Quality;
 
                 // Set building transform info
-                DFBlock.RmbSubRecord subRecord = blockData.RmbBlock.SubRecords[i];
+                ref readonly DFBlock.RmbSubRecord subRecord = ref blockData.RmbBlock.SubRecords[i];
                 buildings[i].Position = new Vector3(subRecord.XPos, 0, BlocksFile.RMBDimension - subRecord.ZPos) * MeshReader.GlobalScale;
                 buildings[i].Rotation = new Vector3(0, -subRecord.YRotation / BlocksFile.RotationDivisor, 0);
                 buildings[i].Matrix = Matrix4x4.TRS(buildings[i].Position, Quaternion.Euler(buildings[i].Rotation), Vector3.one);
@@ -494,9 +503,13 @@ namespace DaggerfallWorkshop.Utility
         /// It will be progressed over time.
         /// </summary>
         /// <param name="location">Location to use.</param>
-        /// <param name="blocksOut">Array of blocks populated with data from MAPS.BSA.</param>
-        public static void GetLocationBuildingData(DFLocation location, out DFBlock[] blocksOut)
+        public static DFBlock[] GetLocationBuildingData(in DFLocation location)
         {
+            int mapId = location.MapTableData.MapId;
+            DFBlock[] blocksArray = locationCache.FirstOrDefault(l => l.Key == mapId).Value;
+            if (blocksArray != null)
+                return blocksArray;
+
             List<BuildingPoolItem> namedBuildingPool = new List<BuildingPoolItem>();
             List<DFBlock> blocks = new List<DFBlock>();
 
@@ -526,23 +539,18 @@ namespace DaggerfallWorkshop.Utility
                 for (int x = 0; x < width; x++)
                 {
                     // Get block name
-                    string blockName = contentReader.BlockFileReader.CheckName(contentReader.MapFileReader.GetRmbBlockName(ref location, x, y));
+                    string blockName = contentReader.BlockFileReader.CheckName(contentReader.MapFileReader.GetRmbBlockName(location, x, y));
 
                     // Get block data
                     DFBlock block;
                     if (!contentReader.GetBlock(blockName, out block))
                         throw new Exception("GetCompleteBuildingData() could not read block " + blockName);
 
-                    // Make a copy of the building data array for our block copy since we're modifying it
-                    DFLocation.BuildingData[] buildingArray = new DFLocation.BuildingData[block.RmbBlock.FldHeader.BuildingDataList.Length];
-                    Array.Copy(block.RmbBlock.FldHeader.BuildingDataList, buildingArray, block.RmbBlock.FldHeader.BuildingDataList.Length);
-                    block.RmbBlock.FldHeader.BuildingDataList = buildingArray;
-
                     // Assign building data for this block
                     BuildingReplacementData buildingReplacementData;
                     for (int i = 0; i < block.RmbBlock.SubRecords.Length; i++)
                     {
-                        DFLocation.BuildingData building = block.RmbBlock.FldHeader.BuildingDataList[i];
+                        ref DFLocation.BuildingData building = ref block.RmbBlock.FldHeader.BuildingDataList[i];
                         if (IsNamedBuilding(building.BuildingType))
                         {
                             // Try to find next building and merge data
@@ -582,9 +590,6 @@ namespace DaggerfallWorkshop.Utility
                                 building.BuildingType = DFLocation.BuildingTypes.GuildHall;
                                 building.FactionId = 414;
                             }
-
-                            // Set whatever building data we could find
-                            block.RmbBlock.FldHeader.BuildingDataList[i] = building;
                         }
                     }
 
@@ -593,8 +598,14 @@ namespace DaggerfallWorkshop.Utility
                 }
             }
 
-            // Send blocks array back to caller
-            blocksOut = blocks.ToArray();
+            blocksArray = blocks.ToArray();
+
+            // Cache blocks
+            if (locationCache.Count == maxLocationCacheSize)
+                locationCache.RemoveAt(0);
+            locationCache.Add(new KeyValuePair<int, DFBlock[]>(mapId, blocksArray));
+
+            return blocksArray;
         }
 
         /// <summary>


### PR DESCRIPTION
While working on new PRs, I noticed again that `RMBLayout.GetLocationBuildingData` takes a long time for big cities when a replacement mod such as _Taverns Redone_ is used (around 1.5s for Daggerfall city on my computer, using a stopwatch). Furthermore, the method is called at least three times when loading a savegame. The more problematic issue is that it is also called in several places like when opening the talking window or selecting a random place for a quest.

Some time ago, I made a first attempt at fixing this issue in PR #1541, however, it was not satisfactory and since I didn't have time to work on it anymore, I closed it.

For this new attempt, I decided to cache RMB blocks as a static field in RMBLayout itself, with a size of 12 locations at most. This works quite well, reduces loading and travelling times a little bit and, most importantly, allow the dialogue window to be displayed almost immediately.

I also took the opportunity to use some very useful new features from C# 7.2 such as `in` and `ref readonly` in a few places, where big structures such as `DFBlock` or `DFLocation` are used.