### PR TITLE
Use _thiefhome_ symbol for rumor mill and anonymous tip

### DIFF
--- a/Assets/StreamingAssets/Quests/K0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y06.txt
@@ -135,7 +135,7 @@ _thief_, well, %g's a retired jewel thief. Or semi-retired, as I understand.
 <--->
 _thief_ used to be quite a jewel thief in __thiefhome_ once upon a time.
 <--->
-Someone told me that _thief_ lurks about _thiefhouse_ this time everyday.
+Someone told me that _thief_ lurks about _thiefhome_ this time everyday.
 <--->
 _merchant_ doesn't believe that _thief_ has reformed %g3 life at all.
 <--->
@@ -283,7 +283,7 @@ Dear %pcn,
       Perhaps it would interest you to know
  that there is at least one person who doesn't
  think you did it. Or maybe I should say
- two people in __thiefhouse_
+ two people in __thiefhome_
  don't think you did it. Me and the one who
  did it -- a =thief_ who
  did do the burglary.
@@ -379,7 +379,7 @@ Message:  1032
  from an anonymous source identifying
  someone named _thief_
  as a notorious jewel-thief living right
- in __thiefhouse_. Even if %g
+ in __thiefhome_. Even if %g
  didn't actually rob __qgiver_,
  a conference may reveal who did.
 


### PR DESCRIPTION
K0C00Y06 features two symbols with very similar names: _thiefhome_ and _thiefhouse_
_thiefhome_ is the location for the usual suspect _thief_ and where they can be found if not the guilty party.
_thiefhouse_ is the site where the incriminating evidence and/or guilty party can be found.

Rumors related to all other usual suspects use appropriate home symbols (e.g. _priesthome_ for _priest_) so rumors for _thief_ should use _thiefhome_.
The anonymous letter you receive when _thief_ is the culprit should similarly reference _thiefhome_  as all other anonymous letters do for their respective culprits.

This change should help reduce confusion in #2191 since now the only way to learn the location of _thiefhouse_ is through meeting the witness.