### PR TITLE
Fix placed NPCs reverting to home location

### DIFF
--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -378,10 +378,11 @@ namespace DaggerfallWorkshop.Game.Questing
             base.Tick(caller);
 
             // Auto-assign NPC to home Place if available and player enters
+            // (but only if not already placed, e.g. by PlaceNpc action)
             // This only happens for very specific NPC types
             // Equivalent to calling "place anNPC at aPlace" from script
             // Will not be called again as assignment is permanent for duration of quest
-            if (homePlaceSymbol != null && !assignedToHome)
+            if (lastAssignedPlaceSymbol == null && homePlaceSymbol != null && !assignedToHome)
             {
                 Place home = ParentQuest.GetPlace(homePlaceSymbol);
                 if (home == null)


### PR DESCRIPTION
Partial fix for #2190, specifically "NPCs who should appear in buildings where they don't."

The Tick method in Person.cs contains logic that attempts to hot-place an NPC at its home location when the player arrives there. While this behavior only occurs once, it did not contain a check to see whether the NPC had already been placed, e.g. by a PlaceNpc action. This had the effect of permitting quantum NPCs that could exist in two places at the same time: both at their placed-at location and at their home location. Once the player visits the NPC's home location, however, the NPC will no longer appear at the placed-at location. These anomalies account for the strange NPC availability noted in the issue.

Test case: Quest A0C00Y16
* _missingperson_ is placed at _hidingplace_ but still has a home location defined
* player visits _hidingplace_ first, _missingperson_ is present until... 
* player visits _missingperson_home_, _missingperson_ auto-placed at home and stops being present at _hidingplace_
* _missingperson_ will only exist at home location for remainder of quest, soft-locking quest path _S.00_

Adding a check that `lastAssignedPlaceSymbol` has not already been assigned prevents NPCs being erroneously hot-placed back to their home locations when placed elsewhere.