### PR TITLE
Fix StreamingWorld.TrackLooseObject "mapPixelX" and "mapPixelY"

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -464,10 +464,17 @@ namespace DaggerfallWorkshop
             // Create loose object description
             LooseObjectDesc desc = new LooseObjectDesc();
             desc.gameObject = gameObject;
+
             if (mapPixelX == -1)
                 desc.mapPixelX = MapPixelX;
+            else
+                desc.mapPixelX = mapPixelX;
+
             if (mapPixelY == -1)
                 desc.mapPixelY = MapPixelY;
+            else
+                desc.mapPixelY = mapPixelY;
+
             desc.statefulObj = statefulObj;
             looseObjectsList.Add(desc);
 


### PR DESCRIPTION
Fix StreamingWorld.TrackLooseObject not setting "mapPixelX" and "mapPixelY" in the loose object description if specified to anything other than player position. 

All code in DFU uses `-1` for both the `mapPixelX` and `mapPixelY` arguments, so this issue is only for mods. 

My mod spawns objects on the terrain outside of the player's current map pixel, and needs the StreamingWorld to track them so they're destroyed in the right order in all cases. Without this fix, the moment the player moves from one map pixel to another, `CollectLooseObjects` is called (with `collectAll = false`), and my objects have (0, 0) as the mapPixelX and mapPixelY, so they're considered "out of range", and get destroyed. With this fix, they have the right mapPixelX and mapPixelY that I set, and only get destroyed if they're actually out of range.

I think this fix is minor, has no impact on DFU, and clearly reflects the intent of the function, so I would appreciate if this could be merged ASAP for the next release.