### PR TITLE
Connect N0000055.RDB disconnected parts

### DIFF
--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -547,6 +547,19 @@ namespace DaggerfallConnect.Arena2
                 ReadRdbUnknownLinkedList(reader, block);
                 ReadRdbObjectSectionRootList(reader, block);
                 ReadRdbObjectLists(reader, block);
+
+                // Hack for N0000055.RDB to connect some disconnected parts.
+                // This should hopefully fix all block combinations issues.
+                if (block == 978)
+                {
+                    // Change a corner to a T block
+                    blocks[block].DFBlock.RdbBlock.ObjectRootList[1].RdbObjects[12].Resources.ModelResource.ModelIndex = 12;
+                    blocks[block].DFBlock.RdbBlock.ObjectRootList[1].RdbObjects[12].Resources.ModelResource.YRotation = 512;
+                    // Change a dead end to an open corridor
+                    blocks[block].DFBlock.RdbBlock.ObjectRootList[1].RdbObjects[9].Resources.ModelResource.ModelIndex = 3;
+                    // Move a random monster to another place since there is already one nearby
+                    blocks[block].DFBlock.RdbBlock.ObjectRootList[1].RdbObjects[30].ZPos = 896;
+                }
             }
             else if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rdi)
             {


### PR DESCRIPTION
Fix potential combination issues with this block, for example in Ruins of Kinghouse Grange, Glenpoint, as reported by @petchema 
: http://forums.dfworkshop.net/viewtopic.php?p=52821&sid=5a152a9109cc38760fd7b4ecb2b34853#p52821

I also moved a random monster to another corner.

Before the fix:
![n0000055-before](https://user-images.githubusercontent.com/46795115/119203271-f39bd600-ba92-11eb-8c34-ba274d0429e8.png)

After:
![n0000055-after](https://user-images.githubusercontent.com/46795115/119203282-f7c7f380-ba92-11eb-8bd7-fac59d3c1997.png)
