### PR TITLE
4 packages to unlock some future performance gains (for either vanilla release or for modders)

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,11 +1,15 @@
 {
   "dependencies": {
     "com.unity.addressables": "1.19.11",
+	"com.unity.burst": "1.7.1",
     "com.unity.collab-proxy": "1.2.16",
+	"com.unity.collections": "0.9.0-preview.6",
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.8",
     "com.unity.ide.vscode": "1.2.3",
+    "com.unity.jobs": "0.2.10-preview.13",
     "com.unity.localization": "1.0.5",
+    "com.unity.mathematics": "1.2.6",
     "com.unity.postprocessing": "3.1.1",
     "com.unity.test-framework": "1.1.24",
     "com.unity.textmeshpro": "2.1.4",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -14,11 +14,30 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.burst": {
+      "version": "1.7.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.mathematics": "1.2.1"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.collab-proxy": {
       "version": "1.2.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.collections": {
+      "version": "0.9.0-preview.6",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework.performance": "2.0.8-preview",
+        "com.unity.burst": "1.3.0-preview.12"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.ext.nunit": {
@@ -53,6 +72,16 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.jobs": {
+      "version": "0.2.10-preview.13",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.collections": "0.9.0-preview.6",
+        "com.unity.mathematics": "1.1.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.localization": {
       "version": "1.0.5",
       "depth": 0,
@@ -61,6 +90,13 @@
         "com.unity.addressables": "1.19.9",
         "com.unity.nuget.newtonsoft-json": "2.0.0"
       },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.mathematics": {
+      "version": "1.2.6",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
@@ -93,6 +129,16 @@
         "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework.performance": {
+      "version": "2.0.8-preview",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.0",
+        "com.unity.nuget.newtonsoft-json": "2.0.0-preview"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
Hi,

This is a small and basic PR. It adds:
- `com.unity.mathematics`
- `com.unity.collections`
- `com.unity.jobs`
- `com.unity.burst`
Hope you approve it.

### Reasons behind it

Adding these 4 packages won't change anything by virtue of just adding them but those can enable some worthwhile performance gains in few areas where the workload can be considerably high. There is probably not a lot of cases like that, but those few still impact the performance & gameplay experience and that is noticeable with older CPUs (my i3-4170 among them).

To give an example, a Burst compilation could make all existing `IJob`s about >=10x faster after adding `BurstCompile` attribute and few changes (removing managed objects and static code references). This won't make a noticeable difference in vanilla release but I saw that a popular terrain mod can stall the main thread for up to few dozen ms for like >1.5s - and this PR could help fix that in the future releases.
To give another example, not a big deal but I also saw a cpu-based billboards somewhere - this one can be flattened with super performant Burst-compiled `IJobParallelForTransform`. More small cases like that will appear in the future I'm sure.

![Screenshot 2022-04-24 164021](https://user-images.githubusercontent.com/3066539/164981871-ab72ef55-2e02-4e87-bac4-49a93d00e2f8.png)

