### PR TITLE
Added "weather", "season", and "climate" quest trigger conditions

### DIFF
--- a/Assets/Scripts/API/DFLocation.cs
+++ b/Assets/Scripts/API/DFLocation.cs
@@ -133,6 +133,7 @@ namespace DaggerfallConnect
             Special2 = 0xdf,
             Special3 = 0xf9,
             Special4 = 0xfa,
+            AnyShop = 0xfffd,       // DaggerfallUnity: all valid shop types
             AnyHouse = 0xfffe,      // DaggerfallUnity: all valid house types
             AllValid = 0xffff,      // DaggerfallUnity: all valid types
         }

--- a/Assets/Scripts/Game/Questing/Actions/Climate.cs
+++ b/Assets/Scripts/Game/Questing/Actions/Climate.cs
@@ -1,0 +1,114 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: kaboissonneault (kaboissonneault@gmail.com)
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using System.Text.RegularExpressions;
+using FullSerializer;
+
+using DaggerfallConnect;
+using DaggerfallConnect.Arena2;
+
+namespace DaggerfallWorkshop.Game.Questing.Actions
+{
+    /// <summary>
+    /// DFU extension action. Triggers when the player is at a location with the right climate
+    /// </summary>
+    public class Climate : ActionTemplate
+    {
+        MapsFile.Climates climate;
+        DFLocation.ClimateBaseType climateBase;
+
+        public override string Pattern
+        {
+            get
+            {
+                return @"climate (?<climate>desert|desert2|mountain|mountainwoods|rainforest|ocean|swamp|subtropical|woodlands|hauntedwoodlands)"
+                  + @"|climate (?<base>base) (?<climatebase>desert|mountain|temperate|swamp)";
+            }
+        }
+
+        public Climate(Quest parentQuest)
+                    : base(parentQuest)
+        {
+            IsTriggerCondition = true;
+        }
+
+        public override IQuestAction CreateNew(string source, Quest parentQuest)
+        {
+            // Source must match pattern
+            Match match = Test(source);
+            if (!match.Success)
+                return null;
+
+            // Factory new action
+            Climate action = new Climate(parentQuest);
+            if (!string.IsNullOrEmpty(match.Groups["base"].Value))
+            {
+                if (!Enum.TryParse(match.Groups["climatebase"].Value, true /*ignore case*/, out action.climateBase))
+                {
+                    throw new Exception("Climate: Syntax is 'climate base desert|mountain|temperate|swamp'");
+                }
+            }
+            else
+            {
+                action.climateBase = DFLocation.ClimateBaseType.None;
+                if (!Enum.TryParse(match.Groups["climate"].Value, true /*ignore case*/, out action.climate))
+                {
+                    throw new Exception("Climate: Syntax is 'climate desert|desert2|mountain|mountainwoods|rainforest|ocean|swamp|subtropical|woodlands|hauntedwoodlands'");
+                }
+            }
+
+            return action;
+        }
+
+        public override bool CheckTrigger(Task caller)
+        {
+            if (climateBase != DFLocation.ClimateBaseType.None)
+            {
+                return GameManager.Instance.PlayerGPS.ClimateSettings.ClimateType == climateBase;
+            }
+            else
+            {
+                return GameManager.Instance.PlayerGPS.ClimateSettings.WorldClimate == (int)climate;
+            }
+        }
+
+        #region Serialization
+
+        [fsObject("v1")]
+        public struct SaveData_v1
+        {
+            public MapsFile.Climates climate;
+            public DFLocation.ClimateBaseType climateBase;
+        }
+
+        public override object GetSaveData()
+        {
+            SaveData_v1 data = new SaveData_v1();
+            data.climate = climate;
+            data.climateBase = climateBase;
+
+            return data;
+        }
+
+        public override void RestoreSaveData(object dataIn)
+        {
+            if (dataIn == null)
+                return;
+
+            SaveData_v1 data = (SaveData_v1)dataIn;
+            climate = data.climate;
+            climateBase = data.climateBase;
+        }
+        #endregion
+
+    }
+}

--- a/Assets/Scripts/Game/Questing/Actions/Climate.cs
+++ b/Assets/Scripts/Game/Questing/Actions/Climate.cs
@@ -39,6 +39,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                     : base(parentQuest)
         {
             IsTriggerCondition = true;
+            IsAlwaysOnTriggerCondition = true;
         }
 
         public override IQuestAction CreateNew(string source, Quest parentQuest)

