### PR TITLE
optimizations: game load time about twice as fast

### DIFF
--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -72,10 +72,7 @@ namespace DaggerfallConnect.Arena2
         /// <summary>
         /// Gets managed BSA file.
         /// </summary>
-        internal BsaFile BsaFile
-        {
-            get { return bsaFile; }
-        }
+        internal BsaFile BsaFile => bsaFile;
 
         #endregion
 
@@ -95,9 +92,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="usage">Determines if the BSA file will read from disk or memory.</param>
         /// <param name="readOnly">File will be read-only if true, read-write if false.</param>
         public BlocksFile(string filePath, FileUsage usage, bool readOnly)
-        {
-            Load(filePath, usage, readOnly);
-        }
+            => Load(filePath, usage, readOnly);
 
         #endregion
 
@@ -119,10 +114,7 @@ namespace DaggerfallConnect.Arena2
         /// <summary>
         /// Number of BSA records in BLOCKS.BSA.
         /// </summary>
-        public int Count
-        {
-            get { return bsaFile.Count; }
-        }
+        public int Count => bsaFile.Count;
 
         #endregion
 
@@ -131,51 +123,33 @@ namespace DaggerfallConnect.Arena2
         /// <summary>
         /// Gets default BLOCKS.BSA filename.
         /// </summary>
-        static public string Filename
-        {
-            get { return "BLOCKS.BSA"; }
-        }
+        static public string Filename => "BLOCKS.BSA";
 
         /// <summary>
         /// Gets rotation divisor used when rotating
         ///  block records and models into place.
         /// </summary>
-        static public float RotationDivisor
-        {
-            get { return 5.68888888888889f; }
-        }
+        static public float RotationDivisor => 5.68888888888889f;
 
         /// <summary>
         /// Gets dimension of a single RMB block.
         /// </summary>
-        static public float RMBDimension
-        {
-            get { return 4096f; }
-        }
+        static public float RMBDimension => 4096f;
 
         /// <summary>
         /// Gets dimension of a single RMB ground tile.
         /// </summary>
-        static public float TileDimension
-        {
-            get { return 256f; }
-        }
+        static public float TileDimension => 256f;
 
         /// <summary>
         /// Gets dimension of a single RDB block.
         /// </summary>
-        static public float RDBDimension
-        {
-            get { return 2048f; }
-        }
+        static public float RDBDimension => 2048f;
 
         /// <summary>
         /// Gets scale divisor for billboards.
         /// </summary>
-        static public float ScaleDivisor
-        {
-            get { return 256f; }
-        }
+        static public float ScaleDivisor => 256f;
 
         #endregion
 
@@ -210,9 +184,7 @@ namespace DaggerfallConnect.Arena2
         /// <param name="block">Index of block.</param>
         /// <returns>Name of the block.</returns>
         public string GetBlockName(int block)
-        {
-            return WorldDataReplacement.GetNewDFBlockName(block) ?? bsaFile.GetRecordName(block);
-        }
+            => WorldDataReplacement.GetNewDFBlockName(block) ?? bsaFile.GetRecordName(block);
 
         /// <summary>
         /// Gets the type of specified block. Does not change the currently loaded block.

--- a/Assets/Scripts/API/Editor.meta
+++ b/Assets/Scripts/API/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f7e0ddbee311b2f4aac05d0a25f25e20
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/API/Editor/BaseImageFileTests.cs
+++ b/Assets/Scripts/API/Editor/BaseImageFileTests.cs
@@ -1,0 +1,198 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes:
+//
+
+using NUnit.Framework;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Collections;
+using System.IO;
+
+namespace DaggerfallConnect.Arena2.Tests
+{
+    static class BaseImageFileTests
+    {
+
+        [Test]
+        public static void BaseImageFile_GetBrightness_Color32___EQUALS___Color_RGBToHSV_V()
+        {
+            Color32 color = new Color32(3, 111, 254, 255);
+            Color.RGBToHSV(color, out float h, out float s, out float expected);
+            float actual = BaseImageFile.GetBrightness(color);
+            float actualDelta = expected - actual;
+            // Debug.Log($"expected:\t{expected:R}\nactual:\t\t{actual:R}\nactualDelta:\t{actualDelta:R}");
+            Assert.AreEqual(expected: expected, actual: actual, delta: 1e-7f);
+        }
+
+        [Test]
+        public static void BaseImageFile_GetBrightness_Color___EQUALS___Color_RGBToHSV_V()
+        {
+            Color color = new Color(0.0123f, 0.5678f, 0.9876f, 1);
+            Color.RGBToHSV(color, out float h, out float s, out float expected);
+            float actual = BaseImageFile.GetBrightness(color);
+            float actualDelta = expected - actual;
+            // Debug.Log($"expected:\t{expected:R}\nactual:\t\t{actual:R}\nactualDelta:\t{actualDelta:R}");
+            Assert.AreEqual(expected: expected, actual: actual, delta: 1e-7f);
+        }
+
+        static void _GetTextureFileDataExampleForTesting(out TextureFile textureFile, out DFBitmap srcBitmap, out DaggerfallWorkshop.GetTextureSettings settings)
+        {
+            // note: I have no idea what image this returns.
+            //       It is not an empty one so it's ok, but might not be good enough for all the test cases so this could use improvement if you know how
+
+            int archive = 210;
+            int record = 0;
+            int frame = 0;
+            int alphaIndex = 0;
+            settings = new DaggerfallWorkshop.GetTextureSettings
+            {
+                archive = archive,
+                record = record,
+                frame = frame,
+                alphaIndex = alphaIndex,
+            };
+            var dfUnity = DaggerfallWorkshop.DaggerfallUnity.Instance;
+            var Arena2Path = dfUnity.Arena2Path;
+            textureFile = new TextureFile();
+            var hasReferenceTexture = textureFile.Load(Path.Combine(Arena2Path, TextureFile.IndexToFileName(settings.archive)), FileUsage.UseMemory, true);
+            srcBitmap = hasReferenceTexture ? textureFile.GetDFBitmap(settings.record, settings.frame) : null;
+        }
+
+        [Test]
+        public static void GetColor32___EQUALS___GetColor32Async()
+        {
+            _GetTextureFileDataExampleForTesting(out TextureFile textureFile, out DFBitmap srcBitmap, out var settings);
+            // srcBitmap.Width /= 2;// just so unit test takes less time
+            // srcBitmap.Height /= 2;// just so unit test takes less time
+
+            Color32[] expectedData = textureFile.GetColor32(srcBitmap, settings.alphaIndex, settings.borderSize, out var _);
+
+            textureFile.GetColor32Async(srcBitmap, settings.alphaIndex, settings.borderSize, out var _, out var actualDataNative).Complete();
+            Color32[] actualData = actualDataNative.ToArray();
+            actualDataNative.Dispose();
+
+            Assert.AreEqual(expected: expectedData.Length, actual: actualData.Length);
+            int length = expectedData.Length;
+            for (int i = 0; i < length; i++)
+            {
+                var expected = expectedData[i];
+                var actual = actualData[i];
+
+                // if ((expected.r + expected.g + expected.b + expected.a) + (actual.r + actual.g + actual.b + actual.a) != 0)// lets not log boring empty pixels
+                //     Debug.Log($"expected: {expected}\tactual: {actual}");
+
+                Assert.AreEqual(expected: expected.r, actual: actual.r, delta: 1e-7f);
+                Assert.AreEqual(expected: expected.g, actual: actual.g, delta: 1e-7f);
+                Assert.AreEqual(expected: expected.b, actual: actual.b, delta: 1e-7f);
+                Assert.AreEqual(expected: expected.a, actual: actual.a, delta: 1e-7f);
+            }
+        }
+
+        [Test]
+        public static void GetWindowColors32___EQUALS___GetWindowColors32Async()
+        {
+            _GetTextureFileDataExampleForTesting(out TextureFile textureFile, out DFBitmap srcBitmap, out var settings);
+            // srcBitmap.Width /= 2;// just so unit test takes less time
+            // srcBitmap.Height /= 2;// just so unit test takes less time
+
+            Color32[] expectedData = textureFile.GetWindowColors32(srcBitmap);
+
+            textureFile.GetWindowColors32Async(srcBitmap, out var actualDataNative).Complete();
+            Color32[] actualData = actualDataNative.ToArray();
+            actualDataNative.Dispose();
+
+            Assert.AreEqual(expected: expectedData.Length, actual: actualData.Length);
+            int length = expectedData.Length;
+            for (int i = 0; i < length; i++)
+            {
+                var expected = expectedData[i];
+                var actual = actualData[i];
+
+                // if ((expected.r + expected.g + expected.b + expected.a) + (actual.r + actual.g + actual.b + actual.a) != 0)// lets not log empty pixels
+                //     Debug.Log($"expected: {expected}\tactual: {actual}");
+
+                Assert.AreEqual(expected: expected.r, actual: actual.r, delta: 1e-7f);
+                Assert.AreEqual(expected: expected.g, actual: actual.g, delta: 1e-7f);
+                Assert.AreEqual(expected: expected.b, actual: actual.b, delta: 1e-7f);
+                Assert.AreEqual(expected: expected.a, actual: actual.a, delta: 1e-7f);
+            }
+        }
+
+        [Test]
+        public static void GetSpectralEmissionColors32___EQUALS___GetSpectralEmissionColors32Async()
+        {
+            _GetTextureFileDataExampleForTesting(out TextureFile textureFile, out DFBitmap srcBitmap, out var settings);
+            // srcBitmap.Width /= 4;// just so unit test takes less time
+            // srcBitmap.Height /= 4;// just so unit test takes less time
+
+            Color32[] albedo = textureFile.GetColor32(srcBitmap, settings.frame, settings.borderSize, out var sz);
+            Color eyeEmission = Color.magenta;
+            Color otherEmission = Color.cyan;
+            byte emissionIndex = 13;
+
+            Color32[] expectedData = textureFile.GetSpectralEmissionColors32(srcBitmap, albedo, settings.borderSize, emissionIndex, eyeEmission, otherEmission);
+
+            textureFile.GetSpectralEmissionColors32Async(srcBitmap, albedo, settings.borderSize, emissionIndex, eyeEmission, otherEmission, out var actualDataNative).Complete();
+            Color32[] actualData = actualDataNative.ToArray();
+            actualDataNative.Dispose();
+
+            Assert.AreEqual(expected: expectedData.Length, actual: actualData.Length);
+            int length = expectedData.Length;
+            for (int i = 0; i < length; i++)
+            {
+                Color32 expected = expectedData[i];
+                Color32 actual = actualData[i];
+
+                // if ((expected.r + expected.g + expected.b + expected.a) + (actual.r + actual.g + actual.b + actual.a) != 0)// lets not log empty pixels
+                //     Debug.Log($"expected: {expected}\tactual: {actual}");
+
+                Assert.AreEqual(expected: expected.r, actual: actual.r);
+                Assert.AreEqual(expected: expected.g, actual: actual.g);
+                Assert.AreEqual(expected: expected.b, actual: actual.b);
+                Assert.AreEqual(expected: expected.a, actual: actual.a);
+            }
+        }
+
+        [Test]
+        public static void GetFireWallColors32___EQUALS___GetFireWallColors32Async()
+        {
+            _GetTextureFileDataExampleForTesting(out TextureFile textureFile, out DFBitmap srcBitmap, out var settings);
+            // srcBitmap.Width /= 4;// just so unit test takes less time
+            // srcBitmap.Height /= 4;// just so unit test takes less time
+            
+            Color32[] albedo = textureFile.GetColor32(srcBitmap, settings.frame, settings.borderSize, out var sz);
+            Color neutralColor = Color.black;
+            float scale = 0.333f;
+
+            Color32[] expectedData = textureFile.GetFireWallColors32(ref albedo, sz.Width, sz.Height, neutralColor, scale);
+
+            textureFile.GetFireWallColors32Async(albedo, neutralColor, scale, out var actualDataNative).Complete();
+            Color32[] actualData = actualDataNative.ToArray();
+            actualDataNative.Dispose();
+
+            Assert.AreEqual(expected: expectedData.Length, actual: actualData.Length);
+            int length = expectedData.Length;
+            for (int i = 0; i < length; i++)
+            {
+                Color32 expected = expectedData[i];
+                Color32 actual = actualData[i];
+
+                // if ((expected.r + expected.g + expected.b + expected.a) + (actual.r + actual.g + actual.b + actual.a) != 0)// lets not log empty pixels
+                //     Debug.Log($"expected: {expected}\tactual: {actual}");
+
+                Assert.AreEqual(expected: expected.r, actual: actual.r);
+                Assert.AreEqual(expected: expected.g, actual: actual.g);
+                Assert.AreEqual(expected: expected.b, actual: actual.b);
+                Assert.AreEqual(expected: expected.a, actual: actual.a);
+            }
+        }
+
+    }
+}

--- a/Assets/Scripts/API/Editor/BaseImageFileTests.cs.meta
+++ b/Assets/Scripts/API/Editor/BaseImageFileTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b52bf13b94de7f4a9c5748bd8b6a40f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/API/FileProxy.cs
+++ b/Assets/Scripts/API/FileProxy.cs
@@ -132,66 +132,42 @@ namespace DaggerfallConnect.Utility
         /// <summary>
         /// Get full path and filename of managed file. Derived from filename for disk files, or specified at construction for managed files.
         /// </summary>
-        public string FilePath
-        {
-            get { return managedFilePath; }
-        }
+        public string FilePath => managedFilePath;
 
         /// <summary>
         /// Get filename of managed file without path.
         /// </summary>
-        public string FileName
-        {
-            get { return Path.GetFileName(managedFilePath); }
-        }
+        public string FileName => Path.GetFileName(managedFilePath);
 
         /// <summary>
         /// Get directory path of managed file without filename.
         /// </summary>
-        public string Directory
-        {
-            get { return Path.GetDirectoryName(managedFilePath); }
-        }
+        public string Directory => Path.GetDirectoryName(managedFilePath);
 
         /// <summary>
         /// Get the file usage in effect for this managed file.
         /// </summary>
-        public FileUsage Usage
-        {
-            get { return fileUsage; }
-        }
+        public FileUsage Usage => fileUsage;
 
         /// <summary>
         /// Access allowed to file.
         /// </summary>
-        public bool ReadOnly
-        {
-            get { return isReadOnly; }
-        }
+        public bool ReadOnly => isReadOnly;
 
         /// <summary>
         /// Gets last exception thrown.
         /// </summary>
-        public Exception LastException
-        {
-            get { return myLastException; }
-        }
+        public Exception LastException => myLastException;
 
         /// <summary>
         /// Gets byte array when using FileUsage.UseMemory.
         /// </summary>
-        public byte[] Buffer
-        {
-            get { return fileBuffer; }
-        }
+        public byte[] Buffer => fileBuffer;
 
         /// <summary>
         /// Gets file stream when using FileUsage.UseDisk
         /// </summary>
-        public FileStream FileStream
-        {
-            get { return fileStream; }
-        }
+        public FileStream FileStream => fileStream;
 
         #endregion
 
