### PR TITLE
performance and productivity utilities

### DIFF
--- a/Assets/Scripts/Terrain/JobHelpers.cs
+++ b/Assets/Scripts/Terrain/JobHelpers.cs
@@ -4,12 +4,14 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Hazelnut
-// Contributors:    
+// Contributors:    Andrzej Łukasik (andrew.r.lukasik)
 // 
 // Notes:
 //
 
 using System;
+using Unity.Collections;
+using Unity.Jobs;
 
 namespace DaggerfallWorkshop
 {
@@ -71,4 +73,19 @@ namespace DaggerfallWorkshop
         }
     }
 
+}
+
+public static class JobUtility
+{
+    /// <summary>
+    /// Schedules a job that calls UnsafeUtility.ReleaseGCObject(gcHandle).
+    /// </summary>
+    public static JobHandle ReleaseGCObject(ulong gcHandle, JobHandle dependency = default)
+        => new ReleaseGCObjectJob(gcHandle).Schedule(dependency);
+
+    /// <summary>
+    /// This equation is yet to be (im)proved experimentally, the current version is merely an initial guesswork
+    /// </summary>
+    public static int OptimalLoopBatchCount(int length)
+        => Unity.Mathematics.math.max(length / (UnityEngine.SystemInfo.processorCount * 3), 1);
 }

--- a/Assets/Scripts/Utility/ArrayExtensionMethods.cs
+++ b/Assets/Scripts/Utility/ArrayExtensionMethods.cs
@@ -27,7 +27,7 @@ public static class ArrayExtensionMethods
         void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
         var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, array.Length, Allocator.None);
         #if ENABLE_UNITY_COLLECTIONS_CHECKS
-        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.Create());
         #endif
         return nativeArray;
     }
@@ -37,7 +37,7 @@ public static class ArrayExtensionMethods
         void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
         var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, array.Length, Allocator.None);
         #if ENABLE_UNITY_COLLECTIONS_CHECKS
-        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.Create());
         #endif
         return nativeArray;
     }
@@ -47,7 +47,7 @@ public static class ArrayExtensionMethods
         void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
         var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, array.Length, Allocator.None);
         #if ENABLE_UNITY_COLLECTIONS_CHECKS
-        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.Create());
         #endif
         return nativeArray;
     }
@@ -59,7 +59,7 @@ public static class ArrayExtensionMethods
         void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
         var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<(T1,T2)>(ptr, array.Length, Allocator.None);
         #if ENABLE_UNITY_COLLECTIONS_CHECKS
-        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.Create());
         #endif
         return nativeArray;
     }
@@ -72,7 +72,7 @@ public static class ArrayExtensionMethods
         void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
         var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<(T1,T2,T3)>(ptr, array.Length, Allocator.None);
         #if ENABLE_UNITY_COLLECTIONS_CHECKS
-        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.Create());
         #endif
         return nativeArray;
     }

