### PR TITLE
DaggerfallBillboardBatch: mesh data creation process multi-threaded

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallBillboardBatch.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboardBatch.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
+// Contributors:    Andrzej Łukasik (andrew.r.lukasik)
 // 
 // Notes:
 //
@@ -12,12 +12,11 @@
 using UnityEngine;
 using UnityEngine.Rendering;
 using System.Collections;
-using System.Collections.Generic;
-using System;
-using System.IO;
-using DaggerfallConnect;
-using DaggerfallConnect.Utility;
 using DaggerfallConnect.Arena2;
+using Unity.Profiling;
+using Unity.Collections;
+using Unity.Jobs;
+using Unity.Mathematics;
 
 namespace DaggerfallWorkshop
 {
@@ -41,13 +40,19 @@ namespace DaggerfallWorkshop
         [SerializeField, HideInInspector]
         CachedMaterial cachedMaterial;
         [SerializeField, HideInInspector]
-        List<BillboardItem> billboardItems = new List<BillboardItem>();
-        [SerializeField, HideInInspector]
         Mesh billboardMesh;
-        [SerializeField, HideInInspector]
-        Vector2[] uvs;
 
-        [NonSerialized, HideInInspector]
+        NativeList<BillboardItem> billboardData;
+        NativeArray<float3> meshVertices;
+        NativeArray<float3> meshNormals;
+        NativeArray<ushort> meshIndices;
+        NativeArray<float4> meshTangents;
+        NativeArray<float2> meshUVs;
+        NativeArray<Bounds> meshAABB;
+        JobHandle Dependency;
+        JobHandle UvAnimationDependency;
+
+        [System.NonSerialized, HideInInspector]
         public Vector3 BlockOrigin = Vector3.zero;
 
         [Range(0, 511)]
@@ -76,16 +81,16 @@ namespace DaggerfallWorkshop
         const int animalFps = 5;
         const int lightFps = 12;
 
-        [Serializable]
+        [System.Serializable]
         struct BillboardItem
         {
             public int record;                  // The texture record to display
-            public Vector3 position;            // Position from origin to render billboard
+            public float3 position;            // Position from origin to render billboard
             public int totalFrames;             // Total animation frames
             public int currentFrame;            // Current animation frame
             public Rect customRect;             // Rect for custom material path
-            public Vector2 customSize;          // Size for custom material path
-            public Vector2 customScale;         // Scale for custom material path
+            public float2 customSize;          // Size for custom material path
+            public float2 customScale;         // Scale for custom material path
         }
 
         public bool IsCustom
@@ -93,8 +98,59 @@ namespace DaggerfallWorkshop
             get { return (customMaterial == null) ? false : true; }
         }
 
-        void Start()
+        #region Profiler Markers
+
+        static readonly ProfilerMarker
+            ___tick = new ProfilerMarker("tick animation"),
+            ___schedule = new ProfilerMarker("schedule"),
+            ___complete = new ProfilerMarker("complete"),
+            ___setUVs = new ProfilerMarker("set uv"),
+            ___getMaterialAtlas = new ProfilerMarker("get material atlas"),
+            ___getCachedMaterialAtlas = new ProfilerMarker("get cached material atlas"),
+            ___assignOtherMaps = new ProfilerMarker("assign other maps"),
+            ___stealTextureFromSourceMaterial = new ProfilerMarker("steal texture from source material"),
+            ___createLocalMaterial = new ProfilerMarker("create local material"),
+            ___createMeshForCustomMaterial = new ProfilerMarker("create mesh for custom material"),
+            ___createMesh = new ProfilerMarker("create mesh"),
+            ___newMesh = new ProfilerMarker("new mesh"),
+            ___reuseMesh = new ProfilerMarker("reuse mesh"),
+            ___assignMesh = new ProfilerMarker("assign mesh"),
+            ___assignMeshData = new ProfilerMarker("push mesh data"),
+            ___indexBuffer = new ProfilerMarker("index buffer"),
+            ___vertexBuffer = new ProfilerMarker("vertex buffer"),
+            ___SetMaterial = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(SetMaterial)}"),
+            ___AddItem = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(AddItem)}"),
+            ___AddItemsAsync = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(AddItemsAsync)}"),
+            ___Apply = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(Apply)}"),
+            ___Clear = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(Clear)}"),
+            ___CreateMeshForCustomMaterial = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(CreateMeshForCustomMaterial)}"),
+            ___ResizeMeshBuffers = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(ResizeMeshBuffers)}"),
+            ___CreateMesh = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(CreateMesh)}"),
+            ___PushNewMeshData = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(PushNewMeshData)}"),
+            ___PushUVData = new ProfilerMarker($"{nameof(DaggerfallBillboardBatch)}.{nameof(PushUVData)}");
+
+        #endregion
+
+        void Awake()
         {
+            billboardData = new NativeList<BillboardItem>(initialCapacity: maxBillboardCount, Allocator.Persistent);
+            meshVertices = new NativeArray<float3>(0, Allocator.Persistent);
+            meshNormals = new NativeArray<float3>(0, Allocator.Persistent);
+            meshIndices = new NativeArray<ushort>(0, Allocator.Persistent);
+            meshTangents = new NativeArray<float4>(0, Allocator.Persistent);
+            meshUVs = new NativeArray<float2>(0, Allocator.Persistent);
+            meshAABB = new NativeArray<Bounds>(1, Allocator.Persistent);
+        }
+
+        void OnDestroy()
+        {
+            if (billboardData.IsCreated) billboardData.Dispose();
+            if (meshVertices.IsCreated) meshVertices.Dispose();
+            if (meshNormals.IsCreated) meshNormals.Dispose();
+            if (meshIndices.IsCreated) meshIndices.Dispose();
+            if (meshTangents.IsCreated) meshTangents.Dispose();
+            if (meshUVs.IsCreated) meshUVs.Dispose();
+            if (meshAABB.IsCreated) meshAABB.Dispose();
         }
 
         void OnDisable()
@@ -123,41 +179,45 @@ namespace DaggerfallWorkshop
 
         IEnumerator AnimateBillboards()
         {
+            float framesPerSecondInUse = FramesPerSecond;
+            WaitForSeconds wait = new WaitForSeconds(1f / FramesPerSecond);// reuse
+
             while (true)
             {
-                // Tick animation when valid
-                if (FramesPerSecond > 0 && cachedMaterial.key != 0 && customMaterial == null && uvs != null)
+                if (FramesPerSecond > framesPerSecondInUse || FramesPerSecond < framesPerSecondInUse)
                 {
-                    // Look for animated billboards
-                    for (int billboard = 0; billboard < billboardItems.Count; billboard++)
-                    {
-                        // Get billboard and do nothing if single frame
-                        BillboardItem bi = billboardItems[billboard];
-                        if (bi.totalFrames > 1)
-                        {
-                            // Increment current billboard frame
-                            if (++bi.currentFrame >= bi.totalFrames)
-                            {
-                                bi.currentFrame = 0;
-                            }
-                            billboardItems[billboard] = bi;
-
-                            // Set new UV properties based on current frame
-                            Rect rect = cachedMaterial.atlasRects[cachedMaterial.atlasIndices[bi.record].startIndex + bi.currentFrame];
-                            int offset = billboard * vertsPerQuad;
-                            uvs[offset] = new Vector2(rect.x, rect.yMax);
-                            uvs[offset + 1] = new Vector2(rect.xMax, rect.yMax);
-                            uvs[offset + 2] = new Vector2(rect.x, rect.y);
-                            uvs[offset + 3] = new Vector2(rect.xMax, rect.y);
-                        }
-                    }
-
-                    // Store new mesh UV set
-                    if (uvs != null && uvs.Length > 0)
-                        billboardMesh.uv = uvs;
+                    framesPerSecondInUse = FramesPerSecond;
+                    wait = new WaitForSeconds(1f / framesPerSecondInUse);
                 }
 
-                yield return new WaitForSeconds(1f / FramesPerSecond);
+                // Tick animation when valid
+                ___tick.Begin();
+                int numBillboardsToAnimate = meshUVs.Length / vertsPerQuad;
+                if (
+                        FramesPerSecond > 0
+                    && cachedMaterial.key != 0
+                    && customMaterial == null
+                    && numBillboardsToAnimate != 0
+                )
+                {
+                    // schedule jobs:
+                    ___schedule.Begin();
+                    AnimateUVJob animateUVJob = new AnimateUVJob
+                    {
+                        AtlasRects = new NativeArray<Rect>(cachedMaterial.atlasRects, Allocator.TempJob),
+                        AtlasIndices = new NativeArray<RecordIndex>(cachedMaterial.atlasIndices, Allocator.TempJob),
+                        Billboards = billboardData,
+                        UV = meshUVs,
+                    };
+                    UvAnimationDependency = animateUVJob.Schedule(numBillboardsToAnimate, 128, Dependency);
+                    ___schedule.End();
+
+                    // delay finalization not to stall this thread:
+                    Invoke(nameof(PushUVData), 0);
+                }
+                ___tick.End();
+
+                yield return wait;
             }
         }
 
@@ -169,6 +229,8 @@ namespace DaggerfallWorkshop
         /// <param name="force">Force new archive, even if already set.</param>
         public void SetMaterial(int archive, bool force = false)
         {
+            ___SetMaterial.Begin();
+
             if (!ReadyCheck())
                 return;
 
@@ -180,40 +242,40 @@ namespace DaggerfallWorkshop
             int size = DaggerfallUnity.Settings.AssetInjection ? 4096 : 2048;
 
             // Get standard atlas material
+            ___getMaterialAtlas.Begin();
             // Just going to steal texture and settings
             // TODO: Revise material loading for custom shaders
-            Rect[] atlasRects;
-            RecordIndex[] atlasIndices;
             Material material = dfUnity.MaterialReader.GetMaterialAtlas(
-                    archive,
-                    0,
-                    4,
-                    size,
-                    out atlasRects,
-                    out atlasIndices,
-                    4,
-                    true,
-                    0,
-                    false,
-                    true);
+                archive, 0, 4, size,
+                out Rect[] atlasRects, out RecordIndex[] atlasIndices,
+                4, true, 0, false, true
+            );
+            ___getMaterialAtlas.End();
 
             // Serialize cached material information
