### PR TITLE
CreateCharClassQuestion: Allow scrolling with controller right stick

### DIFF
--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -1199,6 +1199,41 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
+        /// <summary>
+        /// Calculates UI scroll movement value based on analog axes input.
+        /// Return value:
+        /// Positive values (> 0.1f) - scrolling downwards
+        /// Negative values (< -0.1f) - scrolling upwards
+        /// </summary>
+        public float GetUIScrollMovement()
+        {
+            float horizontal = Input.GetAxis(cameraAxisBindingCache[0]);
+            float vertical = Input.GetAxis(cameraAxisBindingCache[1]);
+
+            if (GetAxisActionInversion(AxisActions.CameraHorizontal))
+                horizontal *= -1;
+
+            if (GetAxisActionInversion(AxisActions.CameraVertical))
+                vertical *= -1;
+
+            float calculatedDeadzone = Mathf.Sqrt(horizontal * horizontal + vertical * vertical);
+            if (calculatedDeadzone <= JoystickDeadzone)
+                return 0.0f;
+
+            /*
+             * With most controllers, positive values on vertical axis usually mean that stick is being tilted upwards.
+             * Similarly, negative values mean that stick is tilted downwards.
+             *
+             * Most common behavior when scrolling is to scroll in the same direction, where the stick is being tilted.
+             * So to achieve this we need to invert vertical axis value.
+             * This issue does not occur with horizontal axis - right tilt is being interpreted as scrolling downwards.
+             */
+            vertical *= -1;
+
+            // Use both analog axes for scrolling movement - for now it doesn't matter which axis we use for scrolling
+            return horizontal + vertical;
+        }
+
         #endregion
 
         #region Public Static Methods

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharClassQuestions.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharClassQuestions.cs
@@ -180,6 +180,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             else if (Input.GetKeyDown(KeyCode.C))
                 AnswerAndPlayAnim(2);
 
+            float movement = InputManager.Instance.GetUIScrollMovement();
+            if (movement > 0.1f)
+                NativePanel_OnMouseScrollDown(null);
+            else if (movement < -0.1f)
+                NativePanel_OnMouseScrollUp(null);
+
             // User is scrolling with a mouseclick
             if (isScrolling)
             {


### PR DESCRIPTION
I tried playing this game on Steam Deck, but I was unable to scroll through questionnaire during character creation (it doesn't react to any input, apart from clicking first visible answer).

I have quickly hacked a solution for this - simulating mouse scroll down event when right stick is being used (though possibly actual scrolling code could have been moved to separate function [so we won't call function with misleading name when using controller input], but I decided to leave it as it is).

Also I made it react to both axes - I have tested this on controller emulator first (because I didn't have any to plug to my dev PC) and it apparently doesn't output proper vertical values. So this version works fine both on Deck and with controller emulator.