### PR TITLE
Match quest NPCs location scopes and genders to classic

### DIFF
--- a/Assets/StreamingAssets/Quests/$CUREVAM.txt
+++ b/Assets/StreamingAssets/Quests/$CUREVAM.txt
@@ -235,9 +235,9 @@ QBN:
 Item _letter_ letter used 1020
 Item _token_ bracelet
 
-Person _vamp1_ face 40 factiontype Vampire_Clan
-Person _vamp2_ face 4 factiontype Vampire_Clan
-Person _hunter_ face 1 factiontype Knightly_Guard anyInfo 1011 rumors 1012
+Person _vamp1_ face 40 factiontype Vampire_Clan remote
+Person _vamp2_ face 4 factiontype Vampire_Clan male remote
+Person _hunter_ face 1 factiontype Knightly_Guard remote anyInfo 1011 rumors 1012
 
 Place _fatherdung_ remote dungeon8
 Place _wrongdung_ remote dungeon5

--- a/Assets/StreamingAssets/Quests/$CUREWER.txt
+++ b/Assets/StreamingAssets/Quests/$CUREWER.txt
@@ -330,12 +330,12 @@ Item _blood_ werewolf_blood
 Item _map_ letter used 1060
 Item map2 letter used 1061
 
-Person _priest_ face 40 group Cleric
-Person _child_ face 1 faction Children
-Person _hunter_ face 1 factiontype Temple anyInfo 1011 rumors 1012
-Person _alchemist_ group Chemist female
-Person _father_ face 5 group Noble male anyInfo 1013 rumors 1014
-Person _local_ group Resident1 female
+Person _priest_ face 40 group Cleric remote
+Person _child_ face 1 faction Children remote
+Person _hunter_ face 1 factiontype Temple remote anyInfo 1011 rumors 1012
+Person _alchemist_ group Chemist remote
+Person _father_ face 5 group Noble male remote anyInfo 1013 rumors 1014
+Person _local_ group Resident1 remote
 
 Place _mapdung_ remote dungeon4
 Place glenmorilCoven permanent GlenmorilCoven

--- a/Assets/StreamingAssets/Quests/00B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/00B00Y00.txt
@@ -93,7 +93,7 @@ Message:  1031
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon9
 

--- a/Assets/StreamingAssets/Quests/20C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/20C00Y00.txt
@@ -131,8 +131,8 @@ QBN:
 Item _artifact_ artifact Mace_of_Molag_Bal used 1013
 Item _map_ letter used 1060
 
-Person _contact_ face 233 faction The_Cabal anyInfo 1012
-Person _dummy_ face 1 group Spellcaster
+Person _contact_ face 233 faction The_Cabal remote anyInfo 1012
+Person _dummy_ face 1 group Spellcaster remote
 
 Place _mondung_ remote dungeon9
 Place _tavern_ remote tavern

--- a/Assets/StreamingAssets/Quests/50C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/50C00Y00.txt
@@ -135,8 +135,8 @@ Message:  1015
 QBN:
 Item _artifact_ artifact Spell_Breaker anyInfo 1013
 
-Person _qgfriend_ group Cleric female anyInfo 1011
-Person questPerson face 1 factiontype Vampire_Clan
+Person _qgfriend_ group Cleric female remote anyInfo 1011
+Person _dummyvamp_ face 1 factiontype Vampire_Clan remote
 
 Place _mondung_ remote dungeon
 
@@ -163,7 +163,7 @@ _pcgetsgold_ task:
 _mondead_ task:
 	killed 1 _monster_ 
 	say 1014 
-	change repute with questPerson by -20 
+	change repute with _dummyvamp_ by -20 
 
 _npcclicked_ task:
 	clicked npc _qgfriend_ 

--- a/Assets/StreamingAssets/Quests/60C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/60C00Y00.txt
@@ -142,7 +142,7 @@ Message:  1030
 QBN:
 Item _artifact_ artifact Wabbajack anyInfo 1013
 
-Person _qgfriend_ face 1 group Innkeeper anyInfo 1011 rumors 1014
+Person _qgfriend_ face 1 group Innkeeper remote anyInfo 1011 rumors 1014
 
 Place _mondung_ remote dungeon
 Place _contactdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/70C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/70C00Y00.txt
@@ -128,7 +128,7 @@ Message:  1020
 QBN:
 Item _artifact_ artifact Sanguine_Rose
 
-Person _contact_ face 232 faction The_Cabal anyInfo 1012
+Person _contact_ face 232 faction The_Cabal remote anyInfo 1012
 
 Place _mondung_ remote dungeon4
 

--- a/Assets/StreamingAssets/Quests/80C0XY00.txt
+++ b/Assets/StreamingAssets/Quests/80C0XY00.txt
@@ -188,9 +188,9 @@ QBN:
 Item _artifact_ artifact Volendrung anyInfo 1013
 Item _note_ letter used 1030
 
-Person _qgfriend_ group Noble female anyInfo 1011
-Person _murder_ face 1 factiontype Province anyInfo 1050 rumors 1051
-Person _ruler_ group Noble female anyInfo 1052 rumors 1053
+Person _qgfriend_ group Noble male remote anyInfo 1011
+Person _murder_ face 1 factiontype Province remote anyInfo 1050 rumors 1051
+Person _ruler_ group Noble remote anyInfo 1052 rumors 1053
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/A0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y00.txt
@@ -209,9 +209,9 @@ Item _letter5_ letter used 1020
 Item _letter6_ letter used 1021
 
 Person _qgiver_ face 1 group Questor anyInfo 1030 rumors 1031
-Person _npc1_ face 4 group Local_4.0 male
-Person _npc2_ face 4 group Local_3.0 male
-Person _npc3_ face 2 group Group_6.0
+Person _npc1_ face 4 group Local_4.0 male remote
+Person _npc2_ face 4 group Local_3.0 male remote
+Person _npc3_ face 2 group Group_6.0 female remote
 
 Place _inn_ remote tavern
 

--- a/Assets/StreamingAssets/Quests/A0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y06.txt
@@ -90,8 +90,8 @@ Message:  1014
 QBN:
 Item _gold_ gold
 
-Person _traitor_ face 1 group Local_4.0
-Person _qgiver_ group Questor male
+Person _traitor_ face 1 group Local_4.0 local
+Person _qgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 Place _meetingplace_ local random

--- a/Assets/StreamingAssets/Quests/A0C00Y07.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y07.txt
@@ -106,7 +106,7 @@ Message:  1012
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ local random
 

--- a/Assets/StreamingAssets/Quests/A0C00Y08.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y08.txt
@@ -129,8 +129,8 @@ Message:  1033
 QBN:
 Item _gold_ gold
 
-Person _questgiver_ group Questor male anyInfo 1030 rumors 1031
-Person _darkb_ face 1 faction The_Dark_Brotherhood anyInfo 1032 rumors 1033
+Person _questgiver_ group Questor anyInfo 1030 rumors 1031
+Person _darkb_ face 1 faction The_Dark_Brotherhood remote anyInfo 1032 rumors 1033
 
 Place _place_ local random
 

--- a/Assets/StreamingAssets/Quests/A0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y11.txt
@@ -189,9 +189,9 @@ Item _gold1_ gold range 5 to 25
 Item _gold2_ gold range 10 to 50
 Item talisman talisman
 
-Person _giver_ group Questor male
-Person _cousin_ group Resident4 female anyInfo 1012 rumors 1012
-Person _healer_ face 64 group Chemist anyInfo 1040 rumors 1041
+Person _giver_ group Questor
+Person _cousin_ group Resident4 remote anyInfo 1012 rumors 1012
+Person _healer_ face 64 group Chemist remote anyInfo 1040 rumors 1041
 
 Clock _questtime_ 00:00 0 flag 1 range 3 5
 

--- a/Assets/StreamingAssets/Quests/A0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y12.txt
@@ -163,9 +163,9 @@ QBN:
 Item _book_ book2 anyInfo 1014 used 1015
 Item _gold_ gold
 
-Person _informant_ face 241 group Cleric
-Person _giver_ group Questor male
-Person _thief_ face 97 faction The_Thieves_Guild anyInfo 1027 rumors 1027
+Person _informant_ face 241 group Cleric local
+Person _giver_ group Questor
+Person _thief_ face 97 faction The_Thieves_Guild local anyInfo 1027 rumors 1027
 
 Place _inn_ local tavern
 Place _store_ local generalstore

--- a/Assets/StreamingAssets/Quests/A0C00Y14.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y14.txt
@@ -173,7 +173,7 @@ Item _jewelry_ trinket
 Item _gold_ gold range 30 to 75
 
 Person _questgiver_ face 137 group Questor
-Person _pickuplocal_ face 232 group Local_3.0
+Person _pickuplocal_ face 232 group Local_3.0 local
 
 Clock _oneday_ 1.00:00
 --added precise timers due to short time limit

--- a/Assets/StreamingAssets/Quests/A0C00Y15.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y15.txt
@@ -178,7 +178,7 @@ Item _jewelry_ trinket
 Item _gold_ gold
 
 Person _questgiver_ face 137 group Questor
-Person _pickupregion_ face 232 group Local_3.0
+Person _pickupregion_ face 232 group Local_3.0 remote
 
 Clock _traveltime_ 00:00 0 flag 1 range 1 4
 --precise timer needed due to short time limit

--- a/Assets/StreamingAssets/Quests/A0C00Y16.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y16.txt
@@ -194,12 +194,12 @@ Message:  1054
 QBN:
 Item _gold_ gold
 
-Person _questgiver_ group Questor male
-Person _missingperson_ face 1 group Group_6.0
-Person _friend1_ group Local_3.1 male
-Person _friend2_ group Local_3.1 male
-Person _friend3_ group Local_3.1 male
-Person _friend4_ group Local_4.1 male
+Person _questgiver_ group Questor
+Person _missingperson_ face 1 group Group_6.0 local
+Person _friend1_ group Local_3.1 local
+Person _friend2_ group Local_3.1 local
+Person _friend3_ group Local_3.1 local
+Person _friend4_ group Local_4.1 local
 
 Place _hidingplace_ local random
 

--- a/Assets/StreamingAssets/Quests/A0C00Y17.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y17.txt
@@ -156,10 +156,10 @@ Message:  1050
 QBN:
 Item _gold_ gold
 
-Person _questgiver_ group Questor male
-Person _mage_ faction The_Mages_Guild female
-Person _thief_ faction The_Thieves_Guild female
-Person _darkb_ faction The_Dark_Brotherhood female
+Person _questgiver_ group Questor
+Person _mage_ faction The_Mages_Guild remote
+Person _thief_ faction The_Thieves_Guild remote
+Person _darkb_ faction The_Dark_Brotherhood remote
 
 Place _destination_ remote random
 

--- a/Assets/StreamingAssets/Quests/A0C01Y03.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y03.txt
@@ -163,10 +163,10 @@ Item _flowers_ yellow_flowers
 Item _answer_ letter used 1017
 Item _gold_ gold
 
-Person _hermit_ face 1 group Group_7.2
-Person _qgiver_ group Questor male
-Person _spouse_ group Group_7.1 female
-Person _teacher_ face 1 faction The_Academics
+Person _hermit_ face 1 group Group_7.2 remote
+Person _qgiver_ group Questor
+Person _spouse_ group Group_7.1 remote
+Person _teacher_ face 1 faction The_Academics remote
 
 Place _dungeon_ remote dungeon
 Place _school_ remote library

--- a/Assets/StreamingAssets/Quests/A0C01Y06.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y06.txt
@@ -147,8 +147,8 @@ The orc shaman's chanting rises.
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _master_ face 1 group Group_6.0 anyInfo 1020 rumors 1021
+Person _qgiver_ group Questor
+Person _master_ face 1 group Group_6.0 local anyInfo 1020 rumors 1021
 
 Place _dungeon_ remote dungeon
 Place _meetingplace_ local tavern

--- a/Assets/StreamingAssets/Quests/A0C01Y09.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y09.txt
@@ -149,8 +149,8 @@ Item _item_ large_plant
 Item _gold_ gold
 
 Person _questg_ face 4 group Questor
-Person _sister_ face 2 group Resident2
-Person _merchant_ face 1 faction The_Merchants
+Person _sister_ face 2 group Resident2 female local
+Person _merchant_ face 1 faction The_Merchants local
 
 Place _item0_ local house2
 -added underscores to item0

--- a/Assets/StreamingAssets/Quests/A0C01Y13.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y13.txt
@@ -240,10 +240,10 @@ Item _letter_ letter used 1015
 Item _gold_ gold
 Item _magicsword_ magic_item
 
-Person _giver_ group Questor male anyInfo 1022 rumors 1022
-Person informant2 face 1 group Innkeeper
-Person _sister_ face 19 group Group_6.0 female
-Person _lover_ face 117 group Group_6.0 male anyInfo 1030 rumors 1030
+Person _giver_ group Questor anyInfo 1022 rumors 1022
+Person _teller_ face 1 group Innkeeper local
+Person _sister_ face 19 group Group_6.0 female local
+Person _lover_ face 117 group Group_6.0 male local anyInfo 1030 rumors 1030
 
 Place _givershouse_ local house2
 Place _sistershouse_ local house2
