### PR TITLE
Change key binds for left/right page in mod settings

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModSettings/ModSettingsWindow.cs
@@ -46,8 +46,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModSettings
         const int columnWidth                       = 140;
         const int columnsOffset                     = columnWidth + startX * 2;
 
-        const KeyCode nextPageKey                   = KeyCode.Tab;
-        const KeyCode previousPageKey               = KeyCode.LeftShift;
+        const KeyCode nextPageKey                   = KeyCode.PageDown;
+        const KeyCode previousPageKey               = KeyCode.PageUp;
 
         Color panelBackgroundColor                  = new Color(0, 0, 0, 0.7f);
         Color resetButtonColor                      = new Color(1, 0, 0, 0.4f);           // red with alpha


### PR DESCRIPTION
This is so they don't interfere with text entry on pages > 1. I was trying to add "Mouse3" to a text box on page 2 and it kept switching back to page 1 every time I pressed left shift... was very confused.

happy if someone can suggest better keys.