### PR TITLE
Check that dependencies of an enabled mod are enabled

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -1051,6 +1051,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                         continue;
                     }
 
+                    if (!target.Enabled)
+                    {
+                        errorMessages.Add(string.Format(GetText("dependencyNotEnabled"), dependency.Name));
+                        continue;
+                    }
+
                     // Check load order priority
                     if (!dependency.IsPeer && mod.LoadPriority < target.LoadPriority)
                     {

--- a/Assets/StreamingAssets/Text/ModSystem.txt
+++ b/Assets/StreamingAssets/Text/ModSystem.txt
@@ -63,6 +63,7 @@ titleOrDescriptionMissing,  Title and Description are mandatory fields.
 
 dependencyErrorMessage,                 One or more mods might not work correctly:
 dependencyIsMissing,                    Failed to retrieve mod {0}
+dependencyNotEnabled,                   Mod dependency {0} is not enabled
 dependencyWithIncorrectPosition,        {0} must be positioned above in the load order
 dependencyWithIncompatibleVersion,      {0} has version {1} but {2} or higher is requested
 sortModsQuestion,                       Do you want to sort mods automatically?


### PR DESCRIPTION

Minimum fix: adds a warning when a dependency of an enabled mod is not enabled

Forums: https://forums.dfworkshop.net/viewtopic.php?f=22&t=5020