### PR TITLE
Layout building exterior flats for RMBs

### DIFF
--- a/Assets/Scripts/Editor/DaggerfallUnityEditor.cs
+++ b/Assets/Scripts/Editor/DaggerfallUnityEditor.cs
@@ -315,7 +315,7 @@ namespace DaggerfallWorkshop
                             // Create block
                             if (propBlockName.stringValue.EndsWith(".RMB"))
                             {
-                                GameObjectHelper.CreateRMBBlockGameObject(propBlockName.stringValue, 0, 0, dfUnity.Option_RMBGroundPlane, dfUnity.Option_CityBlockPrefab);
+                                GameObjectHelper.CreateRMBBlockGameObject(propBlockName.stringValue, 0, 0, 0, 0, dfUnity.Option_RMBGroundPlane, dfUnity.Option_CityBlockPrefab);
                             }
                             else if (propBlockName.stringValue.EndsWith(".RDB"))
                             {

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1917,7 +1917,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public void PlayCastSound(DaggerfallEntityBehaviour casterEntityBehaviour, int castSoundID, bool throttle = false)
         {
             // Throttle casting sound to once per 0.5f seconds to prevent playing overlapping effects on item equip/recast
-            if (throttle & Time.realtimeSinceStartup - timeLastCastSoundPlayed < 0.5f)
+            if (throttle && Time.realtimeSinceStartup - timeLastCastSoundPlayed < 0.5f)
                 return;
 
             if (casterEntityBehaviour)

--- a/Assets/Scripts/Game/Questing/Clock.cs
+++ b/Assets/Scripts/Game/Questing/Clock.cs
@@ -146,7 +146,7 @@ namespace DaggerfallWorkshop.Game.Questing
                     Group ddhhmmGroup = option.Groups["ddhhmm"];
                     Group hhmmGroup = option.Groups["hhmm"];
                     Group mmGroup = option.Groups["mm"];
-                    if (ddhhmmGroup.Success || hhmmGroup.Success | mmGroup.Success)
+                    if (ddhhmmGroup.Success || hhmmGroup.Success || mmGroup.Success)
                     {
                         // Get time value
                         int timeValue = MatchTimeValue(option.Value);

--- a/Assets/Scripts/Game/StaticNPC.cs
+++ b/Assets/Scripts/Game/StaticNPC.cs
@@ -87,9 +87,9 @@ namespace DaggerfallWorkshop.Game
             public Genders gender;
             public Races race;
             public Context context;
+            public int mapID;
 
             // Derived at runtime
-            public int mapID;
             public int locationID;
             public int buildingKey;
             public NameHelper.BankTypes nameBank;
@@ -131,6 +131,7 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         public void SetLayoutData(DFBlock.RdbObject obj)
         {
+            PlayerGPS playerGPS = GameManager.Instance.PlayerGPS;
             SetLayoutData(ref npcData,
                 obj.XPos, obj.YPos, obj.ZPos,
                 obj.Resources.FlatResource.Flags,
@@ -138,6 +139,8 @@ namespace DaggerfallWorkshop.Game
                 obj.Resources.FlatResource.TextureArchive,
                 obj.Resources.FlatResource.TextureRecord,
                 obj.Resources.FlatResource.Position,
+                playerGPS.CurrentMapID,
+                playerGPS.CurrentLocation.LocationIndex,
                 0);
             npcData.context = Context.Dungeon;
         }
@@ -147,6 +150,7 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         public void SetLayoutData(DFBlock.RmbBlockPeopleRecord obj, int buildingKey = 0)
         {
+            PlayerGPS playerGPS = GameManager.Instance.PlayerGPS;
             SetLayoutData(ref npcData,
                 obj.XPos, obj.YPos, obj.ZPos,
                 obj.Flags,
@@ -154,14 +158,17 @@ namespace DaggerfallWorkshop.Game
                 obj.TextureArchive,
                 obj.TextureRecord,
                 obj.Position,
+                playerGPS.CurrentMapID,
+                playerGPS.CurrentLocation.LocationIndex,
                 buildingKey);
             npcData.context = Context.Building;
         }
 
         /// <summary>
         /// Sets NPC data from RMB layout flat record. (exterior NPCs)
+        /// Requires mapID and locationIndex to be passed in as layout may occur without player being in the location.
         /// </summary>
-        public void SetLayoutData(DFBlock.RmbBlockFlatObjectRecord obj)
+        public void SetLayoutData(DFBlock.RmbBlockFlatObjectRecord obj, int mapId, int locationIndex)
         {
             SetLayoutData(ref npcData,
                 obj.XPos, obj.YPos, obj.ZPos,
@@ -170,11 +177,13 @@ namespace DaggerfallWorkshop.Game
                 obj.TextureArchive,
                 obj.TextureRecord,
                 obj.Position,
+                mapId,
+                locationIndex,
                 0);
             npcData.context = Context.Custom;
         }
 
-        public static void SetLayoutData(ref NPCData data, int XPos, int YPos, int ZPos, int flags, int factionId, int archive, int record, long position, int buildingKey)
+        public static void SetLayoutData(ref NPCData data, int XPos, int YPos, int ZPos, int flags, int factionId, int archive, int record, long position, int mapId, int locationIndex, int buildingKey)
         {
             // Store common layout data
             data.hash = GetPositionHash(XPos, YPos, ZPos);
@@ -182,10 +191,11 @@ namespace DaggerfallWorkshop.Game
             data.factionID = factionId;
             data.billboardArchiveIndex = archive;
             data.billboardRecordIndex = record;
-            data.nameSeed = (int)position ^ buildingKey + GameManager.Instance.PlayerGPS.CurrentLocation.LocationIndex;
+            data.nameSeed = (int)position ^ buildingKey + locationIndex;
             data.gender = ((flags & 32) == 32) ? Genders.Female : Genders.Male;
             data.race = GetRaceFromFaction(factionId);
             data.buildingKey = buildingKey;
+            data.mapID = mapId;
         }
 
         /// <summary>
@@ -250,9 +260,6 @@ namespace DaggerfallWorkshop.Game
             // Get reference to player objects holding world information
             PlayerEnterExit playerEnterExit = GameManager.Instance.PlayerEnterExit;
             PlayerGPS playerGPS = GameManager.Instance.PlayerGPS;
-
-            // Store map ID
-            npcData.mapID = playerGPS.CurrentMapID;
 
             // Store location ID (if any - not all locations carry a unique ID)
             npcData.locationID = (int)playerGPS.CurrentLocation.Exterior.ExteriorData.LocationId;

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2739,6 +2739,8 @@ namespace DaggerfallWorkshop.Game
                                                             npc.TextureArchive,
                                                             npc.TextureRecord,
                                                             npc.Position,
+                                                            location.MapTableData.MapId,
+                                                            location.LocationIndex,
                                                             buildingSummary.buildingKey);
 
                                     // Exclude children from NPCs with work

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallItemMakerWindow.cs
@@ -249,7 +249,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 // Get enchantments for this effect
                 EnchantmentSettings[] enchantments = effect.GetEnchantmentSettings();
-                if (enchantments == null | enchantments.Length == 0)
+                if (enchantments == null || enchantments.Length == 0)
                     Debug.LogWarningFormat("Effect template '{0}' returned no settings from GetEnchantmentSettings()", effect.Key);
 
                 // Sort enchantments into powers and side-effects

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -254,7 +254,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         void CreateBackdrop()
         {
             // Add a block into the scene
-            GameObjectHelper.CreateRMBBlockGameObject("CUSTAA06.RMB", 0, 0);
+            GameObjectHelper.CreateRMBBlockGameObject("CUSTAA06.RMB", 0, 0, 0, 0);
             backdropCreated = true;
 
             // Clear background texture

--- a/Assets/Scripts/Internal/DaggerfallLocation.cs
+++ b/Assets/Scripts/Internal/DaggerfallLocation.cs
@@ -428,6 +428,8 @@ namespace DaggerfallWorkshop
                         blockName,
                         x,
                         y,
+                        location.MapTableData.MapId,
+                        location.LocationIndex,
                         dfUnity.Option_RMBGroundPlane,
                         dfUnity.Option_CityBlockPrefab,
                         summary.NatureBillboardBatch,

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -792,6 +792,8 @@ namespace DaggerfallWorkshop
                                 blocks[blockIndex],
                                 x,
                                 y,
+                                location.MapTableData.MapId,
+                                location.LocationIndex,
                                 false,
                                 dfUnity.Option_CityBlockPrefab,
                                 natureBillboardBatch,

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -525,6 +525,9 @@ namespace DaggerfallWorkshop.Utility
             // Layout any subrecord exterior flats
             RMBLayout.AddExteriorBlockFlats(ref blockData, flatsNode.transform, lightsNode.transform, climateNature, climateSeason);
 
+            // Layout any subrecord exterior flats
+            RMBLayout.AddExteriorBlockFlats(ref blockData, flatsNode.transform, lightsNode.transform, climateNature, climateSeason);
+
             // Add ground plane
             if (addGroundPlane)
                 RMBLayout.AddGroundPlane(ref blockData, go.transform);

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -523,7 +523,7 @@ namespace DaggerfallWorkshop.Utility
             RMBLayout.AddMiscBlockFlats(ref blockData, flatsNode.transform, mapId, locationIndex, animalsBillboardBatch, miscBillboardAtlas, miscBillboardBatch);
 
             // Layout any subrecord exterior flats
-            RMBLayout.AddExteriorBlockFlats(ref blockData, flatsNode.transform, animalsBillboardBatch, miscBillboardAtlas, miscBillboardBatch);
+            RMBLayout.AddExteriorBlockFlats(ref blockData, flatsNode.transform, lightsNode.transform, climateNature, climateSeason);
 
             // Add ground plane
             if (addGroundPlane)

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -522,6 +522,9 @@ namespace DaggerfallWorkshop.Utility
             // Layout all other flats
             RMBLayout.AddMiscBlockFlats(ref blockData, flatsNode.transform, mapId, locationIndex, animalsBillboardBatch, miscBillboardAtlas, miscBillboardBatch);
 
+            // Layout any subrecord exterior flats
+            RMBLayout.AddExteriorBlockFlats(ref blockData, flatsNode.transform, animalsBillboardBatch, miscBillboardAtlas, miscBillboardBatch);
+
             // Add ground plane
             if (addGroundPlane)
                 RMBLayout.AddGroundPlane(ref blockData, go.transform);

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -416,6 +416,8 @@ namespace DaggerfallWorkshop.Utility
             string blockName,
             int layoutX,
             int layoutY,
+            int mapId,
+            int locationIndex,
             bool addGroundPlane = true,
             DaggerfallRMBBlock cloneFrom = null,
             DaggerfallBillboardBatch natureBillboardBatch = null,
@@ -436,6 +438,8 @@ namespace DaggerfallWorkshop.Utility
                 blockData,
                 layoutX,
                 layoutY,
+                mapId,
+                locationIndex,
                 addGroundPlane,
                 cloneFrom,
                 natureBillboardBatch,
@@ -456,6 +460,8 @@ namespace DaggerfallWorkshop.Utility
             DFBlock blockData,
             int layoutX,
             int layoutY,
+            int mapId,
+            int locationIndex,
             bool addGroundPlane = true,
             DaggerfallRMBBlock cloneFrom = null,
             DaggerfallBillboardBatch natureBillboardBatch = null,
@@ -514,7 +520,7 @@ namespace DaggerfallWorkshop.Utility
             RMBLayout.AddNatureFlats(ref blockData, flatsNode.transform, natureBillboardBatch, climateNature, climateSeason);
 
             // Layout all other flats
-            RMBLayout.AddMiscBlockFlats(ref blockData, flatsNode.transform, animalsBillboardBatch, miscBillboardAtlas, miscBillboardBatch);
+            RMBLayout.AddMiscBlockFlats(ref blockData, flatsNode.transform, mapId, locationIndex, animalsBillboardBatch, miscBillboardAtlas, miscBillboardBatch);
 
             // Add ground plane
             if (addGroundPlane)

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -326,6 +326,8 @@ namespace DaggerfallWorkshop.Utility
         public static void AddMiscBlockFlats(
             ref DFBlock blockData,
             Transform flatsParent,
+            int mapId,
+            int locationIndex,
             DaggerfallBillboardBatch animalsBillboardBatch = null,
             TextureAtlasBuilder miscBillboardsAtlas = null,
             DaggerfallBillboardBatch miscBillboardsBatch = null)
@@ -387,7 +389,7 @@ namespace DaggerfallWorkshop.Utility
 
                     // Add StaticNPC behaviour
                     StaticNPC npc = go.AddComponent<StaticNPC>();
-                    npc.SetLayoutData(obj);
+                    npc.SetLayoutData(obj, mapId, locationIndex);
                 }
             }
         }

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -482,6 +482,93 @@ namespace DaggerfallWorkshop.Utility
         }
 
         /// <summary>
