### PR TITLE
Allowing players to exit out of UI screens on a controller

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
@@ -55,7 +55,7 @@ namespace Wenzil.Console
         {
             if (DaggerfallWorkshop.Game.InputManager.Instance.GetKeyDown(toggleKey))
                 ui.ToggleConsole();
-            else if (DaggerfallWorkshop.Game.InputManager.Instance.GetBackKeyDown() && closeOnEscape)
+            else if (DaggerfallWorkshop.Game.InputManager.Instance.GetBackButtonDown() && closeOnEscape)
                 ui.CloseConsole();
             else if (Input.GetKeyDown(KeyCode.UpArrow))
                 NavigateInputHistory(true);

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
@@ -55,7 +55,7 @@ namespace Wenzil.Console
         {
             if (DaggerfallWorkshop.Game.InputManager.Instance.GetKeyDown(toggleKey))
                 ui.ToggleConsole();
-            else if (DaggerfallWorkshop.Game.InputManager.Instance.GetUiExitKeyDown() && closeOnEscape)
+            else if (DaggerfallWorkshop.Game.InputManager.Instance.GetBackKeyDown() && closeOnEscape)
                 ui.CloseConsole();
             else if (Input.GetKeyDown(KeyCode.UpArrow))
                 NavigateInputHistory(true);

--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -55,7 +55,7 @@ namespace Wenzil.Console
         {
             if (DaggerfallWorkshop.Game.InputManager.Instance.GetKeyDown(toggleKey))
                 ui.ToggleConsole();
-            else if (Input.GetKeyDown(KeyCode.Escape) && closeOnEscape)
+            else if (DaggerfallWorkshop.Game.InputManager.Instance.GetUiExitKeyDown() && closeOnEscape)
                 ui.CloseConsole();
             else if (Input.GetKeyDown(KeyCode.UpArrow))
                 NavigateInputHistory(true);

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -513,7 +513,7 @@ namespace DaggerfallWorkshop.Game
                 return;
 
             // Post message to open options dialog on escape during gameplay
-            if (InputManager.Instance.ActionComplete(InputManager.Actions.Escape))
+            if (InputManager.Instance.ActionComplete(InputManager.Actions.Pause))
             {
                 DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenPauseOptionsDialog);
             }

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -1041,12 +1041,12 @@ namespace DaggerfallWorkshop.Game
             return Input.GetMouseButton(button) || (EnableController && GetKey(joystickUICache[button], false));
         }
 
-        public bool GetBackKeyDown()
+        public bool GetBackButtonDown()
         {
             return GetKeyDown(KeyCode.Escape) || (EnableController && GetKeyDown(joystickUICache[3], false));
         }
 
-        public bool GetBackKeyUp()
+        public bool GetBackButtonUp()
         {
             return GetKeyUp(KeyCode.Escape) || (EnableController && GetKeyUp(joystickUICache[3], false));
         }

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -296,12 +296,13 @@ namespace DaggerfallWorkshop.Game
         {
             LeftClick,
             RightClick,
-            MiddleClick
+            MiddleClick,
+            UiExit
         }
 
         public enum Actions
         {
-            Escape,
+            Pause,
             ToggleConsole,
 
             MoveForwards,
@@ -954,7 +955,7 @@ namespace DaggerfallWorkshop.Game
                 setJoystickUIBinding = SetJoystickUIBinding;
             }
 
-            setBinding(KeyCode.Escape, Actions.Escape, true);
+            setBinding(KeyCode.Escape, Actions.Pause, true);
             setBinding(KeyCode.BackQuote, Actions.ToggleConsole, true);
 
             setBinding(KeyCode.W, Actions.MoveForwards, true);
@@ -1015,8 +1016,9 @@ namespace DaggerfallWorkshop.Game
             setAxisBinding("Axis5", AxisActions.CameraVertical);
 
             setJoystickUIBinding(KeyCode.JoystickButton0, JoystickUIActions.LeftClick);
-            setJoystickUIBinding(KeyCode.JoystickButton1, JoystickUIActions.RightClick);
+            setJoystickUIBinding(KeyCode.JoystickButton3, JoystickUIActions.RightClick);
             setJoystickUIBinding(KeyCode.JoystickButton2, JoystickUIActions.MiddleClick);
+            setJoystickUIBinding(KeyCode.JoystickButton1, JoystickUIActions.UiExit);
             UpdateBindingCache();
 
             foreach (AxisActions axisAction in Enum.GetValues(typeof(AxisActions)))
@@ -1079,6 +1081,16 @@ namespace DaggerfallWorkshop.Game
         public bool AnyKeyUpIgnoreAxisBinds
         {
             get => GetAnyKeyUpIgnoreAxisBinds() != KeyCode.None;
+        }
+
+        public bool GetUiExitKeyDown()
+        {
+            return GetKeyDown(KeyCode.Escape) || GetKeyDown(GetJoystickUIBinding(JoystickUIActions.UiExit));
+        }
+
+        public bool GetUiExitKeyUp()
+        {
+            return GetKeyUp(KeyCode.Escape) || GetKeyUp(GetJoystickUIBinding(JoystickUIActions.UiExit));
         }
 
         public KeyCode GetAnyKeyDown()

--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -70,7 +70,7 @@ namespace DaggerfallWorkshop.Game
         Dictionary<int, bool> axisActionInvertDict = new Dictionary<int, bool>();
         Dictionary<KeyCode, JoystickUIActions> joystickUIDict = new Dictionary<KeyCode, JoystickUIActions>();
 
-        KeyCode[] joystickUICache = new KeyCode[3]; //leftClick, rightClick, MiddleClick
+        KeyCode[] joystickUICache = new KeyCode[4]; //leftClick, rightClick, MiddleClick, Back
         String[] cameraAxisBindingCache = new String[2];
         String[] movementAxisBindingCache = new String[2];
         Dictionary<int, bool> modifierHeldFirstDict = new Dictionary<int, bool>();
@@ -297,7 +297,7 @@ namespace DaggerfallWorkshop.Game
             LeftClick,
             RightClick,
             MiddleClick,
-            UiExit
+            Back
         }
 
         public enum Actions
