### PR TITLE
Make preset button in mod settings more obvious

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
@@ -165,11 +165,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
             Button presetButton = new Button();
             presetButton.Size = new Vector2(35, 9);
             presetButton.Position = new Vector2(mainPanel.Size.x - 37, 2);
+            presetButton.BackgroundColor = saveButtonColor;
             presetButton.Label.Text = ModManager.GetText("presets");
-            presetButton.Label.Font = DaggerfallUI.Instance.Font1;
-            presetButton.Label.TextScale = 0.4f;
-            presetButton.Label.TextColor = sectionTitleColor;
-            presetButton.Label.ShadowColor = sectionTitleShadow;
+            presetButton.Outline.Enabled = true;
             presetButton.OnMouseClick += PresetButton_OnMouseClick;
             mainPanel.Components.Add(presetButton);
 


### PR DESCRIPTION
I think a lot of players miss the presets function for mod settings and I think the button should be made clearer. Here is my proposal. I used the same background colour as the save button since I am terrible at colour selection and I think it looks fine. See picture below for comparison:

![PresetButton](https://user-images.githubusercontent.com/2278830/149627363-b10c5ad8-d7f2-49a7-a55d-5bf036788a8b.png)

