### PR TITLE
bugfix: NullReferenceException at SaveExplorerWindow.cs:512

### DIFF
--- a/Assets/Scripts/Editor/SaveExplorerWindow.cs
+++ b/Assets/Scripts/Editor/SaveExplorerWindow.cs
@@ -506,18 +506,20 @@ namespace DaggerfallWorkshop
                 // Prevent duplicate names so save games aren't automatically removed from the Save Select GUI
                 for (int i = 0; i < saveNames.Length; i++)
                 {
-                    if (saveNames[i] == null) continue;
+                    var nextName = saveNames[i];
+                    if (nextName == null) continue;
                     int duplicateCount = 0;
                     for (int j = i + 1; j < saveNames.Length; j++)
                     {
-                        if (saveNames[j] == null) continue;
-                        if (saveNames[j].text == saveNames[i].text)
+                        var otherName = saveNames[j];
+                        if (otherName == null) continue;
+                        if (otherName.text == nextName.text)
                         {
                             bool unique = false;
                             while (!unique)
                             {
                                 unique = true;
-                                string replaceText = saveNames[j].text + "(" + ++duplicateCount + ")";
+                                string replaceText = $"{otherName.text}({++duplicateCount})";
                                 for (int k = 0; k < saveNames.Length; k++)
                                 {
                                     if (saveNames[k].text == replaceText)
@@ -528,7 +530,7 @@ namespace DaggerfallWorkshop
                                 }
 
                                 if (unique)
-                                    saveNames[j].text = replaceText;
+                                    otherName.text = replaceText;
                             }
                         }
                     }

--- a/Assets/Scripts/Editor/SaveExplorerWindow.cs
+++ b/Assets/Scripts/Editor/SaveExplorerWindow.cs
@@ -506,9 +506,11 @@ namespace DaggerfallWorkshop
                 // Prevent duplicate names so save games aren't automatically removed from the Save Select GUI
                 for (int i = 0; i < saveNames.Length; i++)
                 {
+                    if (saveNames[i] == null) continue;
                     int duplicateCount = 0;
                     for (int j = i + 1; j < saveNames.Length; j++)
                     {
+                        if (saveNames[j] == null) continue;
                         if (saveNames[j].text == saveNames[i].text)
                         {
                             bool unique = false;


### PR DESCRIPTION
Tiny bugfix. Opening up a new `Daggerfall Tools/Save Explorer` caused a minor case of:

> NullReferenceException: Object reference not set to an instance of an object
> DaggerfallWorkshop.SaveExplorerWindow.IsReady () (at Assets/Scripts/Editor/SaveExplorerWindow.cs:512)
> DaggerfallWorkshop.SaveExplorerWindow.OnGUI () (at Assets/Scripts/Editor/SaveExplorerWindow.cs:72)
> System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
> Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
> System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
> System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
> UnityEditor.HostView.Invoke (System.String methodName, System.Object obj) (at <bd70c40e01f641bdb7d836e1e97755bc>:0)
> UnityEditor.HostView.Invoke (System.String methodName) (at <bd70c40e01f641bdb7d836e1e97755bc>:0)
> UnityEditor.HostView.InvokeOnGUI (UnityEngine.Rect onGUIPosition, UnityEngine.Rect viewRect) (at <bd70c40e01f641bdb7d836e1e97755bc>:0)
> UnityEditor.DockArea.DrawView (UnityEngine.Rect viewRect, UnityEngine.Rect dockAreaRect) (at <bd70c40e01f641bdb7d836e1e97755bc>:0)
> UnityEditor.DockArea.OldOnGUI () (at <bd70c40e01f641bdb7d836e1e97755bc>:0)
> UnityEngine.UIElements.IMGUIContainer.DoOnGUI (UnityEngine.Event evt, UnityEngine.Matrix4x4 parentTransform, UnityEngine.Rect clippingRect, System.Boolean isComputingLayout, UnityEngine.Rect layoutSize, System.Action onGUIHandler, System.Boolean canAffectFocus) (at <a6a8a08b59d34373858eada2d852ad38>:0)
> UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr)
> 