### PR TITLE
Fix automap update not triggering on some occasions

### DIFF
--- a/Assets/Scripts/Game/ExteriorAutomap.cs
+++ b/Assets/Scripts/Game/ExteriorAutomap.cs
@@ -1493,9 +1493,10 @@ namespace DaggerfallWorkshop.Game
 
         private void LoadAndCreateLocationExteriorAutomap()
         {
-            if (location.Loaded && (GameManager.Instance.PlayerGPS.CurrentLocation.Name == location.Name)) // if already loaded
+            // Do nothing if already loaded
+            if (location.Loaded && GameManager.Instance.PlayerGPS.CurrentLocation.MapTableData.MapId == location.MapTableData.MapId)
             {
-                return; // do nothing
+                return;
             }
 
             UnloadLocationExteriorAutomap(); // first make sure to unload location exterior automap and destroy resources

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -290,8 +290,8 @@ namespace DaggerfallWorkshop
             DFPosition pos = CurrentMapPixel;
             if (pos.X != lastMapPixelX || pos.Y != lastMapPixelY)
             {
-                RaiseOnMapPixelChangedEvent(pos);
                 UpdateWorldInfo(pos.X, pos.Y);
+                RaiseOnMapPixelChangedEvent(pos);
 
                 // Clear non-permanent scenes from cache, unless going to/from owned ship
                 DFPosition shipCoords = DaggerfallBankManager.GetShipCoords();


### PR DESCRIPTION
Fix a regression introduced in #2100 and fix a historical issue that could happen when fast travelling to a location with the same name as the current one (for example, from Ashford Manor, Anticlere to Ashford Manor, Dwynnen).