### PR TITLE
Fix typo in DFU macro %pg1

### DIFF
--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -228,7 +228,7 @@ namespace DaggerfallWorkshop.Utility
             { "%wth", Worth }, // Worth
         // DF Unity - new macros:
             { "%pg", PlayerPronoun },   // He/She (player)
-            { "%pg1", PlayerPronoun },  // His/Her (player)
+            { "%pg1", PlayerPronoun1 },  // His/Her (player)
             { "%pg2", PlayerPronoun2 }, // Him/Her (player)
             { "%pg2self", PlayerPronoun2self },// Himself/Herself (player)
             { "%pg3", PlayerPronoun3 },  // His/Her (player)
@@ -772,7 +772,7 @@ namespace DaggerfallWorkshop.Utility
             return (GameManager.Instance.PlayerEntity.Gender == Genders.Female) ? TextManager.Instance.GetLocalizedText("pronounShe") : TextManager.Instance.GetLocalizedText("pronounHe");
         }
         private static string PlayerPronoun1(IMacroContextProvider mcp)
-        {   // %pg1
+        {   // %pg1 (same as %pg3)
             return (GameManager.Instance.PlayerEntity.Gender == Genders.Female) ? TextManager.Instance.GetLocalizedText("pronounHer") : TextManager.Instance.GetLocalizedText("pronounHis");
         }
         private static string PlayerPronoun2(IMacroContextProvider mcp)


### PR DESCRIPTION
It should have been this way when I committed it in 2017. Is now the same as pg3 since the hers plural was removed. Leaving both methods in, but added comment to make it clear they now function the same.