@@ -207,19 +183,18 @@ namespace DaggerfallConnect.Utility
         public bool Load(string filePath, FileUsage usage = FileUsage.UseMemory, bool readOnly = true)
         {
             // Determine file access settings
+            isReadOnly = readOnly;
             FileAccess fileAccess;
             FileShare fileShare;
             if (readOnly)
             {
                 fileAccess = FileAccess.Read;
                 fileShare = FileShare.ReadWrite;
-                isReadOnly = true;
             }
             else
             {
                 fileAccess = FileAccess.ReadWrite;
                 fileShare = FileShare.Read;
-                isReadOnly = false;
             }
 
             // Load based on usage
@@ -433,60 +408,42 @@ namespace DaggerfallConnect.Utility
         /// </summary>
         /// <param name="reader">Source reader.</param>
         /// <returns>Big-endian Int16</returns>
-        public Int16 beReadInt16(BinaryReader reader)
-        {
-            return (Int16)endianSwapUInt16(reader.ReadUInt16());
-        }
+        public Int16 beReadInt16(BinaryReader reader) => (Int16)endianSwapUInt16(reader.ReadUInt16());
 
         /// <summary>
         /// Reads next 2 bytes as a big-endian UInt16.
         /// </summary>
         /// <param name="reader">Source reader.</param>
         /// <returns>Big-endian UInt16.</returns>
-        public UInt16 beReadUInt16(BinaryReader reader)
-        {
-            return endianSwapUInt16(reader.ReadUInt16());
-        }
+        public UInt16 beReadUInt16(BinaryReader reader) => endianSwapUInt16(reader.ReadUInt16());
 
         /// <summary>
         /// Reads next 4 bytes as a big-endian Int32.
         /// </summary>
         /// <param name="reader">Source reader.</param>
         /// <returns>Big-endian Int32.</returns>
-        public Int32 beReadInt32(BinaryReader reader)
-        {
-            return (Int32)endianSwapUInt32(reader.ReadUInt32());
-        }
+        public Int32 beReadInt32(BinaryReader reader) => (Int32)endianSwapUInt32(reader.ReadUInt32());
 
         /// <summary>
         /// Reads next 4 bytes as a big-endian UInt32.
         /// </summary>
         /// <param name="reader">Source reader.</param>
         /// <returns>Big-endian Int32.</returns>
-        public UInt32 beReadUInt32(BinaryReader reader)
-        {
-            return endianSwapUInt32(reader.ReadUInt32());
-        }
+        public UInt32 beReadUInt32(BinaryReader reader) => endianSwapUInt32(reader.ReadUInt32());
 
         /// <summary>
         /// Swaps an unsigned 16-bit big-endian value to little-endian.
         /// </summary>
         /// <param name="value">Source reader.</param>
         /// <returns>Little-endian UInt16.</returns>
-        public UInt16 endianSwapUInt16(UInt16 value)
-        {
-            return (UInt16)((value >> 8) | (value << 8));
-        }
+        public UInt16 endianSwapUInt16(UInt16 value) => (UInt16)((value >> 8) | (value << 8));
 
         /// <summary>
         /// Swaps an unsigned 32-bit big-endian value to little-endian.
         /// </summary>
         /// <param name="value">Source reader.</param>
         /// <returns>Little-endian UInt32.</returns>
-        public UInt32 endianSwapUInt32(UInt32 value)
-        {
-            return (UInt32)((value >> 24) | ((value << 8) & 0x00FF0000) | ((value >> 8) & 0x0000FF00) | (value << 24));
-        }
+        public UInt32 endianSwapUInt32(UInt32 value) => (UInt32)((value >> 24) | ((value << 8) & 0x00FF0000) | ((value >> 8) & 0x0000FF00) | (value << 24));
 
         #endregion
 
@@ -496,19 +453,13 @@ namespace DaggerfallConnect.Utility
         /// Gets stream to disk file.
         /// </summary>
         /// <returns>FileStream object.</returns>
-        private FileStream GetFileStream()
-        {
-            return fileStream;
-        }
+        private FileStream GetFileStream() => fileStream;
 
         /// <summary>
         /// Gets stream to memory file.
         /// </summary>
         /// <returns>FileStream object</returns>
-        private MemoryStream GetMemoryStream()
-        {
-            return new MemoryStream(fileBuffer);
-        }
+        private MemoryStream GetMemoryStream() => new MemoryStream(fileBuffer);
 
         /// <summary>
         /// Loads a file into memory.

--- a/Assets/Scripts/API/WoodsFile.cs
+++ b/Assets/Scripts/API/WoodsFile.cs
@@ -13,6 +13,7 @@
 using System;
 using System.IO;
 using DaggerfallConnect.Utility;
+using Unity.Profiling;
 #endregion
 
 namespace DaggerfallConnect.Arena2
@@ -59,6 +60,16 @@ namespace DaggerfallConnect.Arena2
         /// Height map data buffer.
         /// </summary>
         private Byte[] heightMapBuffer = new Byte[mapBufferLengthValue];
+
+        #endregion
+
+        #region Profiler Markers
+
+        static readonly ProfilerMarker
+            ___GetLargeHeightMapValuesRange = new ProfilerMarker($"{nameof(WoodsFile)}.{nameof(GetLargeHeightMapValuesRange)}"),
+            ___GetLargeMapData = new ProfilerMarker($"{nameof(WoodsFile)}.{nameof(GetLargeMapData)}"),
+            ___GetHeightMapValuesRange1Dim = new ProfilerMarker($"{nameof(WoodsFile)}.{nameof(GetHeightMapValuesRange1Dim)}"),
+            ___GetHeightMapValuesRange = new ProfilerMarker($"{nameof(WoodsFile)}.{nameof(GetHeightMapValuesRange)}");
 
         #endregion
 
@@ -231,6 +242,8 @@ namespace DaggerfallConnect.Arena2
         /// <returns>Byte array dim,dim in size.</returns>
         public Byte[,] GetHeightMapValuesRange(int mapPixelX, int mapPixelY, int dim)
         {
+            ___GetHeightMapValuesRange.Begin();
+
             Byte[,] dstData = new Byte[dim, dim];
             for (int y = 0; y < dim; y++)
             for (int x = 0; x < dim; x++)
@@ -238,6 +251,7 @@ namespace DaggerfallConnect.Arena2
                 dstData[x, y] = GetHeightMapValue(mapPixelX + x, mapPixelY + y);
             }
 
+            ___GetHeightMapValuesRange.End();
             return dstData;
         }
 
@@ -250,12 +264,16 @@ namespace DaggerfallConnect.Arena2
         /// <returns>Byte 1D array dim * dim in size.</returns>
         public Byte[] GetHeightMapValuesRange1Dim(int mapPixelX, int mapPixelY, int dim)
         {
+            ___GetHeightMapValuesRange1Dim.Begin();
+
             Byte[] dstData = new Byte[dim * dim];
             for (int y = 0; y < dim; y++)
             for (int x = 0; x < dim; x++)
             {
                 dstData[x + (y * dim)] = GetHeightMapValue(mapPixelX + x, mapPixelY + y);
             }
+
+            ___GetHeightMapValuesRange1Dim.End();
             return dstData;
         }
 
@@ -268,6 +286,8 @@ namespace DaggerfallConnect.Arena2
         /// <returns>5x5 grid of map data.</returns>
         public Byte[,] GetLargeMapData(int mapPixelX, int mapPixelY)
         {
+            ___GetLargeMapData.Begin();
+
             // Clamp X
             if (mapPixelX < 0) mapPixelX = 0;
             if (mapPixelX >= MapWidth - 1) mapPixelX = MapWidth - 1;
@@ -288,6 +308,7 @@ namespace DaggerfallConnect.Arena2
                 data[x, y] = reader.ReadByte();
             }
 
+            ___GetLargeMapData.End();
             return data;
         }
 
@@ -301,6 +322,8 @@ namespace DaggerfallConnect.Arena2
         /// <returns>Byte array dim*3,dim*3 in size.</returns>
         public Byte[,] GetLargeHeightMapValuesRange(int mapPixelX, int mapPixelY, int dim)
         {
+            ___GetLargeHeightMapValuesRange.Begin();
+
             const int offsetx = 1;
             const int offsety = 1;
             const int len = 3;
@@ -322,6 +345,7 @@ namespace DaggerfallConnect.Arena2
                 }
             }
 
+            ___GetLargeHeightMapValuesRange.End();
             return dstData;
         }
 

--- a/Assets/Scripts/API/WoodsFile.cs
+++ b/Assets/Scripts/API/WoodsFile.cs
@@ -113,26 +113,20 @@ namespace DaggerfallConnect.Arena2
         /// <summary>
         /// Width of heightmap data (always 1000).
         /// </summary>
-        public static int MapWidth
-        {
-            get { return mapWidthValue; }
-        }
+        public static int MapWidth => mapWidthValue;
 
         /// <summary>
         /// Height of heightmap data (always 500).
         /// </summary>
-        public static int MapHeight
-        {
-            get { return mapHeightValue; }
-        }
+        public static int MapHeight => mapHeightValue;
 
         /// <summary>
         /// Gets or sets extracted heightmap data.
         /// </summary>
         public Byte[] Buffer
         {
-            get { return heightMapBuffer; }
-            set { heightMapBuffer = value; }
+            get => heightMapBuffer;
+            set => heightMapBuffer = value;
         }
 
         #endregion
@@ -142,10 +136,7 @@ namespace DaggerfallConnect.Arena2
         /// <summary>
         /// Gets default WOODS.WLD filename.
         /// </summary>
-        static public string Filename
-        {
-            get { return "WOODS.WLD"; }
-        }
+        static public string Filename => "WOODS.WLD";
 
         #endregion
 
@@ -242,11 +233,9 @@ namespace DaggerfallConnect.Arena2
         {
             Byte[,] dstData = new Byte[dim, dim];
             for (int y = 0; y < dim; y++)
+            for (int x = 0; x < dim; x++)
             {
-                for (int x = 0; x < dim; x++)
-                {
-                    dstData[x, y] = GetHeightMapValue(mapPixelX + x, mapPixelY + y);
-                }
+                dstData[x, y] = GetHeightMapValue(mapPixelX + x, mapPixelY + y);
             }
 
             return dstData;
@@ -263,11 +252,9 @@ namespace DaggerfallConnect.Arena2
         {
             Byte[] dstData = new Byte[dim * dim];
             for (int y = 0; y < dim; y++)
+            for (int x = 0; x < dim; x++)
             {
-                for (int x = 0; x < dim; x++)
-                {
-                    dstData[x + (y * dim)] = GetHeightMapValue(mapPixelX + x, mapPixelY + y);
-                }
+                dstData[x + (y * dim)] = GetHeightMapValue(mapPixelX + x, mapPixelY + y);
             }
             return dstData;
         }
@@ -296,11 +283,9 @@ namespace DaggerfallConnect.Arena2
             // Read 5x5 data
             Byte[,] data = new Byte[5, 5];
             for (int y = 0; y < 5; y++)
+            for (int x = 0; x < 5; x++)
             {
-                for (int x = 0; x < 5; x++)
-                {
-                    data[x, y] = reader.ReadByte();
-                }
+                data[x, y] = reader.ReadByte();
             }
 
             return data;
@@ -322,22 +307,18 @@ namespace DaggerfallConnect.Arena2
 
             Byte[,] dstData = new Byte[dim * len, dim * len];
             for (int y = 0; y < dim; y++)
+            for (int x = 0; x < dim; x++)
             {
-                for (int x = 0; x < dim; x++)
-                {
-                    // Get source 5x5 data
-                    Byte[,] srcData = GetLargeMapData(mapPixelX + x, mapPixelY - y);
+                // Get source 5x5 data
+                Byte[,] srcData = GetLargeMapData(mapPixelX + x, mapPixelY - y);
 
-                    // Write 3x3 heightmap pixels to destination array
-                    int startX = x * len;
-                    int startY = y * len;
-                    for (int iy = offsety; iy < offsety + len; iy++)
-                    {
-                        for (int ix = offsetx; ix < offsetx + len; ix++)
-                        {
-                            dstData[startX + ix - offsetx, startY + iy - offsety] = srcData[ix, 4 - iy];
-                        }
-                    }
+                // Write 3x3 heightmap pixels to destination array
+                int startX = x * len;
+                int startY = y * len;
+                for (int iy = offsety; iy < offsety + len; iy++)
+                for (int ix = offsetx; ix < offsetx + len; ix++)
+                {
+                    dstData[startX + ix - offsetx, startY + iy - offsety] = srcData[ix, 4 - iy];
                 }
             }
 

--- a/Assets/Scripts/DaggerfallUnityStructs.cs
+++ b/Assets/Scripts/DaggerfallUnityStructs.cs
@@ -400,7 +400,8 @@ namespace DaggerfallWorkshop
         [HideInInspector, NonSerialized]
         public NativeArray<float> avgMaxHeight;     // Average and max height of terrain for location placement (unmanaged memory)
 
-        [HideInInspector, NonSerialized]
+        // @TODO: remove this nativeArrayList once mods stop using it
+        [HideInInspector, NonSerialized, Obsolete("use [DeallocateOnJobCompletion] attribute or DeallocateArrayJob instead")]
         public List<IDisposable> nativeArrayList;   // List of temp working native arrays (unmanaged memory) for disposal when jobs complete
     }
 

--- a/Assets/Scripts/Game/BuildingDirectory.cs
+++ b/Assets/Scripts/Game/BuildingDirectory.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using DaggerfallConnect;
 using DaggerfallWorkshop.Utility;
+using Unity.Profiling;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -75,6 +76,13 @@ namespace DaggerfallWorkshop.Game
 
         #endregion
 
+        #region Profiler Markers
+
+        static readonly ProfilerMarker
+            ___m_SetLocation = new ProfilerMarker(nameof(SetLocation));
+
+        #endregion
+
         #region Public Methods
 
         /// <summary>
@@ -84,6 +92,8 @@ namespace DaggerfallWorkshop.Game
         /// <param name="blocks">Exterior blocks.</param>
         public void SetLocation(in DFLocation location, out DFBlock[] blocks)
         {
+            ___m_SetLocation.Begin();
+
             // Clear existing buildings
             buildingDict.Clear();
 
@@ -116,6 +126,8 @@ namespace DaggerfallWorkshop.Game
             locationId = location.Exterior.ExteriorData.LocationId;
             mapId = location.MapTableData.MapId;
             locationData = location;
+
+            ___m_SetLocation.End();
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -1195,13 +1195,14 @@ namespace DaggerfallWorkshop.Game
 
             Color32[] newColors = new Color32[(int)subRect.width * (int)subRect.height];
             ImageProcessing.CopyColors(
-                ref colors,
-                ref newColors,
+                colors,
+                newColors,
                 new DFSize(bitmap.Width, bitmap.Height),
                 new DFSize((int)subRect.width, (int)subRect.height),
                 new DFPosition((int)subRect.x, (int)subRect.y),
                 new DFPosition(0, 0),
-                new DFSize((int)subRect.width, (int)subRect.height));
+                new DFSize((int)subRect.width, (int)subRect.height)
+            );
 
             Texture2D texture = new Texture2D((int)subRect.width, (int)subRect.height, format, false);
             texture.SetPixels32(newColors, 0);

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -130,8 +130,7 @@ namespace DaggerfallWorkshop.Game
         DaggerfallCourtWindow dfCourtWindow;
         GameEffectsConfigWindow gameEffectsConfigWindow;
 
-        private List<System.Tuple<string, Action>> pauseOptionsDropdownItems
-            = new List<System.Tuple<string, Action>>();
+        private List<(string text, Action action)> pauseOptionsDropdownItems = new List<(string, Action)>();
 
         Material pixelFontMaterial;
         Material sdfFontMaterial;
@@ -806,16 +805,14 @@ namespace DaggerfallWorkshop.Game
             if (action == null)
                 throw new ArgumentNullException("action");
 
-            pauseOptionsDropdownItems.Add(new System.Tuple<string, Action>(text, action));
+            pauseOptionsDropdownItems.Add((text, action));
         }
 
         /// <summary>
         /// Returns shallow copied list of registered dropdown items in alphabetical order
         /// </summary>
