### PR TITLE
Update GetGroupIndex to simply return input for new items from mods

### DIFF
--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -350,7 +350,6 @@ namespace DaggerfallWorkshop.Game.Items
         /// <param name="itemIndex">Template index.</param>
         /// <param name="priorityToConjured">Prefer (short lived) conjured items.</param>
         /// <returns>An item of this type, or null if none found.</returns>
-
         public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex, bool priorityToConjured)
         {
             return GetItem(itemGroup, itemIndex, true, true, priorityToConjured);
@@ -365,7 +364,6 @@ namespace DaggerfallWorkshop.Game.Items
         /// <param name="allowQuestItem">Include quest items.</param>
         /// <param name="priorityToConjured">Prefer (short lived) conjured items.</param>
         /// <returns>An item of this type, or null if none found.</returns>
-
         public DaggerfallUnityItem GetItem(ItemGroups itemGroup, int itemIndex, bool allowEnchantedItem = true, bool allowQuestItem = true, bool priorityToConjured = false)
         {
             int groupIndex = DaggerfallUnity.Instance.ItemHelper.GetGroupIndex(itemGroup, itemIndex);

--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -237,6 +237,10 @@ namespace DaggerfallWorkshop.Game.Items
         /// <returns>Item group index, or -1 if not found.</returns>
         public int GetGroupIndex(ItemGroups itemGroup, int templateIndex)
         {
+            // Items added by mods are after last DF template, and groupIndex == templateIndex
+            if (templateIndex > LastDFTemplate)
+                return templateIndex;
+
             Array values = GetEnumArray(itemGroup);
             for (int i = 0; i < values.Length; i++)
             {


### PR DESCRIPTION
Update GetGroupIndex to simply return input for new items from mods since groupIndex == templateIndex

This fixes issue #2245 I think.