### PR TITLE
Classic Quests : Suggested dungeon types changes

### DIFF
--- a/Assets/StreamingAssets/Quests/60C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/60C00Y00.txt
@@ -145,7 +145,7 @@ Item _artifact_ artifact Wabbajack anyInfo 1013
 Person _qgfriend_ face 1 group Innkeeper remote anyInfo 1011 rumors 1014
 
 Place _mondung_ remote dungeon
-Place _contactdung_ remote dungeon
+Place _contactdung_ remote dungeon3
 
 Clock _1stparton_ 00:00 0 flag 1 range 2 5
 

--- a/Assets/StreamingAssets/Quests/A0C0XY04.txt
+++ b/Assets/StreamingAssets/Quests/A0C0XY04.txt
@@ -179,7 +179,7 @@ Person _dummymage_ face 1 faction The_Mages_Guild remote
 Person _dummyorc_ face 1 named Gortwog
 Person _dummydarkb_ face 49 faction The_Dark_Brotherhood remote
 
-Place _dungeon_ remote dungeon
+Place _dungeon_ remote dungeon7
 Place _meetingplace_ local apothecary
 
 Clock _extratime_ 00:30 0 flag 1 range 0 1

--- a/Assets/StreamingAssets/Quests/B0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/B0B00Y00.txt
@@ -156,7 +156,7 @@ Person _qgiver_ group Questor
 Person _lady_ face 2 group Noble female local
 Person _vamp_ face 40 factiontype Vampire_Clan local
 
-Place _mondung_ remote dungeon
+Place _mondung_ remote dungeon8
 
 Clock _2mondung_ 00:00 0 flag 17 range 0 2
 Clock _S.07_ 10:00 1.16:00

--- a/Assets/StreamingAssets/Quests/B0B10Y04.txt
+++ b/Assets/StreamingAssets/Quests/B0B10Y04.txt
@@ -134,7 +134,7 @@ QBN:
 
 Person _qgiver_ group Questor
 
-Place _mondung_ remote dungeon
+Place _mondung_ remote dungeon1
 Place tavern local tavern
 
 Clock _2mondung_ 00:00 0 flag 17 range 0 2

--- a/Assets/StreamingAssets/Quests/B0B40Y08.txt
+++ b/Assets/StreamingAssets/Quests/B0B40Y08.txt
@@ -83,7 +83,7 @@ QBN:
 Person _qgiver_ group Questor
 Person _local_ face 207 group Resident2 female local
 
-Place _dungeon_ remote dungeon
+Place _dungeon_ remote dungeon1
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/B0B40Y09.txt
+++ b/Assets/StreamingAssets/Quests/B0B40Y09.txt
@@ -90,7 +90,7 @@ Item _gold_ gold
 Person _qgiver_ group Questor
 Person _local_ face 207 group Resident2 female local
 
-Place _dungeon_ remote dungeon
+Place _dungeon_ remote dungeon13
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/B0B60Y12.txt
+++ b/Assets/StreamingAssets/Quests/B0B60Y12.txt
@@ -124,7 +124,7 @@ Person _qgiver_ group Questor
 Person _nobleman_ group Resident1 remote
 Person _local_ face 1 group Resident2 local
 
-Place _dungeon_ remote dungeon4
+Place _dungeon_ remote dungeon0
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/B0B70Y14.txt
+++ b/Assets/StreamingAssets/Quests/B0B70Y14.txt
@@ -131,7 +131,7 @@ Item _gold_ gold
 
 Person _qgiver_ group Questor
 
-Place _dungeon_ remote dungeon
+Place _dungeon_ remote dungeon7
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/B0B80Y17.txt
+++ b/Assets/StreamingAssets/Quests/B0B80Y17.txt
@@ -95,7 +95,7 @@ QBN:
 Person _qgiver_ group Questor
 Person _local_ face 1 group Resident2 local
 
-Place _dungeon_ remote dungeon
+Place _dungeon_ remote dungeon0
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/B0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y06.txt
@@ -94,7 +94,7 @@ QBN:
 Person _qgiver_ group Questor
 Person _local_ face 207 group Resident2 female local
 
-Place _dungeon_ remote dungeon
+Place _dungeon_ remote dungeon13
 
 Clock _2dung_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/C0B00Y03.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y03.txt
@@ -118,7 +118,7 @@ QBN:
 Person _qgiver_ group Questor
 Person _cleric_ face 105 factiontype Temple
 
-Place _mondung_ remote dungeon
+Place _mondung_ remote dungeon4
 
 Clock _queston_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/E0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/E0B00Y00.txt
@@ -124,7 +124,7 @@ Item _reward_ gold
 
 Person _questgiver_ group Questor
 
-Place _mondung_ remote dungeon
+Place _mondung_ remote dungeon4
 
 Clock _1stparton_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/L0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B10Y03.txt
