### PR TITLE
Floating Origin change now also adjusts EnemyMotor's "last grounded" 

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -205,6 +205,16 @@ namespace DaggerfallWorkshop.Game
 
             return transform.position;
         }
+
+        /// <summary>
+        /// Call this when floating origin ticks on Y to ensure enemy doesn't die from large "grounded" difference
+        /// </summary>
+        /// <param name="y">Amount to increment to fallstart</param>
+        public void AdjustLastGrounded(float y)
+        {
+            lastGroundedY += y;
+        }
+
         #endregion
 
         #region Private Methods

--- a/Assets/Scripts/Utility/FloatingOrigin.cs
+++ b/Assets/Scripts/Utility/FloatingOrigin.cs
@@ -125,6 +125,11 @@ namespace DaggerfallWorkshop.Utility
                 // Offset streaming world
                 OffsetChildren(StreamingWorld.StreamingTarget.gameObject, offset);
 
+                // Offset loaded enemies
+                // Not that many in DFU, but it happens in mods
+                foreach (EnemyMotor enemy in FindObjectsOfType<EnemyMotor>())
+                    enemy.AdjustLastGrounded(offset.y);
+
                 // Raise event
                 RaiseOnPositionUpdateEvent(offset);
             }


### PR DESCRIPTION
The "floating origin" system can cause large position offsets for all entities in the scene over a single frame. For this reason, each time it occurs, the player's controllers are notified so that they can offset the fall damage values. But this isn't done for enemies.

In vanilla DFU, exterior enemies don't happen often, and it's usually in situations where the floating origin doesn't cause issues. With mods, it's another story. Many of them try spawning enemies near a fast travel target or a dungeon entrance, which causes all of them to die from fall damage during the transition. You get "A bandit has died." spam, and a whole bunch of corpses instead of the planned encounter.

This change fixes this issue, at the cost of a `FindObjectsOfType` call per floating origin change (which isn't that often, at least).