--- a/Assets/Scripts/Game/Questing/Actions/Climate.cs.meta
+++ b/Assets/Scripts/Game/Questing/Actions/Climate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 585b02501961f0240ae6c3ed580d9db5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Questing/Actions/Season.cs
+++ b/Assets/Scripts/Game/Questing/Actions/Season.cs
@@ -1,0 +1,86 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: kaboissonneault (kaboissonneault@gmail.com)
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using System.Text.RegularExpressions;
+using FullSerializer;
+
+using DaggerfallWorkshop.Utility;
+
+namespace DaggerfallWorkshop.Game.Questing
+{
+    /// <summary>
+    /// DFU extension action. Triggers when the calendar is at the right season
+    /// </summary>
+    public class Season : ActionTemplate
+    {
+        DaggerfallDateTime.Seasons season;
+
+        public override string Pattern
+        {
+            get { return @"season (?<season>fall|summer|spring|winter)"; }
+        }
+
+        public Season(Quest parentQuest)
+                    : base(parentQuest)
+        {
+            IsTriggerCondition = true;
+        }
+
+        public override IQuestAction CreateNew(string source, Quest parentQuest)
+        {
+            // Source must match pattern
+            Match match = Test(source);
+            if (!match.Success)
+                return null;
+
+            // Factory new action
+            Season action = new Season(parentQuest);
+            if (!Enum.TryParse(match.Groups["season"].Value, true /*ignore case*/, out action.season))
+            {
+                throw new Exception("Season: Syntax is 'season fall|summer|spring|winter'");
+            }
+
+            return action;
+        }
+
+        public override bool CheckTrigger(Task caller)
+        {
+            return DaggerfallUnity.Instance.WorldTime.Now.SeasonValue == season;
+        }
+
+        #region Serialization
+
+        [fsObject("v1")]
+        public struct SaveData_v1
+        {
+            public DaggerfallDateTime.Seasons season;
+        }
+
+        public override object GetSaveData()
+        {
+            SaveData_v1 data = new SaveData_v1();
+            data.season = season;
+
+            return data;
+        }
+
+        public override void RestoreSaveData(object dataIn)
+        {
+            if (dataIn == null)
+                return;
+
+            SaveData_v1 data = (SaveData_v1)dataIn;
+            season = data.season;
+        }
+        #endregion
+    }
+}

--- a/Assets/Scripts/Game/Questing/Actions/Season.cs
+++ b/Assets/Scripts/Game/Questing/Actions/Season.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Game.Questing
                     : base(parentQuest)
         {
             IsTriggerCondition = true;
+            IsAlwaysOnTriggerCondition = true;
         }
 
         public override IQuestAction CreateNew(string source, Quest parentQuest)

