### PR TITLE
K0C0XY01 fix

### DIFF
--- a/Assets/StreamingAssets/Quests/K0C0XY01.txt
+++ b/Assets/StreamingAssets/Quests/K0C0XY01.txt
@@ -186,10 +186,8 @@ Message:  1099
 QBN:
 Item _item_ book2
 Item _reward_ gold
-Item _clanfeather1_ harpy_feather anyInfo 1030
-Item clanfeather2 harpy_feather anyInfo 1031
-Item clanfeather3 harpy_feather anyInfo 1032
-Item clanfeather4 harpy_feather anyInfo 1032
+Item _clanfeather1_ harpy_feather
+-- feather "dialogue" was weird and out of place. Removed from quest since they contribute nothing
 Item _letter26_ letter used 1012
 Item _jewelry_ trinket
 


### PR DESCRIPTION
K0C0XY01 is a harpy-slaying quest with several dummied-out items that still appear as dialogue choices. Not only that, the text is strange, like a description rather than dialogue. It makes more sense to remove them from the game, since they contribute nothing at all. The quest is still completable by delivering the leader's harpy feather to the questgiver, like vanilla.