@@ -255,20 +255,20 @@ Clock _S.00_ 30.00:00 0 flag 9 range 0 1
 
 --	Quest start-up:
 	place item _letter_ at _givershouse_ 
-	dialog link for location _givershouse_ person informant2 
+	dialog link for location _givershouse_ person _teller_ 
 	dialog link for location _sistershouse_ person _lover_ item _letter_ 
 	dialog link for location _dungeon_ person _sister_ item _gold_ 
 	start timer _S.00_ 
 	log 1003 step 0 
 	clicked npc _giver_ say 1020 
-	place npc informant2 at _inn_ 
+	place npc _teller_ at _inn_ 
 	place npc _lover_ at _dungeon_ 
 
 _S.00_ task:
 	end quest 
 
 _S.01_ task:
-	clicked npc informant2 say 1017 
+	clicked npc _teller_ say 1017 
 	log 1010 step 1 
 
 variable _S.02_

--- a/Assets/StreamingAssets/Quests/A0C0XY04.txt
+++ b/Assets/StreamingAssets/Quests/A0C0XY04.txt
@@ -173,11 +173,11 @@ Item _artifact_ artifact Chrysamere anyInfo 1025
 Item _ingredient_ lodestone
 Item _token_ pearl
 
-Person _qgiver_ face 1 group Chemist
-Person _agent_ group Questor male
-Person _dummymage_ face 1 faction The_Mages_Guild
+Person _qgiver_ face 1 group Chemist local
+Person _agent_ group Questor
+Person _dummymage_ face 1 faction The_Mages_Guild remote
 Person _dummyorc_ face 1 named Gortwog
-Person _dummydarkb_ face 49 faction The_Dark_Brotherhood
+Person _dummydarkb_ face 49 faction The_Dark_Brotherhood remote
 
 Place _dungeon_ remote dungeon
 Place _meetingplace_ local apothecary

--- a/Assets/StreamingAssets/Quests/A0C10Y02.txt
+++ b/Assets/StreamingAssets/Quests/A0C10Y02.txt
@@ -122,9 +122,9 @@ Message:  1020
 QBN:
 Item _money_ gold
 
-Person _child_ face 1 faction Children
+Person _child_ face 1 faction Children remote
 Person _qgiver_ face 121 group Questor
-Person _dummydarkb_ face 169 faction The_Dark_Brotherhood
+Person _dummydarkb_ face 169 faction The_Dark_Brotherhood remote
 
 Place _dbguild_ remote house1
 

--- a/Assets/StreamingAssets/Quests/A0C10Y05.txt
+++ b/Assets/StreamingAssets/Quests/A0C10Y05.txt
@@ -154,10 +154,10 @@ Message:  1020
 QBN:
 Item _gold_ gold
 
-Person _betrothed_ face 1 group Group_7.0
-Person _qgiver_ group Questor male
-Person _priest_ face 201 factiontype Temple
-Person _ruler_ factiontype Province female
+Person _betrothed_ face 1 group Group_7.0 remote
+Person _qgiver_ group Questor
+Person _priest_ face 201 factiontype Temple remote
+Person _ruler_ factiontype Province remote
 
 Place _betrothedhome_ remote house2
 Place _temple_ remote temple

--- a/Assets/StreamingAssets/Quests/A0C41Y18.txt
+++ b/Assets/StreamingAssets/Quests/A0C41Y18.txt
@@ -183,9 +183,9 @@ Item _gold1_ gold
 Item _gold2_ gold
 --changed msg 1030 %g2 to %g3
 
-Person _sage_ group Cleric female anyInfo 1050 rumors 1050
-Person _giver_ group Questor male
-Person _dummy_ group Innkeeper female
+Person _sage_ group Cleric remote anyInfo 1050 rumors 1050
+Person _giver_ group Questor
+Person _dummy_ group Innkeeper remote
 
 Place _dungeon_ remote dungeon0
 

--- a/Assets/StreamingAssets/Quests/B0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/B0B00Y00.txt
@@ -153,8 +153,8 @@ QBN:
 Item letter31 letter used 1014
 
 Person _qgiver_ group Questor
-Person _lady_ face 2 group Noble female
-Person _vamp_ face 40 factiontype Vampire_Clan
+Person _lady_ face 2 group Noble female local
+Person _vamp_ face 40 factiontype Vampire_Clan local
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/B0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/B0B00Y01.txt
@@ -93,7 +93,7 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondun_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/B0B10Y04.txt
+++ b/Assets/StreamingAssets/Quests/B0B10Y04.txt
@@ -132,7 +132,7 @@ Message:  1017
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondung_ remote dungeon
 Place tavern local tavern

--- a/Assets/StreamingAssets/Quests/B0B20Y07.txt
+++ b/Assets/StreamingAssets/Quests/B0B20Y07.txt
@@ -105,8 +105,8 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
-Person _local_ face 1 group Resident2
+Person _qgiver_ group Questor
+Person _local_ face 1 group Resident2 local
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/B0B40Y08.txt
+++ b/Assets/StreamingAssets/Quests/B0B40Y08.txt
@@ -80,8 +80,8 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
-Person _local_ face 207 group Resident2
+Person _qgiver_ group Questor
+Person _local_ face 207 group Resident2 female local
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/B0B40Y09.txt
+++ b/Assets/StreamingAssets/Quests/B0B40Y09.txt
@@ -87,8 +87,8 @@ Message:  1011
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _local_ face 207 group Resident2
+Person _qgiver_ group Questor
+Person _local_ face 207 group Resident2 female local
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/B0B50Y11.txt
+++ b/Assets/StreamingAssets/Quests/B0B50Y11.txt
@@ -87,9 +87,9 @@ Message:  1011
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _nobleman_ face 182 factiontype Province
-Person _local_ face 77 group Resident2
+Person _qgiver_ group Questor
+Person _nobleman_ face 182 factiontype Province remote
+Person _local_ face 77 group Resident2 male local
 
 Place _dungeon_ remote dungeon11
 

--- a/Assets/StreamingAssets/Quests/B0B60Y12.txt
+++ b/Assets/StreamingAssets/Quests/B0B60Y12.txt
@@ -120,9 +120,9 @@ Message:  1011
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _nobleman_ group Resident1 female
-Person _local_ face 1 group Resident2
+Person _qgiver_ group Questor
+Person _nobleman_ group Resident1 remote
+Person _local_ face 1 group Resident2 local
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/B0B70Y14.txt
+++ b/Assets/StreamingAssets/Quests/B0B70Y14.txt
@@ -129,7 +129,7 @@ Message:  1011
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/B0B70Y16.txt
+++ b/Assets/StreamingAssets/Quests/B0B70Y16.txt
@@ -128,8 +128,8 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
-Person _local_ face 93 group Resident2
+Person _qgiver_ group Questor
+Person _local_ face 93 group Resident2 male local
 
 Place _dungeon_ remote dungeon14
 

--- a/Assets/StreamingAssets/Quests/B0B71Y03.txt
+++ b/Assets/StreamingAssets/Quests/B0B71Y03.txt
@@ -322,10 +322,10 @@ Item _aurielshield_ artifact Auriels_Shield
 Item _aurielsbow_ artifact Auriels_Bow
 Item _lordsmail_ artifact Lords_Mail
 
-Person _witch_ face 1 faction The_Glenmoril_Witches
-Person _child_ face 211 faction Children
-Person _ruler_ group Noble female
-Person _local_ face 33 group Resident2
+Person _witch_ face 1 faction The_Glenmoril_Witches remote
+Person _child_ face 211 faction Children female remote
+Person _ruler_ group Noble remote
+Person _local_ face 33 group Resident2 local
 Person _questgiver_ face 67 group Questor
 
 Place _dungeon1_ remote dungeon

--- a/Assets/StreamingAssets/Quests/B0B80Y17.txt
+++ b/Assets/StreamingAssets/Quests/B0B80Y17.txt
@@ -92,8 +92,8 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
-Person _local_ face 1 group Resident2
+Person _qgiver_ group Questor
+Person _local_ face 1 group Resident2 local
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/B0B81Y02.txt
+++ b/Assets/StreamingAssets/Quests/B0B81Y02.txt
@@ -222,8 +222,8 @@ Item _I.04_ artifact Staff_of_Magnus
 Item _map_ letter used 1020
 Item _I.06_ item class 17 subclass 13
 
-Person _qgiver_ group Questor male
-Person _wizard_ face 1 group Spellcaster
+Person _qgiver_ group Questor
+Person _wizard_ face 1 group Spellcaster remote
 
 Place _dungeon_ remote dungeon
 Place _dungeon2_ remote dungeon

--- a/Assets/StreamingAssets/Quests/B0C00Y05.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y05.txt
@@ -107,7 +107,7 @@ Message:  1080
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondun_ remote dungeon
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/B0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y06.txt
@@ -91,8 +91,8 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
-Person _local_ face 207 group Resident2
+Person _qgiver_ group Questor
+Person _local_ face 207 group Resident2 female local
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/B0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y10.txt
@@ -92,8 +92,8 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
-Person _local_ face 1 group Resident2
+Person _qgiver_ group Questor
+Person _local_ face 1 group Resident2 local
 
 Place _dungeon_ remote dungeon1
 

--- a/Assets/StreamingAssets/Quests/B0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y13.txt
@@ -92,7 +92,7 @@ Message:  1012
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ local random
 

--- a/Assets/StreamingAssets/Quests/C0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y01.txt
@@ -468,8 +468,8 @@ Person _contact_ face 105 group Local_3.0
 Person _priest_ face 49 group Group_5.0
 Person _prophet_ face 1 group Local_4.0 anyInfo 1009
 --changed anyInfo QuestorPostFailure to 1009
-Person _replace_ face 3 factiontype Temple anyInfo 1023
-Person _lover_ face 104 group Group_7.0 anyInfo 1017
+Person _replace_ face 3 factiontype Temple female anyInfo 1023
+Person _lover_ face 104 group Group_7.0 remote anyInfo 1017
 
 Place _mondung_ remote dungeon4
 Place _tavern_ remote tavern

--- a/Assets/StreamingAssets/Quests/C0B00Y02.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y02.txt
@@ -296,11 +296,11 @@ Item _item_ religious
 Item _reward_ religious
 Item _gold_ gold range 50 to 50
 
-Person _qgiver_ group Questor male
-Person _child_ face 1 faction Children
-Person _guardian_ face 1 factiontype Knightly_Guard
-Person _priest_ face 104 factiontype Temple
-Person _hooker_ face 1 faction The_Prostitutes
+Person _qgiver_ group Questor
+Person _child_ face 1 faction Children local
+Person _guardian_ face 1 factiontype Knightly_Guard local
+Person _priest_ face 104 factiontype Temple remote
+Person _hooker_ face 1 faction The_Prostitutes local
 
 Place _house_ local house2
 Place _house2_ local house2

--- a/Assets/StreamingAssets/Quests/C0B00Y03.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y03.txt
@@ -115,7 +115,7 @@ Message:  1012
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 Person _cleric_ face 105 factiontype Temple
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/C0B00Y14.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y14.txt
@@ -143,8 +143,8 @@ Message:  1061
 QBN:
 Item _I.00_ item class 10 subclass 4
 
-Person _questgiver_ group Questor male
-Person _priest_ group Cleric female
+Person _questgiver_ group Questor
+Person _priest_ group Cleric remote
 
 Place _mondung_ remote dungeon4
 

--- a/Assets/StreamingAssets/Quests/C0B10Y05.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y05.txt
@@ -105,7 +105,7 @@ Item _evilitem_ weapon
 Item _gold_ gold
 
 Person _qgiver_ face 1 group Questor
-Person _custodian_ face 1 group Group_5.0
+Person _custodian_ face 1 group Group_5.0 remote
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/C0B10Y06.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y06.txt
@@ -99,7 +99,7 @@ QBN:
 Item _ingredient_ organs
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/C0B10Y07.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y07.txt
@@ -121,9 +121,9 @@ QBN:
 Item _religitem_ religious
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _priest_ group Group_5.0
-Person _enemy_ face 176 group Local_4.0
+Person _qgiver_ group Questor
+Person _priest_ group Group_5.0 local
+Person _enemy_ face 176 group Local_4.0 remote
 
 Place _goalplace_ remote house
 --without goalplace, priest would always spawn in current city. this quest depends on remote locations.

--- a/Assets/StreamingAssets/Quests/C0B10Y15.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y15.txt
@@ -138,7 +138,7 @@ QBN:
 Item _item_ talisman
 Item _reward_ magic_item
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/C0B20Y08.txt
+++ b/Assets/StreamingAssets/Quests/C0B20Y08.txt
@@ -99,7 +99,7 @@ QBN:
 Item _ingredient_ organs
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/C0B3XY09.txt
+++ b/Assets/StreamingAssets/Quests/C0B3XY09.txt
@@ -119,7 +119,7 @@ Item _evilfocus_ religious
 Item _gold_ gold
 Item _magicitem_ magic_item
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/C0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y10.txt
@@ -157,9 +157,9 @@ QBN:
 Item _talisman_ root_tendrils
 -added underscores to talisman
 
