### PR TITLE
Fix assigned quest places getting re-assigned when setting up places

### DIFF
--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -1202,7 +1202,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 {
                     Place place = (Place)resource;
                     if (place.siteDetails.siteType == SiteTypes.Building &&
-                        place.siteDetails.mapId == location.Exterior.ExteriorData.MapId &&
+                        place.siteDetails.mapId == location.MapTableData.MapId &&
                         place.siteDetails.buildingKey == buildingSummary.buildingKey)
                         return true;
                 }
@@ -1214,7 +1214,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 foreach (SiteDetails site in activeQuestSites)
                 {
                     if (site.siteType == SiteTypes.Building &&
-                        site.mapId == location.Exterior.ExteriorData.MapId &&
+                        site.mapId == location.MapTableData.MapId &&
                         site.buildingKey == buildingSummary.buildingKey)
                         return true;
                 }


### PR DESCRIPTION
IsBuildingAssigned method was comparing site's mapId against location's ExteriorData but everywhere else site mapIds are derived from location's MapTableData instead. Change comparison to compare against proper value.

This PR represents another partial fix for #2190 that addresses errors such as:
* incorrect building names causing confusion on automap and in dialog messages
* created NPCs sometimes existing at the same location
* NPCs placed at locations sometimes reusing their home location (e.g. _missingperson_'s home and _hidingplace_ being the same physical location but having different names)

With this fix in place, all locations chosen for quest A0C00Y16 were unique (within scope of quest itself) in 10 separate tests.