+        /// Add subrecord (building) exterior block flats.
+        /// </summary>
+        public static void AddExteriorBlockFlats(
+            ref DFBlock blockData,
+            Transform flatsParent,
+            Transform lightsParent,
+            ClimateNatureSets climateNature = ClimateNatureSets.TemperateWoodland,
+            ClimateSeason climateSeason = ClimateSeason.Summer)
+        {
+            DaggerfallUnity dfUnity = DaggerfallUnity.Instance;
+            if (!dfUnity.IsReady)
+                return;
+
+            // Get Nature Archive
+            int natureArchive = ClimateSwaps.GetNatureArchive(climateNature, climateSeason);
+
+            foreach (DFBlock.RmbSubRecord subRecord in blockData.RmbBlock.SubRecords)
+            {
+                Vector3 subRecordPosition = new Vector3(subRecord.XPos, 0, -subRecord.ZPos) * MeshReader.GlobalScale;
+
+                foreach (DFBlock.RmbBlockFlatObjectRecord obj in subRecord.Exterior.BlockFlatObjectRecords)
+                {
+                    // Don't add building exterior editor flats since they can't be used by any DFU systems
+                    int archive = obj.TextureArchive;
+                    if (archive == TextureReader.EditorFlatsTextureArchive)
+                        continue;
+
+                    // Calculate position
+                    Vector3 billboardPosition = new Vector3(
+                        obj.XPos,
+                        -obj.YPos + blockFlatsOffsetY,
+                        obj.ZPos + BlocksFile.RMBDimension) * MeshReader.GlobalScale;
+
+                    billboardPosition += subRecordPosition;
+
+                    // Add natures using correct climate set archive
+                    if (archive >= (int)DFLocation.ClimateTextureSet.Nature_RainForest && archive <= (int)DFLocation.ClimateTextureSet.Nature_Mountains_Snow)
+                    {
+                        archive = natureArchive;
+                        billboardPosition.z = natureFlatsOffsetY;
+                    }
+
+                    // Import custom 3d gameobject instead of flat
+                    if (MeshReplacement.ImportCustomFlatGameobject(archive, obj.TextureRecord, billboardPosition, flatsParent) != null)
+                        continue;
+
+                    // Add standalone billboard gameobject
+                    GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(archive, obj.TextureRecord, flatsParent);
+                    go.transform.position = billboardPosition;
+                    AlignBillboardToBase(go);
+
+                    // Add animal sound
+                    if (archive == TextureReader.AnimalsTextureArchive)
+                        AddAnimalAudioSource(go);
+
+                    // If flat record has a non-zero faction id, then it's an exterior NPC
+                    if (obj.FactionID != 0)
+                    {
+                        // Add RMB data to billboard
+                        DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                        dfBillboard.SetRMBPeopleData(obj.FactionID, obj.Flags, obj.Position);
+
+                        // Add StaticNPC behaviour
+                        StaticNPC npc = go.AddComponent<StaticNPC>();
+                        npc.SetLayoutData(obj);
+                    }
+
+                    // If this is a light flat, import light prefab
+                    if (archive == TextureReader.LightsTextureArchive)
+                    {
+                        if (dfUnity.Option_CityLightPrefab == null)
+                            return;
+
+                        Vector2 size = dfUnity.MeshReader.GetScaledBillboardSize(210, obj.TextureRecord);
+                        Vector3 position = new Vector3(
+                            obj.XPos,
+                            -obj.YPos + size.y,
+                            obj.ZPos + BlocksFile.RMBDimension) * MeshReader.GlobalScale;
+                        position += subRecordPosition;
+
+                        GameObjectHelper.InstantiatePrefab(dfUnity.Option_CityLightPrefab.gameObject, string.Empty, lightsParent, position);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Aligns billboard GameObject to centre of base.
         /// This is required for exterior billboard.
         /// </summary>

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -395,6 +395,64 @@ namespace DaggerfallWorkshop.Utility
         }
 
         /// <summary>
+        /// Add exterior block flats.
+        /// Batching is conditionally supported.
+        /// </summary>
+        public static void AddExteriorBlockFlats(
+            ref DFBlock blockData,
+            Transform flatsParent,
+            DaggerfallBillboardBatch animalsBillboardBatch = null,
+            TextureAtlasBuilder miscBillboardsAtlas = null,
+            DaggerfallBillboardBatch miscBillboardsBatch = null)
+        {
+            DaggerfallUnity dfUnity = DaggerfallUnity.Instance;
+            if (!dfUnity.IsReady)
+                return;
+
+            // Add block flats
+            foreach (DFBlock.RmbSubRecord subRecord in blockData.RmbBlock.SubRecords)
+            {
+                foreach (DFBlock.RmbBlockFlatObjectRecord obj in subRecord.Exterior.BlockFlatObjectRecords)
+                {
+                    // Ignore lights as they are handled by AddLights()
+                    if (obj.TextureArchive == TextureReader.LightsTextureArchive)
+                        continue;
+
+                    // Calculate position
+                    Vector3 billboardPosition = new Vector3(
+                        obj.XPos,
+                        -obj.YPos + blockFlatsOffsetY,
+                        obj.ZPos + BlocksFile.RMBDimension) * MeshReader.GlobalScale;
+
+                    // Import custom 3d gameobject instead of flat
+                    if (MeshReplacement.ImportCustomFlatGameobject(obj.TextureArchive, obj.TextureRecord, billboardPosition, flatsParent) != null)
+                        continue;
+
+                    // Add standalone billboard gameobject
+                    GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(obj.TextureArchive, obj.TextureRecord, flatsParent);
+                    go.transform.position = billboardPosition;
+                    AlignBillboardToBase(go);
+
+                    // Add animal sound
+                    if (obj.TextureArchive == TextureReader.AnimalsTextureArchive)
+                        AddAnimalAudioSource(go);
+
+                    // If flat record has a non-zero faction id, then it's an exterior NPC
+                    if (obj.FactionID != 0)
+                    {
+                        // Add RMB data to billboard
+                        DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                        dfBillboard.SetRMBPeopleData(obj.FactionID, obj.Flags, obj.Position);
+
+                        // Add StaticNPC behaviour
+                        StaticNPC npc = go.AddComponent<StaticNPC>();
+                        npc.SetLayoutData(obj);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Aligns billboard GameObject to centre of base.
         /// This is required for exterior billboard.
         /// </summary>

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -450,10 +450,6 @@ namespace DaggerfallWorkshop.Utility
                     if (archive == TextureReader.AnimalsTextureArchive)
                         AddAnimalAudioSource(go);
 
-                    // If this is a light flat, import light prefab
-                    if (archive == TextureReader.LightsTextureArchive)
-                        AddLight(dfUnity, obj, lightsParent);
-
                     // If flat record has a non-zero faction id, then it's an exterior NPC
                     if (obj.FactionID != 0)
                     {
@@ -464,6 +460,22 @@ namespace DaggerfallWorkshop.Utility
                         // Add StaticNPC behaviour
                         StaticNPC npc = go.AddComponent<StaticNPC>();
                         npc.SetLayoutData(obj);
+                    }
+
+                    // If this is a light flat, import light prefab
+                    if (archive == TextureReader.LightsTextureArchive)
+                    {
+                        if (dfUnity.Option_CityLightPrefab == null)
+                            return;
+
+                        Vector2 size = dfUnity.MeshReader.GetScaledBillboardSize(210, obj.TextureRecord);
+                        Vector3 position = new Vector3(
+                            obj.XPos,
+                            -obj.YPos + size.y,
+                            obj.ZPos + BlocksFile.RMBDimension) * MeshReader.GlobalScale;
+                        position += subRecordPosition;
+
+                        GameObjectHelper.InstantiatePrefab(dfUnity.Option_CityLightPrefab.gameObject, string.Empty, lightsParent, position);
                     }
                 }
             }


### PR DESCRIPTION
This allows world data building overrides to have exterior flats without needing to override the entire RMB. In classic data there only appears to be editor flats define, but have filtered these out as they're not used by any DFU systems.

This should change nothing unless world data overrides are being used.