### PR TITLE
Fix "dialog links" and "create npc" to behave as classic quest opcodes

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/AddDialog.cs
+++ b/Assets/Scripts/Game/Questing/Actions/AddDialog.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -70,15 +70,15 @@ namespace DaggerfallWorkshop.Game.Questing
             // add dialog for resources
             if (place != null)
             {
-                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, place.Symbol.Name, TalkManager.QuestInfoResourceType.Location, false);
+                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, place, TalkManager.QuestInfoResourceType.Location, false);
             }
             if (person != null)
             {
-                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, person.Symbol.Name, TalkManager.QuestInfoResourceType.Person, false);
+                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, person, TalkManager.QuestInfoResourceType.Person, false);
             }
             if (item != null)
             {
-                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, item.Symbol.Name, TalkManager.QuestInfoResourceType.Thing, false);
+                GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(ParentQuest.UID, item, TalkManager.QuestInfoResourceType.Thing, false);
             }
 
             SetComplete();

--- a/Assets/Scripts/Game/Questing/Actions/DialogLink.cs
+++ b/Assets/Scripts/Game/Questing/Actions/DialogLink.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -67,47 +67,18 @@ namespace DaggerfallWorkshop.Game.Questing
             // Get related Item resource
             Item item = ParentQuest.GetItem(itemSymbol);
 
-            string namePlace = "", namePerson = "", nameItem = "";
-
             // first create dialog link for just the separated resources (which will hide them)
             if (place != null)
             {
-                /*
-                namePlace = place.SiteDetails.buildingName; // use building name as default
-                if (namePlace == null) // no building?
-                    namePlace = place.SiteDetails.locationName; // use dungeon name
-                */
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, place.Symbol.Name, TalkManager.QuestInfoResourceType.Location);
+                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, place, TalkManager.QuestInfoResourceType.Location);
             }
             if (person != null)
             {
-                namePerson = person.DisplayName;
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, person.Symbol.Name, TalkManager.QuestInfoResourceType.Person);
+                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, person, TalkManager.QuestInfoResourceType.Person);
             }
             if (item != null)
             {
-                nameItem = item.DaggerfallUnityItem.ItemName;
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, item.Symbol.Name, TalkManager.QuestInfoResourceType.Thing);
-            }
-
-            // then create dialog links between the resources
-            if ((place != null) && (person != null))
-            {
-                // register both links (location -> person as well as person -> location)
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, namePlace, TalkManager.QuestInfoResourceType.Location, namePerson, TalkManager.QuestInfoResourceType.Person);
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, namePerson, TalkManager.QuestInfoResourceType.Person, namePlace, TalkManager.QuestInfoResourceType.Location);
-            }
-            if ((place != null) && (item != null))
-            {
-                // register both links (location -> item as well as item -> location)
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, namePlace, TalkManager.QuestInfoResourceType.Location, nameItem, TalkManager.QuestInfoResourceType.Thing);
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, nameItem, TalkManager.QuestInfoResourceType.Thing, namePlace, TalkManager.QuestInfoResourceType.Location);
-            }
-            if ((person != null) && (item != null))
-            {
-                // register both links (person -> item as well as item -> person)
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, namePerson, TalkManager.QuestInfoResourceType.Person, nameItem, TalkManager.QuestInfoResourceType.Thing);
-                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, nameItem, TalkManager.QuestInfoResourceType.Thing, namePerson, TalkManager.QuestInfoResourceType.Person);
+                GameManager.Instance.TalkManager.DialogLinkForQuestInfoResource(ParentQuest.UID, item, TalkManager.QuestInfoResourceType.Thing);
             }
 
             SetComplete();

--- a/Assets/Scripts/Game/Questing/Actions/JournalNote.cs
+++ b/Assets/Scripts/Game/Questing/Actions/JournalNote.cs
@@ -49,7 +49,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
         {
             Message message = ParentQuest.GetMessage(id);
 
-            GameManager.Instance.PlayerEntity.Notebook.AddNote(new List<TextFile.Token>(message.GetTextTokens()));
+            GameManager.Instance.PlayerEntity.Notebook.AddNote(new List<TextFile.Token>(message.GetTextTokens(-1, false)));
 
             SetComplete();
         }

