### PR TITLE
Fixed regression where City watch lost its human sounds (HALT)

### DIFF
--- a/Assets/Scripts/Game/EnemySounds.cs
+++ b/Assets/Scripts/Game/EnemySounds.cs
@@ -218,7 +218,8 @@ namespace DaggerfallWorkshop.Game
 
         private bool IgnoreHumanSounds()
         {
-            if (DaggerfallEntity.IsClassEnemyId(mobile.Enemy.ID) && MuteHumanSounds)
+            // Mute all class enemies, except the City watch
+            if ((mobile.Enemy.ID != (int)MobileTypes.Knight_CityWatch && DaggerfallEntity.IsClassEnemyId(mobile.Enemy.ID)) && MuteHumanSounds)
                 return true;
             else
                 return false;

--- a/Assets/Scripts/Game/Questing/Foe.cs
+++ b/Assets/Scripts/Game/Questing/Foe.cs
@@ -279,7 +279,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
             // Monster types get a random monster name
             // Always treating monsters as male for now as they don't have any gender in game files
-            if ((int)foeType < 128)
+            if (!DaggerfallEntity.IsClassEnemyId((int)foeType))
             {
                 DFRandom.srand(DateTime.Now.Millisecond + DFRandom.random_range(1, 1000000));
                 displayName = DaggerfallUnity.Instance.NameHelper.MonsterName();


### PR DESCRIPTION
Fix for [https://forums.dfworkshop.net/viewtopic.php?t=5847](https://forums.dfworkshop.net/viewtopic.php?t=5847)

I also added an extra custom enemy id fix for Foe quest resources. Once we get quests targeting custom enemies, it would be nice if custom class enemies didn't have monster names.