### PR TITLE
Destroy extant NPC object when placing it somewhere player is not

### DIFF
--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -495,10 +495,10 @@ namespace DaggerfallWorkshop.Game.Questing
                 }
             }
 
-            // Hot-remove resource is player already at this Place and resource was moved elsewhere
+            // Hot-remove resource if moved somewhere player is not
             if (!IsPlayerHere() && resource.QuestResourceBehaviour)
             {
-                resource.QuestResourceBehaviour.gameObject.SetActive(false);
+                GameObject.Destroy(resource.QuestResourceBehaviour.gameObject);
             }
         }
 


### PR DESCRIPTION
In K0C00Y06, the _witness_ NPC is placed at _withouse_ immediately after calling for the guards.

The current implementation of a hot-remove in Place.cs tried to hide the NPC in such an instance but the Tick method of QuestResourceBehavior would un-hide the NPC immediately after. Destroying the NPC's gameobject instead allows for hiding the NPC in a manner that QuestResourceBehavior cannot revert. The NPC will re-instantiate when the player visits its new location.

The only instance in which I can see this causing an issue is if an NPC is placed at an alternate location via `place npc` and then placed back at its original location while the player is still there. If such an instance exists, it should be changed to use `hide npc` and `restore` instead.