### PR TITLE
[BurstCompile] for all existing jobs

### DIFF
--- a/Assets/Scripts/Terrain/DefaultTerrainSampler.cs
+++ b/Assets/Scripts/Terrain/DefaultTerrainSampler.cs
@@ -51,6 +51,7 @@ namespace DaggerfallWorkshop
             throw new System.NotImplementedException();
         }
 
+        [Unity.Burst.BurstCompile]
         struct GenerateSamplesJob : IJobParallelFor
         {
             [ReadOnly]

--- a/Assets/Scripts/Terrain/TerrainHelper.cs
+++ b/Assets/Scripts/Terrain/TerrainHelper.cs
@@ -235,6 +235,7 @@ namespace DaggerfallWorkshop
         #region Terrain Jobs
 
         // Calculates average and maximum heights of terrain data
+        [Unity.Burst.BurstCompile]
         struct CalcAvgMaxHeightJob : IJob
         {
             [ReadOnly]
@@ -258,6 +259,7 @@ namespace DaggerfallWorkshop
         }
 
         // Flattens location terrain and blends with surrounding terrain
+        [Unity.Burst.BurstCompile]
         struct BlendLocationTerrainJob : IJob
         {
             public NativeArray<float> heightmapData;
@@ -329,6 +331,7 @@ namespace DaggerfallWorkshop
         }
 
         // Converts tileMap data to color array for use by shader
+        [Unity.Burst.BurstCompile]
         struct UpdateTileMapDataJob : IJobParallelFor
         {
             [ReadOnly]

--- a/Assets/Scripts/Terrain/TerrainTexturing.cs
+++ b/Assets/Scripts/Terrain/TerrainTexturing.cs
@@ -14,6 +14,7 @@ using System;
 using DaggerfallConnect.Arena2;
 using Unity.Jobs;
 using Unity.Collections;
+using Unity.Mathematics;
 
 namespace DaggerfallWorkshop
 {
@@ -103,6 +104,7 @@ namespace DaggerfallWorkshop
         // Very basic marching squares for water > dirt > grass > stone transitions.
         // Cannot handle water > grass or water > stone, etc.
         // Will improve this at later date to use a wider range of transitions.
+        [Unity.Burst.BurstCompile]
         protected struct AssignTilesJob : IJobParallelFor
         {
             [ReadOnly]
@@ -149,6 +151,7 @@ namespace DaggerfallWorkshop
             }
         }
 
+        [Unity.Burst.BurstCompile]
         protected struct GenerateTileDataJob : IJobParallelFor
         {
             [ReadOnly]
@@ -219,7 +222,7 @@ namespace DaggerfallWorkshop
                 }
                 // Beach texture
                 // Adds a little +/- randomness to threshold so beach line isn't too regular
-                if (height <= beachElevation + (JobRand.Next(-15000000, 15000000) / 10000000f))
+                if (height <= beachElevation + Unity.Mathematics.Random.CreateFromIndex((uint)index).NextFloat(-1.5f, 1.5f))
                 {
                     tileData[index] = dirt;
                     return;


### PR DESCRIPTION
Hi! This PR is part of #2416 saga.

## What

Burst compilation enabled for all existing jobs. That's it, nothing else.

## Why

Burst is not a magical wand necessarily. It is powerful when there is a lot of math calculations but it won't fix a memory access-bound code (L2 cache misses).

## Results

It sped up these existing jobs by around a factor of 10x and nearly `*halves*` my loading time for exteriors (20-40% reduction)

- before: `5 seconds` total of work (left), after `[BurstCompile]`: `0.4 second` total of work (right)
<p float="center">
    <img src="https://user-images.githubusercontent.com/3066539/188665859-a0959da7-a3c3-4472-886c-757efaa321bb.png" width="49%">
    <img src="https://user-images.githubusercontent.com/3066539/188665855-48ae549c-f0a7-40a6-bea7-036dd2f29c72.png" width="49%">
</p>

> **I mean... optimization is *never* this easy, so merge while PR is still hot :T**
