### PR TITLE
Dungeon Micro-Map QoL Option, 7/1/2022

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -174,6 +174,7 @@ AssetInjection=True
 CompressModdedTextures=True
 NearDeathWarning=True
 AdvancedClimbing=False
+MoreReadableDungeonMicroMap=False
 AlternateRandomEnemySelection=False
 DungeonAmbientLightScale=1.0
 NightAmbientLightScale=1.0

--- a/Assets/Scripts/Game/Automap.cs
+++ b/Assets/Scripts/Game/Automap.cs
@@ -1787,7 +1787,17 @@ namespace DaggerfallWorkshop.Game
                 {
                     for (int x = 0; x < microMapBlockSizeInPixels; x++)
                     {
-                        textureMicroMap.SetPixel(xBlockPos * microMapBlockSizeInPixels + x, yBlockPos * microMapBlockSizeInPixels + y, Color.yellow);
+                        if (DaggerfallUnity.Settings.MoreReadableDungeonMicroMap)
+                        {
+                            if (block.BlockName.Substring(0, 1) == "B")
+                                textureMicroMap.SetPixel(xBlockPos * microMapBlockSizeInPixels + x, yBlockPos * microMapBlockSizeInPixels + y, new Color32(250, 180, 3, 255));
+                            else
+                                textureMicroMap.SetPixel(xBlockPos * microMapBlockSizeInPixels + x, yBlockPos * microMapBlockSizeInPixels + y, new Color32(212, 135, 208, 255));
+                        }
+                        else
+                        {
+                            textureMicroMap.SetPixel(xBlockPos * microMapBlockSizeInPixels + x, yBlockPos * microMapBlockSizeInPixels + y, Color.yellow);
+                        }
                     }
                 }
             }

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -257,6 +257,7 @@ namespace DaggerfallWorkshop
         public bool NearDeathWarning { get; set; }
         public bool AlternateRandomEnemySelection { get; set; }
         public bool AdvancedClimbing { get; set; }
+        public bool MoreReadableDungeonMicroMap { get; set; }
         public float DungeonAmbientLightScale { get; set; }
         public float NightAmbientLightScale { get; set; }
         public float PlayerTorchLightScale { get; set; }
@@ -446,6 +447,7 @@ namespace DaggerfallWorkshop
             NearDeathWarning = GetBool(sectionEnhancements, "NearDeathWarning");
             AlternateRandomEnemySelection = GetBool(sectionEnhancements, "AlternateRandomEnemySelection");
             AdvancedClimbing = GetBool(sectionEnhancements, "AdvancedClimbing");
+            MoreReadableDungeonMicroMap = GetBool(sectionEnhancements, "MoreReadableDungeonMicroMap");
             DungeonAmbientLightScale = GetFloat(sectionEnhancements, "DungeonAmbientLightScale", 0.0f, 1.0f);
             NightAmbientLightScale = GetFloat(sectionEnhancements, "NightAmbientLightScale", 0.0f, 1.0f);
             PlayerTorchLightScale = GetFloat(sectionEnhancements, "PlayerTorchLightScale", 0.0f, 1.0f);
@@ -624,6 +626,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionEnhancements, "NearDeathWarning", NearDeathWarning);
             SetBool(sectionEnhancements, "AlternateRandomEnemySelection", AlternateRandomEnemySelection);
             SetBool(sectionEnhancements, "AdvancedClimbing", AdvancedClimbing);
+            SetBool(sectionEnhancements, "MoreReadableDungeonMicroMap", MoreReadableDungeonMicroMap);
             SetFloat(sectionEnhancements, "DungeonAmbientLightScale", DungeonAmbientLightScale);
             SetFloat(sectionEnhancements, "NightAmbientLightScale", NightAmbientLightScale);
             SetFloat(sectionEnhancements, "PlayerTorchLightScale", PlayerTorchLightScale);


### PR DESCRIPTION
Dungeon Micro-Map QoL Option, 7/1/2022.

Originally in relation to this forum thread: https://forums.dfworkshop.net/viewtopic.php?t=5242

This post is mostly related to the above forum thread that I made a good few months back, and finally decided to make a PR for it. I think the difference is fairly clear from the below attached screenshots. I set the option to be disabled by default. Also the purple background is not what occurs in practice, that is just a weird quirk when you try to take a screenshot with "F8" while in the map screen. 

Please do any edits you feel would make this better. I was considering for small possible performance reasons to put the settings check into another for-loop on it's own, but did not want to make the PR look to ugly by doing that, but up to whoever if they feel there is a better way to do this etc. Thanks as usual, I'm still quite the noob when it comes to using Git and pushing commits and such.

Default
![Dungeon_Mini-map_Example](https://user-images.githubusercontent.com/39843717/176947768-182b3203-0552-4eaa-aaeb-22a5543c9fa0.png)

Option On Example 1
![2022_01_20_20_31_28](https://user-images.githubusercontent.com/39843717/176947804-eafa8f0f-acdd-4a29-9bfe-614cca418e3f.jpg)

Option On Example 2
![2022_01_20_20_30_20](https://user-images.githubusercontent.com/39843717/176947851-0dba0147-891a-465b-bb89-01fbd3f8bfdf.jpg)