### PR TITLE
Prevent shops being treated like FG

### DIFF
--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -255,6 +255,9 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public FactionFile.GuildGroups GetGuildGroup(int factionId)
         {
+            if (factionId == 510)   // Shops are marked as FG in faction data, hardcode to none to prevent them acting as FG guildhalls.
+                return FactionFile.GuildGroups.None;
+
             PersistentFactionData persistentFactionData = GameManager.Instance.PlayerEntity.FactionData;
             FactionFile.GuildGroups guildGroup = FactionFile.GuildGroups.None;
             FactionFile.FactionData factionData;


### PR DESCRIPTION
See https://forums.dfworkshop.net/viewtopic.php?t=5200

Alternative would be to change line 5956 to read "ggroup: -1" but that will only affect new games I think as faction data is saved.