-        public IEnumerable<System.Tuple<string, Action>> GetPauseOptionsDropdownItems()
-        {
-            return pauseOptionsDropdownItems.OrderBy(it => it.Item1);
-        }
+        public IEnumerable<(string text, Action action)> GetPauseOptionsDropdownItems()
+            => pauseOptionsDropdownItems.OrderBy(it => it.text);
 
         public void PopupMessage(string text)
         {

--- a/Assets/Scripts/Game/UserInterface/PauseOptionsDropdown.cs
+++ b/Assets/Scripts/Game/UserInterface/PauseOptionsDropdown.cs
@@ -203,8 +203,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             foreach (var opt in DaggerfallUI.Instance.GetPauseOptionsDropdownItems())
             {
-                dropdownList.AddItem(opt.Item1, out ListBox.ListItem item);
-                clickHandlers.Add(opt.Item2);
+                dropdownList.AddItem(opt.text, out var item);
+                clickHandlers.Add(opt.action);
 
                 if (item.textLabel.TextWidth > maxTextWidth)
                     maxTextWidth = item.textLabel.TextWidth + 8;

--- a/Assets/Scripts/Internal/DaggerfallMesh.cs
+++ b/Assets/Scripts/Internal/DaggerfallMesh.cs
@@ -17,6 +17,7 @@ using System.IO;
 using DaggerfallConnect;
 using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
+using Unity.Profiling;
 
 namespace DaggerfallWorkshop
 {
@@ -32,6 +33,10 @@ namespace DaggerfallWorkshop
         private ClimateSeason currentSeason;
         [SerializeField]
         private WindowStyle currentWindowStyle;
+
+        static readonly ProfilerMarker
+            ___getNewMaterialArray = new ProfilerMarker("get new material array"),
+            ___assignMaterialArray = new ProfilerMarker("assign material array");
 
         public ClimateBases Climate
         {
@@ -99,15 +104,17 @@ namespace DaggerfallWorkshop
                 return;
 
             // Get new material array
+            ___getNewMaterialArray.Begin();
             Material[] materials = new Material[defaultTextures.Count];
             for (int i = 0; i < defaultTextures.Count; i++)
-            {
                 materials[i] = dfUnity.MaterialReader.ChangeClimate(defaultTextures[i], climate, season, windowStyle);
-            }
+            ___getNewMaterialArray.End();
 
             // Assign material array
+            ___assignMaterialArray.Begin();
             if (materials != null)
                 GetComponent<MeshRenderer>().sharedMaterials = materials;
+            ___assignMaterialArray.End();
 
             // Store climate settings
             currentClimate = climate;

--- a/Assets/Scripts/Terrain/DefaultTerrainSampler.cs
+++ b/Assets/Scripts/Terrain/DefaultTerrainSampler.cs
@@ -31,10 +31,7 @@ namespace DaggerfallWorkshop
         // Max terrain height of this sampler implementation
         const float maxTerrainHeight = 1539f;
 
-        public override int Version
-        {
-            get { return 1; }
-        }
+        public override int Version => 1;
 
         public DefaultTerrainSampler()
         {

--- a/Assets/Scripts/Terrain/Editor.meta
+++ b/Assets/Scripts/Terrain/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9e7a02c331a7a6e4ea5217c10a791b60
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/Editor/TerrainHelperTests.cs
+++ b/Assets/Scripts/Terrain/Editor/TerrainHelperTests.cs
@@ -1,0 +1,113 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes:
+//
+
+using NUnit.Framework;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Collections;
+
+namespace DaggerfallWorkshop.Tests
+{
+    static class TerrainHelperTests
+    {
+
+        [Test]
+        public static void new_CubicInterpolator_produces_identical_results_as_the_old_one()
+        {
+            float
+                v0 = UnityEngine.Random.Range(0f, 1f),
+                v1 = UnityEngine.Random.Range(0f, 1f),
+                v2 = UnityEngine.Random.Range(0f, 1f),
+                v3 = UnityEngine.Random.Range(0f, 1f),
+                fracy = UnityEngine.Random.Range(0f, 1f),
+                expected = TerrainHelper.CubicInterpolator_old(v0, v1, v2, v3, fracy),
+                actual = TerrainHelper.CubicInterpolator(v0, v1, v2, v3, fracy),
+                actualDelta = expected - actual;
+            // Debug.Log($"expected:\t{expected:R}\nactual:\t\t{actual:R}\nactualDelta:\t{actualDelta:R}");
+            Assert.AreEqual(expected: expected, actual: actual, delta: 1e-7f);
+        }
+
+        [Test]
+        public static void new_BilinearInterpolator_produces_identical_results_as_the_old_one()
+        {
+            float
+                valx0y0 = UnityEngine.Random.Range(0f, 1f),
+                valx0y1 = UnityEngine.Random.Range(0f, 1f),
+                valx1y0 = UnityEngine.Random.Range(0f, 1f),
+                valx1y1 = UnityEngine.Random.Range(0f, 1f),
+                u = UnityEngine.Random.Range(0f, 1f),
+                v = UnityEngine.Random.Range(0f, 1f),
+                expected = TerrainHelper.BilinearInterpolator_old(valx0y0, valx0y1, valx1y0, valx1y1, u, v),
+                actual = TerrainHelper.BilinearInterpolator(valx0y0, valx0y1, valx1y0, valx1y1, u, v),
+                actualDelta = expected - actual;
+            // Debug.Log($"expected:\t{expected:R}\nactual:\t\t{actual:R}\nactualDelta:\t{actualDelta:R}");
+            Assert.AreEqual(expected: expected, actual: actual, delta: 1e-7f);
+        }
+
+        [Test]
+        public static void new_GetGradient_produces_identical_results_as_the_old_one()
+        {
+            float
+                x0y0 = UnityEngine.Random.Range(0f, 1f),
+                x1y0 = UnityEngine.Random.Range(0f, 1f),
+                x0y1 = UnityEngine.Random.Range(0f, 1f),
+                expected = TerrainHelper.GetGradient_old(x0y0, x1y0, x0y1),
+                actual = TerrainHelper.GetGradient(x0y0, x1y0, x0y1),
+                actualDelta = expected - actual;
+            // Debug.Log($"expected:\t{expected:R}\nactual:\t\t{actual:R}\nactualDelta:\t{actualDelta:R}");
+            Assert.AreEqual(expected: expected, actual: actual, delta: 1e-7f);
+        }
+
+        [Test]
+        public static void new_AverageHeights_produces_identical_results_as_the_old_one()
+        {
+            int
+                mapWidth = 13,
+                mapHeight = mapWidth,
+                length = mapWidth * mapWidth;
+
+            // create input data
+            var inputData = new byte[length];
+            for (int i = 0; i < length; i++)
+                inputData[i] = (byte)UnityEngine.Random.Range(0, 255);
+
+            var heightArray = (byte[])inputData.Clone();
+            var heightArrayNative = new NativeArray<byte>(inputData, Allocator.Temp);
+
+            // Search for locations
+            for (int y = 1; y < mapHeight - 1; y++)
+            for (int x = 1; x < mapWidth - 1; x++)
+            {
+                // Use Sobel filter for gradient
+                float x0y0 = heightArray[y * mapWidth + x];
+                float x1y0 = heightArray[y * mapWidth + (x + 1)];
+                float x0y1 = heightArray[(y + 1) * mapWidth + x];
+                TerrainHelper.AverageHeights(heightArray, x, y, mapWidth);
+                TerrainHelper.AverageHeights(heightArrayNative, x, y, mapWidth);
+            }
+
+            // test
+            for (int i = 0; i < length; i++)
+            {
+                byte
+                    original = inputData[i],
+                    expected = heightArray[i],
+                    actual = heightArrayNative[i];
+                int
+                    actualDelta = actual - expected;
+
+                // Debug.Log($"original:{original}\t expected:{expected:000}\t actual:{actual:000}\t delta:{actualDelta}");
+                Assert.AreEqual(expected: expected, actual: actual, delta: 0);
+            }
+        }
+
+    }
+}

--- a/Assets/Scripts/Terrain/Editor/TerrainHelperTests.cs.meta
+++ b/Assets/Scripts/Terrain/Editor/TerrainHelperTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c774665c3797384fa10e76ccbe60e35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/JobHelpers.cs
+++ b/Assets/Scripts/Terrain/JobHelpers.cs
@@ -4,58 +4,45 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Hazelnut
-// Contributors:    
+// Contributors:    Andrzej Łukasik (andrew.r.lukasik)
 // 
 // Notes:
 //
 
 using System;
+using Unity.Collections;
+using Unity.Jobs;
 
 namespace DaggerfallWorkshop
 {
-    // Static helper class for IJobParallelFor jobs convering index to/from rows & columns.
+
+    // static helper class for convering index to/from rows & columns.
     public static class JobA
     {
-        public static int Idx(int r, int c, int dim)
-        {
-            return r + (c * dim);
-        }
-
-        public static int Row(int index, int dim)
-        {
-            return index % dim;
-        }
-
-        public static int Col(int index, int dim)
-        {
-            return index / dim;
-        }
+        [System.Obsolete("use " + nameof(Matrix) + ".Idx")] public static int Idx(int r, int c, int dim) => r + (c * dim);
+        [System.Obsolete("use " + nameof(Matrix) + ".Row")] public static int Row(int index, int dim) => index % dim;
+        [System.Obsolete("use " + nameof(Matrix) + ".Col")] public static int Col(int index, int dim) => index / dim;
     }
 
-    // Static helper class for jobs providing basic thread safe access to system random.
+    // note: identical to JobA class; name change
+    /// <summary> Matrix coordinate calculator. </summary>
+    public static class Matrix
+    {
+        public static int Idx(int r, int c, int dim) => r + c * dim;
+        public static int Row(int i, int dim) => i % dim;
+        public static int Col(int i, int dim) => i / dim;
+    }
+
+    // static helper class for jobs providing basic thread safe access to system random.
     public class JobRand
     {
         private static readonly Random Global = new Random();
         [ThreadStatic]
         private static Random threadRandom;
 
-        public static int Next()
-        {
-            Random localRand = GetLocalRandom();
-            return localRand.Next();
-        }
-
-        public static int Next(int max)
-        {
-            Random localRand = GetLocalRandom();
-            return localRand.Next(max);
-        }
-
-        public static int Next(int min, int max)
-        {
-            Random localRand = GetLocalRandom();
-            return localRand.Next(min, max);
-        }
+        public static int Next() => GetLocalRandom().Next();
+        public static int Next(int max) => GetLocalRandom().Next(max);
+        public static int Next(int min, int max) => GetLocalRandom().Next(min, max);
 
         private static Random GetLocalRandom()
         {
@@ -71,4 +58,19 @@ namespace DaggerfallWorkshop
         }
     }
 
+}
+
+public static class JobUtility
+{
+    /// <summary>
+    /// Schedules a job that calls UnsafeUtility.ReleaseGCObject(gcHandle).
+    /// </summary>
+    public static JobHandle ReleaseGCObject(ulong gcHandle, JobHandle dependency = default)
+        => new ReleaseGCObjectJob(gcHandle).Schedule(dependency);
+
+    /// <summary>
+    /// This equation is yet to be (im)proved experimentally, the current version is merely an initial guesswork
+    /// </summary>
+    public static int OptimalLoopBatchCount(int length)
+        => Unity.Mathematics.math.max(length / (UnityEngine.SystemInfo.processorCount * 3), 1);
 }

--- a/Assets/Scripts/Terrain/TerrainHelper.cs
+++ b/Assets/Scripts/Terrain/TerrainHelper.cs
@@ -4,11 +4,12 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Andrzej Łukasik (andrew.r.lukasik)
 // 
 // Notes:
 //
 
+using System.Linq;
 using UnityEngine;
 using DaggerfallConnect;
 using DaggerfallConnect.Arena2;
@@ -16,6 +17,9 @@ using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Utility;
 using Unity.Jobs;
 using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Mathematics;
+using Unity.Profiling;
 
 namespace DaggerfallWorkshop
 {
@@ -28,6 +32,7 @@ namespace DaggerfallWorkshop
         public const byte maxHeightIdx = 1;
         public const int rotBit = 0x40;
         public const int flipBit = 0x80;
+        const int oceanClimate = 223;
 
         // Ranges and defaults for editor
         // Map pixel ranges are slightly smaller to allow for interpolation of neighbours
@@ -52,6 +57,15 @@ namespace DaggerfallWorkshop
         // Allow mods to set extra blend space around locations for placing content, specifed in # of tiles
         public delegate int AdditionalLocationBlendSpace(DFRegion.LocationTypes locationType);
         public static AdditionalLocationBlendSpace ExtraBlendSpace = (locationType) => { return 0; };
+
+        static readonly ProfilerMarker
+            ___SmoothLocationNeighbourhood = new ProfilerMarker($"{nameof(TerrainHelper)}.{nameof(SmoothLocationNeighbourhood)}"),
+            ___SmoothLocationNeighbourhoodAsync = new ProfilerMarker($"{nameof(TerrainHelper)}.{nameof(SmoothLocationNeighbourhoodAsync)}"),
+            ___DilateCoastalClimate = new ProfilerMarker($"{nameof(TerrainHelper)}.{nameof(DilateCoastalClimate)}"),
+            ___DilateCoastalClimateAsync = new ProfilerMarker($"{nameof(TerrainHelper)}.{nameof(DilateCoastalClimateAsync)}"),
+            ___SetLocationTiles = new ProfilerMarker($"{nameof(TerrainHelper)}.{nameof(SetLocationTiles)}"),
+            ___iterate_location_blocks = new ProfilerMarker("iterate location blocks"),
+            ___CalcAvgMaxHeightAsync = new ProfilerMarker($"{nameof(TerrainHelper)}.{nameof(CalcAvgMaxHeightAsync)}");
 
         /// <summary>
         /// Gets map pixel data for any location in world.
@@ -125,124 +139,146 @@ namespace DaggerfallWorkshop
         // Set location tilemap data
         public static void SetLocationTiles(ref MapPixelData mapPixel)
         {
+            ___SetLocationTiles.Begin();
+
             // Get location
             DaggerfallUnity dfUnity = DaggerfallUnity.Instance;
-            DFLocation location = dfUnity.ContentReader.MapFileReader.GetLocation(mapPixel.mapRegionIndex, mapPixel.mapLocationIndex);
+            var mapFileReader = dfUnity.ContentReader.MapFileReader;
+            var contentReader = dfUnity.ContentReader;
+            DFLocation location = mapFileReader.GetLocation(mapPixel.mapRegionIndex, mapPixel.mapLocationIndex);
 
             // Position tiles inside terrain area
-            DFPosition tilePos = TerrainHelper.GetLocationTerrainTileOrigin(location);
+            int2 tilePos;
+            {
+                DFPosition tilePosObj = TerrainHelper.GetLocationTerrainTileOrigin(location);
+                tilePos = new int2(tilePosObj.X, tilePosObj.Y);
+            }
 
             // Full 8x8 locations have "terrain blend space" around walls to smooth down random terrain towards flat area.
             // This is indicated by texture index > 55 (ground texture range is 0-55), larger values indicate blend space.
             // We need to know rect of actual city area so we can use blend space outside walls.
-            int xmin = int.MaxValue, ymin = int.MaxValue;
-            int xmax = 0, ymax = 0;
+            int2 min = int.MaxValue;
+            int2 max = 0;
 
             // Iterate blocks of this location
-            for (int blockY = 0; blockY < location.Exterior.ExteriorData.Height; blockY++)
+            ___iterate_location_blocks.Begin();
+            int
+                numBlockX = location.Exterior.ExteriorData.Width,
+                numBlockY = location.Exterior.ExteriorData.Height,
+                numTile = RMBLayout.RMBTilesPerBlock;
+            for (int blockY = 0; blockY < numBlockY; blockY++)
+            for (int blockX = 0; blockX < numBlockX; blockX++)
             {
-                for (int blockX = 0; blockX < location.Exterior.ExteriorData.Width; blockX++)
+                // Get block data
+                string blockName = mapFileReader.GetRmbBlockName(location, blockX, blockY);
+                if (!contentReader.GetBlock(blockName, out var block))
+                    continue;
+
+                // Copy ground tile info
+                var groundTiles = block.RmbBlock.FldHeader.GroundData.GroundTiles;
+                for (int row = 0; row < numTile; row++)
+                for (int col = 0; col < numTile; col++)
                 {
-                    // Get block data
-                    DFBlock block;
-                    string blockName = dfUnity.ContentReader.MapFileReader.GetRmbBlockName(location, blockX, blockY);
-                    if (!dfUnity.ContentReader.GetBlock(blockName, out block))
-                        continue;
+                    var tile = groundTiles[row, (numTile - 1) - col];// [row,col]
 
-                    // Copy ground tile info
-                    for (int tileY = 0; tileY < RMBLayout.RMBTilesPerBlock; tileY++)
+                    int2 pos = tilePos + new int2(blockX, blockY) * numTile + new int2(row, col);
+
+                    if (tile.TextureRecord < 56)
                     {
-                        for (int tileX = 0; tileX < RMBLayout.RMBTilesPerBlock; tileX++)
-                        {
-                            DFBlock.RmbGroundTiles tile = block.RmbBlock.FldHeader.GroundData.GroundTiles[tileX, (RMBLayout.RMBTilesPerBlock - 1) - tileY];
-                            int xpos = tilePos.X + blockX * RMBLayout.RMBTilesPerBlock + tileX;
-                            int ypos = tilePos.Y + blockY * RMBLayout.RMBTilesPerBlock + tileY;
+                        // Track interior bounds of location tiled area
+                        min = math.min(min, pos);
+                        max = math.max(max, pos);
 
-                            if (tile.TextureRecord < 56)
-                            {
-                                // Track interior bounds of location tiled area
-                                if (xpos < xmin) xmin = xpos;
-                                if (xpos > xmax) xmax = xpos;
-                                if (ypos < ymin) ymin = ypos;
-                                if (ypos > ymax) ymax = ypos;
-
-                                // Store texture data from block
-                                mapPixel.tilemapData[JobA.Idx(xpos, ypos, MapsFile.WorldMapTileDim)] = tile.TileBitfield == 0 ? byte.MaxValue : tile.TileBitfield;
-                            }
-                        }
+                        // Store texture data from block
+                        mapPixel.tilemapData[Matrix.Idx(pos.x, pos.y, MapsFile.WorldMapTileDim)] = tile.TileBitfield == 0 ? byte.MaxValue : tile.TileBitfield;
                     }
                 }
             }
+            ___iterate_location_blocks.End();
 
             // Update location rect with extra clearance
             int extraClearance = location.MapTableData.LocationType == DFRegion.LocationTypes.TownCity ? 3 : 2;
             Rect locationRect = new Rect();
-            locationRect.xMin = xmin - extraClearance;
-            locationRect.xMax = xmax + extraClearance;
-            locationRect.yMin = ymin - extraClearance;
-            locationRect.yMax = ymax + extraClearance;
+            locationRect.xMin = min.x - extraClearance;
+            locationRect.xMax = max.x + extraClearance;
+            locationRect.yMin = min.y - extraClearance;
+            locationRect.yMax = max.y + extraClearance;
             mapPixel.locationRect = locationRect;
+
+            ___SetLocationTiles.End();
         }
 
         #region Terrain Jobs - Schedulers
 
-        public static JobHandle ScheduleCalcAvgMaxHeightJob(ref MapPixelData mapPixel, JobHandle dependencies)
+        public static JobHandle CalcAvgMaxHeightAsync(MapPixelData mapPixel, JobHandle dependency = default)
         {
-            CalcAvgMaxHeightJob calcAvgMaxHeightJob = new CalcAvgMaxHeightJob()
+            ___CalcAvgMaxHeightAsync.Begin();
+
+            CalcAvgMaxHeightJob calcAvgMaxHeightJob = new CalcAvgMaxHeightJob
             {
                 heightmapData = mapPixel.heightmapData,
                 avgMaxHeight = mapPixel.avgMaxHeight,
             };
-            return calcAvgMaxHeightJob.Schedule(dependencies);
-        }
+            var jobHandle = calcAvgMaxHeightJob.Schedule(dependency);
 
-        public static JobHandle ScheduleBlendLocationTerrainJob(ref MapPixelData mapPixel, JobHandle dependencies)
+            ___CalcAvgMaxHeightAsync.End();
+            return jobHandle;
+        }
+        [System.Obsolete("use "+nameof(CalcAvgMaxHeightAsync)+" instead")]
+        public static JobHandle ScheduleCalcAvgMaxHeightJob(ref MapPixelData mapPixel, JobHandle dependencies)
+            => CalcAvgMaxHeightAsync(mapPixel, dependencies);
+
+        public static JobHandle BlendLocationTerrainAsync(MapPixelData mapPixel, JobHandle dependency = default)
         {
-            BlendLocationTerrainJob blendLocationTerrainJob = new BlendLocationTerrainJob()
+            var blendLocationTerrainJob = new BlendLocationTerrainJob
             {
-                heightmapData = mapPixel.heightmapData,
-                avgMaxHeight = mapPixel.avgMaxHeight,
-                hDim = DaggerfallUnity.Instance.TerrainSampler.HeightmapDimension,
-                locationRect = mapPixel.locationRect,
+                HeightmapData = mapPixel.heightmapData,
+                AvgMaxHeight = mapPixel.avgMaxHeight,
+                HDim = DaggerfallUnity.Instance.TerrainSampler.HeightmapDimension,
+                LocationRect = mapPixel.locationRect,
             };
             int extraBlendSpace = ExtraBlendSpace(mapPixel.LocationType);
             if (extraBlendSpace > 0)
             {
-                blendLocationTerrainJob.locationRect.xMin -= extraBlendSpace;
-                blendLocationTerrainJob.locationRect.xMax += extraBlendSpace;
-                blendLocationTerrainJob.locationRect.yMin -= extraBlendSpace;
-                blendLocationTerrainJob.locationRect.yMax += extraBlendSpace;
+                blendLocationTerrainJob.LocationRect.xMin -= extraBlendSpace;
+                blendLocationTerrainJob.LocationRect.xMax += extraBlendSpace;
+                blendLocationTerrainJob.LocationRect.yMin -= extraBlendSpace;
+                blendLocationTerrainJob.LocationRect.yMax += extraBlendSpace;
             }
-            return blendLocationTerrainJob.Schedule(dependencies);
+            return blendLocationTerrainJob.Schedule(dependency);
         }
+        [System.Obsolete("use "+nameof(BlendLocationTerrainAsync)+" instead")]
+        public static JobHandle ScheduleBlendLocationTerrainJob(ref MapPixelData mapPixel, JobHandle dependencies)
+            => BlendLocationTerrainAsync(mapPixel, dependencies);
 
-        public static JobHandle ScheduleUpdateTileMapDataJob(ref MapPixelData mapPixel, JobHandle dependencies)
+        public static JobHandle UpdateTileMapDataAsync(MapPixelData mapPixel, JobHandle dependency = default)
         {
             int tilemapDim = MapsFile.WorldMapTileDim;
             bool convertWater = DaggerfallUnity.Instance.TerrainTexturing.ConvertWaterTiles();
-            UpdateTileMapDataJob updateTileMapDataJob = new UpdateTileMapDataJob()
+            var updateTileMapDataJob = new UpdateTileMapDataJob
             {
                 tilemapData = mapPixel.tilemapData,
                 tileMap = mapPixel.tileMap,
                 tDim = tilemapDim,
                 convertWater = convertWater,
             };
-            return updateTileMapDataJob.Schedule(tilemapDim * tilemapDim, 64, dependencies);
+            return updateTileMapDataJob.Schedule(tilemapDim * tilemapDim, 64, dependency);
         }
+        [System.Obsolete("use "+nameof(BlendLocationTerrainAsync)+" instead")]
+        public static JobHandle ScheduleUpdateTileMapDataJob(ref MapPixelData mapPixel, JobHandle dependencies)
+            => UpdateTileMapDataAsync(mapPixel, dependencies);
 
         #endregion
 
         #region Terrain Jobs
 
         // Calculates average and maximum heights of terrain data
+        [Unity.Burst.BurstCompile]
         struct CalcAvgMaxHeightJob : IJob
         {
-            [ReadOnly]
-            public NativeArray<float> heightmapData;
-
+            [ReadOnly] public NativeArray<float> heightmapData;
             public NativeArray<float> avgMaxHeight;
-
-            public void Execute()
+            void IJob.Execute()
             {
                 for (int i = 0; i < heightmapData.Length; i++)
                 {
@@ -258,42 +294,41 @@ namespace DaggerfallWorkshop
         }
 
         // Flattens location terrain and blends with surrounding terrain
+        [Unity.Burst.BurstCompile]
         struct BlendLocationTerrainJob : IJob
         {
-            public NativeArray<float> heightmapData;
-            [ReadOnly]
-            public NativeArray<float> avgMaxHeight;
-
-            public int hDim;
-            public Rect locationRect;
-
-            public void Execute()
+            public NativeArray<float> HeightmapData;
+            [ReadOnly] public NativeArray<float> AvgMaxHeight;
+            public int HDim;
+            public Rect LocationRect;
+            void IJob.Execute()
             {
                 // Convert from rect in tilemap space to interior corners in 0-1 range
-                float xMin = locationRect.xMin / MapsFile.WorldMapTileDim;
-                float xMax = locationRect.xMax / MapsFile.WorldMapTileDim;
-                float yMin = locationRect.yMin / MapsFile.WorldMapTileDim;
-                float yMax = locationRect.yMax / MapsFile.WorldMapTileDim;
+                float4 minmax = new float4(LocationRect.xMin, LocationRect.xMax, LocationRect.yMin, LocationRect.yMax) / MapsFile.WorldMapTileDim;
+                float xMin = minmax.x;
+                float xMax = minmax.y;
+                float yMin = minmax.z;
+                float yMax = minmax.w;
 
                 // Scale values for converting blend space into 0-1 range
-                float leftScale = 1 / xMin;
-                float rightScale = 1 / (1 - xMax);
-                float topScale = 1 / yMin;
-                float bottomScale = 1 / (1 - yMax);
+                float4 scale = 1f / new float4(xMin, (1 - xMax), yMin, (1 - yMax));
+                float leftScale = scale.x;
+                float rightScale = scale.y;
+                float topScale = scale.z;
+                float bottomScale = scale.w;
 
                 // Flatten location area and blend with surrounding heights
-                float strength = 0;
-                float targetHeight = avgMaxHeight[avgHeightIdx];
-                for (int y = 0; y < hDim; y++)
+                float targetHeight = AvgMaxHeight[avgHeightIdx];
+                for (int y = 0; y < HDim; y++)
                 {
-                    float v = (float)y / (float)(hDim - 1);
+                    float v = (float)y / (float)(HDim - 1);
                     bool insideY = (v >= yMin && v <= yMax);
 
-                    for (int x = 0; x < hDim; x++)
+                    for (int x = 0; x < HDim; x++)
                     {
-                        float u = (float)x / (float)(hDim - 1);
+                        float u = (float)x / (float)(HDim - 1);
                         bool insideX = (u >= xMin && u <= xMax);
-
+                        float strength = 0;
 
                         if (insideX || insideY)
                         {
@@ -314,41 +349,38 @@ namespace DaggerfallWorkshop
                             strength = TerrainHelper.BilinearInterpolator(0, 0, 0, 1, xs, ys);
                         }
 
-                        int idx = JobA.Idx(y, x, hDim);
-                        float height = heightmapData[idx];
+                        int idx = Matrix.Idx(y, x, HDim);
+                        float height = HeightmapData[idx];
 
                         if (insideX && insideY)
                             height = targetHeight;
                         else
                             height = Mathf.Lerp(height, targetHeight, strength);
 
-                        heightmapData[idx] = height;
+                        HeightmapData[idx] = height;
                     }
                 }
             }
         }
 
         // Converts tileMap data to color array for use by shader
+        [Unity.Burst.BurstCompile]
         struct UpdateTileMapDataJob : IJobParallelFor
         {
-            [ReadOnly]
-            public NativeArray<byte> tilemapData;
-            [WriteOnly]
-            public NativeArray<Color32> tileMap;
-
+            [ReadOnly] public NativeArray<byte> tilemapData;
+            [WriteOnly] public NativeArray<Color32> tileMap;
             public int tDim;
             public bool convertWater;
-
-            public void Execute(int index)
+            void IJobParallelFor.Execute(int index)
             {
-                int x = JobA.Row(index, tDim);
-                int y = JobA.Col(index, tDim);
+                int x = Matrix.Row(index, tDim);
+                int y = Matrix.Col(index, tDim);
 
                 // Assign tile data to tilemap
                 Color32 tileColor = new Color32(0, 0, 0, 0);
 
                 // Get sample tile data
-                byte tile = tilemapData[JobA.Idx(x, y, tDim)];
+                byte tile = tilemapData[Matrix.Idx(x, y, tDim)];
 
                 // Convert from [flip,rotate,6bit-record] => [6bit-record,flip,rotate]
                 int record;
@@ -369,6 +401,50 @@ namespace DaggerfallWorkshop
             }
         }
 
+        // Copies climate data from source to destination if destination is ocean
+        // Used to dilate climate data around shorelines as a pre-process
+        [Unity.Burst.BurstCompile]
+        struct DilateCoastalClimateJob : IJob
+        {
+            public int Passes, XMax, YMax, PakWidth;
+            public NativeArray<byte> Climate;
+            void IJob.Execute()
+            {
+                var previousPass = new NativeArray<byte>(Climate, Allocator.Temp);
+                for (int pass = 0; pass < Passes; pass++)
+                {
+                    // Dilate coastal areas
+                    for (int y = 1; y < YMax; y++)
+                    for (int x = 1; x < XMax; x++)
+                    {
+                        // Source must be land
+                        int srcOffset = y * PakWidth + (x + 1);
+                        byte srcClimate = previousPass[srcOffset];
+                        if (srcClimate == oceanClimate)
+                            continue;
+                        
+                        // Transfer climate of this pixel to any ocean pixel in Moore neighbourhood
+                        TransferLandToOcean(previousPass, Climate, srcClimate, x - 1, y - 1,PakWidth);
+                        TransferLandToOcean(previousPass, Climate, srcClimate, x, y - 1,PakWidth);
+                        TransferLandToOcean(previousPass, Climate, srcClimate, x + 1, y - 1,PakWidth);
+                        TransferLandToOcean(previousPass, Climate, srcClimate, x - 1, y,PakWidth);
+                        TransferLandToOcean(previousPass, Climate, srcClimate, x + 1, y,PakWidth);
+                        TransferLandToOcean(previousPass, Climate, srcClimate, x - 1, y + 1,PakWidth);
+                        TransferLandToOcean(previousPass, Climate, srcClimate, x, y + 1,PakWidth);
+                        TransferLandToOcean(previousPass, Climate, srcClimate, x + 1, y + 1,PakWidth);
+                    }
+                }
+            }
+            void TransferLandToOcean(NativeArray<byte> previousPass, NativeArray<byte> currentPass, byte srcClimate, int dstX, int dstY, int pakWidth)
+            {
+                // Destination must be ocean
+                int dstOffset = dstY * pakWidth + (dstX + 1);
+                byte dstClimate = previousPass[dstOffset];
+                if (dstClimate == oceanClimate)
+                    currentPass[dstOffset] = srcClimate;
+            }
+        }
+
         #endregion
 
         /// <summary>
@@ -379,8 +455,7 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void DilateCoastalClimate(ContentReader contentReader, int passes)
         {
-            //System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
-            //long startTime = stopwatch.ElapsedMilliseconds;
+            ___DilateCoastalClimate.Begin();
 
             for (int pass = 0; pass < passes; pass++)
             {
@@ -388,49 +463,66 @@ namespace DaggerfallWorkshop
                 byte[] climateArray = contentReader.MapFileReader.ClimateFile.Buffer.Clone() as byte[];
 
                 // Dilate coastal areas
-                for (int y = 1; y < WoodsFile.mapHeightValue - 1; y++)
+                int
+                    mapHeight = WoodsFile.mapHeightValue,
+                    mapWidth = WoodsFile.mapWidthValue,
+                    xmax = mapWidth - 1,
+                    ymax = mapHeight - 1;
+                for (int y = 1; y < ymax; y++)
+                for (int x = 1; x < xmax; x++)
                 {
-                    for (int x = 1; x < WoodsFile.mapWidthValue - 1; x++)
-                    {
-                        // Transfer climate of this pixel to any ocean pixel in Moore neighbourhood
-                        TransferLandToOcean(contentReader, ref climateArray, x, y, x - 1, y - 1);
-                        TransferLandToOcean(contentReader, ref climateArray, x, y, x, y - 1);
-                        TransferLandToOcean(contentReader, ref climateArray, x, y, x + 1, y - 1);
-                        TransferLandToOcean(contentReader, ref climateArray, x, y, x - 1, y);
-                        TransferLandToOcean(contentReader, ref climateArray, x, y, x + 1, y);
-                        TransferLandToOcean(contentReader, ref climateArray, x, y, x - 1, y + 1);
-                        TransferLandToOcean(contentReader, ref climateArray, x, y, x, y + 1);
-                        TransferLandToOcean(contentReader, ref climateArray, x, y, x + 1, y + 1);
-                    }
+                    // Transfer climate of this pixel to any ocean pixel in Moore neighbourhood
+                    transferLandToOcean(contentReader, climateArray, x, y, x - 1, y - 1);
+                    transferLandToOcean(contentReader, climateArray, x, y, x, y - 1);
+                    transferLandToOcean(contentReader, climateArray, x, y, x + 1, y - 1);
+                    transferLandToOcean(contentReader, climateArray, x, y, x - 1, y);
+                    transferLandToOcean(contentReader, climateArray, x, y, x + 1, y);
+                    transferLandToOcean(contentReader, climateArray, x, y, x - 1, y + 1);
+                    transferLandToOcean(contentReader, climateArray, x, y, x, y + 1);
+                    transferLandToOcean(contentReader, climateArray, x, y, x + 1, y + 1);
                 }
 
                 // Store modified climate array
                 contentReader.MapFileReader.ClimateFile.Buffer = climateArray;
             }
 
-            //long totalTime = stopwatch.ElapsedMilliseconds - startTime;
-            //DaggerfallUnity.LogMessage(string.Format("Time to dilate coastal climates: {0}ms", totalTime), true);
-        }
-
-        // Copies climate data from source to destination if destination is ocean
-        // Used to dilate climate data around shorelines as a pre-process
-        private static void TransferLandToOcean(ContentReader contentReader, ref byte[] dstClimateArray, int srcX, int srcY, int dstX, int dstY)
-        {
-            const int oceanClimate = 223;
-
-            // Source must be land
-            int srcOffset = srcY * PakFile.pakWidthValue + (srcX + 1);
-            int srcClimate = contentReader.MapFileReader.ClimateFile.Buffer[srcOffset];
-            if (srcClimate == oceanClimate)
-                return;
-
-            // Destination must be ocean
-            int dstOffset = dstY * PakFile.pakWidthValue + (dstX + 1);
-            int dstClimate = contentReader.MapFileReader.ClimateFile.Buffer[dstOffset];
-            if (dstClimate == oceanClimate)
+            // Copies climate data from source to destination if destination is ocean
+            // Used to dilate climate data around shorelines as a pre-process
+            void transferLandToOcean(ContentReader cr, byte[] dstClimateArray, int srcX, int srcY, int dstX, int dstY)
             {
-                dstClimateArray[dstOffset] = (byte)srcClimate;
+                // Source must be land
+                int srcOffset = srcY * PakFile.pakWidthValue + (srcX + 1);
+                int srcClimate = cr.MapFileReader.ClimateFile.Buffer[srcOffset];
+                if (srcClimate == oceanClimate)
+                    return;
+
+                // Destination must be ocean
+                int dstOffset = dstY * PakFile.pakWidthValue + (dstX + 1);
+                int dstClimate = cr.MapFileReader.ClimateFile.Buffer[dstOffset];
+                if (dstClimate == oceanClimate)
+                    dstClimateArray[dstOffset] = (byte)srcClimate;
             }
+
+            ___DilateCoastalClimate.End();
+        }
+        public static JobHandle DilateCoastalClimateAsync( ContentReader contentReader, int passes, JobHandle dependency = default )
+        {
+            ___DilateCoastalClimateAsync.Begin();
+
+            NativeArray<byte> climateFileBuffer = contentReader.MapFileReader.ClimateFile.Buffer.AsNativeArray(out ulong gcHandle);
+            var job = new DilateCoastalClimateJob
+            {
+                Passes = passes,
+                XMax = WoodsFile.mapWidthValue - 1,
+                YMax = WoodsFile.mapHeightValue - 1,
+                PakWidth = PakFile.pakWidthValue,
+                Climate = climateFileBuffer
+            };
+            var jobHandle = job.Schedule(dependency);
+            JobUtility.ReleaseGCObject(gcHandle, jobHandle);
+
+            ___DilateCoastalClimateAsync.End();
+            return jobHandle;
         }
 
         /// <summary>
@@ -439,42 +531,90 @@ namespace DaggerfallWorkshop
         /// </summary>
         public static void SmoothLocationNeighbourhood(ContentReader contentReader, int threshold = 20)
         {
-            //System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
-            //long startTime = stopwatch.ElapsedMilliseconds;
+            ___SmoothLocationNeighbourhood.Begin();
 
             // Get in-memory height array
             byte[] heightArray = contentReader.WoodsFileReader.Buffer;
 
             // Search for locations
-            for (int y = 1; y < WoodsFile.mapHeightValue - 1; y++)
+            int
+                mapHeight = WoodsFile.mapHeightValue,
+                mapWidth = WoodsFile.mapWidthValue,
+                xmax = mapWidth - 1,
+                ymax = mapHeight - 1;
+            for (int y = 1; y < ymax; y++)
+            for (int x = 1; x < xmax; x++)
+            if (contentReader.HasLocation(x, y, out var summary))
             {
-                for (int x = 1; x < WoodsFile.mapWidthValue - 1; x++)
-                {
-                    ContentReader.MapSummary summary;
-                    if (contentReader.HasLocation(x, y, out summary))
-                    {
-                        // Use Sobel filter for gradient
-                        float x0y0 = heightArray[y * WoodsFile.mapWidthValue + x];
-                        float x1y0 = heightArray[y * WoodsFile.mapWidthValue + (x + 1)];
-                        float x0y1 = heightArray[(y + 1) * WoodsFile.mapWidthValue + x];
-                        float gradient = GetGradient(x0y0, x1y0, x0y1);
-                        if (gradient > threshold)
-                        {
-                            AverageHeights(ref heightArray, x, y);
-                        }
-                    }
-                }
+                // Use Sobel filter for gradient
+                float x0y0 = heightArray[y * mapWidth + x];
+                float x1y0 = heightArray[y * mapWidth + (x + 1)];
+                float x0y1 = heightArray[(y + 1) * mapWidth + x];
+                float gradient = GetGradient(x0y0, x1y0, x0y1);
+                if (gradient > threshold)
+                    AverageHeights(heightArray, x, y, mapWidth);
             }
 
-            //long totalTime = stopwatch.ElapsedMilliseconds - startTime;
-            //DaggerfallUnity.LogMessage(string.Format("Time to smooth location neighbourhoods: {0}ms", totalTime), true);
+            ___SmoothLocationNeighbourhood.End();
+        }
+        public static JobHandle SmoothLocationNeighbourhoodAsync(ContentReader contentReader, int threshold = 20, JobHandle dependency = default)
+        {
+            ___SmoothLocationNeighbourhoodAsync.Begin();
+            
+            // get locations hashset
+            NativeArray<int> locations = contentReader.MapSummaries.Keys.ToArray().AsNativeArray(out ulong gcHandleLoc);
+
+            // Get in-memory height array
+            NativeArray<byte> woodsFileReaderBuffer = contentReader.WoodsFileReader.Buffer.AsNativeArray(out ulong gcHandleBuff);
+            var job = new SmoothLocationNeighbourhoodJob
+            {
+                Locations = locations,
+                HeightArray = woodsFileReaderBuffer,
+                MapWidth = WoodsFile.mapWidthValue,
+                MapHeight = WoodsFile.mapHeightValue,
+                Threshold = threshold,
+            };
+            var jobHandle = job.Schedule(dependency);
+            JobUtility.ReleaseGCObject(gcHandleLoc, jobHandle);
+            JobUtility.ReleaseGCObject(gcHandleBuff, jobHandle);
+
+            ___SmoothLocationNeighbourhoodAsync.End();
+            return jobHandle;
+        }
+
+        [Unity.Burst.BurstCompile]
+        struct SmoothLocationNeighbourhoodJob : IJob
+        {
+            [ReadOnly] public NativeArray<int> Locations;
+            public NativeArray<byte> HeightArray;
+            public int MapWidth, MapHeight;
+            public float Threshold;
+            void IJob.Execute()
+            {
+                // @TODO: change to NativeHashSet<int> once collections package becomes >= v0.11 (https://docs.unity3d.com/Packages/com.unity.collections@0.11/api/Unity.Collections.NativeHashSet-1.html)
+                var locationsHashset = new NativeHashMap<int, byte>(Locations.Length, Allocator.Temp);
+                foreach( int id in Locations )
+                    locationsHashset.TryAdd(id, default);
+
+                // Search for locations
+                for (int y = 1; y < MapHeight - 1; y++)
+                for (int x = 1; x < MapWidth - 1; x++)
+                if (locationsHashset.ContainsKey(MapsFile.GetMapPixelID(x, y)))
+                {
+                    // Use Sobel filter for gradient
+                    float x0y0 = HeightArray[y * MapWidth + x];
+                    float x1y0 = HeightArray[y * MapWidth + (x + 1)];
+                    float x0y1 = HeightArray[(y + 1) * MapWidth + x];
+                    float gradient = GetGradient(x0y0, x1y0, x0y1);
+                    if (gradient > Threshold)
+                        AverageHeights(HeightArray, x, y, MapWidth);
+                }
+            }
         }
 
         // Gets terrain key based on map pixel coordinates
         public static int MakeTerrainKey(int mapPixelX, int mapPixelY)
-        {
-            return ((short)mapPixelY << 16) + (short)mapPixelX;
-        }
+            => ((short)mapPixelY << 16) + (short)mapPixelX;
 
         // Reverse terrain key back to map pixel coordinates
         public static void ReverseTerrainKey(int key, out int mapPixelX, out int mapPixelY)
@@ -484,7 +624,13 @@ namespace DaggerfallWorkshop
         }
 
         // Gets fast gradient value from heights
-        private static float GetGradient(float x0y0, float x1y0, float x0y1)
+        public static float GetGradient(float x0y0, float x1y0, float x0y1)
+        {
+            float2 d = new float2(x1y0, x0y1) - x0y0;
+            return math.csum(math.abs(d));// Faster
+            // return math.sqrt(math.csum(d*d));// More accurate
+        }
+        public static float GetGradient_old(float x0y0, float x1y0, float x0y1)
         {
             float dx = x1y0 - x0y0;
             float dy = x0y1 - x0y0;
@@ -493,35 +639,56 @@ namespace DaggerfallWorkshop
         }
 
         // Average centre coordinate height with surrounding heights
-        private static void AverageHeights(ref byte[] heightArray, int cx, int cy)
+        public static void AverageHeights(byte[] heightArray, int cx, int cy, int mapWidth)
         {
             // First pass averages
             float average = 0;
             float counter = 0;
-            for (int y = cy - 1; y < cy + 2; y++)
             {
+                for (int y = cy - 1; y < cy + 2; y++)
                 for (int x = cx - 1; x < cx + 2; x++)
                 {
-                    average += heightArray[y * WoodsFile.mapWidthValue + x];
+                    average += heightArray[y * mapWidth + x];
                     counter++;
                 }
             }
 
             // Next pass applies average
             average /= counter;
-            for (int y = cy - 1; y < cy + 2; y++)
             {
+                byte value = (byte)average;
+                for (int y = cy - 1; y < cy + 2; y++)
+                for (int x = cx - 1; x < cx + 2; x++)
+                    heightArray[y * mapWidth + x] = value;
+            }
+        }
+        public static void AverageHeights(NativeArray<byte> heightArray, int cx, int cy, int mapWidth)
+        {
+            // First pass averages
+            float average = 0;
+            float counter = 0;
+            {
+                for (int y = cy - 1; y < cy + 2; y++)
                 for (int x = cx - 1; x < cx + 2; x++)
                 {
-                    heightArray[y * WoodsFile.mapWidthValue + x] = (byte)average;
+                    average += heightArray[y * mapWidth + x];
+                    counter++;
                 }
+            }
+
+            // Next pass applies average
+            average /= counter;
+            {
+                byte value = (byte)average;
+                for (int y = cy - 1; y < cy + 2; y++)
+                for (int x = cx - 1; x < cx + 2; x++)
+                    heightArray[y * mapWidth + x] = value;
             }
         }
 
         #region Helper Methods
 
-        // Bilinear interpolation of values
-        public static float BilinearInterpolator(float valx0y0, float valx0y1, float valx1y0, float valx1y1, float u, float v)
+        public static float BilinearInterpolator_old(float valx0y0, float valx0y1, float valx1y0, float valx1y1, float u, float v)
         {
             float result =
                         (1 - u) * ((1 - v) * valx0y0 +
@@ -531,9 +698,28 @@ namespace DaggerfallWorkshop
 
             return result;
         }
+        public static float BilinearInterpolator(float valx0y0, float valx0y1, float valx1y0, float valx1y1, float u, float v)
+        {
+            // return
+            //     (1 - u) * ((1 - v) * valx0y0 + v * valx0y1) +
+            //     u * ((1 - v) * valx1y0 + v * valx1y1);
 
-        // Cubic interpolation of values
-        public static float CubicInterpolator(float v0, float v1, float v2, float v3, float fracy)
+            float2 one_sub_uv = new float2(1) - new float2(u, v);
+            // return
+            //     one_sub_uv.x * (one_sub_uv.y * valx0y0 + v * valx0y1) +
+            //     u * (one_sub_uv.y * valx1y0 + v * valx1y1);
+
+            float4 mul1 = new float4(one_sub_uv.y, v, one_sub_uv.y, v) * new float4(valx0y0, valx0y1, valx1y0, valx1y1);
+            float2 add = new float2(mul1.x, mul1.z) + new float2(mul1.y, mul1.w);
+            // return
+            //     one_sub_uv.x * add.x +
+            //     u * add.y;
+
+            float2 mul2 = new float2(one_sub_uv.x, u) * new float2(add.x, add.y);
+            return math.csum(mul2);
+        }
+
+        public static float CubicInterpolator_old(float v0, float v1, float v2, float v3, float fracy)
         {
             float A = (v3 - v2) - (v0 - v1);
             float B = (v0 - v1) - A;
@@ -543,16 +729,29 @@ namespace DaggerfallWorkshop
             return A * (fracy * fracy * fracy) + B * (fracy * fracy) + C * fracy + D;           // Faster
             //return A * Mathf.Pow(fracy, 3) + B * Mathf.Pow(fracy, 2) + C * fracy + D;
         }
+        public static float CubicInterpolator(float v0, float v1, float v2, float v3, float fracy)
+        {
+            // float a = (v3 - v2) - (v0 - v1);
+            // float b = (v0 - v1) - a;
+            // float c = v2 - v0;
+            // float d = v1;
+
+            float3 sub = new float3(v3, v0, v2) - new float3(v2, v1, v0);
+            // float a = sub.x - sub.y;
+            // float b = sub.y - a;
+            // float c = sub.z;
+
+            float a = sub.x - sub.y;
+            float b = sub.y - a;
+            float c = sub.z;
+            float d = v1;
+
+            // return a * (fracy * fracy * fracy) + b * (fracy * fracy) + c * fracy + d;
+            return math.csum(new float4(a, b, c, d) * new float4(fracy, fracy, fracy, 1) * new float4(fracy * fracy, fracy, 1, 1));
+        }
 
         // Get noise sample at coordinates
-        public static float GetNoise(
-            int x,
-            int y,
-            float frequency,
-            float amplitude,
-            float persistance,
-            int octaves,
-            int seed = 0)
+        public static float GetNoise_old(int x, int y, float frequency, float amplitude, float persistance, int octaves, int seed = 0)
         {
             float finalValue = 0f;
             for (int i = 0; i < octaves; ++i)
@@ -561,9 +760,22 @@ namespace DaggerfallWorkshop
                 frequency *= 2.0f;
                 amplitude *= persistance;
             }
-
-            return Mathf.Clamp01(finalValue);
+            return math.saturate(finalValue);
         }
+        public static float GetNoise(int x, int y, float frequency, float amplitude, float persistance, int octaves, int seed = 0)
+        {
+            float finalValue = 0f;
+            for (int i = 0; i < octaves; ++i)
+            {
+                finalValue += PerlinNoise(seed + x * frequency, seed + y * frequency) * amplitude;
+                frequency *= 2.0f;
+                amplitude *= persistance;
+            }
+            return math.saturate(finalValue);
+        }
+
+        public static float PerlinNoise(float x, float y)
+            => (noise.cnoise(new float2(x, y)) + 1f) * 0.5f;
 
         #endregion
     }

--- a/Assets/Scripts/Terrain/TerrainSampler.cs
+++ b/Assets/Scripts/Terrain/TerrainSampler.cs
@@ -4,12 +4,12 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    Michael Rauter (Nystul)
+// Contributors:    Michael Rauter (Nystul), Andrzej Łukasik (andrew.r.lukasik)
 // 
 // Notes:
 //
 
-using System;
+using Unity.Collections;
 using Unity.Jobs;
 
 namespace DaggerfallWorkshop
@@ -115,15 +115,16 @@ namespace DaggerfallWorkshop
             GenerateSamples(ref mapPixel);
 
             // Convert generated samples to the flattened native array used by jobs.
-            int hDim = HeightmapDimension;
-            for (int y = 0; y < hDim; y++)
-            {
-                for (int x = 0; x < hDim; x++)
-                {
-                    mapPixel.heightmapData[JobA.Idx(y, x, hDim)] = mapPixel.heightmapSamples[y, x];
-                }
-            }
-            return new JobHandle();
+            // int hDim = HeightmapDimension;
+            // for (int y = 0; y < hDim; y++)
+            // for (int x = 0; x < hDim; x++)
+            //     mapPixel.heightmapData[Matrix.Idx(y, x, hDim)] = mapPixel.heightmapSamples[y, x];
+
+            var copyJob = new CopyToJob<float>(mapPixel.heightmapSamples.AsNativeArray(out ulong gcHandle), mapPixel.heightmapData);
+            var copyJobHandle = copyJob.Schedule();
+            JobUtility.ReleaseGCObject(gcHandle);
+
+            return copyJobHandle;
         }
     }
 }

--- a/Assets/Scripts/Utility/ArrayExtensionMethods.cs
+++ b/Assets/Scripts/Utility/ArrayExtensionMethods.cs
@@ -1,0 +1,140 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes:
+//
+
+using UnityEngine;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Profiling;
+
+public static class ArrayExtensionMethods
+{
+
+
+    /// <summary>
+    /// Pins this GC array and turns it's pointer into a NativeArray.
+    /// Do not Dispose but call UnsafeUtility.ReleaseGCObject(gcHandle) when done with it.
+    /// </summary>
+    public static unsafe NativeArray<T> AsNativeArray<T>(this T[] array, out ulong gcHandle) where T : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+    /// <inheritdoc />
+    public static unsafe NativeArray<T> AsNativeArray<T>(this T[,] array, out ulong gcHandle) where T : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+    /// <inheritdoc />
+    public static unsafe NativeArray<T> AsNativeArray<T>(this T[,,] array, out ulong gcHandle) where T : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+    /// <inheritdoc />
+    public static unsafe NativeArray<(T1,T2)> AsNativeArray<T1,T2>(this (T1,T2)[] array, out ulong gcHandle)
+        where T1 : unmanaged
+        where T2 : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<(T1,T2)>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+    /// <inheritdoc />
+    public static unsafe NativeArray<(T1,T2,T3)> AsNativeArray<T1,T2,T3>(this (T1,T2,T3)[] array, out ulong gcHandle)
+        where T1 : unmanaged
+        where T2 : unmanaged
+        where T3 : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<(T1,T2,T3)>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+
+
+    public static string ToReadableString<T>(this T[] arr)
+    {
+        if (arr.Length == 0) return "()";
+        var sb = new System.Text.StringBuilder();
+        sb.Append($"({arr[0]}");
+        for (int i = 1; i < arr.Length; i++)
+            sb.Append($",{arr[i]}");
+        sb.Append(')');
+        return sb.ToString();
+    }
+    public static string ToReadableString<T>(this T[,] arr)
+    {
+        int
+            lengthY = arr.GetLength(0),
+            lengthX = arr.GetLength(1),
+            length = arr.Length;
+        var sb = new System.Text.StringBuilder($"[{lengthY},{lengthX}]( ");
+        for (int y = 0; y < lengthY; y++)
+        {
+            if (y != 0)
+                sb.Append(" , ");
+            if (lengthX != 0)
+                sb.Append($"({arr[y, 0]}");
+            for (int x = 1; x < lengthX; x++)
+                sb.Append($",{arr[y, x]}");
+            sb.Append(')');
+        }
+        sb.Append($" )");
+        return sb.ToString();
+    }
+    public static string ToReadableString<T>(this T[,,] arr)
+    {
+        int
+            lengthZ = arr.GetLength(0),
+            lengthY = arr.GetLength(1),
+            lengthX = arr.GetLength(2),
+            length = arr.Length;
+        var sb = new System.Text.StringBuilder($"[{lengthZ},{lengthY},{lengthX}]( ");
+        for (int z = 0; z < lengthZ; z++)
+        {
+            if (z != 0) sb.Append(" , ");
+            sb.Append("( ");
+            for (int y = 0; y < lengthY; y++)
+            {
+                if (y != 0)
+                    sb.Append(" , ");
+                if (lengthX != 0)
+                sb.Append($"({arr[z, y, 0]}");
+                for (int x = 1; x < lengthX; x++)
+                    sb.Append($",{arr[z, y, x]}");
+                sb.Append(')');
+            }
+            sb.Append(" )");
+        }
+        sb.Append($" )");
+        return sb.ToString();
+    }
+
+
+}

--- a/Assets/Scripts/Utility/ArrayExtensionMethods.cs.meta
+++ b/Assets/Scripts/Utility/ArrayExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1dc425bd0a9275b44a85f29c54f9ece5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/TextureReplacement.cs
@@ -28,6 +28,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Game.Items;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.Utility.ModSupport;
+using Unity.Profiling;
 
 namespace DaggerfallWorkshop.Utility.AssetInjection
 {
@@ -140,6 +141,26 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         #endregion
+        
+        #region Profiler Markers
+
+        static readonly ProfilerMarker
+            ___CustomizeMaterial = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(CustomizeMaterial)}"),
+            ___GetStaticBillboardMaterial = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(GetStaticBillboardMaterial)}"),
+            ___GetMobileBillboardMaterial = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(GetMobileBillboardMaterial)}"),
+            ___TryImportTexture = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(TryImportTexture)}"),
+            ___TryImportImage = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(TryImportImage)}"),
+            ___TryImportCifRci = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(TryImportCifRci)}"),
+            ___TryImportTextureArray = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(TryImportTextureArray)}"),
+            ___TryImportTextureFromLooseFiles = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(TryImportTextureFromLooseFiles)}"),
+            ___TryImportTextureFromDisk = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(TryImportTextureFromDisk)}"),
+            ___TryMakeTextureArrayCopyTexture = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(TryMakeTextureArrayCopyTexture)}"),
+            ___LoadFromCacheOrImport = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(LoadFromCacheOrImport)}"),
+            ___MakeBillboardMaterial = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(MakeBillboardMaterial)}"),
+            ___IsDaggerfallTexture = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(IsDaggerfallTexture)}"),
+            ___AssignFiltermode = new ProfilerMarker($"{nameof(TextureReplacement)}.{nameof(AssignFiltermode)}");
+
+        #endregion
 
         #region Textures Import
 
