### PR TITLE
Clear location cache if world data variant is set

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/WorldDataVariants.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataVariants.cs
@@ -85,6 +85,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 locationVariants[locationKey] = variant;
 
             Debug.LogFormat("Set variant \"{0}\" for the location index \"{1}\" in region {2}", variant, locationIndex, regionIndex);
+            RMBLayout.ClearLocationCache();
             return overwrite;
         }
 
@@ -111,6 +112,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     newLocationVariants.Add(locationKey);
 
                 Debug.LogFormat("Set variant \"{0}\" for the new location \"{1}\" in region {2}", variant, locationName, regionIndex);
+                RMBLayout.ClearLocationCache();
                 return overwrite;
             }
             DaggerfallUnity.LogMessage("Failed to set a new location variant.", true);
@@ -134,6 +136,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 blockVariants[blockKey] = variant;
 
             Debug.LogFormat("Set variant \"{0}\" for the block {1} at locationKey {2}", variant, blockName, locationKey);
+            RMBLayout.ClearLocationCache();
             return overwrite;
         }
 
@@ -154,6 +157,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 buildingVariants[buildingKey] = variant;
 
             Debug.LogFormat("Set variant \"{0}\" for building {2} of {1} at locationKey {3}", variant, blockName, recordIndex, locationKey);
+            RMBLayout.ClearLocationCache();
             return overwrite;
         }
 

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -43,6 +43,12 @@ namespace DaggerfallWorkshop.Utility
         private static int maxLocationCacheSize = 12;
         private static List<KeyValuePair<int, DFBlock[]>> locationCache = new List<KeyValuePair<int, DFBlock[]>>();
 
+        /// <summary>Clear the location cache. Use if block data is changed dynamically.</summary>
+        public static void ClearLocationCache()
+        {
+            locationCache.Clear();
+        }
+
         #endregion
 
         // Animal sounds range. Matched to classic.
@@ -600,10 +606,11 @@ namespace DaggerfallWorkshop.Utility
 
             blocksArray = blocks.ToArray();
 
-            // Cache blocks
+#if !UNITY_EDITOR // Cache blocks for this location if not in editor
             if (locationCache.Count == maxLocationCacheSize)
                 locationCache.RemoveAt(0);
             locationCache.Add(new KeyValuePair<int, DFBlock[]>(mapId, blocksArray));
+#endif
 
             return blocksArray;
         }


### PR DESCRIPTION
Also don't cache at all when running in unity editor in the same way the world data caching is disabled in editor. This allows mod developers to see their world data changes without needing to restart the game. The downside to this is to debug issues with the cache the directive needs to be modified.