### PR TITLE
Fix out-of-range error in FormulaHelper.CalculateCastingCost 

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -2394,6 +2394,10 @@ namespace DaggerfallWorkshop.Game.Formulas
         /// <param name="enchantingItem">True if the method is used from the magic item maker.</param>
         public static int CalculateCastingCost(SpellRecord.SpellRecordData spell, bool enchantingItem= true)
         {
+            Func<SpellRecord.SpellRecordData, bool, int> del;
+            if (TryGetOverride("CalculateCastingCost", out del))
+                return del(spell, enchantingItem);
+
             // Indices into effect settings array for each effect and its subtypes
             byte[] effectIndices = {    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Paralysis
                                         0x01, 0x02, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Continuous Damage
@@ -2528,7 +2532,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             int cost = 0;
             int skill = 50; // 50 is used for item enchantments
             
-            for (int i = 0; i < 3; ++i)
+            for (int i = 0; i < spell.effects.Length; ++i)
             {
                 if (spell.effects[i].type != -1)
                 {


### PR DESCRIPTION
The issue was reported on my mod here: https://forums.dfworkshop.net/viewtopic.php?p=57172#p57172
Save with repro steps included in the mod, Hotkey Bar mod probably not actually necessary for repro.

Basically, my custom spells don't always have 3 spell effects in them, and it makes the magic item cost formula throw an exception. 
I just made it use the actual size of the array, instead of assuming all spells have 3 effects (most spells had invalid effects for slot 2 and 3, of course).

I took the opportunity to add a formula override.