### PR TITLE
Classic player death sound option

### DIFF
--- a/Assets/Scripts/Game/PlayerDeath.cs
+++ b/Assets/Scripts/Game/PlayerDeath.cs
@@ -28,6 +28,7 @@ namespace DaggerfallWorkshop.Game
 
         const float fallSpeed = 2.5f;
 
+        public const SoundClips classicPlayerDeathSound = SoundClips.WoodElfMalePain1;
         public float FadeDuration = 2f;
         public float TimeBeforeReset = 3;
 
@@ -160,9 +161,13 @@ namespace DaggerfallWorkshop.Game
             currentCameraHeight = startCameraHeight;
             DaggerfallUI.Instance.FadeBehaviour.FadeHUDToBlack(FadeDuration);
 
-            // There are 3 pain-like sounds for each race/gender. The third one, used here, sounds like
-            // it may have been meant for when the player dies.
-            SoundClips sound = GetRaceGenderPain3Sound(playerEntity.Race, playerEntity.Gender);
+            SoundClips sound = classicPlayerDeathSound;
+            if (DaggerfallUnity.Settings.CombatVoices)
+            {
+                // There are 3 pain-like sounds for each race/gender. The third one, used here, sounds like
+                // it may have been meant for when the player dies.
+                sound = GetRaceGenderPain3Sound(playerEntity.Race, playerEntity.Gender);
+            }
 
             if (DaggerfallUI.Instance.DaggerfallAudioSource)
                 DaggerfallUI.Instance.DaggerfallAudioSource.PlayOneShot(sound, 0);


### PR DESCRIPTION
Ties classic player death sound to combats vocalization; No combats vocalization <=> classic player death sound.
Rationale:
- players bothered by "non classic" death gasp are more than likely also bothered by combats vocalization;
- on the other hand I see a possible case for players that don't want combats vocalization but like race and gender aware death sounds. Seems pretty niche case though.