### PR TITLE
Update Jetbrains Rider Editor package to latest version.

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
     "com.unity.addressables": "1.19.11",
-	"com.unity.burst": "1.7.1",
+    "com.unity.burst": "1.7.1",
     "com.unity.collab-proxy": "1.2.16",
-	"com.unity.collections": "0.9.0-preview.6",
-    "com.unity.ide.rider": "1.2.1",
+    "com.unity.collections": "0.9.0-preview.6",
+    "com.unity.ide.rider": "3.0.15",
     "com.unity.ide.visualstudio": "2.0.8",
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.jobs": "0.2.10-preview.13",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -48,11 +48,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "1.2.1",
+      "version": "3.0.15",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
The Jetbrains Rider Editor package that DFU currently uses is locked to v1.2.1. This package is not compatible with the current version of Rider, which causes a number of issues. Some of the ones I've noticed are:

- The External Script Editor option is labelled as "Rider.exe" rather than the program's name and version.
- Project files can't be regenerated from the Unity editor.
- Rider complains about missing Unity classes.
- Autocomplete doesn't suggest anything from the Unity API.

I haven't noticed any issues caused by telling the Editor to use the latest version of this package instead of the one recommended for this version of Unity.