### PR TITLE
Null reference exception when mod enemies cast

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1905,7 +1905,10 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             // Only supporting LoadID from enemies at this time
             if (caster.EntityType == EntityTypes.EnemyMonster || caster.EntityType == EntityTypes.EnemyClass)
             {
-                ISerializableGameObject serializableEnemy = caster.GetComponent<SerializableEnemy>() as ISerializableGameObject;
+                ISerializableGameObject serializableEnemy = caster.GetComponent<ISerializableGameObject>();
+                if (serializableEnemy == null)
+                    return 0;
+
                 return serializableEnemy.LoadID;
             }
             else


### PR DESCRIPTION
In mods that spawn enemies with a custom flow (ex: World of Daggerfall), a custom serialization component might be used (ex: for extra, mod-specific data).

Previously, `EntityEffectManager.GetCasterLoadID` explicitly checked for the component `SerializableEnemy`, when it really only needs a component that implements the `ISerializableGameObject`, for the LoadID.

I've loosened the `GetComponent` to work with custom `ISerializableGameObject` types.

I've also added a null check, to avoid the null reference exception in the future.