--- a/Assets/Scripts/Game/Questing/Actions/Season.cs.meta
+++ b/Assets/Scripts/Game/Questing/Actions/Season.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20286df77300f0646b659e06b04546df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Questing/Actions/TrainPc.cs
+++ b/Assets/Scripts/Game/Questing/Actions/TrainPc.cs
@@ -1,0 +1,115 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: kaboissonneault (kaboissonneault@gmail.com)
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using System.Text.RegularExpressions;
+using FullSerializer;
+
+using DaggerfallConnect;
+using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.UserInterfaceWindows;
+using DaggerfallWorkshop.Utility;
+
+
+namespace DaggerfallWorkshop.Game.Questing
+{
+    class TrainPc : ActionTemplate
+    {
+        DFCareer.Skills skill;
+
+        public override string Pattern
+        {
+            get { return @"train pc (?<skillName>\w+)"; }
+        }
+
+        public TrainPc(Quest parentQuest)
+            : base(parentQuest)
+        {
+            allowRearm = false;
+        }
+
+        public override IQuestAction CreateNew(string source, Quest parentQuest)
+        {
+            // Source must match pattern
+            Match match = Test(source);
+            if (!match.Success)
+                return null;
+
+            // Factory new action
+            TrainPc action = new TrainPc(parentQuest);
+            string skillName = match.Groups["skillName"].Value;
+            if (!Enum.IsDefined(typeof(DFCareer.Skills), skillName))
+            {
+                SetComplete();
+                throw new Exception(string.Format("TrainPc: Skill name {0} is not a known Daggerfall skill", skillName));
+            }
+            action.skill = (DFCareer.Skills)Enum.Parse(typeof(DFCareer.Skills), skillName);
+
+            return action;
+        }
+
+        public override void Update(Task caller)
+        {
+            base.Update(caller);
+
+            // Quest successful
+            ParentQuest.QuestSuccess = true;
+
+            // Show quest complete message
+            DaggerfallMessageBox messageBox = ParentQuest.ShowMessagePopup((int)QuestMachine.QuestMessages.QuestComplete);
+
+            // Schedule loot window to open when player dismisses message
+            messageBox.OnClose += QuestCompleteMessage_OnClose;
+
+            SetComplete();
+        }
+
+        private void QuestCompleteMessage_OnClose()
+        {
+            PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+
+            // Train the skill, for free
+            DaggerfallDateTime now = DaggerfallUnity.Instance.WorldTime.Now;
+            playerEntity.TimeOfLastSkillTraining = now.ToClassicDaggerfallTime();
+            now.RaiseTime(DaggerfallDateTime.SecondsPerHour * 3);
+            playerEntity.DecreaseFatigue(PlayerEntity.DefaultFatigueLoss * 180);
+            int skillAdvancementMultiplier = DaggerfallSkills.GetAdvancementMultiplier(skill);
+            short tallyAmount = (short)(UnityEngine.Random.Range(10, 20 + 1) * skillAdvancementMultiplier);
+            playerEntity.TallySkill(skill, tallyAmount);
+        }
+
+        #region Serialization 
+        [fsObject("v1")]
+        public struct SaveData_v1
+        {
+            public int skill;
+        }
+
+        public override object GetSaveData()
+        {
+            SaveData_v1 data = new SaveData_v1();
+            data.skill = (int)skill;
+
+            return data;
+        }
+
+        public override void RestoreSaveData(object dataIn)
+        {
+            if (dataIn == null)
+                return;
+
+            SaveData_v1 data = (SaveData_v1)dataIn;
+            skill = (DFCareer.Skills)data.skill;
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Game/Questing/Actions/TrainPc.cs.meta
+++ b/Assets/Scripts/Game/Questing/Actions/TrainPc.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8786555a30490d42aed0bbb5bac4d1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Questing/Actions/Weather.cs
+++ b/Assets/Scripts/Game/Questing/Actions/Weather.cs
@@ -1,0 +1,109 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: kaboissonneault (kaboissonneault@gmail.com)
+// Contributors:    
+// 
+// Notes:
+//
+
+using System;
+using System.Text.RegularExpressions;
+using FullSerializer;
+
+using DaggerfallWorkshop.Game.Weather;
+
+namespace DaggerfallWorkshop.Game.Questing.Actions
+{
+    /// <summary>
+    /// DFU extension action. Triggers when the current weather matches the condition
+    /// </summary>
+    public class Weather : ActionTemplate
+    {
+        WeatherType weather;
+
+        public override string Pattern
+        {
+            get { return @"weather (?<weather>sunny|cloudy|overcast|fog|rain|thunder|snow)"; }
+        }
+
+        public Weather(Quest parentQuest)
+                    : base(parentQuest)
+        {
+            IsTriggerCondition = true;
+        }
+
+        public override IQuestAction CreateNew(string source, Quest parentQuest)
+        {
+            // Source must match pattern
+            Match match = Test(source);
+            if (!match.Success)
+                return null;
+
+            // Factory new action
+            Weather action = new Weather(parentQuest);
+            if (!Enum.TryParse(match.Groups["weather"].Value, true /*ignore case*/, out action.weather))
+            {
+                throw new Exception("Weather: Syntax is 'weather sunny|cloudy|overcast|fog|rain|thunder|snow'");
+            }
+
+            return action;
+        }
+
+        public override bool CheckTrigger(Task caller)
+        {
+            WeatherManager WeatherManager = GameManager.Instance.WeatherManager;
+            switch (weather)
+            {
+                case WeatherType.Sunny:
+                    return !WeatherManager.IsRaining && !WeatherManager.IsOvercast && !WeatherManager.IsStorming && !WeatherManager.IsSnowing
+                        && WeatherManager.currentOutdoorFogSettings.density == WeatherManager.SunnyFogSettings.density;
+                case WeatherType.Cloudy:
+                    return false; // TODO: weather not implemented in the weather manager
+                case WeatherType.Overcast:
+                    return WeatherManager.IsOvercast && WeatherManager.currentOutdoorFogSettings.density != WeatherManager.HeavyFogSettings.density
+                        && !WeatherManager.IsRaining && !WeatherManager.IsStorming && !WeatherManager.IsSnowing;
+                case WeatherType.Fog:
+                    return WeatherManager.IsOvercast && WeatherManager.currentOutdoorFogSettings.density == WeatherManager.HeavyFogSettings.density
+                        && !WeatherManager.IsStorming && !WeatherManager.IsSnowing;
+                case WeatherType.Rain:
+                    return WeatherManager.IsRaining && !WeatherManager.IsStorming && !WeatherManager.IsSnowing;
+                case WeatherType.Thunder:
+                    return WeatherManager.IsStorming && !WeatherManager.IsSnowing;
+                case WeatherType.Snow:
+                    return WeatherManager.IsSnowing;
+                default:
+                    throw new Exception("Weather: unexpected weather type");
+            }
+        }
+
+        #region Serialization
+
+        [fsObject("v1")]
+        public struct SaveData_v1
+        {
+            public WeatherType weather;
+        }
+
+        public override object GetSaveData()
+        {
+            SaveData_v1 data = new SaveData_v1();
+            data.weather = weather;
+
+            return data;
+        }
+
+        public override void RestoreSaveData(object dataIn)
+        {
+            if (dataIn == null)
+                return;
+
+            SaveData_v1 data = (SaveData_v1)dataIn;
+            weather = data.weather;
+        }
+        #endregion
+
+    }
+}

--- a/Assets/Scripts/Game/Questing/Actions/Weather.cs
+++ b/Assets/Scripts/Game/Questing/Actions/Weather.cs
@@ -33,6 +33,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                     : base(parentQuest)
         {
             IsTriggerCondition = true;
+            IsAlwaysOnTriggerCondition = true;
         }
 
         public override IQuestAction CreateNew(string source, Quest parentQuest)

--- a/Assets/Scripts/Game/Questing/Actions/Weather.cs.meta
+++ b/Assets/Scripts/Game/Questing/Actions/Weather.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e262608734e1d5046918785b20e21f6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -592,15 +592,11 @@ namespace DaggerfallWorkshop.Game.Questing
         static readonly int[] validHouseTypes = { 17, 18, 19, 20 };
         static readonly int[] validShopTypes = { 0, 2, 5, 6, 7, 8, 9, 12, 13 }; // not including bank and library
 
-        public static bool IsPlayerAtPlaceType(int p1, int p2, int p3)
+        public static bool IsPlayerAtBuildingType(int p2, int p3)
         {
             // Get component handling player world status and transitions
             PlayerEnterExit playerEnterExit = GameManager.Instance.PlayerEnterExit;
             if (!playerEnterExit)
-                return false;
-
-            // Only support building types for now
-            if (p1 != 0)
                 return false;
 
             if (!playerEnterExit.IsPlayerInsideBuilding)
@@ -620,7 +616,7 @@ namespace DaggerfallWorkshop.Game.Questing
                     case 2: // shop
                         return validShopTypes.Contains(buildingType);
                     default: // unhandled
-                        Debug.LogWarning($"Unhandled building type: p1={p1}, p2={p2}, p3={p3}");
+                        Debug.LogWarning($"Unhandled building type: p1=0, p2={p2}, p3={p3}");
                         return false;
                 }
             }

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -569,6 +569,9 @@ namespace DaggerfallWorkshop.Game.Questing
             }
         }
 