@@ -147,7 +147,7 @@ QBN:
 Person _qgiver_ group Questor
 Person _contact_ face 176 group Innkeeper
 
-Place _mondung_ remote dungeon
+Place _mondung_ remote dungeon8
 
 Clock _queston_ 00:00 0 flag 17 range 0 2
 

--- a/Assets/StreamingAssets/Quests/M0B1XY01.txt
+++ b/Assets/StreamingAssets/Quests/M0B1XY01.txt
@@ -108,7 +108,7 @@ Item _reward_ gold
 
 Person _questgiver_ group Questor
 
-Place _mondung_ remote dungeon
+Place _mondung_ remote dungeon10
 Place _newdung_ remote dungeon
 
 Clock _1stparton_ 00:00 0 flag 17 range 0 2

--- a/Assets/StreamingAssets/Quests/M0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/M0B20Y02.txt
@@ -113,7 +113,7 @@ Item _reward_ gold
 
 Person _questgiver_ group Questor
 
-Place _mondung_ remote dungeon
+Place _mondung_ remote dungeon13
 Place _newdung_ remote dungeon
 
 Clock _1stparton_ 00:00 0 flag 17 range 0 2


### PR DESCRIPTION
Suggested dungeon type changes for 15 quests according to their context.

For some of them, a dungeon type is implied in dialogue or the quest prompt, yet they use the "_dungeon_" place, which randomly selects a dungeon from every type. This can create the scenario of having to hunt down the leader of an orc band in a crypt, which would make the target the only orc in the dungeon.

I went through every quest that used "_dungeon_" as a place and examined the dialogue to see if it could use a specific dungeon type instead of a random one. Since there's already a fallback mechanic in place, regions that do not have these dungeon types will still parse by choosing a random dungeon instead. At least, a dungeon type that offers a theme and foe spawns more in line with the quests' context could be choosen first.

Here are my justifications for each of those changes, taken from [my thread](https://forums.dfworkshop.net/viewtopic.php?f=23&t=4966&p=55865#p55865) on the DFU forums : 


**Quest :** 60C00Y00
**Type :** Prison
_Justification :_
`Then go from ___mondung_ to a lunatic asylum called ___contactdung_`

**Quest :** A0C0XY04
**Type :** Coven
_Justification :_
`Some poor fool went into ___dungeon_. I hear the place is full of demons.`

**Quest :** B0B00Y00
**Type :** Vampire Haunt
_Justification :_
`[...]to rescue the fair Lady _lady_ from ___mondung_, where she has been captured and imprisoned by a (vampire).`

**Quest :** B0B10Y04
**Type :** Orc Stronghold
_Justification :_
`The orc lives in a hole called ___mondung_ with his troops.`

**Quest :** B0B40Y08
**Type :** Orc Stronghold
_Justification :_
`[...]the (orc warlord) of a powerful orc band in ___dungeon_.`

**Quest :** B0B40Y09
**Type :** Giant Stronghold
_Justification :_
`The giant has made a den out of ___dungeon_. Go there and kill him. You might find other giants there.`

**Quest :** B0B60Y12
**Type :**Crypt
_Justification :_
`[...]_nobleman_'s ancient ancestor is entombed in a mausoleum named ___dungeon_`

**Quest :** B0B70Y14
**Type :** Coven
_Justification :_
`All sorts of Daedric beings are entering into our world. [...]
Go quickly then to ___dungeon_. We have no way of knowing how many Daedra are wandering its halls.`
_Note : Both Covens and Desecrated Temples could fit as they have the most daedra spawns. Covens are present in more regions though._

**Quest :** B0B80Y17
**Type :** Crypt
_Justification :_
`[...]a lich is raising an army of undead.`

**Quest :** B0C00Y06
**Type :** Giant Stronghold
_Justification :_
`The giant has made its lair in ___dungeon_. Go there and kill it. There may be other giants there, but I don't care.`

**Quest :** C0B00Y03
**Type :** Desecrated Temple
_Justification :_
`[...]has disappeared while investigating an old ruined temple.`

**Quest :** E0B00Y00
**Type :** Desecrated Temple
_Justification :_
`Quest title : The desecrated temple.`

**Quest :** L0B10Y03
**Type :** Vampire Haunt
_Justification :_
`I haven't heard from =target_ since %g went off looking for that baron in ___mondung_. 
Weird character, that baron. Never came around during the day, lived in that creepy place.`

**Quest :** M0B1XY01
**Type :** Harpy Nest
_Justification :_
`[...]has hired me to exterminate a nest of harpies that has infested ___mondung_
`

**Quest :** M0B20Y02
**Type :** Giant Stronghold
_Justification :_
`Our client places the giants at their stronghold, ___mondung_.`