### PR TITLE
Weapon HUD Animations Mod Support 1, 7/19/2022

### DIFF
--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -549,7 +549,7 @@ namespace DaggerfallWorkshop.Game
                     {
                         filename = WeaponBasics.GetModdedWeaponFilename(SpecificWeapon);
 
-                        if (filename == "")
+                        if (string.IsNullOrEmpty(filename))
                             filename = WeaponBasics.GetWeaponFilename(WeaponType); // Possibly make support for custom weapon types for the HUD in the future.
                     }
 

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    Hazelnut
+// Contributors:    Hazelnut, Kirk.O
 // 
 // Notes:
 //
@@ -22,6 +22,7 @@ using DaggerfallWorkshop.Utility.AssetInjection;
 using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Formulas;
+using DaggerfallWorkshop.Game.Items;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -38,6 +39,7 @@ namespace DaggerfallWorkshop.Game
         public WeaponTypes WeaponType = WeaponTypes.None;
         public MetalTypes MetalType = MetalTypes.None;
         public ItemHands WeaponHands = ItemHands.None;
+        public DaggerfallUnityItem SpecificWeapon = null;
         public float Reach = 2.5f;
         public float AttackSpeedScale = 1.0f;
         public float Cooldown = 0.0f;
@@ -74,6 +76,9 @@ namespace DaggerfallWorkshop.Game
 
         readonly Dictionary<int, Texture2D> customTextures = new Dictionary<int, Texture2D>();
         Texture2D curCustomTexture;
+
+        // Allows a mod to specify if DFU should use custom HUD animations for weapons
+        public static bool moddedWeaponHUDAnimsEnabled = false;
 
         float lastScreenWidth, lastScreenHeight;
         bool lastLargeHUDSetting, lastLargeHUDDockSetting;
@@ -539,6 +544,14 @@ namespace DaggerfallWorkshop.Game
                 for (int frame = 0; frame < frames; frame++)
                 {
                     textures.Add(GetWeaponTexture2D(filename, record, frame, metalType, out rect, border, dilate));
+
+                    if (moddedWeaponHUDAnimsEnabled && SpecificWeapon != null)
+                    {
+                        filename = WeaponBasics.GetModdedWeaponFilename(SpecificWeapon);
+
+                        if (filename == "")
+                            filename = WeaponBasics.GetWeaponFilename(WeaponType); // Possibly make support for custom weapon types for the HUD in the future.
+                    }
 
                     Texture2D tex;
                     if (TextureReplacement.TryImportCifRci(filename, record, frame, metalType, true, out tex))

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    Numidium, Hazelnut
+// Contributors:    Numidium, Hazelnut, Kirk.O
 //
 // Notes:
 //
@@ -763,6 +763,7 @@ namespace DaggerfallWorkshop.Game
             target.WeaponType = DaggerfallUnity.Instance.ItemHelper.ConvertItemToAPIWeaponType(weapon);
             target.MetalType = DaggerfallUnity.Instance.ItemHelper.ConvertItemMaterialToAPIMetalType(weapon);
             target.WeaponHands = ItemEquipTable.GetItemHands(weapon);
+            target.SpecificWeapon = weapon;
             target.DrawWeaponSound = weapon.GetEquipSound();
             target.SwingWeaponSound = weapon.GetSwingSound();
         }

--- a/Assets/Scripts/Utility/WeaponBasics.cs
+++ b/Assets/Scripts/Utility/WeaponBasics.cs
@@ -214,10 +214,17 @@ namespace DaggerfallWorkshop.Utility
                         case (int)Weapons.Dagger:
                             return "MEHRUNESRAZOR.CIF";
                         case (int)Weapons.Staff:
-                            if (weapon.ItemName == "The Wabbajack")
-                                return "WABBAJACK.CIF";
-                            else
-                                return "STAFFOFMAGNUS.CIF";
+                            foreach (DaggerfallConnect.FallExe.DaggerfallEnchantment enchantment in weapon.LegacyEnchantments)
+                            {
+                                if (enchantment.type == DaggerfallConnect.FallExe.EnchantmentTypes.SpecialArtifactEffect)
+                                {
+                                    if (enchantment.param == (int)ArtifactsSubTypes.Wabbajack)
+                                        return "WABBAJACK.CIF";
+                                }
+                                else
+                                    return "STAFFOFMAGNUS.CIF";
+                            }
+                            return "";
                         case (int)Weapons.Katana:
                             return "EBONYBLADE.CIF";
                         case (int)Weapons.Claymore:

--- a/Assets/Scripts/Utility/WeaponBasics.cs
+++ b/Assets/Scripts/Utility/WeaponBasics.cs
@@ -214,7 +214,7 @@ namespace DaggerfallWorkshop.Utility
                         case (int)Weapons.Dagger:
                             return "MEHRUNESRAZOR.CIF";
                         case (int)Weapons.Staff:
-                            if (weapon.ItemName == "Wabbajack")
+                            if (weapon.ItemName == "The Wabbajack")
                                 return "WABBAJACK.CIF";
                             else
                                 return "STAFFOFMAGNUS.CIF";

--- a/Assets/Scripts/Utility/WeaponBasics.cs
+++ b/Assets/Scripts/Utility/WeaponBasics.cs
@@ -4,13 +4,14 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Kirk.O
 // 
 // Notes:
 //
 
 using System;
 using System.Collections.Generic;
+using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 
 namespace DaggerfallWorkshop.Utility
@@ -199,6 +200,130 @@ namespace DaggerfallWorkshop.Utility
                     return "MJIC00C6.CIF";
                 default:
                     throw new Exception("Unsupported element type.");
