### PR TITLE
Fixed guards accidentally not being above the player level

### DIFF
--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -270,7 +270,7 @@ namespace DaggerfallWorkshop.Game.Entity
                 // Enemy class is levelled to player and uses similar health rules
                 // City guards are 3 to 6 levels above the player
                 level = GameManager.Instance.PlayerEntity.Level;
-                if (careerIndex == (int)MobileTypes.Knight_CityWatch)
+                if (careerIndex == (int)MobileTypes.Knight_CityWatch - 128)
                     level += UnityEngine.Random.Range(3, 7);
 
                 maxHealth = FormulaHelper.RollEnemyClassMaxHealth(level, career.HitPointsPerLevel);


### PR DESCRIPTION
`careerIndex` is `18` for the City watch, but `MobileTypes.Knight_CityWatch` is `146`.

See https://github.com/Interkarma/daggerfall-unity/blob/master/Assets/Scripts/Game/Entities/EnemyEntity.cs#L186