### PR TITLE
A0C00Y16: show message popup before hiding NPC

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/AddFace.cs
+++ b/Assets/Scripts/Game/Questing/Actions/AddFace.cs
@@ -59,6 +59,10 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
         {
             base.Update(caller);
 
+            // Popup saying message
+            if (sayingID != 0)
+                ParentQuest.ShowMessagePopup(sayingID, true);
+
             // Add related Person or Foe resource
             if (personSymbol != null && !string.IsNullOrEmpty(personSymbol.Name))
             {
@@ -72,10 +76,6 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                 if (foe != null)
                     DaggerfallUI.Instance.DaggerfallHUD.EscortingFaces.AddFace(foe);
             }
-
-            // Popup saying message
-            if (sayingID != 0)
-                ParentQuest.ShowMessagePopup(sayingID);
 
             SetComplete();
         }

--- a/Assets/StreamingAssets/Quests/A0C00Y16.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y16.txt
@@ -303,8 +303,8 @@ _delay_ task:
 
 _S.22_ task:
 	clicked npc _missingperson_ 
-	hide npc _missingperson_ 
 	add _missingperson_ face saying 1040 
+	hide npc _missingperson_ 
 
 _S.23_ task:
 	when _S.22_ and _S.18_ 


### PR DESCRIPTION
Matched to classic: the message popup should be displayed before the NPC is actually hidden. Quest _Missing Person Case_ is the only quest where `add _npc_ face saying` is used.