### PR TITLE
Modding new enemies

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -443,7 +443,7 @@ namespace Wenzil.Console
                     if (!int.TryParse(args[0], out id))
                         return "Invalid mobile ID.";
 
-                    if (!Enum.IsDefined(typeof(MobileTypes), id))
+                    if (!Enum.IsDefined(typeof(MobileTypes), id) && DaggerfallEntity.GetCustomCareerTemplate(id) == null)
                         return "Invalid mobile ID.";
 
                     int team = 0;

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -929,6 +929,26 @@ namespace DaggerfallWorkshop.Game.Entity
             return monsterFile.GetMonsterClass((int)career);
         }
 
+        /// <summary>
+        /// Allows mods to register a DFCareer template for IDs outside of the values in MobileTypes
+        /// </summary>
+        public static readonly Dictionary<int, DFCareer> CustomCareerTemplates = new Dictionary<int, DFCareer>();
+
+        /// <summary>
+        /// Gets the career template for a custom (ie: mod-provided) enemy type
+        /// </summary>
+        /// <param name="enemyId">ID, as defined in EnemyBasics.Enemies</param>
+        /// <returns></returns>
+        public static DFCareer GetCustomCareerTemplate(int enemyId)
+        {
+            if(!CustomCareerTemplates.TryGetValue(enemyId, out DFCareer value))
+            {
+                return null;
+            }
+
+            return value;
+        }
+
         public static SoundClips GetRaceGenderAttackSound(Races race, Genders gender, bool isPlayerAttack = false)
         {
             // Check for racial override attack sound for player only

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -932,21 +932,33 @@ namespace DaggerfallWorkshop.Game.Entity
         /// <summary>
         /// Allows mods to register a DFCareer template for IDs outside of the values in MobileTypes
         /// </summary>
-        public static readonly Dictionary<int, DFCareer> CustomCareerTemplates = new Dictionary<int, DFCareer>();
+        static readonly Dictionary<int, DFCareer> CustomCareerTemplates = new Dictionary<int, DFCareer>();
 
         /// <summary>
         /// Gets the career template for a custom (ie: mod-provided) enemy type
         /// </summary>
         /// <param name="enemyId">ID, as defined in EnemyBasics.Enemies</param>
-        /// <returns></returns>
+        /// <returns>The custom DFCareer template registered for this id, or null</returns>
         public static DFCareer GetCustomCareerTemplate(int enemyId)
         {
-            if(!CustomCareerTemplates.TryGetValue(enemyId, out DFCareer value))
+            if (!CustomCareerTemplates.TryGetValue(enemyId, out DFCareer value))
             {
                 return null;
             }
 
             return value;
+        }
+
+        /// <summary>
+        /// Sets the career template for a custom (ie: mod-provided) enemy type. 
+        /// </summary>
+        /// <param name="enemyId">ID, as defined in EnemyBasics.Enemies</param>
+        /// <param name="career">The custom DFCareer template to register</param>
+        public static void RegisterCustomCareerTemplate(int enemyId, DFCareer career)
+        {
+            // Use indexer so that mods can overwrite previous values added by mods
+            // ex: mod 1 provides new enemies, mod 2 rebalances them
+            CustomCareerTemplates[enemyId] = career;
         }
 
         public static SoundClips GetRaceGenderAttackSound(Races race, Genders gender, bool isPlayerAttack = false)

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -255,12 +255,21 @@ namespace DaggerfallWorkshop.Game.Entity
                 careerIndex = mobileEnemy.ID;
                 stats.SetPermanentFromCareer(career);
 
-                // Default to the mobile's values. Mods can adjust those values by registering to "OnLootSpawned"
-                level = mobileEnemy.Level;
-                maxHealth = Random.Range(mobileEnemy.MinHealth, mobileEnemy.MaxHealth + 1);
-                for (int i = 0; i < ArmorValues.Length; i++)
+                if (entityType == EntityTypes.EnemyMonster)
                 {
-                    ArmorValues[i] = (sbyte)(mobileEnemy.ArmorValue * 5);
+                    // Default like a monster
+                    level = mobileEnemy.Level;
+                    maxHealth = Random.Range(mobileEnemy.MinHealth, mobileEnemy.MaxHealth + 1);
+                    for (int i = 0; i < ArmorValues.Length; i++)
+                    {
+                        ArmorValues[i] = (sbyte)(mobileEnemy.ArmorValue * 5);
+                    }
+                }
+                else
+                {
+                    // Default like a class enemy
+                    level = GameManager.Instance.PlayerEntity.Level;
+                    maxHealth = FormulaHelper.RollEnemyClassMaxHealth(level, career.HitPointsPerLevel);
                 }
             }
             else if (entityType == EntityTypes.EnemyMonster)

