### PR TITLE
Keep levitating as long as NoClip is active

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Thaumaturgy/Levitate.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Thaumaturgy/Levitate.cs
@@ -116,7 +116,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             // Disable levitation for player or enemies
             if (entityBehaviour.EntityType == EntityTypes.Player)
             {
-                GameManager.Instance.PlayerMotor.GetComponent<LevitateMotor>().IsLevitating = false;
+                GameManager.Instance.PlayerMotor.GetComponent<LevitateMotor>().IsLevitating = GameManager.Instance.PlayerEntity.NoClipMode;
             }
             else if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
             {

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -489,7 +489,7 @@ namespace DaggerfallWorkshop.Game
             // Cancel levitation at start of loading a new save game
             // This prevents levitation flag carrying over and effect system can still restore it if needed
             if (levitateMotor)
-                levitateMotor.IsLevitating = false;
+                levitateMotor.IsLevitating = GameManager.Instance.PlayerEntity.NoClipMode;
 
             //reset speed modifiers.
             //ensures speed modifiers from previous game does not carry over into new game.


### PR DESCRIPTION

Levitation could stop under 2 conditions while NoClip status was still active:
- some levitation spell (on top of levitation caused by NoClip) expired;
- a game was (re)loaded; NoClip status was persistent, but not its associated flying effect.

It is still possible to disable it with "levitation off" in console, in case one absolutely wants NoClip with no levitation.

Another implementation could be to have LevitationMotor::IsLevitating() return playerLevitating || GameManager.Instance.PlayerEntity.NoClipMode if its entity is the player; It could be a little cleaner than spreading PlayerEntity.NoClipMode checks in several places, but a little more expensive at runtime.