@@ -165,7 +186,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(int archive, int record, out Texture2D[] texFrames)
         {
-            return TryImportTexture(texturesPath, frame => GetName(archive, record, frame), out texFrames);
+            ___TryImportTexture.Begin();
+
+            bool success = TryImportTexture(texturesPath, frame => GetName(archive, record, frame), out texFrames);
+
+            ___TryImportTexture.End();
+            return success;
         }
 
         /// <summary>
@@ -178,7 +204,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(int archive, int record, int frame, out Texture2D tex)
         {
-            return TryImportTexture(texturesPath, GetName(archive, record, frame), false, null, out tex);
+            ___TryImportTexture.Begin();
+
+            bool success =  TryImportTexture(texturesPath, GetName(archive, record, frame), false, null, out tex);
+            
+            ___TryImportTexture.End();
+            return success;
         }
 
         /// <summary>
@@ -193,7 +224,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(int archive, int record, int frame, TextureMap textureMap, bool readOnly, out Texture2D tex)
         {
-            return TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap), readOnly, textureMap, out tex);
+            ___TryImportTexture.Begin();
+
+            bool success = TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap), readOnly, textureMap, out tex);
+            
+            ___TryImportTexture.End();
+            return success;
         }
 
         /// <summary>
@@ -209,9 +245,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(int archive, int record, int frame, TextureMap textureMap, TextureImport textureImport, bool readOnly, out Texture2D tex)
         {
+            ___TryImportTexture.Begin();
+
+            bool success =
+                    (textureImport == TextureImport.AllLocations && TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap), readOnly, textureMap, out tex))
+                ||  (textureImport == TextureImport.LooseFiles && TryImportTextureFromLooseFiles(archive, record, frame, textureMap, readOnly, out tex));
+            
             tex = null;
