### PR TITLE
Adds kill msg M0B00Y16

### DIFF
--- a/Assets/StreamingAssets/Quests/M0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y16.txt
@@ -83,6 +83,9 @@ Message:  1030
 <ce>                    towards you.  Perhaps the giant
 <ce>               invited a few friends over for dinner...
 
+Message:  1031
+<ce>  You have slain the giant you came for.
+
 Message:  1040
 <ce>                    Thank %god you're here!  I was
 <ce>                     on my way to market yesterday
@@ -173,6 +176,7 @@ _S.02_ task:
 
 _S.03_ task:
 	killed 1 _giant_ 
+	say 1031
 
 _clickqgiver_ task:
 	clicked npc _questgiver_ 


### PR DESCRIPTION
Giant Killing can be a hectic quest, with multiple giants spawning when the first is injured. A player can lose track of the correct target and kill the wrong one with no notification. This commit adds a kill message.