-Person _giver_ group Questor male
-Person _cousin_ group Local_3.0 female anyInfo 1012 rumors 1012
-Person _healer_ face 64 group Chemist
+Person _giver_ group Questor
+Person _cousin_ group Local_3.0 remote anyInfo 1012 rumors 1012
+Person _healer_ face 64 group Chemist remote
 
 
 Clock _questtime_ 00:00 0 flag 1 range 3 5

--- a/Assets/StreamingAssets/Quests/C0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y11.txt
@@ -105,7 +105,7 @@ Message:  1080
 QBN:
 Item boobyprize gold range 2 to 2
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ remote house2
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/C0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y12.txt
@@ -135,9 +135,9 @@ Message:  1020
 QBN:
 Item _religitem_ religious
 
-Person _qgiver_ group Questor male
-Person _thief_ face 229 faction The_Thieves_Guild anyInfo 1013 rumors 1014
-Person _decoy_ face 92 group Local_3.1
+Person _qgiver_ group Questor
+Person _thief_ face 229 faction The_Thieves_Guild male remote anyInfo 1013 rumors 1014
+Person _decoy_ face 92 group Local_3.1 male remote
 
 Place _thiefplace_ remote house2
 

--- a/Assets/StreamingAssets/Quests/C0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y13.txt
@@ -88,9 +88,9 @@ Message:  1011
 QBN:
 Item _religitem_ religious
 
-Person _qgiver_ group Questor male
-Person _priest_ group Group_5.0 female
-Person _enemy_ face 176 group Local_4.0
+Person _qgiver_ group Questor
+Person _priest_ group Group_5.0 remote
+Person _enemy_ face 176 group Local_4.0 remote
 
 Clock _traveltime_ 00:00 0 flag 1 range 1 2
 

--- a/Assets/StreamingAssets/Quests/D0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/D0B00Y00.txt
@@ -106,7 +106,7 @@ Message:  1030
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/E0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/E0B00Y00.txt
@@ -122,7 +122,7 @@ Message:  1020
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/F0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/F0B00Y00.txt
@@ -143,7 +143,7 @@ Item _reward_ gold
 Item _item_ scarab anyInfo 1013
 
 Person _questgiver_ face 112 group Questor
-Person _contact_ group Innkeeper female anyInfo 1011
+Person _contact_ group Innkeeper remote anyInfo 1011
 
 
 Clock _1stparton_ 00:00 0 flag 17 range 1 4

--- a/Assets/StreamingAssets/Quests/G0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/G0B00Y00.txt
@@ -88,7 +88,7 @@ Message:  1020
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondun_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/H0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/H0B00Y00.txt
@@ -98,7 +98,7 @@ Message:  1020
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon4
 

--- a/Assets/StreamingAssets/Quests/I0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/I0B00Y00.txt
@@ -107,7 +107,7 @@ Item _reward_ common_symbol
 Item _item_ large_plant
 
 Person _questgiver_ face 112 group Questor
-Person _chemist_ group Chemist female
+Person _chemist_ group Chemist remote
 
 
 Clock _1stparton_ 00:00 0 flag 17 range 1 4

--- a/Assets/StreamingAssets/Quests/J0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/J0B00Y00.txt
@@ -91,7 +91,7 @@ Message:  1030
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/K0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y00.txt
@@ -156,8 +156,8 @@ Item _reward_ gold
 Item _letter10_ letter used 1012
 Item _gem_ gem
 
-Person _qgiver_ group Questor male
-Person _competitor_ group Group_5.0 female
+Person _qgiver_ group Questor
+Person _competitor_ group Group_5.0 remote
 
 Place _storehouse_ remote generalstore
 

--- a/Assets/StreamingAssets/Quests/K0C00Y03.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y03.txt
@@ -182,9 +182,9 @@ Item _gold_ gold
 Item _item_ drug
 Item _letter_ letter used 1011
 
-Person _qgiver_ group Questor male
-Person _contact_ face 1 group Innkeeper
-Person _contact2_ group Innkeeper female
+Person _qgiver_ group Questor
+Person _contact_ face 1 group Innkeeper remote
+Person _contact2_ group Innkeeper remote
 
 Place _conhouse_ remote house2
 

--- a/Assets/StreamingAssets/Quests/K0C00Y04.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y04.txt
@@ -218,8 +218,8 @@ Item _dueler_ letter used 1011
 Item _lovgold_ gold
 
 Person _qgiver_ group Questor
-Person _lover_ group Group_7.0
-Person _competitor_ group Group_7.1
+Person _lover_ group Group_7.0 local
+Person _competitor_ group Group_7.1 local
 --UESP suggests any gender is possible
 
 Place _arena_ local house2

--- a/Assets/StreamingAssets/Quests/K0C00Y05.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y05.txt
@@ -207,9 +207,9 @@ Item _letter11_ letter used 1011
 -added underscores to letter11
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _knight_ face 216 faction The_Fighters_Guild
-Person _child_ faction Children
+Person _qgiver_ group Questor
+Person _knight_ face 216 faction The_Fighters_Guild remote
+Person _child_ faction Children female
 
 Place _mondung_ remote dungeon1
 Place _childlocale_ local house2

--- a/Assets/StreamingAssets/Quests/K0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y06.txt
@@ -887,15 +887,15 @@ Item letter23 letter used 1050
 Item letter22 letter used 1049
 Item _reward_ trinket
 
-Person _qgiver_ group Questor male anyInfo 1011
-Person _priest_ factiontype Temple male anyInfo 1014
-Person _noble_ face 174 factiontype Knightly_Guard anyInfo 1013
-Person _merchant_ face 86 faction The_Merchants anyInfo 1012
-Person _thief_ face 190 faction The_Thieves_Guild anyInfo 1015
-Person _witness_ face 1 group Innkeeper anyInfo 1016
-Person necromancer faction The_Necromancers female
-Person underking faction Agents_of_The_Underking female
-Person _tg_ faction The_Thieves_Guild female
+Person _qgiver_ group Questor anyInfo 1011
+Person _priest_ factiontype Temple local anyInfo 1014
+Person _noble_ face 174 factiontype Knightly_Guard female local anyInfo 1013
+Person _merchant_ face 86 faction The_Merchants female local anyInfo 1012
+Person _thief_ face 190 faction The_Thieves_Guild female local anyInfo 1015
+Person _witness_ face 1 group Innkeeper local anyInfo 1016
+Person necromancer faction The_Necromancers remote
+Person underking faction Agents_of_The_Underking remote
+Person _tg_ faction The_Thieves_Guild remote
 
 Place _mondung_ remote dungeon
 Place _thiefhouse_ local house2

--- a/Assets/StreamingAssets/Quests/K0C00Y07.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y07.txt
@@ -241,9 +241,9 @@ Item _gem_ gem
 Item _gold_ gold range 5 to 25
 Item _map_ letter used 1015
 
-Person _qgiver_ group Questor male
-Person _victim_ face 1 group Group_7.0
-Person _kidnapper_ face 36 faction The_Thieves_Guild
+Person _qgiver_ group Questor
+Person _victim_ face 1 group Group_7.0 local
+Person _kidnapper_ face 36 faction The_Thieves_Guild male remote
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/K0C00Y08.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y08.txt
@@ -159,7 +159,7 @@ Item _gold_ gold
 Item _upfront_ gold range 5 to 50
 Item _book_ book2
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/K0C00Y09.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y09.txt
@@ -172,7 +172,7 @@ QBN:
 Item _gold_ gold range 50 to 150
 Item _lessgold_ gold range 10 to 45
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/K0C01Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C01Y00.txt
@@ -191,7 +191,7 @@ Item _gem_ gem
 
 Person _qgiver_ group Questor
 Person _victim_ face 1 group Group_7.0
-Person _tg_ faction The_Thieves_Guild male
+Person _tg_ faction The_Thieves_Guild local
 
 Place _mondung_ remote dungeon
 Place _mondung2_ remote dungeon2

--- a/Assets/StreamingAssets/Quests/K0C01Y10.txt
+++ b/Assets/StreamingAssets/Quests/K0C01Y10.txt
@@ -187,7 +187,7 @@ QBN:
 Item _bothdorjii_ letter used 1011
 --added underscores to bothdorjii
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondung_ remote dungeon4
 

--- a/Assets/StreamingAssets/Quests/K0C0XY01.txt
+++ b/Assets/StreamingAssets/Quests/K0C0XY01.txt
@@ -193,8 +193,8 @@ Item clanfeather4 harpy_feather anyInfo 1032
 Item _letter26_ letter used 1012
 Item _jewelry_ trinket
 
-Person _qgiver_ group Questor male
-Person _contact_ face 1 faction The_Fighters_Guild
+Person _qgiver_ group Questor
+Person _contact_ face 1 faction The_Fighters_Guild remote
 
 Place _mondung_ remote dungeon10
 

--- a/Assets/StreamingAssets/Quests/K0C30Y03.txt
+++ b/Assets/StreamingAssets/Quests/K0C30Y03.txt
@@ -445,14 +445,14 @@ Item _letter15_ letter used 1033
 Item _bothdorjii_ gold range 15 to 50
 Item _letter33_ gold range 20 to 40
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 Person _patsy_ face 1 factiontype Province
-Person _hooker_ face 187 faction The_Prostitutes
+Person _hooker_ face 187 faction The_Prostitutes female
 Person _gaffer_ face 73 named Chulmore_Quill
-Person _banker_ face 1 group Banker anyInfo 1015
+Person _banker_ face 1 group Banker local anyInfo 1015
 Person _guard_ face 80 factiontype Knightly_Guard
 Person _darkb_ face 81 faction The_Dark_Brotherhood
-Person _victin_ face 81 faction The_Thieves_Guild
+Person _tguild_ face 81 faction The_Thieves_Guild local
 
 Place _bank_ remote bank
 Place _house1_ remote house2

--- a/Assets/StreamingAssets/Quests/L0A01L00.txt
+++ b/Assets/StreamingAssets/Quests/L0A01L00.txt
@@ -141,9 +141,9 @@ Item _decanter_ decanter
 Item _poison_ snake_venom
 Item _gold_ gold range 1 to 1
 
-Person _darkbmember_ faction The_Dark_Brotherhood female
-Person _apothecary_ face 144 group Chemist
-Person _npc_ face 1 group Resident1
+Person _darkbmember_ faction The_Dark_Brotherhood remote
+Person _apothecary_ face 144 group Chemist remote
+Person _npc_ face 1 group Resident1 remote
 
 Place _mansion_ remote house1
 Place _apo_ remote apothecary

--- a/Assets/StreamingAssets/Quests/L0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y00.txt
@@ -88,7 +88,7 @@ Message:  1021
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondun_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/L0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y01.txt
@@ -37,16 +37,13 @@ AcceptQuest:  [1002]
 <ce>                           Very good, %pct.
 <ce>                       =target_, having learned
 <ce>                  something during %g3 tenure in the
-<ce>               Brotherhood, has wisely hidden %g2-self,
-<ce>                  but we have a contact in __snitch_
-<ce> of ___snitch_, a miserable =snitch_, a
-<ce>                        snitch named _snitch_.
+<ce>                Brotherhood, has wisely hidden %g2self,
+<ce>                  but we have a contact in __snitch_,
+<ce>                 a miserable =snitch_ named _snitch_.
 <ce>                    Talk to %g2 and get =target_'s
 <ce>               location. I will expect the accounting to
 <ce>                  be accomplished, and you to be back
 <ce>                        here in =queston_ days.
-
--added town name of snitch to 1002
 
 QuestComplete:  [1004]
 <ce>                           Well done, %pct.
@@ -125,8 +122,8 @@ Message:  1013
 
 QBN:
 
-Person _qgiver_ group Questor male
-Person _snitch_ factiontype Temple male
+Person _qgiver_ group Questor
+Person _snitch_ factiontype Temple local
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/L0B00Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y03.txt
@@ -100,7 +100,7 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/L0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B10Y03.txt
@@ -144,7 +144,7 @@ Message:  1014
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 Person _contact_ face 176 group Innkeeper
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/L0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/L0B20Y02.txt
@@ -109,7 +109,7 @@ QBN:
 Item _reward_ gold
 
 Person _questgiver_ face 112 group Questor
-Person _damsel_ face 2 group Group_6.0
+Person _damsel_ face 2 group Group_6.0 female local
 
 Place _mondung_ remote dungeon2
 

--- a/Assets/StreamingAssets/Quests/L0B40Y04.txt
+++ b/Assets/StreamingAssets/Quests/L0B40Y04.txt
@@ -109,7 +109,7 @@ QBN:
 Item _reward_ gold
 
 Person _questgiver_ face 112 group Questor
