### PR TITLE
PR #2284 mod compilation issue workaround

### DIFF
--- a/Assets/Scripts/Internal/Base/Billboard.cs
+++ b/Assets/Scripts/Internal/Base/Billboard.cs
@@ -16,6 +16,30 @@ using DaggerfallWorkshop.Utility.AssetInjection;
 
 namespace DaggerfallWorkshop
 {
+    [Serializable]
+    public struct BillboardSummary
+    {
+        public Vector2 Size;                                // Size and scale in world units
+        public Rect Rect;                                   // Single UV rectangle for non-atlased materials only
+        public Rect[] AtlasRects;                           // Array of UV rectangles for atlased materials only
+        public RecordIndex[] AtlasIndices;                  // Indices into UV rect array for atlased materials only, supports animations
+        public bool AtlasedMaterial;                        // True if material is part of an atlas
+        public bool AnimatedMaterial;                       // True if material uses atlas UV animations (always false for non atlased materials)
+        public int CurrentFrame;                            // Current animation frame
+        public FlatTypes FlatType;                          // Type of flat
+        public EditorFlatTypes EditorFlatType;              // Sub-type of flat when editor/marker
+        public bool IsMobile;                               // Billboard is a mobile enemy
+        public int Archive;                                 // Texture archive index
+        public int Record;                                  // Texture record index
+        public int Flags;                                   // NPC Flags found in RMB and RDB NPC data
+        public int FactionOrMobileID;                       // FactionID for NPCs, Mobile ID for monsters
+        public int NameSeed;                                // NPC name seed
+        public MobileTypes FixedEnemyType;                  // Type for fixed enemy marker
+        public short WaterLevel;                            // Dungeon water level
+        public bool CastleBlock;                            // Non-hostile area of main story castle dungeons
+        public BillboardImportedTextures ImportedTextures;  // Textures imported from mods
+    }
+
     public abstract class Billboard : MonoBehaviour
     {
         /// <summary>
@@ -40,31 +64,7 @@ namespace DaggerfallWorkshop
         {
             get { return summary; }
         }
-
-        [Serializable]
-        public struct BillboardSummary
-        {
-            public Vector2 Size;                                // Size and scale in world units
-            public Rect Rect;                                   // Single UV rectangle for non-atlased materials only
-            public Rect[] AtlasRects;                           // Array of UV rectangles for atlased materials only
-            public RecordIndex[] AtlasIndices;                  // Indices into UV rect array for atlased materials only, supports animations
-            public bool AtlasedMaterial;                        // True if material is part of an atlas
-            public bool AnimatedMaterial;                       // True if material uses atlas UV animations (always false for non atlased materials)
-            public int CurrentFrame;                            // Current animation frame
-            public FlatTypes FlatType;                          // Type of flat
-            public EditorFlatTypes EditorFlatType;              // Sub-type of flat when editor/marker
-            public bool IsMobile;                               // Billboard is a mobile enemy
-            public int Archive;                                 // Texture archive index
-            public int Record;                                  // Texture record index
-            public int Flags;                                   // NPC Flags found in RMB and RDB NPC data
-            public int FactionOrMobileID;                       // FactionID for NPCs, Mobile ID for monsters
-            public int NameSeed;                                // NPC name seed
-            public MobileTypes FixedEnemyType;                  // Type for fixed enemy marker
-            public short WaterLevel;                            // Dungeon water level
-            public bool CastleBlock;                            // Non-hostile area of main story castle dungeons
-            public BillboardImportedTextures ImportedTextures;  // Textures imported from mods
-        }
-
+        
         /// <summary>
         /// Sets extended data about people billboard from RMB resource data.
         /// </summary>

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -461,7 +461,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// Always creates an emission map for textures marked as emissive by TextureReader, import emission maps for others only if available.
         /// </remarks>
         /// <returns>A material or null.</returns>
-        public static Material GetStaticBillboardMaterial(GameObject go, int archive, int record, ref Billboard.BillboardSummary summary, out Vector2 scale)
+        public static Material GetStaticBillboardMaterial(GameObject go, int archive, int record, ref BillboardSummary summary, out Vector2 scale)
         {
             scale = Vector2.one;
 


### PR DESCRIPTION
As discussed with IK, the change from `DaggerfallBillboard.BillboardSummary` to `Billboard.BillboardSummary` can cause mods relying on `BillboardSummary` to fail to compile. To mitigate this, I moved the struct to the DaggerfallWorkshop namespace instead.