### PR TITLE
Fixed "has bow attack" crash for custom enemy casters

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -117,7 +117,12 @@ namespace DaggerfallWorkshop.Game
             attack = GetComponent<EnemyAttack>();
 
             // Only need to check for ability to shoot bow once.
-            hasBowAttack = mobile.Enemy.HasRangedAttack1 && mobile.Enemy.ID > 129 && mobile.Enemy.ID != 132;
+            // A mobile has a bow attack if:
+            //   - it has RangedAttack1 and does not cast magic (ex: Mage, Healer, ...), or 
+            //   - it has both RangedAttack1 and RangedAttack2 (ex: Nightblade)
+            // If a mobile only has RangedAttack1 and casts magic, then its ranged attack is only shooting spells, not shooting a bow
+            hasBowAttack =
+                (mobile.Enemy.HasRangedAttack1 && (!mobile.Enemy.CastsMagic || mobile.Enemy.HasRangedAttack2));
 
             // Add things AI should ignore when checking for a clear path to shoot.
             ignoreMaskForShooting = ~(1 << LayerMask.NameToLayer("SpellMissiles") | 1 << LayerMask.NameToLayer("Ignore Raycast"));


### PR DESCRIPTION
(could have sworn I'd fixed that in #2163 ...)

Previously, EnemyMotor's "hasBowAttack" check was hardcoded to be true for enemy ids above 129 and not equal to 132.
This is obviously a problem for custom enemies, which use IDs above 129 and not equal to 132. If they don't have ranged attack animations, their mobile crashes.

I changed the logic so that it stays the same for DF class enemies, while allowing the full logic to be accessible to custom enemies.

If an enemy uses neither spells nor bows:
- HasRangedAttack1 is false

If an enemy only casts spells:
- HasRangedAttack1 is true
- HasRangedAttack2 is not true
- CastsMagic is true

If an enemy only shoots bows:
- HasRangedAttack1 is true
- HasRangedAttack2 is not true
- CastsMagic is not true

If an enemy uses both spells and bows:
- HasRangedAttack1 is true
- HasRangedAttack2 is true
- CastsMagic is true

