### PR TITLE
Add divide by zero protection to ConditionPercentage property

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -446,7 +446,7 @@ namespace DaggerfallWorkshop.Game.Items
         /// <summary>Gets current item condition as a percentage of max.</summary>
         public int ConditionPercentage
         {
-            get { return 100 * currentCondition / maxCondition; }
+            get { return maxCondition > 0 ? 100 * currentCondition / maxCondition : 100; }
         }
 
         #endregion


### PR DESCRIPTION
Fixes an edge case for 2 vanilla items with 0 max condition defined (finger and dead body) - it was causing exceptions when the curse quest that gives the finger when used with a mod that repairs items as it checks all items in player inventory.