### PR TITLE
Fixed multiple calls to Billboard.SetMaterial

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -338,7 +338,9 @@ namespace DaggerfallWorkshop
             // Add NPC trigger collider
             if (summary.FlatType == FlatTypes.NPC)
             {
-                Collider col = gameObject.AddComponent<BoxCollider>();
+                Collider col = gameObject.GetComponent<BoxCollider>();
+                if(col == null)
+                    col = gameObject.AddComponent<BoxCollider>();
                 col.isTrigger = true;
             }
 


### PR DESCRIPTION
It was observed while using the World Data Editor that multiple calls to `SetMaterial` on NPC Billboards causes many Box Colliders to be added.

![image](https://user-images.githubusercontent.com/5789925/168285930-77f0b594-ed11-48cc-af69-7d564f75b60c.png)

This probably doesn't occur in gameplay, but I don't think my fix hurts gameplay either, so might as well be more robust here.