### PR TITLE
Added PlayerSpeedChanger.ModifySpeedMod(), Includes Console Commands

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -643,9 +643,10 @@ namespace Wenzil.Console
         private static class SetWalkSpeed
         {
             public static readonly string name = "set_walkspeed";
+            public static readonly string uid = "speedmod_uid";
             public static readonly string error = "Failed to set walk speed - invalid setting or PlayerMotor object not found";
-            public static readonly string description = "Set walk speed by multiplying current walk speed by inserted percentage. Set to -1 to disable or enable speed overrides. Set to -2 to clear out all speed modifiers";
-            public static readonly string usage = "set_walkspeed [#]";
+            public static readonly string description = "Set or update walk speed by multiplying current walk speed by inserted percentage. To update existing modifier, put in its UID after the updated speed value. Set to -1 to disable or enable speed overrides. Set to -2 to clear out all speed modifiers";
+            public static readonly string usage = "set_walkspeed [#] [uid]";
 
             public static string Execute(params string[] args)
             {
@@ -691,20 +692,36 @@ namespace Wenzil.Console
                     speedChanger.ResetSpeed(true, false);
                     return string.Format("Walk speed modifiers cleared. Walk speed is " + speedChanger.RefreshWalkSpeed().ToString()); 
                 }
+                else if (args.Count() == 2)
+                {
+                    string uidUpdate;
+                    uidUpdate = args[1].ToString();
+
+                    if (uidUpdate != "")
+                    {
+                        if (speedChanger.WalkSpeedModifierList.ContainsKey(uidUpdate))
+                        {
+                            speedChanger.ModifySpeedMod(uidUpdate, speed, false);
+                            return string.Format("Walk speed modifier updated (UID: " + uidUpdate + "). Walk speed is " + speedChanger.RefreshWalkSpeed().ToString());
+                        }
+                        return string.Format("Walk speed modifier list does not contain modifer" + uidUpdate + ". Ensure you have an existing UID speed modifier value.");
+                    }
+                    return string.Format("Insert existing modifier UID value to update your walk speed modifier");
+                }
                 else
                 {
                     speedChanger.AddWalkSpeedMod(out UID, speed);
                     return string.Format("Walk speed Modifier added (UID: " + UID + "). Walk speed is " + speedChanger.RefreshWalkSpeed().ToString());
                 }
-
             }
         }
 
         private static class SetRunSpeed
         {
             public static readonly string name = "set_runspeed";
+            public static readonly string uid = "speedmod_uid";
             public static readonly string error = "Failed to set run speed - invalid setting or PlayerMotor object not found.";
-            public static readonly string description = "Set run speed by multiplying current run speed by inserted percentage. Set to -1 to disable or enable speed overrides. Set to -2 to clear out all speed modifiers";
+            public static readonly string description = "Set run speed by multiplying current run speed by inserted percentage. To update existing modifier, put in its UID after the updated speed value. Set to -1 to disable or enable speed overrides. Set to -2 to clear out all speed modifiers";
             public static readonly string usage = "set_runspeed [#]";
 
             public static string Execute(params string[] args)
@@ -751,6 +768,22 @@ namespace Wenzil.Console
                 {
                     speedChanger.ResetSpeed(false, true);
                     return string.Format("Run speed modifiers cleared. Run speed is " + speedChanger.RefreshRunSpeed().ToString());
+                }
+                else if (args.Count() == 2)
+                {
+                    string uidUpdate;
+                    uidUpdate = args[1].ToString();
+
+                    if (uidUpdate != "")
+                    {
+                        if (speedChanger.RunSpeedModifierList.ContainsKey(uidUpdate))
+                        {
+                            speedChanger.ModifySpeedMod(uidUpdate, speed, true);
+                            return string.Format("Walk speed modifier updated (UID: " + uidUpdate + "). Walk speed is " + speedChanger.RefreshRunSpeed().ToString());
+                        }
+                        return string.Format("Walk speed modifier list does not contain modifer" + uidUpdate + ". Ensure you have an existing UID speed modifier value.");
+                    }
+                    return string.Format("Insert existing modifier UID value to update your walk speed modifier");
                 }
                 else
                 {

--- a/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerSpeedChanger.cs
@@ -35,10 +35,12 @@ namespace DaggerfallWorkshop.Game
 
         public bool walkSpeedOverride = true;
         private float currentWalkSpeed = 0;
+        public Dictionary<string, float> WalkSpeedModifierList { get { return walkSpeedModifierList; } private set { ; }  }
         private Dictionary<string, float> walkSpeedModifierList = new Dictionary<string, float>();
 
         public bool runSpeedOverride = true;
         private float currentRunSpeed = 0;
+        public Dictionary<string, float> RunSpeedModifierList { get { return runSpeedModifierList; } private set {; } }
         private Dictionary<string, float> runSpeedModifierList = new Dictionary<string, float>();
 
         public delegate bool CanPlayerRun();
@@ -214,6 +216,36 @@ namespace DaggerfallWorkshop.Game
             updateRunSpeed = refreshRunSpeed;
 
             return added;
+        }
+
+        public bool ModifySpeedMod(string UUID, float updatedSpeed, bool modifyRunSpeed = false, bool refreshSpeed = true)
+        {
+            //setup false bool for manipulation.
+            bool modified = false;
+
+            //if there is no uuid put in, return false as error catching.
+            if (UUID == "" || UUID == null)
+                return modified;
+
+            //if there is a modifier put in, see if dictionary contains it in the unique keys, and then modify it and return true.
+            if (!modifyRunSpeed && walkSpeedModifierList.ContainsKey(UUID))
+            {
+                walkSpeedModifierList[UUID] = updatedSpeed;
+                modified = true;
+            }
+
+            //if there is a modifier put in, see if dictionary contains it in the unique keys, and then modify it and return true.
+            if (modifyRunSpeed && runSpeedModifierList.ContainsKey(UUID))
+            {
+                runSpeedModifierList[UUID] = updatedSpeed;
+                modified = true;
+            }
+
+            //trigger an update to the walk speed loop to push updated walk speed value.
+            updateWalkSpeed = refreshSpeed;
+            updateRunSpeed = refreshSpeed;
+
+            return modified;
         }
 
         /// <summary>


### PR DESCRIPTION
I've added ModifySpeedMod to PlayerSpeedChanger.cs. This object allows developers to modify an already injected walk or run speed modifier value. This helps resolve the issue of having to continually add and remove walk and run speed modifier values to update them by providing a method to update a current modifier value through its assigned UID value. Also, it will make lerping speed changes over time easier and less cycle expensive.

I also added commands to the set_walkspeed and set_runspeed commands for testing this out via console. To modify an already existing/inject speed modifier value merely call set_walkspeed or set_runspeed and after the wanted updated speed value put the UID you want to update. And you're done, value is updated.