+            ___getCachedMaterialAtlas.Begin();
             dfUnity.MaterialReader.GetCachedMaterialAtlas(archive, out cachedMaterial);
+            ___getCachedMaterialAtlas.End();
 
             // Steal textures from source material
+            ___stealTextureFromSourceMaterial.Begin();
             Texture albedoMap = material.mainTexture;
             Texture normalMap = material.GetTexture(Uniforms.BumpMap);
             Texture emissionMap = material.GetTexture(Uniforms.EmissionMap);
+            ___stealTextureFromSourceMaterial.End();
 
             // Create local material
+            ___createLocalMaterial.Begin();
             // TODO: This should be created by MaterialReader
             Shader shader = (DaggerfallUnity.Settings.NatureBillboardShadows) ?
                 Shader.Find(MaterialReader._DaggerfallBillboardBatchShaderName) :
                 Shader.Find(MaterialReader._DaggerfallBillboardBatchNoShadowsShaderName);
             Material atlasMaterial = new Material(shader);
             atlasMaterial.mainTexture = albedoMap;
+            ___createLocalMaterial.End();
 
             // Assign other maps
+            ___assignOtherMaps.Begin();
             if (normalMap != null)
             {
                 atlasMaterial.SetTexture(Uniforms.BumpMap, normalMap);
@@ -225,6 +287,7 @@ namespace DaggerfallWorkshop
                 atlasMaterial.SetColor(Uniforms.EmissionColor, material.GetColor(Uniforms.EmissionColor));
                 atlasMaterial.EnableKeyword(KeyWords.Emission);
             }
+            ___assignOtherMaps.End();
 
             // Assign renderer properties
             // Turning off receive shadows to prevent self-shadowing
@@ -250,6 +313,8 @@ namespace DaggerfallWorkshop
 
             TextureArchive = archive;
             currentArchive = archive;
+
+            ___SetMaterial.End();
         }
 
         /// <summary>
@@ -283,29 +348,50 @@ namespace DaggerfallWorkshop
         /// </summary>
         public void Clear()
         {
-            billboardItems.Clear();
+            ___Clear.Begin();
+
+            Dependency.Complete();// make sure there are no unfinished jobs
+            billboardData.Clear();
+
+            ___Clear.End();
         }
 
         /// <summary>
         /// Add a billboard to batch.
         /// </summary>
+        [System.Obsolete("Use " + nameof(AddItemsAsync) + " instead. Reason: billboards are never added in amount of one.")]
+        public void AddItem(BasicInfo item)
+        {
+            AddItem(item.textureRecord, item.localPosition);
+        }
+        /// <inheritdoc />
+        [System.Obsolete("Use " + nameof(AddItemsAsync) + " instead. Reason: billboards are never added in amount of one.")]
         public void AddItem(int record, Vector3 localPosition)
         {
+            ___AddItem.Begin();
+
+            Dependency.Complete();// make sure there are no unfinished jobs
+
             // Cannot use with a custom material
             if (customMaterial != null)
-                throw new Exception("Cannot use with custom material. Use AddItem(Rect rect, Vector2 size, Vector2 scale, Vector3 localPosition) overload instead.");
+            {
+                ___AddItem.End();
+                throw new System.Exception("Cannot use with custom material. Use AddItem(Rect rect, Vector2 size, Vector2 scale, Vector3 localPosition) overload instead.");
+            }
 
             // Must have set a material
             if (cachedMaterial.key == 0)
             {
                 DaggerfallUnity.LogMessage("DaggerfallBillboardBatch: Must call SetMaterial() before adding items.", true);
+                ___AddItem.End();
                 return;
             }
 
             // Limit maximum billboards in batch
-            if (billboardItems.Count + 1 > maxBillboardCount)
+            if (billboardData.Length + 1 > maxBillboardCount)
             {
                 DaggerfallUnity.LogMessage("DaggerfallBillboardBatch: Maximum batch size reached.", true);
+                ___AddItem.End();
                 return;
             }
 
@@ -316,35 +402,152 @@ namespace DaggerfallWorkshop
                 startFrame = UnityEngine.Random.Range(0, frameCount);
 
             // Add new billboard to batch
-            BillboardItem bi = new BillboardItem()
+            BillboardItem billboard = new BillboardItem
             {
                 record = record,
                 position = BlockOrigin + localPosition,
                 totalFrames = frameCount,
                 currentFrame = startFrame,
             };
-            billboardItems.Add(bi);
+            billboardData.Add(billboard);
+
+            ___AddItem.End();
+        }
+
+        /// <summary>
+        /// Schedules a job that queues an array of billboard items.
+        /// Call <see cref="Apply"/> once there is no more entries to add.
+        /// </summary>
+        public JobHandle AddItemsAsync(NativeArray<BasicInfo> items, JobHandle dependency = default)
+        {
+            ___AddItemsAsync.Begin();
+
+            // Cannot use with a custom material
+            if (customMaterial != null)
+            {
+                ___AddItemsAsync.End();
+                throw new System.Exception("Cannot use with custom material. Use AddItem(Rect rect, Vector2 size, Vector2 scale, Vector3 localPosition) overload instead.");
+            }
+
+            // Must have set a material
+            if (cachedMaterial.key == 0)
+            {
+                DaggerfallUnity.LogMessage("DaggerfallBillboardBatch: Must call SetMaterial() before adding items.", true);
+                ___AddItemsAsync.End();
+                return default;
+            }
+
+            // Limit maximum billboards in batch
+            int available = maxBillboardCount - billboardData.Length;
+            int numItemsToAdd = math.min(available, items.Length);
+            if (numItemsToAdd != 0)
+            {
+                ___schedule.Begin();
+                AddItemsJob job = new AddItemsJob
+                {
+                    Source = items,
+                    AtlasFrameCounts = new NativeArray<int>(cachedMaterial.atlasFrameCounts, Allocator.TempJob),
+                    RandomStartFrame = RandomStartFrame,
+                    Seed = (uint)((System.Environment.TickCount * this.GetHashCode()).GetHashCode()),
+                    BlockOrigin = BlockOrigin,
+                    BillboardItems = billboardData.AsParallelWriter(),
+                };
+                Dependency = job.Schedule(arrayLength: numItemsToAdd, innerloopBatchCount: 128, dependsOn: JobHandle.CombineDependencies(Dependency, dependency));
+                ___schedule.End();
+            }
+
+            if (billboardData.Length == maxBillboardCount)
+                DaggerfallUnity.LogMessage("DaggerfallBillboardBatch: Maximum batch size reached.", true);
+
+            ___AddItemsAsync.End();
+            return Dependency;
+        }
+        /// <inheritdoc />
+        public JobHandle AddItemsAsync(BasicInfo[] items, JobHandle dependency = default)
+        {
+            ___AddItemsAsync.Begin();
+
+            NativeArray<BasicInfo> data = new NativeArray<BasicInfo>(items, Allocator.TempJob);
+            JobHandle op = AddItemsAsync(data, dependency);
+            new DeallocateArrayJob<BasicInfo>(data).Schedule(op);
+
+            ___AddItemsAsync.End();
+            return op;
         }
 
         /// <summary>
         /// Add a billboard to batch.
         /// Use this overload for custom atlas material.
         /// </summary>
+        [System.Obsolete("Use " + nameof(AddItemsAsync) + " instead. Reason: billboards are never added in amount of one.")]
+        public void AddItem(CustomInfo item)
+        {
+            AddItem(item.rect, item.size, item.scale, item.localPosition);
+        }
+        /// <inheritdoc />
+        [System.Obsolete("Use " + nameof(AddItemsAsync) + " instead. Reason: billboards are never added in amount of one.")]
         public void AddItem(Rect rect, Vector2 size, Vector2 scale, Vector3 localPosition)
         {
+            ___AddItem.Begin();
+
+            Dependency.Complete();// make sure there are no unfinished jobs
+
             // Cannot use with auto material
             if (customMaterial == null)
-                throw new Exception("Cannot use with auto material. Use AddItem(int record, Vector3 localPosition) overload instead.");
+                throw new System.Exception("Cannot use with auto material. Use AddItem(int record, Vector3 localPosition) overload instead.");
 
             // Add new billboard to batch
-            BillboardItem bi = new BillboardItem()
+            BillboardItem billboard = new BillboardItem
             {
                 position = BlockOrigin + localPosition,
                 customRect = rect,
                 customSize = size,
                 customScale = scale,
             };
-            billboardItems.Add(bi);
+            billboardData.Add(billboard);
+
+            ___AddItem.End();
+        }
+
+        /// <summary>
+        /// Schedules a job that queues an array of billboard items.
+        /// Call <see cref="Apply"/> once there is no more entries to add.
+        /// </summary>
+        public JobHandle AddItemsAsync(NativeArray<CustomInfo> items, JobHandle dependency = default)
+        {
+            ___AddItemsAsync.Begin();
+
+            // Cannot use with auto material
+            if (customMaterial == null)
+            {
+                ___AddItemsAsync.End();
+                throw new System.Exception("Cannot use with auto material. Use AddItem(int record, Vector3 localPosition) overload instead.");
+            }
+            
+            ___schedule.Begin();
+            AddCustomItemsJob job = new AddCustomItemsJob
+            {
+                Source = items,
+                BlockOrigin = BlockOrigin,
+                BillboardItems = billboardData.AsParallelWriter(),
+            };
+            JobHandle jobHandle = job.Schedule(items.Length, items.Length, JobHandle.CombineDependencies(Dependency, dependency));
+            ___schedule.End();
+
+            ___AddItemsAsync.End();
+            return jobHandle;
+        }
+        /// <inheritdoc />
+        public JobHandle AddItemsAsync(CustomInfo[] items, JobHandle dependency = default)
+        {
+            ___AddItemsAsync.Begin();
+
+            NativeArray<CustomInfo> data = new NativeArray<CustomInfo>(items, Allocator.TempJob);
+            JobHandle op = AddItemsAsync(data, dependency);
+            new DeallocateArrayJob<CustomInfo>(data).Schedule(op);
+
+            ___AddItemsAsync.End();
+            return op;
         }
 
         /// <summary>