-            return (textureImport == TextureImport.AllLocations && TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap), readOnly, textureMap, out tex))
-                || (textureImport == TextureImport.LooseFiles && TryImportTextureFromLooseFiles(archive, record, frame, textureMap, readOnly, out tex));
+            ___TryImportTexture.End();
+            return success;
         }
 
         /// <summary>
@@ -226,7 +268,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(int archive, int record, int frame, DyeColors dye, TextureMap textureMap, out Texture2D tex)
         {
-            return TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap, dye), false, null, out tex);
+            ___TryImportTexture.Begin();
+
+            bool success = TryImportTexture(texturesPath, GetName(archive, record, frame, textureMap, dye), false, null, out tex);
+
+            ___TryImportTexture.End();
+            return success;
         }
 
         /// <summary>
@@ -238,7 +285,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTexture(string name, bool readOnly, out Texture2D tex)
         {
-            return TryImportTexture(texturesPath, name, readOnly, null, out tex);
+            ___TryImportTexture.Begin();
+
+            bool success = TryImportTexture(texturesPath, name, readOnly, null, out tex);
+
+            ___TryImportTexture.End();
+            return success;
         }
 
         /// <summary>
@@ -250,7 +302,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if image imported.</returns>
         public static bool TryImportImage(string name, bool readOnly, out Texture2D tex)
         {
-            return TryImportTexture(imgPath, name, readOnly, null, out tex);
+            ___TryImportImage.Begin();
+
+            bool success =  TryImportTexture(imgPath, name, readOnly, null, out tex);
+
+            ___TryImportImage.End();
+            return success;
         }
 
         /// <summary>
