### PR TITLE
Allow Argonians to get random names in character creation

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharNameSelect.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharNameSelect.cs
@@ -104,9 +104,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 return;
             }
 
-            // Disable random name button only for Argonians because their race id
-            // would give them Imperial names from namegen
-            randomNameButton.Enabled = raceTemplate.ID != (int) Races.Argonian;
+            randomNameButton.Enabled = true;
 
             // Randomise DFRandom seed from System.Random
             // A bit of a hack but better than starting with a seed of 0 every time


### PR DESCRIPTION
The original code comment said:

>Disable random name button only for Argonians because their race id
>would give them Imperial names from namegen

but that's only true in games after Daggerfall. In both Arena and Daggerfall, Argonians get latin names, that's just how it works in those games. Imperials don't even exist. Even in Daggerfall Unity, an Argonian character will have named characters with latin names in their background History. 

There's no reason for this arbitrary exclusion in DFU. It's going to be a surprise to veterans of the series, but it's consistent with Daggerfall itself. Worst case, they can name their character Makes-Up-Names themselves.