### PR TITLE
Colorblind accessibility settings

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -108,6 +108,10 @@ AutomapRememberSliceLevel=False
 AutomapAlwaysMaxOutSliceLevel=False
 ExteriorMapDefaultZoomLevel=8
 ExteriorMapResetZoomLevelOnNewLocation=True
+AutomapTempleColor=457DC3FF
+AutomapShopColor=BE5518FF
+AutomapTavernColor=557530FF
+AutomapHouseColor=453C28FF
 
 [Startup]
 StartCellX=109

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -61,6 +61,10 @@ namespace DaggerfallWorkshop.Game
         public static Color DaggerfallPrisonDaysUntilFreedomColor = new Color32(232, 196, 76, 255);
         public static Color DaggerfallPrisonDaysUntilFreedomShadowColor = new Color32(48, 36, 20, 255);
         public static Color DaggerfallInfoPanelTextColor = new Color32(250, 250, 220, 255);
+        public static Color DaggerfallDefaultTempleAutomapColor = new Color32(69, 125, 195, 255);
+        public static Color DaggerfallDefaultShopAutomapColor = new Color32(190, 85, 24, 255);
+        public static Color DaggerfallDefaultTavernAutomapColor = new Color32(85, 117, 48, 255);
+        public static Color DaggerfallDefaultHouseAutomapColor = new Color32(69, 60, 40, 255);
         public static Vector2 DaggerfallDefaultShadowPos = Vector2.one;
 
         public FilterMode globalFilterMode = FilterMode.Point;

--- a/Assets/Scripts/Game/ExteriorAutomap.cs
+++ b/Assets/Scripts/Game/ExteriorAutomap.cs
@@ -1398,10 +1398,7 @@ namespace DaggerfallWorkshop.Game
                             // guilds
                             case 12: // guildhall
                             case 15: // temple
-                                colors[o].r = 69;
-                                colors[o].g = 125;
-                                colors[o].b = 195;
-                                colors[o].a = 255;
+                                colors[o] = DaggerfallUnity.Settings.AutomapTempleColor;
                                 break;
                             // shops
                             case 1: // alchemist
@@ -1414,16 +1411,10 @@ namespace DaggerfallWorkshop.Game
                             case 11: // library
                             case 13: // pawn shop
                             case 14: // weapon smith
-                                colors[o].r = 190;
-                                colors[o].g = 85;
-                                colors[o].b = 24;
-                                colors[o].a = 255;
+                                colors[o] = DaggerfallUnity.Settings.AutomapShopColor;
                                 break;
                             case 16: // tavern
-                                colors[o].r = 85;
-                                colors[o].g = 117;
-                                colors[o].b = 48;
-                                colors[o].a = 255;
+                                colors[o] = DaggerfallUnity.Settings.AutomapTavernColor;
                                 break;
                             // common
                             case 2: // house for sale
@@ -1437,10 +1428,7 @@ namespace DaggerfallWorkshop.Game
                             case 22: // house 5 (hedge)
                             case 23: // house 6
                             case 24: // town23
-                                colors[o].r = 69;
-                                colors[o].g = 60;
-                                colors[o].b = 40;
-                                colors[o].a = 255;
+                                colors[o] = DaggerfallUnity.Settings.AutomapHouseColor;
                                 break;
                             case 25: // ship
                             case 117: // special 1
@@ -1449,10 +1437,7 @@ namespace DaggerfallWorkshop.Game
                             case 251: // special 4
                                 if (showAll)
                                 {
-                                    colors[o].r = 69;
-                                    colors[o].g = 60;
-                                    colors[o].b = 40;
-                                    colors[o].a = 255;
+                                    colors[o] = DaggerfallUnity.Settings.AutomapHouseColor;
                                 }
                                 break;
                             case 0:

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -167,6 +167,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button automapTavernColor;
         Button automapHouseColor;
 
+        Button automapReset;
+
         #endregion
 
         #region Override Methods
@@ -390,6 +392,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             automapShopColor = AddColorPicker(leftPanel, "automapShopColor", DaggerfallUnity.Settings.AutomapShopColor);
             automapTavernColor = AddColorPicker(leftPanel, "automapTavernColor", DaggerfallUnity.Settings.AutomapTavernColor);
             automapHouseColor = AddColorPicker(leftPanel, "automapHouseColor", DaggerfallUnity.Settings.AutomapHouseColor);
