### PR TITLE
Fix questor NPC not hiding when using startquest via console

### DIFF
--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -702,6 +702,13 @@ namespace DaggerfallWorkshop.Game.Questing
             quests.Add(quest.UID, quest);            
 
             RaiseOnQuestStartedEvent(quest);
+
+            // Assign QuestResourceBehaviour to questor NPC - this will be last NPC clicked
+            // This will ensure quests actions like "hide npc" will operate on questor at quest startup
+            if (LastNPCClicked != null)
+            {
+                LastNPCClicked.AssignQuestResourceBehaviour();
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -134,11 +134,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 sender.CloseWindow();
                 ShowQuestPopupMessage(offeredQuest, (int)QuestMachine.QuestMessages.AcceptQuest);
                 QuestMachine.Instance.StartQuest(offeredQuest);
-
-                // Assign QuestResourceBehaviour to questor NPC - this will be last NPC clicked
-                // This will ensure quests actions like "hide npc" will operate on questor at quest startup
-                if (QuestMachine.Instance.LastNPCClicked != null)
-                    QuestMachine.Instance.LastNPCClicked.AssignQuestResourceBehaviour();
             }
             else
             {


### PR DESCRIPTION
LastClickedNPC quest resource behavior fixup only occurred when starting quest via popup window. Moving it within StartQuest method of QuestMachine ensures it will take effect for any code path that starts a quest. AssignQuestResourceBehavior method already ignores non-questor NPCs and will only create a single behavior component per NPC so this should be a safe fix globally.

Quest K0C00Y06 hides its questor NPC shortly after quest start. Prior to this fix, this would only occur if starting the quest from a dialog popup. With fix in place, questor now also hides properly when invoking quest via `startquest` console command.