### PR TITLE
Make controller cursor and controller-look frame-independent

### DIFF
--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -570,8 +570,13 @@ namespace DaggerfallWorkshop.Game
 
                     if (distMovement > JoystickDeadzone)
                     {
-                        controllerCursorPosition.x += JoystickCursorSensitivity * controllerCursorHorizontalSpeed * horizj * Time.fixedDeltaTime;
-                        controllerCursorPosition.y += JoystickCursorSensitivity * controllerCursorVerticalSpeed * vertj * Time.fixedDeltaTime;
+                        // Since OnGUI is not fixed, make sure the mouse keeps consistent speed regardless of framerate
+                        // Speed = speed * 0.02 * 60 frames / (1 / unscaledDeltaTime) or speed * 1.2 * unscaledDeltaTime
+                        // 60 frames -> speed * 60 / 60 = speed * 1.0
+                        // 30 frames -> speed * 60 / 30 = speed * 2.0
+                        // 120 frames -> speed * 60 / 120 = speed * 0.5
+                        controllerCursorPosition.x += JoystickCursorSensitivity * controllerCursorHorizontalSpeed * horizj * 1.2f * Time.unscaledDeltaTime;
+                        controllerCursorPosition.y += JoystickCursorSensitivity * controllerCursorVerticalSpeed * vertj * 1.2f * Time.unscaledDeltaTime;
                     }
 
                     controllerCursorPosition.x = Mathf.Clamp(controllerCursorPosition.x, 0, Screen.width);

--- a/Assets/Scripts/Game/PlayerMouseLook.cs
+++ b/Assets/Scripts/Game/PlayerMouseLook.cs
@@ -174,8 +174,13 @@ namespace DaggerfallWorkshop.Game
 
             if (InputManager.Instance.UsingController)
             {
-                sensitivityX = sensitivity.x * joystickSensitivityScale;
-                sensitivityY = sensitivity.y * joystickSensitivityScale;
+                // Make sure it keeps consistent speed regardless of framerate
+                // Speed = speed * 60 frames / (1 / unscaledDeltaTime) or speed * 60 * unscaledDeltaTime
+                // 60 frames -> speed * 60 / 60 = speed * 1.0
+                // 30 frames -> speed * 60 / 30 = speed * 2.0
+                // 120 frames -> speed * 60 / 120 = speed * 0.5
+                sensitivityX = sensitivity.x * joystickSensitivityScale * 60f * Time.unscaledDeltaTime;
+                sensitivityY = sensitivity.y * joystickSensitivityScale * 60f * Time.unscaledDeltaTime;
             }
             else
             {


### PR DESCRIPTION
Using the Steam Deck and capping the framerate, I noticed that if I set the game to 30 fps, the cursor and controller-look moved half as fast, 15 fps a quarter speed, and 60 the desired speed.

This commit fixes the issue by adding a multiplier with an inverse relationship where if the frames go down, the speed goes up and vice versa.

You can test the different speeds by adding an Awake function and comparing:

```cs
void Awake()
{
    Application.targetFrameRate = 30;
}
```