### PR TITLE
Use classic hack to fix Orsinium overlapping blocks

### DIFF
--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -1290,6 +1290,10 @@ namespace DaggerfallConnect.Arena2
                 dfLocation.Dungeon.Blocks[i].BlockName = String.Format("{0}{1:0000000}.RDB", rdbBlockLetters[dfLocation.Dungeon.Blocks[i].BlockIndex], dfLocation.Dungeon.Blocks[i].BlockNumber);
             }
 
+            // Orsinium hack to move a border block overlapping another one. Reversed engineered from classic
+            if (dfLocation.Dungeon.RecordElement.Header.LocationId == 50015)
+                dfLocation.Dungeon.Blocks[13].Z = -2;
+
             // Set dungeon flag
             dfLocation.HasDungeon = true;
         }

--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -1931,12 +1931,6 @@ namespace DaggerfallWorkshop.Game
                     // Create dungeon layout
                     foreach (DFLocation.DungeonBlock block in blocks)
                     {
-                        if (location.Name == "Orsinium")
-                        {
-                            if (block.X == -1 && block.Z == -1 && block.BlockName == "N0000065.RDB")
-                                continue;
-                        }
-
                         DFBlock blockData;
                         int[] textureTable = GameManager.Instance.PlayerEnterExit?.Dungeon?.DungeonTextureTable;
                         Automap.isCreatingDungeonAutomapBaseGameObjects = true;

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -1404,15 +1404,6 @@ namespace DaggerfallWorkshop.Game.Questing
                 // Get block data
                 DFBlock blockData = DaggerfallUnity.Instance.ContentReader.BlockFileReader.GetBlock(dungeonBlock.BlockName);
 
-                // Skip misplaced overlapping N block at -1,-1 in Orsinium
-                // This must be a B block to close out dungeon on that edge, not an N block which opens dungeon to void
-                // DaggerfallDungeon skips this N block during layout, so prevent it being available to quest system
-                if (location.MapTableData.MapId == 19021260 &&
-                    dungeonBlock.X == -1 && dungeonBlock.Z == -1 && dungeonBlock.BlockName == "N0000065.RDB")
-                {
-                    continue;
-                }
-
                 // Iterate all groups
                 foreach (DFBlock.RdbObjectRoot group in blockData.RdbBlock.ObjectRootList)
                 {


### PR DESCRIPTION
Instead of discarding one block as DFU does, classic simply moves one of the block south of the other.