### PR TITLE
Ensure only new locations are picked up from mods

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -159,8 +159,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 {
                     foreach (TextAsset locationReplacementJsonAsset in assets)
                     {
-                        DFLocation dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJsonAsset.text);
-                        newBlocksAssigned &= AddLocationToRegion(regionIndex, ref dfRegion, ref mapNames, ref mapTable, ref dfLocation);
+                        if (locationReplacementJsonAsset.name.StartsWith("locationnew-"))
+                        {
+                            DFLocation dfLocation = (DFLocation)SaveLoadManager.Deserialize(typeof(DFLocation), locationReplacementJsonAsset.text);
+                            newBlocksAssigned &= AddLocationToRegion(regionIndex, ref dfRegion, ref mapNames, ref mapTable, ref dfLocation);
+                        }
                     }
                 }
                 // If found any new locations for this region,


### PR DESCRIPTION
This corrects an issue where a location override is also loaded and applied as a new location when in a mod package rather than loose files. Bad mistake on my part, but thankfully I found it while developing an update for my guild mod.

----
One other thing I noticed while investigating this issue is that disabling the mod didn't prevent this bug, which made me realise that the use of FindAssets is returning assets from and mod (as I expected) including mods that are disabled - which is not what I expected. I'd not noticed before now also causes my dungeon tester mod to put a location pixel dot on the travel map that has no name and you can't travel to, this is also because my World Data replacement code is finding the new location asset even though the mod is disabled.

@rossipaolo Could you take a look at FindAssets (line 449 of ModManager.cs) and say whether this is working as you expect please? I'm really not sure whether this is a bug in that code or if it's intended to return matching assets regardless of mod being enabled or disabled. If it's meant to work this way then I'll need to do a second pass and load each asset individually by name or something like that,
