### PR TITLE
Fix flying enemies fall damage

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -1385,6 +1385,9 @@ namespace DaggerfallWorkshop.Game
 
                 lastGroundedY = transform.position.y;
             }
+            // For flying enemies, "lastGroundedY" is really "lastAltitudeControlY"
+            else if (flies && !flyerFalls)
+                lastGroundedY = transform.position.y;
         }
 
         /// <summary>


### PR DESCRIPTION
Flying enemies hitting ground (recoil, under paralysis,...) were taking fall damage relative to their spawn location, because their lastGroundedY was never updated.

This can be fixed several ways, in this patch I extend lastGroundedY to flying enemies by updating it as long as flyingFalls is false; It could be renamed say lastAltitudeControlY, the last value of Y when the enemy had control over its altitude.

Forums: https://forums.dfworkshop.net/viewtopic.php?t=5874