+            }
+        }
+
+        public static string GetModdedWeaponFilename(DaggerfallUnityItem weapon)
+        {
+            if (weapon.IsEnchanted)
+            {
+                if (weapon.IsArtifact)
+                {
+                    switch (weapon.TemplateIndex)
+                    {
+                        case (int)Weapons.Dagger:
+                            return "MEHRUNESRAZOR.CIF";
+                        case (int)Weapons.Staff:
+                            if (weapon.ItemName == "Wabbajack")
+                                return "WABBAJACK.CIF";
+                            else
+                                return "STAFFOFMAGNUS.CIF";
+                        case (int)Weapons.Katana:
+                            return "EBONYBLADE.CIF";
+                        case (int)Weapons.Claymore:
+                            return "CHRYSAMERE.CIF";
+                        case (int)Weapons.Mace:
+                            return "MACEOFMOLAGBAL.CIF";
+                        case (int)Weapons.Warhammer:
+                            return "VOLENDRUNG.CIF";
+                        case (int)Weapons.Long_Bow:
+                            return "AURIELSBOW.CIF";
+                        default:
+                            return ""; // Just place-holder for now, may see about allowing custom weapon types to use this in some way.
+                    }
+                }
+                else
+                {
+                    switch (weapon.TemplateIndex)
+                    {
+                        case (int)Weapons.Dagger:
+                            return "DAGGERMAGIC.CIF";
+                        case (int)Weapons.Tanto:
+                            return "TANTOMAGIC.CIF";
+                        case (int)Weapons.Staff:
+                            return "STAFFMAGIC.CIF";
+                        case (int)Weapons.Shortsword:
+                            return "SHORTSWORDMAGIC.CIF";
+                        case (int)Weapons.Wakazashi:
+                            return "WAKAZASHIMAGIC.CIF";
+                        case (int)Weapons.Broadsword:
+                            return "BROADSWORDMAGIC.CIF";
+                        case (int)Weapons.Saber:
+                            return "SABERMAGIC.CIF";
+                        case (int)Weapons.Longsword:
+                            return "LONGSWORDMAGIC.CIF";
+                        case (int)Weapons.Katana:
+                            return "KATANAMAGIC.CIF";
+                        case (int)Weapons.Claymore:
+                            return "CLAYMOREMAGIC.CIF";
+                        case (int)Weapons.Dai_Katana:
+                            return "DAIKATANAMAGIC.CIF";
+                        case (int)Weapons.Mace:
+                            return "MACEMAGIC.CIF";
+                        case (int)Weapons.Flail:
+                            return "FLAILMAGIC.CIF";
+                        case (int)Weapons.Warhammer:
+                            return "WARHAMMERMAGIC.CIF";
+                        case (int)Weapons.Battle_Axe:
+                            return "BATTLEAXEMAGIC.CIF";
+                        case (int)Weapons.War_Axe:
+                            return "WARAXEMAGIC.CIF";
+                        case (int)Weapons.Short_Bow:
+                            return "SHORTBOWMAGIC.CIF";
+                        case (int)Weapons.Long_Bow:
+                            return "LONGBOWMAGIC.CIF";
+                        case (int)Weapons.Arrow:
+                            return "ARROWMAGIC.CIF";
+                        default:
+                            return ""; // Just place-holder for now, may see about allowing custom weapon types to use this in some way.
+                    }
+                }
+            }
+            else
+            {
+                switch (weapon.TemplateIndex)
+                {
+                    case (int)Weapons.Dagger:
+                        return "DAGGER.CIF";
+                    case (int)Weapons.Tanto:
+                        return "TANTO.CIF";
+                    case (int)Weapons.Staff:
+                        return "STAFF.CIF";
+                    case (int)Weapons.Shortsword:
+                        return "SHORTSWORD.CIF";
+                    case (int)Weapons.Wakazashi:
+                        return "WAKAZASHI.CIF";
+                    case (int)Weapons.Broadsword:
+                        return "BROADSWORD.CIF";
+                    case (int)Weapons.Saber:
+                        return "SABER.CIF";
+                    case (int)Weapons.Longsword:
+                        return "LONGSWORD.CIF";
+                    case (int)Weapons.Katana:
+                        return "KATANA.CIF";
+                    case (int)Weapons.Claymore:
+                        return "CLAYMORE.CIF";
+                    case (int)Weapons.Dai_Katana:
+                        return "DAIKATANA.CIF";
+                    case (int)Weapons.Mace:
+                        return "MACE.CIF";
+                    case (int)Weapons.Flail:
+                        return "FLAIL.CIF";
+                    case (int)Weapons.Warhammer:
+                        return "WARHAMMER.CIF";
+                    case (int)Weapons.Battle_Axe:
+                        return "BATTLEAXE.CIF";
+                    case (int)Weapons.War_Axe:
+                        return "WARAXE.CIF";
+                    case (int)Weapons.Short_Bow:
+                        return "SHORTBOW.CIF";
+                    case (int)Weapons.Long_Bow:
+                        return "LONGBOW.CIF";
+                    case (int)Weapons.Arrow:
+                        return "ARROW.CIF";
+                    default:
+                        return ""; // Just place-holder for now, may see about allowing custom weapon types to use this in some way.
+                }
             }
         }
 


### PR DESCRIPTION
Very basic mod support for making it possible through a mod with texture replacements to add unique HUD animation frames for the various different vanilla weapons.

So instead of only being able to replace the entire group of the generic "long-blade" animations that most bladed weapons use, the modder can specify through texture naming if they want to replace the animations for say the Claymore and Katana so they look different from one another on the HUD. Or even adding unique HUD animations for the vanilla weapon artifacts and enchanted magic weapons, etc, 7/19/2022.