### PR TITLE
Display warning label for runtime mod settings

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
@@ -43,7 +43,6 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         const float textScale                       = 0.7f;
         const int startX                            = 10;
         const int startY                            = 15;
-        const int columnHeight                      = 165;
         const int columnWidth                       = 140;
         const int columnsOffset                     = columnWidth + startX * 2;
 
@@ -64,6 +63,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         readonly Mod mod;
         readonly ModSettingsData settings;
         readonly bool liveChange;
+        readonly int columnHeight;
 
         int x = startX;
         int y = startY;
@@ -104,6 +104,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             this.mod = mod;
             this.liveChange = liveChange;
 
+            // Make room for warning label about applying settings during runtime
+            columnHeight = liveChange ? 155 : 165;
+
             settings = ModSettingsData.Make(mod);
             settings.SaveDefaults();
             settings.LoadLocalValues();
@@ -132,6 +135,19 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             titleLabel.Position = new Vector2(0, 3);
             titleLabel.HorizontalAlignment = HorizontalAlignment.Center;
             mainPanel.Components.Add(titleLabel);
+
+            if (liveChange)
+            {
+                // Add warning label that some settings may not be applied while game is running
+                TextLabel warningLabel = new TextLabel(DaggerfallUI.DefaultFont);
+                warningLabel.Text = TextManager.Instance.GetLocalizedText("settingsNotApplied");
+                warningLabel.Position = new Vector2(0, columnHeight + 1);
+                warningLabel.TextScale = 0.85f;
+                warningLabel.HorizontalAlignment = HorizontalAlignment.Center;
+                warningLabel.ShadowPosition = Vector2.zero;
+                warningLabel.TextColor = new Color(0.8f, 0.8f, 0.8f, 1.0f);
+                mainPanel.Components.Add(warningLabel);
+            }
 
             // Reset button
             Button resetButton = GetButton(ModManager.GetText("reset"), HorizontalAlignment.Left, resetButtonColor);

--- a/Assets/Localization/StringTables/Internal_Strings Shared Data.asset
+++ b/Assets/Localization/StringTables/Internal_Strings Shared Data.asset
@@ -3255,6 +3255,10 @@ MonoBehaviour:
     m_Key: nord
     m_Metadata:
       m_Items: []
+  - m_Id: 813
+    m_Key: settingsNotApplied
+    m_Metadata:
+      m_Items: []
   - m_Id: 29516644352
     m_Key: temple
     m_Metadata:

--- a/Assets/Localization/StringTables/Internal_Strings_en.asset
+++ b/Assets/Localization/StringTables/Internal_Strings_en.asset
@@ -3634,6 +3634,10 @@ MonoBehaviour:
     m_Localized: Nord
     m_Metadata:
       m_Items: []
+  - m_Id: 813
+    m_Localized: 'Note: Some changes may not be applied until you restart the game.'
+    m_Metadata:
+      m_Items: []
   - m_Id: 29516644352
     m_Localized: temple
     m_Metadata:


### PR DESCRIPTION
#2004 

Implemented starting point for a universal warning sign whenever a player changes a mod's settings while running the game, saying "Note: Some changes may not be applied until you restart the game." right above the save button.

In the future, we can add a flag to each mod setting that will instead prompt the warning when necessary.