### PR TITLE
Prevent setting null values for setting text in TextBox and TextLabel with empty string

### DIFF
--- a/Assets/Scripts/Game/UserInterface/TextBox.cs
+++ b/Assets/Scripts/Game/UserInterface/TextBox.cs
@@ -69,13 +69,17 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public string Text
         {
             get { return text; }
-            set { text = value; SetCursorPosition(text.Length); }
+            set
+            {
+                text = value ?? string.Empty;
+                SetCursorPosition(text.Length);
+            }
         }
 
         public string DefaultText
         {
             get { return defaultText; }
-            set { defaultText = value; }
+            set { defaultText = value ?? string.Empty; }
         }
 
         public string ResultText

--- a/Assets/Scripts/Game/UserInterface/TextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/TextLabel.cs
@@ -295,6 +295,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         protected virtual void SetText(string value)
         {
+            if (value == null)
+                value = string.Empty;
+
             // Truncate string to max characters
             if (maxCharacters != -1)
                 value = value.Substring(0, Math.Min(value.Length, maxCharacters));


### PR DESCRIPTION
Setting these values to null would create exceptions elsewhere in their respective classes, including in the `set` action for TextBox.Text and TextLabel.Text.