### PR TITLE
Added a TextAssetReader Merge for SPELLS.STD spell records

### DIFF
--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -16,7 +16,6 @@ using System.Linq;
 using System.Collections.Generic;
 using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
-using DaggerfallConnect.Save;
 using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.Serialization;
@@ -790,25 +789,12 @@ namespace DaggerfallWorkshop.Game.Entity
             if (otherSpellbook == null || otherSpellbook.Length == 0)
                 return;
 
+            // Migrate from old spell icon index
+            // The old icon index will be changed into a SpellIcon with a null pack key
             for (int i = 0; i < otherSpellbook.Length; i++)
             {
-                ref EffectBundleSettings bundleSettings = ref otherSpellbook[i];
-
-                // Migrate from old spell icon index
-                // The old icon index will be changed into a SpellIcon with a null pack key
-                if (string.IsNullOrEmpty(bundleSettings.Icon.key) && bundleSettings.Icon.index == 0)
-                    bundleSettings.Icon.index = bundleSettings.IconIndex;
-
-                // Our spell records might have changed since last load because of mods. Reassing spells based on standard spells
-                if(bundleSettings.StandardSpellIndex.HasValue)
-                {
-                    int spellIndex = bundleSettings.StandardSpellIndex.Value;
-                    if(GameManager.Instance.EntityEffectBroker.GetClassicSpellRecord(spellIndex, out SpellRecord.SpellRecordData spell))
-                    {
-                        if (!GameManager.Instance.EntityEffectBroker.ClassicSpellRecordDataToEffectBundleSettings(spell, bundleSettings.BundleType, out bundleSettings))
-                            Debug.LogError($"Failed to update spell bundle '{bundleSettings.Name}'");
-                    }
-                }
+                if (string.IsNullOrEmpty(otherSpellbook[i].Icon.key) && otherSpellbook[i].Icon.index == 0)
+                    otherSpellbook[i].Icon.index = otherSpellbook[i].IconIndex;
             }
 
             spellbook.AddRange(otherSpellbook);

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -861,6 +861,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                 Name = spellRecordData.spellName,
                 IconIndex = spellRecordData.icon,
                 Icon = new SpellIcon(),
+                StandardSpellIndex = spellRecordData.index, 
             };
             effectBundleSettingsOut.Icon.index = effectBundleSettingsOut.IconIndex;
 

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -21,6 +21,7 @@ using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop.Game.MagicAndEffects
 {
@@ -55,7 +56,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         readonly Dictionary<int, string> classicEffectMapping = new Dictionary<int, string>();
         readonly Dictionary<string, BaseEntityEffect> magicEffectTemplates = new Dictionary<string, BaseEntityEffect>();
         readonly Dictionary<int, BaseEntityEffect> potionEffectTemplates = new Dictionary<int, BaseEntityEffect>();
-        readonly Dictionary<int, SpellRecord.SpellRecordData> classicSpells = new Dictionary<int, SpellRecord.SpellRecordData>();
+        readonly Dictionary<int, SpellRecord.SpellRecordData> standardSpells = new Dictionary<int, SpellRecord.SpellRecordData>();
         readonly Dictionary<string, CustomSpellBundleOffer> customSpellBundleOffers = new Dictionary<string, CustomSpellBundleOffer>();
 
         #endregion
@@ -78,6 +79,14 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// This flag is lowered at the end of each magic update.
         /// </summary>
         public bool SyntheticTimeIncrease { get; private set; }
+
+        /// <summary>
+        /// The list of standard spells (aka circinate spells), taken from SPELLS.STD and potentially modified (or added to) by mods
+        /// </summary>
+        public IEnumerable<SpellRecord.SpellRecordData> StandardSpells
+        {
+            get { return standardSpells.Values; }
+        }
 
         #endregion
 
@@ -692,9 +701,9 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// <returns>True if spell found, otherwise false.</returns>
         public bool GetClassicSpellRecord(int id, out SpellRecord.SpellRecordData spellOut)
         {
-            if (classicSpells.ContainsKey(id))
+            if (standardSpells.ContainsKey(id))
             {
-                spellOut = classicSpells[id];
+                spellOut = standardSpells[id];
                 return true;
             }
 
@@ -711,20 +720,21 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         /// </summary>
         void RebuildClassicSpellsDict()
         {
-            classicSpells.Clear();
+            standardSpells.Clear();
 
             List<SpellRecord.SpellRecordData> spells = DaggerfallSpellReader.ReadSpellsFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, DaggerfallSpellReader.DEFAULT_FILENAME));
+            TextAssetReader.Merge(spells, "SpellRecords.json", (record, data) => record.index == data["index"].AsInt64);
             foreach (SpellRecord.SpellRecordData spell in spells)
             {
                 // "Holy Touch" and "Holy Word" have same ID but different properties
                 // Not sure of best way to handle - just ignoring duplicate for now
-                if (classicSpells.ContainsKey(spell.index))
+                if (standardSpells.ContainsKey(spell.index))
                 {
                     //Debug.LogErrorFormat("RebuildClassicSpellsDict found duplicate key {0} for spell {1}. Existing spell={2}", spell.index, spell.spellName, classicSpells[spell.index].spellName);
                     continue;
                 }
 
-                classicSpells.Add(spell.index, spell);
+                standardSpells.Add(spell.index, spell);
             }
         }
 