@@ -354,14 +557,26 @@ namespace DaggerfallWorkshop
         /// </summary>
         public void Apply()
         {
+            ___Apply.Begin();
+
             // Apply material
             if (customMaterial != null)
+            {
+                ___createMeshForCustomMaterial.Begin();
                 CreateMeshForCustomMaterial();
+                ___createMeshForCustomMaterial.End();
+            }
             else
+            {
+                ___createMesh.Begin();
                 CreateMesh();
-           
+                ___createMesh.End();
+            }
+
             // Update name
             UpdateName();
+
+            ___Apply.End();
         }
 
         #region Editor Support
@@ -381,21 +596,62 @@ namespace DaggerfallWorkshop
             int minRecord = (TextureArchive < 500) ? 0 : 1;
             int maxRecord = cachedMaterial.atlasIndices.Length;
 
+            NativeArray<BasicInfo> items = new NativeArray<BasicInfo>(RandomDepth * RandomWidth, Allocator.TempJob);
             float dist = RandomSpacing;
+            int i = 0;
             for (int y = 0; y < RandomDepth; y++)
+            for (int x = 0; x < RandomWidth; x++)
             {
-                for (int x = 0; x < RandomWidth; x++)
-                {
-                    int record = UnityEngine.Random.Range(minRecord, maxRecord);
-                    AddItem(record, new Vector3(x * dist, 0, y * dist));
-                }
+                int record = UnityEngine.Random.Range(minRecord, maxRecord);
+                float3 localPosition = new float3(x * dist, 0, y * dist);
+                items[i++] = new BasicInfo(record, localPosition);
             }
+            JobHandle op = AddItemsAsync(items);
+            op.Complete();
             Apply();
         }
 
         #endregion
 
         #region Private Methods
+
+
+        /// <summary> Resizes when it's size is invalid. </summary>
+        void ResizeMeshBuffers()
+        {
+            ___ResizeMeshBuffers.Begin();
+
+            int numBillboards = billboardData.Length;
+            int numVertices = numBillboards * vertsPerQuad;
+            int numIndices = numBillboards * indicesPerQuad;
+            if (meshVertices.Length != numVertices)
+            {
+                new DeallocateArrayJob<float3>(meshVertices).Schedule(Dependency);
+                meshVertices = new NativeArray<float3>(numVertices, Allocator.Persistent);
+            }
+            if (meshNormals.Length != numVertices)
+            {
+                new DeallocateArrayJob<float3>(meshNormals).Schedule(Dependency);
+                meshNormals = new NativeArray<float3>(numVertices, Allocator.Persistent);
+            }
+            if (meshIndices.Length != numIndices)
+            {
+                new DeallocateArrayJob<ushort>(meshIndices).Schedule(Dependency);
+                meshIndices = new NativeArray<ushort>(numIndices, Allocator.Persistent);
+            }
+            if (meshTangents.Length != numVertices)
+            {
+                new DeallocateArrayJob<float4>(meshTangents).Schedule(Dependency);
+                meshTangents = new NativeArray<float4>(numVertices, Allocator.Persistent);
+            }
+            if (meshUVs.Length != numVertices)
+            {
+                new DeallocateArrayJob<float2>(meshUVs).Schedule(Dependency);
+                meshUVs = new NativeArray<float2>(numVertices, Allocator.Persistent);
+            }
+
+            ___ResizeMeshBuffers.End();
+        }
 
         /// <summary>
         /// TEMP: Create mesh for custom material path.
@@ -404,165 +660,197 @@ namespace DaggerfallWorkshop
         /// </summary>
         private void CreateMeshForCustomMaterial()
         {
-            // Using half way between forward and up for billboard normal
-            // Workable for most lighting but will need a better system eventually
-            Vector3 normalTemplate = Vector3.Normalize(Vector3.up + Vector3.forward);
+            ___CreateMeshForCustomMaterial.Begin();
+
+            ___complete.Begin();
+            Dependency.Complete();// make sure there are no unfinished jobs
+            ___complete.End();
 
             // Create billboard data
-            Bounds newBounds = new Bounds();
-            int vertexCount = billboardItems.Count * vertsPerQuad;
-            int indexCount = billboardItems.Count * indicesPerQuad;
-            Vector3[] vertices = new Vector3[vertexCount];
-            Vector3[] normals = new Vector3[vertexCount];
-            Vector4[] tangents = new Vector4[vertexCount];
-            uvs = new Vector2[vertexCount];
-            int[] indices = new int[indexCount];
-            int currentIndex = 0;
-            for (int billboard = 0; billboard < billboardItems.Count; billboard++)
+            ___schedule.Begin();
+            ResizeMeshBuffers();
+            int numBillboards = billboardData.Length;
+            NativeArray<float3> origins = new NativeArray<float3>(numBillboards, Allocator.TempJob, NativeArrayOptions.UninitializedMemory);
+            NativeArray<float2> sizes = new NativeArray<float2>(numBillboards, Allocator.TempJob, NativeArrayOptions.UninitializedMemory);
+
+            JobHandle getCustomBatchDataJobHandle = new GetCustomMaterialBatchDataJob
             {
-                int offset = billboard * vertsPerQuad;
-                BillboardItem bi = billboardItems[billboard];
+                Billboards = billboardData,
+                AtlasRects = new NativeArray<Rect>(cachedMaterial.atlasRects, Allocator.TempJob),
+                AtlasIndices = new NativeArray<RecordIndex>(cachedMaterial.atlasIndices, Allocator.TempJob),
+                Origin = origins,
+                Size = sizes,
+            }.Schedule(numBillboards, 128, Dependency);
 
-                // Billboard size and origin
-                Vector2 finalSize = GetScaledBillboardSize(bi.customSize, bi.customScale);
-                float hy = (finalSize.y / 2);
-                Vector3 position = bi.position + new Vector3(0, hy, 0);
+            JobHandle boundsJobHandle = new BoundsJob
+            {
+                NumBillboards = numBillboards,
+                Origin = origins,
+                Size = sizes,
+                AABB = meshAABB
+            }.Schedule(getCustomBatchDataJobHandle);
 
-                // Billboard UVs
-                Rect rect = bi.customRect;
-                uvs[offset] = new Vector2(rect.x, rect.yMax);
-                uvs[offset + 1] = new Vector2(rect.xMax, rect.yMax);
-                uvs[offset + 2] = new Vector2(rect.x, rect.y);
-                uvs[offset + 3] = new Vector2(rect.xMax, rect.y);
+            JobHandle vertexJobHandle = new VertexJob
+            {
+                Origin = origins,
+                Vertex = meshVertices,
+            }.Schedule(numBillboards, 128, getCustomBatchDataJobHandle);
 
-                // Tangent data for shader is used to size billboard
-                tangents[offset] = new Vector4(finalSize.x, finalSize.y, 0, 1);
-                tangents[offset + 1] = new Vector4(finalSize.x, finalSize.y, 1, 1);
-                tangents[offset + 2] = new Vector4(finalSize.x, finalSize.y, 0, 0);
-                tangents[offset + 3] = new Vector4(finalSize.x, finalSize.y, 1, 0);
+            JobHandle uvJobHandle = new CustomRectUVJob
+            {
+                Billboards = billboardData,
+                UV = meshUVs,
+            }.Schedule(numBillboards, 128, getCustomBatchDataJobHandle);
 
-                // Other data for shader
-                for (int vertex = 0; vertex < vertsPerQuad; vertex++)
-                {
-                    vertices[offset + vertex] = position;
-                    normals[offset + vertex] = normalTemplate;
-                }
+            JobHandle tangentJobHandle = new TangentJob
+            {
+                Size = sizes,
+                Tangent = meshTangents,
+            }.Schedule(numBillboards, 128, getCustomBatchDataJobHandle);
 
-                // Assign index data
-                indices[currentIndex] = offset;
-                indices[currentIndex + 1] = offset + 1;
-                indices[currentIndex + 2] = offset + 2;
-                indices[currentIndex + 3] = offset + 3;
-                indices[currentIndex + 4] = offset + 2;
-                indices[currentIndex + 5] = offset + 1;
-                currentIndex += indicesPerQuad;
+            JobHandle indicesJobHandle = new Indices16Job
+            {
+                Indices = meshIndices,
+            }.Schedule(numBillboards, 128, Dependency);
 
-                // Update bounds tracking using actual position and size
-                // This can be a little wonky with single billboards side-on as AABB does not rotate
-                // But it generally works well for large batches as intended
-                // Multiply finalSize * 2f if culling problems with standalone billboards
-                Bounds currentBounds = new Bounds(position, finalSize);
-                newBounds.Encapsulate(currentBounds);
-            }
+            JobHandle normalsJobHandle = new NormalsJob
+            {
+                Normal = meshNormals
+            }.Schedule(meshNormals.Length, meshNormals.Length / SystemInfo.processorCount * 4, Dependency);
+
+            NativeArray<JobHandle> handles = new NativeArray<JobHandle>(6, Allocator.Temp);
+            handles[0] = vertexJobHandle;
+            handles[1] = normalsJobHandle;
+            handles[2] = indicesJobHandle;
+            handles[3] = tangentJobHandle;
+            handles[4] = uvJobHandle;
+            handles[5] = boundsJobHandle;
+            Dependency = JobHandle.CombineDependencies(handles);
+
+            // deallocate leftovers:
+            new DeallocateArrayJob<float3>(origins).Schedule(Dependency);
+            new DeallocateArrayJob<float2>(sizes).Schedule(Dependency);
+            ___schedule.End();
 
             // Create mesh
             if (billboardMesh == null)
             {
                 // New mesh
+                ___newMesh.Begin();
                 billboardMesh = new Mesh();
                 billboardMesh.name = "BillboardBatchMesh [CustomPath]";
+                ___newMesh.End();
             }
             else
             {
-                // Existing mesh
-                if (billboardMesh.vertexCount == vertices.Length)
-                    billboardMesh.Clear(true);      // Same vertex layout
-                else
-                    billboardMesh.Clear(false);     // New vertex layout
+                ___reuseMesh.Begin();
+                billboardMesh.Clear(keepVertexLayout: billboardMesh.vertexCount == meshVertices.Length);
+                ___reuseMesh.End();
             }
 
