### PR TITLE
optimization: `DaggerfallBillboardSystem` increases performance of `DaggerfallBillboard` with `IJobParallelForTransform`-based multithreading

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -80,10 +80,19 @@ namespace DaggerfallWorkshop
                     meshRenderer.enabled = false;
                 }
 
-                yield return null;// without this delay many billboards were broken (not animating or visible when shouldn't)
+                // wait a single frame so all objects initialize
+                yield return null;
 
-                if (faceY) DaggerfallBillboardSystem.AddPointBillboard(transform);
-                else DaggerfallBillboardSystem.AddAxialBillboard(transform);
+                // Rotate to face camera in game
+                // Do not rotate if MeshRenderer disabled. The player can't see it anyway and this could be a hidden editor marker with child objects.
+                // In the case of hidden editor markers with child treasure objects, we don't want a 3D replacement spinning around like a billboard.
+                // Treasure objects are parented to editor marker in this way as the moving action data for treasure is actually on editor marker parent.
+                // Visible child of treasure objects have their own MeshRenderer and DaggerfallBillboard to apply rotations.
+                if (meshRenderer.enabled)
+                {
+                    if (faceY) DaggerfallBillboardSystem.AddPointBillboard(transform);
+                    else DaggerfallBillboardSystem.AddAxialBillboard(transform);
+                }
 
                 // Restart animation coroutine if not running
                 if (summary.AnimatedMaterial)

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -98,7 +98,6 @@ namespace DaggerfallWorkshop
                 if (summary.AnimatedMaterial)
                     StartCoroutine(AnimateBillboard());
             }
-            else yield return null;
         }
 
         void OnDestroy()

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -60,13 +60,7 @@ namespace DaggerfallWorkshop
         public override bool FaceY
         {
             get { return faceY; }
-            set
-            {
-                DaggerfallBillboardSystem.RemoveBillboard(transform);
-                faceY = value;
-                if (faceY) DaggerfallBillboardSystem.AddPointBillboard(transform);
-                else DaggerfallBillboardSystem.AddAxialBillboard(transform);
-            }
+            set { faceY = value; }
         }
 
         IEnumerator Start()

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -180,7 +180,7 @@ namespace DaggerfallWorkshop
             summary.Flags = flags;
 
             // TEMP: Add name seed
-            summary.NameSeed = (int)position;
+            summary.NameSeed = (int) position;
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace DaggerfallWorkshop
                         summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID & 0xff);
                     else
                         summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID);
-                }
+                }       
                 else if (resource.TextureRecord == 10) // Start marker. Holds data for dungeon block water level and castle block status.
                 {
                     if (resource.SoundIndex != 0)
@@ -337,7 +337,7 @@ namespace DaggerfallWorkshop
             if (summary.FlatType == FlatTypes.NPC)
             {
                 Collider col = gameObject.GetComponent<BoxCollider>();
-                if (col == null)
+                if(col == null)
                     col = gameObject.AddComponent<BoxCollider>();
                 col.isTrigger = true;
             }
@@ -439,7 +439,7 @@ namespace DaggerfallWorkshop
                 }
             }
         }
-
+        
         /// <summary>
         /// Draws a circle at the bottom of the bilboard to make it easier to judge the size regardless of rotation.
         /// </summary>

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -178,7 +178,7 @@ namespace DaggerfallWorkshop
             summary.Flags = flags;
 
             // TEMP: Add name seed
-            summary.NameSeed = (int) position;
+            summary.NameSeed = (int)position;
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace DaggerfallWorkshop
                         summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID & 0xff);
                     else
                         summary.FixedEnemyType = (MobileTypes)(summary.FactionOrMobileID);
-                }       
+                }
                 else if (resource.TextureRecord == 10) // Start marker. Holds data for dungeon block water level and castle block status.
                 {
                     if (resource.SoundIndex != 0)
@@ -335,7 +335,7 @@ namespace DaggerfallWorkshop
             if (summary.FlatType == FlatTypes.NPC)
             {
                 Collider col = gameObject.GetComponent<BoxCollider>();
-                if(col == null)
+                if (col == null)
                     col = gameObject.AddComponent<BoxCollider>();
                 col.isTrigger = true;
             }
@@ -437,7 +437,7 @@ namespace DaggerfallWorkshop
                 }
             }
         }
-        
+
         /// <summary>
         /// Draws a circle at the bottom of the bilboard to make it easier to judge the size regardless of rotation.
         /// </summary>

--- a/Assets/Scripts/Internal/DaggerfallBillboardSystem.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboardSystem.cs
@@ -79,7 +79,6 @@ namespace DaggerfallWorkshop
 
                     // schedule axial billboard job:
                     var jobAxial = new SetRotationJob { Value = Quaternion.LookRotation(-new Vector3(cameraForward.x, 0, cameraForward.z)) };
