### PR TITLE
Fix bright UI rendering on Mac

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -378,6 +378,12 @@ namespace DaggerfallWorkshop.Game
             // Create UI blit material
             if (uiBlitMaterial == null)
                 uiBlitMaterial = new Material(Shader.Find(MaterialReader._DaggerfallUIBlitShaderName));
+
+            // Set shader platform keyword for MacOSX
+            if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX)
+                Shader.EnableKeyword(KeyWords.MacOSX);
+            else
+                Shader.DisableKeyword(KeyWords.MacOSX);
         }
 
         void Update()

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -1421,7 +1421,11 @@ namespace DaggerfallWorkshop.Game
             }
             else
             {
-                // TODO: UI rendering on other platforms works as expected
+                // UI rendering on other platforms works as expected
+                Color oldColor = GUI.color;
+                GUI.color = color;
+                GUI.DrawTexture(position, image, scaleMode);
+                GUI.color = oldColor;
             }
         }
 
@@ -1457,7 +1461,11 @@ namespace DaggerfallWorkshop.Game
             }
             else
             {
-                // TODO: UI rendering on other platforms works as expected
+                // UI rendering on other platforms works as expected
+                Color oldColor = GUI.color;
+                GUI.color = color;
+                GUI.DrawTextureWithTexCoords(position, image, texCoords, alphaBlend);
+                GUI.color = oldColor;
             }
         }
 

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -381,9 +381,10 @@ namespace DaggerfallWorkshop.Game
 
             // Set shader platform keyword for MacOSX
             if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX)
-                Shader.EnableKeyword(KeyWords.MacOSX);
-            else
-                Shader.DisableKeyword(KeyWords.MacOSX);
+            {
+                pixelFontMaterial.EnableKeyword(KeyWords.MacOSX);
+                sdfFontMaterial.EnableKeyword(KeyWords.MacOSX);
+            }
         }
 
         void Update()

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -30,6 +30,13 @@ using static DaggerfallWorkshop.Game.UserInterface.BaseScreenComponent;
 
 namespace DaggerfallWorkshop.Game
 {
+    // Common shader params
+    public class UIShaderParam
+    {
+        public static int _Color = Shader.PropertyToID("_Color");
+        public static int _ColorTint = Shader.PropertyToID("_ColorTint");
+    }
+
     /// <summary>
     /// Implements Daggerfall's user interface with internal UI system.
     /// </summary>
@@ -1415,7 +1422,7 @@ namespace DaggerfallWorkshop.Game
                 Material mat = (alphaBlend) ? DaggerfallUI.Instance.UIBlendMaterial : DaggerfallUI.Instance.UIBlitMaterial;
                 if (CalculateScaledTextureRects(position, scaleMode, imageAspect, ref screenRect, ref sourceRect))
                 {
-                    mat.SetColor("_ColorTint", color);
+                    mat.SetColor(UIShaderParam._ColorTint, color);
                     Graphics.DrawTexture(screenRect, image, sourceRect, 0, 0, 0, 0, ModulateColor(color), mat);
                 }
             }
@@ -1456,7 +1463,7 @@ namespace DaggerfallWorkshop.Game
             if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX)
             {
                 Material mat = (alphaBlend) ? DaggerfallUI.Instance.UIBlendMaterial : DaggerfallUI.Instance.UIBlitMaterial;
-                mat.SetColor("_ColorTint", color);
+                mat.SetColor(UIShaderParam._ColorTint, color);
                 Graphics.DrawTexture(position, image, texCoords, 0, 0, 0, 0, ModulateColor(color), mat);
             }
             else

--- a/Assets/Scripts/Game/FPSCrosshair.cs
+++ b/Assets/Scripts/Game/FPSCrosshair.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Unity
+// Project:         Daggerfall Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -25,13 +25,15 @@ namespace DaggerfallWorkshop.Game
         {
             if (CrosshairTexture != null)
             {
-                GUI.color = new Color(1, 1, 1, 0.75f);
-                GUI.DrawTexture(
+                Color color = new Color(1, 1, 1, 0.75f);
+                DaggerfallUI.DrawTexture(
                     new Rect((Screen.width * 0.5f) - (CrosshairTexture.width * 0.5f),
                         (Screen.height * 0.5f) - (CrosshairTexture.height * 0.5f),
-                        CrosshairTexture.width,
-                        CrosshairTexture.height), (Texture2D)CrosshairTexture);
-                GUI.color = Color.white;
+                        CrosshairTexture.width, CrosshairTexture.height),
+                        (Texture2D)CrosshairTexture,
+                        ScaleMode.StretchToFill,
+                        true,
+                        color);
             }
         }
     }

--- a/Assets/Scripts/Game/FPSSpellCasting.cs
+++ b/Assets/Scripts/Game/FPSSpellCasting.cs
@@ -118,8 +118,8 @@ namespace DaggerfallWorkshop.Game
                 int frameIndex = frameIndices[currentFrame];
 
                 // Draw spell cast texture behind other HUD elements
