### PR TITLE
Pass face record id into mobile person asset

### DIFF
--- a/Assets/Scripts/Game/MobilePersonNPC.cs
+++ b/Assets/Scripts/Game/MobilePersonNPC.cs
@@ -209,7 +209,7 @@ namespace DaggerfallWorkshop.Game
 
             // set billboard to correct race, gender and outfit variant
             Asset = GetComponentInChildren<MobilePersonAsset>();
-            Asset.SetPerson(race, gender, personOutfitVariant, IsGuard);
+            Asset.SetPerson(race, gender, personOutfitVariant, IsGuard, personFaceVariant, personFaceRecordId);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/MobilePersonNPC.cs
+++ b/Assets/Scripts/Game/MobilePersonNPC.cs
@@ -32,10 +32,10 @@ namespace DaggerfallWorkshop.Game
         int[] maleRedguardFaceRecordIndex = new int[] { 336, 312, 336, 312 };   // matching textures 381, 382, 383, 384 from MobilePersonBillboard class texture definition
         int[] femaleRedguardFaceRecordIndex = new int[] { 144, 144, 120, 96 };  // matching texture 395, 396, 397, 398 from MobilePersonBillboard class texture definition
 
-        int[] maleNordFaceRecordIndex = new int[] { 240, 264, 168, 216 };       // matching texture 387, 388, 389, 390 from MobilePersonBillboard class texture definition
+        int[] maleNordFaceRecordIndex = new int[] { 240, 264, 168, 192 };       // matching texture 387, 388, 389, 390 from MobilePersonBillboard class texture definition
         int[] femaleNordFaceRecordIndex = new int[] { 72, 0, 48, 72 };          // matching texture 392, 393, 451, 452 from MobilePersonBillboard class texture definition
 
-        int[] maleBretonFaceRecordIndex = new int[] { 192, 216, 240, 240 };     // matching texture 385, 386, 391, 394 from MobilePersonBillboard class texture definition
+        int[] maleBretonFaceRecordIndex = new int[] { 192, 216, 288, 240 };     // matching texture 385, 386, 391, 394 from MobilePersonBillboard class texture definition
         int[] femaleBretonFaceRecordIndex = new int[] { 72, 72, 24, 72 };       // matching texture 453, 454, 455, 456 from MobilePersonBillboard class texture definition
 
         // display races for npcs (only Breton, Redguard and Nord mobile billboards for displaying exist)

--- a/Assets/Scripts/Internal/MobilePersonBillboard.cs
+++ b/Assets/Scripts/Internal/MobilePersonBillboard.cs
@@ -55,7 +55,7 @@ namespace DaggerfallWorkshop
         /// <param name="gender">Gender of target npc.</param>
         /// <param name="personVariant">Which basic outfit does the person wear.</param>
         /// <param name="isGuard">True if this npc is a city watch guard.</param>
-        public abstract void SetPerson(Races race, Genders gender, int personVariant, bool isGuard);
+        public abstract void SetPerson(Races race, Genders gender, int personVariant, bool isGuard, int personFaceVariant, int personFaceRecordId);
 
         /// <summary>
         /// Gets size of asset used by this person (i.e size of bounds). Used to adjust position on terrain.
@@ -226,7 +226,7 @@ namespace DaggerfallWorkshop
         /// <summary>
         /// Setup this person based on race and gender.
         /// </summary>
-        public override void SetPerson(Races race, Genders gender, int personVariant, bool isGuard)
+        public override void SetPerson(Races race, Genders gender, int personVariant, bool isGuard, int personFaceVariant, int personFaceRecordId)
         {
             // Must specify a race
             if (race == Races.None)
@@ -389,7 +389,7 @@ namespace DaggerfallWorkshop
             meshFilter.sharedMesh = mesh;
 
             // Create material
-            Material material = TextureReplacement.GetMobileBillboardMaterial(textureArchive, GetComponent<MeshFilter>(), ref importedTextures) ??
+            Material material = TextureReplacement.GetMobileBillboardMaterial(textureArchive, meshFilter, ref importedTextures) ??
                 DaggerfallUnity.Instance.MaterialReader.GetMaterialAtlas(
                 textureArchive,
                 0,


### PR DESCRIPTION
This allows mods to use the assigned face to change the look of the mobile to match.

@rossipaolo If you want I will add backwards compatibility, but I haven't because I'm pretty sure no one has released a mod yet that uses the MobilePersonAsset override so it would feel like adding cruft for no reason. 
(BTW Kamers villager mod VIO overrides the PopulationManager as far as I can see)