### PR TITLE
Fixed custom textures for NPC billboards not having a collider

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -932,6 +932,13 @@ namespace DaggerfallWorkshop
                     // Spawn billboard gameobject
                     go = GameObjectHelper.CreateDaggerfallBillboardGameObject(obj.TextureArchive, obj.TextureRecord, node.transform);
 
+                    // Handle non-classic textures, which may not have had their collision component added
+                    if(!go.GetComponent<Collider>())
+                    {
+                        Collider col = go.AddComponent<BoxCollider>();
+                        col.isTrigger = true;
+                    }
+
                     // Set position
                     DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
                     go.transform.position = billboardPosition;


### PR DESCRIPTION
With #2242, mods can add static NPCs with new textures using world variants.

![image](https://user-images.githubusercontent.com/5789925/136717058-2ab32e6c-5a23-4e48-88ef-2ddc0f30fbba.png)
Pictured: Lady Flyte, in the Anticlere palace

However, there is an issue: they cannot be interacted with like a normal NPC.

`MaterialReader.GetFlatType` only handles textures between 0 and 511, so custom textures will not get detected as a `FlatTypes.NPC`. 

`DaggerfallBillboard.SetMaterial` uses this enum value to know whether to add a collider on it. Therefore, custom textures don't get that collider.

There were a few ways to go about fixing this, but I went, again, with something short that affects as few code as possible. Let me know if you think we could do with something cleaner.