-                GUI.DrawTextureWithTexCoords(leftHandPosition, currentAnims[frameIndex].Texture, leftHandAnimRect);
-                GUI.DrawTextureWithTexCoords(rightHandPosition, currentAnims[frameIndex].Texture, rightHandAnimRect);
+                DaggerfallUI.DrawTextureWithTexCoords(leftHandPosition, currentAnims[frameIndex].Texture, leftHandAnimRect);
+                DaggerfallUI.DrawTextureWithTexCoords(rightHandPosition, currentAnims[frameIndex].Texture, rightHandAnimRect);
             }
         }
 

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -151,7 +151,7 @@ namespace DaggerfallWorkshop.Game
             if (Event.current.type.Equals(EventType.Repaint) && ShowWeapon)
             {
                 // Draw weapon texture behind other HUD elements
-                GUI.DrawTextureWithTexCoords(weaponPosition, curCustomTexture ? curCustomTexture : weaponAtlas, curAnimRect);
+                DaggerfallUI.DrawTextureWithTexCoords(weaponPosition, curCustomTexture ? curCustomTexture : weaponAtlas, curAnimRect);
             }
         }
 

--- a/Assets/Scripts/Game/PlayerCompass.cs
+++ b/Assets/Scripts/Game/PlayerCompass.cs
@@ -136,8 +136,8 @@ namespace DaggerfallWorkshop.Game
             compassDstRect.width = compassBoxRect.width - (boxOutlineSize * 2) * scale;
             compassDstRect.height = compassTexture.height * scale;
 
-            GUI.DrawTextureWithTexCoords(compassDstRect, compassTexture, compassSrcRect, false);
-            GUI.DrawTexture(compassBoxRect, compassBoxTexture, ScaleMode.StretchToFill, true);
+            DaggerfallUI.DrawTextureWithTexCoords(compassDstRect, compassTexture, compassSrcRect, false);
+            DaggerfallUI.DrawTexture(compassBoxRect, compassBoxTexture, ScaleMode.StretchToFill, true);
         }
 
         #endregion

