### PR TITLE
Using a public list instead of the hardcoded archive IDs allows mods to register custom texture archives that should be treated as NPCs

### DIFF
--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1247,18 +1247,10 @@ namespace DaggerfallWorkshop.Utility
             return go;
         }
 
+        public static List<int> NPCFlatArchives = new List<int>{334, 346, 357, 176, 177, 178, 179, 180, 181, 182, 183};
         public static bool IsNPCFlat(int archive)
         {
-            // These texture archives are NPCs
-            if (archive == 334 ||                               // Daggerfall people
-                archive == 346 ||                               // Wayrest people
-                archive == 357 ||                               // Sentinel people
-                archive >= 175 && archive <= 184)               // Other people
-            {
-                return true;
-            }
-
-            return false;
+            return NPCFlatArchives.Contains(archive);
         }
 
         public static bool IsTorchFlat(int archive, int record)

--- a/Assets/Scripts/Utility/RDBLayout.cs
+++ b/Assets/Scripts/Utility/RDBLayout.cs
@@ -1247,7 +1247,7 @@ namespace DaggerfallWorkshop.Utility
             return go;
         }
 
-        public static List<int> NPCFlatArchives = new List<int>{334, 346, 357, 176, 177, 178, 179, 180, 181, 182, 183};
+        public static List<int> NPCFlatArchives = new List<int>{334, 346, 357, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184};
         public static bool IsNPCFlat(int archive)
         {
             return NPCFlatArchives.Contains(archive);


### PR DESCRIPTION
After this change, a mod can register its custom NPC archives by calling `RDBLayout.NPCFlatArchives.Add(textureArchiveID);`. This also opens up the way for custom NPC portraits by adding new FlatData to the FlatsFileReader.FlatsDict. I have tested this already and it works but I can provide the mod for testing if necessary.

Without this change, the billboard's collider is never added since the custom archive can't be identified as an NPC archive and just gets treated as a regular billboard.

Please let me know if anything more is needed