-Person _knight_ face 5 faction The_Host_of_the_Horn
+Person _knight_ face 5 faction The_Host_of_the_Horn male remote
 
 Place _mondung_ remote palace
 

--- a/Assets/StreamingAssets/Quests/L0B50Y11.txt
+++ b/Assets/StreamingAssets/Quests/L0B50Y11.txt
@@ -13,7 +13,7 @@ QRC:
 
 QuestorOffer:  [1000]
 <ce>                 We have an interesting job available
-<ce>                      %pcn. A high ranking member
+<ce>                       to a high ranking member
 <ce>                  of the Thieves Guild. This will be
 <ce>                     a tough one. Do you want it?
 
@@ -154,9 +154,9 @@ QBN:
 Item _gold_ gold
 Item _bribe3_ gold range 50 to 50
 
-Person _mistress_ face 3 named Whitka
+Person _mistress_ face 3 group Group_7.2 female local
 Person _questgiver_ face 1 group Questor
-Person _marknpc_ face 5 faction The_Thieves_Guild anyInfo 1030
+Person _marknpc_ face 5 faction The_Thieves_Guild male local anyInfo 1030
 
 Place _house_ local house2
 Place _inn_ local tavern

--- a/Assets/StreamingAssets/Quests/M0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y00.txt
@@ -101,7 +101,7 @@ Message:  1080
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B00Y06.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y06.txt
@@ -117,7 +117,7 @@ Message:  1080
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ local random
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B00Y07.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y07.txt
@@ -96,7 +96,7 @@ Message:  1080
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ remote random
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B00Y15.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y15.txt
@@ -99,7 +99,7 @@ Message:  1020
 QBN:
 Item _reward_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ local random
 

--- a/Assets/StreamingAssets/Quests/M0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y16.txt
@@ -142,9 +142,9 @@ QBN:
 Item _gold_ gold
 Item _magic_ magic_item
 
-Person _questgiver_ group Questor male
-Person _dummy_ face 9 group Noble
-Person _villager_ face 8 group Shopkeeper
+Person _questgiver_ group Questor
+Person _dummy_ face 9 group Noble remote
+Person _villager_ face 8 group Shopkeeper remote
 
 Place _mondung_ remote dungeon
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B00Y17.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y17.txt
@@ -203,10 +203,10 @@ Item _gold_ gold
 Item _letter_ letter used 1060
 Item _magic_ magic_item
 
-Person _questgiver_ group Questor male
-Person _victim_ face 1 group Group_6.0
-Person _love_ face 1 group Group_7.0
-Person _dummy_ group Noble male
+Person _questgiver_ group Questor
+Person _victim_ face 1 group Group_6.0 remote
+Person _love_ face 1 group Group_7.0 remote
+Person _dummy_ group Noble local
 
 Place _mondung_ remote dungeon6
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B11Y18.txt
+++ b/Assets/StreamingAssets/Quests/M0B11Y18.txt
@@ -331,9 +331,9 @@ Item _queenreward_ magic_item
 Item _traitorreward_ diamond
 
 Person _ruler_ named Queen_Akorithi atHome
-Person _questgiver_ group Questor male
-Person _target_ face 1 factiontype Knightly_Guard
-Person _enemy_ face 1 group Resident2
+Person _questgiver_ group Questor
+Person _target_ face 1 factiontype Knightly_Guard remote
+Person _enemy_ face 1 group Resident2 remote
 Person _traitor_ face 1 named Lord_K'avar
 
 Place _L.00_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B1XY01.txt
+++ b/Assets/StreamingAssets/Quests/M0B1XY01.txt
@@ -106,7 +106,7 @@ Message:  1080
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/M0B20Y02.txt
@@ -111,7 +111,7 @@ Message:  1080
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B21Y19.txt
+++ b/Assets/StreamingAssets/Quests/M0B21Y19.txt
@@ -196,10 +196,10 @@ Item _reward_ magic_item
 Item _I.02_ dead_body
 Item _letter_ letter used 1031
 
-Person _victim_ face 5 faction People_of_Sentinel male
-Person _questgiver_ group Questor male
-Person _daughter_ face 3 faction People_of_Sentinel female
-Person _darkb_ faction The_Dark_Brotherhood anyInfo 1015 rumors 1016
+Person _victim_ face 5 faction People_of_Sentinel male remote
+Person _questgiver_ group Questor
+Person _daughter_ face 3 faction People_of_Sentinel female remote
+Person _darkb_ faction The_Dark_Brotherhood remote anyInfo 1015 rumors 1016
 
 Place _victimhouse_ local house4
 Place _daughterhouse_ remote house4

--- a/Assets/StreamingAssets/Quests/M0B30Y03.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y03.txt
@@ -106,7 +106,7 @@ Message:  1080
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B30Y04.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y04.txt
@@ -114,7 +114,7 @@ Message:  1080
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 Place _newdung_ remote dungeon14

--- a/Assets/StreamingAssets/Quests/M0B30Y08.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y08.txt
@@ -97,7 +97,7 @@ Message:  1080
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ remote random
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B40Y05.txt
+++ b/Assets/StreamingAssets/Quests/M0B40Y05.txt
@@ -154,8 +154,8 @@ Message:  1080
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _woodsman_ face 168 group Resident2
+Person _qgiver_ group Questor
+Person _woodsman_ face 168 group Resident2 remote
 
 Place _dungeon_ remote dungeon
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0B50Y09.txt
+++ b/Assets/StreamingAssets/Quests/M0B50Y09.txt
@@ -93,7 +93,7 @@ Message:  1080
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 Place _newdung_ remote dungeon8

--- a/Assets/StreamingAssets/Quests/M0B60Y10.txt
+++ b/Assets/StreamingAssets/Quests/M0B60Y10.txt
@@ -103,7 +103,7 @@ Message:  1080
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/M0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y11.txt
@@ -84,7 +84,7 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ local random
 

--- a/Assets/StreamingAssets/Quests/M0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y12.txt
@@ -85,7 +85,7 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ local random
 

--- a/Assets/StreamingAssets/Quests/M0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y13.txt
@@ -85,7 +85,7 @@ Message:  1011
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ local random
 

--- a/Assets/StreamingAssets/Quests/M0C00Y14.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y14.txt
@@ -91,7 +91,7 @@ Message:  1020
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _house_ local random
 

--- a/Assets/StreamingAssets/Quests/N0B00Y04.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y04.txt
@@ -162,7 +162,7 @@ QBN:
 Item _ingredient_ organs
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/N0B00Y06.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y06.txt
@@ -148,7 +148,7 @@ QBN:
 Item _wrappings_ mummy_wrappings
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondung_ remote dungeon0
 

--- a/Assets/StreamingAssets/Quests/N0B00Y08.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y08.txt
@@ -120,9 +120,9 @@ Message:  1011
 QBN:
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _warrior_ face 219 group Group_5.0
-Person _total_ face 218 factiontype Witches_Coven
+Person _qgiver_ group Questor
+Person _warrior_ face 219 group Group_5.0 female remote
+Person _witch_ face 218 factiontype Witches_Coven female remote
 
 Place _castle_ remote house1
 
@@ -144,7 +144,7 @@ _queston_ task:
 _reward_ task:
 	when _qgclicked_ and _out_ 
 	give pc _gold_ 
-	change repute with _total_ by -5 
+	change repute with _witch_ by -5 
 	end quest 
 
 _S.02_ task:

--- a/Assets/StreamingAssets/Quests/N0B00Y09.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y09.txt
@@ -283,9 +283,9 @@ Item research2 letter used 1016
 Item _dbgold_ gold
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _db_ face 78 faction The_Dark_Brotherhood
-Person _scholar_ factiontype Temple female anyInfo 1017
+Person _qgiver_ group Questor
+Person _db_ face 78 faction The_Dark_Brotherhood female local
+Person _scholar_ factiontype Temple remote anyInfo 1017
 
 
 Clock _queston_ 00:00 0 flag 17 range 1 2

--- a/Assets/StreamingAssets/Quests/N0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y16.txt
@@ -168,8 +168,8 @@ Item _crn_ item class 1 subclass 8
 Item _I.01_ wand
 
 Person _questgiver_ face 86 group Questor
-Person _merchant_ face 87 group Pawnbroker
-Person _mage_ face 1 group Spellcaster
+Person _merchant_ face 87 group Pawnbroker female local
+Person _mage_ face 1 group Spellcaster remote
 
 Place _shop_ local pawnshop
 

--- a/Assets/StreamingAssets/Quests/N0B00Y17.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y17.txt
@@ -326,9 +326,9 @@ Item _scholarreward_ magic_item
 Item _gold_ gold
 
 Person _questgiver_ face 8 group Questor
-Person _scholar_ group Chemist male
-Person _maker_ face 1 group Spellcaster
-Person _contact_ face 14 group Chemist
+Person _scholar_ group Chemist local
+Person _maker_ face 1 group Spellcaster remote
+Person _contact_ face 14 group Chemist female remote
 
 Place _scholardung_ remote dungeon
 Place _hintdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/N0B10Y01.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y01.txt
@@ -121,7 +121,7 @@ Message:  1020
 QBN:
 Item _reward_ gold
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/N0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y03.txt
@@ -115,7 +115,7 @@ QBN:
 Item _treasure_ magic_item
 Item _potion_ gem
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _magesguild_ local magery
 

--- a/Assets/StreamingAssets/Quests/N0B11Y18.txt
+++ b/Assets/StreamingAssets/Quests/N0B11Y18.txt
@@ -179,7 +179,7 @@ Item _letter_ letter used 1040
 Item _reward_ magic_item
 
 Person _rebel_ named Baltham_Greyman
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place aide remote dungeon
 Place _rebelhouse_ remote house1

--- a/Assets/StreamingAssets/Quests/N0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/N0B20Y02.txt
@@ -146,8 +146,8 @@ Message:  1030
 QBN:
 Item _magicitem_ magic_item
 
-Person _sleepingmage_ face 5 faction The_Mages_Guild
-Person _qgiver_ group Questor male
+Person _sleepingmage_ face 5 faction The_Mages_Guild male local
+Person _qgiver_ group Questor
 
 Place _magesguild_ local magery
 

--- a/Assets/StreamingAssets/Quests/N0B20Y05.txt
+++ b/Assets/StreamingAssets/Quests/N0B20Y05.txt
@@ -119,8 +119,8 @@ Message:  1040
 QBN:
 Item _reward_ magic_item
 
-Person _questgiver_ group Questor male
-Person _wizard_ face 249 faction The_Mages_Guild
+Person _questgiver_ group Questor
+Person _wizard_ face 249 faction The_Mages_Guild remote
 
 Place _mondung_ remote dungeon9
 

--- a/Assets/StreamingAssets/Quests/N0B21Y14.txt
+++ b/Assets/StreamingAssets/Quests/N0B21Y14.txt
@@ -83,7 +83,7 @@ The Oracle has traditionally been the counselor to the monarchs of Sentinel.
 <--->
 The Oracle advised King Camaron against warring with Daggerfall.
 <--->
-King Camaron didn't the Oracle's advice against warring with Daggerfall.
+King Camaron didn't listen to the Oracle's advice against warring with Daggerfall.
 <--->
 The Oracle knew that Sentinel would lose the war with Daggerfall.
 <--->
@@ -98,7 +98,7 @@ Message:  1014
 
 Message:  1015
 <ce>                      Thank you for coming, %pcf.
-<ce>               The Oracle has foreseen the death of one
+<ce>                The Oracle has foreseen the death of one
 <ce>                   of the great nobles of __temple_,
 <ce>                      the noble _noble_, and like
 <ce>               a pebble in a still pond, %g3 death will
@@ -106,7 +106,7 @@ Message:  1015
 <ce>               speaking with %g2, but I am not permitted
 <ce>                 to enter %g3 company in _noblehouse_.
 <ce>              My mistress, the Oracle, intends to come to
-<ce>                       __temple_ to speak with %g3
+<ce>                      __temple_ to speak with %g3
 <ce>                Grace, and I last heard that she was in
 <ce>                  __oracletemple_. I am not familiar
 <ce>               with these parts, so I don't know how far
@@ -258,11 +258,11 @@ Item _gold_ gold
 Person _oracle_ face 251 named The_Oracle anyInfo 1013
 Person _acolyte_ face 5 named The_Acolyte anyInfo 1012
 -changed oracle and acolyte to Named instead of Faction to prevent dialogue beginning
-Person _noble_ face 25 factiontype Province
+Person _noble_ face 25 factiontype Province local
 Person _thd_ named Queen_Akorithi
 --%thd corrected to _thd_
 Person _love_ face 1 group Group_7.0
-Person _giver_ group Questor male
+Person _giver_ group Questor
 
 Place _mondung_ remote dungeon
 Place _temple_ local temple

--- a/Assets/StreamingAssets/Quests/N0B40Y07.txt
+++ b/Assets/StreamingAssets/Quests/N0B40Y07.txt
@@ -152,8 +152,8 @@ Item _book_ book
 Item _spellScroll_ letter used 1030
 --added underscores to spellScroll
 
