### PR TITLE
Log exceptions that occur when importing a Classic save

### DIFF
--- a/Assets/Scripts/API/Save/SaveGames.cs
+++ b/Assets/Scripts/API/Save/SaveGames.cs
@@ -4,8 +4,8 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
-// 
+// Contributors:
+//
 // Notes:
 //
 
@@ -17,6 +17,8 @@ using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop;
 using DaggerfallWorkshop.Game;
+using UnityEngine;
+
 #endregion
 
 namespace DaggerfallConnect.Save
@@ -275,8 +277,9 @@ namespace DaggerfallConnect.Save
             {
                 return OpenSave(save);
             }
-            catch
+            catch  (Exception e)
             {
+                Debug.LogError($"An Exception occurred while attempting to load Classic save #{save.ToString()}:\n{e}");
                 return false;
             }
         }


### PR DESCRIPTION
While diagnosing an issue someone was having with my mod, I noticed that the SaveGame class' TrySave method checks for if an exception occurred while importing a Classic save, and reports that the save failed to load if this is the case. 

The problem is that this behaviour gives no indication why the exception occurred. This PR changes this behaviour so that the exception that occurred will be logged to the console and log file.