### PR TITLE
Custom enemy support in RDB

### DIFF
--- a/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditor.cs
+++ b/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditor.cs
@@ -934,13 +934,7 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
                 obj.Type = DFBlock.RdbResourceTypes.Flat;
                 obj.Resources.FlatResource.TextureArchive = int.Parse(selectedObjectID.Split('.')[0]);
                 obj.Resources.FlatResource.TextureRecord = int.Parse(selectedObjectID.Split('.')[1]);
-
-                // Only add "Custom Marker" flag to this marker for now
-                // Some markers (ex: Random Monster) may use Flags differently
-                if (selectedObjectID == "199.16") // Marker: Monster
-                {
-                    obj.Resources.FlatResource.Flags |= RDBLayout.CustomMarkerFlag;
-                }
+                obj.Resources.FlatResource.IsCustomData = true;
 
                 go = WorldDataEditorDungeonHelper.AddFlatObject(obj);
                 if (go != null)

--- a/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditor.cs
+++ b/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditor.cs
@@ -13,6 +13,7 @@ using UnityEngine;
 using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility.AssetInjection;
+using DaggerfallWorkshop.Utility;
 
 namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
 {
@@ -933,6 +934,14 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
                 obj.Type = DFBlock.RdbResourceTypes.Flat;
                 obj.Resources.FlatResource.TextureArchive = int.Parse(selectedObjectID.Split('.')[0]);
                 obj.Resources.FlatResource.TextureRecord = int.Parse(selectedObjectID.Split('.')[1]);
+
+                // Only add "Custom Marker" flag to this marker for now
+                // Some markers (ex: Random Monster) may use Flags differently
+                if(selectedObjectID == "199.16") // Marker: Monster
+                {
+                    obj.Resources.FlatResource.Flags |= RDBLayout.CustomMarkerFlag;
+                }
+
                 go = WorldDataEditorDungeonHelper.AddFlatObject(obj);
                 if (go != null)
                 {

--- a/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditor.cs
+++ b/Assets/Game/Addons/WorldDataEditor/Editor/WorldDataEditor.cs
@@ -937,7 +937,7 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
 
                 // Only add "Custom Marker" flag to this marker for now
                 // Some markers (ex: Random Monster) may use Flags differently
-                if(selectedObjectID == "199.16") // Marker: Monster
+                if (selectedObjectID == "199.16") // Marker: Monster
                 {
                     obj.Resources.FlatResource.Flags |= RDBLayout.CustomMarkerFlag;
                 }

--- a/Assets/Game/Addons/WorldDataEditor/WorldDataEditorObject.cs
+++ b/Assets/Game/Addons/WorldDataEditor/WorldDataEditorObject.cs
@@ -43,6 +43,7 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
             {
                 id = obj.Resources.FlatResource.TextureArchive + "." + obj.Resources.FlatResource.TextureRecord;
                 factionID = (short)obj.Resources.FlatResource.FactionOrMobileId;
+                flags = (byte)obj.Resources.FlatResource.Flags;
             }
             else if (type == DataType.Light)
             {

--- a/Assets/Game/Addons/WorldDataEditor/WorldDataEditorObject.cs
+++ b/Assets/Game/Addons/WorldDataEditor/WorldDataEditorObject.cs
@@ -43,7 +43,6 @@ namespace DaggerfallWorkshop.Game.Utility.WorldDataEditor
             {
                 id = obj.Resources.FlatResource.TextureArchive + "." + obj.Resources.FlatResource.TextureRecord;
                 factionID = (short)obj.Resources.FlatResource.FactionOrMobileId;
-                flags = (byte)obj.Resources.FlatResource.Flags;
             }
             else if (type == DataType.Light)
             {

--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -1057,6 +1057,11 @@ namespace DaggerfallConnect
 
             /// <summary>Action flag.</summary>
             public Byte Action;
+
+            /* DFU custom fields */
+
+            /// <summary>True if the data is custom data placed by a DFU tool. False if the data comes from arena2</summary>
+            public bool IsCustomData;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -78,7 +78,10 @@ namespace DaggerfallWorkshop.Game
         {
             DaggerfallUnity dfUnity = DaggerfallUnity.Instance;
             Dictionary<int, MobileEnemy> enemyDict = GameObjectHelper.EnemyDict;
-            MobileEnemy mobileEnemy = enemyDict[(int)EnemyType];
+
+            if (!enemyDict.TryGetValue((int)EnemyType, out MobileEnemy mobileEnemy))
+                return;
+
             if (AlliedToPlayer)
                 mobileEnemy.Team = MobileTeams.PlayerAlly;
 

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -210,8 +210,13 @@ namespace DaggerfallWorkshop
                 {
                     summary.IsMobile = true;
                     summary.EditorFlatType = EditorFlatTypes.FixedMobile;
-                    summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID & 0xff);
-                }
+
+                    bool isCustomMarker = (summary.Flags & RDBLayout.CustomMarkerFlag) == RDBLayout.CustomMarkerFlag;
+                    if (!isCustomMarker)
+                        summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID & 0xff);
+                    else
+                        summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID);
+                }       
                 else if (resource.TextureRecord == 10) // Start marker. Holds data for dungeon block water level and castle block status.
                 {
                     if (resource.SoundIndex != 0)

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -211,7 +211,7 @@ namespace DaggerfallWorkshop
                     summary.IsMobile = true;
                     summary.EditorFlatType = EditorFlatTypes.FixedMobile;
 
-                    bool isCustomMarker = (summary.Flags & RDBLayout.CustomMarkerFlag) == RDBLayout.CustomMarkerFlag;
+                    bool isCustomMarker = resource.IsCustomData;
                     if (!isCustomMarker)
                         summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID & 0xff);
                     else

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -43,8 +43,6 @@ namespace DaggerfallWorkshop.Utility
         const float torchMaxDistance = 5f;
         const float torchVolume = 0.7f;
 
-        public const int CustomMarkerFlag = 128;
-
         #region Structs & Enums
 
         /// <summary>
@@ -1468,7 +1466,7 @@ namespace DaggerfallWorkshop.Utility
 
         private static void AddFixedRDBEnemy(DFBlock.RdbObject obj, Transform parent, ref DFBlock blockData, GameObject[] startMarkers, bool serialize)
         {
-            bool isCustomMarker = (obj.Resources.FlatResource.Flags & CustomMarkerFlag) == CustomMarkerFlag;
+            bool isCustomMarker = obj.Resources.FlatResource.IsCustomData;
 
             if (!isCustomMarker)
             {


### PR DESCRIPTION
It's something @ajrb and I discussed a while ago.

We have a conflicting situation when it comes to the `FactionOrMobileId` field of the `FlatResource` of a Monster marker (archive 199, record 16). 
- classic DF data needs to be masked with `& 0xFF` to get the correct mobile Id
- custom enemies need to support ids bigger than 255

My solution here is to add a bit flag to annotate a marker as "custom" (ie: not from DF data).

Flags usage is a bit hard to find in DFU code, but this is the assumptions I've relied on:
- In DF data, "Monster" marker uses Flags=0 for unspecified gender, Flags=1 for Female, Flags=2 for Male (source: `RDBLayout.AddEnemy`, with `useGenderFlag==true` only for FixedRDB Enemy)
- "Random Monster" marker uses Flags as a seed between 0 and 255 for indexing into the monster spawn table (source: `RDBLayout.AddRandomRDBEnemyClassic`)
- Static NPC flats use `.Flags & 32 == 32` to identify a Female character

To make sure "Random Monster" marker doesn't get affected, I've limited the use of this flag to only the fixed "Monster" marker. I've kept 1 as the Female flag, 2 as the Male flag. If neither are set, the gender is left Unspecified as before.

With this, I can make use of custom monster ids in the WorldData Editor. For example, I've added our mod's id 261 "Medusa" at the start of Privateer's Hold.

![image](https://user-images.githubusercontent.com/5789925/175954194-43b85219-0086-40e3-8cf4-0a002376a538.png)

and once I load in-game, I get one-shot by Kamer's nightmare fuel (might be a bit too dark lol)

![image](https://user-images.githubusercontent.com/5789925/175954379-7e3ba2cb-53b8-4fc3-90e6-6928d5acbd78.png)
