### PR TITLE
Add frame speed divisor to abstract class

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -36,7 +36,6 @@ namespace DaggerfallWorkshop.Game
         EnemySenses senses;
         EnemySounds sounds;
         MobileUnit mobile;
-        DaggerfallMobileUnit dfMobile;
         DaggerfallEntityBehaviour entityBehaviour;
         int damage = 0;
 
@@ -46,7 +45,6 @@ namespace DaggerfallWorkshop.Game
             senses = GetComponent<EnemySenses>();
             sounds = GetComponent<EnemySounds>();
             mobile = GetComponent<DaggerfallEnemy>().MobileUnit;
-            dfMobile = mobile as DaggerfallMobileUnit;
             entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
         }
 
@@ -76,7 +74,7 @@ namespace DaggerfallWorkshop.Game
 
             // Slow down enemy frame rate based on floored speed value
             // If enemy is still at maximum speed then divisor is 1 and will experience no change to frame rate
-            dfMobile.FrameSpeedDivisor = entity.Stats.PermanentSpeed / speed;
+            mobile.FrameSpeedDivisor = entity.Stats.PermanentSpeed / speed;
 
             // Note: Speed comparison here is reversed from classic. Classic's way makes fewer attack
             // attempts at higher speeds, so it seems backwards.

--- a/Assets/Scripts/Internal/Base/MobileUnit.cs
+++ b/Assets/Scripts/Internal/Base/MobileUnit.cs
@@ -70,6 +70,12 @@ namespace DaggerfallWorkshop
         /// </summary>
         public abstract bool ShootArrow { get; set; }
 
+        /// <summary>
+        /// Slow down the animation of this mobile unit by a divisor of frames per second.
+        /// Used when enemies are slowed by spells etc.
+        /// </summary>
+        public abstract int FrameSpeedDivisor { get; set; }
+
         #endregion
 
         #region Public Methods

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -78,7 +78,7 @@ namespace DaggerfallWorkshop
             get { return currentFrame; }
         }
 
-        public int FrameSpeedDivisor
+        public override int FrameSpeedDivisor
         {
             get { return frameSpeedDivisor; }
             set { frameSpeedDivisor = (value < 1) ? 1 : value; }


### PR DESCRIPTION
Otherwise mods adding custom mobile units get log spammed with null pointer exceptions. Not sure if this is the best correction but figured I'd take a stab at it.

Was broken by the fix for slow spells commit 47e2c588