+        static readonly int[] validBuildingTypes = { 0, 2, 3, 5, 6, 8, 9, 11, 12, 13, 14, 15, 17, 18, 19, 20 };
+        static readonly int[] validHouseTypes = { 17, 18, 19, 20 };
+        static readonly int[] validShopTypes = { 0, 2, 5, 6, 7, 8, 9, 12, 13 }; // not including bank and library
         #endregion
 
         #region Local Site Methods
@@ -601,6 +604,8 @@ namespace DaggerfallWorkshop.Game.Questing
                 foundSites = CollectQuestSitesOfBuildingType(location, DFLocation.BuildingTypes.AllValid, p3);
             else if (p2 == -1 && p3 == 1)
                 foundSites = CollectQuestSitesOfBuildingType(location, DFLocation.BuildingTypes.AnyHouse, p3);
+            else if (p2 == -1 && p3 == 2)
+                foundSites = CollectQuestSitesOfBuildingType(location, DFLocation.BuildingTypes.AnyShop, p3);
             else
                 foundSites = CollectQuestSitesOfBuildingType(location, (DFLocation.BuildingTypes)p2, p3);
 
@@ -1024,10 +1029,6 @@ namespace DaggerfallWorkshop.Game.Questing
         /// </summary>
         SiteDetails[] CollectQuestSitesOfBuildingType(DFLocation location, DFLocation.BuildingTypes buildingType, int guildHallFaction)
         {
-            // Valid building types for valid search
-            int[] validBuildingTypes = { 0, 2, 3, 5, 6, 8, 9, 11, 12, 13, 14, 15, 17, 18, 19, 20 };
-            int[] validHouseTypes = { 17, 18, 19, 20 };
-
             List<SiteDetails> foundSites = new List<SiteDetails>();
 
             // Get sites already involved in active quests and this quest so far
@@ -1071,6 +1072,18 @@ namespace DaggerfallWorkshop.Game.Questing
                                 {
                                     wildcardFound = true;
                                     wildcardType = (DFLocation.BuildingTypes)validHouseTypes[j];
+                                    break;
+                                }
+                            }
+                        }
+                        else if (buildingType == DFLocation.BuildingTypes.AnyShop)
+                        {
+                            for (int j = 0; j < validShopTypes.Length; j++)
+                            {
+                                if (validShopTypes[j] == (int)buildingSummary[i].BuildingType)
+                                {
+                                    wildcardFound = true;
+                                    wildcardType = (DFLocation.BuildingTypes)validShopTypes[j];
                                     break;
                                 }
                             }

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -346,6 +346,9 @@ namespace DaggerfallWorkshop.Game.Questing
             RegisterAction(new TotingItemAndClickedNpc(null));
             RegisterAction(new DailyFrom(null));
             RegisterAction(new DroppedItemAtPlace(null));
+            RegisterAction(new Season(null));
+            RegisterAction(new Actions.Weather(null));
+            RegisterAction(new Climate(null));
 
             // Register default actions
             RegisterAction(new EndQuest(null));
@@ -411,6 +414,7 @@ namespace DaggerfallWorkshop.Game.Questing
             RegisterAction(new SetPlayerCrime(null));
             RegisterAction(new SpawnCityGuards(null));
             RegisterAction(new UnrestrainFoe(null));
+            RegisterAction(new TrainPc(null));
 
             // Raise event for custom actions to be registered
             RaiseOnRegisterCustomerActionsEvent();

--- a/Assets/StreamingAssets/Tables/Quests-Places.txt
+++ b/Assets/StreamingAssets/Tables/Quests-Places.txt
@@ -102,6 +102,7 @@ house4,             0, 20, 0
 house5,             0, 21, 0
 house6,             0, 22, 0
 house7,             0, 23, 0
+shop,               0, -1, 2
 house,              0, -1, 1
 random,             0, -1, 0
 dungeon,            1, -1, 0


### PR DESCRIPTION
Added "weather", "season", and "climate" quest trigger conditions, and "train pc" quest action.

I was originally going to keep this as a mod since I made them for a modder, but after he shared his results, other people said they wanted those quest actions too, so might as well share it here.

The syntaxes are:
- weather sunny|cloudy|overcast|fog|rain|thunder|snow
- season fall|summer|spring|winter
- climate desert|desert2|mountain|mountainwoods|rainforest|ocean|swamp|subtropical|woodlands|hauntedwoodlands
- climate base desert|mountain|temperate|swamp
- train pc <skillName>

Note: "train pc" uses the same formula as the default training window, except it's free. It works like quest rewards, and therefore works after ending the quest (with the quest end message).

@rossipaolo Are you the one maintaining the VS Code plugin for quests? You might want to keep an eye on this 