### PR TITLE
Use FLATS.CFG to set gender of exterior NPCs

### DIFF
--- a/Assets/Scripts/API/FlatsFile.cs
+++ b/Assets/Scripts/API/FlatsFile.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -51,7 +51,7 @@ namespace DaggerfallConnect.Arena2
             public string gender; // values are 1 for male, 2 for female. If preceded by a "?", in classic the flat would be censored in ChildGard mode.
             public int unknown2;
             public int unknown3;
-            public int faceIndex; // index of face in FACES.CIF
+            public int faceIndex; // index of face in TFAC00I0.RCI
         }
 
         #endregion

--- a/Assets/Scripts/Game/StaticNPC.cs
+++ b/Assets/Scripts/Game/StaticNPC.cs
@@ -159,10 +159,20 @@ namespace DaggerfallWorkshop.Game
         }
 
         /// <summary>
-        /// Sets NPC data from RMB layout flat record. (exterior NPCs)
+        /// Sets NPC data from RMB layout flat record (exterior NPCs).
         /// </summary>
         public void SetLayoutData(DFBlock.RmbBlockFlatObjectRecord obj)
         {
+            // Gender flag is invalid for RMB exterior NPCs: get it from FLATS.CFG instead
+            int flatID = FlatsFile.GetFlatID(obj.TextureArchive, obj.TextureRecord);
+            if (DaggerfallUnity.Instance.ContentReader.FlatsFileReader.GetFlatData(flatID, out FlatsFile.FlatData flatCFG))
+            {
+                if (flatCFG.gender.Contains("2"))
+                    obj.Flags |= 32;
+                else
+                    obj.Flags &= 223;
+            }
+
             SetLayoutData(ref npcData,
                 obj.XPos, obj.YPos, obj.ZPos,
                 obj.Flags,


### PR DESCRIPTION
Fix a game data related bug by using FLATS.CFG information to set exterior NPCs gender (mostly, if not only, witches). The issue was reported by @Ralzar81 [on the forum](http://forums.dfworkshop.net/viewtopic.php?f=5&t=4914&sid=d6db9aca862954531d2f267f04f01ff0).