### PR TITLE
Quest can target Individual Static NPCs outside of dungeons

### DIFF
--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -266,7 +266,8 @@ namespace DaggerfallWorkshop.Game.Guilds
                 guildGroup = (FactionFile.GuildGroups)factionData.ggroup;
 
                 // Handle temples nested under deity
-                if (factionData.children != null && (guildGroup == FactionFile.GuildGroups.None && factionData.children.Count > 0))
+                if (factionData.type == (int)FactionFile.FactionTypes.God
+                    && factionData.children != null && (guildGroup == FactionFile.GuildGroups.None && factionData.children.Count > 0))
                 {
                     FactionFile.FactionData firstChild;
                     if (persistentFactionData.GetFactionData(factionData.children[0], out firstChild))

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -1293,6 +1293,44 @@ namespace DaggerfallWorkshop.Game.Questing
         }
 
         /// <summary>
+        /// Checks if NPC is a special individual NPC, then sets it up with components required for quests.
+        /// If the NPC has an Individual faction, and the NPC is currently placed somewhere else in a quest,
+        /// the GameObject will be deactivated
+        /// </summary>
+        /// <param name="go">GameObject representing the static NPC</param>
+        /// <param name="factionID">Faction ID of the NPC</param>
+        /// <returns></returns>
+        public bool SetupIndividualStaticNPC(GameObject go, int factionID)
+        {
+            if (IsIndividualNPC(factionID))
+            {
+                // Check if NPC has been placed elsewhere on a quest
+                if (IsIndividualQuestNPCAtSiteLink(factionID))
+                {
+                    // Disable individual NPC if placed elsewhere
+                    go.SetActive(false);
+                    return false;
+                }
+                else
+                {
+                    // Always add QuestResourceBehaviour to individual NPC
+                    // This is required to bootstrap quest as often questor is not set until after player clicks resource
+                    QuestResourceBehaviour questResourceBehaviour = go.AddComponent<QuestResourceBehaviour>();
+                    Person[] activePersonResources = QuestMachine.Instance.ActiveFactionPersons(factionID);
+                    if (activePersonResources != null && activePersonResources.Length > 0)
+                    {
+                        Person person = activePersonResources[0];
+                        questResourceBehaviour.AssignResource(person);
+                        person.QuestResourceBehaviour = questResourceBehaviour;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+
+        /// <summary>
         /// Walks SiteLink > Quest > Place > QuestMarkers > Target to see if an individual NPC has been placed elsewhere.
         /// Used only to determine if an individual NPC should be disabled at home location by layout builders.
         /// Ignores non-individual NPCs.

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -21,6 +21,7 @@ using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.Banking;
 using DaggerfallWorkshop.Game.Guilds;
+using DaggerfallWorkshop.Game.Questing;
 
 namespace DaggerfallWorkshop
 {
@@ -975,6 +976,10 @@ namespace DaggerfallWorkshop
                 else if (buildingData.buildingType == DFLocation.BuildingTypes.House2 && buildingData.factionID != 0 && !isMemberOfBuildingGuild)
                 {
                     go.SetActive(false);
+                }
+                else
+                {
+                    QuestMachine.Instance.SetupIndividualStaticNPC(go, obj.FactionID);
                 }
             }
         }

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1226,28 +1226,7 @@ namespace DaggerfallWorkshop.Utility
             // Special handling for individual NPCs found in layout data
             // This NPC may be used in 0 or more active quests at home
             int factionID = obj.Resources.FlatResource.FactionOrMobileId;
-            if (QuestMachine.Instance.IsIndividualNPC(factionID))
-            {
-                // Check if NPC has been placed elsewhere on a quest
-                if (QuestMachine.Instance.IsIndividualQuestNPCAtSiteLink(factionID))
-                {
-                    // Disable individual NPC if placed elsewhere
-                    go.SetActive(false);
-                }
-                else
-                {
-                    // Always add QuestResourceBehaviour to individual NPC
-                    // This is required to bootstrap quest as often questor is not set until after player clicks resource
-                    QuestResourceBehaviour questResourceBehaviour = go.AddComponent<QuestResourceBehaviour>();
-                    Person[] activePersonResources = QuestMachine.Instance.ActiveFactionPersons(factionID);
-                    if (activePersonResources != null && activePersonResources.Length > 0)
-                    {
-                        Person person = activePersonResources[0];
-                        questResourceBehaviour.AssignResource(person);
-                        person.QuestResourceBehaviour = questResourceBehaviour;
-                    }
-                }
-            }
+            QuestMachine.Instance.SetupIndividualStaticNPC(go, factionID);
 
             // Disable enemy editor flats
             if (archive == TextureReader.EditorFlatsTextureArchive && (record == 15 || record == 16))

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -17,6 +17,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game;
 using System.Linq;
+using DaggerfallWorkshop.Game.Questing;
 
 namespace DaggerfallWorkshop.Utility
 {
@@ -373,6 +374,8 @@ namespace DaggerfallWorkshop.Utility
                     // Add StaticNPC behaviour
                     StaticNPC npc = go.AddComponent<StaticNPC>();
                     npc.SetLayoutData(obj, mapId, locationIndex);
+
+                    QuestMachine.Instance.SetupIndividualStaticNPC(go, obj.FactionID);
                 }
             }
         }
@@ -447,6 +450,8 @@ namespace DaggerfallWorkshop.Utility
                         // Add StaticNPC behaviour
                         StaticNPC npc = go.AddComponent<StaticNPC>();
                         npc.SetLayoutData(obj, mapId, locationIndex);
+
+                        QuestMachine.Instance.SetupIndividualStaticNPC(go, obj.FactionID);
                     }
 
                     // If this is a light flat, import light prefab


### PR DESCRIPTION
For example, mods can add NPCs with unused faction IDs (ex: Lady Doryanna Flyte) to normal city Palaces. Unlike Daggerfall, Sentinel, and Wayrest Palace, the other palaces aren't dungeons, and previously no QuestResourceBehaviour would be allocated to Individual NPCs in RMBs (RDBLayout.AddFlat is what's handling that for vanilla Main Quest NPCs). This changelist adds the QuestResourceBehaviour component for Individuals NPCs in DaggerfallInteriors and RMB exteriors.

Impact:
- Classic NPCs with garbage faction ids corresponding to Individual factions (ex: Lord Kilbar) will now have an extra QuestResourceBehaviour component

Tested with:
- Famous Faces of the Iliac Bay (mod)
- Test quest here: [testface.txt](https://github.com/Interkarma/daggerfall-unity/files/8645740/testface.txt)
- Go to Anticlere Palace and `startquest testface`. Click on Lord Flyte (he's on the third floor) to start the quest.

Without the changes, `clicked npc _npc_` won't recognize Lord Flyte.


I also fixed an issue where non-God factions would check their child factions for guilds, which would break on Knight Order logic. For example, Lady Flyte has the Knights of the Flame as child faction, but 400 does not represent the Orders enum. This would cause GuildManager.GetGuild to throw an exception. This made quests involving custom Individual NPCs spam errors in the log, though DFU handles it gracefully, so this change is not necessary.

Impact:
- Hopefully this code path was really only used by deities...