### PR TITLE
Fixed "MuteHumanSounds" and "CharmEffect" for custom class enemies

### DIFF
--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -12,6 +12,7 @@
 using UnityEngine;
 using System.Collections;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.Entity;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -217,7 +218,7 @@ namespace DaggerfallWorkshop.Game
 
         private bool IgnoreHumanSounds()
         {
-            if (mobile.Enemy.ID > 127 && mobile.Enemy.ID < 146 && MuteHumanSounds)
+            if (DaggerfallEntity.IsClassEnemyId(mobile.Enemy.ID) && MuteHumanSounds)
                 return true;
             else
                 return false;

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -961,6 +961,21 @@ namespace DaggerfallWorkshop.Game.Entity
             CustomCareerTemplates[enemyId] = career;
         }
 
+        /// <summary>
+        /// Returns whether the provided enemy id refers to a Class enemy (as opposed to a Monster enemy)
+        /// For custom enemies, we use the 7th bit to tell whether a class or monster was intended
+        /// 0-127 is monster
+        /// 128-255 is class
+        /// 256-383 is monster again
+        /// etc
+        /// </summary>
+        /// <param name="enemyId">Id of the enemy type</param>
+        /// <returns>True if Class type enemy, False if Monster type enemy</returns>
+        public static bool IsClassEnemyId(int enemyId)
+        {
+            return (enemyId & 128) != 0;
+        }
+
         public static SoundClips GetRaceGenderAttackSound(Races race, Genders gender, bool isPlayerAttack = false)
         {
             // Check for racial override attack sound for player only

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Thaumaturgy/CharmEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Thaumaturgy/CharmEffect.cs
@@ -76,7 +76,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 
             // Check target match
             // Note: Charm only works on enemy classes (not monstrous humanoids)
-            return (entity as EnemyEntity).MobileEnemy.ID >= 128;
+            return DaggerfallEntity.IsClassEnemyId((entity as EnemyEntity).MobileEnemy.ID);
         }
     }
 }

--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -172,12 +172,7 @@ namespace DaggerfallWorkshop.Game
                     }
                     else if (DaggerfallEntity.GetCustomCareerTemplate(enemyIndex) != null)
                     {
-                        // For custom enemies, we use the 7th bit to tell whether a class or monster was intended
-                        // 0-127 is monster
-                        // 128-255 is class
-                        // 256-383 is monster again
-                        // etc
-                        if ((enemyIndex & 128) != 0)
+                        if (DaggerfallEntity.IsClassEnemyId(enemyIndex))
                         {
                             entityBehaviour.EntityType = EntityTypes.EnemyClass;
                         }


### PR DESCRIPTION
Replace "id >= 128" logic in DFU with a new helper, `DaggerfallEntity.IsClassEnemyId`, for better consistency in custom enemy support. Remember that for custom enemies, for every multiple of 256, the first 128 ids are monsters, and the last 128 ids are class enemies (this allows infinite extensibility while allowing mods to reserve an id space for themselves).

I made this change at first thinking MuteHumanSounds was an actual user-facing feature that players could turn off, and I wanted custom class enemies to properly support it. But I eventually realized only code can disable it. So that part of the change is not really necessary, I can just remove the sounds from my custom enemies. 

But the CharmEffect fix is useful, so I kept it all. It's not that big