-Person _qgiver_ group Questor male
-Person _dummydaedra_ face 249 factiontype Daedra
+Person _qgiver_ group Questor
+Person _dummydaedra_ face 249 factiontype Daedra remote
 
 Place _mondung_ remote dungeon9
 Place aide remote dungeon

--- a/Assets/StreamingAssets/Quests/N0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y10.txt
@@ -164,9 +164,9 @@ Message:  1040
 QBN:
 Item _book_ book1 anyInfo 1010 used 1011
 
-Person _informant_ face 245 group Group_6.0
-Person _giver_ group Questor male
-Person _thief_ face 99 group Chemist anyInfo 1027 rumors 1027
+Person _informant_ face 245 group Group_6.0 male local
+Person _giver_ group Questor
+Person _thief_ face 99 group Chemist female local anyInfo 1027 rumors 1027
 
 Place _inn_ local tavern
 Place _store_ local weaponstore

--- a/Assets/StreamingAssets/Quests/N0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y11.txt
@@ -167,7 +167,7 @@ Message:  1080
 QBN:
 Item _ingredient_ organs
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 Place _newdung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/N0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y12.txt
@@ -103,7 +103,7 @@ Message:  1020
 
 QBN:
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/N0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y13.txt
@@ -183,7 +183,7 @@ QuestTimeLapse:  [1045]
 QBN:
 Item _ingredient_ letter used 1020
 
-Person _questgiver_ group Questor male
+Person _questgiver_ group Questor
 
 Place _dungeon_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/O0A0AL00.txt
+++ b/Assets/StreamingAssets/Quests/O0A0AL00.txt
@@ -182,8 +182,8 @@ Item _letter_ letter used 1024
 Item _note_ letter used 1019
 Item _gold_ gold range 1 to 1
 
-Person _thiefmember_ face 88 faction The_Thieves_Guild
-Person _npc_ face 218 group Group_6.0
+Person _thiefmember_ face 88 faction The_Thieves_Guild remote
+Person _npc_ face 218 group Group_6.0 female remote
 
 Place _mansion_ remote house1
 Place _dungeon_ remote dungeon

--- a/Assets/StreamingAssets/Quests/O0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y00.txt
@@ -138,7 +138,7 @@ Item _metal_ element
 Item _gems_ gem
 
 Person _questgiver_ face 72 group Questor
-Person _contact_ face 80 group Innkeeper
+Person _contact_ face 80 group Innkeeper remote
 
 Clock _1stparton_ 00:00 0 flag 18 range 1 4
 

--- a/Assets/StreamingAssets/Quests/O0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y01.txt
@@ -143,7 +143,7 @@ Item _weapons_ weapon
 Item _gems_ gem
 
 Person _questgiver_ face 72 group Questor
-Person _contact_ face 80 group Group_5.0
+Person _contact_ face 80 group Group_5.0 remote
 
 
 Clock _1stparton_ 00:00 0 flag 18 range 1 4

--- a/Assets/StreamingAssets/Quests/O0B00Y11.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y11.txt
@@ -159,8 +159,8 @@ Item _heist_ ivory
 Item _reward_ gold
 
 Person _questgiver_ face 44 group Questor
-Person _contact_ face 1 group Local_3.0
-Person _dummy_ face 209 group Resident1
+Person _contact_ face 1 group Local_3.0 remote
+Person _dummy_ face 209 group Resident1 local
 
 Place _target_ local house1 anyInfo 1011 rumors 1011
 Place _safehouse_ remote house3

--- a/Assets/StreamingAssets/Quests/O0B00Y12.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y12.txt
@@ -123,9 +123,9 @@ Item _drugs_ drug
 Item _note_ letter used 1030
 Item _gold_ gold
 
-Person _contact1_ group Group_5.1 female
-Person _questgiver_ group Questor male
-Person _contact2_ group Local_3.0 female
+Person _contact1_ group Group_5.1 remote
+Person _questgiver_ group Questor
+Person _contact2_ group Local_3.0 remote
 
 
 Clock _qtime_ 00:00 0 flag 1 range 3 5

--- a/Assets/StreamingAssets/Quests/O0B10Y00.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y00.txt
@@ -138,7 +138,7 @@ Item _metal_ element
 Item _gems_ gem
 
 Person _questgiver_ face 72 group Questor
-Person _contact_ face 80 group Innkeeper
+Person _contact_ face 80 group Innkeeper remote
 
 
 Clock _1stparton_ 00:00 0 flag 18 range 1 4

--- a/Assets/StreamingAssets/Quests/O0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y03.txt
@@ -125,7 +125,7 @@ QBN:
 Item _religiousitem_ religious
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _temple_ remote temple
 

--- a/Assets/StreamingAssets/Quests/O0B10Y05.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y05.txt
@@ -113,7 +113,7 @@ QBN:
 Item _painting_ painting
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _townhouse_ remote house4
 --reverted to house4 as original

--- a/Assets/StreamingAssets/Quests/O0B10Y06.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y06.txt
@@ -85,7 +85,7 @@ QBN:
 Item _jewelry_ trinket
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mansion_ remote house1
 

--- a/Assets/StreamingAssets/Quests/O0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/O0B20Y02.txt
@@ -84,7 +84,7 @@ QBN:
 Item _magicitem_ magic_item
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mansion_ remote house1
 

--- a/Assets/StreamingAssets/Quests/O0B2XY04.txt
+++ b/Assets/StreamingAssets/Quests/O0B2XY04.txt
@@ -81,7 +81,7 @@ QBN:
 Item _book_ book3
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mansion_ remote house1
 

--- a/Assets/StreamingAssets/Quests/O0B2XY08.txt
+++ b/Assets/StreamingAssets/Quests/O0B2XY08.txt
@@ -88,7 +88,7 @@ QBN:
 Item _drugs_ drug
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mansion_ remote house1
 

--- a/Assets/StreamingAssets/Quests/O0B2XY09.txt
+++ b/Assets/StreamingAssets/Quests/O0B2XY09.txt
@@ -89,7 +89,7 @@ QBN:
 Item _coastal_ mineral
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _mansion_ remote generalstore
 

--- a/Assets/StreamingAssets/Quests/O0B2XY10.txt
+++ b/Assets/StreamingAssets/Quests/O0B2XY10.txt
@@ -84,7 +84,7 @@ QBN:
 Item _potion_ Elixir_vitae
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 
 Place _alchemyshop_ remote apothecary
 

--- a/Assets/StreamingAssets/Quests/P0A01L00.txt
+++ b/Assets/StreamingAssets/Quests/P0A01L00.txt
@@ -131,7 +131,7 @@ QBN:
 Item _reward_ ring
 Item _letter_ letter used QuestorOffer
 
-Person _questgiver_ factiontype Vampire_Clan female anyInfo 1010 rumors 1011
+Person _questgiver_ factiontype Vampire_Clan remote anyInfo 1010 rumors 1011
 
 Place _mondung_ remote dungeon0
 

--- a/Assets/StreamingAssets/Quests/P0B00L01.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L01.txt
@@ -179,8 +179,8 @@ Item _reward_ magic_item
 Item _letter_ letter used 1013
 Item letter36 letter used 1020
 
-Person _vampire_ factiontype Vampire_Clan male anyInfo 1011 rumors 1012
-Person _pawn_ group Group_5.0 female anyInfo 1014 rumors 1015
+Person _vampire_ factiontype Vampire_Clan local anyInfo 1011 rumors 1012
+Person _pawn_ group Group_5.0 remote anyInfo 1014 rumors 1015
 
 
 Clock _1stparton_ 00:00 0 flag 17 range 1 2

--- a/Assets/StreamingAssets/Quests/P0B00L03.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L03.txt
@@ -166,8 +166,8 @@ Item _reward_ magic_item
 Item _vampproof_ boots anyInfo 1013
 Item _letter_ letter used 1020
 
-Person _vampire_ face 40 factiontype Vampire_Clan anyInfo 1011 rumors 1012
-Person _vampname_ face 4 factiontype Vampire_Clan
+Person _vampire_ face 40 factiontype Vampire_Clan local anyInfo 1011 rumors 1012
+Person _vampname_ face 4 factiontype Vampire_Clan male remote
 
 Place _mondung_ remote dungeon8
 

--- a/Assets/StreamingAssets/Quests/P0B00L04.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L04.txt
@@ -209,7 +209,7 @@ Message:  1016
 QBN:
 Item _letter_ letter used 1010
 
-Person _vamp_ factiontype Vampire_Clan male
+Person _vamp_ factiontype Vampire_Clan local
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/P0B00L06.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L06.txt
@@ -264,9 +264,9 @@ Item letter37 letter used 1013
 Item research1 letter used 1020
 Item _mggold_ gold
 
-Person _vamp_ factiontype Vampire_Clan male
-Person _mg_ faction The_Mages_Guild male
-Person _mage_ face 1 group Group_5.1
+Person _vamp_ factiontype Vampire_Clan local
+Person _mg_ faction The_Mages_Guild local
+Person _mage_ face 1 group Group_5.1 remote
 
 Place _mondung_ remote dungeon9
 

--- a/Assets/StreamingAssets/Quests/P0B01L02.txt
+++ b/Assets/StreamingAssets/Quests/P0B01L02.txt
@@ -125,7 +125,7 @@ QBN:
 Item _vamprelic_ religious anyInfo 1013 used 1015
 Item _letter_ letter used QuestorOffer
 
-Person _vampire_ factiontype Vampire_Clan female anyInfo 1011 rumors 1010
+Person _vampire_ factiontype Vampire_Clan remote anyInfo 1011 rumors 1010
 
 Place _itemdung_ remote magery
 

--- a/Assets/StreamingAssets/Quests/P0B10L07.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L07.txt
@@ -156,8 +156,8 @@ QBN:
 Item _letter_ letter used 1010
 Item _jewelry_ trinket
 
-Person _vamp_ factiontype Vampire_Clan male
-Person _knight_ face 69 factiontype Knightly_Guard
+Person _vamp_ factiontype Vampire_Clan local
+Person _knight_ face 69 factiontype Knightly_Guard male remote
 
 Place _mondung_ remote dungeon2
 

--- a/Assets/StreamingAssets/Quests/P0B10L08.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L08.txt
@@ -191,8 +191,8 @@ Item _letter_ letter used 1010
 Item _letter2_ letter used 1013
 Item _gem_ gem
 
-Person _vamp_ factiontype Vampire_Clan male
-Person _daedra_ face 1 factiontype Daedra
+Person _vamp_ factiontype Vampire_Clan local
+Person _daedra_ face 1 factiontype Daedra remote
 
 Place _mondung_ remote dungeon7
 

--- a/Assets/StreamingAssets/Quests/P0B10L10.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L10.txt
@@ -141,8 +141,8 @@ Message:  1017
 QBN:
 Item _letter_ letter used 1010
 
-Person _vamp_ factiontype Vampire_Clan male
-Person _vamp2_ factiontype Vampire_Clan female
+Person _vamp_ factiontype Vampire_Clan local
+Person _vamp2_ factiontype Vampire_Clan remote
 
 
 Clock _queston_ 00:00 0 flag 1 range 1 2

--- a/Assets/StreamingAssets/Quests/P0B20L09.txt
+++ b/Assets/StreamingAssets/Quests/P0B20L09.txt
@@ -123,7 +123,7 @@ QBN:
 Item _letter_ letter used 1010
 Item _I.01_ tusk
 
-Person _vamp_ factiontype Vampire_Clan male
+Person _vamp_ factiontype Vampire_Clan local
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y01.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y01.txt
@@ -125,8 +125,8 @@ Item _document_ letter used 1012
 --added underscores to document
 Item _mitem_ magic_item
 
-Person _qgiver_ group Questor male
-Person _daedra_ face 80 factiontype Daedra
+Person _qgiver_ group Questor
+Person _daedra_ face 80 factiontype Daedra remote
 
 Place _temple_ remote temple
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y03.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y03.txt
@@ -144,9 +144,9 @@ Message:  1013
 QBN:
 Item _gem_ gem
 
-Person _qgiver_ group Questor male
+Person _qgiver_ group Questor
 Person _child_ face 105 faction Children
-Person _daedra_ face 69 factiontype Daedra
+Person _daedra_ face 69 factiontype Daedra male remote
 
 Place _home_ remote house2
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y04.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y04.txt
@@ -150,8 +150,8 @@ QBN:
 Item _potion_ Pure_water
 Item _gold_ gold
 
-Person _qgiver_ group Questor male
-Person _mage_ face 105 faction The_Mages_Guild
+Person _qgiver_ group Questor
+Person _mage_ face 105 faction The_Mages_Guild remote
 
 Place _mguild_ remote magery
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y07.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y07.txt
@@ -110,8 +110,8 @@ Message:  1013
 QBN:
 Item _clothes_ womens_robe
 