-                    // var jobAxial = new AxialLookAtPointJob { Point = cameraPosition };// better looking but about x2 more costly
                     var jobHandleAxial = jobAxial.Schedule(axialBillboards);
 
                     // schedule point billboard job:
@@ -141,28 +140,6 @@ namespace DaggerfallWorkshop
             public quaternion Value;
             void IJobParallelForTransform.Execute(int index, TransformAccess transform)
                 => transform.rotation = Value;
-        }
-
-        [Unity.Burst.BurstCompile]
-        public struct LookAtPointJob : IJobParallelForTransform
-        {
-            public float3 Point;
-            void IJobParallelForTransform.Execute(int index, TransformAccess transform)
-                => transform.rotation = quaternion.LookRotationSafe(Point - (float3)transform.position, new float3 { y = 1 });
-        }
-
-        [Unity.Burst.BurstCompile]
-        public struct AxialLookAtPointJob : IJobParallelForTransform
-        {
-            public float3 Point;
-            void IJobParallelForTransform.Execute(int index, TransformAccess transform)
-            {
-                float3 position = (float3)transform.position;
-                transform.rotation = quaternion.LookRotationSafe(
-                    new float3 { x = Point.x, y = position.y, z = Point.z } - position,
-                    new float3 { y = 1 }
-                );
-            }
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]

--- a/Assets/Scripts/Internal/DaggerfallBillboardSystem.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboardSystem.cs
@@ -69,11 +69,6 @@ namespace DaggerfallWorkshop
             if (mainCamera == null)
                 mainCamera = GameObject.FindGameObjectWithTag("MainCamera")?.GetComponent<Camera>();
 