-            // Assign mesh data
-            billboardMesh.vertices = vertices;              // Each vertex is positioned at billboard origin
-            billboardMesh.tangents = tangents;              // Tangent stores corners and size
-            billboardMesh.triangles = indices;              // Standard indices
-            billboardMesh.normals = normals;                // Standard normals
-            billboardMesh.uv = uvs;                         // Standard uv coordinates into atlas
-
-            // Manually update bounds to account for max billboard height
-            billboardMesh.bounds = newBounds;
-
             // Assign mesh
-            MeshFilter filter = GetComponent<MeshFilter>();
-            filter.sharedMesh = billboardMesh;
+            ___assignMesh.Begin();
+            MeshFilter mf = GetComponent<MeshFilter>();
+            mf.sharedMesh = billboardMesh;
+            ___assignMesh.End();
+
+            // delay finalization until the end of the current frame:
+            Invoke(nameof(PushNewMeshData), 0);
+
+            ___CreateMeshForCustomMaterial.End();
         }
 
         // Packs all billboards into single mesh
         private void CreateMesh()
         {
-            // Using half way between forward and up for billboard normal
-            // Workable for most lighting but will need a better system eventually
-            Vector3 normalTemplate = Vector3.Normalize(Vector3.up + Vector3.forward);
+            ___CreateMesh.Begin();
+
+            ___complete.Begin();
+            Dependency.Complete();// make sure there are no unfinished jobs
+            ___complete.End();
 
             // Create billboard data
-            // Serializing UV array creates less garbage than recreating every time animation ticks
-            Bounds newBounds = new Bounds();
-            int vertexCount = billboardItems.Count * vertsPerQuad;
-            int indexCount = billboardItems.Count * indicesPerQuad;
-            Vector3[] vertices = new Vector3[vertexCount];
-            Vector3[] normals = new Vector3[vertexCount];
-            Vector4[] tangents = new Vector4[vertexCount];
-            uvs = new Vector2[vertexCount];
-            int[] indices = new int[indexCount];
-            int currentIndex = 0;
-            for (int billboard = 0; billboard < billboardItems.Count; billboard++)
+            ___schedule.Begin();
+            ResizeMeshBuffers();
+            int numBillboards = billboardData.Length;
+            NativeArray<float3> origins = new NativeArray<float3>(numBillboards, Allocator.TempJob, NativeArrayOptions.UninitializedMemory);
+            NativeArray<float2> sizes = new NativeArray<float2>(numBillboards, Allocator.TempJob, NativeArrayOptions.UninitializedMemory);
+            NativeArray<Rect> uvrects = new NativeArray<Rect>(numBillboards, Allocator.TempJob, NativeArrayOptions.UninitializedMemory);
+
+            GetBatchDataJob getBatchDataJob = new GetBatchDataJob
             {
-                int offset = billboard * vertsPerQuad;
-                BillboardItem bi = billboardItems[billboard];
+                Billboards = billboardData,
+                RecordSize = new NativeArray<Vector2>(cachedMaterial.recordSizes, Allocator.TempJob).Reinterpret<float2>(),
+                RecordScale = new NativeArray<Vector2>(cachedMaterial.recordScales, Allocator.TempJob).Reinterpret<float2>(),
+                AtlasRects = new NativeArray<Rect>(cachedMaterial.atlasRects, Allocator.TempJob),
+                AtlasIndices = new NativeArray<RecordIndex>(cachedMaterial.atlasIndices, Allocator.TempJob),
+                ScaleDivisor = BlocksFile.ScaleDivisor,
 
-                // Billboard size and origin
-                Vector2 finalSize = GetScaledBillboardSize(bi.record);
-                //float hx = (finalSize.x / 2);
-                float hy = (finalSize.y / 2);
-                Vector3 position = bi.position + new Vector3(0, hy, 0);
+                Origin = origins,
+                Size = sizes,
+                UVRect = uvrects,
+            };
+            JobHandle getBatchDataJobHandle = getBatchDataJob.Schedule(numBillboards, 128, Dependency);
 
-                // Billboard UVs
-                Rect rect = cachedMaterial.atlasRects[cachedMaterial.atlasIndices[bi.record].startIndex + bi.currentFrame];
-                uvs[offset] = new Vector2(rect.x, rect.yMax);
-                uvs[offset + 1] = new Vector2(rect.xMax, rect.yMax);
-                uvs[offset + 2] = new Vector2(rect.x, rect.y);
-                uvs[offset + 3] = new Vector2(rect.xMax, rect.y);
+            BoundsJob boundsJob = new BoundsJob
+            {
+                NumBillboards = numBillboards,
+                Origin = origins,
+                Size = sizes,
+                AABB = meshAABB
+            };
+            JobHandle boundsJobHandle = boundsJob.Schedule(getBatchDataJobHandle);
 
-                // Tangent data for shader is used to size billboard
-                tangents[offset] = new Vector4(finalSize.x, finalSize.y, 0, 1);
-                tangents[offset + 1] = new Vector4(finalSize.x, finalSize.y, 1, 1);
-                tangents[offset + 2] = new Vector4(finalSize.x, finalSize.y, 0, 0);
-                tangents[offset + 3] = new Vector4(finalSize.x, finalSize.y, 1, 0);
+            VertexJob vertexJob = new VertexJob
+            {
+                Origin = origins,
+                Vertex = meshVertices,
+            };
+            JobHandle vertexJobHandle = vertexJob.Schedule(numBillboards, 128, getBatchDataJobHandle);
 
-                // Other data for shader
-                for (int vertex = 0; vertex < vertsPerQuad; vertex++)
-                {
-                    vertices[offset + vertex] = position;
-                    normals[offset + vertex] = normalTemplate;
-                }
+            UVJob uvJob = new UVJob
+            {
+                UVRect = uvrects,
+                UV = meshUVs,
+            };
+            JobHandle uvJobHandle = uvJob.Schedule(numBillboards, 128, getBatchDataJobHandle);
 
-                // Assign index data
-                indices[currentIndex] = offset;
-                indices[currentIndex + 1] = offset + 1;
-                indices[currentIndex + 2] = offset + 2;
-                indices[currentIndex + 3] = offset + 3;
-                indices[currentIndex + 4] = offset + 2;
-                indices[currentIndex + 5] = offset + 1;
-                currentIndex += indicesPerQuad;
+            TangentJob tangentJob = new TangentJob
+            {
+                Size = sizes,
+                Tangent = meshTangents,
+            };
+            JobHandle tangentJobHandle = tangentJob.Schedule(numBillboards, 128, getBatchDataJobHandle);
 
-                // Update bounds tracking using actual position and size
-                // This can be a little wonky with single billboards side-on as AABB does not rotate
-                // But it generally works well for large batches as intended
-                // Multiply finalSize * 2f if culling problems with standalone billboards
-                Bounds currentBounds = new Bounds(position, finalSize);
-                newBounds.Encapsulate(currentBounds);
-            }
+            Indices16Job indicesJob = new Indices16Job
+            {
+                Indices = meshIndices,
+            };
+            JobHandle indicesJobHandle = indicesJob.Schedule(numBillboards, 128, Dependency);
+
+            NormalsJob normalsJob = new NormalsJob
+            {
+                Normal = meshNormals
+            };
+            JobHandle normalsJobHandle = normalsJob.Schedule(meshNormals.Length, meshNormals.Length / SystemInfo.processorCount * 4, Dependency);
+
+            NativeArray<JobHandle> handles = new NativeArray<JobHandle>(6, Allocator.Temp);
+            handles[0] = vertexJobHandle;
+            handles[1] = normalsJobHandle;
+            handles[2] = indicesJobHandle;
+            handles[3] = tangentJobHandle;
+            handles[4] = uvJobHandle;
+            handles[5] = boundsJobHandle;
+            Dependency = JobHandle.CombineDependencies(handles);
+
+            // deallocate leftovers:
+            new DeallocateArrayJob<float3>(origins).Schedule(Dependency);
+            new DeallocateArrayJob<float2>(sizes).Schedule(Dependency);
+            new DeallocateArrayJob<Rect>(uvrects).Schedule(Dependency);
+            ___schedule.End();
 
             // Create mesh
+            ___createMesh.Begin();
             if (billboardMesh == null)
             {
                 // New mesh
@@ -572,25 +860,73 @@ namespace DaggerfallWorkshop
             else
             {
                 // Existing mesh
-                if (billboardMesh.vertexCount == vertices.Length)
-                    billboardMesh.Clear(true);      // Same vertex layout
-                else
-                    billboardMesh.Clear(false);     // New vertex layout
+                billboardMesh.Clear(keepVertexLayout: billboardMesh.vertexCount == meshVertices.Length);
             }
-
-            // Assign mesh data
-            billboardMesh.vertices = vertices;              // Each vertex is positioned at billboard origin
-            billboardMesh.tangents = tangents;              // Tangent stores corners and size
-            billboardMesh.triangles = indices;              // Standard indices
-            billboardMesh.normals = normals;                // Standard normals
-            billboardMesh.uv = uvs;                         // Standard uv coordinates into atlas
-
-            // Manually update bounds to account for max billboard height
-            billboardMesh.bounds = newBounds;
+            ___createMesh.End();
 
             // Assign mesh
-            MeshFilter filter = GetComponent<MeshFilter>();
-            filter.sharedMesh = billboardMesh;
+            ___assignMesh.Begin();
+            MeshFilter mf = GetComponent<MeshFilter>();
+            mf.sharedMesh = billboardMesh;
+            ___assignMesh.End();
+
+            // delay finalization until the end of the current frame:
+            Invoke(nameof(PushNewMeshData), 0);
+
+            ___CreateMesh.End();
+        }
+
+        /// <summary> Pushes mesh data from buffers to the GPU </summary>
+        public void PushNewMeshData()
+        {
+            ___PushNewMeshData.Begin();
+
+            ___complete.Begin();
+            Dependency.Complete();
+            ___complete.End();
+
+            // Assign mesh data
+            ___assignMeshData.Begin();
+            {
+                const MeshUpdateFlags flags = MeshUpdateFlags.DontRecalculateBounds | MeshUpdateFlags.DontNotifyMeshUsers | MeshUpdateFlags.DontValidateIndices | MeshUpdateFlags.DontResetBoneBounds;
+
+                ___vertexBuffer.Begin();
+                billboardMesh.SetVertices(meshVertices);// Each vertex is positioned at billboard origin
+                billboardMesh.SetNormals(meshNormals);// Standard normals
+                billboardMesh.SetTangents(meshTangents);// Tangent stores corners and size
+                billboardMesh.SetUVs(channel: 0, meshUVs);// Standard uv coordinates into atlas
+                ___vertexBuffer.End();
+
+                ___indexBuffer.Begin();
+                billboardMesh.SetIndexBufferParams(meshIndices.Length, IndexFormat.UInt16);
+                billboardMesh.SetIndexBufferData(meshIndices, 0, 0, meshIndices.Length, flags);
+                billboardMesh.subMeshCount = 1;
+                billboardMesh.SetSubMesh(0, new SubMeshDescriptor(0, meshIndices.Length, MeshTopology.Triangles), flags);
+                ___indexBuffer.End();
+
+                billboardMesh.bounds = meshAABB[0];// Manually update bounds to account for max billboard height
+            }
+            ___assignMeshData.End();
+
+            ___PushNewMeshData.End();
+        }
+
+        void PushUVData()
+        {
+            ___PushUVData.Begin();
+
+            // complete jobs:
+            ___complete.Begin();
+            UvAnimationDependency.Complete();
+            ___complete.End();
+
+            // Store new mesh UV set
+            ___setUVs.Begin();
+            if (billboardMesh.vertexCount == meshUVs.Length)
+                billboardMesh.SetUVs(channel: 0, meshUVs);
+            ___setUVs.End();
+
+            ___PushUVData.End();
         }
 
         // Gets scaled billboard size to properly size billboard in world