-Person _qgiver_ group Questor male
-Person _witch_ face 1 faction The_Prostitutes
+Person _qgiver_ group Questor
+Person _witch_ face 1 faction The_Prostitutes female remote
 Person _daedra_ face 105 factiontype Daedra
 
 Place _mondung_ remote dungeon3

--- a/Assets/StreamingAssets/Quests/Q0C00Y08.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y08.txt
@@ -120,9 +120,9 @@ QBN:
 Item _mitem_ magic_item
 Item _book_ book2
 
-Person _qgiver_ group Questor male
-Person _daedra_ face 1 factiontype Daedra
-Person _contact_ face 68 group Innkeeper
+Person _qgiver_ group Questor
+Person _daedra_ face 1 factiontype Daedra local
+Person _contact_ face 68 group Innkeeper male remote
 
 
 Clock _queston_ 00:00 0 flag 17 range 1 2

--- a/Assets/StreamingAssets/Quests/Q0C0XY02.txt
+++ b/Assets/StreamingAssets/Quests/Q0C0XY02.txt
@@ -135,9 +135,9 @@ QBN:
 Item _jewelry_ trinket
 Item _mitem_ magic_item
 
-Person _qgiver_ group Questor male
-Person _daedra_ face 1 factiontype Daedra
-Person _man_ faction Dancers
+Person _qgiver_ group Questor
+Person _daedra_ face 1 factiontype Daedra remote
+Person _man_ faction Dancers male remote
 --Group 7.0 wouldn't work, needed a local site. Dancers is sufficient for the quest
 
 Place _tavern_ remote tavern

--- a/Assets/StreamingAssets/Quests/Q0C10Y00.txt
+++ b/Assets/StreamingAssets/Quests/Q0C10Y00.txt
@@ -138,7 +138,7 @@ Item _reward2_ turquoise
 Item _reward3_ jade
 --added messages 1024, 1025 and 1026 and their handling in the quest. previously you had to click the witch 3 times and turn in the items with no confirmation.
 
-Person _qgiver_ group Questor male anyInfo 1011
+Person _qgiver_ group Questor anyInfo 1011
 
 Place _dungeon1_ remote dungeon6
 Place _dungeon2_ remote dungeon12

--- a/Assets/StreamingAssets/Quests/Q0C20Y02.txt
+++ b/Assets/StreamingAssets/Quests/Q0C20Y02.txt
@@ -125,7 +125,7 @@ Item _reward_ gem
 Item _magicitem_ magic_item
 
 Person _questgiver_ face 112 group Questor anyInfo 1011
-Person _other_ factiontype Knightly_Guard female
+Person _other_ factiontype Knightly_Guard remote
 
 Clock _1stparton_ 00:00 0 flag 17 range 1 4
 

--- a/Assets/StreamingAssets/Quests/Q0C4XY04.txt
+++ b/Assets/StreamingAssets/Quests/Q0C4XY04.txt
@@ -120,7 +120,7 @@ QBN:
 Item _reward_ malachite
 Item _heart_ daedra_heart
 
-Person _questgiver_ group Questor male anyInfo 1011
+Person _questgiver_ group Questor anyInfo 1011
 
 Place _mondung_ remote dungeon8 anyInfo 1012
 

--- a/Assets/StreamingAssets/Quests/R0C10Y00.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y00.txt
@@ -137,9 +137,8 @@ Item _item1_ emerald
 Item _item2_ drug
 
 Person _questgiver_ face 136 group Questor
-Person _npc1_ group Local_3.0 female
-Person _npc2_ face 248 group Shopkeeper
---removed female tag on npc1. always spawned male sprite with female name.
+Person _npc1_ group Local_3.0 remote
+Person _npc2_ face 248 group Shopkeeper remote
 
 Clock _1stparton_ 00:00 0 flag 1 range 1 4
 Clock _2ndparton_ 00:00 0 flag 1 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C10Y01.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y01.txt
@@ -105,8 +105,8 @@ QBN:
 Item _reward_ ruby
 Item _item_ ruby
 
-Person _questgiver_ group Questor male
-Person _contact_ group Local_3.0 female
+Person _questgiver_ group Questor
+Person _contact_ group Local_3.0 remote
 
 
 Clock _queston_ 00:00 0 flag 1 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C10Y02.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y02.txt
@@ -142,7 +142,7 @@ Item _item1_ gold_bar
 Item _item2_ magic_item
 
 Person _questgiver_ face 76 group Questor
-Person _contact_ face 80 group Local_3.0
+Person _contact_ face 80 group Local_3.0 remote
 
 
 Clock _1stparton_ 00:00 0 flag 1 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C10Y04.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y04.txt
@@ -118,7 +118,7 @@ QBN:
 Item _reward_ gold
 
 Person _questgiver_ face 112 group Questor anyInfo 1011 rumors 1011
-Person _fakename_ group Local_4.0 female
+Person _fakename_ group Local_4.0 female remote
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/R0C10Y05.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y05.txt
@@ -142,7 +142,7 @@ QBN:
 Item _reward_ gold
 
 Person _questgiver_ face 112 group Questor
-Person _qgfriend_ group Local_3.0 female anyInfo 1011 rumors 1011
+Person _qgfriend_ group Local_3.0 remote anyInfo 1011 rumors 1011
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/R0C10Y08.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y08.txt
@@ -144,8 +144,8 @@ Item _reward_ gold
 Item _item_ religious
 
 Person _questgiver_ face 112 group Questor
-Person _transporter_ face 1 group Local_3.0 anyInfo 1011
-Person shopkeeper2 factiontype Temple female
+Person _transporter_ face 1 group Local_3.0 remote anyInfo 1011
+Person _dummypriest_ factiontype Temple remote
 
 Place _itemplace_ remote temple
 Place _inn_ remote tavern
@@ -171,7 +171,7 @@ _pchasitem_ task:
 	clicked item _item_ 
 	pc at _itemplace_ set _S.09_ 
 	say 1012 
-	change repute with shopkeeper2 by -10 
+	change repute with _dummypriest_ by -10 
 
 _queston_ task:
 	when _2ndparton_ 

--- a/Assets/StreamingAssets/Quests/R0C10Y09.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y09.txt
@@ -142,7 +142,7 @@ Item _reward_ gold
 Item _item_ trinket
 
 Person _questgiver_ face 112 group Questor
-Person _spy_ face 1 group Local_3.0 anyInfo 1011
+Person _spy_ face 1 group Local_3.0 remote anyInfo 1011
 
 Place _hidingplace_ remote random
 

--- a/Assets/StreamingAssets/Quests/R0C10Y10.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y10.txt
@@ -104,7 +104,7 @@ Item _weapon_ weapon
 Item _reward_ gold
 
 Person _questgiver_ face 112 group Questor
-Person _contact_ group Local_3.0 female
+Person _contact_ group Local_3.0 remote
 
 
 Clock _queston_ 00:00 0 flag 1 range 1 2

--- a/Assets/StreamingAssets/Quests/R0C10Y11.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y11.txt
@@ -119,8 +119,8 @@ QBN:
 Item _reward_ gold
 Item _item_ ring
 
-Person _questgiver_ group Questor male anyInfo 1011
-Person _qgfriend_ group Local_3.0 female anyInfo 1012
+Person _questgiver_ group Questor anyInfo 1011
+Person _qgfriend_ group Local_3.0 remote anyInfo 1012
 
 
 Clock _queston_ 00:00 0 flag 1 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C10Y12.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y12.txt
@@ -124,8 +124,8 @@ QBN:
 Item _reward_ gold
 Item _item_ drug
 
-Person _questgiver_ group Questor male anyInfo 1011
-Person _contact_ group Local_3.0 female anyInfo 1012
+Person _questgiver_ group Questor anyInfo 1011
+Person _contact_ group Local_3.0 remote anyInfo 1012
 
 
 Clock _queston_ 00:00 0 flag 1 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C10Y13.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y13.txt
@@ -111,8 +111,8 @@ QBN:
 Item _reward_ gold
 Item _item_ trinket
 
-Person _questgiver_ group Questor male
-Person _contact_ face 1 group Local_3.0
+Person _questgiver_ group Questor
+Person _contact_ face 1 group Local_3.0 remote
 
 Place _palace_ remote palace
 

--- a/Assets/StreamingAssets/Quests/R0C10Y14.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y14.txt
@@ -111,8 +111,8 @@ QBN:
 Item _reward_ gold
 Item _item_ magic_item
 
-Person _questgiver_ group Questor male
-Person _contact_ group Local_3.0
+Person _questgiver_ group Questor
+Person _contact_ group Local_3.0 remote
 --removed "female" parameter. UESP says it could be either.
 
 

--- a/Assets/StreamingAssets/Quests/R0C10Y15.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y15.txt
@@ -136,8 +136,8 @@ Item _item1_ diamond
 Item _item2_ magic_item
 
 Person _questgiver_ face 136 group Questor
-Person _npc1_ group Local_3.0 female
-Person _npc2_ face 248 group Local_3.1
+Person _npc1_ group Local_3.0 remote
+Person _npc2_ face 248 group Local_3.1 remote
 
 
 Clock _1stparton_ 00:00 0 flag 1 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C10Y17.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y17.txt
@@ -141,8 +141,8 @@ Item _item1_ misc
 Item _item2_ drug
 
 Person _questgiver_ face 136 group Questor
-Person _npc1_ group Chemist female
-Person _npc2_ face 248 group Local_3.0
+Person _npc1_ group Chemist remote
+Person _npc2_ face 248 group Local_3.0 remote
 
 
 Clock _1stparton_ 00:00 0 flag 1 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C10Y18.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y18.txt
@@ -149,9 +149,9 @@ Item _item1_ religious
 Item _item2_ gem
 
 Person _questgiver_ face 140 group Questor
-Person _npc1_ group Cleric female
-Person _npc2_ face 254 group Local_3.0
-Person _P.03_ faction The_Thieves_Guild female
+Person _npc1_ group Cleric remote
+Person _npc2_ face 254 group Local_3.0 female remote
+Person _dummythief_ faction The_Thieves_Guild remote
 
 
 Clock _1stparton_ 00:00 0 flag 1 range 1 4
@@ -167,7 +167,7 @@ Foe _thief_ is Rogue
 _pcgetsgold_ task:
 	toting _item2_ and _npc2_ clicked 
 	give pc _reward_ 
-	change repute with _P.03_ by -20 
+	change repute with _dummythief_ by -20 
 	end quest 
 
 variable _pchasitem1_

--- a/Assets/StreamingAssets/Quests/R0C10Y20.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y20.txt
@@ -127,7 +127,7 @@ Item _item1_ turquoise
 Item _item2_ skin
 
 Person _questgiver_ face 72 group Questor
-Person _contact_ face 80 group Chemist
+Person _contact_ face 80 group Chemist remote
 
 
 Clock _1stparton_ 00:00 0 flag 17 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C10Y21.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y21.txt
@@ -117,8 +117,8 @@ QBN:
 Item _reward_ gold
 
 Person _questgiver_ face 112 group Questor
-Person _qgfriend_ group Noble female anyInfo 1011
-Person _dummyorc_ faction Orsinium
+Person _qgfriend_ group Noble remote anyInfo 1011
+Person _dummyorc_ faction Orsinium remote
 
 Place _mondung_ remote dungeon4
 

--- a/Assets/StreamingAssets/Quests/R0C11Y03.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y03.txt
@@ -157,8 +157,8 @@ Item _reward_ gold
 Item _item_ daedra_heart anyInfo 1013
 
 Person _questgiver_ face 112 group Questor anyInfo 1012
-Person _chemist_ group Chemist female anyInfo 1011
-Person _dummydaedra_ face 102 factiontype Daedra
+Person _chemist_ group Chemist remote anyInfo 1011
+Person _dummydaedra_ face 102 factiontype Daedra female remote
 
 Clock _1stparton_ 00:00 0 flag 1 range 2 5
 Clock _2ndparton_ 00:00 0 flag 1 range 2 5

--- a/Assets/StreamingAssets/Quests/R0C11Y16.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y16.txt
@@ -141,8 +141,8 @@ Item _item1_ telescope
 Item _item2_ Holy_relic
 
 Person _questgiver_ face 140 group Questor
-Person _npc1_ group Local_3.0 female
-Person _npc2_ face 248 group Local_3.1
+Person _npc1_ group Local_3.0 remote
+Person _npc2_ face 248 group Local_3.1 remote
 
 
 Clock _1stparton_ 00:00 0 flag 1 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C11Y19.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y19.txt
@@ -130,7 +130,7 @@ Item _item1_ gold_bar
 Item _item2_ ring
 
 Person _questgiver_ face 72 group Questor
-Person _contact_ face 80 group Pawnbroker
+Person _contact_ face 80 group Pawnbroker remote
 
 
 Clock _1stparton_ 00:00 0 flag 17 range 1 4

--- a/Assets/StreamingAssets/Quests/R0C11Y26.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y26.txt
@@ -285,10 +285,10 @@ Item _I.04_ dead_body
 Item _I.05_ dead_body
 Item _reward_ gold
 
