### PR TITLE
Allow to ask about individual NPCs in some quests

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2956,7 +2956,8 @@ namespace DaggerfallWorkshop.Game
             {
                 QuestResource questResource = quest.GetResource(item.key);
                 Person person = (Person)questResource;
-                if (person.HomeRegionName != GameManager.Instance.PlayerGPS.CurrentRegionName)
+                if (person.HomeRegionIndex != -1 &&
+                    person.HomeRegionName != GameManager.Instance.PlayerGPS.CurrentRegionName)
                     return false;
             }
 
@@ -2999,6 +3000,10 @@ namespace DaggerfallWorkshop.Game
             {
                 place = person.GetHomePlace(); // get home place if no assigned place was found
             }
+
+            // Some individuals such as The Underking have no assigned place
+            if (place == null)
+                return false;
 
             if (place.SiteDetails.regionName != GameManager.Instance.PlayerGPS.CurrentRegionName)
                 return false;

--- a/Assets/StreamingAssets/Quests/10C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/10C00Y00.txt
@@ -123,6 +123,7 @@ Message:  1040
 QBN:
 Item _artifact_ artifact Ring_of_Khajiit anyInfo 1014
 
+Person _questgiver_ face 112 named Meridia anyInfo 1013
 Person _qgfriend_ group Librarian anyInfo 1011 rumors 1012
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/20C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/20C00Y00.txt
@@ -128,9 +128,10 @@ Message:  1060
 --          _tavern_ occurs 2 times.
 
 QBN:
-Item _artifact_ artifact Mace_of_Molag_Bal used 1013
+Item _artifact_ artifact Mace_of_Molag_Bal anyInfo 1013
 Item _map_ letter used 1060
 
+Person _questgiver_ face 112 named Molag_Bal anyInfo 1011
 Person _contact_ face 233 faction The_Cabal remote anyInfo 1012
 Person _dummy_ face 1 group Spellcaster remote
 

--- a/Assets/StreamingAssets/Quests/30C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/30C00Y00.txt
@@ -120,9 +120,9 @@ Message:  1030
 --        _qgfriend_ occurs 12 times.
 
 QBN:
-Item _artifact_ artifact Ring_of_Namira used 1013
+Item _artifact_ artifact Ring_of_Namira anyInfo 1013
 
-Person _questgiver_ face 112 group Questor anyInfo 1013
+Person _questgiver_ face 112 named Namira
 Person _qgfriend_ group Librarian anyInfo 1011 rumors 1012
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/40C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/40C00Y00.txt
@@ -328,13 +328,13 @@ Message:  1050
 --           _staff_ occurs 40 times.
 
 QBN:
-Item _artifact_ artifact Skeletons_Key used 1014
+Item _artifact_ artifact Skeletons_Key anyInfo 1014
 Item _bow_ artifact Auriels_Bow
 Item _ring_ artifact Warlocks_Ring
 Item _staff_ artifact Staff_of_Magnus
 Item _letter_ letter used 1016
 
-Person _questgiver_ face 112 group Questor anyInfo 1013
+Person _questgiver_ face 112 named Nocturnal anyInfo 1013
 Person _qgfriend_ group Librarian anyInfo 1011 rumors 1012
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/50C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/50C00Y00.txt
@@ -135,6 +135,7 @@ Message:  1015
 QBN:
 Item _artifact_ artifact Spell_Breaker anyInfo 1013
 
+Person _questgiver_ face 112 named Peryite anyInfo 1012
 Person _qgfriend_ group Cleric female remote anyInfo 1011
 Person _dummyvamp_ face 1 factiontype Vampire_Clan remote
 

--- a/Assets/StreamingAssets/Quests/60C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/60C00Y00.txt
@@ -142,6 +142,7 @@ Message:  1030
 QBN:
 Item _artifact_ artifact Wabbajack anyInfo 1013
 
+Person _questgiver_ face 112 named Sheogorath anyInfo 1012
 Person _qgfriend_ face 1 group Innkeeper remote anyInfo 1011 rumors 1014
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/70C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/70C00Y00.txt
@@ -86,7 +86,7 @@ _contact_ is the name of a naughty =contact_ in __contact_.
 Message:  1014
 <ce>The Sanguine Rose summons a daedra to fight for you.  A risky proposition
 <ce>                                at best.
-                                     <--->
+<--->
 <ce>The possessor of the Sanguine Rose is supposed to have the power to summon
 <ce>                    aid from the plane of Oblivion.
 
@@ -126,8 +126,9 @@ Message:  1020
 --         _contact_ occurs 5 times.
 
 QBN:
-Item _artifact_ artifact Sanguine_Rose
+Item _artifact_ artifact Sanguine_Rose anyInfo 1014
 
+Person _questgiver_ face 112 named Sanguine anyInfo 1011
 Person _contact_ face 232 faction The_Cabal remote anyInfo 1012
 
 Place _mondung_ remote dungeon4

--- a/Assets/StreamingAssets/Quests/80C0XY00.txt
+++ b/Assets/StreamingAssets/Quests/80C0XY00.txt
@@ -188,6 +188,7 @@ QBN:
 Item _artifact_ artifact Volendrung anyInfo 1013
 Item _note_ letter used 1030
 
+Person _questgiver_ face 112 named Malacath anyInfo 1012
 Person _qgfriend_ group Noble male remote anyInfo 1011
 Person _murder_ face 1 factiontype Province remote anyInfo 1050 rumors 1051
 Person _ruler_ group Noble remote anyInfo 1052 rumors 1053

--- a/Assets/StreamingAssets/Quests/90C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/90C00Y00.txt
@@ -137,6 +137,7 @@ Message:  1020
 QBN:
 Item _artifact_ artifact Skull_of_Corruption anyInfo 1014
 