@@ -604,7 +940,7 @@ namespace DaggerfallWorkshop
         }
 
         // Gets scaled billboard size to properly size billboard in world
-        private Vector2 GetScaledBillboardSize(Vector2 size, Vector2 scale)
+        private static Vector2 GetScaledBillboardSize(Vector2 size, Vector2 scale)
         {
             // Apply scale
             Vector2 finalSize;
@@ -613,6 +949,14 @@ namespace DaggerfallWorkshop
             finalSize.x = (size.x + xChange);
             finalSize.y = (size.y + yChange);
 
+            return finalSize * MeshReader.GlobalScale;
+        }
+        static float2 GetScaledBillboardSize(int record, NativeArray<float2> recordSizes, NativeArray<float2> recordScales, float scaleDivisor)
+        {
+            float2 size = recordSizes[record];
+            float2 scale = recordScales[record];
+            int2 change = (int2)(size * (scale / scaleDivisor));
+            float2 finalSize = size + change;
             return finalSize * MeshReader.GlobalScale;
         }
 
@@ -649,5 +993,292 @@ namespace DaggerfallWorkshop
         }
 
         #endregion
+
+        #region Jobs
+
+        [Unity.Burst.BurstCompile]
+        public struct Indices16Job : IJobParallelFor
+        {
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<ushort> Indices;
+            void IJobParallelFor.Execute(int billboard)
+            {
+                int currentIndex = billboard * indicesPerQuad;
+
+                ushort a = (ushort)(billboard * vertsPerQuad);
+                ushort b = (ushort)(a + 1);
+                ushort c = (ushort)(a + 2);
+                ushort d = (ushort)(a + 3);
+
+                Indices[currentIndex] = a;
+                Indices[currentIndex + 1] = b;
+                Indices[currentIndex + 2] = c;
+                Indices[currentIndex + 3] = d;
+                Indices[currentIndex + 4] = c;
+                Indices[currentIndex + 5] = b;
+            }
+        }
+
+        [Unity.Burst.BurstCompile]
+        public struct NormalsJob : IJobParallelFor
+        {
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float3> Normal;
+            void IJobParallelFor.Execute(int index)
+            {
+                // Using half way between forward and up for billboard normal
+                // Workable for most lighting but will need a better system eventually
+                Normal[index] = new float3(0, 0.707106781187f, 0.707106781187f);// Vector3.Normalize(Vector3.up + Vector3.forward);
+            }
+        }
+
+        [Unity.Burst.BurstCompile]
+        public struct VertexJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<float3> Origin;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float3> Vertex;
+            void IJobParallelFor.Execute(int billboard)
+            {
+                float3 origin = Origin[billboard];
+                int offset = billboard * vertsPerQuad;
+                Vertex[offset] = origin;
+                Vertex[offset + 1] = origin;
+                Vertex[offset + 2] = origin;
+                Vertex[offset + 3] = origin;
+            }
+        }
+
+        [Unity.Burst.BurstCompile]
+        struct UVJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<Rect> UVRect;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float2> UV;
+            void IJobParallelFor.Execute(int billboard)
+            {
+                Rect rect = UVRect[billboard];
+                int offset = billboard * vertsPerQuad;
+
+                UV[offset] = new float2(rect.x, rect.yMax);
+                UV[offset + 1] = new float2(rect.xMax, rect.yMax);
+                UV[offset + 2] = new float2(rect.x, rect.y);
+                UV[offset + 3] = new float2(rect.xMax, rect.y);
+            }
+        }
+        [Unity.Burst.BurstCompile]
+        struct CustomRectUVJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<BillboardItem> Billboards;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float2> UV;
+            void IJobParallelFor.Execute(int billboard)
+            {
+                BillboardItem bi = Billboards[billboard];
+                int offset = billboard * vertsPerQuad;
+
+                Rect rect = bi.customRect;
+                UV[offset] = new float2(rect.x, rect.yMax);
+                UV[offset + 1] = new float2(rect.xMax, rect.yMax);
+                UV[offset + 2] = new float2(rect.x, rect.y);
+                UV[offset + 3] = new float2(rect.xMax, rect.y);
+            }
+        }
+        [Unity.Burst.BurstCompile]
+        struct AnimateUVJob : IJobParallelFor
+        {
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<Rect> AtlasRects;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<RecordIndex> AtlasIndices;
+            public NativeArray<BillboardItem> Billboards;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float2> UV;
+            void IJobParallelFor.Execute(int billboard)
+            {
+                BillboardItem bi = Billboards[billboard];
+                // Look for animated billboards. Do nothing if single frame
+                if (bi.totalFrames > 1)
+                {
+                    // Increment current billboard frame
+                    if (++bi.currentFrame >= bi.totalFrames)
+                        bi.currentFrame = 0;
+                    Billboards[billboard] = bi;
+
+                    // Set new UV properties based on current frame
+                    Rect rect = AtlasRects[AtlasIndices[bi.record].startIndex + bi.currentFrame];
+                    int offset = billboard * vertsPerQuad;
+                    UV[offset] = new float2(rect.x, rect.yMax);
+                    UV[offset + 1] = new float2(rect.xMax, rect.yMax);
+                    UV[offset + 2] = new float2(rect.x, rect.y);
+                    UV[offset + 3] = new float2(rect.xMax, rect.y);
+                }
+            }
+        }
+
+        [Unity.Burst.BurstCompile]
+        struct TangentJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<float2> Size;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float4> Tangent;
+            void IJobParallelFor.Execute(int billboard)
+            {
+                float2 size = Size[billboard];
+                int offset = billboard * vertsPerQuad;
+
+                // Tangent data for shader is used to size billboard
+                Tangent[offset] = new float4(size.x, size.y, 0, 1);
+                Tangent[offset + 1] = new float4(size.x, size.y, 1, 1);
+                Tangent[offset + 2] = new float4(size.x, size.y, 0, 0);
+                Tangent[offset + 3] = new float4(size.x, size.y, 1, 0);
+            }
+        }
+
+        [Unity.Burst.BurstCompile]
+        struct GetBatchDataJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<BillboardItem> Billboards;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<float2> RecordSize;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<float2> RecordScale;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<Rect> AtlasRects;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<RecordIndex> AtlasIndices;
+            public float ScaleDivisor;
+
+            [WriteOnly] public NativeArray<float3> Origin;
+            [WriteOnly] public NativeArray<float2> Size;
+            [WriteOnly] public NativeArray<Rect> UVRect;
+
+            void IJobParallelFor.Execute(int billboard)
+            {
+                BillboardItem bi = Billboards[billboard];
+
+                float2 size = DaggerfallBillboardBatch.GetScaledBillboardSize(bi.record, RecordSize, RecordScale, ScaleDivisor);
+                float3 origin = bi.position + new float3(0, size.y * 0.5f, 0);
+                Rect uvrect = AtlasRects[AtlasIndices[bi.record].startIndex + bi.currentFrame];
+
+                Size[billboard] = size;
+                UVRect[billboard] = uvrect;
+                Origin[billboard] = origin;
+            }
+        }
+        [Unity.Burst.BurstCompile]
+        struct GetCustomMaterialBatchDataJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<BillboardItem> Billboards;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<Rect> AtlasRects;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<RecordIndex> AtlasIndices;
+
+            [WriteOnly] public NativeArray<float3> Origin;
+            [WriteOnly] public NativeArray<float2> Size;
+
+            void IJobParallelFor.Execute(int billboard)
+            {
+                BillboardItem bi = Billboards[billboard];
+
+                float2 size = DaggerfallBillboardBatch.GetScaledBillboardSize((Vector2)bi.customSize, (Vector2)bi.customScale);
+                float3 origin = bi.position + new float3(0, size.y * 0.5f, 0);
+                Rect uvrect = AtlasRects[AtlasIndices[bi.record].startIndex + bi.currentFrame];
+
+                Size[billboard] = size;
+                Origin[billboard] = origin;
+            }
+        }
+
+        [Unity.Burst.BurstCompile]
+        struct BoundsJob : IJob
+        {
+            public int NumBillboards;
+            [ReadOnly] public NativeArray<float3> Origin;
+            [ReadOnly] public NativeArray<float2> Size;
+
+            [WriteOnly] public NativeArray<Bounds> AABB;
+            void IJob.Execute()
+            {
+                // Update bounds tracking using actual position and size
+                // This can be a little wonky with single billboards side-on as AABB does not rotate
+                // But it generally works well for large batches as intended
+                // Multiply finalSize * 2f if culling problems with standalone billboards
+                AABB[0] = new Bounds();
+                if (NumBillboards == 0) return;
+                Bounds aabb = new Bounds(Origin[0], (Vector2)Size[0]); ;
+                for (int billboard = 0; billboard < NumBillboards; billboard++)
+                    aabb.Encapsulate(new Bounds(Origin[billboard], (Vector2)Size[billboard]));
+                AABB[0] = aabb;
+            }
+        }
+
+        [Unity.Burst.BurstCompile]
+        struct AddItemsJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<BasicInfo> Source;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<int> AtlasFrameCounts;
+            public bool RandomStartFrame;
+            public uint Seed;
+            public float3 BlockOrigin;
+            [WriteOnly] public NativeList<BillboardItem>.ParallelWriter BillboardItems;
+            void IJobParallelFor.Execute(int index)
+            {
+                var item = Source[index];
+
+                // Get frame count and start frame
+                int frameCount = AtlasFrameCounts[item.textureRecord];
+                int startFrame = 0;
+                if (RandomStartFrame)
+                    startFrame = new Unity.Mathematics.Random(Seed * (uint)(index + 1)).NextInt(0, frameCount);
+
+                // Add new billboard to batch
+                var billboard = new BillboardItem
+                {
+                    record = item.textureRecord,
+                    position = BlockOrigin + item.localPosition,
+                    totalFrames = frameCount,
+                    currentFrame = startFrame,
+                };
+                BillboardItems.AddNoResize(billboard);
+            }
+        }
+
+        [Unity.Burst.BurstCompile]
+        struct AddCustomItemsJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<CustomInfo> Source;
+            public float3 BlockOrigin;
+            [WriteOnly] public NativeList<BillboardItem>.ParallelWriter BillboardItems;
+            void IJobParallelFor.Execute(int index)
+            {
+                CustomInfo item = Source[index];
+                BillboardItem billboard = new BillboardItem
+                {
+                    position = BlockOrigin + item.localPosition,
+                    customRect = item.rect,
+                    customSize = item.size,
+                    customScale = item.scale,
+                };
+                BillboardItems.AddNoResize(billboard);
+            }
+        }
+
+        // @TODO: move this job outside into a dedicated "UniversalJobs.cs" file, later on
+        [Unity.Burst.BurstCompile]
+        struct DeallocateArrayJob<T> : IJob where T : unmanaged
+        {
+            [ReadOnly] [DeallocateOnJobCompletion] NativeArray<T> Array;
+            public DeallocateArrayJob(NativeArray<T> array) => this.Array = array;
+            void IJob.Execute() { }
+        }
+
+        #endregion
+
+        public struct BasicInfo
+        {
+            public int textureRecord;
+            public float3 localPosition;
+            public BasicInfo(int record, float3 localPosition)
+            {
+                this.textureRecord = record;
+                this.localPosition = localPosition;
+            }
+        }
+
+        public struct CustomInfo
+        {
+            public Rect rect;
+            public float2 size;
+            public float2 scale;
+            public float3 localPosition;
+        }
+
     }
 }

