### PR TITLE
Fix ground seams on some hardware/drivers

### DIFF
--- a/Assets/Shaders/DaggerfallTilemap.shader
+++ b/Assets/Shaders/DaggerfallTilemap.shader
@@ -40,9 +40,9 @@ Shader "Daggerfall/Tilemap" {
 		sampler2D _TileAtlasTex;
 		sampler2D _TilemapTex;
 		sampler2D _BumpMap;
-		int _TilesetDim;
-		int _TilemapDim;
-		int _MaxIndex;
+		uint _TilesetDim;
+		uint _TilemapDim;
+		uint _MaxIndex;
 		float _AtlasSize;
 		float _GutterSize;
 
@@ -54,16 +54,17 @@ Shader "Daggerfall/Tilemap" {
 
 		void surf (Input IN, inout SurfaceOutput o)
 		{
+			float2 unwrappedUV = IN.uv_MainTex * _TilemapDim;
+
 			// Get offset to tile in atlas
-			int index = tex2D(_TilemapTex, IN.uv_MainTex).a * _MaxIndex + 0.5;
-			int xpos = index % _TilesetDim;
-			int ypos = index / _TilesetDim;
+			uint index = tex2D(_TilemapTex, floor(unwrappedUV) / _TilemapDim).a * _MaxIndex + 0.5;
+			uint xpos = index % _TilesetDim;
+			uint ypos = index / _TilesetDim;
 			float2 uv = float2(xpos, ypos) / _TilesetDim;
 
 			// Offset to fragment position inside tile
-			float xoffset = frac(IN.uv_MainTex.x * _TilemapDim) / _GutterSize;
-			float yoffset = frac(IN.uv_MainTex.y * _TilemapDim) / _GutterSize;
-			uv += float2(xoffset, yoffset) + _GutterSize / _AtlasSize;
+			float2 offset = frac(unwrappedUV) / _GutterSize;
+			uv += offset + _GutterSize / _AtlasSize;
 
 			// Sample based on gradient and set output
 			float2 uvr = IN.uv_MainTex * ((float)_TilemapDim / _GutterSize);

--- a/Assets/Shaders/DaggerfallTilemap.shader
+++ b/Assets/Shaders/DaggerfallTilemap.shader
@@ -67,7 +67,7 @@ Shader "Daggerfall/Tilemap" {
 			uv += offset + _GutterSize / _AtlasSize;
 
 			// Sample based on gradient and set output
-			float2 uvr = IN.uv_MainTex * ((float)_TilemapDim / _GutterSize);
+			float2 uvr = unwrappedUV / _GutterSize;
 			half4 c = tex2Dgrad(_TileAtlasTex, uv, ddx(uvr), ddy(uvr));
 			o.Albedo = c.rgb;
 			o.Alpha = c.a;

--- a/Assets/Shaders/DaggerfallTilemapTextureArray.shader
+++ b/Assets/Shaders/DaggerfallTilemapTextureArray.shader
@@ -96,14 +96,17 @@ Shader "Daggerfall/TilemapTextureArray" {
         void surf (Input IN, inout SurfaceOutput o)
         {
             // Get offset to tile in atlas
-            uint index = tex2D(_TilemapTex, IN.uv_MainTex).a * _MaxIndex + 0.5;
+            uint tileData = tex2D(_TilemapTex, IN.uv_MainTex).a * _MaxIndex + 0.5;
+            uint tileIndex = tileData >> 2; // compute correct texture array index from index
+            uint tileTransformation = tileData & 0x3;
 
             // Offset to fragment position inside tile
             float2 unwrappedUV = IN.uv_MainTex * _TilemapDim;
-            float2 uv = mul(rotations[index % 4], frac(unwrappedUV)) + translations[index % 4];
+            float2 tileUV = frac(unwrappedUV);
+            float2 transformedTileUV = mul(rotations[tileTransformation], tileUV) + translations[tileTransformation];
 
             // Sample based on gradient and set output
-            float3 uv3 = float3(uv, index / 4); // compute correct texture array index from index
+            float3 uv3 = float3(transformedTileUV, tileIndex);
 
             // Get mipmap level
             float mipMapLevel = GetMipLevel(unwrappedUV, _TileTexArr_TexelSize);

--- a/Assets/Shaders/DaggerfallTilemapTextureArray.shader
+++ b/Assets/Shaders/DaggerfallTilemapTextureArray.shader
@@ -29,6 +29,7 @@ Shader "Daggerfall/TilemapTextureArray" {
         _TilemapTex("Tilemap (R)", 2D) = "red" {}
         _TilemapDim("Tilemap Dimension (in tiles)", Int) = 128
         _MaxIndex("Max Tileset Index", Int) = 255
+        _Padding("Padding", Range(0, 0.1)) = 0.0005
     }
     SubShader {
         Tags { "RenderType"="Opaque" }
@@ -59,6 +60,7 @@ Shader "Daggerfall/TilemapTextureArray" {
         float4 _TileTexArr_TexelSize;
         int _MaxIndex;
         int _TilemapDim;
+        float _Padding;
 
         struct Input
         {
@@ -102,7 +104,7 @@ Shader "Daggerfall/TilemapTextureArray" {
 
             // Offset to fragment position inside tile
             float2 unwrappedUV = IN.uv_MainTex * _TilemapDim;
-            float2 tileUV = frac(unwrappedUV);
+            float2 tileUV = frac(unwrappedUV) * (1 - 2 * _Padding) + _Padding;
             float2 transformedTileUV = mul(rotations[tileTransformation], tileUV) + translations[tileTransformation];
 
             // Sample based on gradient and set output


### PR DESCRIPTION
Attempt to fix ground seams to appear on some hardware/drivers (AMD, integrated Intel graphics), based on
https://forum.unity.com/threads/tiling-textures-within-an-atlas-by-wrapping-uvs-within-frag-shader-getting-artifacts.535793/

Again, I no longer have access to some hardware to test this issue, so I need feedback from developers with such hardware!

Forums: https://forums.dfworkshop.net/viewtopic.php?t=1464