--- a/Assets/Scripts/Utility/ArrayExtensionMethods.cs
+++ b/Assets/Scripts/Utility/ArrayExtensionMethods.cs
@@ -1,0 +1,140 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes:
+//
+
+using UnityEngine;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Profiling;
+
+public static class ArrayExtensionMethods
+{
+
+
+    /// <summary>
+    /// Pins this GC array and turns it's pointer into a NativeArray.
+    /// Do not Dispose but call UnsafeUtility.ReleaseGCObject(gcHandle) when done with it.
+    /// </summary>
+    public static unsafe NativeArray<T> AsNativeArray<T>(this T[] array, out ulong gcHandle) where T : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+    /// <inheritdoc />
+    public static unsafe NativeArray<T> AsNativeArray<T>(this T[,] array, out ulong gcHandle) where T : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+    /// <inheritdoc />
+    public static unsafe NativeArray<T> AsNativeArray<T>(this T[,,] array, out ulong gcHandle) where T : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+    /// <inheritdoc />
+    public static unsafe NativeArray<(T1,T2)> AsNativeArray<T1,T2>(this (T1,T2)[] array, out ulong gcHandle)
+        where T1 : unmanaged
+        where T2 : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<(T1,T2)>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+    /// <inheritdoc />
+    public static unsafe NativeArray<(T1,T2,T3)> AsNativeArray<T1,T2,T3>(this (T1,T2,T3)[] array, out ulong gcHandle)
+        where T1 : unmanaged
+        where T2 : unmanaged
+        where T3 : unmanaged
+    {
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<(T1,T2,T3)>(ptr, array.Length, Allocator.None);
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+        return nativeArray;
+    }
+
+
+    public static string ToReadableString<T>(this T[] arr)
+    {
+        if (arr.Length == 0) return "()";
+        var sb = new System.Text.StringBuilder();
+        sb.Append($"({arr[0]}");
+        for (int i = 1; i < arr.Length; i++)
+            sb.Append($",{arr[i]}");
+        sb.Append(')');
+        return sb.ToString();
+    }
+    public static string ToReadableString<T>(this T[,] arr)
+    {
+        int
+            lengthY = arr.GetLength(0),
+            lengthX = arr.GetLength(1),
+            length = arr.Length;
+        var sb = new System.Text.StringBuilder($"[{lengthY},{lengthX}]( ");
+        for (int y = 0; y < lengthY; y++)
+        {
+            if (y != 0)
+                sb.Append(" , ");
+            if (lengthX != 0)
+                sb.Append($"({arr[y, 0]}");
+            for (int x = 1; x < lengthX; x++)
+                sb.Append($",{arr[y, x]}");
+            sb.Append(')');
+        }
+        sb.Append($" )");
+        return sb.ToString();
+    }
+    public static string ToReadableString<T>(this T[,,] arr)
+    {
+        int
+            lengthZ = arr.GetLength(0),
+            lengthY = arr.GetLength(1),
+            lengthX = arr.GetLength(2),
+            length = arr.Length;
+        var sb = new System.Text.StringBuilder($"[{lengthZ},{lengthY},{lengthX}]( ");
+        for (int z = 0; z < lengthZ; z++)
+        {
+            if (z != 0) sb.Append(" , ");
+            sb.Append("( ");
+            for (int y = 0; y < lengthY; y++)
+            {
+                if (y != 0)
+                    sb.Append(" , ");
+                if (lengthX != 0)
+                sb.Append($"({arr[z, y, 0]}");
+                for (int x = 1; x < lengthX; x++)
+                    sb.Append($",{arr[z, y, x]}");
+                sb.Append(')');
+            }
+            sb.Append(" )");
+        }
+        sb.Append($" )");
+        return sb.ToString();
+    }
+
+
+}