@@ -1018,7 +1018,7 @@ namespace DaggerfallWorkshop.Game
             setJoystickUIBinding(KeyCode.JoystickButton0, JoystickUIActions.LeftClick);
             setJoystickUIBinding(KeyCode.JoystickButton3, JoystickUIActions.RightClick);
             setJoystickUIBinding(KeyCode.JoystickButton2, JoystickUIActions.MiddleClick);
-            setJoystickUIBinding(KeyCode.JoystickButton1, JoystickUIActions.UiExit);
+            setJoystickUIBinding(KeyCode.JoystickButton1, JoystickUIActions.Back);
             UpdateBindingCache();
 
             foreach (AxisActions axisAction in Enum.GetValues(typeof(AxisActions)))
@@ -1039,6 +1039,16 @@ namespace DaggerfallWorkshop.Game
         public bool GetMouseButton(int button)
         {
             return Input.GetMouseButton(button) || (EnableController && GetKey(joystickUICache[button], false));
+        }
+
+        public bool GetBackKeyDown()
+        {
+            return GetKeyDown(KeyCode.Escape) || (EnableController && GetKeyDown(joystickUICache[3], false));
+        }
+
+        public bool GetBackKeyUp()
+        {
+            return GetKeyUp(KeyCode.Escape) || (EnableController && GetKeyUp(joystickUICache[3], false));
         }
 
         public bool GetKey(KeyCode k, bool useSecondary = true)
