### PR TITLE
Fix for switching back to original enemy Team

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -14,6 +14,7 @@ using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using System.Collections.Generic;
 using DaggerfallWorkshop.Utility;
+using System.Linq;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -186,7 +187,7 @@ namespace DaggerfallWorkshop.Game
                 if (entityBehaviour.Entity.Team == MobileTeams.PlayerAlly)
                 {
                     int id = (entityBehaviour.Entity as EnemyEntity).MobileEnemy.ID;
-                    entityBehaviour.Entity.Team = EnemyBasics.Enemies[id].Team;
+                    entityBehaviour.Entity.Team = EnemyBasics.Enemies.First(x => x.ID == id).Team;
                 }
             }
         }


### PR DESCRIPTION
The EnemyBasics.Enemies array size is only 62, and the ids of the objects are not sequential in this array (It goes straight from Lamia id: 42 to Mage id: 128).

So just using the id as the array position would only work for enemies with an id of 42 or less. Better to check with Linq on the actual id of the object.