### PR TITLE
Allow building greeting message boxes to be disabled by mods

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -105,7 +105,7 @@ namespace DaggerfallWorkshop.Game
         }
 
         // Allows the building greeting message boxes to be disabled by mods
-        public static bool buildingGreetingEnabled = true;
+        public static bool buildingGreetingsEnabled = true;
 
         #region custom mod activation
         private struct CustomModActivation
@@ -561,7 +561,7 @@ namespace DaggerfallWorkshop.Game
 
                     // If entering a shop let player know the quality level
                     // If entering an open home, show greeting
-                    if (hitBuilding && buildingGreetingEnabled)
+                    if (hitBuilding && buildingGreetingsEnabled)
                     {
                         const int houseGreetingsTextId = 256;
 

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -104,6 +104,9 @@ namespace DaggerfallWorkshop.Game
                     closeHours[(int)buildingType] > DaggerfallUnity.Instance.WorldTime.Now.Hour);
         }
 
+        // Allows the building greeting message boxes to be disabled by mods
+        public static bool buildingGreetingEnabled = true;
+
         #region custom mod activation
         private struct CustomModActivation
         {
@@ -558,7 +561,7 @@ namespace DaggerfallWorkshop.Game
 
                     // If entering a shop let player know the quality level
                     // If entering an open home, show greeting
-                    if (hitBuilding)
+                    if (hitBuilding && buildingGreetingEnabled)
                     {
                         const int houseGreetingsTextId = 256;
 


### PR DESCRIPTION
Simple switch for the building greetings so mods can turn them off, and optionally replace using enter exit events