### PR TITLE
Preserve rumors line breaks on bulletin boards

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -665,15 +665,15 @@ namespace DaggerfallWorkshop.Game
             };
 
             // formatting message is split into 2 parts, depending whether we got any news or not.
-            if (bulletinBoardMessage != string.Empty)
+            if (bulletinBoardMessage != null)
             {
                 tokens.AddRange(new List<TextFile.Token>
                 {
                     new TextFile.Token(TextFile.Formatting.NewLineOffset, null),
                     new TextFile.Token(TextFile.Formatting.Text, string.Empty),
                     new TextFile.Token(TextFile.Formatting.NewLineOffset, null),
-                    new TextFile.Token(TextFile.Formatting.Text, bulletinBoardMessage),
                 });
+                tokens.AddRange(bulletinBoardMessage);
             }
 
             // Display message

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -1289,14 +1289,12 @@ namespace DaggerfallWorkshop.Game
             return question;
         }
 
-        public string GetNewsOrRumorsForBulletinBoard()
+        public TextFile.Token[] GetNewsOrRumorsForBulletinBoard()
         {
-            string news = string.Empty;
-
             List<RumorMillEntry> validRumors = GetValidRumors(true);
 
             if (validRumors.Count == 0)
-                return news;
+                return null;
 
             // Simply use first rumor available
             RumorMillEntry validRumor = validRumors.FirstOrDefault(x => x.rumorType == RumorType.CommonRumor);
@@ -1318,10 +1316,10 @@ namespace DaggerfallWorkshop.Game
                 MacroHelper.SetFactionIdsAndRegionID(validRumor.faction1, validRumor.faction2, regionID);
                 MacroHelper.ExpandMacros(ref tokens, this);
                 MacroHelper.SetFactionIdsAndRegionID(-1, -1, -1); // Reset again so %reg macro may resolve to current region if needed
-                news = TokensToString(tokens, false);
+                return tokens;
             }
 
-            return news;
+            return null;
         }
 
         public string GetNewsOrRumors()


### PR DESCRIPTION

Keep the line breaks from rumors for display on town bulletinboards; It's not guaranteed to be perfectly formatted, but is better than current concatenated text on one line. It's also most likely a step in the right direction for text adjustment to display width, since it preserves text as text tokens.

By the way I had a hard time testing to PR, I found few towns with rumors
![2021_06_02_11_22_50](https://user-images.githubusercontent.com/1211431/120554042-904a6600-c3f9-11eb-83e9-7148541f2e49.jpg)
![2021_06_02_10_34_13](https://user-images.githubusercontent.com/1211431/120554062-96404700-c3f9-11eb-8f6d-6a7578bf2647.jpg)

