### PR TITLE
Use generic IEnumerables for 'AddItems' methods

### DIFF
--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -484,15 +484,15 @@ namespace DaggerfallWorkshop.Game.Items
         /// UIDs will be retained.
         /// </summary>
         /// <param name="items">Items array.</param>
-        public void Import(DaggerfallUnityItem[] items)
+        public void Import(IEnumerable<DaggerfallUnityItem> items)
         {
-            if (items == null || items.Length == 0)
+            if (items == null)
                 return;
 
             Clear();
-            for (int i = 0; i < items.Length; i++)
+            foreach (var item in items)
             {
-                AddItem(items[i]);
+                AddItem(item);
             }
         }
 
@@ -502,14 +502,14 @@ namespace DaggerfallWorkshop.Game.Items
         /// UIDs will be retained.
         /// </summary>
         /// <param name="items">Items array.</param>
-        public void AddItems(DaggerfallUnityItem[] items)
+        public void AddItems(IEnumerable<DaggerfallUnityItem> items)
         {
-            if (items == null || items.Length == 0)
+            if (items == null)
                 return;
 
-            for (int i = 0; i < items.Length; i++)
+            foreach (var item in items)
             {
-                AddItem(items[i]);
+                AddItem(item);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterface/ListBox.cs
+++ b/Assets/Scripts/Game/UserInterface/ListBox.cs
@@ -558,15 +558,18 @@ namespace DaggerfallWorkshop.Game.UserInterface
             AddItem(text, out itemOut, position, tag);
         }
 
-        public void AddItems(string[] items)
+        public void AddItems(IEnumerable<string> items)
         {
+            if (items == null)
+                return;
+
             foreach (string item in items)
                 AddItem(item);
         }
 
-        public void AddItems(TextLabel[] labels)
+        public void AddItems(IEnumerable<TextLabel> labels)
         {
-            if (labels == null || labels.Length == 0)
+            if (labels == null)
                 return;
 
             ListItem itemOut;


### PR DESCRIPTION
Small change to prevent using a needless "ToArray()" method when using a non-array[] collection for the 'AddItems' methods. Parameter takes in an IEnumerable instead, which are the superclass of all collections, including regular arrays[], Lists, HashSets, etc. Checking for its length is no longer needed when using a foreach loop after confirming that the collection is not null.