### PR TITLE
Fixed missing "OnLootSpawned" event for house/shop containers

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -42,11 +42,22 @@ namespace DaggerfallWorkshop.Game
         void Activate(RaycastHit hit);
     }
 
+    public class ContainerLootSpawnedEventArgs : System.EventArgs
+    {
+        public LootContainerTypes ContainerType;
+        public ItemCollection Loot;
+    }
+
     /// <summary>
     /// Example class to handle activation of doors, switches, etc. from Fire1 input.
     /// </summary>
     public class PlayerActivate : MonoBehaviour
     {
+        /// <summary>
+        /// When Loot is generated for an activated container, such as a shop shelve or a house container
+        /// </summary>
+        public static System.EventHandler<ContainerLootSpawnedEventArgs> OnLootSpawned;
+
         PlayerGPS playerGPS;
         PlayerEnterExit playerEnterExit;        // Example component to enter/exit buildings
         Camera mainCamera;
@@ -821,7 +832,10 @@ namespace DaggerfallWorkshop.Game
                 case LootContainerTypes.ShopShelves:
                     // Stock shop shelf on first access
                     if (loot.stockedDate < DaggerfallLoot.CreateStockedDate(DaggerfallUnity.Instance.WorldTime.Now))
+                    {
                         loot.StockShopShelf(playerEnterExit.BuildingDiscoveryData);
+                        OnLootSpawned?.Invoke(this, new ContainerLootSpawnedEventArgs { ContainerType = loot.ContainerType, Loot = loot.Items });
+                    }
                     // Open Trade Window if shop is open
                     if (GameManager.Instance.PlayerEnterExit.IsPlayerInsideOpenShop)
                     {
@@ -847,7 +861,10 @@ namespace DaggerfallWorkshop.Game
                     }
                     // Stock house container on first access
                     if (loot.stockedDate < DaggerfallLoot.CreateStockedDate(DaggerfallUnity.Instance.WorldTime.Now))
+                    {
                         loot.StockHouseContainer(playerEnterExit.BuildingDiscoveryData);
+                        OnLootSpawned?.Invoke(this, new ContainerLootSpawnedEventArgs { ContainerType = loot.ContainerType, Loot = loot.Items });
+                    }
                     // If no contents, do nothing
                     if (loot.Items.Count == 0)
                         return;


### PR DESCRIPTION
Sorry for breaking the 0 PR pending, but

#2087 was meant to cover all spawned loot, and Ralzar noticed that I missed containers, which are spawned from PlayerActivate.

PlayerActivate generates loot for containers, both for house/shop "private property" crates and shop shelves. Shop shelves do cover modded items in a more automatic manner, but I put the event anyway for consistency.

![image](https://user-images.githubusercontent.com/5789925/126336370-9f458a9d-22e6-4be6-91cf-f92c92f65cc6.png)

![image](https://user-images.githubusercontent.com/5789925/126336399-f2c809b7-5fe4-4d31-8dda-86cbe5b24072.png)