--- a/Assets/Scripts/Utility/ArrayExtensionMethods.cs.meta
+++ b/Assets/Scripts/Utility/ArrayExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1dc425bd0a9275b44a85f29c54f9ece5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/Editor.meta
+++ b/Assets/Scripts/Utility/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3b62139d5af48e44bd8e0d278556518
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/Editor/NativeArrayExtensionMethodsTests.cs
+++ b/Assets/Scripts/Utility/Editor/NativeArrayExtensionMethodsTests.cs
@@ -1,0 +1,281 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes:
+//
+
+using NUnit.Framework;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+
+static class NativeArrayExtensionMethodsTests
+{
+
+
+    [Test] public static void CopyTo__NativeArray__managed_array_2d()
+    {
+        // create both arrays
+        var dst = new int[2, 4];
+        int
+            lengthY = dst.GetLength(0),
+            lengthX = dst.GetLength(1),
+            length = dst.Length;
+        var src = new NativeArray<int>(length, Allocator.Temp);
+        for (int i = 0; i < length; i++)
+            src[i] = i;
+
+        Debug.Log($"src before: {src.ToReadableString()}");
+        Debug.Log($"dst before: {dst.ToReadableString()}");
+
+        // copy
+        src.CopyTo(dst);
+
+        Debug.Log($"src after: {src.ToReadableString()}");
+        Debug.Log($"dst after: {dst.ToReadableString()}");
+
+        // test
+        {
+            int i = 0;
+            for (int y = 0; y < lengthY; y++)
+            for (int x = 0; x < lengthX; x++)
+            {
+                int
+                    expected = src[i++],
+                    actual = dst[y, x];
+                Assert.AreEqual(expected: expected, actual: actual, delta: 0);
+            }
+        }
+    }
+
+    [Test] public static void CopyTo__NativeArray__managed_array_3d()
+    {
+        // create both arrays
+        var dst = new int[2, 4, 3];
+        int
+            lengthZ = dst.GetLength(0),
+            lengthY = dst.GetLength(1),
+            lengthX = dst.GetLength(2),
+            length = dst.Length;
+        var src = new NativeArray<int>(length, Allocator.Temp);
+        for (int i = 0; i < length; i++)
+            src[i] = i;
+
+        Debug.Log($"src before: {src.ToReadableString()}");
+        Debug.Log($"dst before: {dst.ToReadableString()}");
+
+        // copy
+        src.CopyTo(dst);
+
+        Debug.Log($"src after: {src.ToReadableString()}");
+        Debug.Log($"dst after: {dst.ToReadableString()}");
+
+        // test
+        {
+            int i = 0;
+            for (int z = 0; z < lengthZ; z++)
+            for (int y = 0; y < lengthY; y++)
+            for (int x = 0; x < lengthX; x++)
+            {
+                int
+                    expected = src[i++],
+                    actual = dst[z, y, x];
+                Assert.AreEqual(expected: expected, actual: actual, delta: 0);
+            }
+        }
+    }
+
+    [Test] public static void CopyFrom__NativeArray__managed_array_2d()
+    {
+        // create both arrays
+        var src = new int[2, 4];
+        int
+            lengthY = src.GetLength(0),
+            lengthX = src.GetLength(1),
+            length = src.Length;
+        for (int y = 0; y < lengthY; y++)
+        for (int x = 0; x < lengthX; x++)
+            src[y, x] = y * 100 + x;
+        var dst = new NativeArray<int>(length, Allocator.Temp);        
+
+        Debug.Log($"src before: {src.ToReadableString()}");
+        Debug.Log($"dst before: {dst.ToReadableString()}");
+
+        // copy
+        dst.CopyFrom(src);
+
+        Debug.Log($"src after: {src.ToReadableString()}");
+        Debug.Log($"dst after: {dst.ToReadableString()}");
+
+        // test
+        {
+            int i = 0;
+            for (int y = 0; y < lengthY; y++)
+            for (int x = 0; x < lengthX; x++)
+            {
+                int
+                    expected = src[y, x],
+                    actual = dst[i++];
+                Assert.AreEqual(expected: expected, actual: actual, delta: 0);
+            }
+        }
+    }
+
+    [Test] public static void CopyFrom__NativeArray__managed_array_3d()
+    {
+        // create both arrays
+        var src = new int[2, 4, 3];
+        int
+            lengthZ = src.GetLength(0),
+            lengthY = src.GetLength(1),
+            lengthX = src.GetLength(2),
+            length = src.Length;
+        for (int z = 0; z < lengthZ; z++)
+        for (int y = 0; y < lengthY; y++)
+        for (int x = 0; x < lengthX; x++)
+            src[z, y, x] = z * 10000 + y * 100 + x;
+        var dst = new NativeArray<int>(length, Allocator.Temp);
+
+        Debug.Log($"src before: {src.ToReadableString()}");
+        Debug.Log($"dst before: {dst.ToReadableString()}");
+
+        // copy
+        dst.CopyFrom(src);
+
+        Debug.Log($"src after: {src.ToReadableString()}");
+        Debug.Log($"dst after: {dst.ToReadableString()}");
+
+        // test
+        {
+            int i = 0;
+            for (int z = 0; z < lengthZ; z++)
+            for (int y = 0; y < lengthY; y++)
+            for (int x = 0; x < lengthX; x++)
+            {
+                int
+                    expected = src[z, y, x],
+                    actual = dst[i++];
+                Assert.AreEqual(expected: expected, actual: actual, delta: 0);
+            }
+        }
+    }
+
+
+    [Test] public static unsafe void AssertPtrScope__NativeArray__ptr___byte_pointer_address_0()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        byte* ptr = (byte*)0;
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope__NativeArray__ptr___long_pointer_address_12345566890()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        long* ptr = (long*)12345566890;
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope__NativeArray__ptr___long_pointer_address_12345566890_negative()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        long* ptr = (long*)-12345566890;
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__start_of_the_array()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array);
+        array.AssertPtrScope(ptr);
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__start_of_the_array_plus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+1);
+        array.AssertPtrScope(ptr);
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__end_of_the_array_minus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)((float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+3)-1);
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__end_of_the_array_plus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)((float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+3)+1);
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__last_item_of_the_array()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+2;
+        array.AssertPtrScope(ptr);
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__last_item_of_the_array_minus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)((float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+2)-1);
+        array.AssertPtrScope(ptr);
+    }
+    [Test] public static unsafe void AssertPtrScope_float__NativeArray__last_item_of_the_array_plus_1_byte()
+    {
+        var array = new NativeArray<float>(3, Allocator.Temp);
+        float* ptr = (float*)((byte*)((float*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array)+2)+1);
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => array.AssertPtrScope(ptr));
+    }
+
+
+    [Test] public static unsafe void does_AsNativeArray_work()
+    {
+        var array = new int[]{ 1 , 2 , 3 , 4 };
+        var nativeArray = array.AsNativeArray(out ulong gcHandle);
+
+        Assert.AreEqual(expected:array.Length, actual:nativeArray.Length);
+        for (int i = 0; i < array.Length; i++)
+            Assert.AreEqual(expected:array[i], actual:nativeArray[i]);
+        
+        JobUtility.ReleaseGCObject(gcHandle);
+    }
+
+    [Test] public static unsafe void does_ConvertExistingDataToNativeArray_work()
+    {
+        var array = new int[]{ 1 , 2 , 3 , 4 };
+        
+        void* ptr = UnsafeUtility.PinGCArrayAndGetDataAddress(array, out ulong gcHandle);
+        var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<int>(ptr, array.Length, Allocator.None);
+        
+        #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.GetTempMemoryHandle());
+        #endif
+
+        Assert.AreEqual(expected:array.Length, actual:nativeArray.Length);
+        for (int i = 0; i < array.Length; i++)
+            Assert.AreEqual(expected:array[i], actual:nativeArray[i]);
+        
+        UnsafeUtility.ReleaseGCObject(gcHandle);
+    }
+
+
+    [Test] public static unsafe void does_AsNativeArray_2d_work()
+    {
+        var array = new int[,] { { 1, 2, 3, 4 }, { 11, 22, 33, 44}, { 111, 222, 333, 444} };
+        var nativeArray = array.AsNativeArray(out ulong gcHandle);
+        
+        int dim0 = array.GetLength(0);
+        int dim1 = array.GetLength(1);
+
+        Assert.AreEqual(expected:array.Length, actual:nativeArray.Length);
+        int i = 0;
+        for (int y = 0; y < dim0; y++)
+        for (int x = 0; x < dim1; x++)
+            Assert.AreEqual(expected:array[y,x], actual:nativeArray[i++]);
+        
+        JobUtility.ReleaseGCObject(gcHandle);
+    }
+
+
+}

