### PR TITLE
Fix IsValueEqual for ColorKey's

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsTypes.cs
@@ -725,7 +725,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
 
         protected override bool IsValueEqual(Color32 value)
         {
-            return Value.r == value.r || Value.g == value.g || Value.b == value.b || Value.a == value.a;
+            return Value.r == value.r && Value.g == value.g && Value.b == value.b && Value.a == value.a;
         }
 
         protected override string Serialize()


### PR DESCRIPTION
This enables dynamically changing a colour setting for a mod using the recent menu option to work. The method was allowing any single element not being changed to indicate the colour as a whole had not changed.