### PR TITLE
Fixed custom enemies using ids above 145 not having any sounds

### DIFF
--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -217,7 +217,7 @@ namespace DaggerfallWorkshop.Game
 
         private bool IgnoreHumanSounds()
         {
-            if (mobile.Enemy.ID > 127 && mobile.Enemy.ID != 146 && MuteHumanSounds)
+            if (mobile.Enemy.ID > 127 && mobile.Enemy.ID < 146 && MuteHumanSounds)
                 return true;
             else
                 return false;


### PR DESCRIPTION
Most people play with human sounds muted, but Kamer noticed that it made his custom goblins muted too.

Small fix so custom enemies don't get affected by this mute feature. If someone wants a mute custom enemy, they can just remove the sounds.