--- a/Assets/Scripts/Game/ShowPlayerDamage.cs
+++ b/Assets/Scripts/Game/ShowPlayerDamage.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Unity
+// Project:         Daggerfall Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -43,8 +43,8 @@ namespace DaggerfallWorkshop.Game
                 alphaFadeValue -= fadeSpeed * Time.deltaTime;
                 if (alphaFadeValue > 0)
                 {
-                    GUI.color = new Color(1, 0, 0, alphaFadeValue);
-                    GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), damageTexture);
+                    Color color = new Color(1, 0, 0, alphaFadeValue);
+                    DaggerfallUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), damageTexture, ScaleMode.StretchToFill, true, color);
                 }
                 else
                 {

--- a/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
+++ b/Assets/Scripts/Game/UserInterface/BaseScreenComponent.cs
@@ -780,17 +780,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // Draw background colour or mouse over background colour
             if (mouseOverComponent && mouseOverBackgroundColor != Color.clear && backgroundColorTexture)
             {
-                Color color = GUI.color;
-                GUI.color = mouseOverBackgroundColor;
-                GUI.DrawTexture(myRect, backgroundColorTexture, ScaleMode.StretchToFill);
-                GUI.color = color;
+                DaggerfallUI.DrawTexture(myRect, backgroundColorTexture, ScaleMode.StretchToFill, true, mouseOverBackgroundColor);
             }
             else if (backgroundColor != Color.clear && backgroundColorTexture)
             {
-                Color color = GUI.color;
-                GUI.color = backgroundColor;
-                GUI.DrawTexture(myRect, backgroundColorTexture, ScaleMode.StretchToFill);
-                GUI.color = color;
+                DaggerfallUI.DrawTexture(myRect, backgroundColorTexture, ScaleMode.StretchToFill, true, backgroundColor);
             }
 
             // Draw background texture if present
@@ -800,19 +794,19 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 {
                     case BackgroundLayout.Tile:
                         backgroundTexture.wrapMode = TextureWrapMode.Repeat;
-                        GUI.DrawTextureWithTexCoords(myRect, backgroundTexture, new Rect(0, 0, myRect.width / backgroundTexture.width, myRect.height / backgroundTexture.height));
+                        DaggerfallUI.DrawTextureWithTexCoords(myRect, backgroundTexture, new Rect(0, 0, myRect.width / backgroundTexture.width, myRect.height / backgroundTexture.height));
                         break;
                     case BackgroundLayout.StretchToFill:
                         backgroundTexture.wrapMode = TextureWrapMode.Clamp;
-                        GUI.DrawTexture(myRect, backgroundTexture, ScaleMode.StretchToFill);
+                        DaggerfallUI.DrawTexture(myRect, backgroundTexture, ScaleMode.StretchToFill);
                         break;
                     case BackgroundLayout.ScaleToFit:
                         backgroundTexture.wrapMode = TextureWrapMode.Clamp;
-                        GUI.DrawTexture(myRect, backgroundTexture, ScaleMode.ScaleToFit);
+                        DaggerfallUI.DrawTexture(myRect, backgroundTexture, ScaleMode.ScaleToFit);
                         break;
                     case BackgroundLayout.Cropped:
                         backgroundTexture.wrapMode = TextureWrapMode.Clamp;
-                        GUI.DrawTextureWithTexCoords(myRect, backgroundTexture, new Rect(
+                        DaggerfallUI.DrawTextureWithTexCoords(myRect, backgroundTexture, new Rect(
                             BackgroundCroppedRect.x / backgroundTexture.width,
                             BackgroundCroppedRect.y / backgroundTexture.height,
                             BackgroundCroppedRect.width / backgroundTexture.width,

--- a/Assets/Scripts/Game/UserInterface/Checkbox.cs
+++ b/Assets/Scripts/Game/UserInterface/Checkbox.cs
@@ -131,15 +131,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             rect.height = checkTextureSize.y * LocalScale.y;
 
             // Draw checkbox in current state
-            Color guiColor = GUI.color;
-            GUI.color = checkboxColor;
             if (!isChecked)
-                GUI.DrawTexture(rect, uncheckedTexture);
+                DaggerfallUI.DrawTexture(rect, uncheckedTexture, ScaleMode.StretchToFill, true, checkboxColor);
             else
-                GUI.DrawTexture(rect, checkedTexture);
-
-            // Restore previous color
-            GUI.color = guiColor;
+                DaggerfallUI.DrawTexture(rect, checkedTexture, ScaleMode.StretchToFill, true, checkboxColor);
 
             // Draw label
             label.Position = new Vector2(checkTextureSize.x + checkTextHorzOffset, textOffset + checkTextVertOffset);

--- a/Assets/Scripts/Game/UserInterface/DaggerfallFont.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallFont.cs
@@ -154,7 +154,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
         void DrawClassicGlyph(byte rawAscii, Rect targetRect, Color color)
         {
             Rect atlasRect = atlasRects[rawAscii - asciiStart];
-            Graphics.DrawTexture(targetRect, atlasTexture, atlasRect, 0, 0, 0, 0, color, DaggerfallUI.Instance.PixelFontMaterial);
+            DaggerfallUI.Instance.PixelFontMaterial.SetColor(UIShaderParam._Color, color);
+            Graphics.DrawTexture(targetRect, atlasTexture, atlasRect, 0, 0, 0, 0, DaggerfallUI.Instance.PixelFontMaterial);
         }
 
         void DrawClassicGlyphWithShadow(byte rawAscii, Rect targetRect, Color color, Vector2 shadowPosition, Color shadowColor)
@@ -245,7 +246,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Rect targetRect = new Rect(xpos, ypos, glyph.size.x * scalingRatio, glyph.size.y * scalingRatio);
 
             // Draw glyph
-            Graphics.DrawTexture(targetRect, sdfFontInfo.Value.atlasTexture, glyph.rect, 0, 0, 0, 0, color, DaggerfallUI.Instance.SDFFontMaterial);
+            DaggerfallUI.Instance.SDFFontMaterial.SetColor(UIShaderParam._Color, color);
+            Graphics.DrawTexture(targetRect, sdfFontInfo.Value.atlasTexture, glyph.rect, 0, 0, 0, 0, DaggerfallUI.Instance.SDFFontMaterial);
             return GetGlyphWidth(glyph, scale, GlyphSpacing);
         }
 

--- a/Assets/Scripts/Game/UserInterface/DaggerfallFont.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallFont.cs
@@ -154,8 +154,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
         void DrawClassicGlyph(byte rawAscii, Rect targetRect, Color color)
         {
             Rect atlasRect = atlasRects[rawAscii - asciiStart];
-            DaggerfallUI.Instance.PixelFontMaterial.SetColor(UIShaderParam._Color, color);
-            Graphics.DrawTexture(targetRect, atlasTexture, atlasRect, 0, 0, 0, 0, DaggerfallUI.Instance.PixelFontMaterial);
+            if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX)
+            {
+                DaggerfallUI.Instance.SDFFontMaterial.SetColor(UIShaderParam._Color, color);
+                Graphics.DrawTexture(targetRect, atlasTexture, atlasRect, 0, 0, 0, 0, DaggerfallUI.Instance.PixelFontMaterial);
+            }
+            else
+            {
+                Graphics.DrawTexture(targetRect, atlasTexture, atlasRect, 0, 0, 0, 0, color, DaggerfallUI.Instance.PixelFontMaterial);
+            }
         }
 
         void DrawClassicGlyphWithShadow(byte rawAscii, Rect targetRect, Color color, Vector2 shadowPosition, Color shadowColor)
@@ -246,8 +253,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Rect targetRect = new Rect(xpos, ypos, glyph.size.x * scalingRatio, glyph.size.y * scalingRatio);
 
             // Draw glyph
-            DaggerfallUI.Instance.SDFFontMaterial.SetColor(UIShaderParam._Color, color);
-            Graphics.DrawTexture(targetRect, sdfFontInfo.Value.atlasTexture, glyph.rect, 0, 0, 0, 0, DaggerfallUI.Instance.SDFFontMaterial);
+            if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX)
+            {
+                DaggerfallUI.Instance.SDFFontMaterial.SetColor(UIShaderParam._Color, color);
+                Graphics.DrawTexture(targetRect, sdfFontInfo.Value.atlasTexture, glyph.rect, 0, 0, 0, 0, DaggerfallUI.Instance.SDFFontMaterial);
+            }
+            else
+            {
+                Graphics.DrawTexture(targetRect, sdfFontInfo.Value.atlasTexture, glyph.rect, 0, 0, 0, 0, color, DaggerfallUI.Instance.SDFFontMaterial);
+            }
             return GetGlyphWidth(glyph, scale, GlyphSpacing);
         }
 

--- a/Assets/Scripts/Game/UserInterface/DaggerfallFont.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallFont.cs
@@ -156,7 +156,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Rect atlasRect = atlasRects[rawAscii - asciiStart];
             if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX)
             {
-                DaggerfallUI.Instance.SDFFontMaterial.SetColor(UIShaderParam._Color, color);
+                DaggerfallUI.Instance.PixelFontMaterial.SetColor(UIShaderParam._Color, color);
                 Graphics.DrawTexture(targetRect, atlasTexture, atlasRect, 0, 0, 0, 0, DaggerfallUI.Instance.PixelFontMaterial);
             }
             else

--- a/Assets/Scripts/Game/UserInterface/DaggerfallVideo.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallVideo.cs
@@ -163,7 +163,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 float temp = rect.yMin;
                 rect.yMin = rect.yMax;
                 rect.yMax = temp;
-                GUI.DrawTexture(rect, vidTexture, ScaleMode.StretchToFill);
+                DaggerfallUI.DrawTexture(rect, vidTexture, ScaleMode.StretchToFill);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterface/HUDCompass.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCompass.cs
@@ -152,8 +152,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             compassDstRect.width = compassBoxRect.width - (boxOutlineSize * 2) * Scale.x;
             compassDstRect.height = compassTextureHeight * Scale.y;
 
-            GUI.DrawTextureWithTexCoords(compassDstRect, compassTexture, compassSrcRect, false);
-            GUI.DrawTexture(compassBoxRect, compassBoxTexture, ScaleMode.StretchToFill, true);
+            DaggerfallUI.DrawTextureWithTexCoords(compassDstRect, compassTexture, compassSrcRect, false);
+            DaggerfallUI.DrawTexture(compassBoxRect, compassBoxTexture, ScaleMode.StretchToFill, true);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/UserInterface/HUDCompass.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCompass.cs
@@ -245,7 +245,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             };
 
             // Draw marker
