### PR TITLE
Enemy corpse custom texture fix

### DIFF
--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -416,7 +416,7 @@ namespace DaggerfallWorkshop
                 }
 
                 // Get texture
-                results = textureReader.GetTexture2D(settings, AlphaTextureFormat, TextureImport.LooseFiles);
+                results = textureReader.GetTexture2D(settings, AlphaTextureFormat, TextureImport.AllLocations);
 
                 // Create material
                 if (isBillboard)
@@ -459,13 +459,32 @@ namespace DaggerfallWorkshop
 
             }
 
+            Vector2[] recordSizes;
+            Vector2[] recordScales;
+            Vector2[] recordOffsets;
+            int singleFrameCount;
+
             // Setup cached material
-            DFSize size = results.textureFile.GetSize(record);
-            DFSize scale = results.textureFile.GetScale(record);
-            DFPosition offset = results.textureFile.GetOffset(record);
-            Vector2[] recordSizes = new Vector2[1] { new Vector2(size.Width, size.Height) };
-            Vector2[] recordScales = new Vector2[1] { new Vector2(scale.Width, scale.Height) };
-            Vector2[] recordOffsets = new Vector2[1] { new Vector2(offset.X, offset.Y) };
+            if (results.textureFile != null)
+            {
+                DFSize size = results.textureFile.GetSize(record);
+                DFSize scale = results.textureFile.GetScale(record);
+                DFPosition offset = results.textureFile.GetOffset(record);
+                recordSizes = new Vector2[1] { new Vector2(size.Width, size.Height) };
+                recordScales = new Vector2[1] { new Vector2(scale.Width, scale.Height) };
+                recordOffsets = new Vector2[1] { new Vector2(offset.X, offset.Y) };
+                singleFrameCount = results.textureFile.GetFrameCount(record);
+            }
+            else
+            {
+                // If we have no texture file, this means this is a non-classic texture
+                // Just use the albedo texture directly
+                recordSizes = new Vector2[1] { new Vector2(results.albedoMap.width, results.albedoMap.height) };
+                recordScales = new Vector2[1] { new Vector2(1.0f, 1.0f) };
+                recordOffsets = new Vector2[1] { new Vector2(0.0f, 0.0f) };
+                singleFrameCount = 1;
+            }
+
             CachedMaterial newcm = new CachedMaterial()
             {
                 key = key,
@@ -480,7 +499,7 @@ namespace DaggerfallWorkshop
                 recordSizes = recordSizes,
                 recordScales = recordScales,
                 recordOffsets = recordOffsets,
-                singleFrameCount = results.textureFile.GetFrameCount(record),
+                singleFrameCount = singleFrameCount,
                 framesPerSecond = archive == FireWallsArchive ? 5 : 0, // Slow down fire walls
             };
             materialDict.Add(key, newcm);


### PR DESCRIPTION
See issue #2230 

It seems lots of this code is older, back from 2019. For example, the Material code only checked loose files, not "all locations" (assets from the dfmod). 

Graphics isn't my area, and I don't know what are the users of these graphics settings. However, I tried to make my changes have no effects on people replacing texture 0 to 511 - there shouldn't be any users for textures outside of these in materials, as it didn't work before this PR.

I'm open to suggestions to make this cleaner.

Hopefully with this, Kamer can complete his mod.

EDIT: yes, this works for him :)
![image](https://user-images.githubusercontent.com/5789925/133497778-b3df5852-785d-4cab-8713-6fbc3ed54b03.png)
