### PR TITLE
Per-enemy name for custom enemies

### DIFF
--- a/Assets/Scripts/Game/TextManager.cs
+++ b/Assets/Scripts/Game/TextManager.cs
@@ -360,7 +360,13 @@ namespace DaggerfallWorkshop.Game
             // Handle custom enemies
             else
             {
-                // TODO: maybe go through TextProvider so mods can try to offer localization?
+                string name = DaggerfallUnity.Instance.TextProvider.GetCustomEnemyName(enemyID);
+                if (!string.IsNullOrEmpty(name))
+                {
+                    return name;
+                }
+
+                // Fallback to career name
                 DaggerfallConnect.DFCareer career = DaggerfallEntity.GetCustomCareerTemplate(enemyID);
                 if (career == null)
                 {

--- a/Assets/Scripts/Utility/FallbackTextProvider.cs
+++ b/Assets/Scripts/Utility/FallbackTextProvider.cs
@@ -191,6 +191,17 @@ namespace DaggerfallWorkshop.Utility
         }
 
         /// <summary>
+        /// Gets the name associated with a custom enemy id (ie: not defined in MobileTypes).
+        /// Returns null if the enemy id is unknown.
+        /// </summary>
+        /// <param name="enemyId">Custom enemy id</param>
+        /// <returns>Name if the enemy id is known, null otherwise</returns>
+        public virtual string GetCustomEnemyName(int enemyId)
+        {
+            return fallback.GetCustomEnemyName(enemyId);
+        }
+
+        /// <summary>
         /// Attempts to read a localized string from a named table collection.
         /// </summary>
         /// <param name="collection">Name of table collection.</param>

--- a/Assets/Scripts/Utility/TextProvider.cs
+++ b/Assets/Scripts/Utility/TextProvider.cs
@@ -126,6 +126,14 @@ namespace DaggerfallWorkshop.Utility
         int GetStatDescriptionTextID(DFCareer.Stats stat);
 
         /// <summary>
+        /// Gets the name associated with a custom enemy id (ie: not defined in MobileTypes).
+        /// Returns null if the enemy id is unknown.
+        /// </summary>
+        /// <param name="enemyId">Custom enemy id</param>
+        /// <returns>Name if the enemy id is known, null otherwise</returns>
+        string GetCustomEnemyName(int enemyId);
+
+        /// <summary>
         /// Attempts to read a localized string from a named table collection.
         /// </summary>
         /// <param name="collection">Name of table collection.</param>
@@ -139,6 +147,7 @@ namespace DaggerfallWorkshop.Utility
         /// </summary>
         /// <param name="enable">True to enable, false to disable.</param>
         void EnableLocalizedStringDebug(bool enable);
+
     }
 
     /// <summary>
@@ -593,6 +602,12 @@ namespace DaggerfallWorkshop.Utility
                 default:
                     return -1;
             }
+        }
+
+        // This interface function is meant for mods, the default TextProvider implementation does not know any custom enemy
+        public string GetCustomEnemyName(int enemyId)
+        {
+            return null;
         }
 
         #region Protected Methods


### PR DESCRIPTION
Added ability for mods to provider per enemy name through a new TextProvider function. Previously, custom enemies could only be named after their career name.

This removes a TODO I left last year :)

Usage example: 
https://github.com/SquidKamer/DaggerfallBestiaryProject/blob/feat/enemy-name/Scripts/BestiaryTextProvider.cs#L16

For custom enemies, it makes sense to me that mods should be able to reuse the same DFCareer for multiple enemy ids. For example, a mod might have a Goblin Soldier, a Goblin Archer, and a Goblin Skirmisher, all using the same Goblin career. Before this change, however, info-clicking the goblin would always say "You see a Goblin" - you'd need a unique career for each to get their unique name.

This change allows the career reuse.