-            GUI.DrawTexture(markerRect, defaultTrackingIcon, ScaleMode.StretchToFill, true);
+            DaggerfallUI.DrawTexture(markerRect, defaultTrackingIcon, ScaleMode.StretchToFill, true);
         }
 
         float ChangeRange(float value, float oldMin, float oldMax, float newMin, float newMax)

--- a/Assets/Scripts/Game/UserInterface/HorizontalSlider.cs
+++ b/Assets/Scripts/Game/UserInterface/HorizontalSlider.cs
@@ -323,13 +323,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Rect rightRect = new Rect((int)bodyRect.xMax, (int)totalRect.y, (int)rightTextureWidth, (int)totalRect.height);
 
             // Draw thumb texture slices in screen space
-            Color color = DaggerfallUI.ModulateColor(Color.white);
-            if (TintColor.HasValue)
-                GUI.color = TintColor.Value;
-            GUI.DrawTexture(leftRect, hScrollThumbLeft, ScaleMode.StretchToFill);
-            GUI.DrawTexture(bodyRect, hScrollThumbBody, ScaleMode.StretchToFill);
-            GUI.DrawTexture(rightRect, hScrollThumbRight, ScaleMode.StretchToFill);
-            GUI.color = color;
+            Color color = (TintColor.HasValue) ? TintColor.Value : Color.white;
+            DaggerfallUI.DrawTexture(leftRect, hScrollThumbLeft, ScaleMode.StretchToFill, true, color);
+            DaggerfallUI.DrawTexture(bodyRect, hScrollThumbBody, ScaleMode.StretchToFill, true, color);
+            DaggerfallUI.DrawTexture(rightRect, hScrollThumbRight, ScaleMode.StretchToFill, true, color);
         }
 
         void SetupIndicator(int min, int max, int start)

--- a/Assets/Scripts/Game/UserInterface/Panel.cs
+++ b/Assets/Scripts/Game/UserInterface/Panel.cs
@@ -250,19 +250,19 @@ namespace DaggerfallWorkshop.Game.UserInterface
             }
 
             // Draw fill