+
+            automapReset = AddButton(leftPanel, GetText("reset"), AutomapReset_OnMouseClick);
+        }
+
+        private void AutomapReset_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            automapTempleColor.BackgroundColor = DaggerfallUI.DaggerfallDefaultTempleAutomapColor;
+            automapShopColor.BackgroundColor = DaggerfallUI.DaggerfallDefaultShopAutomapColor;
+            automapTavernColor.BackgroundColor = DaggerfallUI.DaggerfallDefaultTavernAutomapColor;
+            automapHouseColor.BackgroundColor = DaggerfallUI.DaggerfallDefaultHouseAutomapColor;
         }
 
         private void SaveSettings()
@@ -732,6 +744,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             y += itemSpacing;
             return colorPicker;
+        }
+
+        private Button AddButton(Panel panel, string label, BaseScreenComponent.OnMouseClickHandler onMouseClickHandler)
+        {
+            Button button = DaggerfallUI.AddButton(new Vector2(panel.Size.x / 2, y), new Vector2(30, 8), panel);
+            button.Label.Text = label;
+            button.OnMouseClick += onMouseClickHandler;
+            button.Outline.Enabled = true;
+            button.BackgroundColor = new Color(0.0f, 0.5f, 0.0f, 0.4f);
+
+            y += itemSpacing + 2;
+
+            return button;
         }
 
         private static string GetText(string key)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -161,6 +161,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox interiorLightShadows;
         Checkbox exteriorLightShadows;
 
+        // Accessibility
+        Button automapTempleColor;
+        Button automapShopColor;
+        Button automapTavernColor;
+        Button automapHouseColor;
+
         #endregion
 
         #region Override Methods
@@ -223,6 +229,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             AddPage("interface", Interface);
             AddPage("enhancements", Enhancements);
             AddPage("video", Video);
+            AddPage("accessibility", Accessibility);
         }
 
         private void Gameplay(Panel leftPanel, Panel rightPanel)
@@ -376,6 +383,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 DaggerfallUnity.Settings.PostProcessingInRetroMode, "Off", "Posterization (full)", "Posterization (-sky)", "Palettization (full)", "Palettization (-sky)");
         }
 
