### PR TITLE
Allow cast when held to be overridden and modified by mods.

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/CastWhenHeld.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Enchanting/CastWhenHeld.cs
@@ -24,8 +24,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
     /// </summary>
     public class CastWhenHeld : BaseEntityEffect
     {
-        const int normalMagicItemDegradeRate = 4;
-        const int restingMagicItemDegradeRate = 60;
+        protected const int normalMagicItemDegradeRate = 4;
+        protected const int restingMagicItemDegradeRate = 60;
 
         public static readonly string EffectKey = EnchantmentTypes.CastWhenHeld.ToString();
 
@@ -128,7 +128,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             return null;
         }
 
-        void ApplyDurabilityLoss(DaggerfallUnityItem item, DaggerfallEntityBehaviour entity)
+        protected virtual void ApplyDurabilityLoss(DaggerfallUnityItem item, DaggerfallEntityBehaviour entity)
         {
             if (!GameManager.Instance.EntityEffectBroker.SyntheticTimeIncrease)
             {
@@ -141,7 +141,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             }
         }
 
-        void InstantiateSpellBundle(EnchantmentParam param, DaggerfallEntityBehaviour sourceEntity, DaggerfallUnityItem sourceItem, EntityEffectManager casterManager, bool recast = false)
+        protected virtual void InstantiateSpellBundle(EnchantmentParam param, DaggerfallEntityBehaviour sourceEntity, DaggerfallUnityItem sourceItem, EntityEffectManager casterManager, bool recast = false)
         {
             if (!string.IsNullOrEmpty(param.CustomParam))
             {


### PR DESCRIPTION
This is so travel options can prevent ticking of damage when time accelerated travelling, since fast travel doesn't damage condition.