### PR TITLE
Modding new mobile textures

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -696,9 +696,9 @@ namespace DaggerfallWorkshop
                 true);
 
             // Update cached record values in case of non-classic texture
-            if(summary.RecordSizes == null || summary.RecordSizes.Length == 0)
+            if (summary.RecordSizes == null || summary.RecordSizes.Length == 0)
             {
-                if(summary.ImportedTextures.Albedo != null && summary.ImportedTextures.Albedo.Length > 0)
+                if (summary.ImportedTextures.Albedo != null && summary.ImportedTextures.Albedo.Length > 0)
                 {
                     int recordCount = summary.ImportedTextures.Albedo.Length;
 

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -549,7 +549,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
                 // If the archive has a Arena2 texture file, use it to get record and frame count
                 string fileName = TextureFile.IndexToFileName(archive);
-                var textureFile = new TextureFile();                
+                var textureFile = new TextureFile();
                 if (textureFile.Load(Path.Combine(DaggerfallUnity.Instance.Arena2Path, fileName), FileUsage.UseMemory, true))
                 {
                     // Import all textures in this archive
@@ -583,13 +583,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     List<Texture2D[]> allEmission = importedTextures.IsEmissive ? new List<Texture2D[]>() : null;
 
                     int record = 0;
-                    while(TryImportTexture(archive, record, out Texture2D[] currentAlbedo))
+                    while (TryImportTexture(archive, record, out Texture2D[] currentAlbedo))
                     {
                         allAlbedo.Add(currentAlbedo);
 
-                        if(importedTextures.IsEmissive)
+                        if (importedTextures.IsEmissive)
                         {
-                            if(TryImportTexture(texturesPath, frame => GetName(archive, record, frame, TextureMap.Emission), out Texture2D[] currentEmissive))
+                            if (TryImportTexture(texturesPath, frame => GetName(archive, record, frame, TextureMap.Emission), out Texture2D[] currentEmissive))
                             {
                                 allEmission.Add(currentEmissive);
                             }

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -547,32 +547,63 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 // Enable emission
                 ToggleEmission(material, importedTextures.IsEmissive |= emission != null);
 
-                // Load texture file to get record and frame count
+                // If the archive has a Arena2 texture file, use it to get record and frame count
                 string fileName = TextureFile.IndexToFileName(archive);
-                var textureFile = new TextureFile(Path.Combine(DaggerfallUnity.Instance.Arena2Path, fileName), FileUsage.UseMemory, true);
-
-                // Import all textures in this archive
-                importedTextures.Albedo = new Texture2D[textureFile.RecordCount][];
-                importedTextures.EmissionMaps = importedTextures.IsEmissive ? new Texture2D[textureFile.RecordCount][] : null;
-                for (int record = 0; record < textureFile.RecordCount; record++)
+                var textureFile = new TextureFile();                
+                if (textureFile.Load(Path.Combine(DaggerfallUnity.Instance.Arena2Path, fileName), FileUsage.UseMemory, true))
                 {
-                    int frames = textureFile.GetFrameCount(record);
-                    var frameTextures = new Texture2D[frames];
-                    var frameEmissionMaps = importedTextures.IsEmissive ? new Texture2D[frames] : null;
-
-                    for (int frame = 0; frame < frames; frame++)
+                    // Import all textures in this archive
+                    importedTextures.Albedo = new Texture2D[textureFile.RecordCount][];
+                    importedTextures.EmissionMaps = importedTextures.IsEmissive ? new Texture2D[textureFile.RecordCount][] : null;
+                    for (int record = 0; record < textureFile.RecordCount; record++)
                     {
-                        if (record != 0 || frame != 0)
-                            LoadFromCacheOrImport(archive, record, frame, importedTextures.IsEmissive, true, out tex, out emission);
+                        int frames = textureFile.GetFrameCount(record);
+                        var frameTextures = new Texture2D[frames];
+                        var frameEmissionMaps = importedTextures.IsEmissive ? new Texture2D[frames] : null;
 
-                        frameTextures[frame] = tex ?? ImageReader.GetTexture(fileName, record, frame, true);
-                        if (frameEmissionMaps != null)
-                            frameEmissionMaps[frame] = emission ?? frameTextures[frame];
+                        for (int frame = 0; frame < frames; frame++)
+                        {
+                            if (record != 0 || frame != 0)
+                                LoadFromCacheOrImport(archive, record, frame, importedTextures.IsEmissive, true, out tex, out emission);
+
+                            frameTextures[frame] = tex ?? ImageReader.GetTexture(fileName, record, frame, true);
+                            if (frameEmissionMaps != null)
+                                frameEmissionMaps[frame] = emission ?? frameTextures[frame];
+                        }
+
+                        importedTextures.Albedo[record] = frameTextures;
+                        if (importedTextures.EmissionMaps != null)
+                            importedTextures.EmissionMaps[record] = frameEmissionMaps;
+                    }
+                }
+                // Otherwise, check what files are available in the injected assets
+                else
+                {
+                    List<Texture2D[]> allAlbedo = new List<Texture2D[]>();
+                    List<Texture2D[]> allEmission = importedTextures.IsEmissive ? new List<Texture2D[]>() : null;
+
+                    int record = 0;
+                    while(TryImportTexture(archive, record, out Texture2D[] currentAlbedo))
+                    {
+                        allAlbedo.Add(currentAlbedo);
+
+                        if(importedTextures.IsEmissive)
+                        {
+                            if(TryImportTexture(texturesPath, frame => GetName(archive, record, frame, TextureMap.Emission), out Texture2D[] currentEmissive))
+                            {
+                                allEmission.Add(currentEmissive);
+                            }
+                            else
+                            {
+                                allEmission.Add(currentAlbedo);
+                            }
+                        }
+
+                        ++record;
                     }
 
-                    importedTextures.Albedo[record] = frameTextures;
-                    if (importedTextures.EmissionMaps != null)
-                        importedTextures.EmissionMaps[record] = frameEmissionMaps;
+                    importedTextures.Albedo = allAlbedo.ToArray();
+                    importedTextures.EmissionMaps = importedTextures.IsEmissive ? allEmission.ToArray() : null;
                 }
 
                 // Update UV map


### PR DESCRIPTION
As part of a greater effort to allow mods to add new enemies to DFU, this PR allows mods to add new "mobile" textures, and use them for MobileEnemy's MaleTexture/FemaleTexture.

On its own, the only use case I see would be for mods to give Class enemies distinct textures. For example, Mage and Healer both use 486/485, and one could be changed to use a new texture id beyond the 512 original Textures. It is my hope that eventually, this will be useful to add new MobileEnemy types too.

Here's an example
![image](https://user-images.githubusercontent.com/5789925/123882356-a4a85280-d914-11eb-83c1-c8b3c08cf3e7.png)

I'm not familiar with all the graphics features, but I tried to keep the emission textures working at least. Tell me if I'm forgetting something that's usually supported in mobile textures.

The extent of my testing is just adding a bunch of palette swaps of TEXTURE.486 as PNGs in the Textures folder of my test mod. Tell me if you have ideas for test cases I should consider.