### PR TITLE
Fixed saves failing to load custom class enemies

### DIFF
--- a/Assets/Scripts/Game/SetupDemoEnemy.cs
+++ b/Assets/Scripts/Game/SetupDemoEnemy.cs
@@ -221,12 +221,22 @@ namespace DaggerfallWorkshop.Game
         {
             // Get mobile type based on entity type and career index
             MobileTypes mobileType;
-            if (entityType == EntityTypes.EnemyMonster)
-                mobileType = (MobileTypes)careerIndex;
-            else if (entityType == EntityTypes.EnemyClass)
-                mobileType = (MobileTypes)(careerIndex + 128);
+
+            // For classic enemies, careerIndex is equal to enemyId for monsters, or enemyId - 128 for class enemies (ex: Mage, enemyId=128, careerIndex=0)
+            // For custom enemies, we just always store the enemyId in careerIndex, even if class type
+            if (careerIndex < 256)
+            {                
+                if (entityType == EntityTypes.EnemyMonster)
+                    mobileType = (MobileTypes)careerIndex;
+                else if (entityType == EntityTypes.EnemyClass)
+                    mobileType = (MobileTypes)(careerIndex + 128);
+                else
+                    return;
+            }
             else
-                return;
+            {
+                mobileType = (MobileTypes)careerIndex;
+            }
 
             MobileReactions enemyReaction = (isHostile) ? MobileReactions.Hostile : MobileReactions.Passive;
             MobileGender enemyGender = gender;


### PR DESCRIPTION
This is caused by an invalid careerIndex to mobileType conversion. For example, custom class enemy 384 would be converted to 512 (384+128), and the save would softlock if enemy id 512 didn't exist.

Sorry for the many PRs in recent weeks, our monster expansion mod is getting close to release, and so we're playtesting it a lot more.