### PR TITLE
Remove ModifyFoundLootItems formula

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -2015,21 +2015,6 @@ namespace DaggerfallWorkshop.Game.Formulas
         }
 
         /// <summary>
-        /// Allows loot found in containers and enemy corpses to be modified.
-        /// </summary>
-        /// <param name="lootItems">An array of the loot items to modify</param>
-        /// <returns>The array of modified loot items</returns>
-        public static DaggerfallUnityItem[] ModifyFoundLootItems(ref DaggerfallUnityItem[] lootItems)
-        {
-            Func<DaggerfallUnityItem[], DaggerfallUnityItem[]> del;
-            if (TryGetOverride("ModifyFoundLootItems", out del))
-                return del(lootItems);
-
-            // DFU does no post-processing of loot items hence return array unchanged. This function is solely for mods to override.
-            return lootItems;
-        }
-
-        /// <summary>
         /// Gets a random material based on player level.
         /// Note, this is called by default RandomArmorMaterial function.
         /// </summary>

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -71,9 +71,7 @@ namespace DaggerfallWorkshop
             LootChanceMatrix matrix = LootTables.GetMatrix(LootTableKey);
             DaggerfallUnityItem[] newitems = LootTables.GenerateRandomLoot(matrix, GameManager.Instance.PlayerEntity);
 
-            DaggerfallUnityItem[] modifieditems = FormulaHelper.ModifyFoundLootItems(ref newitems);
-
-            collection.Import(modifieditems);
+            collection.Import(newitems);
         }
 
         /// <summary>


### PR DESCRIPTION
Formula is redundant now there are EnemyEntity and LootTables OnLootSpawned events, and it was never really a formula anyway.

Follows up PR #2087 