### PR TITLE
Add a runtime method to fix invalid RDB blocks

### DIFF
--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -494,6 +494,130 @@ namespace DaggerfallConnect.Arena2
             return found;
         }
 
+        /// <summary>
+        /// Fix invalid RDB data that prevents access to other dungeon blocks in some cases:
+        /// N0000071.RDB: connect the lower western dead-end to the rest of the block
+        /// W0000009.RDB: move the exit to another corner (classic applies another but less clean trick)
+        /// W0000018.RDB: connect the upper rooms together and fix a wrong door model
+        /// N0000071.RDB: connect the lower western dead-end to the rest of the block
+        /// </summary>
+        /// <param name="block">The index of the block being read.</param>
+        private void FixRdbData(int block)
+        {
+            if (block == 994) // N0000071.RDB
+            {
+                // Connect the western dead-en to the rest of the block using a long corridor model
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[4].RdbObjects[18].Resources.ModelResource.ModelIndex = 10;
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[4].RdbObjects[18].XPos = 640;
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[5].RdbObjects[8].Resources.ModelResource.ModelIndex = 11;
+            }
+            else if (block == 1025) // W0000009.RDB
+            {
+                // Add a brick wall door model
+                ushort wallModelIndex = 0;
+                var modelList = blocks[block].DFBlock.RdbBlock.ModelReferenceList;
+                for (ushort i = 0; i < modelList.Length; ++i)
+                {
+                    // Replace the first non used model reference by the wall
+                    if (modelList[i].ModelIdNum == 0)
+                    {
+                        var model = new DFBlock.RdbModelReference
+                        {
+                            ModelId = "72100",
+                            ModelIdNum = 72100,
+                            Description = "DOR"
+                        };
+                        modelList[i] = model;
+                        wallModelIndex = i;
+                        break;
+                    }
+                }
+
+                // Replace a corner near the original exit with a model having a door
+                ref var rdbObject = ref blocks[block].DFBlock.RdbBlock.ObjectRootList[5].RdbObjects[39];
+                rdbObject.XPos += 64;
+                rdbObject.ZPos -= 64;
+                int x = rdbObject.XPos;
+                int y = rdbObject.YPos;
+                int z = rdbObject.ZPos;
+                rdbObject.Resources.ModelResource.ModelIndex = 35;
+                rdbObject.Resources.ModelResource.YRotation = -512;
+                // Move the exit to the corner door position
+                rdbObject = ref blocks[block].DFBlock.RdbBlock.ObjectRootList[8].RdbObjects[0];
+                rdbObject.XPos = x;
+                rdbObject.ZPos = z + 126;
+                // Move the start marker near the exit
+                rdbObject = ref blocks[block].DFBlock.RdbBlock.ObjectRootList[4].RdbObjects[5];
+                rdbObject.XPos = x;
+                rdbObject.ZPos = z;
+
+                // Add an wall to seal the door in case the block is not the starting one
+                var rdbObjects = new List<DFBlock.RdbObject>(blocks[block].DFBlock.RdbBlock.ObjectRootList[8].RdbObjects);
+                var wall = new DFBlock.RdbObject
+                {
+                    Index = rdbObjects.Count,
+                    XPos = x,
+                    YPos = y,
+                    ZPos = z + 128,
+                    Type = DFBlock.RdbResourceTypes.Model
+                };
+                wall.Resources.ModelResource.ModelIndex = wallModelIndex;
+                wall.Resources.ModelResource.YRotation = -512;
+                rdbObjects.Add(wall);
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[8].RdbObjects = rdbObjects.ToArray();
+            }
+            else if (block == 1034) // W0000018.RDB
+            {
+                // Change two upper corners into T junctions
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[4].RdbObjects[38].Resources.ModelResource.ModelIndex = 10;
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[4].RdbObjects[38].Resources.ModelResource.YRotation = -512;
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[5].RdbObjects[40].Resources.ModelResource.ModelIndex = 10;
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[5].RdbObjects[40].Resources.ModelResource.YRotation = -2560;
+
+                // Add a corridor to join the above junctions
+                List<DFBlock.RdbObject> rdbObjects = new List<DFBlock.RdbObject>(blocks[block].DFBlock.RdbBlock.ObjectRootList[6].RdbObjects);
+                DFBlock.RdbObject corridor = new DFBlock.RdbObject
+                {
+                    Index = rdbObjects.Count,
+                    XPos = 1152,
+                    YPos = -1792,
+                    ZPos = 1920,
+                    Type = DFBlock.RdbResourceTypes.Model
+                };
+                corridor.Resources.ModelResource.ModelIndex = 11;
+                corridor.Resources.ModelResource.YRotation = -512;
+                rdbObjects.Add(corridor);
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[6].RdbObjects = rdbObjects.ToArray();
+
+                // Fix a door
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[2].RdbObjects[0].Resources.ModelResource.ModelIndex = 23;
+            }
+            else if (block == 1036) // W0000020.RDB
+            {
+                // Replace the lower western dead-end by an open corridor
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[4].RdbObjects[15].Resources.ModelResource.ModelIndex = 5;
+
+                // Replace a nearby turn by a T junction
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[5].RdbObjects[34].Resources.ModelResource.ModelIndex = 7;
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[5].RdbObjects[34].Resources.ModelResource.YRotation = -512;
+
+                // Add a stair to join the above models
+                List<DFBlock.RdbObject> rdbObjects = new List<DFBlock.RdbObject>(blocks[block].DFBlock.RdbBlock.ObjectRootList[5].RdbObjects);
+                DFBlock.RdbObject corridor = new DFBlock.RdbObject
+                {
+                    Index = rdbObjects.Count,
+                    XPos = 1152,
+                    YPos = -384,
+                    ZPos = 1408,
+                    Type = DFBlock.RdbResourceTypes.Model
+                };
+                corridor.Resources.ModelResource.ModelIndex = 4;
+                corridor.Resources.ModelResource.YRotation = 512;
+                rdbObjects.Add(corridor);
+                blocks[block].DFBlock.RdbBlock.ObjectRootList[5].RdbObjects = rdbObjects.ToArray();
+            }
+        }
+
         #endregion
 
         #region Readers
@@ -547,6 +671,7 @@ namespace DaggerfallConnect.Arena2
                 ReadRdbUnknownLinkedList(reader, block);
                 ReadRdbObjectSectionRootList(reader, block);
                 ReadRdbObjectLists(reader, block);
+                FixRdbData(block);
             }
             else if (blocks[block].DFBlock.Type == DFBlock.BlockTypes.Rdi)
             {


### PR DESCRIPTION
This fixes the following blocks:
N0000071.RDB: connect the lower western dead-end to the rest of the block, can be checked in Ruins of Kinghouse Grange, Glenpoint
W0000009.RDB: move the exit to another corner (classic applies another but less clean trick), can be checked in The Tower of Hearthhouse, Wrothgarian Mountains
W0000018.RDB: connect the upper rooms together and fix a wrong door model, can be checked in the The Roost of Grumerus, Wayrest
W0000020.RDB: connect the lower western dead-end to the rest of the block, can also be checked in The Roost of Grumerus, Wayrest

Supersedes #2125 and #2126