--- a/Assets/Scripts/Game/Entities/EnemyEntity.cs
+++ b/Assets/Scripts/Game/Entities/EnemyEntity.cs
@@ -246,7 +246,24 @@ namespace DaggerfallWorkshop.Game.Entity
         /// </summary>
         public void SetEnemyCareer(MobileEnemy mobileEnemy, EntityTypes entityType)
         {
-            if (entityType == EntityTypes.EnemyMonster)
+            // Try custom career first
+            career = GetCustomCareerTemplate(mobileEnemy.ID);
+
+            if (career != null)
+            {
+                // Custom enemy
+                careerIndex = mobileEnemy.ID;
+                stats.SetPermanentFromCareer(career);
+
+                // Default to the mobile's values. Mods can adjust those values by registering to "OnLootSpawned"
+                level = mobileEnemy.Level;
+                maxHealth = Random.Range(mobileEnemy.MinHealth, mobileEnemy.MaxHealth + 1);
+                for (int i = 0; i < ArmorValues.Length; i++)
+                {
+                    ArmorValues[i] = (sbyte)(mobileEnemy.ArmorValue * 5);
+                }
+            }
+            else if (entityType == EntityTypes.EnemyMonster)
             {
                 careerIndex = mobileEnemy.ID;
                 career = GetMonsterCareerTemplate((MonsterCareers)careerIndex);

--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -167,7 +167,7 @@ namespace DaggerfallWorkshop.Game
                         entityBehaviour.EntityType = EntityTypes.EnemyClass;
                         entity.SetEnemyCareer(mobileEnemy, entityBehaviour.EntityType);
                     }
-                    else if(DaggerfallEntity.GetCustomCareerTemplate(enemyIndex) != null)
+                    else if (DaggerfallEntity.GetCustomCareerTemplate(enemyIndex) != null)
                     {
                         // For custom enemies, we use the 7th bit to tell whether a class or monster was intended
                         // 0-127 is monster

--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -167,6 +167,23 @@ namespace DaggerfallWorkshop.Game
                         entityBehaviour.EntityType = EntityTypes.EnemyClass;
                         entity.SetEnemyCareer(mobileEnemy, entityBehaviour.EntityType);
                     }
+                    else if(DaggerfallEntity.GetCustomCareerTemplate(enemyIndex) != null)
+                    {
+                        // For custom enemies, we use the 7th bit to tell whether a class or monster was intended
+                        // 0-127 is monster
+                        // 128-255 is class
+                        // 256-383 is monster again
+                        // etc
+                        if ((enemyIndex & 128) != 0)
+                        {
+                            entityBehaviour.EntityType = EntityTypes.EnemyClass;
+                        }
+                        else
+                        {
+                            entityBehaviour.EntityType = EntityTypes.EnemyMonster;
+                        }
+                        entity.SetEnemyCareer(mobileEnemy, entityBehaviour.EntityType);
+                    }
                     else
                     {
                         entityBehaviour.EntityType = EntityTypes.None;

--- a/Assets/Scripts/Game/TextManager.cs
+++ b/Assets/Scripts/Game/TextManager.cs
@@ -348,8 +348,10 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 // TODO: maybe go through TextProvider so mods can try to offer localization?
-                if (!DaggerfallEntity.CustomCareerTemplates.TryGetValue(enemyID, out DaggerfallConnect.DFCareer career))
+                DaggerfallConnect.DFCareer career = DaggerfallEntity.GetCustomCareerTemplate(enemyID);
+                if (career == null)
                 {
+                    Debug.LogError($"Enemy ID '{enemyID}' did not have a registered custom career template");
                     return "(invalid enemy)";
                 }
 

--- a/Assets/Scripts/Game/TextManager.cs
+++ b/Assets/Scripts/Game/TextManager.cs
@@ -18,6 +18,7 @@ using UnityEngine.Localization;
 using UnityEngine.Localization.Settings;
 using Wenzil.Console;
 using DaggerfallWorkshop.Game.UserInterface;
+using DaggerfallWorkshop.Game.Entity;
 using UnityEngine.Localization.Tables;
 
 namespace DaggerfallWorkshop.Game
@@ -331,15 +332,29 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Gets display name of an enemy from their ID.
         /// </summary>
-        /// <param name="enemyID">ID of enemy. Valid IDs are 0-42 and 128-146.</param>
+        /// <param name="enemyID">ID of enemy. Valid IDs are 0-42 and 128-146, or values registered in Daggerfallentity.CustomCareerTemplates</param>
         /// <returns>Name of enemy from localization if found, or exception if not found.</returns>
         public string GetLocalizedEnemyName(int enemyID)
         {
-            string[] enemyNames = GetLocalizedTextList("enemyNames", exception:true);
-            if (enemyID < 128)
-                return enemyNames[enemyID];
+            if (Enum.IsDefined(typeof(MobileTypes), (MobileTypes)enemyID))
+            {
+                string[] enemyNames = GetLocalizedTextList("enemyNames", exception: true);
+                if (enemyID < 128)
+                    return enemyNames[enemyID];
+                else
+                    return enemyNames[43 + enemyID - 128];
+            }
+            // Handle custom enemies
             else
-                return enemyNames[43 + enemyID - 128];
+            {
+                // TODO: maybe go through TextProvider so mods can try to offer localization?
+                if (!DaggerfallEntity.CustomCareerTemplates.TryGetValue(enemyID, out DaggerfallConnect.DFCareer career))
+                {
+                    return "(invalid enemy)";
+                }
+
+                return career.Name;
+            }
         }
 
         #endregion


### PR DESCRIPTION
This is the main part of my efforts to let mods add new enemies to DFU, as discussed here: https://forums.dfworkshop.net/viewtopic.php?f=23&t=4915

This is actually a draft PR, more for raising discussion to see if the solution is appropriate for this point in development.

What this PR does:
- SetupEnemyDemo now recognizes enemy IDs beyond those defined in MobileTypes. For every group of 256 IDs, the first 128 will be EnemyMonster, and the last 128 will be EnemyClass (0-127 Monster, 128-255 Class, 256-383 Monster, 384-511 Class, etc...)
- DaggerfallEntity now has "custom" DFCareer templates, created from mods. This can be used to create new or replace enemy careers for a given enemy ID 
- EnemyEntity will now use that "custom" career template if available, when a DFCareer is needed
- When issued a non-standard enemy ID, TextManager will return the custom career name if available

What this allows:
- With IDs outside the classic values (ie: 0-42 and 128-146), Mod scripts can add new MobileEnemy to `EnemyBasics.Enemies`, and a new DFCareer to `DaggerfallEntity.CustomCareerTemplates`
- Those new enemies can be spawned in three ways: by a quest (through adding the enemy to Quests-Foes), by random encounter (ie: `RandomEncounters.EncounterTables`), and possibly through a Locations editor (not tested)
- With #2160, new enemies would be able to use entirely new graphics

The Mobile will function like a normal enemy, with all the moves normally available to them (nothing special like the seducer transformation, of course). Their name appears when using the Info cursor, and they can be assigned normal equipment through the "OnLootSpawned" event.

A reference implementation for what a mod adding a new enemy type would look like can be found here: https://github.com/KABoissonneault/DFU-NewSprites/blob/main/Scripts/NewSprites.cs

While there is certainly more that could be done to improve this system, I think it works well enough for a first iteration, and I don't think the current limitations prevent future extensions (ex: letting mods change the encounter formula entirely).

I consider this a draft because I'm not too satisfied with some of the technical decisions. After all, I tried to make the code changes minimal, rather than ideal. For example, to decide whether or not the mod wants an EnemyMonster or an EnemyClass, I went with the ID mapping solution, in a way that doesn't break the classic IDs while allowing for virtually infinite expansion. Also, for `CustomCareerTemplate`, it might not be the best solution, though it may be just sufficient.

In conclusion: IK, don't delay your release for this if you want to think about it, but please consider it before the code freeze. I do believe being able to mod new enemies is a basic mod support feature one would expect from a Daggerfall Unity 1.0 release.