### PR TITLE
Disable doppler effect

### DIFF
--- a/ProjectSettings/AudioManager.asset
+++ b/ProjectSettings/AudioManager.asset
@@ -5,7 +5,7 @@ AudioManager:
   m_ObjectHideFlags: 0
   m_Volume: 1
   Rolloff Scale: 1
-  Doppler Factor: 1
+  Doppler Factor: 0
   Default Speaker Mode: 2
   m_SampleRate: 0
   m_DSPBufferSize: 0


### PR DESCRIPTION
The Doppler effect implementation in Unity causes odd-sounding, and at times extreme, pitch shifts to occur during play. This is most noticeable to me when I run past an enemy as it plays its bark. It's a matter of preference but I believe it may be best to simply disable it since it was not something present in classic.