### PR TITLE
Added a "generator" customization point for PopulationManager

### DIFF
--- a/Assets/Scripts/Game/MobilePersonNPC.cs
+++ b/Assets/Scripts/Game/MobilePersonNPC.cs
@@ -69,6 +69,7 @@ namespace DaggerfallWorkshop.Game
         public Races Race
         {
             get { return (race); }
+            set { race = value; }
         }
         
         public DisplayRaces DisplayRace
@@ -79,21 +80,25 @@ namespace DaggerfallWorkshop.Game
         public Genders Gender
         {
             get { return (gender); }
+            set { gender = value; }
         }
 
         public string NameNPC
         {
             get { return (nameNPC); }
+            set { nameNPC = value; }
         }
 
         public int PersonOutfitVariant
         {
             get { return (personOutfitVariant); }
+            set { personOutfitVariant = value; }
         }
 
         public int PersonFaceRecordId
         {
             get { return (personFaceRecordId); }
+            set { personFaceRecordId = value; }
         }
 
         public bool PickpocketByPlayerAttempted
@@ -105,12 +110,12 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// True if this npc is a city watch guard.
         /// </summary>
-        public bool IsGuard { get; private set; }
+        public bool IsGuard { get; set; }
 
         /// <summary>
         /// Billboard or custom asset for npc.
         /// </summary>
-        public MobilePersonAsset Asset { get; private set; }
+        public MobilePersonAsset Asset { get; set; }
 
         public MobilePersonMotor Motor
         {
@@ -208,7 +213,6 @@ namespace DaggerfallWorkshop.Game
             this.personFaceRecordId = recordIndices[personOutfitVariant] + personFaceVariant;
 
             // set billboard to correct race, gender and outfit variant
-            Asset = GetComponentInChildren<MobilePersonAsset>();
             Asset.SetPerson(race, gender, personOutfitVariant, IsGuard, personFaceVariant, personFaceRecordId);
         }
 

--- a/Assets/Scripts/Game/Utility/PopulationManager.cs
+++ b/Assets/Scripts/Game/Utility/PopulationManager.cs
@@ -192,7 +192,16 @@ namespace DaggerfallWorkshop.Game.Utility
                 {
                     poolItem.npc.Motor.gameObject.SetActive(true);
                     poolItem.scheduleEnable = false;
-                    poolItem.npc.RandomiseNPC(GetEntityRace());
+
+                    if (MobileNPCGenerator != null)
+                    {
+                        MobileNPCGenerator(poolItem);
+                    }
+                    else
+                    {
+                        poolItem.npc.RandomiseNPC(GetEntityRace());
+                    }
+
                     poolItem.npc.Motor.InitMotor();
 
                     // Adjust billboard position for actual size
@@ -279,6 +288,7 @@ namespace DaggerfallWorkshop.Game.Utility
             PoolItem poolItem = new PoolItem();
             poolItem.npc = npc;
             poolItem.npc.Motor = motor;
+            poolItem.npc.Asset = motor.MobileAsset;
 
             // Add to pool
             populationPool.Add(poolItem);
@@ -332,6 +342,10 @@ namespace DaggerfallWorkshop.Game.Utility
         //OnMobileNPCCreate
         public delegate void OnMobileNPCCreateHandler(PoolItem poolItem);
         public static event OnMobileNPCCreateHandler OnMobileNPCCreate;
+
+        // MobileNPCGenerator
+        public delegate void MobileNPCGenerationHandler(PoolItem poolItem);
+        public static MobileNPCGenerationHandler MobileNPCGenerator;
 
         //OnMobileNPCEnable
         public delegate void OnMobileNPCEnableHandler(PoolItem poolItem);


### PR DESCRIPTION
One of our mod plans is to expand the selection of mobile NPCs generated in towns.

Currently, the PopulationManager chooses the race of the mobile using the climate settings, then passes it on to `MobilePersonNPC.RandomiseNPC` which takes care of the rest. Other NPC settings like gender, outfit, face, guard, and name are determined internally.

We've previously worked around some of these limitations with `PopulationManager.OnMobileNPCEnable`, but all we can really do is call `RandomiseNPC` a second time with another race (we've put Redguards in Swamp and Subtropical climates, for example). This approach only works for Bretons, Redguards, and Nords, since other races aren't supported.
In addition to the limitations of this approach, this also had the issue of causing two calls to `MobilePersonAsset.SetPerson`, which cause two sets of textures to be loaded per NPC.

This PR thus does two things:
- give mods access to setting `MobilePersonNPC` properties from the outside
- Give `PopulationManager` a hook for mods to do their own thing instead of calling `.RandomiseNPC` (avoids the double call to `MobilePersonAsset.SetPerson` problem)

With this, we can generate NPCs of any race, with any outfit and face we want. Custom portrait records are already supported by `DaggerfallTalkWindow.SetNPCPortrait`.

Results (ignore sprite scale lol):
![image](https://user-images.githubusercontent.com/5789925/188498957-5d7c8d41-b3d7-4fa2-8ddc-b30761e96d87.png)
![image](https://user-images.githubusercontent.com/5789925/188498995-bd44bd5e-2fef-4dd6-9d73-e278e9ff64c4.png)
