### PR TITLE
Extract abstract class from DaggerfallBillboard and move summary struct into MobileUnit base class

### DIFF
--- a/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditor.cs
+++ b/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditor.cs
@@ -681,7 +681,7 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
                     {
                         data.rdbObj.Resources.FlatResource.TextureArchive = archive;
                         data.rdbObj.Resources.FlatResource.TextureRecord = record;
-                        DaggerfallBillboard billboard = Selection.activeGameObject.GetComponent<DaggerfallBillboard>();
+                        Billboard billboard = Selection.activeGameObject.GetComponent<Billboard>();
                         billboard.SetMaterial(archive, record);
                     }
                 }
@@ -1443,7 +1443,7 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
                     }
 
                     record.XPos = Mathf.RoundToInt(modelPosition.x);
-                    record.YPos = Mathf.RoundToInt(-((child.localPosition.y - (child.GetComponent<DaggerfallBillboard>().Summary.Size.y / 2)) / MeshReader.GlobalScale));
+                    record.YPos = Mathf.RoundToInt(-((child.localPosition.y - (child.GetComponent<Billboard>().Summary.Size.y / 2)) / MeshReader.GlobalScale));
                     record.ZPos = Mathf.RoundToInt(modelPosition.z);
 
                     if (data.isExterior)
@@ -1462,7 +1462,7 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
 
                     modelPosition = child.transform.localPosition / MeshReader.GlobalScale;
                     record.XPos = Mathf.RoundToInt(modelPosition.x);
-                    record.YPos = Mathf.RoundToInt(-((child.localPosition.y - (child.GetComponent<DaggerfallBillboard>().Summary.Size.y / 2)) / MeshReader.GlobalScale));
+                    record.YPos = Mathf.RoundToInt(-((child.localPosition.y - (child.GetComponent<Billboard>().Summary.Size.y / 2)) / MeshReader.GlobalScale));
                     record.ZPos = Mathf.RoundToInt(modelPosition.z);
 
                     ArrayUtility.Add(ref buildingData.RmbSubRecord.Interior.BlockPeopleRecords, record);

--- a/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditorBuildingHelper.cs
+++ b/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditorBuildingHelper.cs
@@ -138,7 +138,7 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
             GameObject go = DaggerfallWorkshop.Utility.GameObjectHelper.CreateDaggerfallBillboardGameObject(rmbBlock.TextureArchive, rmbBlock.TextureRecord, null);
 
             // Set position
-            DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+            Billboard dfBillboard = go.GetComponent<Billboard>();
             go.transform.position = billboardPosition;
             go.transform.position += new Vector3(0, dfBillboard.Summary.Size.y / 2, 0);
 
@@ -153,7 +153,7 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
             GameObject go = DaggerfallWorkshop.Utility.GameObjectHelper.CreateDaggerfallBillboardGameObject(rmbBlock.TextureArchive, rmbBlock.TextureRecord, null);
 
             // Set position
-            DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+            Billboard dfBillboard = go.GetComponent<Billboard>();
             go.transform.position = billboardPosition;
             go.transform.position += new Vector3(0, dfBillboard.Summary.Size.y / 2, 0);
 

--- a/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditorDungeonHelper.cs
+++ b/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditorDungeonHelper.cs
@@ -129,7 +129,7 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
                 // Setup standard billboard and assign RDB data
                 go = GameObjectHelper.CreateDaggerfallBillboardGameObject(archive, record, null);
                 go.transform.position = targetPosition;
-                DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                Billboard dfBillboard = go.GetComponent<Billboard>();
                 dfBillboard.SetRDBResourceData(obj.Resources.FlatResource);
             }
             return go;

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -68,7 +68,7 @@ namespace DaggerfallWorkshop.Game
         SphereCollider myCollider;
         DaggerfallAudioSource audioSource;
         Rigidbody myRigidbody;
-        DaggerfallBillboard myBillboard;
+        Billboard myBillboard;
         bool forceDisableSpellLighting;
         bool noSpellsSpatialBlend = false;
         float lifespan = 0f;
@@ -524,7 +524,7 @@ namespace DaggerfallWorkshop.Game
             GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(GetMissileTextureArchive(), record, transform);
             go.transform.localPosition = Vector3.zero;
             go.layer = gameObject.layer;