@@ -919,14 +929,14 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             {
                 effectSettings.DurationBase = effectRecordData.durationBase;
                 effectSettings.DurationPlus = effectRecordData.durationMod;
-                effectSettings.DurationPerLevel = effectRecordData.durationPerLevel;
+                effectSettings.DurationPerLevel = Math.Max(effectRecordData.durationPerLevel, 1);
             }
 
             if (supportChance)
             {
                 effectSettings.ChanceBase = effectRecordData.chanceBase;
                 effectSettings.ChancePlus = effectRecordData.chanceMod;
-                effectSettings.ChancePerLevel = effectRecordData.chancePerLevel;
+                effectSettings.ChancePerLevel = Math.Max(effectRecordData.chancePerLevel, 1);
             }
 
             if (supportMagnitude)
@@ -935,7 +945,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                 effectSettings.MagnitudeBaseMax = effectRecordData.magnitudeBaseHigh;
                 effectSettings.MagnitudePlusMin = effectRecordData.magnitudeLevelBase;
                 effectSettings.MagnitudePlusMax = effectRecordData.magnitudeLevelHigh;
-                effectSettings.MagnitudePerLevel = effectRecordData.magnitudePerLevel;
+                effectSettings.MagnitudePerLevel = Math.Max(effectRecordData.magnitudePerLevel, 1);
             }
 
             return effectSettings;

--- a/Assets/Scripts/Game/MagicAndEffects/MagicAndEffectsStructs.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/MagicAndEffectsStructs.cs
@@ -153,6 +153,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public string Tag;
         public EffectEntry[] Effects;
         public LegacyEffectEntry[] LegacyEffects;
+        public int? StandardSpellIndex;
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -283,18 +283,21 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             // Load spells for sale
             offeredSpells.Clear();
-            List<SpellRecord.SpellRecordData> standardSpells = DaggerfallSpellReader.ReadSpellsFile(Path.Combine(DaggerfallUnity.Arena2Path, spellsFilename));
-            if (standardSpells == null || standardSpells.Count == 0)
+
+            var effectBroker = GameManager.Instance.EntityEffectBroker;
+
+            IEnumerable<SpellRecord.SpellRecordData> standardSpells = effectBroker.StandardSpells;
+            if (standardSpells == null || standardSpells.Count() == 0)
             {
                 Debug.LogError("Failed to load SPELLS.STD for spellbook in buy mode.");
                 return;
             }
 
             // Add standard spell bundles to offer