+Person _questgiver_ face 112 named Vaernima anyInfo 1013
 Person _qgfriend_ group Librarian anyInfo 1011 rumors 1012
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/S0000001.txt
+++ b/Assets/StreamingAssets/Quests/S0000001.txt
@@ -312,6 +312,7 @@ Person _greklith_ face 88 named Prince_Greklith atHome
 Person Vhosek face 88 named Lord_Vhosek atHome
 Person _brother_ face 5 faction Children male remote anyInfo 1030 rumors 1031
 Person _agentuk_ face 1 faction Agents_of_The_Underking remote
+Person _underking_ face 1 named The_Underking anyInfo 1013
 
 Place _ukcrypt_ remote dungeon11 anyInfo 1015 rumors 1016
 Place _dirennitower_ permanent DirenniTowerEntry

--- a/Assets/StreamingAssets/Quests/T0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/T0C00Y00.txt
@@ -135,8 +135,9 @@ Message:  1030
 --        _qgfriend_ occurs 7 times.
 
 QBN:
-Item _artifact_ artifact Azuras_Star used 1014
+Item _artifact_ artifact Azuras_Star anyInfo 1014
 
+Person _questgiver_ face 112 named Azura anyInfo 1013
 Person _qgfriend_ group Librarian anyInfo 1011 rumors 1012
 
 Place _mondung_ remote dungeon4

--- a/Assets/StreamingAssets/Quests/U0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/U0C00Y00.txt
@@ -76,17 +76,17 @@ It's a tragedy for all of %reg. What monster would've killed =monster_?
 Message:  1011
 _qgfriend_ is the name of that tough-talking =qgfriend_ over at __qgfriend_.
 <--->
-that's the name of that bully at __qgfriend_, off over to the %di.
+That's the name of that bully at __qgfriend_, off over to the %di.
 
 Message:  1012
 _qgfriend_ is one of the Daedra Prince Boethiah's agents in Tamriel.
 <--->
 _qgfriend_ is a mean-spirited bully who works for the Daedra Prince Boethiah.
 
--Message:  1013
--Boethiah is the Daedra Prince of Cruelty and Torture. Not a nice lady.
--<--->
--She's a Prince of Oblivion, one of the Daedric Regents, and a real killer.
+Message:  1013
+Boethiah is the Daedra Prince of Cruelty and Torture. Not a nice lady.
+<--->
+She's a Prince of Oblivion, one of the Daedric Regents, and a real killer.
 
 Message:  1014
 _artifact_ protects it's wearer from many kinds of harm. Fire and life draining are the two commonly known.
@@ -172,7 +172,7 @@ QBN:
 Item _artifact_ artifact Ebony_Mail anyInfo 1014
 Item _letter_ letter used 1040
 
--Person _questgiver_ face 112 group Questor anyInfo 1013
+Person _questgiver_ face 112 named Boethiah anyInfo 1013
 Person _qgfriend_ group Librarian anyInfo 1011 rumors 1012
 Person _mfriend_ group Local_4.0 remote
 

--- a/Assets/StreamingAssets/Quests/V0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/V0C00Y00.txt
@@ -123,6 +123,7 @@ Message:  1030
 QBN:
 Item _artifact_ artifact Masque_of_Clavicus_Vile anyInfo 1014
 
+Person _questgiver_ face 112 named Clavicus_Vile anyInfo 1011
 Person _contact_ face 238 faction The_Cabal female remote anyInfo 1012
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/W0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/W0C00Y00.txt
@@ -142,7 +142,7 @@ QBN:
 Item _artifact_ artifact Oghma_Infinium anyInfo 1013
 Item _magic_ magic_item
 
-Person _questgiver_ face 112 group Questor anyInfo 1012
+Person _questgiver_ face 112 named Hermaeus_Mora anyInfo 1012
 Person _contact_ group Librarian remote anyInfo 1011
 Person _enemy_ face 1 factiontype Province remote
 

--- a/Assets/StreamingAssets/Quests/X0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/X0C00Y00.txt
@@ -122,6 +122,7 @@ Message:  1030
 QBN:
 Item _artifact_ artifact Hircine_Ring anyInfo 1013
 
+Person _questgiver_ face 112 named Hircine anyInfo 1011
 Person _contact_ face 238 faction The_Cabal female remote
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/Y0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/Y0C00Y00.txt
@@ -122,6 +122,7 @@ Dagon's prey returns to Oblivion.
 QBN:
 Item _artifact_ artifact Mehrunes_Razor anyInfo 1013
 
+Person _questgiver_ face 112 named Mehrunes_Dagon anyInfo 1011
 Person _contact_ face 239 faction The_Cabal female remote anyInfo 1012
 
 Place _mondung_ remote dungeon

--- a/Assets/StreamingAssets/Quests/Z0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/Z0C00Y00.txt
@@ -139,8 +139,9 @@ Message:  1041
 --        _qgfriend_ occurs 8 times.
 
 QBN:
-Item _artifact_ artifact Ebony_Blade anyInfo 1013
+Item _artifact_ artifact Ebony_Blade anyInfo 1014
 
+Person _questgiver_ face 112 named Mephala remote anyInfo 1013
 Person _qgfriend_ group Librarian remote anyInfo 1011
 Person _enemy_ face 1 factiontype Knightly_Guard remote
 


### PR DESCRIPTION
Fix all Daedra quests as well as Lhotun's part of the main quest to allow asking about Daedra princes and The Underking. The only exception is Namira who has no dialogue for anyInfo.

Also fixed some artifacts dialogue messages which where incorrectly associated with the `used` command instead of `anyInfo`.