### PR TITLE
Add OnItemHover to inventory window for mods

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -465,6 +465,7 @@ namespace DaggerfallWorkshop.Game
             dfExteriorAutomapWindow = (DaggerfallExteriorAutomapWindow)UIWindowFactory.GetInstance(UIWindowType.ExteriorAutomap, uiManager);
 
             instantiatePersistentWindowInstances = false;
+            RaiseOnInstantiatePersistentWindowInstances();
         }
 
         void ProcessMessages()
@@ -1493,6 +1494,16 @@ namespace DaggerfallWorkshop.Game
         private void GivePc_OnOfferPending(Questing.Actions.GivePc sender)
         {
             lastPendingOfferSender = sender;
+        }
+
+        /// <summary>
+        /// Event raised when the persistent window instances have been instantiated.
+        /// </summary>
+        public delegate void OnInstantiatePersistentWindowInstancesHandler();
+        public event OnInstantiatePersistentWindowInstancesHandler OnInstantiatePersistentWindowInstances;
+        protected virtual void RaiseOnInstantiatePersistentWindowInstances()
+        {
+            OnInstantiatePersistentWindowInstances?.Invoke();
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -2146,6 +2146,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Hover & StartGame Event Handlers
 
+        /// <summary>
+        /// Event raised when an item is hovered over in either list, the paperdoll, or accessories.
+        /// </summary>
+        public delegate void OnItemHoverHandler(DaggerfallUnityItem item);
+        public event OnItemHoverHandler OnItemHover;
+        protected virtual void RaiseOnItemHoverEvent(DaggerfallUnityItem item)
+        {
+            OnItemHover?.Invoke(item);
+        }
+
         protected virtual void PaperDoll_OnMouseMove(int x, int y)
         {
             byte value = paperDoll.GetEquipIndex(x, y);
@@ -2168,6 +2178,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     // Update the info panel if used
                     if (itemInfoPanelLabel != null)
                         UpdateItemInfoPanel(item);
+
+                    RaiseOnItemHoverEvent(item);
                 }
                 // Update tooltip text
                 paperDoll.ToolTipText = text;
@@ -2187,12 +2199,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnityItem item = playerEntity.ItemEquipTable.GetItem(slot);
             if (item == null)
                 return;
-            UpdateItemInfoPanel(item);
+
+            // Update the info panel if used
+            if (itemInfoPanelLabel != null)
+                UpdateItemInfoPanel(item);
+
+            RaiseOnItemHoverEvent(item);
         }
 
         protected virtual void ItemListScroller_OnHover(DaggerfallUnityItem item)
         {
-            UpdateItemInfoPanel(item);
+            // Update the info panel if used
+            if (itemInfoPanelLabel != null)
+                UpdateItemInfoPanel(item);
+
+            RaiseOnItemHoverEvent(item);
         }
 
         protected virtual void GoldButton_OnMouseEnter(BaseScreenComponent sender)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -375,7 +375,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             localItemListScroller.OnItemRightClick += LocalItemListScroller_OnItemRightClick;
             localItemListScroller.OnItemMiddleClick += LocalItemListScroller_OnItemMiddleClick;
             if (itemInfoPanelLabel != null)
-                localItemListScroller.OnItemHover += ItemListScroller_OnHover;
+                localItemListScroller.OnItemHover += LocalItemListScroller_OnHover;
 
             remoteItemListScroller = new ItemListScroller(defaultToolTip)
             {
@@ -392,7 +392,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetRemoteItemsAnimation();
 
             if (itemInfoPanelLabel != null)
-                remoteItemListScroller.OnItemHover += ItemListScroller_OnHover;
+                remoteItemListScroller.OnItemHover += RemoteItemListScroller_OnHover;
         }
 
         protected virtual Color ItemBackgroundColourHandler(DaggerfallUnityItem item)
@@ -2149,11 +2149,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         /// <summary>
         /// Event raised when an item is hovered over in either list, the paperdoll, or accessories.
         /// </summary>
-        public delegate void OnItemHoverHandler(DaggerfallUnityItem item);
+        public enum ItemHoverLocation { Accessories, Paperdoll, LocalList, RemoteList }
+        public delegate void OnItemHoverHandler(DaggerfallUnityItem item, ItemHoverLocation loc);
         public event OnItemHoverHandler OnItemHover;
-        protected virtual void RaiseOnItemHoverEvent(DaggerfallUnityItem item)
+        protected virtual void RaiseOnItemHoverEvent(DaggerfallUnityItem item, ItemHoverLocation loc)
         {
-            OnItemHover?.Invoke(item);
+            OnItemHover?.Invoke(item, loc);
         }
 
         protected virtual void PaperDoll_OnMouseMove(int x, int y)
@@ -2179,7 +2180,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     if (itemInfoPanelLabel != null)
                         UpdateItemInfoPanel(item);
 
-                    RaiseOnItemHoverEvent(item);
+                    RaiseOnItemHoverEvent(item, ItemHoverLocation.Paperdoll);
                 }
                 // Update tooltip text
                 paperDoll.ToolTipText = text;
@@ -2204,7 +2205,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (itemInfoPanelLabel != null)
                 UpdateItemInfoPanel(item);
 
-            RaiseOnItemHoverEvent(item);
+            RaiseOnItemHoverEvent(item, ItemHoverLocation.Accessories);
+        }
+
+        protected virtual void LocalItemListScroller_OnHover(DaggerfallUnityItem item)
+        {
+            ItemListScroller_OnHover(item);
+            RaiseOnItemHoverEvent(item, ItemHoverLocation.LocalList);
+        }
+
+        protected virtual void RemoteItemListScroller_OnHover(DaggerfallUnityItem item)
+        {
+            ItemListScroller_OnHover(item);
+            RaiseOnItemHoverEvent(item, ItemHoverLocation.RemoteList);
         }
 
         protected virtual void ItemListScroller_OnHover(DaggerfallUnityItem item)
@@ -2212,8 +2225,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Update the info panel if used
             if (itemInfoPanelLabel != null)
                 UpdateItemInfoPanel(item);
-
-            RaiseOnItemHoverEvent(item);
         }
 
         protected virtual void GoldButton_OnMouseEnter(BaseScreenComponent sender)


### PR DESCRIPTION
Includes an event for when the persistent windows have been instantiated so mods can easily register to listen to the UI window event. It's possible other events for other persistent windows would be useful, and the same technique can be used for them. However I am not going to try to divine what they are.

Using this from a mod looks like this:

```
DaggerfallUI.Instance.OnInstantiatePersistentWindowInstances += OnInstantiatePersistentWindowInstances_TestItemHover;

static void OnInstantiatePersistentWindowInstances_TestItemHover()
{
    DaggerfallUI.Instance.InventoryWindow.OnItemHover += TestItemHover;
}

static void TestItemHover(DaggerfallUnityItem item, DaggerfallInventoryWindow.ItemHoverLocation loc)
{
    Debug.LogFormat("Hovered {0}  uid:(1)", item.ItemName, item.UID);
}
```