-            for (int i = 0; i < standardSpells.Count; i++)
+            foreach(SpellRecord.SpellRecordData standardSpell in standardSpells)
             {
                 // Filter internal spells starting with exclamation point '!'
-                if (standardSpells[i].spellName.StartsWith("!"))
+                if (standardSpell.spellName.StartsWith("!"))
                     continue;
 
                 // NOTE: Classic allows purchase of duplicate spells
@@ -303,7 +306,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 // Get effect bundle settings from classic spell
                 EffectBundleSettings bundle;
-                if (!GameManager.Instance.EntityEffectBroker.ClassicSpellRecordDataToEffectBundleSettings(standardSpells[i], BundleTypes.Spell, out bundle))
+                if (!effectBroker.ClassicSpellRecordDataToEffectBundleSettings(standardSpell, BundleTypes.Spell, out bundle))
                     continue;
 
                 // Store offered spell and add to list box
@@ -311,7 +314,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
 
             // Add custom spells for sale bundles to list of offered spells
-            offeredSpells.AddRange(GameManager.Instance.EntityEffectBroker.GetCustomSpellBundles(EntityEffectBroker.CustomSpellBundleOfferUsage.SpellsForSale));
+            offeredSpells.AddRange(effectBroker.GetCustomSpellBundles(EntityEffectBroker.CustomSpellBundleOfferUsage.SpellsForSale));
 
             // Sort spells for easier finding
             offeredSpells = offeredSpells.OrderBy(x => x.Name).ToList();


### PR DESCRIPTION
Summary:
- Added a TextAssetReader Merge for SPELLS.STD spell records through a "SpellRecords.json" file, similar to "ItemTemplates.json". 
- Ensured the DaggerfallSpellBookWindow uses the modded standard spells rather than reading SPELLS.STD directly.

So, as part of my magic modding, I started feeling the need to replace the "classic" (aka circinate) spells. Those spells are sold by spell vendors, and are part of potions and enchanted items. As one starts tweaking spell costs for spell effects, they suddenly find the need to tweak those spell bundles too.

I looked into the existing work, and I found only the "custom bundle" in EntityEffectBroker. However, this can only add new spells, and the work seems incomplete (ex: see TODO in CastWhenUsed.EnchantmentPayloadCallback).

I thought the TextAssetReader Merge used for ItemTemplates was simple enough and essentially only requires 1 line of code to work.

However, there's some points to consider:
- Changing the `effects` field is an all-or-nothing kind of deal. You can't just change the `magnitudeBaseLow` of one effect, you have to copy-paste the entire array of effects with all its relevant fields. However, few spells have more than one effect, so it's not that much of a problem for most spells
- EffectRecordData fields that aren't specified in the JSON are going to default to 0, rather than 1 or -1 as expected for certain fields. I had to go and ensure modders wouldn't accidentally cause issues in the code by leaving a field as 0. `descriptionTextIndex` and `spellMakerTextIndex` are unused, so not an issue, The effect attributes (duration, chance, magnitude) can be at 0 just fine, except I ensured the "per level" value sent to EffectSettings was at least 1 to avoid divisions by 0. The only one that concerns me is `subType` for effect types that don't have variants: for the most part, 0 should have the same effect as -1, but I hope I'm not forgetting anything
- Changing the length of `effects` from 3 to 1 or 2 does not cause any issues from my testing, as all places that use the effects of SpellRecordData use `spellRecordData.effects.Length` rather than assuming a size of 3.
- This approach "accidentally" lets users create new spells, by using an unused index. I'm only pointing this out because there's already a system to add new spells, the "custom bundle" I mentioned above. Spells created this way properly appear in the spell vendor, and don't appear in the item maker.
- A mod that changes a spell won't change a spell already written in the player's Spellbook. I'm not sure it's possible to fix this, since spellbook entries don't track the spell record they were created from, I believe?

Anyway, I believe letting mods tweak classic spells this way will be useful in general. For example, many players find poisons way too strong, and this change would allow a modder to change its effects.
