### PR TITLE
Made ShowSkillsDialog() protected virtual to allow overriding by mods

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -270,7 +270,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             button.OnMouseClick += StatButton_OnMouseClick;
         }
 
-        void ShowSkillsDialog(List<DFCareer.Skills> skills, bool twoColumn = false)
+        protected virtual void ShowSkillsDialog(List<DFCareer.Skills> skills, bool twoColumn = false)
         {
             bool secondColumn = false;
             bool showHandToHandDamage = false;


### PR DESCRIPTION
I changed the signature of `DaggerfallCharacterSheetWindow.ShowSkillsDialog()` to `protected virtual` to allow mods such as[ Viewable Skill Progress](https://www.nexusmods.com/daggerfallunity/mods/298) to override it and display a custom popup with the skills.

Right now this mod creates another set of buttons on top of the originals (primary, major, minor, misc skills) to add an extra popup showing the progress of the skills when clicked, because it does not have access to modify the behavior of the original buttons.

After applying this change, I could remove all that duplicated button and click handler code from that mod and display the skill progress together with the levels in a single popup.

Since the original behavior of this method just displays a popup and doesn't change anything persistently, I think it is safe to allow the override for it.

This is my first ever contribution attempt to this project, please excuse if I do not conform to some conventions or did something wrong, it was just my idea to improve this as I didn't like that double popup :)