### PR TITLE
AI pathfinding issues when getting shot at

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -67,6 +67,7 @@ namespace DaggerfallWorkshop.Game
         float strafeAngle;
         int searchMult;
         int ignoreMaskForShooting;
+        int ignoreMaskForObstacles;
         bool canAct;
         bool falls;
         bool flyerFalls;
@@ -119,6 +120,9 @@ namespace DaggerfallWorkshop.Game
 
             // Add things AI should ignore when checking for a clear path to shoot.
             ignoreMaskForShooting = ~(1 << LayerMask.NameToLayer("SpellMissiles") | 1 << LayerMask.NameToLayer("Ignore Raycast"));
+
+            // Also ignore arrows and "Ignore Raycast" layer for obstacles
+            ignoreMaskForObstacles = ~(1 << LayerMask.NameToLayer("SpellMissiles") | 1 << LayerMask.NameToLayer("Ignore Raycast"));
 
             lastGroundedY = transform.position.y;
 
@@ -1104,7 +1108,7 @@ namespace DaggerfallWorkshop.Game
             Vector3 p1 = transform.position + (Vector3.up * -originalHeight * 0.1388F);
             Vector3 p2 = p1 + (Vector3.up * Mathf.Min(originalHeight, doorCrouchingHeight) / 2);
 
-            if (Physics.CapsuleCast(p1, p2, controller.radius / 2, direction, out hit, checkDistance))
+            if (Physics.CapsuleCast(p1, p2, controller.radius / 2, direction, out hit, checkDistance, ignoreMaskForObstacles))
             {
                 // Debug.DrawRay(transform.position, direction, Color.red, 2.0f);
                 obstacleDetected = true;


### PR DESCRIPTION
Fixed enemy AIs treating arrows and spell projectiles as obstacles, causing them to shortly initiate a detour every time they get shot at.

I started investigating as part of https://forums.dfworkshop.net/viewtopic.php?f=5&t=4890. As mentioned in the thread, I noticed that the CapsuleCast detects triggers, and therefore arrows were detected but not handled as "not an obstacle" in the EnemyMotor, so the AI treated them as an obstacle. Even if the CapsulaCast didn't detect triggers, spell projectiles are solid, and would be detected as an obstacle anyway.

Pango suggested I use the layer mask, as used for detecting a clear path for shooting. This worked well enough in my tests. 

Here's the save I used for testing. It's just a level 1 Archer at the start of Privateer's Hold.
[SAVE29.zip](https://github.com/Interkarma/daggerfall-unity/files/6650169/SAVE29.zip)

I go up the stairs, get to the bat and imp, wait for either of them to start chasing me, then run backward down the corridor I just came from while shooting (the imp was easier to test with since it doesn't die from Iron arrows).

Without the fix, the imp constantly moves left or right for a short time after every shot. 
With the fix, the imp only gets a slight knockback from the attack, but keeps moving in a straight line otherwise.