### PR TITLE
Layout building exterior flats

### DIFF
--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -522,6 +522,9 @@ namespace DaggerfallWorkshop.Utility
             // Layout all other flats
             RMBLayout.AddMiscBlockFlats(ref blockData, flatsNode.transform, mapId, locationIndex, animalsBillboardBatch, miscBillboardAtlas, miscBillboardBatch);
 
+            // Layout any subrecord exterior flats
+            RMBLayout.AddExteriorBlockFlats(ref blockData, flatsNode.transform, lightsNode.transform, mapId, locationIndex, climateNature, climateSeason);
+
             // Add ground plane
             if (addGroundPlane)
                 RMBLayout.AddGroundPlane(ref blockData, go.transform);


### PR DESCRIPTION
This allows wold data building overrides to have exterior flats without needing to override the entire RMB. In classic data there only appears to be editor flats define, but have filtered these out as they're not used by any DFU systems.