### PR TITLE
Fixed "pc at any <location>" guildhall issue

### DIFF
--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -620,6 +620,19 @@ namespace DaggerfallWorkshop.Game.Questing
                         return false;
                 }
             }
+            // Handle guild halls
+            else if(p2 == (int)DFLocation.BuildingTypes.GuildHall)
+            {
+                if (buildingType != p2)
+                    return false;
+
+                // Accept any guild hall
+                if (p3 == 0)
+                    return true;
+
+                // Faction id must match
+                return playerEnterExit.FactionID == p3;
+            }
             else
             {
                 return buildingType == p2;

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -621,7 +621,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 }
             }
             // Handle guild halls
-            else if(p2 == (int)DFLocation.BuildingTypes.GuildHall)
+            else if (p2 == (int)DFLocation.BuildingTypes.GuildHall)
             {
                 if (buildingType != p2)
                     return false;


### PR DESCRIPTION
Fixed an issue where locations "magery" and "fighters" are treated the same as "guildhall" in "pc at any <location>".

I forgot guild halls have a "p3" parameter.