### PR TITLE
Don't override faction id if the replacement id is zero

### DIFF
--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -850,7 +850,8 @@ namespace DaggerfallConnect.Arena2
                 if (WorldDataReplacement.GetBuildingReplacementData(blocks[block].Name, block, i, out buildingReplacementData))
                 {
                     blocks[block].DFBlock.RmbBlock.SubRecords[i] = buildingReplacementData.RmbSubRecord;
-                    blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].FactionId = buildingReplacementData.FactionId;
+                    if (buildingReplacementData.FactionId > 0)
+                        blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].FactionId = buildingReplacementData.FactionId;
                     blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.BuildingType;
                     if (buildingReplacementData.Quality > 0)
                         blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].Quality = buildingReplacementData.Quality;


### PR DESCRIPTION
This was added to allow named buildings to be altered without affecting the pool matching. Unfortunately I missed this one when I made that change.