### PR TITLE
Start difficulty dagger trail in correct place

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharCustomClass.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharCustomClass.cs
@@ -473,8 +473,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 daggerY = Math.Min(maxDaggerY, (int)(defaultDaggerY + (41 * (-difficultyPoints / 12f))));
             }
 
-            DaggerfallUI.Instance.StartCoroutine(AnimateDagger());
             daggerPanel.Position = new Vector2(defaultDaggerX, daggerY);
+            DaggerfallUI.Instance.StartCoroutine(AnimateDagger());
         }
 
         IEnumerator AnimateDagger()


### PR DESCRIPTION
When the custom class creator window appears, the difficulty dagger trail starts at the top left of the screen and fades out. This moves it to the correct position at the start.