### PR TITLE
Changes to allow randomized billboard scaling in billboard batches.

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallBillboardBatch.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboardBatch.cs
@@ -61,6 +61,9 @@ namespace DaggerfallWorkshop
         [Range(1, 127)]
         public int RandomDepth = 16;
         public float RandomSpacing = BlocksFile.TileDimension * MeshReader.GlobalScale;
+        public float MinRandomScale = 1.0f;
+        public float MaxRandomScale = 1.0f;
+        public int RandomSeed = -1;
 
         DaggerfallUnity dfUnity;
         int currentArchive = -1;
@@ -424,7 +427,7 @@ namespace DaggerfallWorkshop
                 BillboardItem bi = billboardItems[billboard];
 
                 // Billboard size and origin
-                Vector2 finalSize = GetScaledBillboardSize(bi.customSize, bi.customScale);
+                Vector2 finalSize = ApplyRandomScale(GetScaledBillboardSize(bi.customSize, bi.customScale));
                 float hy = (finalSize.y / 2);
                 Vector3 position = bi.position + new Vector3(0, hy, 0);
 
@@ -514,13 +517,16 @@ namespace DaggerfallWorkshop
             uvs = new Vector2[vertexCount];
             int[] indices = new int[indexCount];
             int currentIndex = 0;
+            if(RandomSeed > -1) {
+                UnityEngine.Random.InitState(RandomSeed);
+            }
             for (int billboard = 0; billboard < billboardItems.Count; billboard++)
             {
                 int offset = billboard * vertsPerQuad;
                 BillboardItem bi = billboardItems[billboard];
 
                 // Billboard size and origin
-                Vector2 finalSize = GetScaledBillboardSize(bi.record);
+                Vector2 finalSize = ApplyRandomScale(GetScaledBillboardSize(bi.record));
                 //float hx = (finalSize.x / 2);
                 float hy = (finalSize.y / 2);
                 Vector3 position = bi.position + new Vector3(0, hy, 0);
@@ -591,6 +597,17 @@ namespace DaggerfallWorkshop
             // Assign mesh
             MeshFilter filter = GetComponent<MeshFilter>();
             filter.sharedMesh = billboardMesh;
+        }
+
+        //Applies random scaling
+        private Vector2 ApplyRandomScale(Vector2 finalSize) {
+            if(RandomSeed == -1) {
+                return finalSize;
+            }
+            float randomScale = UnityEngine.Random.Range(MinRandomScale, MaxRandomScale);
+            finalSize.x *= randomScale;
+            finalSize.y *= randomScale;
+            return finalSize;
         }
 
         // Gets scaled billboard size to properly size billboard in world


### PR DESCRIPTION
I've added three new properties and one method to facilitate randomized billboard scaling when applying a billboard batch. This allows batched flats to vary in size, making for a more natural looking canopy / skyline in case of the nature flats but it can be applied to any billboard batch.

I exaggerated the scaling values in the screenshot, min scale was 0.75, max scale was 2.75 but it does help to illustrate the effect. I've seen performance drops when I set max scale to 4.0, probably due to overlapping sprites, at some point they just become too big. 

![natureScaleExample](https://user-images.githubusercontent.com/4460167/188308592-db45ee5b-4c92-459c-92df-ec2fc1792043.png)