-            GUI.DrawTextureWithTexCoords(fillBordersRect, fillBordersTexture, new Rect(0, 0, (fillBordersRect.width / LocalScale.x) / virtualSizes.Fill.x, (fillBordersRect.height / LocalScale.y) / virtualSizes.Fill.y));
+            DaggerfallUI.DrawTextureWithTexCoords(fillBordersRect, fillBordersTexture, new Rect(0, 0, (fillBordersRect.width / LocalScale.x) / virtualSizes.Fill.x, (fillBordersRect.height / LocalScale.y) / virtualSizes.Fill.y));
 
             // Draw corners
-            GUI.DrawTexture(topLeftBorderRect, topLeftBorderTexture);
-            GUI.DrawTexture(topRightBorderRect, topRightBorderTexture);
-            GUI.DrawTexture(bottomLeftBorderRect, bottomLeftBorderTexture);
-            GUI.DrawTexture(bottomRightBorderRect, bottomRightBorderTexture);
+            DaggerfallUI.DrawTexture(topLeftBorderRect, topLeftBorderTexture);
+            DaggerfallUI.DrawTexture(topRightBorderRect, topRightBorderTexture);
+            DaggerfallUI.DrawTexture(bottomLeftBorderRect, bottomLeftBorderTexture);
+            DaggerfallUI.DrawTexture(bottomRightBorderRect, bottomRightBorderTexture);
 
             // Draw edges
-            GUI.DrawTextureWithTexCoords(topBorderRect, topBorderTexture, new Rect(0, 0, (topBorderRect.width / LocalScale.x) / virtualSizes.Top.x, 1));
-            GUI.DrawTextureWithTexCoords(leftBorderRect, leftBorderTexture, new Rect(0, 0, 1, (leftBorderRect.height / LocalScale.y) / virtualSizes.Left.y));
-            GUI.DrawTextureWithTexCoords(rightBorderRect, rightBorderTexture, new Rect(0, 0, 1, (rightBorderRect.height / LocalScale.y) / virtualSizes.Right.y));
-            GUI.DrawTextureWithTexCoords(bottomBorderRect, bottomBorderTexture, new Rect(0, 0, (bottomBorderRect.width / LocalScale.y) / virtualSizes.Bottom.x, 1));
+            DaggerfallUI.DrawTextureWithTexCoords(topBorderRect, topBorderTexture, new Rect(0, 0, (topBorderRect.width / LocalScale.x) / virtualSizes.Top.x, 1));
+            DaggerfallUI.DrawTextureWithTexCoords(leftBorderRect, leftBorderTexture, new Rect(0, 0, 1, (leftBorderRect.height / LocalScale.y) / virtualSizes.Left.y));
+            DaggerfallUI.DrawTextureWithTexCoords(rightBorderRect, rightBorderTexture, new Rect(0, 0, 1, (rightBorderRect.height / LocalScale.y) / virtualSizes.Right.y));
+            DaggerfallUI.DrawTextureWithTexCoords(bottomBorderRect, bottomBorderTexture, new Rect(0, 0, (bottomBorderRect.width / LocalScale.y) / virtualSizes.Bottom.x, 1));
         }
 
         void UpdateBorderDrawRects(Rect drawRect)

--- a/Assets/Scripts/Game/UserInterface/ReflexPicker.cs
+++ b/Assets/Scripts/Game/UserInterface/ReflexPicker.cs
@@ -60,7 +60,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             base.Draw();
 
-            GUI.DrawTextureWithTexCoords(buttonRect, highlightTexture, highlightRect);
+            DaggerfallUI.DrawTextureWithTexCoords(buttonRect, highlightTexture, highlightRect);
         }
 
         #region Private Methods

--- a/Assets/Scripts/Game/UserInterface/TextCursor.cs
+++ b/Assets/Scripts/Game/UserInterface/TextCursor.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Unity
+// Project:         Daggerfall Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -81,12 +81,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             if (blinkOn)
             {
-                Color guiColor = GUI.color;
-
-                GUI.color = cursorColor;
                 DrawCursor();
-
-                GUI.color = guiColor;
             }
         }
 
@@ -103,7 +98,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             Rect rect = Rectangle;
             rect.width = cursorThickness * LocalScale.x;
-            GUI.DrawTexture(rect, cursorTexture);
+            DaggerfallUI.DrawTexture(rect, cursorTexture, ScaleMode.StretchToFill, true, cursorColor);
         }
 
         void SetThickness(int value)

--- a/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceRenderTarget.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Unity
+// Project:         Daggerfall Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -162,7 +162,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (!IsReady())
                 return;
 
-            GUI.DrawTexture(position, image);
+            DaggerfallUI.DrawTexture(position, image);
         }
 
         public void DrawTexture(Rect position, Texture2D image, ScaleMode scaleMode, bool alphaBlend = true, float imageAspect = 0)
@@ -170,7 +170,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (!IsReady())
                 return;
 
-            GUI.DrawTexture(position, image, scaleMode, alphaBlend);
+            DaggerfallUI.DrawTexture(position, image, scaleMode, alphaBlend);
         }
 
         public void DrawTextureWithTexCoords(Rect position, Texture image, Rect texCoords, bool alphaBlend = true)