-            myBillboard = go.GetComponent<DaggerfallBillboard>();
+            myBillboard = go.GetComponent<Billboard>();
             myBillboard.FramesPerSecond = BillboardFramesPerSecond;
             myBillboard.FaceY = true;
             myBillboard.OneShot = oneShot;

--- a/Assets/Scripts/Game/EnemyBlood.cs
+++ b/Assets/Scripts/Game/EnemyBlood.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -31,7 +31,7 @@ namespace DaggerfallWorkshop.Game
             {
                 GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(bloodArchive, bloodIndex, null);
                 go.name = "BloodSplash";
-                DaggerfallBillboard c = go.GetComponent<DaggerfallBillboard>();
+                Billboard c = go.GetComponent<Billboard>();
                 go.transform.position = bloodPosition + transform.forward * 0.02f;
                 c.OneShot = true;
                 c.FramesPerSecond = 10;
@@ -46,7 +46,7 @@ namespace DaggerfallWorkshop.Game
             {
                 GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(bloodArchive, sparklesIndex, null);
                 go.name = "MagicSparkles";
-                DaggerfallBillboard c = go.GetComponent<DaggerfallBillboard>();
+                Billboard c = go.GetComponent<Billboard>();
                 go.transform.position = sparklesPosition + transform.forward * 0.02f;
                 c.OneShot = true;
                 c.FramesPerSecond = 10;

--- a/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableLootContainer.cs
@@ -93,7 +93,7 @@ namespace DaggerfallWorkshop.Game.Serialization
                 loot.ContainerType == LootContainerTypes.CorpseMarker ||
                 loot.ContainerType == LootContainerTypes.DroppedLoot)
             {
-                DaggerfallBillboard billboard = loot.GetComponent<DaggerfallBillboard>();
+                Billboard billboard = loot.GetComponent<Billboard>();
 
                 // Interiors and exteriors need special handling to ensure loot is always placed correctly for pre and post floating y saves
                 // Dungeons are not involved with floating y and don't need any changes

--- a/Assets/Scripts/Internal/Base/Billboard.cs
+++ b/Assets/Scripts/Internal/Base/Billboard.cs
@@ -1,0 +1,112 @@
+// Project:         Daggerfall Tools For Unity
+// Copyright:       Copyright (C) 2009-2021 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Gavin Clayton (interkarma@dfworkshop.net)
+// Contributors:    Hazelnut 
+// 
+// Notes:
+//
+
+using UnityEngine;
+using System;
+using DaggerfallConnect;
+using DaggerfallWorkshop.Utility.AssetInjection;
+
+namespace DaggerfallWorkshop
+{
+    public abstract class Billboard : MonoBehaviour
+    {
+        /// <summary>
+        /// General frames per second for animation
+        /// </summary>
+        public abstract int FramesPerSecond { get; set; }
+
+        /// <summary>
+        /// Plays animation once then destroys GameObject
+        /// </summary>
+        public abstract bool OneShot { get; set; }
+
+        /// <summary>
+        /// Billboard should also face camera up/down
+        /// </summary>
+        public abstract bool FaceY { get; set; }
+
+        [SerializeField]
+        protected BillboardSummary summary = new BillboardSummary();
+
+        public BillboardSummary Summary
+        {
+            get { return summary; }
+        }
+
+        [Serializable]
+        public struct BillboardSummary
+        {
+            public Vector2 Size;                                // Size and scale in world units
+            public Rect Rect;                                   // Single UV rectangle for non-atlased materials only
+            public Rect[] AtlasRects;                           // Array of UV rectangles for atlased materials only
+            public RecordIndex[] AtlasIndices;                  // Indices into UV rect array for atlased materials only, supports animations
+            public bool AtlasedMaterial;                        // True if material is part of an atlas
+            public bool AnimatedMaterial;                       // True if material uses atlas UV animations (always false for non atlased materials)
+            public int CurrentFrame;                            // Current animation frame
+            public FlatTypes FlatType;                          // Type of flat
+            public EditorFlatTypes EditorFlatType;              // Sub-type of flat when editor/marker
+            public bool IsMobile;                               // Billboard is a mobile enemy
+            public int Archive;                                 // Texture archive index
+            public int Record;                                  // Texture record index
+            public int Flags;                                   // NPC Flags found in RMB and RDB NPC data
+            public int FactionOrMobileID;                       // FactionID for NPCs, Mobile ID for monsters
+            public int NameSeed;                                // NPC name seed
+            public MobileTypes FixedEnemyType;                  // Type for fixed enemy marker
+            public short WaterLevel;                            // Dungeon water level
+            public bool CastleBlock;                            // Non-hostile area of main story castle dungeons
+            public BillboardImportedTextures ImportedTextures;  // Textures imported from mods
+        }
+
+        /// <summary>
+        /// Sets extended data about people billboard from RMB resource data.
+        /// </summary>
+        /// <param name="person"></param>
+        public abstract void SetRMBPeopleData(DFBlock.RmbBlockPeopleRecord person);
+
+        /// <summary>
+        /// Sets people data directly.
+        /// </summary>
+        /// <param name="factionID">FactionID of person.</param>
+        /// <param name="flags">Person flags.</param>
+        public abstract void SetRMBPeopleData(int factionID, int flags, long position = 0);
+
+        /// <summary>
+        /// Sets extended data about billboard from RDB flat resource data.
+        /// </summary>
+        public abstract void SetRDBResourceData(DFBlock.RdbFlatResource resource);
+
+        /// <summary>
+        /// Sets new Daggerfall material and recreates mesh.
+        /// Will use an atlas if specified in DaggerfallUnity singleton.
+        /// </summary>
+        /// <param name="dfUnity">DaggerfallUnity singleton. Required for content readers and settings.</param>
+        /// <param name="archive">Texture archive index.</param>
+        /// <param name="record">Texture record index.</param>
+        /// <param name="frame">Frame index.</param>
+        /// <returns>Material.</returns>
+        public abstract Material SetMaterial(int archive, int record, int frame = 0);
+
+        /// <summary>
+        /// Sets billboard material with a custom texture.
+        /// </summary>
+        /// <param name="texture">Texture2D to set on material.</param>
+        /// <param name="size">Size of billboard quad in normal units (not Daggerfall units).</param>
+        /// <returns>Material.</returns>
+        public abstract Material SetMaterial(Texture2D texture, Vector2 size, bool isLightArchive = false);
+
+        /// <summary>
+        /// Aligns billboard to centre of base, rather than exact centre.
+        /// Must have already set material using SetMaterial() for billboard dimensions to be known.
+        /// </summary>
+        public abstract void AlignToBase();
+
+    }
+}

--- a/Assets/Scripts/Internal/Base/Billboard.cs.meta
+++ b/Assets/Scripts/Internal/Base/Billboard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2b7eb251af6b7b45a288756975c9fe6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Internal/Base/MobileUnit.cs
+++ b/Assets/Scripts/Internal/Base/MobileUnit.cs
@@ -11,6 +11,8 @@
 
 using UnityEngine;
 using DaggerfallWorkshop.Utility;
+using System;
+using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop
 {
@@ -75,6 +77,32 @@ namespace DaggerfallWorkshop
         /// Used when enemies are slowed by spells etc.
         /// </summary>
         public abstract int FrameSpeedDivisor { get; set; }
+
+        /// <summary>
+        /// Get the MobileUnitSummary data
+        /// </summary>
+        public MobileUnitSummary Summary { get { return summary; } }
+
+        [SerializeField]
+        protected MobileUnitSummary summary = new MobileUnitSummary();
+
+        [Serializable]
+        public struct MobileUnitSummary
+        {
+            public bool IsSetup;                                        // Flagged true when mobile settings are populated
+            public Rect[] AtlasRects;                                   // Array of rectangles for atlased materials
+            public RecordIndex[] AtlasIndices;                          // Indices into rect array for atlased materials, supports animations
+            public Vector2[] RecordSizes;                               // Size and scale of individual records
+            public int[] RecordFrames;                                  // Number of frames of individual records
+            public MobileEnemy Enemy;                                   // Mobile enemy settings
+            public MobileStates EnemyState;                             // Animation state
+            public MobileAnimation[] StateAnims;                        // Animation frames for this state
+            public MobileBillboardImportedTextures ImportedTextures;    // Textures imported from mods
+            public int AnimStateRecord;                                 // Record number of animation state
+            public int[] StateAnimFrames;                               // Sequence of frames to play for this animation. Used for attacks
+            public byte ClassicSpawnDistanceType;                       // 0 through 6 value read from spawn marker that determines distance at which enemy spawns/despawns in classic.
+            public bool specialTransformationCompleted;                 // Mobile has completed special transformation (e.g. Daedra Seducer)
+        }
 
         #endregion
 

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -14,13 +14,8 @@ using UnityEditor;
 #endif
 using UnityEngine;
 using UnityEngine.Rendering;
-using System;
-using System.IO;
 using System.Collections;
-using System.Collections.Generic;
 using DaggerfallConnect;
-using DaggerfallConnect.Utility;
-using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Utility;
@@ -32,55 +27,38 @@ namespace DaggerfallWorkshop
 #endif
     [RequireComponent(typeof(MeshFilter))]
     [RequireComponent(typeof(MeshRenderer))]
-    public class DaggerfallBillboard : MonoBehaviour
+    public class DaggerfallBillboard : Billboard
     {
-        public int FramesPerSecond = 5;     // General FPS
-        public bool OneShot = false;        // Plays animation once then destroys GameObject
-        public bool FaceY = false;          // Billboard should also face camera up/down
-
-        [SerializeField]
-        BillboardSummary summary = new BillboardSummary();
-
-        public int customArchive = 210;
-        public int customRecord = 0;
+        // Just using a simple animation speed for simple billboard anims
+        // You can adjust this or extend as needed
+        const int animalFps = 5;
+        const int lightFps = 12;
 
         Camera mainCamera = null;
         MeshFilter meshFilter = null;
         bool restartAnims = true;
         MeshRenderer meshRenderer;
 
-        // Just using a simple animation speed for simple billboard anims
-        // You can adjust this or extend as needed
-        const int animalFps = 5;
-        const int lightFps = 12;
+        int framesPerSecond = 5;     // General FPS
+        bool oneShot = false;        // Plays animation once then destroys GameObject
+        bool faceY = false;          // Billboard should also face camera up/down
 
-        public BillboardSummary Summary
+        public override int FramesPerSecond
         {
-            get { return summary; }
+            get { return framesPerSecond; }
+            set { framesPerSecond = value; }
         }
 
-        [Serializable]
-        public struct BillboardSummary
+        public override bool OneShot
         {
-            public Vector2 Size;                                // Size and scale in world units
-            public Rect Rect;                                   // Single UV rectangle for non-atlased materials only
-            public Rect[] AtlasRects;                           // Array of UV rectangles for atlased materials only
-            public RecordIndex[] AtlasIndices;                  // Indices into UV rect array for atlased materials only, supports animations
-            public bool AtlasedMaterial;                        // True if material is part of an atlas
-            public bool AnimatedMaterial;                       // True if material uses atlas UV animations (always false for non atlased materials)
-            public int CurrentFrame;                            // Current animation frame
-            public FlatTypes FlatType;                          // Type of flat
-            public EditorFlatTypes EditorFlatType;              // Sub-type of flat when editor/marker
-            public bool IsMobile;                               // Billboard is a mobile enemy
-            public int Archive;                                 // Texture archive index
-            public int Record;                                  // Texture record index
-            public int Flags;                                   // NPC Flags found in RMB and RDB NPC data
-            public int FactionOrMobileID;                       // FactionID for NPCs, Mobile ID for monsters
-            public int NameSeed;                                // NPC name seed
-            public MobileTypes FixedEnemyType;                  // Type for fixed enemy marker
-            public short WaterLevel;                            // Dungeon water level
-            public bool CastleBlock;                            // Non-hostile area of main story castle dungeons
-            public BillboardImportedTextures ImportedTextures;  // Textures imported from mods
+            get { return oneShot; }
+            set { oneShot = value; }
+        }
+
+        public override bool FaceY
+        {
+            get { return faceY; }
+            set { faceY = value; }
         }
 
         void Start()
@@ -187,7 +165,7 @@ namespace DaggerfallWorkshop
         /// Sets extended data about people billboard from RMB resource data.
         /// </summary>
         /// <param name="person"></param>
-        public void SetRMBPeopleData(DFBlock.RmbBlockPeopleRecord person)
+        public override void SetRMBPeopleData(DFBlock.RmbBlockPeopleRecord person)
         {
             SetRMBPeopleData(person.FactionID, person.Flags, person.Position);
         }
@@ -197,7 +175,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         /// <param name="factionID">FactionID of person.</param>
         /// <param name="flags">Person flags.</param>
-        public void SetRMBPeopleData(int factionID, int flags, long position = 0)
+        public override void SetRMBPeopleData(int factionID, int flags, long position = 0)
         {
             // Add common data
             summary.FactionOrMobileID = factionID;
@@ -211,7 +189,7 @@ namespace DaggerfallWorkshop
         /// <summary>
         /// Sets extended data about billboard from RDB flat resource data.
         /// </summary>
-        public void SetRDBResourceData(DFBlock.RdbFlatResource resource)
+        public override void SetRDBResourceData(DFBlock.RdbFlatResource resource)
         {
             // Add common data
             summary.Flags = resource.Flags;
@@ -251,7 +229,7 @@ namespace DaggerfallWorkshop
         /// <param name="record">Texture record index.</param>
         /// <param name="frame">Frame index.</param>
         /// <returns>Material.</returns>
-        public Material SetMaterial(int archive, int record, int frame = 0)
+        public override Material SetMaterial(int archive, int record, int frame = 0)
         {
             // Get DaggerfallUnity
             DaggerfallUnity dfUnity = DaggerfallUnity.Instance;
@@ -369,7 +347,7 @@ namespace DaggerfallWorkshop
         /// <param name="texture">Texture2D to set on material.</param>
         /// <param name="size">Size of billboard quad in normal units (not Daggerfall units).</param>
         /// <returns>Material.</returns>
-        public Material SetMaterial(Texture2D texture, Vector2 size, bool isLightArchive = false)
+        public override Material SetMaterial(Texture2D texture, Vector2 size, bool isLightArchive = false)
         {
             // Get DaggerfallUnity
             DaggerfallUnity dfUnity = DaggerfallUnity.Instance;
@@ -418,7 +396,7 @@ namespace DaggerfallWorkshop
         /// Aligns billboard to centre of base, rather than exact centre.
         /// Must have already set material using SetMaterial() for billboard dimensions to be known.
         /// </summary>
-        public void AlignToBase()
+        public override void AlignToBase()
         {
             // Calcuate offset for correct positioning in scene
             Vector3 offset = Vector3.zero;

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -29,6 +29,10 @@ namespace DaggerfallWorkshop
     [RequireComponent(typeof(MeshRenderer))]
     public class DaggerfallBillboard : Billboard
     {
+        // Used by DaggerfallBillboardEditor.DisplayAboutGUI()
+        public int customArchive = 210;
+        public int customRecord = 0;
+
         // Just using a simple animation speed for simple billboard anims
         // You can adjust this or extend as needed
         const int animalFps = 5;

--- a/Assets/Scripts/Internal/DaggerfallDungeon.cs
+++ b/Assets/Scripts/Internal/DaggerfallDungeon.cs
@@ -405,7 +405,7 @@ namespace DaggerfallWorkshop
                 if (assign)
                     startMarker = dfBlock.StartMarkers[0];
 
-                DaggerfallBillboard dfBillboard = dfBlock.StartMarkers[0].GetComponent<DaggerfallBillboard>();
+                Billboard dfBillboard = dfBlock.StartMarkers[0].GetComponent<Billboard>();
                 block.WaterLevel = dfBillboard.Summary.WaterLevel;
                 block.CastleBlock = dfBillboard.Summary.CastleBlock;
             }

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -620,7 +620,7 @@ namespace DaggerfallWorkshop
                 GameObject go = GameObjectHelper.CreateDaggerfallBillboardGameObject(obj.TextureArchive, obj.TextureRecord, node.transform);
 
                 // Set position
-                DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                Billboard dfBillboard = go.GetComponent<Billboard>();
                 go.transform.position = billboardPosition;
                 go.transform.position += new Vector3(0, dfBillboard.Summary.Size.y / 2, 0);
 
@@ -940,7 +940,7 @@ namespace DaggerfallWorkshop
                     }
 
                     // Set position
-                    DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                    Billboard dfBillboard = go.GetComponent<Billboard>();
                     go.transform.position = billboardPosition;
                     go.transform.position += new Vector3(0, dfBillboard.Summary.Size.y / 2, 0);
 

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -947,6 +947,12 @@ namespace DaggerfallWorkshop
                     // Add RMB data to billboard
                     dfBillboard.SetRMBPeopleData(obj);
                 }
+                else
+                {
+                    Billboard dfBillboard = go.GetComponent<Billboard>();
+                    if (dfBillboard)
+                        dfBillboard.SetRMBPeopleData(obj);
+                }
 
                 // Add StaticNPC behaviour
                 StaticNPC npc = go.AddComponent<StaticNPC>();

--- a/Assets/Scripts/Internal/DaggerfallLocation.cs
+++ b/Assets/Scripts/Internal/DaggerfallLocation.cs
@@ -248,7 +248,7 @@ namespace DaggerfallWorkshop
             int natureArchive = GetNatureArchive();
 
             // Process all DaggerfallBillboard child components
-            DaggerfallBillboard[] billboardArray = GetComponentsInChildren<DaggerfallBillboard>();
+            Billboard[] billboardArray = GetComponentsInChildren<Billboard>();
             foreach (var db in billboardArray)
             {
                 if (db.Summary.FlatType == FlatTypes.Nature)
@@ -277,7 +277,7 @@ namespace DaggerfallWorkshop
         public void EnumerateStartMarkers()
         {
             // Process all DaggerfallBillboard child components
-            DaggerfallBillboard[] billboardArray = GetComponentsInChildren<DaggerfallBillboard>();
+            Billboard[] billboardArray = GetComponentsInChildren<Billboard>();
             startMarkers.Clear();
             foreach (var db in billboardArray)
             {

--- a/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
+++ b/Assets/Scripts/Internal/DaggerfallMobileUnit.cs
@@ -43,9 +43,6 @@ namespace DaggerfallWorkshop
         const int numberOrientations = 8;
         const float anglePerOrientation = 360f / numberOrientations;
 
-        [SerializeField]
-        MobileUnitSummary summary = new MobileUnitSummary();
-
         Camera mainCamera = null;
         MeshFilter meshFilter = null;
         MeshRenderer meshRenderer = null;
@@ -61,11 +58,6 @@ namespace DaggerfallWorkshop
         bool freezeAnims = false;
         bool animReversed = false;
         int frameSpeedDivisor = 1;
-
-        public MobileUnitSummary Summary
-        {
-            get { return summary; }
-        }
 
         public override bool IsSetup
         {
@@ -129,24 +121,6 @@ namespace DaggerfallWorkshop
         {
             get { return Summary.specialTransformationCompleted; }
             protected set { summary.specialTransformationCompleted = value; }
-        }
-
-        [Serializable]
-        public struct MobileUnitSummary
-        {
-            public bool IsSetup;                                        // Flagged true when mobile settings are populated
-            public Rect[] AtlasRects;                                   // Array of rectangles for atlased materials
-            public RecordIndex[] AtlasIndices;                          // Indices into rect array for atlased materials, supports animations
-            public Vector2[] RecordSizes;                               // Size and scale of individual records
-            public int[] RecordFrames;                                  // Number of frames of individual records
-            public MobileEnemy Enemy;                                   // Mobile enemy settings
-            public MobileStates EnemyState;                             // Animation state
-            public MobileAnimation[] StateAnims;                        // Animation frames for this state
-            public MobileBillboardImportedTextures ImportedTextures;    // Textures imported from mods
-            public int AnimStateRecord;                                 // Record number of animation state
-            public int[] StateAnimFrames;                               // Sequence of frames to play for this animation. Used for attacks
-            public byte ClassicSpawnDistanceType;                       // 0 through 6 value read from spawn marker that determines distance at which enemy spawns/despawns in classic.
-            public bool specialTransformationCompleted;                 // Mobile has completed special transformation (e.g. Daedra Seducer)
         }
 
         void Start()

--- a/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/MeshReplacement.cs
@@ -168,7 +168,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <summary>
         /// Ensures that the requested imported model is assigned to the given transform and is positioned correctly.
         /// If archive and record mismatch, the requested prefab is imported while currently loaded gameobject is destroyed.
-        /// This has a similar purpose to <see cref="DaggerfallBillboard.SetMaterial(int, int, int)"/>.
+        /// This has a similar purpose to <see cref="Billboard.SetMaterial(int, int, int)"/>.
         /// </summary>
         /// <param name="archive">Texture archive for original billboard.</param>
         /// <param name="record">Texture record for original billboard.</param>

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -461,7 +461,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// Always creates an emission map for textures marked as emissive by TextureReader, import emission maps for others only if available.
         /// </remarks>
         /// <returns>A material or null.</returns>
-        public static Material GetStaticBillboardMaterial(GameObject go, int archive, int record, ref DaggerfallBillboard.BillboardSummary summary, out Vector2 scale)
+        public static Material GetStaticBillboardMaterial(GameObject go, int archive, int record, ref Billboard.BillboardSummary summary, out Vector2 scale)
         {
             scale = Vector2.one;
 

--- a/Assets/Scripts/Utility/GameObjectHelper.cs
+++ b/Assets/Scripts/Utility/GameObjectHelper.cs
@@ -277,7 +277,7 @@ namespace DaggerfallWorkshop.Utility
             GameObject go = new GameObject(flatName);
             if (parent) go.transform.parent = parent;
 
-            DaggerfallBillboard dfBillboard = go.AddComponent<DaggerfallBillboard>();
+            Billboard dfBillboard = go.AddComponent<DaggerfallBillboard>();
             dfBillboard.SetMaterial(archive, record);
 
             if (PlayerActivate.HasCustomActivation(flatName)) 
@@ -634,13 +634,13 @@ namespace DaggerfallWorkshop.Utility
             if (MeshReplacement.ImportCustomFlatGameobject(textureArchive, textureRecord, Vector3.zero, go.transform))
             {
                 // Use imported model instead of billboard
-                GameObject.Destroy(go.GetComponent<DaggerfallBillboard>());
+                GameObject.Destroy(go.GetComponent<Billboard>());
                 GameObject.Destroy(go.GetComponent<MeshRenderer>());
             }
             else
             {
                 // Setup billboard component
-                DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                Billboard dfBillboard = go.GetComponent<Billboard>();
                 dfBillboard.SetMaterial(textureArchive, textureRecord);
 
                 // Now move up loot icon by half own size so bottom is aligned with position
@@ -986,7 +986,7 @@ namespace DaggerfallWorkshop.Utility
             // Set position and adjust up by half height if not inside a dungeon
             Vector3 dungeonBlockPosition = new Vector3(marker.dungeonX * RDBLayout.RDBSide, 0, marker.dungeonZ * RDBLayout.RDBSide);
             go.transform.localPosition = dungeonBlockPosition + marker.flatPosition;
-            DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+            Billboard dfBillboard = go.GetComponent<Billboard>();
             if (siteType != SiteTypes.Dungeon)
                 go.transform.localPosition += new Vector3(0, dfBillboard.Summary.Size.y / 2, 0);
 
@@ -1064,7 +1064,7 @@ namespace DaggerfallWorkshop.Utility
 
             // Create billboard
             GameObject go = CreateDaggerfallBillboardGameObject(textureArchive, textureRecord, parent);
-            DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+            Billboard dfBillboard = go.GetComponent<Billboard>();
 
             // Set name
             go.name = string.Format("Quest Item [{0} | {1}]", item.Symbol.Original, item.DaggerfallUnityItem.LongName);

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1211,9 +1211,10 @@ namespace DaggerfallWorkshop.Utility
                 // Setup standard billboard and assign RDB data
                 go = GameObjectHelper.CreateDaggerfallBillboardGameObject(archive, record, parent);
                 go.transform.position = targetPosition;
-                Billboard dfBillboard = go.GetComponent<Billboard>();
-                dfBillboard.SetRDBResourceData(obj.Resources.FlatResource);
             }
+            Billboard dfBillboard = go.GetComponent<Billboard>();
+            if (dfBillboard)
+                dfBillboard.SetRDBResourceData(obj.Resources.FlatResource);
 
             // Add StaticNPC behaviour - required for quest system
             if (IsNPCFlat(archive))

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1211,7 +1211,7 @@ namespace DaggerfallWorkshop.Utility
                 // Setup standard billboard and assign RDB data
                 go = GameObjectHelper.CreateDaggerfallBillboardGameObject(archive, record, parent);
                 go.transform.position = targetPosition;
-                DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                Billboard dfBillboard = go.GetComponent<Billboard>();
                 dfBillboard.SetRDBResourceData(obj.Resources.FlatResource);
             }
 
@@ -1326,9 +1326,9 @@ namespace DaggerfallWorkshop.Utility
             if (dungeonIndex < RandomEncounters.EncounterTables.Length)
             {
                 // Get water level from start marker if it exists
-                DaggerfallBillboard dfBillboard;
+                Billboard dfBillboard;
                 if (startMarkers.Length > 0)
-                    dfBillboard = startMarkers[0].GetComponent<DaggerfallBillboard>();
+                    dfBillboard = startMarkers[0].GetComponent<Billboard>();
                 else
                     dfBillboard = null;
 
@@ -1398,9 +1398,9 @@ namespace DaggerfallWorkshop.Utility
             if (dungeonIndex < RandomEncounters.EncounterTables.Length)
             {
                 // Get water level from start marker if it exists
-                DaggerfallBillboard dfBillboard;
+                Billboard dfBillboard;
                 if (startMarkers.Length > 0)
-                    dfBillboard = startMarkers[0].GetComponent<DaggerfallBillboard>();
+                    dfBillboard = startMarkers[0].GetComponent<Billboard>();
                 else
                     dfBillboard = null;
 
@@ -1494,9 +1494,9 @@ namespace DaggerfallWorkshop.Utility
             byte classicSpawnDistanceType = obj.Resources.FlatResource.SoundIndex;
 
             // Get water level from start marker if it exists
-            DaggerfallBillboard dfBillboard;
+            Billboard dfBillboard;
             if (startMarkers.Length > 0)
-                dfBillboard = startMarkers[0].GetComponent<DaggerfallBillboard>();
+                dfBillboard = startMarkers[0].GetComponent<Billboard>();
             else
                 dfBillboard = null;
 

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -366,7 +366,7 @@ namespace DaggerfallWorkshop.Utility
                 if (obj.FactionID != 0)
                 {
                     // Add RMB data to billboard
-                    DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                    Billboard dfBillboard = go.GetComponent<Billboard>();
                     if (dfBillboard != null)
                         dfBillboard.SetRMBPeopleData(obj.FactionID, obj.Flags, obj.Position);
 
@@ -440,7 +440,7 @@ namespace DaggerfallWorkshop.Utility
                     if (obj.FactionID != 0)
                     {
                         // Add RMB data to billboard
-                        DaggerfallBillboard dfBillboard = go.GetComponent<DaggerfallBillboard>();
+                        Billboard dfBillboard = go.GetComponent<Billboard>();
                         if (dfBillboard != null)
                             dfBillboard.SetRMBPeopleData(obj.FactionID, obj.Flags, obj.Position);
 
@@ -475,7 +475,7 @@ namespace DaggerfallWorkshop.Utility
         /// <param name="go">GameObject with DaggerfallBillboard component.</param>
         public static void AlignBillboardToBase(GameObject go)
         {
-            DaggerfallBillboard c = go.GetComponent<DaggerfallBillboard>();
+            Billboard c = go.GetComponent<Billboard>();
             if (c)
             {
                 c.AlignToBase();


### PR DESCRIPTION
This is to allow mods contributing new MobileUnit or Billboard implementations to allow most DFU and other mod logic to continue to work. Billboard is based on the same base class structure as MobileUnit.

@Interkarma Would you like a different name for the base class, maybe AbstractBillboard or BillboardBase? I just followed the pattern already set. Apologies for the blast radius of this one. 

Pretty sure I did the refactoring correctly but could use some review in case I made a mistake somewhere. @KABoissonneault can you please review my work here?