### PR TITLE
Re-fix riding sprint in mods

### DIFF
--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -396,7 +396,7 @@ namespace DaggerfallWorkshop.Game
         public float GetRunSpeed()
         {
             Entity.PlayerEntity player = GameManager.Instance.PlayerEntity;
-            float baseRunSpeed = (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
+            float baseRunSpeed = playerMotor.IsRiding ? baseSpeed : (player.Stats.LiveSpeed + dfWalkBase) / classicToUnitySpeedUnitRatio;
             return baseRunSpeed * (1.35f + (player.Skills.GetLiveSkillValue(DFCareer.Skills.Running) / 200f));
         }
 


### PR DESCRIPTION
The previous fix (PR #1987) was removed in commit https://github.com/Interkarma/daggerfall-unity/commit/721522c0d032b8d23c510f38867fb6bb82694e6b from PR #2084 

@l3lessed: Unless there's a good reason not to I'd like to put my fix back so the galloping in my mod continues to work.