### PR TITLE
Don't level up if already dead

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -1353,6 +1353,9 @@ namespace DaggerfallWorkshop.Game.Entity
         {
             const int youAreNowAMasterOfTextID = 4020;
 
+            if (GameManager.Instance.PlayerDeath.DeathInProgress)
+                return;
+
             DaggerfallDateTime now = DaggerfallUnity.Instance.WorldTime.Now;
             if ((now.ToClassicDaggerfallTime() - timeOfLastSkillIncreaseCheck) <= 360)
                 return;


### PR DESCRIPTION
Corner case seen in a stream, player tried to sleep over some poisoning, but was also close to leveling up.

He died while resting, but had to level up before death scene could start.