### PR TITLE
Add Support For Jewelry Type Items To Be Rendered On Paper-doll If They Have Their Equip Slot Set To The Body, Mod Support.

### DIFF
--- a/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
+++ b/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
@@ -415,7 +415,8 @@ namespace DaggerfallWorkshop.Game.Utility
             foreach (var item in orderedItems)
             {
                 if (item.ItemGroup == ItemGroups.MensClothing || item.ItemGroup == ItemGroups.WomensClothing ||
-                    item.ItemGroup == ItemGroups.Armor || item.ItemGroup == ItemGroups.Weapons)
+                    item.ItemGroup == ItemGroups.Armor || item.ItemGroup == ItemGroups.Weapons || 
+					item.ItemGroup == ItemGroups.Jewellery)
                 {
                     BlitItem(item);
                 }


### PR DESCRIPTION
Add Support For Jewelry Type Items To Be Rendered On Paper-doll If They Have Their Equip Slot Set To The Body, Mod Support.

Forum Post About "Issue": https://forums.dfworkshop.net/viewtopic.php?t=5323