@@ -178,7 +178,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (!IsReady())
                 return;
 
-            GUI.DrawTextureWithTexCoords(position, image, texCoords, alphaBlend);
+            DaggerfallUI.DrawTextureWithTexCoords(position, image, texCoords, alphaBlend);
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterface/VerticalProgress.cs
+++ b/Assets/Scripts/Game/UserInterface/VerticalProgress.cs
@@ -74,13 +74,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             dstRect.height = scaledAmount;
 
             if (ProgressTexture)
-                GUI.DrawTextureWithTexCoords(dstRect, ProgressTexture, srcRect, false);
+                DaggerfallUI.DrawTextureWithTexCoords(dstRect, ProgressTexture, srcRect, false);
             else if (colorTexture)
             {
-                Color lastColor = GUI.color;
-                GUI.color = color;
-                GUI.DrawTextureWithTexCoords(dstRect, colorTexture, srcRect, false);
-                GUI.color = lastColor;
+                DaggerfallUI.DrawTextureWithTexCoords(dstRect, colorTexture, srcRect, false, color);
             }
         }
     }

--- a/Assets/Scripts/Game/UserInterface/VerticalScrollBar.cs
+++ b/Assets/Scripts/Game/UserInterface/VerticalScrollBar.cs
@@ -216,9 +216,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Rect topRect = new Rect((int)totalRect.x, (int)(totalRect.y + thumbY), (int)totalRect.width, (int)topTextureHeight);
             Rect bodyRect = new Rect((int)totalRect.x, (int)topRect.yMax, (int)totalRect.width, (int)(thumbHeight - topTextureHeight - bottomTextureHeight));
             Rect bottomRect = new Rect((int)totalRect.x, (int)bodyRect.yMax, (int)totalRect.width, (int)bottomTextureHeight);
-            GUI.DrawTexture(topRect, vScrollThumbTop, ScaleMode.StretchToFill);
-            GUI.DrawTexture(bodyRect, vScrollThumbBody, ScaleMode.StretchToFill);
-            GUI.DrawTexture(bottomRect, vScrollThumbBottom, ScaleMode.StretchToFill);
+            DaggerfallUI.DrawTexture(topRect, vScrollThumbTop, ScaleMode.StretchToFill);
+            DaggerfallUI.DrawTexture(bodyRect, vScrollThumbBody, ScaleMode.StretchToFill);
+            DaggerfallUI.DrawTexture(bottomRect, vScrollThumbBottom, ScaleMode.StretchToFill);
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterface/VideoPlayerDrawer.cs
+++ b/Assets/Scripts/Game/UserInterface/VideoPlayerDrawer.cs
@@ -75,7 +75,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             base.Draw();
 
-            GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), videoPlayer.texture, ScaleMode);
+            DaggerfallUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), videoPlayer.texture, ScaleMode);
         }
 
         /// <summary>

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -142,6 +142,8 @@ namespace DaggerfallWorkshop
         public const string _DaggerfallRetroDepthShaderName = "Daggerfall/DepthProcessShader";
         public const string _DaggerfallRetroPosterizationShaderName = "Daggerfall/RetroPosterization";
         public const string _DaggerfallRetroPalettizationShaderName = "Daggerfall/RetroPalettization";
+        public const string _DaggerfallUIBlendShaderName = "Daggerfall/UIBlend";
+        public const string _DaggerfallUIBlitShaderName = "Daggerfall/UIBlit";
 
         DaggerfallUnity dfUnity;
         TextureReader textureReader;

--- a/Assets/Scripts/MaterialReader.cs
+++ b/Assets/Scripts/MaterialReader.cs
@@ -37,6 +37,7 @@ namespace DaggerfallWorkshop
         public const string HeightMap                             = "_PARALLAXMAP";
         public const string Emission                              = "_EMISSION";
         public const string MetallicGlossMap                      = "_METALLICGLOSSMAP";
+        public const string MacOSX                                = "_MacOSX";
     }
 
     public static class Uniforms

--- a/Assets/Shaders/DaggerfallPixelFont.shader
+++ b/Assets/Shaders/DaggerfallPixelFont.shader
@@ -22,6 +22,7 @@ Shader "Daggerfall/PixelFont"
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment frag
+            #pragma shader_feature _MacOSX
 
 			#include "UnityCG.cginc"
 
@@ -61,7 +62,11 @@ Shader "Daggerfall/PixelFont"
 
                 float alpha = tex2D(_MainTex, i.texcoord).a;
 
-                return float4(_Color.rgb, alpha);
+                #ifdef _MacOSX
+                    return float4(_Color.rgb, alpha);
+                #else
+                    return float4(i.color.rgb, alpha);
+                #endif
 			}
 			ENDCG 
 		}

