### PR TITLE
Fixed "PayMoney" quest action infinite money drain

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/PayMoney.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PayMoney.cs
@@ -89,6 +89,8 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                     }
                 }
             }
+
+            SetComplete();
         }
 
         #region Serialization


### PR DESCRIPTION
Issue reported here:
https://old.reddit.com/r/Daggerfall/comments/vjsdkn/disappearing_gold_glitch_unity_a_cohort_of_the/

Quest in question:
https://github.com/JayH2971/dfunity-questpacks/blob/master/QP1/QuestPacks/QP1/Temples/JHTP111.txt

The custom DFU quest action "PayMoney" was missing a call to `SetComplete()`. Therefore, the task would infinitely try to pay the specified amount, rather than only once as expected.