### PR TITLE
Add colliders to custom dungeon models added using "COL" in the World Data Editor I'm working on.

### DIFF
--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -665,6 +665,14 @@ namespace DaggerfallWorkshop.Utility
                                 combiner.Add(ref modelData, modelMatrix);
                             }
                         }
+                        else if (blockData.RdbBlock.ModelReferenceList[modelReference].Description == "COL")
+                        {
+                            // Add colliders to custom dungeon models added using "COL" in the World Data Editor.
+                            MeshCollider collider = standaloneObject.GetComponent<MeshCollider>();
+                            if (collider == null) collider = standaloneObject.AddComponent<MeshCollider>();
+                            MeshFilter meshFilter = standaloneObject.GetComponent<MeshFilter>();
+                            collider.sharedMesh = meshFilter.sharedMesh;
+                        }
 
                         // Add action
                         if (hasAction && standaloneObject != null)


### PR DESCRIPTION
This will enable custom models for new dungeons to automatically have colliders applied by unity via DFU RDB layout code.