### PR TITLE
Fix billboard animation so frame 0 is rendered first

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -139,8 +139,6 @@ namespace DaggerfallWorkshop
                 else if (summary.Archive == Utility.TextureReader.LightsTextureArchive) speed = lightFps;
                 if (meshFilter != null)
                 {
-                    summary.CurrentFrame++;
-
                     // Original Daggerfall textures
                     if (!summary.ImportedTextures.HasImportedTextures)
                     {
@@ -178,6 +176,7 @@ namespace DaggerfallWorkshop
                         if (summary.ImportedTextures.IsEmissive)
                             meshRenderer.material.SetTexture(Uniforms.EmissionMap, summary.ImportedTextures.Emission[summary.CurrentFrame]);
                     }
+                    summary.CurrentFrame++;
                 }
 
                 yield return new WaitForSeconds(1f / speed);


### PR DESCRIPTION
Mostly important for one shot animations. Is there anywhere else than may have the increment before the first frame?

As reported here: https://forums.dfworkshop.net/viewtopic.php?f=5&p=55561