### PR TITLE
Expose and virtualize members in Open and Lock magic effects

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Lock.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Lock.cs
@@ -22,8 +22,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
     {
         public static readonly string EffectKey = "Lock";
 
-        int forcedRoundsRemaining = 1;
-        bool awakeAlert = true;
+        protected int forcedRoundsRemaining = 1;
+        protected bool awakeAlert = true;
 
         public override void SetProperties()
         {
@@ -73,7 +73,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
         }
 
-        void StartWaitingForDoor()
+        protected virtual void StartWaitingForDoor()
         {
             // Do nothing if failed
             if (!ChanceSuccess)
@@ -97,7 +97,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         /// This effect will automatically close door if open when spell triggered.
         /// </summary>
         /// <param name="actionDoor">DaggerfallActionDoor activated by entity.</param>
-        public void TriggerLockEffect(DaggerfallActionDoor actionDoor)
+        public virtual void TriggerLockEffect(DaggerfallActionDoor actionDoor)
         {
             if (forcedRoundsRemaining == 0)
                 return;

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Open.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Open.cs
@@ -22,10 +22,10 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
     {
         public static readonly string EffectKey = "Open";
 
-        int forcedRoundsRemaining = 1;
-        bool awakeAlert = true;
-        bool castByItem = false;
-        bool castBySkeletonKey = false;
+        protected int forcedRoundsRemaining = 1;
+        protected bool awakeAlert = true;
+        protected bool castByItem = false;
+        protected bool castBySkeletonKey = false;
 
         public override void SetProperties()
         {
@@ -78,7 +78,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         {
         }
 
-        void StartWaitingForDoor()
+        protected virtual void StartWaitingForDoor()
         {
             // Do nothing if spell chance fails
             // Always succeeds chance roll when cast by item but still subject to level vs. door requirement
@@ -104,7 +104,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         /// This effect will automatically open door if closed when spell triggered.
         /// </summary>
         /// <param name="actionDoor">DaggerfallActionDoor activated by entity.</param>
-        public void TriggerOpenEffect(DaggerfallActionDoor actionDoor)
+        public virtual void TriggerOpenEffect(DaggerfallActionDoor actionDoor)
         {
             if (forcedRoundsRemaining == 0)
                 return;
@@ -138,13 +138,13 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
         /// <summary>
         /// Cancel effect.
         /// </summary>
-        public void CancelEffect()
+        public virtual void CancelEffect()
         {
             forcedRoundsRemaining = 0;
             ResignAsIncumbent();
         }
 
-        void CheckCastByItem()
+        protected virtual void CheckCastByItem()
         {
             castByItem = ParentBundle.castByItem != null;
 


### PR DESCRIPTION
Not really a fix, but it's small enough at least.

In my Unleveled Spells mod, I managed to remove level scaling from all the spells in the game, except for spells featuring the Open and Lock magic effects. My users would appreciate if I could fix this.

You can't replace those effects without inheriting from them and replacing `TriggerOpenEffect` / `TriggerLockEffect`, since the DFU code is hardcoded to search for them specifically, so a DFU code change was necessary.