-Person _qgiver_ group Questor male
-Person _contact_ face 1 group Librarian anyInfo 1025 rumors 1026
-Person _hooker_ face 1 faction The_Prostitutes
-Person _rippername_ face 101 group Group_6.0 anyInfo 1040 rumors 1041
+Person _qgiver_ group Questor
+Person _contact_ face 1 group Librarian local anyInfo 1025 rumors 1026
+Person _hooker_ face 1 faction The_Prostitutes local
+Person _rippername_ face 101 group Group_6.0 male local anyInfo 1040 rumors 1041
 
 Place _bookstore_ local house2
 Place _hookerhouse_ local house4

--- a/Assets/StreamingAssets/Quests/R0C11Y28.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y28.txt
@@ -397,11 +397,11 @@ Item _reward2_ trinket
 Item _I.08_ item class 26 subclass 3
 Item _I.09_ item class 15 subclass 13
 
-Person _qgiver_ group Questor male
-Person _contact_ face 1 group Librarian anyInfo 1027 rumors 1028
-Person _vamp_ face 1 factiontype Vampire_Clan anyInfo 1016 rumors 1017
-Person _widow_ face 82 group Resident2 anyInfo 1018
-Person _rippername_ face 5 group Group_6.0
+Person _qgiver_ group Questor
+Person _contact_ face 1 group Librarian local anyInfo 1027 rumors 1028
+Person _vamp_ face 1 factiontype Vampire_Clan local anyInfo 1016 rumors 1017
+Person _widow_ face 82 group Resident2 female local anyInfo 1018
+Person _rippername_ face 5 group Group_6.0 male local
 
 Place _bookstore_ local house2
 Place _hookerhouse_ local tavern

--- a/Assets/StreamingAssets/Quests/R0C20Y07.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y07.txt
@@ -114,7 +114,7 @@ Item _reward_ magic_item
 Item _item_ sapphire
 
 Person _questgiver_ face 112 group Questor
-Person _qgfriend_ group Local_3.0 female
+Person _qgfriend_ group Local_3.0 remote
 
 Place _itemdung_ remote dungeon13
 

--- a/Assets/StreamingAssets/Quests/R0C20Y22.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y22.txt
@@ -161,9 +161,9 @@ QBN:
 Item _reward_ ruby
 Item _item_ trinket
 
-Person _questgiver_ group Questor male anyInfo 1015 rumors 1016
-Person _contact_ group Local_3.0 female
-Person _orsinium_ face 184 faction Orsinium anyInfo 1012 rumors 1013
+Person _questgiver_ group Questor anyInfo 1015 rumors 1016
+Person _contact_ group Local_3.0 remote
+Person _orsinium_ face 184 faction Orsinium remote anyInfo 1012 rumors 1013
 
 Place orcCastle permanent OrsiniumCastle3
 

--- a/Assets/StreamingAssets/Quests/R0C30Y25.txt
+++ b/Assets/StreamingAssets/Quests/R0C30Y25.txt
@@ -169,10 +169,10 @@ Item _item3_ magic_item
 Item _map_ letter used 1035
 
 Person _questgiver_ face 72 group Questor
-Person _contact_ faction Dancers
+Person _contact_ faction Dancers remote
 -- Person:    1 80 -1 0 13278 0 0.
 
-Person _qgenemy_ face 1 faction The_Thieves_Guild anyInfo 1015 rumors 1016
+Person _qgenemy_ face 1 faction The_Thieves_Guild remote anyInfo 1015 rumors 1016
 
 Place _thievesguild_ remote house1
 Place totambuCoven permanent MyrkwasaCoven

--- a/Assets/StreamingAssets/Quests/R0C4XY23.txt
+++ b/Assets/StreamingAssets/Quests/R0C4XY23.txt
@@ -161,11 +161,11 @@ Item _reward_ ruby
 Item _item_ book2
 Item _map_ letter used 1030
 
-Person _questgiver_ group Questor male
-Person _contact_ faction Dancers
+Person _questgiver_ group Questor
+Person _contact_ faction Dancers remote
 -- Person:    1 0 -1 0 13278 0 0.
 
-Person _oblivion_ factiontype Daedra female anyInfo 1013 rumors 1014
+Person _oblivion_ factiontype Daedra remote anyInfo 1013 rumors 1014
 
 Place _skeffingcoven_ permanent SkeffingtonCoven
 

--- a/Assets/StreamingAssets/Quests/R0C60Y24.txt
+++ b/Assets/StreamingAssets/Quests/R0C60Y24.txt
@@ -176,9 +176,9 @@ Item _note_ letter used 1040
 Item _vampreward_ gold
 Item _vampitem_ magic_item
 
-Person _questgiver_ group Questor male
-Person _contact_ group Cleric female anyInfo 1015 rumors 1015
-Person _vampire_ face 1 factiontype Vampire_Clan
+Person _questgiver_ group Questor
+Person _contact_ group Cleric remote anyInfo 1015 rumors 1015
+Person _vampire_ face 1 factiontype Vampire_Clan remote
 
 Place kykosCoven permanent KykosCoven
 Place _vamphouse_ remote house1

--- a/Assets/StreamingAssets/Quests/S0000001.txt
+++ b/Assets/StreamingAssets/Quests/S0000001.txt
@@ -310,8 +310,8 @@ Person _lhotun_ named Prince_Lhotun atHome
 Person _akorithi_ named Queen_Akorithi atHome
 Person _greklith_ face 88 named Prince_Greklith atHome
 Person Vhosek face 88 named Lord_Vhosek atHome
-Person _brother_ face 5 faction Children male anyInfo 1030 rumors 1031
-Person _agentuk_ face 1 faction Agents_of_The_Underking
+Person _brother_ face 5 faction Children male remote anyInfo 1030 rumors 1031
+Person _agentuk_ face 1 faction Agents_of_The_Underking remote
 
 Place _ukcrypt_ remote dungeon11 anyInfo 1015 rumors 1016
 Place _dirennitower_ permanent DirenniTowerEntry

--- a/Assets/StreamingAssets/Quests/S0000007.txt
+++ b/Assets/StreamingAssets/Quests/S0000007.txt
@@ -332,7 +332,7 @@ Item _I.01_ letter used 1017
 Item _relic_ magic_item used 1026
 
 Person _cyndassa_ named Cyndassa atHome anyInfo 1019
-Person courtier face 89 faction Court_of_Daggerfall
+Person courtier face 89 faction Court_of_Daggerfall remote
 Person _barmaid_ face 115 faction The_Daggerfall_Witches anyInfo 1020
 Person _P.03_ faction The_Sisters_of_the_Bluff female
 Person _wereBrother_ face 13 faction The_Mages_Guild anyInfo 1025 male

--- a/Assets/StreamingAssets/Quests/S0000008.txt
+++ b/Assets/StreamingAssets/Quests/S0000008.txt
@@ -350,12 +350,12 @@ Item totemReward3 gold range 25000 to 25000
 Item totemReward4 gold range 25000 to 25000
 
 Person Brisienna face 1 named Lady_Brisienna
-Person Gothryd1 named King_Gothryd atHome
+Person _Gothryd_ named King_Gothryd atHome
 Person Eadwyre named King_Eadwyre atHome
 Person _Akorithi_ named Queen_Akorithi atHome
 Person Gortwog named Gortwog atHome
-Person _Underking_ face 1 faction Agents_of_The_Underking
-Person KingOfWorms2 named King_of_Worms atHome
+Person _Underking_ face 1 faction Agents_of_The_Underking remote
+Person _Kingoworms_ named King_of_Worms atHome
 
 Place _daggerfall_ permanent DaggerfallCastle2
 Place _tavern_ remote tavern
@@ -415,11 +415,11 @@ _S.07_ task:
 	repute with Eadwyre exceeds 15 do _S.12_ 
 	repute with Gortwog exceeds 10 do _S.15_ 
 	repute with _Underking_ exceeds 0 do _S.16_ 
-	repute with KingOfWorms2 exceeds 0 do _S.17_ 
+	repute with _Kingoworms_ exceeds 0 do _S.17_ 
 	have _totem_ set _S.27_ 
 	add Gortwog as questor 
 	add _Akorithi_ as questor 
-	add Gothryd1 as questor 
+	add _Gothryd_ as questor 
 	add Eadwyre as questor 
 	place npc Brisienna at _newplace_ 
 
@@ -519,7 +519,7 @@ BrisiennaGotTotem _S.32_
 	make _artifact4_ permanent 
 
 KingOfWormsGotTotem _S.33_
-	toting _totem_ and KingOfWorms2 clicked 
+	toting _totem_ and _Kingoworms_ clicked 
 	start quest 106 106 
 	say 1054 
 
@@ -542,7 +542,7 @@ EadwyreGotTotem _S.36_
 
 _S.37_ task:
 	when _S.46_ and _S.07_ 
-	get item _goldgoth_ from Gothryd1 
+	get item _goldgoth_ from _Gothryd_ 
 	say 1053 
 	make _goldgoth_ permanent 
 
@@ -575,9 +575,9 @@ _S.45_ task:
 	drop Brisienna as questor 
 	drop Eadwyre as questor 
 	drop Gortwog as questor 
-	drop Gothryd1 as questor 
+	drop _Gothryd_ as questor 
 	end quest 
 
 _S.46_ task:
-	toting _totem_ and Gothryd1 clicked 
+	toting _totem_ and _Gothryd_ clicked 
 	start task _S.31_ 

--- a/Assets/StreamingAssets/Quests/S0000009.txt
+++ b/Assets/StreamingAssets/Quests/S0000009.txt
@@ -161,8 +161,8 @@ Item _letter46_ letter used 1016
 Item _bribe_ gold
 
 Person _elysana_ named Princess_Elysana atHome
-Person _foil_ face 115 faction The_Prostitutes
-Person _contact_ group Local_3.3 female
+Person _foil_ face 115 faction The_Prostitutes female remote
+Person _contact_ group Local_3.3 remote
 Person Woodborne face 1 named Lord_Woodborne
 
 Clock _giveLetter_ 7.00:00 14.00:00

--- a/Assets/StreamingAssets/Quests/S0000010.txt
+++ b/Assets/StreamingAssets/Quests/S0000010.txt
@@ -138,9 +138,8 @@ QBN:
 Item _reward_ magic_item
 Item letter14 letter used 1021
 
-Person _agentuk_ face 1 faction Agents_of_The_Underking
-Person shopkeeper1 face 1 faction The_Necromancers
---removed ? from shopkeeper1. variable names should not contain punctuation.
+Person _agentuk_ face 1 faction Agents_of_The_Underking remote
+Person _necromancer_ face 1 faction The_Necromancers remote
 
 Place _llugwych_ permanent LlugwychCastle
 Place _agentplace_ remote house2
@@ -158,7 +157,7 @@ _pcgetsgold_ task:
 	toting _reward_ and _agentuk_ clicked 
 	give pc _reward_ 
 	reveal _lysandustomb_ in province 33 at 210794 
-	change repute with shopkeeper1 by -20 
+	change repute with _necromancer_ by -20 
 	change repute with _agentuk_ by +15 
 	end quest 
 

--- a/Assets/StreamingAssets/Quests/S0000012.txt
+++ b/Assets/StreamingAssets/Quests/S0000012.txt
@@ -169,8 +169,8 @@ Item letter47 letter used 1017
 Item _jewelry_ trinket
 
 Person _Mynisera_ face 96 named Mynisera atHome
-Person _messenger_ face 1 faction The_Knights_of_the_Dragon
-Person _dispatcher_ faction The_Knights_of_the_Dragon
+Person _messenger_ face 1 faction The_Knights_of_the_Dragon remote
+Person _dispatcher_ faction The_Knights_of_the_Dragon remote
 Person _aubki_ named Queen_Aubk-i atHome
 
 Place _location_ remote random

--- a/Assets/StreamingAssets/Quests/S0000021.txt
+++ b/Assets/StreamingAssets/Quests/S0000021.txt
@@ -105,9 +105,9 @@ QBN:
 Item _scarab_ scarab used 1012
 Item _magicitem_ magic_item
 
-Person KingOfWorms4 named King_of_Worms atHome
-Person Karolis1 face 169 named Lord_Darkworth
-Person KingOfWorms1 face 1 named King_of_Worms
+Person _kingoworms_ named King_of_Worms atHome
+Person _lichface_ face 169 named Lord_Darkworth
+Person _fakekow_ face 1 named King_of_Worms
 
 Place _sentinel_ permanent SentinelCastle
 
@@ -118,14 +118,14 @@ Foe _lich_ is Lich
 --	Quest start-up:
 	dialog link for item _magicitem_ 
 	dialog link for item _scarab_ 
-	repute with KingOfWorms4 exceeds 0 do _S.01_ 
+	repute with _kingoworms_ exceeds 0 do _S.01_ 
 
 _S.00_ task:
 	level 7 completed 
 
 variable _S.01_
 _S.02_ task:
