### PR TITLE
Changed the way rotations are applied on models / doors in RDBLayout

### DIFF
--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -687,23 +687,14 @@ namespace DaggerfallWorkshop.Utility
         /// </summary>
         private static Matrix4x4 GetModelMatrix(DFBlock.RdbObject obj)
         {
-            // Get rotation angle for each axis
-            float degreesX = -obj.Resources.ModelResource.XRotation / BlocksFile.RotationDivisor;
-            float degreesY = -obj.Resources.ModelResource.YRotation / BlocksFile.RotationDivisor;
-            float degreesZ = -obj.Resources.ModelResource.ZRotation / BlocksFile.RotationDivisor;
-
-            // Calcuate transform
+            // Calculate transform
             Vector3 position = new Vector3(obj.XPos, -obj.YPos, obj.ZPos) * MeshReader.GlobalScale;
 
-            // Calculate matrix
-            Vector3 rx = new Vector3(degreesX, 0, 0);
-            Vector3 ry = new Vector3(0, degreesY, 0);
-            Vector3 rz = new Vector3(0, 0, degreesZ);
+            // Calculate rotation
+            Vector3 rotation = new Vector3(-obj.Resources.ModelResource.XRotation / BlocksFile.RotationDivisor, -obj.Resources.ModelResource.YRotation / BlocksFile.RotationDivisor, -obj.Resources.ModelResource.ZRotation / BlocksFile.RotationDivisor);
+
             Matrix4x4 modelMatrix = Matrix4x4.identity;
-            modelMatrix *= Matrix4x4.TRS(position, Quaternion.identity, Vector3.one);
-            modelMatrix *= Matrix4x4.TRS(Vector3.zero, Quaternion.Euler(rz), Vector3.one);
-            modelMatrix *= Matrix4x4.TRS(Vector3.zero, Quaternion.Euler(rx), Vector3.one);
-            modelMatrix *= Matrix4x4.TRS(Vector3.zero, Quaternion.Euler(ry), Vector3.one);
+            modelMatrix *= Matrix4x4.TRS(position, Quaternion.Euler(rotation), Vector3.one);
 
             return modelMatrix;
         }
@@ -1148,15 +1139,10 @@ namespace DaggerfallWorkshop.Utility
                 }
             }
 
-            // Get rotation angle for each axis
-            float degreesX = -obj.Resources.ModelResource.XRotation / BlocksFile.RotationDivisor;
-            float degreesY = -obj.Resources.ModelResource.YRotation / BlocksFile.RotationDivisor;
-            float degreesZ = -obj.Resources.ModelResource.ZRotation / BlocksFile.RotationDivisor;
+            // Apply rotation
+            Vector3 rotation = new Vector3(-obj.Resources.ModelResource.XRotation / BlocksFile.RotationDivisor, -obj.Resources.ModelResource.YRotation / BlocksFile.RotationDivisor, -obj.Resources.ModelResource.ZRotation / BlocksFile.RotationDivisor);
+            go.transform.Rotate(rotation, Space.World);
 
-            // Apply transforms
-            go.transform.Rotate(0, degreesY, 0, Space.World);
-            go.transform.Rotate(degreesX, 0, 0, Space.World);
-            go.transform.Rotate(0, 0, degreesZ, Space.World);
             go.transform.localPosition = modelMatrix.GetColumn(3);
 
             // Get action door script


### PR DESCRIPTION
Changed the way rotation is applied to the models to avoid breaking orientation. All rotations are now set at once instead of being applied one after another.

Me and Ralzar both ran into the issue of certain rotation combinations not working, it will look fine in the editor but not when the RDB data is loaded in-game.

I linked to Imgur but I've added the images here now so that they won't go missing at some point. 

I compared the way rotation is handled in RMBLayout, there the model rotations are applied in one pass instead of applying each axis rotation separately. I have changed the code in RDBLayout to do the same and this solves the rotation issues. Most classic models only rotate around 1 axis so they won't exhibit this issue.

In the Unity Editor:
![UnityEditor1](https://user-images.githubusercontent.com/4460167/157247416-a0e710dc-2103-4a14-8c04-cee49e12e1ed.png)

In the live build:
![LiveBuild1](https://user-images.githubusercontent.com/4460167/157247428-bf3e0757-96bf-4fa3-a0c9-490516f8b6bb.png)

In my custom build:
![MyBuild1](https://user-images.githubusercontent.com/4460167/157247454-0dd3656c-801b-4df5-bbc6-61558eca4f19.png)

In the Unity Editor:
![UnityEditor2](https://user-images.githubusercontent.com/4460167/157247843-702e3978-c607-42d8-9866-327275599942.png)

In the live build:
![LiveBuild2](https://user-images.githubusercontent.com/4460167/157247856-b38a6922-d6ef-4523-8526-6a8e7b11988d.png)

In my custom build:
![MyBuild2](https://user-images.githubusercontent.com/4460167/157247877-7b09a4c1-d021-44e9-a888-cf4f60562adc.png)
)

I've also supplied Ralzar's RDB, go to the Bish Mines in Dragontail Mountains, when you enter you will be right beside the two beams that have the wrong orientation in the live build.

[N0000052.RDB.zip](https://github.com/Interkarma/daggerfall-unity/files/8204594/N0000052.RDB.zip