### PR TITLE
Allow overriding standard guild services

### DIFF
--- a/Assets/Scripts/Game/Guilds/Services.cs
+++ b/Assets/Scripts/Game/Guilds/Services.cs
@@ -342,6 +342,11 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public static string GetServiceLabelText(GuildServices service)
         {
+            // Check custom names
+            string serviceName;
+            if (customNpcServiceNames.TryGetValue((int)service, out serviceName))
+                return serviceName;
+
             switch (service)
             {
                 case GuildServices.Training:
@@ -385,16 +390,17 @@ namespace DaggerfallWorkshop.Game.Guilds
                     return TextManager.Instance.GetLocalizedText("serviceReceiveHouse");
 
                 default:
-                    string serviceName;
-                    if (customNpcServiceNames.TryGetValue((int)service, out serviceName))
-                        return serviceName;
-                    else
-                        return "?";
+                    return "?";
             }
         }
 
         public static DaggerfallShortcut.Buttons GetServiceShortcutButton(GuildServices service)
         {
+            // Check custom shortcut buttons
+            DaggerfallShortcut.Buttons serviceButton;
+            if (customNpcServiceButtons.TryGetValue((int)service, out serviceButton))
+                return serviceButton;
+
             switch (service)
             {
                 case GuildServices.Training:
@@ -438,11 +444,7 @@ namespace DaggerfallWorkshop.Game.Guilds
                     return DaggerfallShortcut.Buttons.GuildsReceiveHouse;
 
                 default:
-                    DaggerfallShortcut.Buttons serviceButton;
-                    if (customNpcServiceButtons.TryGetValue((int)service, out serviceButton))
-                        return serviceButton;
-                    else
-                        return DaggerfallShortcut.Buttons.None;
+                    return DaggerfallShortcut.Buttons.None;
             }
         }
 

--- a/Assets/Scripts/Game/Guilds/Services.cs
+++ b/Assets/Scripts/Game/Guilds/Services.cs
@@ -342,7 +342,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public static string GetServiceLabelText(GuildServices service)
         {
-            // Check custom names
+            // Check custom service labels
             string serviceName;
             if (customNpcServiceNames.TryGetValue((int)service, out serviceName))
                 return serviceName;

--- a/Assets/Scripts/Game/Guilds/Services.cs
+++ b/Assets/Scripts/Game/Guilds/Services.cs
@@ -210,6 +210,17 @@ namespace DaggerfallWorkshop.Game.Guilds
             return false;
         }
 
+        public static bool RegisterGuildService(GuildServices serviceId, CustomGuildService service)
+        {
+            DaggerfallUnity.LogMessage("RegisterGuildService: " + serviceId, true);
+            if (!guildNpcServices.ContainsKey((int)serviceId))
+            {
+                customNpcServices.Add((int)serviceId, service);
+                return true;
+            }
+            return false;
+        }
+
         public static bool RegisterGuildService(int npcFactionId, CustomGuildService service, string serviceName, DaggerfallShortcut.Buttons serviceButton = DaggerfallShortcut.Buttons.None)
         {
             DaggerfallUnity.LogMessage("RegisterGuildService: " + npcFactionId + " with service: " + serviceName, true);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -322,6 +322,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
                 return;
             }
+
+            // Handle custom service
+            Services.CustomGuildService customService;
+            if (Services.GetCustomGuildService((int)service, out customService))
+            {
+                CloseWindow();
+                customService(this);
+                return;
+            }
+
             // Handle known service
             DaggerfallTradeWindow tradeWindow;
             switch (service)
@@ -433,11 +443,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
                 default:
                     CloseWindow();
-                    Services.CustomGuildService customService;
-                    if (Services.GetCustomGuildService((int)service, out customService))
-                        customService(this);
-                    else
-                        DaggerfallUI.MessageBox("Guild service not yet implemented.");
+                    DaggerfallUI.MessageBox("Guild service not yet implemented.");
                     break;
             }
         }


### PR DESCRIPTION
his allows standard service handling to be replaced by mods.

Examples:

```
// Override cure service without changing label or shortcut key
Services.RegisterGuildService(GuildServices.CureDisease, CustomCureService);

// Override cure service, changing label
Services.RegisterGuildService((int)GuildServices.CureDisease, CustomCureService, "Custom Cure");
```