### PR TITLE
Fix a loading issue when EnumerateMaps() is run before mods enable/disable state is set.

### DIFF
--- a/Assets/Scripts/Utility/ContentReader.cs
+++ b/Assets/Scripts/Utility/ContentReader.cs
@@ -189,6 +189,8 @@ namespace DaggerfallWorkshop.Utility
             if (!isReady)
                 return false;
 
+            MapDictCheck();
+
             // Get mapId from locationId
             int mapId = LocationIdToMapId(locationId);
             if (mapDict.ContainsKey(mapId))
@@ -213,6 +215,7 @@ namespace DaggerfallWorkshop.Utility
                 summaryOut = new MapSummary();
                 return false;
             }
+            MapDictCheck();
 
             int id = MapsFile.GetMapPixelID(mapPixelX, mapPixelY);
             if (mapDict.ContainsKey(id))
@@ -237,6 +240,7 @@ namespace DaggerfallWorkshop.Utility
             {
                 return false;
             }
+            MapDictCheck();
 
             int id = MapsFile.GetMapPixelID(mapPixelX, mapPixelY);
             if (mapDict.ContainsKey(id))
@@ -296,12 +300,15 @@ namespace DaggerfallWorkshop.Utility
             if (paintFileReader == null)
                 paintFileReader = new PaintFile(Path.Combine(arena2Path, PaintFile.Filename), FileUsage.UseMemory, true);
 
+            // Raise ready flag
+            isReady = true;
+        }
+
+        private void MapDictCheck()
+        {
             // Build map lookup dictionary
             if (mapDict == null && mapFileReader != null)
                 EnumerateMaps();
-
-            // Raise ready flag
-            isReady = true;
         }
 
         /// <summary>


### PR DESCRIPTION
As discussed on PR #2173, the EnumerateMaps() is running before the mod settings have been confirmed and thus partially loading new locations regardless of whether a mod containing them is enabled or disabled. (since that state is undefined at that point) New locations have to be included and checked for collisions when the map dictionary is created.

This PR moves the setting up of the map dictionary to happen the first time it needed rather than on construction of the ContentReader. I felt this was less intrusive code change wise, but it could be done differently if you don't like the check method calls.