@@ -1081,16 +1091,6 @@ namespace DaggerfallWorkshop.Game
         public bool AnyKeyUpIgnoreAxisBinds
         {
             get => GetAnyKeyUpIgnoreAxisBinds() != KeyCode.None;
-        }
-
-        public bool GetUiExitKeyDown()
-        {
-            return GetKeyDown(KeyCode.Escape) || GetKeyDown(GetJoystickUIBinding(JoystickUIActions.UiExit));
-        }
-
-        public bool GetUiExitKeyUp()
-        {
-            return GetKeyUp(KeyCode.Escape) || GetKeyUp(GetJoystickUIBinding(JoystickUIActions.UiExit));
         }
 
         public KeyCode GetAnyKeyDown()
@@ -1285,6 +1285,7 @@ namespace DaggerfallWorkshop.Game
             joystickUICache[0] = GetJoystickUIBinding(JoystickUIActions.LeftClick);
             joystickUICache[1] = GetJoystickUIBinding(JoystickUIActions.RightClick);
             joystickUICache[2] = GetJoystickUIBinding(JoystickUIActions.MiddleClick);
+            joystickUICache[3] = GetJoystickUIBinding(JoystickUIActions.Back);
 
             cameraAxisBindingCache[0] = GetAxisBinding(AxisActions.CameraHorizontal);
             cameraAxisBindingCache[1] = GetAxisBinding(AxisActions.CameraVertical);

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharRaceSelect.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharRaceSelect.cs
@@ -75,7 +75,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (InputManager.Instance.GetBackKeyDown())
+            if (InputManager.Instance.GetBackButtonDown())
             {
                 selectedRace = null;
                 CancelWindow();

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharRaceSelect.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharRaceSelect.cs
@@ -75,7 +75,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (Input.GetKeyDown(exitKey))
+            if (InputManager.Instance.GetUiExitKeyDown())
             {
                 selectedRace = null;
                 CancelWindow();

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharRaceSelect.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharRaceSelect.cs
@@ -75,7 +75,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.Update();
 
-            if (InputManager.Instance.GetUiExitKeyDown())
+            if (InputManager.Instance.GetBackKeyDown())
             {
                 selectedRace = null;
                 CancelWindow();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBaseWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBaseWindow.cs
@@ -25,8 +25,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
     /// </summary>
     public abstract class DaggerfallBaseWindow : UserInterfaceWindow
     {
-        public const KeyCode exitKey = KeyCode.Escape;
-
         bool isSetup;
         DaggerfallUnity dfUnity;
         Panel nativePanel = new Panel();

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -297,7 +297,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 if (playerEntity.InPrison)
                 {
-                    if (Input.GetKey(exitKey)) // Speed up prison day countdown. Not in classic.
+                    if (InputManager.Instance.GetUiExitKeyDown()) // Speed up prison day countdown. Not in classic.
                         prisonUpdateInterval = 0.001f;
                     else
                         prisonUpdateInterval = 0.3f;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -297,7 +297,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 if (playerEntity.InPrison)
                 {
-                    if (InputManager.Instance.GetBackKeyDown()) // Speed up prison day countdown. Not in classic.
+                    if (InputManager.Instance.GetBackButtonDown()) // Speed up prison day countdown. Not in classic.
                         prisonUpdateInterval = 0.001f;
                     else
                         prisonUpdateInterval = 0.3f;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCourtWindow.cs
@@ -297,7 +297,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 if (playerEntity.InPrison)
                 {
-                    if (InputManager.Instance.GetUiExitKeyDown()) // Speed up prison day countdown. Not in classic.
+                    if (InputManager.Instance.GetBackKeyDown()) // Speed up prison day countdown. Not in classic.
                         prisonUpdateInterval = 0.001f;
                     else
                         prisonUpdateInterval = 0.3f;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
@@ -34,6 +34,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const string rightClickString = "Right-Click";
         const string middleClickString = "Middle-Click";
         const string leftClickString = "Left-Click";
+        const string uiExitString = "UI Exit";
 
         Color mainPanelBackgroundColor = new Color(0.0f, 0.0f, 0.0f, 1.0f);
         Color keybindButtonBackgroundColor = new Color(0.2f, 0.2f, 0.2f, 1.0f);
@@ -45,6 +46,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected Button leftClickKeybindButton = new Button();
         protected Button middleClickKeybindButton = new Button();
         protected Button rightClickKeybindButton = new Button();
+        protected Button uiExitKeybindButton = new Button();
         protected Button movementHorizontalAxisKeybindButton = new Button();
         protected Button movementVerticalAxisKeybindButton = new Button();
         protected Button lookHorizontalAxisKeybindButton = new Button();
@@ -153,9 +155,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupAxisKeybindButton(lookVerticalAxisKeybindButton,       InputManager.AxisActions.CameraVertical, 115, 80);
             invertLookVerticalCheckbox =        AddOption(158, 100, "Invert", InputManager.Instance.GetAxisActionInversion(InputManager.AxisActions.CameraVertical));
 
-            SetupUIKeybindButton(leftClickKeybindButton, 0, 210, 40);
-            SetupUIKeybindButton(middleClickKeybindButton, 2, 210, 60);
-            SetupUIKeybindButton(rightClickKeybindButton, 1, 210, 80);
+            SetupUIKeybindButton(leftClickKeybindButton, leftClickString, 210, 40);
+            SetupUIKeybindButton(middleClickKeybindButton, middleClickString, 210, 60);
+            SetupUIKeybindButton(rightClickKeybindButton, rightClickString, 210, 80);
+            SetupUIKeybindButton(uiExitKeybindButton, uiExitString, 210, 100);
 
             joystickCameraSensitivitySlider = CreateSlider("Look Sensitivity", 15, 120, 0.1f, 4.0f, DaggerfallUnity.Settings.JoystickLookSensitivity);
 
@@ -199,6 +202,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             UnsavedKeybindDict[leftClickString] = InputManager.Instance.GetKeyString(InputManager.Instance.GetJoystickUIBinding(InputManager.JoystickUIActions.LeftClick));
             UnsavedKeybindDict[middleClickString] = InputManager.Instance.GetKeyString(InputManager.Instance.GetJoystickUIBinding(InputManager.JoystickUIActions.MiddleClick));
             UnsavedKeybindDict[rightClickString] = InputManager.Instance.GetKeyString(InputManager.Instance.GetJoystickUIBinding(InputManager.JoystickUIActions.RightClick));
+            UnsavedKeybindDict[uiExitString] = InputManager.Instance.GetKeyString(InputManager.Instance.GetJoystickUIBinding(InputManager.JoystickUIActions.UiExit));
 
             foreach (InputManager.AxisActions a in Enum.GetValues(typeof(InputManager.AxisActions)))
                 UnsavedKeybindDict[a.ToString()] = InputManager.Instance.GetAxisBinding(a);
@@ -245,7 +249,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         //for "reset defaults" overload
         private void SetupKeybindButton(Button button, string action)
         {
-            if (action == leftClickString || action == middleClickString || action == rightClickString)
+            if (action == leftClickString || action == middleClickString || action == rightClickString || action == uiExitString)
             {
                 var code = InputManager.Instance.ParseKeyCodeString(UnsavedKeybindDict[action]);
                 button.Label.Text = ControlsConfigManager.Instance.GetButtonText(code);
@@ -260,24 +264,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             button.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
         }
 
-        private void SetupUIKeybindButton(Button button, int mouseButton, int x, int y)
+        private void SetupUIKeybindButton(Button button, string text, int x, int y)
         {
-            string action = "";
-
-            switch (mouseButton)
-            {
-                case 0:
-                    action = leftClickString;
-                    break;
-                case 1:
-                    action = rightClickString;
-                    break;
-                case 2:
-                    action = middleClickString;
-                    break;
-            }
-
-            SetupKeybindButton(button, action, x, y);
+            SetupKeybindButton(button, text, x, y);
             button.OnMouseClick += UIKeybindButton_OnMouseClick;
         }
 
@@ -390,6 +379,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupKeybindButton(leftClickKeybindButton, leftClickString);
             SetupKeybindButton(middleClickKeybindButton, middleClickString);
             SetupKeybindButton(rightClickKeybindButton, rightClickString);
+            SetupKeybindButton(uiExitKeybindButton, uiExitString);
             SetupKeybindButton(movementHorizontalAxisKeybindButton, InputManager.AxisActions.MovementHorizontal.ToString());
             SetupKeybindButton(movementVerticalAxisKeybindButton, InputManager.AxisActions.MovementVertical.ToString());
             SetupKeybindButton(lookHorizontalAxisKeybindButton, InputManager.AxisActions.CameraHorizontal.ToString());
@@ -470,7 +460,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             foreach(var action in UnsavedKeybindDict.Keys)
             {
-                if (action == leftClickString || action == middleClickString || action == rightClickString)
+                if (action == leftClickString || action == middleClickString || action == rightClickString || action == uiExitString)
                 {
                     KeyCode code = InputManager.Instance.ParseKeyCodeString(UnsavedKeybindDict[action]);
                     InputManager.JoystickUIActions uiAction = InputManager.JoystickUIActions.LeftClick;
@@ -479,6 +469,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         uiAction = InputManager.JoystickUIActions.MiddleClick;
                     else if (action == rightClickString)
                         uiAction = InputManager.JoystickUIActions.RightClick;
+                    else if (action == uiExitString)
+                        uiAction = InputManager.JoystickUIActions.UiExit;
 
                     KeyCode curCode = InputManager.Instance.GetJoystickUIBinding(uiAction);
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
@@ -34,7 +34,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         const string rightClickString = "Right-Click";
         const string middleClickString = "Middle-Click";
         const string leftClickString = "Left-Click";
-        const string uiExitString = "UI Exit";
+        const string backString = "Back";
 
         Color mainPanelBackgroundColor = new Color(0.0f, 0.0f, 0.0f, 1.0f);
         Color keybindButtonBackgroundColor = new Color(0.2f, 0.2f, 0.2f, 1.0f);
@@ -46,7 +46,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected Button leftClickKeybindButton = new Button();
         protected Button middleClickKeybindButton = new Button();
         protected Button rightClickKeybindButton = new Button();
-        protected Button uiExitKeybindButton = new Button();
+        protected Button backKeybindButton = new Button();
         protected Button movementHorizontalAxisKeybindButton = new Button();
         protected Button movementVerticalAxisKeybindButton = new Button();
         protected Button lookHorizontalAxisKeybindButton = new Button();
@@ -158,7 +158,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupUIKeybindButton(leftClickKeybindButton, leftClickString, 210, 40);
             SetupUIKeybindButton(middleClickKeybindButton, middleClickString, 210, 60);
             SetupUIKeybindButton(rightClickKeybindButton, rightClickString, 210, 80);
-            SetupUIKeybindButton(uiExitKeybindButton, uiExitString, 210, 100);
+            SetupUIKeybindButton(backKeybindButton, backString, 210, 100);
 
             joystickCameraSensitivitySlider = CreateSlider("Look Sensitivity", 15, 120, 0.1f, 4.0f, DaggerfallUnity.Settings.JoystickLookSensitivity);
 
@@ -202,7 +202,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             UnsavedKeybindDict[leftClickString] = InputManager.Instance.GetKeyString(InputManager.Instance.GetJoystickUIBinding(InputManager.JoystickUIActions.LeftClick));
             UnsavedKeybindDict[middleClickString] = InputManager.Instance.GetKeyString(InputManager.Instance.GetJoystickUIBinding(InputManager.JoystickUIActions.MiddleClick));
             UnsavedKeybindDict[rightClickString] = InputManager.Instance.GetKeyString(InputManager.Instance.GetJoystickUIBinding(InputManager.JoystickUIActions.RightClick));
-            UnsavedKeybindDict[uiExitString] = InputManager.Instance.GetKeyString(InputManager.Instance.GetJoystickUIBinding(InputManager.JoystickUIActions.UiExit));
+            UnsavedKeybindDict[backString] = InputManager.Instance.GetKeyString(InputManager.Instance.GetJoystickUIBinding(InputManager.JoystickUIActions.Back));
 
             foreach (InputManager.AxisActions a in Enum.GetValues(typeof(InputManager.AxisActions)))
                 UnsavedKeybindDict[a.ToString()] = InputManager.Instance.GetAxisBinding(a);
@@ -249,7 +249,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         //for "reset defaults" overload
         private void SetupKeybindButton(Button button, string action)
         {
-            if (action == leftClickString || action == middleClickString || action == rightClickString || action == uiExitString)
+            if (action == leftClickString || action == middleClickString || action == rightClickString || action == backString)
             {
                 var code = InputManager.Instance.ParseKeyCodeString(UnsavedKeybindDict[action]);
                 button.Label.Text = ControlsConfigManager.Instance.GetButtonText(code);
@@ -379,7 +379,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             SetupKeybindButton(leftClickKeybindButton, leftClickString);
             SetupKeybindButton(middleClickKeybindButton, middleClickString);
             SetupKeybindButton(rightClickKeybindButton, rightClickString);
-            SetupKeybindButton(uiExitKeybindButton, uiExitString);
+            SetupKeybindButton(backKeybindButton, backString);
             SetupKeybindButton(movementHorizontalAxisKeybindButton, InputManager.AxisActions.MovementHorizontal.ToString());
             SetupKeybindButton(movementVerticalAxisKeybindButton, InputManager.AxisActions.MovementVertical.ToString());
             SetupKeybindButton(lookHorizontalAxisKeybindButton, InputManager.AxisActions.CameraHorizontal.ToString());
@@ -460,7 +460,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             foreach(var action in UnsavedKeybindDict.Keys)
             {
-                if (action == leftClickString || action == middleClickString || action == rightClickString || action == uiExitString)
+                if (action == leftClickString || action == middleClickString || action == rightClickString || action == backString)
                 {
                     KeyCode code = InputManager.Instance.ParseKeyCodeString(UnsavedKeybindDict[action]);
                     InputManager.JoystickUIActions uiAction = InputManager.JoystickUIActions.LeftClick;
@@ -469,8 +469,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         uiAction = InputManager.JoystickUIActions.MiddleClick;
                     else if (action == rightClickString)
                         uiAction = InputManager.JoystickUIActions.RightClick;
-                    else if (action == uiExitString)
-                        uiAction = InputManager.JoystickUIActions.UiExit;
+                    else if (action == backString)
+                        uiAction = InputManager.JoystickUIActions.Back;
 
                     KeyCode curCode = InputManager.Instance.GetJoystickUIBinding(uiAction);
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPauseOptionsWindow.cs
@@ -154,7 +154,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             base.OnPush();
 
-            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Escape);
+            toggleClosedBinding = InputManager.Instance.GetBinding(InputManager.Actions.Pause);
 
             hud = DaggerfallUI.Instance.DaggerfallHUD;
             if (fullScreenTick != null)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
@@ -69,7 +69,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             cancelled = false;
             if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
-                if (allowCancel && InputManager.Instance.GetUiExitKeyUp())
+                if (allowCancel && InputManager.Instance.GetBackKeyUp())
                     CancelWindow();
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
@@ -69,7 +69,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             cancelled = false;
             if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
-                if (allowCancel && Input.GetKeyUp(exitKey))
+                if (allowCancel && InputManager.Instance.GetUiExitKeyUp())
                     CancelWindow();
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
@@ -69,7 +69,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             cancelled = false;
             if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)
             {
-                if (allowCancel && InputManager.Instance.GetBackKeyUp())
+                if (allowCancel && InputManager.Instance.GetBackButtonUp())
                     CancelWindow();
             }
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -188,7 +188,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 // Toggle window closed with same hotkey used to open it, or the DaggerfallBaseWindow's exitKey
                 // Window will properly end the rest if the player was currently resting
-                if (InputManager.Instance.GetKeyUp(toggleClosedBinding) || InputManager.Instance.GetUiExitKeyUp())
+                if (InputManager.Instance.GetKeyUp(toggleClosedBinding) || InputManager.Instance.GetBackKeyUp())
                     if (currentRestMode != RestModes.Selection)
                         EndRest();
                     else

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -188,7 +188,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 // Toggle window closed with same hotkey used to open it, or the DaggerfallBaseWindow's exitKey
                 // Window will properly end the rest if the player was currently resting
-                if (InputManager.Instance.GetKeyUp(toggleClosedBinding) || Input.GetKeyUp(exitKey))
+                if (InputManager.Instance.GetKeyUp(toggleClosedBinding) || InputManager.Instance.GetUiExitKeyUp())
                     if (currentRestMode != RestModes.Selection)
                         EndRest();
                     else

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -188,7 +188,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 // Toggle window closed with same hotkey used to open it, or the DaggerfallBaseWindow's exitKey
                 // Window will properly end the rest if the player was currently resting
-                if (InputManager.Instance.GetKeyUp(toggleClosedBinding) || InputManager.Instance.GetBackKeyUp())
+                if (InputManager.Instance.GetKeyUp(toggleClosedBinding) || InputManager.Instance.GetBackButtonUp())
                     if (currentRestMode != RestModes.Selection)
                         EndRest();
                     else

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -38,7 +38,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         protected Panel mainPanel;
         protected TextLabel titleLabel;
-        protected Button escapeKeybindButton = new Button();
+        protected Button pauseKeybindButton = new Button();
         protected Button consoleKeybindButton = new Button();
         protected Button screenshotKeybindButton = new Button();
         protected Button quickSaveKeybindButton = new Button();
@@ -116,7 +116,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             mainPanel.Components.Add(continueButton);
 
             // keybind buttons
-            SetupKeybindButton(escapeKeybindButton, InputManager.Actions.Escape, 20, 20);
+            SetupKeybindButton(pauseKeybindButton, InputManager.Actions.Pause, 20, 20);
             SetupKeybindButton(autoRunKeybindButton, InputManager.Actions.AutoRun, 20, 40);
             SetupKeybindButton(consoleKeybindButton, InputManager.Actions.ToggleConsole, 115, 20);
             SetupKeybindButton(screenshotKeybindButton, InputManager.Actions.PrintScreen, 115, 40);
@@ -191,8 +191,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             //"ToggleConsole" is too long as a word when looking in non-SDF font view
             //"Screenshot" is a better word and is one letter less than "PrintScreen"
-            label.Text = action == InputManager.Actions.Escape ? "Pause"
-                                   : action == InputManager.Actions.ToggleConsole ? "Console"
+            label.Text = action == InputManager.Actions.ToggleConsole ? "Console"
                                    : action == InputManager.Actions.PrintScreen ? "Screenshot"
                                    : action.ToString();
 
@@ -222,7 +221,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         private void UpdateKeybindButtons()
         {
-            SetupKeybindButton(escapeKeybindButton, InputManager.Actions.Escape);
+            SetupKeybindButton(pauseKeybindButton, InputManager.Actions.Pause);
             SetupKeybindButton(consoleKeybindButton, InputManager.Actions.ToggleConsole);
             SetupKeybindButton(screenshotKeybindButton, InputManager.Actions.PrintScreen);
             SetupKeybindButton(quickSaveKeybindButton, InputManager.Actions.QuickSave);


### PR DESCRIPTION
Adding support so players can exit out of UI screens with a button on the controller, just like how the escape key is used to back out of UI screens with the keyboard. The key binding can be set in the joystick controller configuration screen.

![image](https://user-images.githubusercontent.com/108307224/176102938-08bb8978-cc8e-42a9-96a6-9bea23887fb3.png)

This also allows users to cancel rest with the controller by pressing the same UI back button, since now in code where it was previously hardcoded to check for the keyboard escape key are now checking both for the escape key and the UI exit controller button.

Also noticed that the pause binding was named Escape in code, which could be confused with this new UI exit binding, so that has been renamed to Pause.