### PR TITLE
Allow water tile conversion to be handled by terrain texture mods

### DIFF
--- a/Assets/Scripts/Terrain/TerrainHelper.cs
+++ b/Assets/Scripts/Terrain/TerrainHelper.cs
@@ -219,11 +219,13 @@ namespace DaggerfallWorkshop
         public static JobHandle ScheduleUpdateTileMapDataJob(ref MapPixelData mapPixel, JobHandle dependencies)
         {
             int tilemapDim = MapsFile.WorldMapTileDim;
+            bool convertWater = DaggerfallUnity.Instance.TerrainTexturing.ConvertWaterTiles();
             UpdateTileMapDataJob updateTileMapDataJob = new UpdateTileMapDataJob()
             {
                 tilemapData = mapPixel.tilemapData,
                 tileMap = mapPixel.tileMap,
                 tDim = tilemapDim,
+                convertWater = convertWater,
             };
             return updateTileMapDataJob.Schedule(tilemapDim * tilemapDim, 64, dependencies);
         }
@@ -335,6 +337,7 @@ namespace DaggerfallWorkshop
             public NativeArray<Color32> tileMap;
 
             public int tDim;
+            public bool convertWater;
 
             public void Execute(int index)
             {
@@ -349,7 +352,7 @@ namespace DaggerfallWorkshop
 
                 // Convert from [flip,rotate,6bit-record] => [6bit-record,flip,rotate]
                 int record;
-                if (tile == byte.MaxValue)
+                if (convertWater && tile == byte.MaxValue)
                 {   // Zeros are converted to FF so assign tiles doesn't overwrite location tiles, convert back.
                     record = 0;
                 }

--- a/Assets/Scripts/Terrain/TerrainTexturing.cs
+++ b/Assets/Scripts/Terrain/TerrainTexturing.cs
@@ -23,6 +23,9 @@ namespace DaggerfallWorkshop
     public interface ITerrainTexturing
     {
         JobHandle ScheduleAssignTilesJob(ITerrainSampler terrainSampler, ref MapPixelData mapData, JobHandle dependencies, bool march = true);
+
+        // Does the conversion of tilemapData require water tiles converting from 0xFF (the default)
+        bool ConvertWaterTiles();
     }
 
     /// <summary>
@@ -48,6 +51,11 @@ namespace DaggerfallWorkshop
         public DefaultTerrainTexturing()
         {
             CreateLookupTable();
+        }
+
+        public virtual bool ConvertWaterTiles()
+        {
+            return true;
         }
 
         public virtual JobHandle ScheduleAssignTilesJob(ITerrainSampler terrainSampler, ref MapPixelData mapData, JobHandle dependencies, bool march = true)

--- a/Assets/Scripts/Terrain/TerrainTexturing.cs
+++ b/Assets/Scripts/Terrain/TerrainTexturing.cs
@@ -22,10 +22,11 @@ namespace DaggerfallWorkshop
     /// </summary>
     public interface ITerrainTexturing
     {
-        JobHandle ScheduleAssignTilesJob(ITerrainSampler terrainSampler, ref MapPixelData mapData, JobHandle dependencies, bool march = true);
-
         // Does the conversion of tilemapData require water tiles converting from 0xFF (the default)
         bool ConvertWaterTiles();
+
+        // Schedule the terrain tile generation and assignment jobs
+        JobHandle ScheduleAssignTilesJob(ITerrainSampler terrainSampler, ref MapPixelData mapData, JobHandle dependencies, bool march = true);
     }
 
     /// <summary>


### PR DESCRIPTION
This does change the interface, but almost all implementation extend from the default and will inherit the new method. I will assist any that I've missed.