### PR TITLE
Fix code mistake in building variant getter

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/WorldDataVariants.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataVariants.cs
@@ -221,7 +221,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         public static string GetBuildingVariant(int regionIndex, int locationIndex, string blockName, int recordIndex)
         {
             int locationKey = WorldDataReplacement.MakeLocationKey(regionIndex, locationIndex);
-            VariantBuildingKey buildingKey = new VariantBuildingKey(lastLocationKey, blockName, recordIndex);
+            VariantBuildingKey buildingKey = new VariantBuildingKey(locationKey, blockName, recordIndex);
             return buildingVariants.ContainsKey(buildingKey) ? buildingVariants[buildingKey] : null;
         }
 


### PR DESCRIPTION
When I added the code in feb I made a small mistake. Doesn't affect most uses since lastLocationKey is usually the correct one anyway, but needs correcting for future uses.

So not essential for 0.11.5 release, but could go in.