### PR TITLE
Disable interactions during touch-range spell

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -234,6 +234,7 @@ namespace DaggerfallWorkshop.Game
             // Do nothing further if player has spell ready to cast as activate button is now used to fire spell
             // The exception is a readied touch spell where player can activate doors, etc.
             // Touch spells only fire once a target entity is in range
+            bool touchCastPending = false;
             if (GameManager.Instance.PlayerEffectManager)
             {
                 // Handle pending spell cast
@@ -245,6 +246,10 @@ namespace DaggerfallWorkshop.Game
                     {
                         castPending = true;
                         return;
+                    }
+                    else
+                    {
+                        touchCastPending = true;
                     }
                 }
 
@@ -395,18 +400,22 @@ namespace DaggerfallWorkshop.Game
                         ActivateStaticNPC(hit, npc);
                     }
 
-                    // Check for mobile NPC hit
-                    MobilePersonNPC mobileNpc = null;
-                    if (MobilePersonMotorCheck(hit, out mobileNpc))
+                    // Avoid non-action interactions while a Touch cast is readied
+                    if (!touchCastPending)
                     {
-                        ActivateMobileNPC(hit, mobileNpc);
-                    }
+                        // Check for mobile NPC hit
+                        MobilePersonNPC mobileNpc;
+                        if (MobilePersonMotorCheck(hit, out mobileNpc))
+                        {
+                            ActivateMobileNPC(hit, mobileNpc);
+                        }
 
-                    // Check for mobile enemy hit
-                    DaggerfallEntityBehaviour mobileEnemyBehaviour;
-                    if (MobileEnemyCheck(hit, out mobileEnemyBehaviour))
-                    {
-                        ActivateMobileEnemy(hit, mobileEnemyBehaviour);
+                        // Check for mobile enemy hit
+                        DaggerfallEntityBehaviour mobileEnemyBehaviour;
+                        if (MobileEnemyCheck(hit, out mobileEnemyBehaviour))
+                        {
+                            ActivateMobileEnemy(hit, mobileEnemyBehaviour);
+                        }
                     }
 
                     // Check for functional interior furniture: Ladders, Bookshelves.


### PR DESCRIPTION
UX improvement for issue #2232.

I considered disabling all interactions except doors, "action" (ex: levers), ladders, and custom. Then, I decided that for most other interactions, if you're clicking on them, you probably meant to interact, not cast a spell on them.

Maybe loot markers might be accidentally misclicked in combat, and some may prefer disabling interactions with them while casting spells.
I decided not to, since players might be readying a spell from an auto-recast mod (ex: Hotkey Bar) and deliberately clicking a loot container. 

So, in the end, I only disabled mobiles, since you're most likely intending to fight them. It was already dangerous to talk to villagers with a spell ready since it would go off even when you could successfully interact with them.