### PR TITLE
QoL: Draw circle gizmo at the bottom of BillBoards

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -439,6 +439,7 @@ namespace DaggerfallWorkshop
                 }
             }
         }
+        
         /// <summary>
         /// Draws a circle at the bottom of the bilboard to make it easier to judge the size regardless of rotation.
         /// </summary>
@@ -449,7 +450,7 @@ namespace DaggerfallWorkshop
                 UnityEditor.SceneView sceneView = GetActiveSceneView();
                 if (sceneView)
                 {
-                    float radius;
+                    float radius = 0.0f;
                     Vector3 offset = Vector3.zero;
 
                     radius = (summary.Size.x / 2);

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -439,6 +439,26 @@ namespace DaggerfallWorkshop
                 }
             }
         }
+        /// <summary>
+        /// Draws a circle at the bottom of the bilboard to make it easier to judge the size regardless of rotation.
+        /// </summary>
+        public void OnDrawGizmosSelected()
+        {
+            if (!Application.isPlaying)
+            {
+                UnityEditor.SceneView sceneView = GetActiveSceneView();
+                if (sceneView)
+                {
+                    float radius;
+                    Vector3 offset = Vector3.zero;
+
+                    radius = (summary.Size.x / 2);
+                    offset.y = (summary.Size.y / 2);
+
+                    Handles.DrawWireDisc(transform.position - offset, Vector3.up, radius);
+                }
+            }
+        }
 
         private SceneView GetActiveSceneView()
         {

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -443,22 +443,10 @@ namespace DaggerfallWorkshop
         /// <summary>
         /// Draws a circle at the bottom of the bilboard to make it easier to judge the size regardless of rotation.
         /// </summary>
-        public void OnDrawGizmosSelected()
+        void OnDrawGizmosSelected()
         {
-            if (!Application.isPlaying)
-            {
-                UnityEditor.SceneView sceneView = GetActiveSceneView();
-                if (sceneView)
-                {
-                    float radius = 0.0f;
-                    Vector3 offset = Vector3.zero;
-
-                    radius = (summary.Size.x / 2);
-                    offset.y = (summary.Size.y / 2);
-
-                    Handles.DrawWireDisc(transform.position - offset, Vector3.up, radius);
-                }
-            }
+            Vector3 sizeHalf = summary.Size * 0.5f;
+            Handles.DrawWireDisc(transform.position - new Vector3(0, sizeHalf.y, 0), Vector3.up, sizeHalf.x);
         }
 
         private SceneView GetActiveSceneView()


### PR DESCRIPTION
I was watching a stream by Cliffworms where he was using the world data editor to place items and I thought it might be helpful to have a bounding circle displayed at the bottom of billboards to make it easier to see how big they are. 

I tried to match the existing code style as closely as possible so hopefully it's not too bad.
![image](https://user-images.githubusercontent.com/46614201/166160696-3d98b648-ba4b-4955-afd2-dc02a93e8b66.png)