--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -664,6 +664,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
             // Complete assigning home place
             homePlaceSymbol = homePlace.Symbol.Clone();
+            homePlace.IsAvailableForDialog = false;
             ParentQuest.AddResource(homePlace);
             LogHomePlace(homePlace);
         }

--- a/Assets/Scripts/Game/Questing/QuestResource.cs
+++ b/Assets/Scripts/Game/Questing/QuestResource.cs
@@ -23,6 +23,7 @@ namespace DaggerfallWorkshop.Game.Questing
         int rumorsMessageID = -1;
         bool hasPlayerClicked = false;
         bool isHidden = false;
+        bool isAvailableForDialog = true;
 
         [NonSerialized]
         QuestResourceBehaviour questResourceBehaviour = null;
@@ -91,6 +92,15 @@ namespace DaggerfallWorkshop.Game.Questing
         {
             get { return isHidden; }
             set { SetHidden(value); }
+        }
+
+        /// <summary>
+        /// Gets or sets flag to show this quest resource in dialog.
+        /// </summary>
+        public bool IsAvailableForDialog
+        {
+            get { return isAvailableForDialog; }
+            set { isAvailableForDialog = value; }
         }
 
         /// <summary>

--- a/Assets/Scripts/Utility/QuestMacroHelper.cs
+++ b/Assets/Scripts/Utility/QuestMacroHelper.cs
@@ -127,15 +127,15 @@ namespace DaggerfallWorkshop.Utility
                                 System.Type t = resource.GetType();
                                 if (t.Equals(typeof(DaggerfallWorkshop.Game.Questing.Place)))
                                 {
-                                        GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, macro.symbol, TalkManager.QuestInfoResourceType.Location);
+                                     GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, resource, TalkManager.QuestInfoResourceType.Location);
                                 }
                                 else if (t.Equals(typeof(DaggerfallWorkshop.Game.Questing.Person)))
                                 {
-                                        GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, macro.symbol, TalkManager.QuestInfoResourceType.Person);
+                                     GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, resource, TalkManager.QuestInfoResourceType.Person);
                                 }
                                 else if (t.Equals(typeof(DaggerfallWorkshop.Game.Questing.Item)))
                                 {
-                                        GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, macro.symbol, TalkManager.QuestInfoResourceType.Thing);
+                                     GameManager.Instance.TalkManager.AddDialogForQuestInfoResource(parentQuest.UID, resource, TalkManager.QuestInfoResourceType.Thing);
                                 }
                             }
                         }


### PR DESCRIPTION
While working on A0C00Y16 to fix issue #2190, I noticed so-called "dialog links" were not working correctly. Furthermore, there were other issues, like the fact than all NPCs homes were available as topics under the "Where Is > Locations > General" list. That's not correct at all since these houses should only be available when mentioned by other NPCs, and none of the NPC houses are mentioned at start.

I also reverse engineered classic regarding the `dialog link` and `add dialog` opcodes and it appears that Tipton's documentation for these opcodes was inaccurate. In fact `dialog link` should have been named `remove dialog` as that's the only function it does. When several quest resources are mentioned in a `dialog link` command, this only means that all of these resources need to be hidden, nothing more. There is no "link" between any of the resources, which means than hearing about one does not necessarily reveal any of the other, except if the quest explicitly uses the `add dialog` command to do so.

I corrected all of this, and I now have a perfectly working version of A0C00Y16, which I will submit as another PR. Of course I tested other quests to be sure that my changes do not break any stuff and it appears to be working pretty well.

One other thing I corrected is the fact that quest journal entries should not reveal anything regarding quest resources, only speaking with other NPCs or reading letters and other written quest items should do so.