### PR TITLE
Restore dungeon types from classic

### DIFF
--- a/Assets/StreamingAssets/Quests/B0B20Y07.txt
+++ b/Assets/StreamingAssets/Quests/B0B20Y07.txt
@@ -108,7 +108,7 @@ QBN:
 Person _qgiver_ group Questor
 Person _local_ face 1 group Resident2 local
 
-Place _dungeon_ remote dungeon
+Place _dungeon_ remote dungeon1
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/B0B60Y12.txt
+++ b/Assets/StreamingAssets/Quests/B0B60Y12.txt
@@ -124,7 +124,7 @@ Person _qgiver_ group Questor
 Person _nobleman_ group Resident1 remote
 Person _local_ face 1 group Resident2 local
 
-Place _dungeon_ remote dungeon
+Place _dungeon_ remote dungeon4
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 


### PR DESCRIPTION
Restore dungeon types from classic that were removed before the fallback was implemented in 2019.

I made these changes originally in 061ca3ee because the quests were failing in major regions that don't have orc strongholds (like Daggerfall) not being able to find a suitable dungeon location. I'd forgotten about this until recently. Restored to classic and tested.

There are some quest candidates for refined dungeon type use that were not like that in classic being produced which will come in a separate PR for consideration. I was only prepared to do these to restore to classic.