-	clicked npc KingOfWorms4 
+	clicked npc _kingoworms_ 
 
 _S.03_ task:
 	when _S.02_ and _S.15_ 
@@ -149,7 +149,7 @@ _S.06_ task:
 	send _zombie_ every 1410 minutes with 100% success 
 
 until _S.06_ performed:
-	mute npc KingOfWorms4 
+	mute npc _kingoworms_ 
 
 _S.07_ task:
 	injured _zombie_ 
@@ -157,7 +157,7 @@ _S.07_ task:
 _S.08_ task:
 	killed 1 _lich_ 
 	setvar _killmon_
-	add Karolis1 face 
+	add _lichface_ face 
 
 variable _killmon_
 _S.10_ task:
@@ -171,8 +171,8 @@ _givereward_ task:
 	when _S.10_ and _S.08_ 
 	give pc _magicitem_ 
 	start task _S.14_ 
-	drop Karolis1 face 
-	change repute with KingOfWorms4 by +15 
+	drop _lichface_ face 
+	change repute with _kingoworms_ by +15 
 	end quest 
 
 KingOfWormsGotTotem _S.13_

--- a/Assets/StreamingAssets/Quests/S0000106.txt
+++ b/Assets/StreamingAssets/Quests/S0000106.txt
@@ -42,22 +42,22 @@ QuestorPostfailure:  [1009]
 
 QBN:
 
-Person Gothryd named King_Gothryd atHome
-Person Eadwyre named King_Eadwyre atHome
+Person _gothryd_ named King_Gothryd atHome
+Person _eadwyre_ named King_Eadwyre atHome
 Person _akorithi_ face 240 named Queen_Akorithi atHome
-Person _magesguild_ face 97 faction The_Mages_Guild
-Person _P.04_ face 72 faction The_Fighters_Guild
-Person _thievesguild_ face 1 faction The_Thieves_Guild
-Person _P.06_ face 201 faction The_Dark_Brotherhood
-Person _P.07_ face 1 faction The_Temple_of_Kynareth
-Person _queston2_ face 217 faction The_Temple_of_Stendarr
-Person _P.09_ faction The_School_of_Julianos female
-Person _gogo_ face 1 faction The_Benevolence_of_Mara
-Person _P.11_ face 1 faction The_House_of_Dibella
-Person _P.12_ face 97 faction The_Akatosh_Chantry
-Person _P.13_ face 1 faction The_Order_of_Arkay
-Person _zen_ face 1 faction The_Resolution_of_Z'en
-Person _P.15_ face 1 faction The_Merchants
+Person _magesguild_ face 97 faction The_Mages_Guild remote
+Person _fightersguild_ face 72 faction The_Fighters_Guild local
+Person _thievesguild_ face 1 faction The_Thieves_Guild remote
+Person _darkbrother_ face 201 faction The_Dark_Brotherhood remote
+Person _kynareth_ face 1 faction The_Temple_of_Kynareth remote
+Person _stendarr_ face 217 faction The_Temple_of_Stendarr remote
+Person _julianos_ faction The_School_of_Julianos remote
+Person _mara_ face 1 faction The_Benevolence_of_Mara remote
+Person _dibella_ face 1 faction The_House_of_Dibella remote
+Person _akatosh_ face 97 faction The_Akatosh_Chantry remote
+Person _arkay_ face 1 faction The_Order_of_Arkay remote
+Person _zen_ face 1 faction The_Resolution_of_Z'en remote
+Person _merchants_ face 1 faction The_Merchants remote
 
 
 Clock _delay_ 00:01 0 flag 1 range 0 1
@@ -67,20 +67,20 @@ Clock _delay_ 00:01 0 flag 1 range 0 1
 	start timer _delay_ 
 
 _delay_ task:
-	change repute with _P.12_ by +100 
+	change repute with _akatosh_ by +100 
 	change repute with _akorithi_ by +100 
-	change repute with _P.13_ by +100 
-	change repute with _P.06_ by +100 
-	change repute with _P.11_ by +100 
-	change repute with Eadwyre by +100 
-	change repute with _P.04_ by +100 
-	change repute with Gothryd by +100 
-	change repute with _P.09_ by +100 
-	change repute with _P.07_ by +100 
+	change repute with _arkay_ by +100 
+	change repute with _darkbrother_ by +100 
+	change repute with _dibella_ by +100 
+	change repute with _eadwyre_ by +100 
+	change repute with _fightersguild_ by +100 
+	change repute with _gothryd_ by +100 
+	change repute with _julianos_ by +100 
+	change repute with _kynareth_ by +100 
 	change repute with _magesguild_ by +100 
-	change repute with _gogo_ by +100 
-	change repute with _P.15_ by +100 
-	change repute with _queston2_ by +100 
+	change repute with _mara_ by +100 
+	change repute with _merchants_ by +100 
+	change repute with _stendarr_ by +100 
 	change repute with _thievesguild_ by +100 
 	change repute with _zen_ by +100 
 	end quest 

--- a/Assets/StreamingAssets/Quests/S0000500.txt
+++ b/Assets/StreamingAssets/Quests/S0000500.txt
@@ -145,9 +145,9 @@ Item _letter_ letter used 1030
 Item _gold_ gold
 
 Person _traitor_ face 1 named Lord_K'avar
-Person _contact1_ face 15 group Banker
+Person _contact1_ face 15 group Banker female remote
 Person _queen_ named Queen_Akorithi atHome
-Person _contact2_ face 1 group Local_3.0
+Person _contact2_ face 1 group Local_3.0 remote
 
 Place _tavern_ remote tavern
 Place _sentinel_ permanent SentinelCastle4

--- a/Assets/StreamingAssets/Quests/S0000503.txt
+++ b/Assets/StreamingAssets/Quests/S0000503.txt
@@ -167,7 +167,7 @@ Item _I.05_ gold
 Item _key_ item class 10 subclass 11
 
 Person _rebel_ face 1 named Baltham_Greyman
-Person _dummy_ face 249 group Spellcaster
+Person _dummy_ face 249 group Spellcaster remote
 
 Place _tavern_ remote tavern
 --Place aide remote dungeon

--- a/Assets/StreamingAssets/Quests/S0000988.txt
+++ b/Assets/StreamingAssets/Quests/S0000988.txt
@@ -124,22 +124,41 @@ Item _letter1_ letter used 1010
 Item _letter2_ letter used 1011
 Item _letter3_ letter used 1012
 
-Person _gortwog_ named Gortwog atHome
-Person _thievesguild_ face 1 faction The_Thieves_Guild
-Person _magesguild_ face 13 faction The_Mages_Guild
-Person _P.03_ face 1 faction The_Merchants
+Person _darkb_ face 1 faction Dark_Plotters remote
+Person _lhotun_ named Prince_Lhotun atHome
+Person _vampires_ face 113 factiontype Vampire_Clan remote
+Person _gortwog_ face 144 named Gortwog atHome
+Person _underking_ named The_Underking
+Person _aubk-i_ named Queen_Aubk-i atHome
+Person _thievesguild_ face 1 faction The_Thieves_Guild remote
+Person _kingofworms_ named King_of_Worms atHome
+Person _elysana_ named Princess_Elysana atHome
+Person _witches_ face 1 factiontype Witches_Coven remote
+Person _magesguild_ face 13 faction The_Mages_Guild male remote
 
 
 Clock _delay_ 1.00:00 0 flag 1 range 0 1
 
 
 --	Quest start-up:
+	dialog link for person _darkb_ 
+	dialog link for person _gortwog_ 
+	dialog link for person _kingofworms_ 
 	dialog link for person _magesguild_ 
 	dialog link for person _thievesguild_ 
-	dialog link for person _P.03_ 
+	dialog link for person _vampires_ 
+	dialog link for person _witches_ 
+	dialog link for person _underking_ 
+	repute with _darkb_ exceeds 50 do _S.00_ 
+	repute with _lhotun_ exceeds 25 do _S.00_
+	repute with _vampires_ exceeds 10 do _S.00_
 	repute with _gortwog_ exceeds 25 do _S.00_ 
+	repute with _underking_ exceeds 5 do _S.01_ 
+	repute with _aubk-i_ exceeds 25 do _S.01_
 	repute with _thievesguild_ exceeds 50 do _S.01_ 
-	repute with _P.03_ exceeds 50 do _S.00_ 
+	repute with _kingofworms_ exceeds 15 do _S.02_ 
+	repute with _elysana_ exceeds 25 do _S.02_ 
+	repute with _witches_ exceeds 25 do _S.02_ 
 	repute with _magesguild_ exceeds 50 do _S.02_ 
 
 _S.00_ task:

--- a/Assets/StreamingAssets/Quests/U0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/U0C00Y00.txt
@@ -6,7 +6,7 @@
 -- QuestId: 0
 Messages: 43
 Quest: U0C00Y00
-DisplayName: Beothiah's Quest
+DisplayName: Boethiah's Quest
 -- Message panels
 QRC:
 
@@ -174,7 +174,7 @@ Item _letter_ letter used 1040
 
 -Person _questgiver_ face 112 group Questor anyInfo 1013
 Person _qgfriend_ group Librarian anyInfo 1011 rumors 1012
-Person _mfriend_ group Resident1 female
+Person _mfriend_ group Local_4.0 remote
 
 Place _mondung_ remote dungeon2
 Place _hideout_ remote dungeon6

--- a/Assets/StreamingAssets/Quests/V0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/V0C00Y00.txt
@@ -123,7 +123,7 @@ Message:  1030
 QBN:
 Item _artifact_ artifact Masque_of_Clavicus_Vile anyInfo 1014
 
-Person _contact_ face 238 faction The_Cabal anyInfo 1012
+Person _contact_ face 238 faction The_Cabal female remote anyInfo 1012
 
 Place _mondung_ remote dungeon
 Place _tavern_ remote tavern

--- a/Assets/StreamingAssets/Quests/W0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/W0C00Y00.txt
@@ -143,8 +143,8 @@ Item _artifact_ artifact Oghma_Infinium anyInfo 1013
 Item _magic_ magic_item
 
 Person _questgiver_ face 112 group Questor anyInfo 1012
-Person _contact_ group Librarian female anyInfo 1011
-Person _enemy_ face 1 factiontype Province
+Person _contact_ group Librarian remote anyInfo 1011
+Person _enemy_ face 1 factiontype Province remote
 
 Place _palace_ remote palace
 Place _L.01_ remote dungeon

--- a/Assets/StreamingAssets/Quests/X0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/X0C00Y00.txt
@@ -122,7 +122,7 @@ Message:  1030
 QBN:
 Item _artifact_ artifact Hircine_Ring anyInfo 1013
 
-Person _contact_ face 238 faction The_Cabal
+Person _contact_ face 238 faction The_Cabal female remote
 
 Place _mondung_ remote dungeon
 

--- a/Assets/StreamingAssets/Quests/Y0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/Y0C00Y00.txt
@@ -122,7 +122,7 @@ Dagon's prey returns to Oblivion.
 QBN:
 Item _artifact_ artifact Mehrunes_Razor anyInfo 1013
 
-Person _contact_ face 239 faction The_Cabal anyInfo 1012
+Person _contact_ face 239 faction The_Cabal female remote anyInfo 1012
 
 Place _mondung_ remote dungeon
 Place _tavern_ remote tavern

--- a/Assets/StreamingAssets/Quests/Z0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/Z0C00Y00.txt
@@ -141,8 +141,8 @@ Message:  1041
 QBN:
 Item _artifact_ artifact Ebony_Blade anyInfo 1013
 
-Person _qgfriend_ group Librarian female anyInfo 1011
-Person _enemy_ face 1 factiontype Knightly_Guard
+Person _qgfriend_ group Librarian remote anyInfo 1011
+Person _enemy_ face 1 factiontype Knightly_Guard remote
 
 Place _palace_ remote palace
 


### PR DESCRIPTION
Quest NPCs location scope and gender information is available from QBN data, however it was not correctly understood until now. After having reverse engineered classic original function used to setup a quest NPC, I made a small program to extract the information from QBN data and patch DFU quests. This PR is the result of this patch, which also required to modify `Person.cs` in order to parse the new location scope information.

This should fix all quests reported by Tamalak in this post: http://forums.dfworkshop.net/viewtopic.php?p=52023&sid=9dce69880ec5c26f698316ab5c0a47d6#p52023

I also took this occasion to fix some incorrect quest variables names and to restore quest S0000988 to its original state, where several NPCs should be able to send a letter regarding Numidium. The DFQFIX patch which was integrated in DFU was intended for classic but DFU does not have the same engine issue, so the original quest should work.

Some other modifications I made:
50C00Y00: Set `_qgfriend_` to `female` even if the gender is random in classic, as it matches the description.
80C0XY00: Set `_qgfriend_` to `male` for the same reason.
B0B50Y11: Remove `_nobleman_` gender as there is no reason to use a specific gender to this NPC.

@rossipaolo This adds the "remote" and "local" attribute to a quest Person, so you may need to update your VS Code template when this PR gets merged.