@@ -264,7 +321,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if CifRci imported.</returns>
         public static bool TryImportCifRci(string name, int record, int frame, bool readOnly, out Texture2D tex)
         {
-            return TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame), readOnly, null, out tex);
+            ___TryImportCifRci.Begin();
+
+            bool success = TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame), readOnly, null, out tex);
+
+            ___TryImportCifRci.End();
+            return success;
         }
 
         /// <summary>
@@ -279,7 +341,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if CifRci imported.</returns>
         public static bool TryImportCifRci(string name, int record, int frame, MetalTypes metalType, bool readOnly, out Texture2D tex)
         {
-            return TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame, metalType), readOnly, null, out tex);
+            ___TryImportCifRci.Begin();
+
+            bool success = TryImportTexture(cifRciPath, GetNameCifRci(name, record, frame, metalType), readOnly, null, out tex);
+
+            ___TryImportCifRci.End();
+            return success;
         }
 
         /// <summary>
@@ -295,9 +362,12 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if the texture array has been imported or created.</returns>
         internal static bool TryImportTextureArray(int archive, int depth, TextureMap textureMap, Color32? fallbackColor, out Texture2DArray textureArray)
         {
+            ___TryImportTextureArray.Begin();
+
             if (!DaggerfallUnity.Settings.AssetInjection)
             {
                 textureArray = null;
+                ___TryImportTextureArray.End();
                 return false;
             }
 
@@ -312,14 +382,20 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 if (ModManager.Instance.TryGetAsset(names, null, out texture) && texture.dimension == TextureDimension.Tex2DArray)
                 {
                     if ((textureArray = texture as Texture2DArray).depth == depth)
+                    {
+                        ___TryImportTextureArray.End();
                         return true;
+                    }
 
                     Debug.LogErrorFormat("{0}: expected depth {0} but got {1}.", textureArray.name, depth, textureArray.depth);
                 }
             }
 
             // Seek individual textures from mods and loose files
-            return TryMakeTextureArrayCopyTexture(archive, depth, textureMap, fallbackColor, out textureArray);
+            var success = TryMakeTextureArrayCopyTexture(archive, depth, textureMap, fallbackColor, out textureArray);
+            
+            ___TryImportTextureArray.End();
+            return success;
         }
 
         /// <summary>
@@ -334,13 +410,18 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         public static bool TryImportTextureFromLooseFiles(int archive, int record, int frame, TextureMap textureMap, bool readOnly, out Texture2D tex)
         { 
+            ___TryImportTextureFromLooseFiles.Begin();
+
             if (DaggerfallUnity.Settings.AssetInjection)
             {
                 string path = Path.Combine(texturesPath, GetName(archive, record, frame, textureMap));
-                return TryImportTextureFromDisk(path, true, IsLinearTextureMap(textureMap), readOnly, out tex);
+                bool success = TryImportTextureFromDisk(path, true, IsLinearTextureMap(textureMap), readOnly, out tex);
+                ___TryImportTextureFromLooseFiles.End();
+                return success;
             }
 
             tex = null;
+            ___TryImportTextureFromLooseFiles.End();
             return false;           
         }
 
@@ -411,9 +492,10 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="material">Material.</param>
         public static void CustomizeMaterial(int archive, int record, int frame, Material material)
         {
+            ___CustomizeMaterial.Begin();
+
             // MetallicGloss map
-            Texture2D metallicGloss;
-            if (TryImportTextureFromLooseFiles(archive, record, frame, TextureMap.MetallicGloss, true, out metallicGloss))
+            if (TryImportTextureFromLooseFiles(archive, record, frame, TextureMap.MetallicGloss, true, out Texture2D metallicGloss))
             {
                 metallicGloss.filterMode = MainFilterMode;
                 material.EnableKeyword(KeyWords.MetallicGlossMap);
@@ -422,8 +504,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             }
 
             // Height Map
-            Texture2D height;
-            if (TryImportTextureFromLooseFiles(archive, record, frame, TextureMap.Height, true, out height))
+            if (TryImportTextureFromLooseFiles(archive, record, frame, TextureMap.Height, true, out Texture2D height))
             {
                 height.filterMode = MainFilterMode;
                 material.EnableKeyword(KeyWords.HeightMap);
@@ -446,6 +527,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 if (xml.TryGetFloat("smoothness", out smoothness))
                     material.SetFloat(Uniforms.Glossiness, smoothness);
             }
+
+            ___CustomizeMaterial.End();
         }
 
         /// <summary>
@@ -463,24 +546,27 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>A material or null.</returns>
         public static Material GetStaticBillboardMaterial(GameObject go, int archive, int record, ref BillboardSummary summary, out Vector2 scale)
         {
+            ___GetStaticBillboardMaterial.Begin();
+
             scale = Vector2.one;
 
             if (!DaggerfallUnity.Settings.AssetInjection)
+            {
+                ___GetStaticBillboardMaterial.End();
                 return null;
+            }
 
             //MeshRenderer meshRenderer = go.GetComponent<MeshRenderer>();
             int frame = 0;
 
-            Texture2D albedo, emission;
-            if (summary.ImportedTextures.HasImportedTextures = LoadFromCacheOrImport(archive, record, frame, true, true, out albedo, out emission))
+            if (summary.ImportedTextures.HasImportedTextures = LoadFromCacheOrImport(archive, record, frame, true, true, out Texture2D albedo, out Texture2D emission))
             {
                 bool isEmissive = emission || DaggerfallUnity.Instance.MaterialReader.TextureReader.IsEmissive(archive, record);
 
                 // Read xml configuration
                 Vector2 uv = Vector2.zero;
                 string renderMode = null;
-                XMLManager xml;
-                if (XMLManager.TryReadXml(texturesPath, GetName(archive, record), out xml))
+                if (XMLManager.TryReadXml(texturesPath, GetName(archive, record), out XMLManager xml))
                 {
                     xml.TryGetString("renderMode", out renderMode);
                     isEmissive |= xml.GetBool("emission");
@@ -519,9 +605,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 summary.ImportedTextures.Albedo = albedoTextures;
                 summary.ImportedTextures.Emission = emissionTextures;
 
+                ___GetStaticBillboardMaterial.End();
                 return material;
             }
 
+            ___GetStaticBillboardMaterial.End();
             return null;
         }
 
@@ -538,17 +626,20 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>A material or null.</returns>
         public static Material GetMobileBillboardMaterial(int archive, MeshFilter meshFilter, ref MobileBillboardImportedTextures importedTextures)
         {
-            if (!DaggerfallUnity.Settings.AssetInjection)
-                return null;
+            ___GetMobileBillboardMaterial.Begin();
 
-            Texture2D tex, emission;
-            if (importedTextures.HasImportedTextures = LoadFromCacheOrImport(archive, 0, 0, true, true, out tex, out emission))
+            if (!DaggerfallUnity.Settings.AssetInjection)
+            {
+                ___GetMobileBillboardMaterial.End();
+                return null;
+            }
+
+            if (importedTextures.HasImportedTextures = LoadFromCacheOrImport(archive, 0, 0, true, true, out Texture2D tex, out Texture2D emission))
             {
                 string renderMode = null;
 
                 // Read xml configuration
-                XMLManager xml;
-                if (XMLManager.TryReadXml(ImagesPath, string.Format("{0:000}", archive), out xml))
+                if (XMLManager.TryReadXml(ImagesPath, string.Format("{0:000}", archive), out XMLManager xml))
                 {
                     xml.TryGetString("renderMode", out renderMode);
                     importedTextures.IsEmissive = xml.GetBool("emission");
@@ -622,9 +713,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 // Update UV map
                 SetUv(meshFilter);
 
+                ___GetMobileBillboardMaterial.End();
                 return material;
             }
 
+            ___GetMobileBillboardMaterial.End();
             return null;
         }
 
@@ -731,17 +824,18 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture is a Daggerfall texture.</returns>
         static public bool IsDaggerfallTexture(string name, out int archive, out int record)
         {
+            ___IsDaggerfallTexture.Begin();
+
             if ((name[3] == '_') && name.EndsWith("-0", StringComparison.CurrentCulture))
+            if (Int32.TryParse(name.Substring(0, 3), out archive))
+            if ((name[5] == '-' && Int32.TryParse(name.Substring(4, 1), out record)) || (name[6] == '-' && Int32.TryParse(name.Substring(4, 2), out record)))
             {
-                if (Int32.TryParse(name.Substring(0, 3), out archive))
-                {
-                    if ((name[5] == '-' && Int32.TryParse(name.Substring(4, 1), out record)) ||
-                            (name[6] == '-' && Int32.TryParse(name.Substring(4, 2), out record)))
-                        return true;
-                }
+                ___IsDaggerfallTexture.End();
+                return true;
             }
 
             archive = record = -1;
+            ___IsDaggerfallTexture.End();
             return false;
         }
 
@@ -799,12 +893,16 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// </summary>
         public static void AssignFiltermode(Material material)
         {
+            ___AssignFiltermode.Begin();
+
             FilterMode filterMode = MainFilterMode;
             foreach (var property in Uniforms.Textures.Where(x => material.HasProperty(x)))
             {
                 Texture tex = material.GetTexture(property);
                 if (tex) tex.filterMode = filterMode;
             }
+
+            ___AssignFiltermode.End();
         }
 
         /// <summary>
@@ -954,12 +1052,17 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         private static bool TryImportTexture(string path, string name, bool readOnly, TextureMap? textureMap, out Texture2D tex)
         {
+            ___TryImportTexture.Begin();
+
             bool isLinear = textureMap != null && IsLinearTextureMap(textureMap.Value);
             if (DaggerfallUnity.Settings.AssetInjection)
             {
                 // Seek from loose files
                 if (TryImportTextureFromDisk(Path.Combine(path, name), false, isLinear, readOnly, out tex))
+                {
+                    ___TryImportTexture.End();
                     return true;
+                }
 
                 // Seek from mods
                 if (ModManager.Instance && ModManager.Instance.TryGetAsset(name, null, out tex))
@@ -967,11 +1070,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                     if (!readOnly && !tex.isReadable)
                         Debug.LogWarning($"Texture {name} is not readable.");
 
+                    ___TryImportTexture.End();
                     return true;
                 }
             }
 
             tex = null;
+            ___TryImportTexture.End();
             return false;
         }
 
@@ -984,6 +1089,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture imported.</returns>
         private static bool TryImportTexture(string path, Func<int, string> getName, out Texture2D[] texFrames)
         {
+            ___TryImportTexture.Begin();
+            
             int frame = 0;
             Texture2D tex;
             if (TryImportTexture(path, getName(frame), false, null, out tex))
@@ -992,10 +1099,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 do textures.Add(tex);
                 while (TryImportTexture(path, getName(++frame), false, null, out tex));
                 texFrames = textures.ToArray();
+                
+                ___TryImportTexture.End();
                 return true;
             }
 
             texFrames = null;
+            ___TryImportTexture.End();
             return false;
         }
 
