### PR TITLE
Fixed ArgumentOutOfRangeException on loading game with new dungeon models

### DIFF
--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -2305,7 +2305,9 @@ namespace DaggerfallWorkshop.Game
 
         void UpdateMeshRendererDungeonState(MeshRenderer meshRenderer, AutomapDungeonState automapDungeonState, int indexBlock, int indexElement, int indexModel, bool forceNotVisitedInThisRun)
         {
-            if (automapDungeonState.blocks[indexBlock].blockElements[indexElement].models[indexModel].discovered == true)
+            if ((indexBlock < automapDungeonState.blocks.Count) && (indexElement < automapDungeonState.blocks[indexBlock].blockElements.Count) &&
+                (indexModel < automapDungeonState.blocks[indexBlock].blockElements[indexElement].models.Count) &&
+                (automapDungeonState.blocks[indexBlock].blockElements[indexElement].models[indexModel].discovered == true))
             {
                 meshRenderer.enabled = true;
 


### PR DESCRIPTION
I have noticed that if you load a save that was made inside a dungeon after installing a modified dungeon block override that adds new models, you can get an `ArgumentOutOfRangeException` if the dungeon you are in uses any of those overrides. This exception also causes other issues. The most serious I've noticed is that if you try to load the same save again after getting that exception, another exception is triggered and the game loads to a black screen.

I believe that the cause of this is that after creating the dungeon's automap models, the game iterates through each model in the block's automap and checks it's status against the save game's `AutomapData.txt`. The problem is that if the block has had new models added to it, the game will try to load an entry in the TXT file that doesn't exist, triggering the exception.

You can reproduce this issue with the files I have attached. The W0000018.RDB.json adds a new corridor model to the dungeon and the attached save was made before this model was added. 


[Save.zip](https://github.com/Interkarma/daggerfall-unity/files/6525313/Save.zip)
[W0000018.RDB.zip](https://github.com/Interkarma/daggerfall-unity/files/6525315/W0000018.RDB.zip)

