### PR TITLE
Greatly reduce Lord Kavar spawns

### DIFF
--- a/Assets/StreamingAssets/Quests/M0B11Y18.txt
+++ b/Assets/StreamingAssets/Quests/M0B11Y18.txt
@@ -432,7 +432,7 @@ _S.12_ task:
 
 _conhouse_ task:
 	when _S.00_ and not _S.12_ 
-	create foe _F.03_ every 10 minutes 100 times with 10% success 
+	create foe _F.03_ every 30 minutes 5 times with 10% success 
 
 _S.14_ task:
 	injured _F.03_ 


### PR DESCRIPTION
At current, there is no event more complained of than the Lord K'avar quest. This PR greatly reduces the spawn rate for Lord K'avar's soldiers.