### PR TITLE
Prevent levitating and swimming diagonally from being 40% faster

### DIFF
--- a/Assets/Scripts/Game/LevitateMotor.cs
+++ b/Assets/Scripts/Game/LevitateMotor.cs
@@ -68,21 +68,25 @@ namespace DaggerfallWorkshop.Game
             if (GameManager.Instance.PlayerEntity.IsParalyzed)
                 return;
 
-            Vector3 horizontalVector = new Vector3 (0, 0, 0);
+            float inputX = 0f;
+            float inputY = 0f;
             // Forward/backwards
             if (InputManager.Instance.HasAction(InputManager.Actions.MoveForwards))
-                horizontalVector += playerCamera.transform.forward;
+                inputY++;
             if (InputManager.Instance.HasAction(InputManager.Actions.MoveBackwards))
-                horizontalVector -= playerCamera.transform.forward;
+                inputY--;
 
             // Right/left
             if (InputManager.Instance.HasAction(InputManager.Actions.MoveRight))
-                horizontalVector += playerCamera.transform.right;
+                inputX++;
             if (InputManager.Instance.HasAction(InputManager.Actions.MoveLeft))
-                horizontalVector -= playerCamera.transform.right;
+                inputX--;
 
-            if (horizontalVector != Vector3.zero)
-                AddMovement(horizontalVector.normalized);
+            if (inputX != 0.0f || inputY != 0.0f)
+            {
+                float inputModifyFactor = (inputX != 0.0f && inputY != 0.0f && playerMotor.limitDiagonalSpeed) ? .7071f : 1.0f;
+                AddMovement(playerCamera.transform.TransformDirection(new Vector3(inputX * inputModifyFactor, 0, inputY * inputModifyFactor)));
+            }
 
             // Up/down
             Vector3 upDownVector = new Vector3 (0, 0, 0);

--- a/Assets/Scripts/Game/LevitateMotor.cs
+++ b/Assets/Scripts/Game/LevitateMotor.cs
@@ -68,17 +68,21 @@ namespace DaggerfallWorkshop.Game
             if (GameManager.Instance.PlayerEntity.IsParalyzed)
                 return;
 
+            Vector3 horizontalVector = new Vector3 (0, 0, 0);
             // Forward/backwards
             if (InputManager.Instance.HasAction(InputManager.Actions.MoveForwards))
-                AddMovement(playerCamera.transform.forward);
-            else if (InputManager.Instance.HasAction(InputManager.Actions.MoveBackwards))
-                AddMovement(-playerCamera.transform.forward);
+                horizontalVector += playerCamera.transform.forward;
+            if (InputManager.Instance.HasAction(InputManager.Actions.MoveBackwards))
+                horizontalVector -= playerCamera.transform.forward;
 
             // Right/left
             if (InputManager.Instance.HasAction(InputManager.Actions.MoveRight))
-                AddMovement(playerCamera.transform.right);
-            else if (InputManager.Instance.HasAction(InputManager.Actions.MoveLeft))
-                AddMovement(-playerCamera.transform.right);
+                horizontalVector += playerCamera.transform.right;
+            if (InputManager.Instance.HasAction(InputManager.Actions.MoveLeft))
+                horizontalVector -= playerCamera.transform.right;
+
+            if (horizontalVector != Vector3.zero)
+                AddMovement(horizontalVector.normalized);
 
             // Up/down
             Vector3 upDownVector = new Vector3 (0, 0, 0);

--- a/Assets/Scripts/Game/LevitateMotor.cs
+++ b/Assets/Scripts/Game/LevitateMotor.cs
@@ -68,19 +68,8 @@ namespace DaggerfallWorkshop.Game
             if (GameManager.Instance.PlayerEntity.IsParalyzed)
                 return;
 
-            float inputX = 0f;
-            float inputY = 0f;
-            // Forward/backwards
-            if (InputManager.Instance.HasAction(InputManager.Actions.MoveForwards))
-                inputY++;
-            if (InputManager.Instance.HasAction(InputManager.Actions.MoveBackwards))
-                inputY--;
-
-            // Right/left
-            if (InputManager.Instance.HasAction(InputManager.Actions.MoveRight))
-                inputX++;
-            if (InputManager.Instance.HasAction(InputManager.Actions.MoveLeft))
-                inputX--;
+            float inputX = InputManager.Instance.Horizontal;
+            float inputY = InputManager.Instance.Vertical;
 
             if (inputX != 0.0f || inputY != 0.0f)
             {


### PR DESCRIPTION
Also fix forward taking priority over backward, and right taking priority over left when pressing both controls simultaneously