+        private void Accessibility(Panel leftPanel, Panel rightPanel)
+        {
+            AddSectionTitle(leftPanel, "automap");
+            automapTempleColor = AddColorPicker(leftPanel, "automapTempleColor", DaggerfallUnity.Settings.AutomapTempleColor);
+            automapShopColor = AddColorPicker(leftPanel, "automapShopColor", DaggerfallUnity.Settings.AutomapShopColor);
+            automapTavernColor = AddColorPicker(leftPanel, "automapTavernColor", DaggerfallUnity.Settings.AutomapTavernColor);
+            automapHouseColor = AddColorPicker(leftPanel, "automapHouseColor", DaggerfallUnity.Settings.AutomapHouseColor);
+        }
+
         private void SaveSettings()
         {
             /* GamePlay */
@@ -488,6 +504,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.ExteriorLightShadows = exteriorLightShadows.IsChecked;
             DaggerfallUnity.Settings.RetroRenderingMode = retroRenderingMode.ScrollIndex;
             DaggerfallUnity.Settings.PostProcessingInRetroMode = postProcessingInRetroMode.ScrollIndex;
+
+            /* Accessibility */
+            DaggerfallUnity.Settings.AutomapTempleColor = automapTempleColor.BackgroundColor;
+            DaggerfallUnity.Settings.AutomapShopColor = automapShopColor.BackgroundColor;
+            DaggerfallUnity.Settings.AutomapTavernColor = automapTavernColor.BackgroundColor;
+            DaggerfallUnity.Settings.AutomapHouseColor = automapHouseColor.BackgroundColor;
 
             DaggerfallUnity.Settings.SaveSettings();
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -111,6 +111,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         ToolTip buttonToolTip = null;
 
+        protected Panel panelTempleColor;
+        protected Panel panelShopColor;
+        protected Panel panelTavernColor;
+
         // these boolean flags are used to indicate which mouse button was pressed over which gui button/element - these are set in the event callbacks
         bool leftMouseDownOnPanelAutomap = false;
         bool rightMouseDownOnPanelAutomap = false;
@@ -459,15 +463,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected virtual void SetupCaptionColors(Texture2D textureCaption)
         {
-            for(int i = 0; i < 5; ++i)
-            {
-                for(int j = 0; j < 5; ++j)
-                {
-                    textureCaption.SetPixel(97 + i, 3 + j, DaggerfallUnity.Settings.AutomapTempleColor);
-                    textureCaption.SetPixel(141 + i, 3 + j, DaggerfallUnity.Settings.AutomapShopColor);
-                    textureCaption.SetPixel(183 + i, 3 + j, DaggerfallUnity.Settings.AutomapTavernColor);
-                }
-            }
+            panelTempleColor = DaggerfallUI.AddPanel(new Rect(new Vector2(97, 2), new Vector2(5, 5)), panelCaption);
+            panelTempleColor.BackgroundColor = DaggerfallUnity.Settings.AutomapTempleColor;
+
+            panelShopColor = DaggerfallUI.AddPanel(new Rect(new Vector2(141, 2), new Vector2(5, 5)), panelCaption);
+            panelShopColor.BackgroundColor = DaggerfallUnity.Settings.AutomapShopColor;
+
+            panelTavernColor = DaggerfallUI.AddPanel(new Rect(new Vector2(183, 2), new Vector2(5, 5)), panelCaption);
+            panelTavernColor.BackgroundColor = DaggerfallUnity.Settings.AutomapTavernColor;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallExteriorAutomapWindow.cs
@@ -255,7 +255,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 throw new Exception("DaggerfallExteriorAutomapWindow: Could not load native texture (AMAP00I0.IMG).");
 
             // Load caption line
-            Texture2D nativeTextureCaption = DaggerfallUI.GetTextureFromImg(nativeImgNameCaption, TextureFormat.ARGB32, true);
+            Texture2D nativeTextureCaption = DaggerfallUI.GetTextureFromImg(nativeImgNameCaption, TextureFormat.ARGB32, false);
             nativeTextureCaption.filterMode = DaggerfallUI.Instance.GlobalFilterMode;
             if (!nativeTextureCaption)
                 throw new Exception("DaggerfallExteriorAutomapWindow: Could not load native texture (TOWN00I0.IMG).");
@@ -264,6 +264,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             rectPanelCaption.position = new Vector2(0, 200 - 10);
             rectPanelCaption.size = new Vector2(320, 10);
             panelCaption = DaggerfallUI.AddPanel(rectPanelCaption, NativePanel);
+
+            SetupCaptionColors(nativeTextureCaption);
+
+            nativeTextureCaption.Apply(false, true);
 
             // set caption line in bottom part of exterior automap window background image texture
             panelCaption.BackgroundTexture = nativeTextureCaption;
@@ -451,6 +455,19 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             resetZoomLevelOnNewLocation = DaggerfallUnity.Settings.ExteriorMapResetZoomLevelOnNewLocation;
 
             isSetup = true;
+        }
+
+        protected virtual void SetupCaptionColors(Texture2D textureCaption)
+        {
+            for(int i = 0; i < 5; ++i)
+            {
+                for(int j = 0; j < 5; ++j)
+                {
+                    textureCaption.SetPixel(97 + i, 3 + j, DaggerfallUnity.Settings.AutomapTempleColor);
+                    textureCaption.SetPixel(141 + i, 3 + j, DaggerfallUnity.Settings.AutomapShopColor);
+                    textureCaption.SetPixel(183 + i, 3 + j, DaggerfallUnity.Settings.AutomapTavernColor);
+                }
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -190,6 +190,10 @@ namespace DaggerfallWorkshop
         public bool AutomapAlwaysMaxOutSliceLevel { get; set; }
         public float ExteriorMapDefaultZoomLevel { get; set; }
         public bool ExteriorMapResetZoomLevelOnNewLocation { get; set; }
+        public Color32 AutomapTempleColor { get; set; }
+        public Color32 AutomapShopColor { get; set; }
+        public Color32 AutomapTavernColor { get; set; }
+        public Color32 AutomapHouseColor { get; set; }
 
         // [Startup]
         public int StartCellX { get; set; }
@@ -337,6 +341,10 @@ namespace DaggerfallWorkshop
             AutomapAlwaysMaxOutSliceLevel = GetBool(sectionMap, "AutomapAlwaysMaxOutSliceLevel");            
             ExteriorMapDefaultZoomLevel = GetFloat(sectionMap, "ExteriorMapDefaultZoomLevel", 4, 31);
             ExteriorMapResetZoomLevelOnNewLocation = GetBool(sectionMap, "ExteriorMapResetZoomLevelOnNewLocation");
+            AutomapTempleColor = GetColor(sectionMap, "AutomapTempleColor", DaggerfallUI.DaggerfallDefaultTempleAutomapColor);
+            AutomapShopColor = GetColor(sectionMap, "AutomapShopColor", DaggerfallUI.DaggerfallDefaultShopAutomapColor);
+            AutomapTavernColor = GetColor(sectionMap, "AutomapTavernColor", DaggerfallUI.DaggerfallDefaultTavernAutomapColor);
+            AutomapHouseColor = GetColor(sectionMap, "AutomapHouseColor", DaggerfallUI.DaggerfallDefaultHouseAutomapColor);
 
             StartCellX = GetInt(sectionStartup, "StartCellX", 2, 997);
             StartCellY = GetInt(sectionStartup, "StartCellY", 2, 497);
@@ -469,6 +477,11 @@ namespace DaggerfallWorkshop
             SetBool(sectionControls, "InstantRepairs", InstantRepairs);
             SetBool(sectionControls, "AllowMagicRepairs", AllowMagicRepairs);
             SetBool(sectionControls, "BowDrawback", BowDrawback);
+
+            SetColor(sectionMap, "AutomapTempleColor", AutomapTempleColor);
+            SetColor(sectionMap, "AutomapShopColor", AutomapShopColor);
+            SetColor(sectionMap, "AutomapTavernColor", AutomapTavernColor);
+            SetColor(sectionMap, "AutomapHouseColor", AutomapHouseColor);
 
             SetInt(sectionStartup, "StartCellX", StartCellX);
             SetInt(sectionStartup, "StartCellY", StartCellY);

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -8,6 +8,7 @@ gamePlay,                                           GamePlay
 interface,                                          Interface
 enhancements,                                       Enhancements
 video,                                              Video
+accessibility,                                      Accessibility
 
 game,                                               Game
 controls,                                           Controls
@@ -19,6 +20,7 @@ gui,                                                GUI
 light,                                              Lighting
 basic,                                              Basic
 advanced,                                           Advanced
+automap,                                            Automap
 
 - Settings and tooltip descriptions
 
@@ -97,6 +99,14 @@ bowLeftHandWithSwitching,                           Equip bows in left hand only
 bowLeftHandWithSwitchingInfo,                       Equip bows in left hand and allow 1H weapon switching - switching has a short delay
 loiterLimitInHours,                                 Maximum loiter time in hours
 loiterLimitInHoursInfo,                             Change default loiter time limit in hours
+automapTempleColor,                                 Temple/guildhall color
+automapTempleColorInfo,                             The color of temples and guildhalls on the exterior automap
+automapShopColor,                                   Shop color
+automapShopColorInfo,                               The color of shops on the exterior automap
+automapTavernColor,                                 Tavern color
+automapTavernColorInfo,                             The color of taverns on the exterior automap
+automapHouseColor,                                  Residence color
+automapHouseColorInfo,                              The color of residences and others on the exterior automap
 
 modSystem,                                          Mod System
 modSystemInfo,                                      Enable support for mods.

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -99,7 +99,7 @@ bowLeftHandWithSwitching,                           Equip bows in left hand only
 bowLeftHandWithSwitchingInfo,                       Equip bows in left hand and allow 1H weapon switching - switching has a short delay
 loiterLimitInHours,                                 Maximum loiter time in hours
 loiterLimitInHoursInfo,                             Change default loiter time limit in hours
-automapTempleColor,                                 Temple/guildhall color
+automapTempleColor,                                 Guildhall color
 automapTempleColorInfo,                             The color of temples and guildhalls on the exterior automap
 automapShopColor,                                   Shop color
 automapShopColorInfo,                               The color of shops on the exterior automap
@@ -202,3 +202,5 @@ minimal,                                            minimal
 large,                                              large
 colour,                                             colour
 monochrome,                                         monochrome
+
+reset,                                              Reset


### PR DESCRIPTION
A player mentioned that they had trouble seeing taverns and shops in the exterior automap, due to red-green color blindness. Nothing else in the game seems to cause any issues.

There's many kinds of color blindness, and various degrees of it, so I thought letting each person tweak colors to their preferences is best. DFU already has a color picker UI used in the Settings.

This PR adds a new Settings tab, and 4 new color settings used by the ExteriorAutomap.
![image](https://user-images.githubusercontent.com/5789925/122113575-4b0e3700-cdf0-11eb-8721-a71ed63e5035.png)

For example, changing the taverns to yellow and brightening the residences looks like this:
![image](https://user-images.githubusercontent.com/5789925/122114012-cd96f680-cdf0-11eb-9320-a3770b5fe631.png)

Note how the caption at the bottom is updated with the selected colors.

I checked with the colorblind user, and this was much better for them. I hope others will find this useful too.

Side note, but perhaps DFU could use a "restore defaults" button for the settings. Right now, the only way to restore them is to delete `settings.ini`.