--- a/Assets/Shaders/DaggerfallPixelFont.shader
+++ b/Assets/Shaders/DaggerfallPixelFont.shader
@@ -22,7 +22,7 @@ Shader "Daggerfall/PixelFont"
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment frag
-            #pragma shader_feature _MacOSX
+            #pragma multi_compile_local __ _MacOSX
 
 			#include "UnityCG.cginc"
 

--- a/Assets/Shaders/DaggerfallPixelFont.shader
+++ b/Assets/Shaders/DaggerfallPixelFont.shader
@@ -4,6 +4,7 @@ Shader "Daggerfall/PixelFont"
     {
         _MainTex ("Texture", any) = "" {}
         _ScissorRect("Scissor Rectangle", Vector) = (0,1,0,1)   // x=left, y=right, z=bottom, w=top - fullscreen is (0,1,0,1)
+		_Color("Color", Color) = (1.0, 1.0, 1.0, 1.0)
     }
 
 	SubShader {
@@ -40,6 +41,7 @@ Shader "Daggerfall/PixelFont"
 			sampler2D _MainTex;
             uniform float4 _MainTex_ST;
             float4 _ScissorRect;
+			float4 _Color;
 			
 			v2f vert (appdata_t v)
 			{
@@ -59,7 +61,7 @@ Shader "Daggerfall/PixelFont"
 
                 float alpha = tex2D(_MainTex, i.texcoord).a;
 
-                return float4(i.color.rgb, alpha);
+                return float4(_Color.rgb, alpha);
 			}
 			ENDCG 
 		}

--- a/Assets/Shaders/DaggerfallSDFFont.shader
+++ b/Assets/Shaders/DaggerfallSDFFont.shader
@@ -22,7 +22,7 @@ Shader "Daggerfall/SDFFont"
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment frag
-            #pragma shader_feature _MacOSX
+            #pragma multi_compile_local __ _MacOSX
 
 			#include "UnityCG.cginc"
 

