### PR TITLE
Fix the placement of quest NPCs

### DIFF
--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -627,9 +627,25 @@ namespace DaggerfallWorkshop.Game.Questing
                 }
             }
 
-            // For other NPCs use the given scope if any, else generate it at random
+            // If this is an individual NPC who is not at home, don't place for now
+            // as this has to be done by the "place _person_ at" command
+            if (IsIndividualNPC)
+                return;
+
+            // For other NPCs use the given scope if any 
             if (string.IsNullOrEmpty(scopeString))
-                scopeString = UnityEngine.Random.Range(0.0f, 1.0f) < 0.5f ? "local" : "remote";
+            {
+                // Else generate it at random only if there are local buildings
+                if (GameManager.Instance.PlayerGPS.HasCurrentLocation &&
+                    GameManager.Instance.PlayerGPS.CurrentLocation.Exterior.BuildingCount > 0)
+                {
+                    scopeString = UnityEngine.Random.Range(0.0f, 1.0f) < 0.5f ? "local" : "remote";
+                }
+                else
+                {
+                    scopeString = "remote";
+                }
+            }
 
             // Adjust building type based on faction hints
             string buildingTypeString = houseString;


### PR DESCRIPTION
Fix two issues related to the placement of quest NPCs:

- Named NPCs (i.e. Individuals and Daedras) are not supposed to be placed by default as they can be present in a quest person list only for reputation change purpose. This is the case, for example, of quest A0C0XY04, where Gortwog is not supposed to be placed anywhere. Furthermore, for quests where an indivudal NPC is supposed to be placed somewhere, this is always done by the `place _person_ at` command.
 
- When getting a quest from a location where there is no building at all, always choose a remote scope when selecting the place of a quest NPC who has no assigned location scope. This is the case when getting quests from Witch Covens, but it could also happen from a static NPC placed in the wilderness by a mod, for example.