-            // Rotate to face camera in game
-            // Do not rotate if MeshRenderer disabled. The player can't see it anyway and this could be a hidden editor marker with child objects.
-            // In the case of hidden editor markers with child treasure objects, we don't want a 3D replacement spinning around like a billboard.
-            // Treasure objects are parented to editor marker in this way as the moving action data for treasure is actually on editor marker parent.
-            // Visible child of treasure objects have their own MeshRenderer and DaggerfallBillboard to apply rotations.
             if (mainCamera != null)
             {
                 pmCalculateQuaterions.Begin();

--- a/Assets/Scripts/Internal/DaggerfallBillboardSystem.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboardSystem.cs
@@ -1,0 +1,163 @@
+﻿// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Gavin Clayton (interkarma@dfworkshop.net)
+// Contributors:    
+// 
+// Notes:
+//
+
+using UnityEngine;
+using UnityEngine.Rendering;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.Jobs;
+using Unity.Mathematics;
+using Unity.Jobs;
+using Unity.Collections;
+using Unity.Profiling;
+using DaggerfallConnect;
+using DaggerfallWorkshop.Utility.AssetInjection;
+using DaggerfallWorkshop.Game;
+using DaggerfallWorkshop.Utility;
+
+namespace DaggerfallWorkshop
+{
+    /// <summary>
+    /// System to update transforms for all DaggerfallBillboard instances.
+    /// (singleton)
+    /// </summary>
+    [AddComponentMenu("")]
+    public class DaggerfallBillboardSystem : MonoBehaviour
+    {
+
+        static TransformAccessArray
+            pointBillboards,
+            axialBillboards;
+        static Dictionary<Transform, int>
+            pointIndices = new Dictionary<Transform, int>(),
+            axialIndices = new Dictionary<Transform, int>();
+        static ProfilerMarker
+            pmCalculateQuaterions = new ProfilerMarker("calculate quaterions"),
+            pmScheduleJobs = new ProfilerMarker("schedule jobs");
+        Camera mainCamera = null;
+        JobHandle dependency;
+
+#if UNITY_EDITOR
+        ~DaggerfallBillboardSystem() => OnDestroy();// fixes: ocassional alloc warning
+#endif
+
+        void Awake()
+        {
+            pointBillboards = new TransformAccessArray(32);
+            axialBillboards = new TransformAccessArray(32);
+        }
+
+        void OnDestroy()
+        {
+            if (pointBillboards.isCreated) pointBillboards.Dispose();
+            if (axialBillboards.isCreated) axialBillboards.Dispose();
+            pointIndices.Clear();
+            axialIndices.Clear();
+        }
+
+        void Update()
+        {
+            if (mainCamera == null)
+                mainCamera = GameObject.FindGameObjectWithTag("MainCamera")?.GetComponent<Camera>();
+
+            // Rotate to face camera in game
+            // Do not rotate if MeshRenderer disabled. The player can't see it anyway and this could be a hidden editor marker with child objects.
+            // In the case of hidden editor markers with child treasure objects, we don't want a 3D replacement spinning around like a billboard.
+            // Treasure objects are parented to editor marker in this way as the moving action data for treasure is actually on editor marker parent.
+            // Visible child of treasure objects have their own MeshRenderer and DaggerfallBillboard to apply rotations.
+            if (mainCamera != null)
+            {
+                pmCalculateQuaterions.Begin();
+                var forward = mainCamera.transform.forward;
+                var lookAxial = Quaternion.LookRotation(-new Vector3(forward.x, 0, forward.z));
+                var lookPoint = Quaternion.LookRotation(-forward);
+                pmCalculateQuaterions.End();
+
+                pmScheduleJobs.Begin();
+                {
+                    dependency.Complete();// make sure these jobs take no more than a single frame:
+
+                    var jobAxial = new SetRotationJob
+                    {
+                        Value = lookAxial
+                    };
+                    var jobHandleAxial = jobAxial.Schedule(axialBillboards);
+
+                    var jobPoint = new SetRotationJob
+                    {
+                        Value = lookPoint
+                    };
+                    var jobHandlePoint = jobPoint.Schedule(pointBillboards);
+
+                    dependency = JobHandle.CombineDependencies(jobHandleAxial, jobHandlePoint);
+                }
+                pmScheduleJobs.End();
+            }
+        }
+
+        public static void AddPointBillboard(Transform t)
+        {
+            int index = pointBillboards.length;
+            pointBillboards.Add(t);
+            pointIndices.Add(t, index);
+        }
+
+        public static void RemoveBillboard(Transform t)
+        {
+#if UNITY_EDITOR
+            // TransformAccessArray should always exists, *except* when in-editor game just stopped playing, hence this null-check.
+            if (!axialBillboards.isCreated || !pointBillboards.isCreated) return;
+#endif
+
+            if (pointIndices.ContainsKey(t))
+            {
+                int index = pointIndices[t];
+                pointBillboards.RemoveAtSwapBack(index);
+                pointIndices.Remove(t);
+
+                int indexThatGotReplaced = pointBillboards.length;
+                var found = pointIndices.FirstOrDefault((next) => next.Value == indexThatGotReplaced);
+                if (found.Key) pointIndices[found.Key] = index;
+            }
+            else if (axialIndices.ContainsKey(t))
+            {
+                int index = axialIndices[t];
+                axialBillboards.RemoveAtSwapBack(index);
+                axialIndices.Remove(t);
+
+                int indexThatGotReplaced = axialBillboards.length;
+                var found = axialIndices.FirstOrDefault((next) => next.Value == indexThatGotReplaced);
+                if (found.Key) axialIndices[found.Key] = index;
+            }
+        }
+
+        public static void AddAxialBillboard(Transform t)
+        {
+            int index = axialBillboards.length;
+            axialBillboards.Add(t);
+            axialIndices.Add(t, index);
+        }
+
+        [Unity.Burst.BurstCompile]
+        public struct SetRotationJob : IJobParallelForTransform
+        {
+            public quaternion Value;
+            void IJobParallelForTransform.Execute(int index, TransformAccess transform)
+                => transform.rotation = Value;
+        }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        static void InitializeType()
+            => DontDestroyOnLoad(new GameObject($"#{nameof(DaggerfallBillboardSystem)}").AddComponent<DaggerfallBillboardSystem>().gameObject);
+
+    }
+}

--- a/Assets/Scripts/Internal/DaggerfallBillboardSystem.cs.meta
+++ b/Assets/Scripts/Internal/DaggerfallBillboardSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b85dcd99c159ca419ee965c962e7bff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hi guys,

This is my first attempt here at implementing something that #2316 enabled.
I picked billboards not because those were causing any mayor performance issues, **they weren't**, but because I knew how to optimize them already and it is pretty much an isolated system from many complexities of this project.

<br>

These are **very** rough (editor & debug) numbers how billboards performed
> **Before**: `0.6 ms` (main thread)

![Screenshot 2022-07-12 181808](https://user-images.githubusercontent.com/3066539/179237191-bc10e0d3-1f9f-4ad5-9d06-3fb52f8f01f8.png)

> **After**:  `0.03 ms` (main thread) + `0.06 ms` (different thread)

![Screenshot 2022-07-13 120343](https://user-images.githubusercontent.com/3066539/179237192-31d74c57-3529-4e3f-bb5f-f4613d93fcd5.png)

![Screenshot 2022-07-13 120516](https://user-images.githubusercontent.com/3066539/179237189-64fab5bc-fe4c-4878-8090-d1a5f61562a2.png)
> ☝ different thread

We can see that raw computation cost decreased about 10x, but that is not even that important. The thing that matters here is that this `0.5 ms` disappeared from the main thread, so it will no longer affect the main gameplay/rendering loop from now on.

<br>

If you point me any cases which I should test and make sure it works, that would be great. It looks fine on my machine, but I want to make sure my changes won't break something that I didn't even consider.
