### PR TITLE
Fix default binding accidental overrides

### DIFF
--- a/Assets/Scripts/Game/ControlsConfigManager.cs
+++ b/Assets/Scripts/Game/ControlsConfigManager.cs
@@ -311,9 +311,6 @@ namespace DaggerfallWorkshop.Game
                     button.Label.Text = KeyCode.None.ToString();
                     SetUnsavedBinding(action, button.Label.Text);
 
-                    if (UsingPrimary)
-                        InputManager.Instance.AddRemovedPrimaryAction(action);
-
                     checkDuplicates();
                 }
                 s.CloseWindow();
@@ -552,6 +549,9 @@ namespace DaggerfallWorkshop.Game
                 KeyCode curCode = InputManager.Instance.GetBinding(action, primary);
                 if (curCode != code)
                 {
+                    if (primary && code == KeyCode.None)
+                        InputManager.Instance.AddRemovedPrimaryAction(action);
+
                     InputManager.Instance.SetBinding(code, action, primary);
                     Debug.LogFormat("({0}) Bound Action {1} with Code {2} ({3})", primary ? "Primary" : "Secondary", action, code.ToString(), (int)code);
                 }

--- a/Assets/Scripts/Game/ControlsConfigManager.cs
+++ b/Assets/Scripts/Game/ControlsConfigManager.cs
@@ -310,6 +310,10 @@ namespace DaggerfallWorkshop.Game
                 {
                     button.Label.Text = KeyCode.None.ToString();
                     SetUnsavedBinding(action, button.Label.Text);
+
+                    if (UsingPrimary)
+                        InputManager.Instance.AddRemovedPrimaryAction(action);
+
                     checkDuplicates();
                 }
                 s.CloseWindow();

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -1277,10 +1277,13 @@ namespace DaggerfallWorkshop.Game
             foreach (Actions a in enums)
                 MapSecondaryBindings(a);
 
-            var mods = primarySecondaryKeybindDict.Keys.Where(x => (int)x >= startingComboKeyCode);
+            // Get combo codes of both primary and secondary bindings
+            var combos = actionKeyDict.Keys
+                .Concat(secondaryActionKeyDict.Keys)
+                .Where(x => (int)x >= startingComboKeyCode);
 
             modifierHeldFirstDict.Clear();
-            foreach (var key in mods)
+            foreach (var key in combos)
             {
                 modifierHeldFirstDict[(int)this.GetCombo((KeyCode)key).Item1] = false;
             }
@@ -1325,7 +1328,8 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Sets KeyCode binding only if action is missing,
-        // and its default key is not used in alternate bindings.
+        // and its default key is not used in the primary or
+        // secondary bindings (including as modifiers in combos.)
         // This is to ensure default actions are restored if missing
         // and to push out new actions to existing keybind files
         private void TestSetBinding(KeyCode code, Actions action, bool primary = true)
@@ -1333,8 +1337,12 @@ namespace DaggerfallWorkshop.Game
             var dict = primary ? actionKeyDict : secondaryActionKeyDict;
             var alt = primary ? secondaryActionKeyDict : actionKeyDict;
 
-            if (!dict.ContainsValue(action) && !alt.ContainsKey(code))
+            if (!dict.ContainsKey(code) && !alt.ContainsKey(code) && !dict.ContainsValue(action))
             {
+                foreach (var mod in modifierHeldFirstDict.Keys)
+                    if ((int)code == mod)
+                        return;
+
                 SetBinding(code, action, primary);
             }
         }


### PR DESCRIPTION
[Fixes this forum post issue](https://forums.dfworkshop.net/viewtopic.php?f=5&t=4943)

Default bindings now only get set when the default KeyCode is no longer used in either binding page, and that it isn't used as a modifier. This fix also lead me to find another bug where not all modifiers were being found, which has also been resolved.

Also integrated idea from @KABoissonneault to have a list of primary bindings specifically removed by the player. While the primary fix should suffice, this idea will help keep the binding behavior expected.