### PR TITLE
Always consume teleportation anchor when recalling

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Teleport.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Mysticism/Teleport.cs
@@ -130,6 +130,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             {
                 // Just need to move player
                 serializablePlayer.RestorePosition(anchorPosition);
+                GameManager.Instance.PlayerEntity.AnchorPosition = null;
             }
             else
             {


### PR DESCRIPTION
When recalling, anchor was not consumed in all code paths

Regression since 239ad207661804c33d02a86ed9aa5e05db9a484e

Forums: https://forums.dfworkshop.net/viewtopic.php?t=5788