--- a/Assets/Shaders/DaggerfallSDFFont.shader
+++ b/Assets/Shaders/DaggerfallSDFFont.shader
@@ -4,6 +4,7 @@ Shader "Daggerfall/SDFFont"
     {
         _MainTex ("Texture", any) = "" {}
         _ScissorRect("Scissor Rectangle", Vector) = (0,1,0,1)   // x=left, y=right, z=bottom, w=top - fullscreen is (0,1,0,1)
+		_Color("Color", Color) = (1.0, 1.0, 1.0, 1.0)
     }
 
 	SubShader {
@@ -40,6 +41,7 @@ Shader "Daggerfall/SDFFont"
 			sampler2D _MainTex;
             uniform float4 _MainTex_ST;
             float4 _ScissorRect;
+			float4 _Color;
 			
 			v2f vert (appdata_t v)
 			{
@@ -60,7 +62,7 @@ Shader "Daggerfall/SDFFont"
                 float dist = tex2D(_MainTex, i.texcoord).a;
                 float smoothing = fwidth(dist);
                 float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
-                return float4(i.color.rgb, alpha);
+                return float4(_Color.rgb, alpha);
 
                 //return float4(float3(1,1,1), 1 - alpha);  // Glyph visualisation
                 //return float4(float3(i.screenPos.x, i.screenPos.y, 0), 1 - alpha);  // screenPos visualisation

--- a/Assets/Shaders/DaggerfallSDFFont.shader
+++ b/Assets/Shaders/DaggerfallSDFFont.shader
@@ -22,6 +22,7 @@ Shader "Daggerfall/SDFFont"
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment frag
+            #pragma shader_feature _MacOSX
 
 			#include "UnityCG.cginc"
 
@@ -62,7 +63,11 @@ Shader "Daggerfall/SDFFont"
                 float dist = tex2D(_MainTex, i.texcoord).a;
                 float smoothing = fwidth(dist);
                 float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
-                return float4(_Color.rgb, alpha);
+                #ifdef _MacOSX
+                    return float4(_Color.rgb, alpha);
+                #else
+                    return float4(i.color.rgb, alpha);
+                #endif
 
                 //return float4(float3(1,1,1), 1 - alpha);  // Glyph visualisation
                 //return float4(float3(i.screenPos.x, i.screenPos.y, 0), 1 - alpha);  // screenPos visualisation

--- a/Assets/Shaders/DaggerfallUIBlendShader.shader
+++ b/Assets/Shaders/DaggerfallUIBlendShader.shader
@@ -1,0 +1,64 @@
+Shader "Daggerfall/UIBlend"
+{
+	Properties
+    {
+        _MainTex ("Texture", any) = "" {}
+		_ColorTint ("Tint", Color) = (1.0, 1.0, 1.0, 1.0)
+    }
+
+	SubShader {
+
+		Tags { "ForceSupported" = "True" "RenderType"="Overlay" } 
+		
+		Lighting Off
+		Cull Off
+		ZWrite Off
+        ZTest Always
+		Fog { Mode Off }
+
+        // Renders texture with normal alpha blending
+		Pass {
+            Blend SrcAlpha OneMinusSrcAlpha
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#include "UnityCG.cginc"
+
+			struct appdata_t {
+				float4 vertex : POSITION;
+				fixed4 color : COLOR;
+				float2 texcoord : TEXCOORD0;
+			};
+
+			struct v2f {
+				float4 vertex : SV_POSITION;
+				fixed4 color : COLOR;
+				float2 texcoord : TEXCOORD0;
+                float2 screenPos : TEXCOORD1;
+			};
+
+			sampler2D _MainTex;
+            uniform float4 _MainTex_ST;
+			float4 _ColorTint;
+			
+			v2f vert (appdata_t v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.color = v.color;
+				o.texcoord = TRANSFORM_TEX(v.texcoord,_MainTex);
+                o.screenPos = ComputeScreenPos(o.vertex);
+				return o;
+			}
+
+			fixed4 frag (v2f i) : SV_Target
+			{
+                return tex2D(_MainTex, i.texcoord).rgba * _ColorTint;
+			}
+			ENDCG 
+		}
+	} 
+	
+	Fallback off
+}

--- a/Assets/Shaders/DaggerfallUIBlendShader.shader.meta
+++ b/Assets/Shaders/DaggerfallUIBlendShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 452ba406f28df487a92bfee64cf0df38
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/DaggerfallUIBlitShader.shader
+++ b/Assets/Shaders/DaggerfallUIBlitShader.shader
@@ -1,0 +1,64 @@
+Shader "Daggerfall/UIBlit"
+{
+	Properties
+    {
+        _MainTex ("Texture", any) = "" {}
+		_ColorTint ("Tint", Color) = (1.0, 1.0, 1.0, 1.0)
+    }
+
+	SubShader {
+
+		Tags { "ForceSupported" = "True" "RenderType"="Overlay" } 
+		
+		Lighting Off
+		Cull Off
+		ZWrite Off
+        ZTest Always
+		Fog { Mode Off }
+
+        // Renders texture with normal alpha blending
+		Pass {
+            Blend Off
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#include "UnityCG.cginc"
+
+			struct appdata_t {
+				float4 vertex : POSITION;
+				fixed4 color : COLOR;
+				float2 texcoord : TEXCOORD0;
+			};
+
+			struct v2f {
+				float4 vertex : SV_POSITION;
+				fixed4 color : COLOR;
+				float2 texcoord : TEXCOORD0;
+                float2 screenPos : TEXCOORD1;
+			};
+
+			sampler2D _MainTex;
+            uniform float4 _MainTex_ST;
+			float4 _ColorTint;
+			
+			v2f vert (appdata_t v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.color = v.color;
+				o.texcoord = TRANSFORM_TEX(v.texcoord,_MainTex);
+                o.screenPos = ComputeScreenPos(o.vertex);
+				return o;
+			}
+
+			fixed4 frag (v2f i) : SV_Target
+			{
+                return tex2D(_MainTex, i.texcoord).rgba * _ColorTint;
+			}
+			ENDCG 
+		}
+	} 
+	
+	Fallback off
+}

--- a/Assets/Shaders/DaggerfallUIBlitShader.shader.meta
+++ b/Assets/Shaders/DaggerfallUIBlitShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 342732c70e47440889e202f010447560
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/RequiredShaderVariants.shadervariants
+++ b/Assets/Shaders/RequiredShaderVariants.shadervariants
@@ -112,10 +112,16 @@ ShaderVariantCollection:
   - first: {fileID: 4800000, guid: a5ff30e56bb71d24d9eee4b8af0b25ba, type: 3}
     second:
       variants: []
+  - first: {fileID: 4800000, guid: 452ba406f28df487a92bfee64cf0df38, type: 3}
+    second:
+      variants: []
   - first: {fileID: 4800000, guid: 91530837b4a4d414c8aaf7899343ac5d, type: 3}
     second:
       variants: []
   - first: {fileID: 4800000, guid: 9e6df0875b8898444a3b513dc8afd6dd, type: 3}
+    second:
+      variants: []
+  - first: {fileID: 4800000, guid: 342732c70e47440889e202f010447560, type: 3}
     second:
       variants: []
   - first: {fileID: 4800000, guid: 7a713b7991f72154d9f5c6a8686cb591, type: 3}


### PR DESCRIPTION
Implemented DaggerfallUI.DrawTexture to handle separate UI rendering pathways for Mac and PC/Linux.
The PC/Linux pathway is still using GUI.DrawTexture as before. Mac pathway uses Graphics.DrawTexture and font shader customisations to yield correct colour space output.
This should be a low impact change for mods as only internal UI DrawTexture handling involved. Any mods using GUI.DrawTexture or GUI.DrawTextureWithTexCoords should use the equivalent method in DaggerfallUI to render textures in correct colour space on Mac.
Tested with and without DREAM in editor and builds across Mac/PC and working OK, so texture mods should not be impacted by this.
Tagging @ajrb and @KABoissonneault - please quickly test your mods build with the changes in this PR and it doesn't cause any problems you can see. I'd like to include this in 0.14.1 if no issues found.