### PR TITLE
Added public property for MobileAsset

### DIFF
--- a/Assets/Scripts/Game/MobilePersonMotor.cs
+++ b/Assets/Scripts/Game/MobilePersonMotor.cs
@@ -55,6 +55,11 @@ namespace DaggerfallWorkshop.Game
         // References
         DaggerfallEntityBehaviour entityBehaviour;
         MobilePersonAsset mobileAsset;
+        public MobilePersonAsset MobileAsset
+        {
+            get { return mobileAsset; }
+            set { mobileAsset = value; }
+        }
 
         #endregion
 


### PR DESCRIPTION
I altered the code to only change one line as suggested in my other PR, which I closed.
Maybe using `public MobilePersonAsset MobileAsset { private get; set; }` would be an alternative without "duplictating" the member. 

Reason for the Change:
`MobilePersonMotor.FindMobilePersonAsset()` instantiates my custom MobilePersonAsset and calls `SetPerson()`. 
My implementations tries to find a 3d model prefab based on the race and gender etc. If it fails it falls back to Billboards.

I do it using this way:

```cs
    //Find parent and get billboard child
    Transform parent = transform.parent;
    GameObject goBillboard = parent.Find("MobilePersonBillboard").gameObject;
    MobilePersonBillboard billboard = goBillboard.GetComponent<MobilePersonBillboard>();

    //Activate billboard, reset correct asset to the motor, and destroy this instance
    goBillboard.SetActive(true);
    this.gameObject.SetActive(false);
--> parent.gameObject.GetComponent<MobilePersonMotor>().MobileAsset = billboard;
    billboard.SetPerson(race, gender, personVariant, isGuard, personFaceVariant, personFaceRecordId);

    Destroy(this.gameObject);
    return;
```

I want to prevent duplicating the whole code of  `MobilePersonBillboard` in my own implementation, which is based around 3D Models. 

(Also I had to close the previous PR, because I forgot to do it from within a custom branch)