@@ -1011,6 +1121,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if texture exists and has been imported.</returns>
         private static bool TryImportTextureFromDisk(string path, bool mipMaps, bool isLinear, bool readOnly, out Texture2D tex)
         {
+            ___TryImportTextureFromDisk.Begin();
+
             const int retroThreshold = 256; // Imported textures with a width or height below this threshold will never be compressed to preserve retro appearance
 
             if (!path.EndsWith(extension))
@@ -1031,10 +1143,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 #endif
 
                 tex.filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
+                
+                ___TryImportTextureFromDisk.End();
                 return true;
             }
 
             tex = null;
+            ___TryImportTextureFromDisk.End();
             return false;
         }
 
@@ -1055,10 +1170,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if the texture array has been created.</returns>
         private static bool TryMakeTextureArrayCopyTexture(int archive, int depth, TextureMap textureMap, Color32? fallbackColor, out Texture2DArray textureArray)
         {
+            ___TryMakeTextureArrayCopyTexture.Begin();
+
             textureArray = null;
 
             if ((SystemInfo.copyTextureSupport & CopyTextureSupport.DifferentTypes) == CopyTextureSupport.None)
+            {
+                ___TryMakeTextureArrayCopyTexture.End();
                 return false;
+            }
 
             bool mipMaps = false;
             Texture2D fallback = null;
@@ -1069,7 +1189,10 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 if (!TryImportTexture(archive, record, 0, textureMap, true, out tex))
                 {
                     if (!textureArray)
+                    {
+                        ___TryMakeTextureArrayCopyTexture.End();
                         return false;
+                    }
 
                     if (!fallbackColor.HasValue)
                     {
@@ -1094,7 +1217,10 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 if (!textureArray)
                 {
                     if (fallbackColor.HasValue && tex.format != TextureFormat.RGBA32 && tex.format != TextureFormat.ARGB32)
+                    {
+                        ___TryMakeTextureArrayCopyTexture.End();
                         return false;
+                    }
 
                     textureArray = new Texture2DArray(tex.width, tex.height, depth, tex.format, mipMaps = tex.mipmapCount > 1, IsLinearTextureMap(textureMap));
                     textureArray.filterMode = (FilterMode)DaggerfallUnity.Settings.MainFilterMode;
@@ -1113,9 +1239,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             {
                 textureArray.wrapMode = TextureWrapMode.Clamp;
                 textureArray.anisoLevel = 8;
+                ___TryMakeTextureArrayCopyTexture.End();
                 return true;
             }
 
+            ___TryMakeTextureArrayCopyTexture.End();
             return false;
         }
 
@@ -1152,8 +1280,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             bool allowEmissionMap,
             bool readOnly,
             out Texture2D albedo,
-            out Texture2D emission)
+            out Texture2D emission
+        )
         {
+            ___LoadFromCacheOrImport.Begin();
+
             MaterialReader materialReader = DaggerfallUnity.Instance.MaterialReader;
 
             CachedMaterial cachedMaterial;
@@ -1165,6 +1296,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             {
                 albedo = cachedMaterial.albedoMap;
                 emission = cachedMaterial.emissionMap;
+                ___LoadFromCacheOrImport.End();
                 return true;
             }
 
@@ -1183,9 +1315,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 }
 
                 materialReader.SetCachedMaterialCustomBillboard(archive, record, frame, cachedMaterial);
+                ___LoadFromCacheOrImport.End();
                 return true;
             }
 
+            ___LoadFromCacheOrImport.End();
             return false;
         }
 
@@ -1215,6 +1349,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
         private static Material MakeBillboardMaterial(string renderMode = null)
         {
+            ___MakeBillboardMaterial.Begin();
+
             // Parse blendMode from string or use Cutout if no custom blendMode specified
             MaterialReader.CustomBlendMode blendMode =
                 renderMode != null && Enum.IsDefined(customBlendModeType, renderMode) ?
@@ -1223,9 +1359,15 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
             // Use Daggerfall/Billboard material for standard cutout billboards or create a Standard material if using any other custom blendMode
             if (blendMode == MaterialReader.CustomBlendMode.Cutout)
+            {
+                ___MakeBillboardMaterial.End();
                 return MaterialReader.CreateBillboardMaterial();
+            }
             else
+            {
+                ___MakeBillboardMaterial.End();
                 return MaterialReader.CreateStandardMaterial(blendMode);
+            }
         }
 
         private static bool MakeName(ImageData imageData, DyeColors dyeColor, out string directory, out string name)

--- a/Assets/Scripts/Utility/Editor.meta
+++ b/Assets/Scripts/Utility/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3b62139d5af48e44bd8e0d278556518
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/Editor/ImageProcessingTests.cs
+++ b/Assets/Scripts/Utility/Editor/ImageProcessingTests.cs
@@ -1,0 +1,95 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes:
+//
+
+using NUnit.Framework;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+using DaggerfallWorkshop.Utility;
+
+static class ImageProcessingTests
+{
+
+    [Test]
+    public static void SharpenAsync___EQUALS___Sharpen()
+    {
+        const int
+            width = 64,
+            height = 64,
+            length = width * height;
+        Color32[] input = new Color32[length];
+        for (int i = 0; i < length; i++)
+            input[i] = UnityEngine.Random.ColorHSV();
+
+        var ___sw = System.Diagnostics.Stopwatch.StartNew();
+        Color32[] expectedData = ImageProcessing.Sharpen(input, width, height);
+        var expectedTime = ___sw.Elapsed;
+        Color32[] actualData = (Color32[])input.Clone();
+        {
+            var buff = actualData.AsNativeArray(out ulong gcHandle);
+            ___sw.Restart();
+            ImageProcessing.SharpenAsync(buff, width, height).Complete();
+            var actualTime = ___sw.Elapsed;
+            actualData = buff.ToArray();
+            JobUtility.ReleaseGCObject(gcHandle);
+
+            Debug.Log($"Sharpen took {expectedTime.Milliseconds}[ms] ({expectedTime.Ticks}[ticks]) \t SharpenAsync took {actualTime.Milliseconds}[ms] ({actualTime.Ticks}[ticks])");
+        }
+        
+        for (int i = 0; i < length; i++)
+        {
+            var expected = expectedData[i];
+            var actual = actualData[i];
+            // Debug.Log($"input:{input[i]}\texpected:{expected}\tactual:{actual}");
+            Assert.AreEqual(expected: expected, actual: actual);
+        }
+    }
+
+    [Test]
+    public static void WrapBorderAsync___EQUALS___WrapBorder()
+    {
+        const int
+            width = 64,
+            height = 64,
+            length = width * height,
+            border = 3;
+        Color32[] input = new Color32[length];
+        for (int i = 0; i < length; i++)
+            input[i] = UnityEngine.Random.ColorHSV();
+
+        var ___sw = System.Diagnostics.Stopwatch.StartNew();
+        Color32[] expectedData = (Color32[])input.Clone();
+        ImageProcessing.WrapBorder(expectedData, new DaggerfallConnect.Utility.DFSize(width, height), border, true, true);
+        var expectedTime = ___sw.Elapsed;
+        Color32[] actualData = (Color32[])input.Clone();
+        {
+            var buff = actualData.AsNativeArray(out ulong gcHandle);
+            ___sw.Restart();
+            ImageProcessing.WrapBorderAsync(buff, width, height, border, true, true).Complete();
+            var actualTime = ___sw.Elapsed;
+            actualData = buff.ToArray();
+            JobUtility.ReleaseGCObject(gcHandle);
+
+            Debug.Log($"WrapBorder took {expectedTime.Milliseconds}[ms] ({expectedTime.Ticks}[ticks]) \t WrapBorderAsync took {actualTime.Milliseconds}[ms] ({actualTime.Ticks}[ticks])");
+        }
+        
+        for (int i = 0; i < length; i++)
+        {
+            var expected = expectedData[i];
+            var actual = actualData[i];
+            // Debug.Log($"input:{input[i]}\texpected:{expected}\tactual:{actual}");
+            Assert.AreEqual(expected: expected, actual: actual);
+        }
+    }
+
+}

--- a/Assets/Scripts/Utility/Editor/ImageProcessingTests.cs.meta
+++ b/Assets/Scripts/Utility/Editor/ImageProcessingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a0748c54bbd689429fb208cedf5f4b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/Editor/NativeArrayExtensionMethodsTests.cs
+++ b/Assets/Scripts/Utility/Editor/NativeArrayExtensionMethodsTests.cs
@@ -1,0 +1,281 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes:
+//
+
+using NUnit.Framework;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+
+static class NativeArrayExtensionMethodsTests
+{
+
+
+    [Test] public static void CopyTo__NativeArray__managed_array_2d()
+    {
+        // create both arrays
+        var dst = new int[2, 4];
+        int
+            lengthY = dst.GetLength(0),
+            lengthX = dst.GetLength(1),
+            length = dst.Length;
+        var src = new NativeArray<int>(length, Allocator.Temp);
+        for (int i = 0; i < length; i++)
+            src[i] = i;
+
+        Debug.Log($"src before: {src.ToReadableString()}");
+        Debug.Log($"dst before: {dst.ToReadableString()}");
+
+        // copy
+        src.CopyTo(dst);
+
+        Debug.Log($"src after: {src.ToReadableString()}");
+        Debug.Log($"dst after: {dst.ToReadableString()}");
+
+        // test
+        {
+            int i = 0;
+            for (int y = 0; y < lengthY; y++)
+            for (int x = 0; x < lengthX; x++)
+            {
+                int
+                    expected = src[i++],
+                    actual = dst[y, x];
+                Assert.AreEqual(expected: expected, actual: actual, delta: 0);
+            }
+        }
+    }
+
+    [Test] public static void CopyTo__NativeArray__managed_array_3d()
+    {
+        // create both arrays
+        var dst = new int[2, 4, 3];
+        int
+            lengthZ = dst.GetLength(0),
+            lengthY = dst.GetLength(1),
+            lengthX = dst.GetLength(2),
+            length = dst.Length;
+        var src = new NativeArray<int>(length, Allocator.Temp);
+        for (int i = 0; i < length; i++)
+            src[i] = i;
+
+        Debug.Log($"src before: {src.ToReadableString()}");
+        Debug.Log($"dst before: {dst.ToReadableString()}");
+
+        // copy
+        src.CopyTo(dst);
+
+        Debug.Log($"src after: {src.ToReadableString()}");
+        Debug.Log($"dst after: {dst.ToReadableString()}");
+
+        // test
+        {
+            int i = 0;
+            for (int z = 0; z < lengthZ; z++)
+            for (int y = 0; y < lengthY; y++)
+            for (int x = 0; x < lengthX; x++)
+            {
+                int
+                    expected = src[i++],
+                    actual = dst[z, y, x];
+                Assert.AreEqual(expected: expected, actual: actual, delta: 0);
+            }
+        }
+    }
+
+    [Test] public static void CopyFrom__NativeArray__managed_array_2d()
+    {
+        // create both arrays
+        var src = new int[2, 4];
+        int
+            lengthY = src.GetLength(0),
+            lengthX = src.GetLength(1),
+            length = src.Length;
+        for (int y = 0; y < lengthY; y++)
+        for (int x = 0; x < lengthX; x++)
+            src[y, x] = y * 100 + x;
+        var dst = new NativeArray<int>(length, Allocator.Temp);        
+
+        Debug.Log($"src before: {src.ToReadableString()}");
+        Debug.Log($"dst before: {dst.ToReadableString()}");
+
+        // copy
+        dst.CopyFrom(src);
+
+        Debug.Log($"src after: {src.ToReadableString()}");
+        Debug.Log($"dst after: {dst.ToReadableString()}");
+
+        // test
+        {
+            int i = 0;
+            for (int y = 0; y < lengthY; y++)
+            for (int x = 0; x < lengthX; x++)
+            {
+                int
+                    expected = src[y, x],
+                    actual = dst[i++];
+                Assert.AreEqual(expected: expected, actual: actual, delta: 0);
+            }
+        }
+    }
+
+    [Test] public static void CopyFrom__NativeArray__managed_array_3d()
+    {
+        // create both arrays
+        var src = new int[2, 4, 3];
+        int
+            lengthZ = src.GetLength(0),
+            lengthY = src.GetLength(1),
+            lengthX = src.GetLength(2),
+            length = src.Length;
+        for (int z = 0; z < lengthZ; z++)
+        for (int y = 0; y < lengthY; y++)
+        for (int x = 0; x < lengthX; x++)
+            src[z, y, x] = z * 10000 + y * 100 + x;
+        var dst = new NativeArray<int>(length, Allocator.Temp);
+
+        Debug.Log($"src before: {src.ToReadableString()}");
+        Debug.Log($"dst before: {dst.ToReadableString()}");
+
+        // copy
+        dst.CopyFrom(src);
+
+        Debug.Log($"src after: {src.ToReadableString()}");
+        Debug.Log($"dst after: {dst.ToReadableString()}");
+
+        // test
+        {
+            int i = 0;
+            for (int z = 0; z < lengthZ; z++)
+            for (int y = 0; y < lengthY; y++)
+            for (int x = 0; x < lengthX; x++)
+            {
+                int
+                    expected = src[z, y, x],
+                    actual = dst[i++];
+                Assert.AreEqual(expected: expected, actual: actual, delta: 0);
+            }
+        }
+    }
+
+
+    [Test] public static unsafe void AssertPtrScope__NativeArray__ptr___byte_pointer_address_0()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        byte* ptr = (byte*)0;
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope__NativeArray__ptr___long_pointer_address_12345566890()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        long* ptr = (long*)12345566890;
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope__NativeArray__ptr___long_pointer_address_12345566890_negative()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        long* ptr = (long*)-12345566890;
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__start_of_the_array()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array);
+        array.AssertPtrScope(ptr);
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__start_of_the_array_plus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+1);
+        array.AssertPtrScope(ptr);
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__end_of_the_array_minus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)((float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+3)-1);
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__end_of_the_array_plus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)((float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+3)+1);
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__last_item_of_the_array()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+2;
+        array.AssertPtrScope(ptr);
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__last_item_of_the_array_minus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)((float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+2)-1);
+        array.AssertPtrScope(ptr);
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__last_item_of_the_array_plus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)((float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+2)+1);
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+
+
+    [Test] public static unsafe void does_AsNativeArray_work()
+    {
+        var array = new int[]{ 1 , 2 , 3 , 4 };
+        var nativeArray = array.AsNativeArray(out ulong gcHandle);
+
+        Assert.AreEqual(expected:array.Length, actual:nativeArray.Length);
+        for (int i = 0; i < array.Length; i++)
+            Assert.AreEqual(expected:array[i], actual:nativeArray[i]);
+        
+        JobUtility.ReleaseGCObject(gcHandle);
+    }
+
+    [Test] public static unsafe void does_ConvertExistingDataToNativeArray_work()
+    {
+        var array = new int[]{ 1 , 2 , 3 , 4 };
+        
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out ulong gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<int>(ptr, array.Length, Allocator.None);
+        
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+
+        Assert.AreEqual(expected:array.Length, actual:nativeArray.Length);
+        for (int i = 0; i < array.Length; i++)
+            Assert.AreEqual(expected:array[i], actual:nativeArray[i]);
+        
+        UnsafeUtility.ReleaseGCObject(gcHandle);
+    }
+
+
+    [Test] public static unsafe void does_AsNativeArray_2d_work()
+    {
+        var array = new int[,] { { 1, 2, 3, 4 }, { 11, 22, 33, 44}, { 111, 222, 333, 444} };
+        var nativeArray = array.AsNativeArray(out ulong gcHandle);
+        
+        int dim0 = array.GetLength(0);
+        int dim1 = array.GetLength(1);
+
+        Assert.AreEqual(expected:array.Length, actual:nativeArray.Length);
+        int i = 0;
+        for (int y = 0; y < dim0; y++)
+        for (int x = 0; x < dim1; x++)
+            Assert.AreEqual(expected:array[y,x], actual:nativeArray[i++]);
+        
+        JobUtility.ReleaseGCObject(gcHandle);
+    }
+
+
+}