--- a/Assets/Scripts/Internal/DaggerfallBillboardBatch.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboardBatch.cs
@@ -144,6 +144,10 @@ namespace DaggerfallWorkshop
 
         void OnDestroy()
         {
+            // make sure there are no unfinished jobs:
+            Dependency.Complete();
+            UvAnimationDependency.Complete();
+
             if (billboardData.IsCreated) billboardData.Dispose();
             if (meshVertices.IsCreated) meshVertices.Dispose();
             if (meshNormals.IsCreated) meshNormals.Dispose();

--- a/Assets/Scripts/Internal/DaggerfallBillboardBatch.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboardBatch.cs
@@ -204,10 +204,10 @@ namespace DaggerfallWorkshop
                     ___schedule.Begin();
                     AnimateUVJob animateUVJob = new AnimateUVJob
                     {
-                        AtlasRects = new NativeArray<Rect>(cachedMaterial.atlasRects, Allocator.TempJob),
-                        AtlasIndices = new NativeArray<RecordIndex>(cachedMaterial.atlasIndices, Allocator.TempJob),
-                        Billboards = billboardData,
-                        UV = meshUVs,
+                        atlasRects = new NativeArray<Rect>(cachedMaterial.atlasRects, Allocator.TempJob),
+                        atlasIndices = new NativeArray<RecordIndex>(cachedMaterial.atlasIndices, Allocator.TempJob),
+                        billboards = billboardData,
+                        uv = meshUVs,
                     };
                     UvAnimationDependency = animateUVJob.Schedule(numBillboardsToAnimate, 128, Dependency);
                     ___schedule.End();
@@ -445,12 +445,12 @@ namespace DaggerfallWorkshop
                 ___schedule.Begin();
                 AddItemsJob job = new AddItemsJob
                 {
-                    Source = items,
-                    AtlasFrameCounts = new NativeArray<int>(cachedMaterial.atlasFrameCounts, Allocator.TempJob),
-                    RandomStartFrame = RandomStartFrame,
-                    Seed = (uint)((System.Environment.TickCount * this.GetHashCode()).GetHashCode()),
-                    BlockOrigin = BlockOrigin,
-                    BillboardItems = billboardData.AsParallelWriter(),
+                    source = items,
+                    atlasFrameCounts = new NativeArray<int>(cachedMaterial.atlasFrameCounts, Allocator.TempJob),
+                    randomStartFrame = RandomStartFrame,
+                    seed = (uint)((System.Environment.TickCount * this.GetHashCode()).GetHashCode()),
+                    blockOrigin = BlockOrigin,
+                    billboardItems = billboardData.AsParallelWriter(),
                 };
                 Dependency = job.Schedule(arrayLength: numItemsToAdd, innerloopBatchCount: 128, dependsOn: JobHandle.CombineDependencies(Dependency, dependency));
                 ___schedule.End();
@@ -527,9 +527,9 @@ namespace DaggerfallWorkshop
             ___schedule.Begin();
             AddCustomItemsJob job = new AddCustomItemsJob
             {
-                Source = items,
-                BlockOrigin = BlockOrigin,
-                BillboardItems = billboardData.AsParallelWriter(),
+                source = items,
+                blockOrigin = BlockOrigin,
+                billboardItems = billboardData.AsParallelWriter(),
             };
             JobHandle jobHandle = job.Schedule(items.Length, items.Length, JobHandle.CombineDependencies(Dependency, dependency));
             ___schedule.End();
@@ -675,47 +675,47 @@ namespace DaggerfallWorkshop
 
             JobHandle getCustomBatchDataJobHandle = new GetCustomMaterialBatchDataJob
             {
-                Billboards = billboardData,
-                AtlasRects = new NativeArray<Rect>(cachedMaterial.atlasRects, Allocator.TempJob),
-                AtlasIndices = new NativeArray<RecordIndex>(cachedMaterial.atlasIndices, Allocator.TempJob),
-                Origin = origins,
-                Size = sizes,
+                billboards = billboardData,
+                atlasRects = new NativeArray<Rect>(cachedMaterial.atlasRects, Allocator.TempJob),
+                atlasIndices = new NativeArray<RecordIndex>(cachedMaterial.atlasIndices, Allocator.TempJob),
+                origin = origins,
+                size = sizes,
             }.Schedule(numBillboards, 128, Dependency);
 
             JobHandle boundsJobHandle = new BoundsJob
             {
-                NumBillboards = numBillboards,
-                Origin = origins,
-                Size = sizes,
-                AABB = meshAABB
+                numBillboards = numBillboards,
+                origin = origins,
+                size = sizes,
+                aabb = meshAABB
             }.Schedule(getCustomBatchDataJobHandle);
 
             JobHandle vertexJobHandle = new VertexJob
             {
-                Origin = origins,
-                Vertex = meshVertices,
+                origin = origins,
+                vertex = meshVertices,
             }.Schedule(numBillboards, 128, getCustomBatchDataJobHandle);
 
             JobHandle uvJobHandle = new CustomRectUVJob
             {
-                Billboards = billboardData,
-                UV = meshUVs,
+                billboards = billboardData,
+                uv = meshUVs,
             }.Schedule(numBillboards, 128, getCustomBatchDataJobHandle);
 
             JobHandle tangentJobHandle = new TangentJob
             {
-                Size = sizes,
-                Tangent = meshTangents,
+                size = sizes,
+                tangent = meshTangents,
             }.Schedule(numBillboards, 128, getCustomBatchDataJobHandle);
 
             JobHandle indicesJobHandle = new Indices16Job
             {
-                Indices = meshIndices,
+                indices = meshIndices,
             }.Schedule(numBillboards, 128, Dependency);
 
             JobHandle normalsJobHandle = new NormalsJob
             {
-                Normal = meshNormals
+                normal = meshNormals
             }.Schedule(meshNormals.Length, meshNormals.Length / SystemInfo.processorCount * 4, Dependency);
 
             NativeArray<JobHandle> handles = new NativeArray<JobHandle>(6, Allocator.Temp);
@@ -779,58 +779,58 @@ namespace DaggerfallWorkshop
 
             GetBatchDataJob getBatchDataJob = new GetBatchDataJob
             {
-                Billboards = billboardData,
-                RecordSize = new NativeArray<Vector2>(cachedMaterial.recordSizes, Allocator.TempJob).Reinterpret<float2>(),
-                RecordScale = new NativeArray<Vector2>(cachedMaterial.recordScales, Allocator.TempJob).Reinterpret<float2>(),
-                AtlasRects = new NativeArray<Rect>(cachedMaterial.atlasRects, Allocator.TempJob),
-                AtlasIndices = new NativeArray<RecordIndex>(cachedMaterial.atlasIndices, Allocator.TempJob),
-                ScaleDivisor = BlocksFile.ScaleDivisor,
+                billboards = billboardData,
+                recordSize = new NativeArray<Vector2>(cachedMaterial.recordSizes, Allocator.TempJob).Reinterpret<float2>(),
+                recordScale = new NativeArray<Vector2>(cachedMaterial.recordScales, Allocator.TempJob).Reinterpret<float2>(),
+                atlasRects = new NativeArray<Rect>(cachedMaterial.atlasRects, Allocator.TempJob),
+                atlasIndices = new NativeArray<RecordIndex>(cachedMaterial.atlasIndices, Allocator.TempJob),
+                scaleDivisor = BlocksFile.ScaleDivisor,
 
-                Origin = origins,
-                Size = sizes,
-                UVRect = uvrects,
+                origin = origins,
+                size = sizes,
+                uvRect = uvrects,
             };
             JobHandle getBatchDataJobHandle = getBatchDataJob.Schedule(numBillboards, 128, Dependency);
 
             BoundsJob boundsJob = new BoundsJob
             {
-                NumBillboards = numBillboards,
-                Origin = origins,
-                Size = sizes,
-                AABB = meshAABB
+                numBillboards = numBillboards,
+                origin = origins,
+                size = sizes,
+                aabb = meshAABB
             };
             JobHandle boundsJobHandle = boundsJob.Schedule(getBatchDataJobHandle);
 
             VertexJob vertexJob = new VertexJob
             {
-                Origin = origins,
-                Vertex = meshVertices,
+                origin = origins,
+                vertex = meshVertices,
             };
             JobHandle vertexJobHandle = vertexJob.Schedule(numBillboards, 128, getBatchDataJobHandle);
 
             UVJob uvJob = new UVJob
             {
-                UVRect = uvrects,
-                UV = meshUVs,
+                uvRect = uvrects,
+                uv = meshUVs,
             };
             JobHandle uvJobHandle = uvJob.Schedule(numBillboards, 128, getBatchDataJobHandle);
 
             TangentJob tangentJob = new TangentJob
             {
-                Size = sizes,
-                Tangent = meshTangents,
+                size = sizes,
+                tangent = meshTangents,
             };
             JobHandle tangentJobHandle = tangentJob.Schedule(numBillboards, 128, getBatchDataJobHandle);
 
             Indices16Job indicesJob = new Indices16Job
             {
-                Indices = meshIndices,
+                indices = meshIndices,
             };
             JobHandle indicesJobHandle = indicesJob.Schedule(numBillboards, 128, Dependency);
 
             NormalsJob normalsJob = new NormalsJob
             {
-                Normal = meshNormals
+                normal = meshNormals
             };
             JobHandle normalsJobHandle = normalsJob.Schedule(meshNormals.Length, meshNormals.Length / SystemInfo.processorCount * 4, Dependency);
 
@@ -999,7 +999,7 @@ namespace DaggerfallWorkshop
         [Unity.Burst.BurstCompile]
         public struct Indices16Job : IJobParallelFor
         {
-            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<ushort> Indices;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<ushort> indices;
             void IJobParallelFor.Execute(int billboard)
             {
                 int currentIndex = billboard * indicesPerQuad;
@@ -1009,101 +1009,101 @@ namespace DaggerfallWorkshop
                 ushort c = (ushort)(a + 2);
                 ushort d = (ushort)(a + 3);
 
-                Indices[currentIndex] = a;
-                Indices[currentIndex + 1] = b;
-                Indices[currentIndex + 2] = c;
-                Indices[currentIndex + 3] = d;
-                Indices[currentIndex + 4] = c;
-                Indices[currentIndex + 5] = b;
+                indices[currentIndex] = a;
+                indices[currentIndex + 1] = b;
+                indices[currentIndex + 2] = c;
+                indices[currentIndex + 3] = d;
+                indices[currentIndex + 4] = c;
+                indices[currentIndex + 5] = b;
             }
         }
 
         [Unity.Burst.BurstCompile]
         public struct NormalsJob : IJobParallelFor
         {
-            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float3> Normal;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float3> normal;
             void IJobParallelFor.Execute(int index)
             {
                 // Using half way between forward and up for billboard normal
                 // Workable for most lighting but will need a better system eventually
-                Normal[index] = new float3(0, 0.707106781187f, 0.707106781187f);// Vector3.Normalize(Vector3.up + Vector3.forward);
+                normal[index] = new float3(0, 0.707106781187f, 0.707106781187f);// Vector3.Normalize(Vector3.up + Vector3.forward);
             }
         }
 
         [Unity.Burst.BurstCompile]
         public struct VertexJob : IJobParallelFor
         {
-            [ReadOnly] public NativeArray<float3> Origin;
-            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float3> Vertex;
+            [ReadOnly] public NativeArray<float3> origin;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float3> vertex;
             void IJobParallelFor.Execute(int billboard)
             {
-                float3 origin = Origin[billboard];
+                float3 o = origin[billboard];
                 int offset = billboard * vertsPerQuad;
-                Vertex[offset] = origin;
-                Vertex[offset + 1] = origin;
-                Vertex[offset + 2] = origin;
-                Vertex[offset + 3] = origin;
+                vertex[offset] = o;
+                vertex[offset + 1] = o;
+                vertex[offset + 2] = o;
+                vertex[offset + 3] = o;
             }
         }
 
         [Unity.Burst.BurstCompile]
         struct UVJob : IJobParallelFor
         {
-            [ReadOnly] public NativeArray<Rect> UVRect;
-            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float2> UV;
+            [ReadOnly] public NativeArray<Rect> uvRect;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float2> uv;
             void IJobParallelFor.Execute(int billboard)
             {
-                Rect rect = UVRect[billboard];
+                Rect rect = uvRect[billboard];
                 int offset = billboard * vertsPerQuad;
 
-                UV[offset] = new float2(rect.x, rect.yMax);
-                UV[offset + 1] = new float2(rect.xMax, rect.yMax);
-                UV[offset + 2] = new float2(rect.x, rect.y);
-                UV[offset + 3] = new float2(rect.xMax, rect.y);
+                uv[offset] = new float2(rect.x, rect.yMax);
+                uv[offset + 1] = new float2(rect.xMax, rect.yMax);
+                uv[offset + 2] = new float2(rect.x, rect.y);
+                uv[offset + 3] = new float2(rect.xMax, rect.y);
             }
         }
         [Unity.Burst.BurstCompile]
         struct CustomRectUVJob : IJobParallelFor
         {
-            [ReadOnly] public NativeArray<BillboardItem> Billboards;
-            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float2> UV;
+            [ReadOnly] public NativeArray<BillboardItem> billboards;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float2> uv;
             void IJobParallelFor.Execute(int billboard)
             {
-                BillboardItem bi = Billboards[billboard];
+                BillboardItem bi = billboards[billboard];
                 int offset = billboard * vertsPerQuad;
 
                 Rect rect = bi.customRect;
-                UV[offset] = new float2(rect.x, rect.yMax);
-                UV[offset + 1] = new float2(rect.xMax, rect.yMax);
-                UV[offset + 2] = new float2(rect.x, rect.y);
-                UV[offset + 3] = new float2(rect.xMax, rect.y);
+                uv[offset] = new float2(rect.x, rect.yMax);
+                uv[offset + 1] = new float2(rect.xMax, rect.yMax);
+                uv[offset + 2] = new float2(rect.x, rect.y);
+                uv[offset + 3] = new float2(rect.xMax, rect.y);
             }
         }
         [Unity.Burst.BurstCompile]
         struct AnimateUVJob : IJobParallelFor
         {
-            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<Rect> AtlasRects;
-            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<RecordIndex> AtlasIndices;
-            public NativeArray<BillboardItem> Billboards;
-            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float2> UV;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<Rect> atlasRects;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<RecordIndex> atlasIndices;
+            public NativeArray<BillboardItem> billboards;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float2> uv;
             void IJobParallelFor.Execute(int billboard)
             {
-                BillboardItem bi = Billboards[billboard];
+                BillboardItem bi = billboards[billboard];
                 // Look for animated billboards. Do nothing if single frame
                 if (bi.totalFrames > 1)
                 {
                     // Increment current billboard frame
                     if (++bi.currentFrame >= bi.totalFrames)
                         bi.currentFrame = 0;
-                    Billboards[billboard] = bi;
+                    billboards[billboard] = bi;
 
                     // Set new UV properties based on current frame
-                    Rect rect = AtlasRects[AtlasIndices[bi.record].startIndex + bi.currentFrame];
+                    Rect rect = atlasRects[atlasIndices[bi.record].startIndex + bi.currentFrame];
                     int offset = billboard * vertsPerQuad;
-                    UV[offset] = new float2(rect.x, rect.yMax);
-                    UV[offset + 1] = new float2(rect.xMax, rect.yMax);
-                    UV[offset + 2] = new float2(rect.x, rect.y);
-                    UV[offset + 3] = new float2(rect.xMax, rect.y);
+                    uv[offset] = new float2(rect.x, rect.yMax);
+                    uv[offset + 1] = new float2(rect.xMax, rect.yMax);
+                    uv[offset + 2] = new float2(rect.x, rect.y);
+                    uv[offset + 3] = new float2(rect.xMax, rect.y);
                 }
             }
         }
@@ -1111,142 +1111,137 @@ namespace DaggerfallWorkshop
         [Unity.Burst.BurstCompile]
         struct TangentJob : IJobParallelFor
         {
-            [ReadOnly] public NativeArray<float2> Size;
-            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float4> Tangent;
+            [ReadOnly] public NativeArray<float2> size;
+            [WriteOnly] [NativeDisableParallelForRestriction] public NativeArray<float4> tangent;
             void IJobParallelFor.Execute(int billboard)
             {
-                float2 size = Size[billboard];
+                float2 s = size[billboard];
                 int offset = billboard * vertsPerQuad;
 
                 // Tangent data for shader is used to size billboard
-                Tangent[offset] = new float4(size.x, size.y, 0, 1);
-                Tangent[offset + 1] = new float4(size.x, size.y, 1, 1);
-                Tangent[offset + 2] = new float4(size.x, size.y, 0, 0);
-                Tangent[offset + 3] = new float4(size.x, size.y, 1, 0);
+                tangent[offset] = new float4(s.x, s.y, 0, 1);
+                tangent[offset + 1] = new float4(s.x, s.y, 1, 1);
+                tangent[offset + 2] = new float4(s.x, s.y, 0, 0);
+                tangent[offset + 3] = new float4(s.x, s.y, 1, 0);
             }
         }
 
         [Unity.Burst.BurstCompile]
         struct GetBatchDataJob : IJobParallelFor
         {
-            [ReadOnly] public NativeArray<BillboardItem> Billboards;
-            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<float2> RecordSize;
-            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<float2> RecordScale;
-            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<Rect> AtlasRects;
-            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<RecordIndex> AtlasIndices;
-            public float ScaleDivisor;
-
-            [WriteOnly] public NativeArray<float3> Origin;
-            [WriteOnly] public NativeArray<float2> Size;
-            [WriteOnly] public NativeArray<Rect> UVRect;
-
+            [ReadOnly] public NativeArray<BillboardItem> billboards;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<float2> recordSize;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<float2> recordScale;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<Rect> atlasRects;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<RecordIndex> atlasIndices;
+            public float scaleDivisor;
+            [WriteOnly] public NativeArray<float3> origin;
+            [WriteOnly] public NativeArray<float2> size;
+            [WriteOnly] public NativeArray<Rect> uvRect;
             void IJobParallelFor.Execute(int billboard)
             {
-                BillboardItem bi = Billboards[billboard];
+                BillboardItem bi = billboards[billboard];
 
-                float2 size = DaggerfallBillboardBatch.GetScaledBillboardSize(bi.record, RecordSize, RecordScale, ScaleDivisor);
+                float2 size = DaggerfallBillboardBatch.GetScaledBillboardSize(bi.record, recordSize, recordScale, scaleDivisor);
                 float3 origin = bi.position + new float3(0, size.y * 0.5f, 0);
-                Rect uvrect = AtlasRects[AtlasIndices[bi.record].startIndex + bi.currentFrame];
+                Rect uvrect = atlasRects[atlasIndices[bi.record].startIndex + bi.currentFrame];
 
-                Size[billboard] = size;
-                UVRect[billboard] = uvrect;
-                Origin[billboard] = origin;
+                this.size[billboard] = size;
+                uvRect[billboard] = uvrect;
+                this.origin[billboard] = origin;
             }
         }
         [Unity.Burst.BurstCompile]
         struct GetCustomMaterialBatchDataJob : IJobParallelFor
         {
-            [ReadOnly] public NativeArray<BillboardItem> Billboards;
-            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<Rect> AtlasRects;
-            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<RecordIndex> AtlasIndices;
-
-            [WriteOnly] public NativeArray<float3> Origin;
-            [WriteOnly] public NativeArray<float2> Size;
-
+            [ReadOnly] public NativeArray<BillboardItem> billboards;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<Rect> atlasRects;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<RecordIndex> atlasIndices;
+            [WriteOnly] public NativeArray<float3> origin;
+            [WriteOnly] public NativeArray<float2> size;
             void IJobParallelFor.Execute(int billboard)
             {
-                BillboardItem bi = Billboards[billboard];
+                BillboardItem bi = billboards[billboard];
 
-                float2 size = DaggerfallBillboardBatch.GetScaledBillboardSize((Vector2)bi.customSize, (Vector2)bi.customScale);
-                float3 origin = bi.position + new float3(0, size.y * 0.5f, 0);
-                Rect uvrect = AtlasRects[AtlasIndices[bi.record].startIndex + bi.currentFrame];
+                float2 s = DaggerfallBillboardBatch.GetScaledBillboardSize((Vector2)bi.customSize, (Vector2)bi.customScale);
+                float3 origin = bi.position + new float3(0, s.y * 0.5f, 0);
+                Rect uvrect = atlasRects[atlasIndices[bi.record].startIndex + bi.currentFrame];
 
-                Size[billboard] = size;
-                Origin[billboard] = origin;
+                size[billboard] = s;
+                this.origin[billboard] = origin;
             }
         }
 
         [Unity.Burst.BurstCompile]
         struct BoundsJob : IJob
         {
-            public int NumBillboards;
-            [ReadOnly] public NativeArray<float3> Origin;
-            [ReadOnly] public NativeArray<float2> Size;
-
-            [WriteOnly] public NativeArray<Bounds> AABB;
+            public int numBillboards;
+            [ReadOnly] public NativeArray<float3> origin;
+            [ReadOnly] public NativeArray<float2> size;
+            [WriteOnly] public NativeArray<Bounds> aabb;
             void IJob.Execute()
             {
                 // Update bounds tracking using actual position and size
                 // This can be a little wonky with single billboards side-on as AABB does not rotate
                 // But it generally works well for large batches as intended
                 // Multiply finalSize * 2f if culling problems with standalone billboards
-                AABB[0] = new Bounds();
-                if (NumBillboards == 0) return;
-                Bounds aabb = new Bounds(Origin[0], (Vector2)Size[0]); ;
-                for (int billboard = 0; billboard < NumBillboards; billboard++)
-                    aabb.Encapsulate(new Bounds(Origin[billboard], (Vector2)Size[billboard]));
-                AABB[0] = aabb;
+                this.aabb[0] = new Bounds();
+                if (numBillboards == 0) return;
+                Bounds aabb = new Bounds(origin[0], (Vector2)size[0]); ;
+                for (int billboard = 0; billboard < numBillboards; billboard++)
+                    aabb.Encapsulate(new Bounds(origin[billboard], (Vector2)size[billboard]));
+                this.aabb[0] = aabb;
             }
         }
 
         [Unity.Burst.BurstCompile]
         struct AddItemsJob : IJobParallelFor
         {
-            [ReadOnly] public NativeArray<BasicInfo> Source;
-            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<int> AtlasFrameCounts;
-            public bool RandomStartFrame;
-            public uint Seed;
-            public float3 BlockOrigin;
-            [WriteOnly] public NativeList<BillboardItem>.ParallelWriter BillboardItems;
+            [ReadOnly] public NativeArray<BasicInfo> source;
+            [ReadOnly] [DeallocateOnJobCompletion] public NativeArray<int> atlasFrameCounts;
+            public bool randomStartFrame;
+            public uint seed;
+            public float3 blockOrigin;
+            [WriteOnly] public NativeList<BillboardItem>.ParallelWriter billboardItems;
             void IJobParallelFor.Execute(int index)
             {
-                var item = Source[index];
+                var item = source[index];
 
                 // Get frame count and start frame
-                int frameCount = AtlasFrameCounts[item.textureRecord];
+                int frameCount = atlasFrameCounts[item.textureRecord];
                 int startFrame = 0;
-                if (RandomStartFrame)
-                    startFrame = new Unity.Mathematics.Random(Seed * (uint)(index + 1)).NextInt(0, frameCount);
+                if (randomStartFrame)
+                    startFrame = new Unity.Mathematics.Random(seed * (uint)(index + 1)).NextInt(0, frameCount);
 
                 // Add new billboard to batch
                 var billboard = new BillboardItem
                 {
                     record = item.textureRecord,
-                    position = BlockOrigin + item.localPosition,
+                    position = blockOrigin + item.localPosition,
                     totalFrames = frameCount,
                     currentFrame = startFrame,
                 };
-                BillboardItems.AddNoResize(billboard);
+                billboardItems.AddNoResize(billboard);
             }
         }
 
         [Unity.Burst.BurstCompile]
         struct AddCustomItemsJob : IJobParallelFor
         {
-            [ReadOnly] public NativeArray<CustomInfo> Source;
-            public float3 BlockOrigin;
-            [WriteOnly] public NativeList<BillboardItem>.ParallelWriter BillboardItems;
+            [ReadOnly] public NativeArray<CustomInfo> source;
+            public float3 blockOrigin;
+            [WriteOnly] public NativeList<BillboardItem>.ParallelWriter billboardItems;
             void IJobParallelFor.Execute(int index)
             {
-                CustomInfo item = Source[index];
+                CustomInfo item = source[index];
                 BillboardItem billboard = new BillboardItem
                 {
-                    position = BlockOrigin + item.localPosition,
+                    position = blockOrigin + item.localPosition,
                     customRect = item.rect,
                     customSize = item.size,
                     customScale = item.scale,
                 };
-                BillboardItems.AddNoResize(billboard);
+                billboardItems.AddNoResize(billboard);
             }
         }
 
@@ -1254,8 +1249,8 @@ namespace DaggerfallWorkshop
         [Unity.Burst.BurstCompile]
         struct DeallocateArrayJob<T> : IJob where T : unmanaged
         {
-            [ReadOnly] [DeallocateOnJobCompletion] NativeArray<T> Array;
-            public DeallocateArrayJob(NativeArray<T> array) => this.Array = array;
+            [ReadOnly] [DeallocateOnJobCompletion] NativeArray<T> array;
+            public DeallocateArrayJob(NativeArray<T> array) => this.array = array;
             void IJob.Execute() { }
         }
 


### PR DESCRIPTION
Hi! This PR is part of https://github.com/Interkarma/daggerfall-unity/pull/2416 saga.

# What

I refactored #2416 changes to the `DaggerfallBillboardBatch.cs` to make them more conservative, safe and limited to a single file. It delivers less benefits than original, but will serve as a good foundation for future improvements which has been identified so far.

I know you guys have other priorities now so no worries - take your time. I am posting this now while my mind is still familiar with this code.

# Results

- `CreateMesh` takes less time from the main thread. Before: about `266 ms` (left), after: about `34 [s]` (right):
<p float="center">
    <img src="https://user-images.githubusercontent.com/3066539/189755528-f406d57f-0c53-4304-bf25-c43fca48e5c7.png" width="49%">
    <img src="https://user-images.githubusercontent.com/3066539/189755532-fc8c4de2-d5e6-426b-8210-6f507ad65590.png" width="49%">
</p>

- `AddItemsAsync` were added to open the door for future decrease in the overhead from the thousands of separate  `AddItem` calls (about an `100 ms`, sometimes more)

- `ProfilerMarker` introduced, to make profiling much more granular and informative. My controversial proposal here is in it's naming convention ie. `____PascalCase` (for methods) and `____camelCase` (for generic markers). I tried different schemes and this was my conclusion as most consistent and readable, but you might have different conclusions. Prefix `___` especially helps with readability as it makes these markers * immediately * apparent and distinguishable from the rest of the code mid-all these busy methods.
