### PR TITLE
bugfix: DivideByZeroException at DaggerfallGuildServiceDonation.cs:68

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs
@@ -65,7 +65,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                     // Change reputation
                     int rep = Math.Abs(playerEntity.FactionData.GetReputation(factionId));
-                    if (Dice100.SuccessRoll(2 * amount / ((2 * amount / Math.Max(rep, 1)) + 1)))
+                    if (Dice100.SuccessRoll((2 * amount / Math.Max(rep, 1)) + 1))
                         playerEntity.FactionData.ChangeReputation(factionId, 1); // Does not propagate in classic
 
                     // Show thanks message

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs
@@ -65,7 +65,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                     // Change reputation
                     int rep = Math.Abs(playerEntity.FactionData.GetReputation(factionId));
-                    if (Dice100.SuccessRoll(2 * amount / Math.Max(rep, 1)))
+                    if (Dice100.SuccessRoll(2 * amount / ((2 * amount / Math.Max(rep, 1)) + 1)))
                         playerEntity.FactionData.ChangeReputation(factionId, 1); // Does not propagate in classic
 
                     // Show thanks message

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs
@@ -65,7 +65,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                     // Change reputation
                     int rep = Math.Abs(playerEntity.FactionData.GetReputation(factionId));
-                    if (Dice100.SuccessRoll(2 * amount / Math.Max(rep + 1, 1)))
+                    if (Dice100.SuccessRoll(2 * amount / Math.Max(rep, 1)))
                         playerEntity.FactionData.ChangeReputation(factionId, 1); // Does not propagate in classic
 
                     // Show thanks message

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs
@@ -65,7 +65,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                     // Change reputation
                     int rep = Math.Abs(playerEntity.FactionData.GetReputation(factionId));
-                    if (Dice100.SuccessRoll(2 * amount / rep + 1))
+                    if (Dice100.SuccessRoll(2 * amount / Math.Max(rep + 1, 1)))
                         playerEntity.FactionData.ChangeReputation(factionId, 1); // Does not propagate in classic
 
                     // Show thanks message


### PR DESCRIPTION
Donating to a temple while at reputation `0` causes `DivideByZeroException`

> DivideByZeroException: Attempted to divide by zero.
> DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallGuildServiceDonation.DonationMsgBox_OnGotUserInput (DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallInputMessageBox sender, System.String input) (at Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs:68)
> DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallInputMessageBox.ReturnPlayerInputEvent (DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallInputMessageBox sender, System.String userInput) (at Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs:270)
> DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallInputMessageBox.Update () (at Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInputMessageBox.cs:172)
> DaggerfallWorkshop.Game.DaggerfallUI.Update () (at Assets/Scripts/Game/DaggerfallUI.cs:397)

Code at fault:
https://github.com/Interkarma/daggerfall-unity/blob/10881473e2e0e5c73d7f72dba996e8134d457a8b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServiceDonation.cs#L66-L69


This PR replaces `2 * amount / rep + 1` with `(2 * amount / Math.Max(rep, 1)) + 1`