--- a/Assets/Scripts/Utility/Editor/NativeArrayExtensionMethodsTests.cs.meta
+++ b/Assets/Scripts/Utility/Editor/NativeArrayExtensionMethodsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c406df4e09fef043a95348b04f7d90b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/ImageReader.cs
+++ b/Assets/Scripts/Utility/ImageReader.cs
@@ -217,13 +217,14 @@ namespace DaggerfallWorkshop.Utility
             // Create new Color32 array
             Color32[] newColors = new Color32[(int)subRect.width * (int)subRect.height];
             ImageProcessing.CopyColors(
-                ref colors,
-                ref newColors,
+                colors,
+                newColors,
                 new DFSize(srcWidth, srcHeight),
                 new DFSize((int)subRect.width, (int)subRect.height),
                 new DFPosition((int)subRect.x, (int)subRect.y),
                 new DFPosition(0, 0),
-                new DFSize((int)subRect.width, (int)subRect.height));
+                new DFSize((int)subRect.width, (int)subRect.height)
+            );
 
             return newColors;
         }

--- a/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs
+++ b/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs
@@ -1,0 +1,154 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes: Requires "Allow Unsafe Code" enabled ☑
+//
+
+using UnityEngine;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+using Unity.Profiling;
+
+public static class NativeArrayExtensionMethods
+{
+
+    static readonly ProfilerMarker
+        ___CopyTo = new ProfilerMarker("CopyTo"),
+        ___CopyFrom = new ProfilerMarker("CopyFrom");
+
+    public static unsafe void CopyTo<T>(this NativeArray<T> src, T[,] dst) where T : unmanaged
+    {
+        ___CopyTo.Begin();
+        if (src.Length == dst.Length)
+        {
+            int size = src.Length * UnsafeUtility.SizeOf<T>();
+            void* srcPtr = NativeArrayUnsafeUtility.GetUnsafePtr(src);
+            void* dstPtr = UnsafeUtility.PinGCArrayAndGetDataAddress(dst, out ulong dstHandle);
+            UnsafeUtility.MemCpy(destination: dstPtr, source: srcPtr, size: size);
+            UnsafeUtility.ReleaseGCObject(dstHandle);
+        }
+        else Debug.LogError($"<b>{nameof(src)}.Length</b> ({src}[b]) and <b>{nameof(dst)}.Length</b> ({dst.Length}[b]) must be equal. MemCpy aborted.");
+        ___CopyTo.End();
+    }
+    public static unsafe void CopyTo<T>(this NativeArray<T> src, T[,,] dst) where T : unmanaged
+    {
+        ___CopyTo.Begin();
+        if (src.Length == dst.Length)
+        {
+            int size = src.Length * UnsafeUtility.SizeOf<T>();
+            void* srcPtr = NativeArrayUnsafeUtility.GetUnsafePtr(src);
+            void* dstPtr = UnsafeUtility.PinGCArrayAndGetDataAddress(dst, out ulong dstHandle);
+            UnsafeUtility.MemCpy(destination: dstPtr, source: srcPtr, size: size);
+            UnsafeUtility.ReleaseGCObject(dstHandle);
+        }
+        else Debug.LogError($"<b>{nameof(src)}.Length</b> ({src}[b]) and <b>{nameof(dst)}.Length</b> ({dst.Length}[b]) must be equal. MemCpy aborted.");
+        ___CopyTo.End();
+    }
+
+    public static unsafe void CopyFrom<T>(this NativeArray<T> dst, T[,] src) where T : unmanaged
+    {
+        ___CopyFrom.Begin();
+        if (src.Length == dst.Length)
+        {
+            int size = src.Length * UnsafeUtility.SizeOf<T>();
+            void* srcPtr = UnsafeUtility.PinGCArrayAndGetDataAddress(src, out ulong dstHandle);
+            void* dstPtr = NativeArrayUnsafeUtility.GetUnsafePtr(dst);
+            UnsafeUtility.MemCpy(destination: dstPtr, source: srcPtr, size: size);
+            UnsafeUtility.ReleaseGCObject(dstHandle);
+        }
+        else Debug.LogError($"<b>{nameof(src)}.Length</b> ({src}[b]) and <b>{nameof(dst)}.Length</b> ({dst.Length}[b]) must be equal. MemCpy aborted.");
+        ___CopyFrom.End();
+    }
+    public static unsafe void CopyFrom<T>(this NativeArray<T> dst, T[,,] src) where T : unmanaged
+    {
+        ___CopyFrom.Begin();
+        if (src.Length == dst.Length)
+        {
+            int size = src.Length * UnsafeUtility.SizeOf<T>();
+            void* srcPtr = UnsafeUtility.PinGCArrayAndGetDataAddress(src, out ulong dstHandle);
+            void* dstPtr = NativeArrayUnsafeUtility.GetUnsafePtr(dst);
+            UnsafeUtility.MemCpy(destination: dstPtr, source: srcPtr, size: size);
+            UnsafeUtility.ReleaseGCObject(dstHandle);
+        }
+        else Debug.LogError($"<b>{nameof(src)}.Length</b> ({src}[b]) and <b>{nameof(dst)}.Length</b> ({dst.Length}[b]) must be equal. MemCpy aborted.");
+        ___CopyFrom.End();
+    }
+
+
+    /// <summary> Schedules a <see cref="CopyToJob{T}"/>. </summary>
+    [Unity.Burst.BurstDiscard]// Burst warning without it, not sure why
+    public static JobHandle CopyTo<T>(this NativeArray<T> src, NativeArray<T> dst, JobHandle dependency) where T : unmanaged
+        => new CopyToJob<T>(src,dst).Schedule(dependency);
+    
+    /// <summary> Schedules a <see cref="CopyToJob{T}"/>. </summary>
+    public static JobHandle CopyFrom<T>(this NativeArray<T> dst, NativeArray<T> src, JobHandle dependency) where T : unmanaged
+        => new CopyToJob<T>(src,dst).Schedule(dependency);
+
+    /// <summary> Fills entire array using given value. </summary>
+    public static unsafe void Fill<T>(this NativeArray<T> Array, T value) where T : unmanaged
+    {
+        void* src = UnsafeUtility.Malloc(UnsafeUtility.SizeOf<T>(), UnsafeUtility.AlignOf<T>(), Allocator.Temp);
+        void* dst = NativeArrayUnsafeUtility.GetUnsafePtr<T>(Array);
+        int size = UnsafeUtility.SizeOf<T>();
+        int count = Array.Length;
+        UnsafeUtility.MemCpyReplicate(destination: dst, source: src, size: size, count: count);
+    }
+
+
+    /// <summary>
+    /// Raises an exception when given pointer refers to address outside this array.
+    /// This makes sure this pointer won't crash the game.
+    /// <b>NOTE</b>: Editor and DEBUG builds only.
+    /// </summary>
+    [System.Diagnostics.Conditional("DEBUG")]
+    public static unsafe void AssertPtrScope<ARRAY_ITEM, POINTER>(this NativeSlice<ARRAY_ITEM> array, POINTER* ptr)
+        where ARRAY_ITEM : unmanaged
+        where POINTER : unmanaged
+    {
+        long addr = (long)ptr;
+        long firstItemAddr = (long)NativeSliceUnsafeUtility.GetUnsafeReadOnlyPtr(array);
+        long lastItemAddr = firstItemAddr + array.Length * (long)UnsafeUtility.SizeOf<ARRAY_ITEM>() - UnsafeUtility.SizeOf<POINTER>();
+        if (!(addr >= firstItemAddr && addr < lastItemAddr))
+        {
+            string message = $"Pointer is out of scope, so considered unsafe (possible crash prevented). Ptr:{addr}, array first item addr:{firstItemAddr}, array last item addr:{lastItemAddr}";
+            Debug.LogWarning(message);
+            throw new System.ArgumentOutOfRangeException(message);
+        }
+    }
+
+    /// <inheritdoc />
+    [System.Diagnostics.Conditional("DEBUG")]
+    public static unsafe void AssertPtrScope<ARRAY_ITEM, POINTER>(this NativeArray<ARRAY_ITEM> array, POINTER* ptr)
+        where ARRAY_ITEM : unmanaged
+        where POINTER : unmanaged
+    {
+        long addr = (long)ptr;
+        long firstItemAddr = (long)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array);
+        long lastItemAddr = firstItemAddr + array.Length * (long)UnsafeUtility.SizeOf<ARRAY_ITEM>() - UnsafeUtility.SizeOf<POINTER>();
+        if (!(addr >= firstItemAddr && addr <= lastItemAddr))
+        {
+            string message = $"Pointer is out of scope, so considered unsafe (possible crash prevented). Ptr:{addr}, array first item addr:{firstItemAddr}, array last item addr:{lastItemAddr}";
+            Debug.LogWarning(message);
+            throw new System.ArgumentOutOfRangeException(message);
+        }
+    }
+
+    public static string ToReadableString<T>(this NativeArray<T> arr) where T : unmanaged
+    {
+        if (arr.Length == 0) return "()";
+        var sb = new System.Text.StringBuilder();
+        sb.Append($"({arr[0]}");
+        for (int i = 1; i < arr.Length; i++)
+            sb.Append($",{arr[i]}");
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+
+}

--- a/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs.meta
+++ b/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06f4e4095efc38e49bdab68c583f88ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/universal jobs.cs
+++ b/Assets/Scripts/Utility/universal jobs.cs
@@ -1,0 +1,87 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes:
+//
+
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+
+[Unity.Burst.BurstCompile]
+public struct DeallocateArrayJob<T> : IJob where T : unmanaged
+{
+    [ReadOnly] [DeallocateOnJobCompletion] NativeArray<T> Array;
+    public DeallocateArrayJob(NativeArray<T> array) => this.Array = array;
+    void IJob.Execute() { }
+}
+
+[Unity.Burst.BurstCompile]
+public struct DeallocateListJob<T> : IJob where T : unmanaged
+{
+    [ReadOnly] [DeallocateOnJobCompletion] NativeList<T> List;
+    public DeallocateListJob(NativeList<T> list) => this.List = list;
+    void IJob.Execute() { }
+}
+
+[Unity.Burst.BurstCompile]
+public struct FillJob<T> : IJob where T : unmanaged
+{
+    T Value;
+    [WriteOnly] NativeArray<T> Array;
+    public FillJob(NativeArray<T> array, T value)
+    {
+        this.Value = value;
+        this.Array = array;
+    }
+    unsafe void IJob.Execute()
+    {
+        void* src = UnsafeUtility.Malloc(UnsafeUtility.SizeOf<T>(), UnsafeUtility.AlignOf<T>(), Allocator.Temp);
+        void* dst = NativeArrayUnsafeUtility.GetUnsafePtr<T>(Array);
+        int size = UnsafeUtility.SizeOf<T>();
+        int count = this.Array.Length;
+        UnsafeUtility.MemCpyReplicate(destination: dst, source: src, size: size, count: count);
+    }
+}
+
+[Unity.Burst.BurstCompile]
+public struct CopyToJob<T> : IJob where T : unmanaged
+{
+    [ReadOnly] NativeArray<T> Src;
+    [WriteOnly] NativeArray<T> Dst;
+    int SrcIndex, DstIndex, Length;
+    public CopyToJob(NativeArray<T> src, NativeArray<T> dst)
+    {
+        this.Src = src;
+        this.SrcIndex = -1;
+        this.Dst = dst;
+        this.DstIndex = -1;
+        this.Length = -1;
+    }
+    public CopyToJob(NativeArray<T> src, int srcIndex, NativeArray<T> dst, int dstIndex, int length)
+    {
+        this.Src = src;
+        this.SrcIndex = srcIndex;
+        this.Dst = dst;
+        this.DstIndex = dstIndex;
+        this.Length = length;
+    }
+    void IJob.Execute()
+    {
+        if (Length == -1) NativeArray<T>.Copy(Src, Dst);
+        else NativeArray<T>.Copy(Src, SrcIndex, Dst, DstIndex, Length);
+    }
+}
+
+[Unity.Burst.BurstCompile]
+public struct ReleaseGCObjectJob : IJob
+{
+    ulong Handle;
+    public ReleaseGCObjectJob(ulong handle) => this.Handle = handle;
+    void IJob.Execute() => UnsafeUtility.ReleaseGCObject(Handle);
+}

--- a/Assets/Scripts/Utility/universal jobs.cs.meta
+++ b/Assets/Scripts/Utility/universal jobs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cba73a9d27144fa40a92ec9e88c7e392
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -680,7 +680,7 @@ PlayerSettings:
   incrementalIl2cppBuild:
     iPhone: 0
   suppressCommonWarnings: 1
-  allowUnsafeCode: 0
+  allowUnsafeCode: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 1


### PR DESCRIPTION
Hi guys, I am working on this for a few weeks now and wanted to get some feedback from you

# what
- a lots of different optimizations that all targets game one single issue: load time
- adds profiler markers (load time related code only)
- adds utility methods & jobs. **One is worth noting here**:`any_managed_array.AsNativeArray()` extension method.
- few unit tests to make sure those few parts aren't broken (will see, maybe I will write more of them)

# why
- load time on my machine was too high (up to 5-8 seconds)

# result
- it reduced load time to 2-4 seconds for initial load and to 1-2 for subsequent ones
- performance markers give some ideas where further optimizations can be made
- auxiliary cores work less now, which seems bad but this is the result of Burst compiling jobs that previously weren't AND general deficit of `IJob`-ified code to throw at them

- Old profiler view (left) - basically no useful info. New profiler view (right) - detailed insight on what cpu is doing
<p float="center">
    <img src="https://user-images.githubusercontent.com/3066539/188334788-a6ec72ed-e56b-4d52-98bf-84f2e59fdf4b.png" width="49%">
    <img src="https://user-images.githubusercontent.com/3066539/188334630-5fbfd349-22aa-4373-a6f7-598e5a70942f.png" width="49%">
</p>

- Unit tests. Low coverage but a good start.
<p float="center">
    <img src="https://user-images.githubusercontent.com/3066539/188334493-6be39b0d-0943-429d-92ae-4827bc672810.png" height="100px">
</p>