--- a/Assets/Scripts/Utility/Editor/NativeArrayExtensionMethodsTests.cs.meta
+++ b/Assets/Scripts/Utility/Editor/NativeArrayExtensionMethodsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c406df4e09fef043a95348b04f7d90b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs
+++ b/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs
@@ -1,0 +1,154 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes: Requires "Allow Unsafe Code" enabled ☑
+//
+
+using UnityEngine;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+using Unity.Profiling;
+
+public static class NativeArrayExtensionMethods
+{
+
+    static readonly ProfilerMarker
+        ___CopyTo = new ProfilerMarker("CopyTo"),
+        ___CopyFrom = new ProfilerMarker("CopyFrom");
+
+    public static unsafe void CopyTo<T>(this NativeArray<T> src, T[,] dst) where T : unmanaged
+    {
+        ___CopyTo.Begin();
+        if (src.Length == dst.Length)
+        {
+            int size = src.Length * UnsafeUtility.SizeOf<T>();
+            void* srcPtr = NativeArrayUnsafeUtility.GetUnsafePtr(src);
+            void* dstPtr = UnsafeUtility.PinGCArrayAndGetDataAddress(dst, out ulong dstHandle);
+            UnsafeUtility.MemCpy(destination: dstPtr, source: srcPtr, size: size);
+            UnsafeUtility.ReleaseGCObject(dstHandle);
+        }
+        else Debug.LogError($"<b>{nameof(src)}.Length</b> ({src}[b]) and <b>{nameof(dst)}.Length</b> ({dst.Length}[b]) must be equal. MemCpy aborted.");
+        ___CopyTo.End();
+    }
+    public static unsafe void CopyTo<T>(this NativeArray<T> src, T[,,] dst) where T : unmanaged
+    {
+        ___CopyTo.Begin();
+        if (src.Length == dst.Length)
+        {
+            int size = src.Length * UnsafeUtility.SizeOf<T>();
+            void* srcPtr = NativeArrayUnsafeUtility.GetUnsafePtr(src);
+            void* dstPtr = UnsafeUtility.PinGCArrayAndGetDataAddress(dst, out ulong dstHandle);
+            UnsafeUtility.MemCpy(destination: dstPtr, source: srcPtr, size: size);
+            UnsafeUtility.ReleaseGCObject(dstHandle);
+        }
+        else Debug.LogError($"<b>{nameof(src)}.Length</b> ({src}[b]) and <b>{nameof(dst)}.Length</b> ({dst.Length}[b]) must be equal. MemCpy aborted.");
+        ___CopyTo.End();
+    }
+
+    public static unsafe void CopyFrom<T>(this NativeArray<T> dst, T[,] src) where T : unmanaged
+    {
+        ___CopyFrom.Begin();
+        if (src.Length == dst.Length)
+        {
+            int size = src.Length * UnsafeUtility.SizeOf<T>();
+            void* srcPtr = UnsafeUtility.PinGCArrayAndGetDataAddress(src, out ulong dstHandle);
+            void* dstPtr = NativeArrayUnsafeUtility.GetUnsafePtr(dst);
+            UnsafeUtility.MemCpy(destination: dstPtr, source: srcPtr, size: size);
+            UnsafeUtility.ReleaseGCObject(dstHandle);
+        }
+        else Debug.LogError($"<b>{nameof(src)}.Length</b> ({src}[b]) and <b>{nameof(dst)}.Length</b> ({dst.Length}[b]) must be equal. MemCpy aborted.");
+        ___CopyFrom.End();
+    }
+    public static unsafe void CopyFrom<T>(this NativeArray<T> dst, T[,,] src) where T : unmanaged
+    {
+        ___CopyFrom.Begin();
+        if (src.Length == dst.Length)
+        {
+            int size = src.Length * UnsafeUtility.SizeOf<T>();
+            void* srcPtr = UnsafeUtility.PinGCArrayAndGetDataAddress(src, out ulong dstHandle);
+            void* dstPtr = NativeArrayUnsafeUtility.GetUnsafePtr(dst);
+            UnsafeUtility.MemCpy(destination: dstPtr, source: srcPtr, size: size);
+            UnsafeUtility.ReleaseGCObject(dstHandle);
+        }
+        else Debug.LogError($"<b>{nameof(src)}.Length</b> ({src}[b]) and <b>{nameof(dst)}.Length</b> ({dst.Length}[b]) must be equal. MemCpy aborted.");
+        ___CopyFrom.End();
+    }
+
+
+    /// <summary> Schedules a <see cref="CopyToJob{T}"/>. </summary>
+    [Unity.Burst.BurstDiscard]// Burst warning without it, not sure why
+    public static JobHandle CopyTo<T>(this NativeArray<T> src, NativeArray<T> dst, JobHandle dependency) where T : unmanaged
+        => new CopyToJob<T>(src,dst).Schedule(dependency);
+    
+    /// <summary> Schedules a <see cref="CopyToJob{T}"/>. </summary>
+    public static JobHandle CopyFrom<T>(this NativeArray<T> dst, NativeArray<T> src, JobHandle dependency) where T : unmanaged
+        => new CopyToJob<T>(src,dst).Schedule(dependency);
+
+    /// <summary> Fills entire array using given value. </summary>
+    public static unsafe void Fill<T>(this NativeArray<T> Array, T value) where T : unmanaged
+    {
+        void* src = UnsafeUtility.Malloc(UnsafeUtility.SizeOf<T>(), UnsafeUtility.AlignOf<T>(), Allocator.Temp);
+        void* dst = NativeArrayUnsafeUtility.GetUnsafePtr<T>(Array);
+        int size = UnsafeUtility.SizeOf<T>();
+        int count = Array.Length;
+        UnsafeUtility.MemCpyReplicate(destination: dst, source: src, size: size, count: count);
+    }
+
+
+    /// <summary>
+    /// Raises an exception when given pointer refers to address outside this array.
+    /// This makes sure this pointer won't crash the game.
+    /// <b>NOTE</b>: Editor and DEBUG builds only.
+    /// </summary>
+    [System.Diagnostics.Conditional("DEBUG")]
+    public static unsafe void AssertPtrScope<ARRAY_ITEM, POINTER>(this NativeSlice<ARRAY_ITEM> array, POINTER* ptr)
+        where ARRAY_ITEM : unmanaged
+        where POINTER : unmanaged
+    {
+        long addr = (long)ptr;
+        long firstItemAddr = (long)NativeSliceUnsafeUtility.GetUnsafeReadOnlyPtr(array);
+        long lastItemAddr = firstItemAddr + array.Length * (long)UnsafeUtility.SizeOf<ARRAY_ITEM>() - UnsafeUtility.SizeOf<POINTER>();
+        if (!(addr >= firstItemAddr && addr < lastItemAddr))
+        {
+            string message = $"Pointer is out of scope, so considered unsafe (possible crash prevented). Ptr:{addr}, array first item addr:{firstItemAddr}, array last item addr:{lastItemAddr}";
+            Debug.LogWarning(message);
+            throw new System.ArgumentOutOfRangeException(message);
+        }
+    }
+
+    /// <inheritdoc />
+    [System.Diagnostics.Conditional("DEBUG")]
+    public static unsafe void AssertPtrScope<ARRAY_ITEM, POINTER>(this NativeArray<ARRAY_ITEM> array, POINTER* ptr)
+        where ARRAY_ITEM : unmanaged
+        where POINTER : unmanaged
+    {
+        long addr = (long)ptr;
+        long firstItemAddr = (long)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(array);
+        long lastItemAddr = firstItemAddr + array.Length * (long)UnsafeUtility.SizeOf<ARRAY_ITEM>() - UnsafeUtility.SizeOf<POINTER>();
+        if (!(addr >= firstItemAddr && addr <= lastItemAddr))
+        {
+            string message = $"Pointer is out of scope, so considered unsafe (possible crash prevented). Ptr:{addr}, array first item addr:{firstItemAddr}, array last item addr:{lastItemAddr}";
+            Debug.LogWarning(message);
+            throw new System.ArgumentOutOfRangeException(message);
+        }
+    }
+
+    public static string ToReadableString<T>(this NativeArray<T> arr) where T : unmanaged
+    {
+        if (arr.Length == 0) return "()";
+        var sb = new System.Text.StringBuilder();
+        sb.Append($"({arr[0]}");
+        for (int i = 1; i < arr.Length; i++)
+            sb.Append($",{arr[i]}");
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+
+}

--- a/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs
+++ b/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs
@@ -93,7 +93,7 @@ public static class NativeArrayExtensionMethods
     /// <summary> Fills entire array using given value. </summary>
     public static unsafe void Fill<T>(this NativeArray<T> Array, T value) where T : unmanaged
     {
-        void* src = UnsafeUtility.Malloc(UnsafeUtility.SizeOf<T>(), UnsafeUtility.AlignOf<T>(), Allocator.Temp);
+        void* src = &value;
         void* dst = NativeArrayUnsafeUtility.GetUnsafePtr<T>(Array);
         int size = UnsafeUtility.SizeOf<T>();
         int count = Array.Length;

--- a/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs.meta
+++ b/Assets/Scripts/Utility/NativeArrayExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06f4e4095efc38e49bdab68c583f88ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/UniversalJobs.cs
+++ b/Assets/Scripts/Utility/UniversalJobs.cs
@@ -22,14 +22,6 @@ public struct DeallocateArrayJob<T> : IJob where T : unmanaged
 }
 
 [Unity.Burst.BurstCompile]
-public struct DeallocateListJob<T> : IJob where T : unmanaged
-{
-    [ReadOnly] [DeallocateOnJobCompletion] NativeList<T> List;
-    public DeallocateListJob(NativeList<T> list) => this.List = list;
-    void IJob.Execute() { }
-}
-
-[Unity.Burst.BurstCompile]
 public struct FillJob<T> : IJob where T : unmanaged
 {
     T Value;

--- a/Assets/Scripts/Utility/UniversalJobs.cs
+++ b/Assets/Scripts/Utility/UniversalJobs.cs
@@ -33,7 +33,7 @@ public struct FillJob<T> : IJob where T : unmanaged
     }
     unsafe void IJob.Execute()
     {
-        void* src = UnsafeUtility.Malloc(UnsafeUtility.SizeOf<T>(), UnsafeUtility.AlignOf<T>(), Allocator.Temp);
+        void* src = &Value;
         void* dst = NativeArrayUnsafeUtility.GetUnsafePtr<T>(Array);
         int size = UnsafeUtility.SizeOf<T>();
         int count = this.Array.Length;

--- a/Assets/Scripts/Utility/UniversalJobs.cs
+++ b/Assets/Scripts/Utility/UniversalJobs.cs
@@ -1,0 +1,87 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: Andrzej Łukasik (andrew.r.lukasik)
+// Contributors:    
+// 
+// Notes:
+//
+
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+
+[Unity.Burst.BurstCompile]
+public struct DeallocateArrayJob<T> : IJob where T : unmanaged
+{
+    [ReadOnly] [DeallocateOnJobCompletion] NativeArray<T> Array;
+    public DeallocateArrayJob(NativeArray<T> array) => this.Array = array;
+    void IJob.Execute() { }
+}
+
+[Unity.Burst.BurstCompile]
+public struct DeallocateListJob<T> : IJob where T : unmanaged
+{
+    [ReadOnly] [DeallocateOnJobCompletion] NativeList<T> List;
+    public DeallocateListJob(NativeList<T> list) => this.List = list;
+    void IJob.Execute() { }
+}
+
+[Unity.Burst.BurstCompile]
+public struct FillJob<T> : IJob where T : unmanaged
+{
+    T Value;
+    [WriteOnly] NativeArray<T> Array;
+    public FillJob(NativeArray<T> array, T value)
+    {
+        this.Value = value;
+        this.Array = array;
+    }
+    unsafe void IJob.Execute()
+    {
+        void* src = UnsafeUtility.Malloc(UnsafeUtility.SizeOf<T>(), UnsafeUtility.AlignOf<T>(), Allocator.Temp);
+        void* dst = NativeArrayUnsafeUtility.GetUnsafePtr<T>(Array);
+        int size = UnsafeUtility.SizeOf<T>();
+        int count = this.Array.Length;
+        UnsafeUtility.MemCpyReplicate(destination: dst, source: src, size: size, count: count);
+    }
+}
+
+[Unity.Burst.BurstCompile]
+public struct CopyToJob<T> : IJob where T : unmanaged
+{
+    [ReadOnly] NativeArray<T> Src;
+    [WriteOnly] NativeArray<T> Dst;
+    int SrcIndex, DstIndex, Length;
+    public CopyToJob(NativeArray<T> src, NativeArray<T> dst)
+    {
+        this.Src = src;
+        this.SrcIndex = -1;
+        this.Dst = dst;
+        this.DstIndex = -1;
+        this.Length = -1;
+    }
+    public CopyToJob(NativeArray<T> src, int srcIndex, NativeArray<T> dst, int dstIndex, int length)
+    {
+        this.Src = src;
+        this.SrcIndex = srcIndex;
+        this.Dst = dst;
+        this.DstIndex = dstIndex;
+        this.Length = length;
+    }
+    void IJob.Execute()
+    {
+        if (Length == -1) NativeArray<T>.Copy(Src, Dst);
+        else NativeArray<T>.Copy(Src, SrcIndex, Dst, DstIndex, Length);
+    }
+}
+
+[Unity.Burst.BurstCompile]
+public struct ReleaseGCObjectJob : IJob
+{
+    ulong Handle;
+    public ReleaseGCObjectJob(ulong handle) => this.Handle = handle;
+    void IJob.Execute() => UnsafeUtility.ReleaseGCObject(Handle);
+}

--- a/Assets/Scripts/Utility/UniversalJobs.cs.meta
+++ b/Assets/Scripts/Utility/UniversalJobs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cba73a9d27144fa40a92ec9e88c7e392
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -680,7 +680,7 @@ PlayerSettings:
   incrementalIl2cppBuild:
     iPhone: 0
   suppressCommonWarnings: 1
-  allowUnsafeCode: 0
+  allowUnsafeCode: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 1


### PR DESCRIPTION
Hi! This PR is part of #2416 saga.

## `UniversalJobs.sc`
contains jobs that can come useful anywhere:
- `DeallocateArrayJob`
- `FillJob`
- `CopyToJob`
- `ReleaseGCObjectJob` - more on what this does below

## `NativeArrayExtensionMethods.cs`
contains methods such as
- `CopyTo(this NativeArray<T> src, T[,] dst)`
- `CopyTo(this NativeArray<T> src, NativeArray<T> dst, JobHandle dependency)` - delayed copy
- `Fill(this NativeArray<T> Array, T value)`
- `AssertPtrScope(this NativeSlice<ARRAY_ITEM> array, POINTER* ptr)` - pointer safety assertion (mandatory before dereferencing any pointer)

## `NativeArrayExtensionMethodsTests.cs`
unit tests

## `ArrayExtensionMethods.cs`
contains:
- `AsNativeArray(this T[] array, out ulong gcHandle)` variants
Yes you red that right - this is not a pedestrian `ToNativeArray` (copy) but `AsNativeArray` and creates a `NativeArray` struct that represents any managed array. Im super exited for this as I finally figured how to do this and figured out the proper safe workflow (as seen in #2416)

## `JobHelpers.cs`

Hosts `JobUtility` as I couldn't find a more suitable place for this.

It allows to call `JobUtility.ReleaseGCObject(ulong gcHandle, JobHandle dependency)` which is a convenient way of releasing managed arrays (it schedules `ReleaseGCObjectJob`).

##