### PR TITLE
improvement: mod compilation error message

### DIFF
--- a/Assets/Game/Addons/CSharpCompiler/Compiler.cs
+++ b/Assets/Game/Addons/CSharpCompiler/Compiler.cs
@@ -97,8 +97,25 @@ namespace DaggerfallWorkshop.Game.Utility
                 var msg = new StringBuilder();
                 foreach (CompilerError error in result.Errors)
                 {
-                    msg.AppendFormat("Error ({0}): {1}\n",
-                        error.ErrorNumber, error.ErrorText);
+                    if (int.TryParse(error.FileName, out int fileIndex))
+                        msg.AppendFormat("Error ({0}): {1} (at: \"{2}\")\n", error.ErrorNumber, error.ErrorText, readLine(sources[fileIndex], error.Line));
+                    else
+                        msg.AppendFormat("Error ({0}): {1} (at {2}:{3})\n", error.ErrorNumber, error.ErrorText, error.FileName, error.Line);
+                }
+
+                // src* https://stackoverflow.com/a/2606447/2528943 (author: Paul Ruane)
+                string readLine(string text, int lineNumber)
+                {
+                    var reader = new System.IO.StringReader(text);
+                    string line;
+                    int currentLineNumber = 0;
+                    do
+                    {
+                        currentLineNumber += 1;
+                        line = reader.ReadLine();
+                    }
+                    while (line != null && currentLineNumber < lineNumber);
+                    return (currentLineNumber == lineNumber) ? line : string.Empty;
                 }
 
                 throw new Exception(msg.ToString());

--- a/Assets/Game/Addons/CSharpCompiler/Compiler.cs
+++ b/Assets/Game/Addons/CSharpCompiler/Compiler.cs
@@ -106,7 +106,7 @@ namespace DaggerfallWorkshop.Game.Utility
                     if (int.TryParse(error.FileName, out int fileIndex) && GetSpecificLine(sources[fileIndex], error.Line, out lineContentText))
                         lineContentText = $"\"{lineContentText}\"";
 
-                    msg.AppendLine($"Error {errorCodeText}: {errorText}");
+                    msg.AppendLine($"<b>Compilation Error {errorCodeText}</b>: {errorText}");
                     msg.AppendLine($"\tat {numLineText} {numColumnText} {lineContentText}");
                 }
 

--- a/Assets/Game/Addons/CSharpCompiler/Compiler.cs
+++ b/Assets/Game/Addons/CSharpCompiler/Compiler.cs
@@ -97,19 +97,17 @@ namespace DaggerfallWorkshop.Game.Utility
                 var msg = new StringBuilder();
                 foreach (CompilerError error in result.Errors)
                 {
-                    string errorCode = !string.IsNullOrEmpty(error.ErrorNumber) ? $"CS{error.ErrorNumber}" : "(unknown)";
-                    if (
-                           int.TryParse(error.FileName, out int fileIndex)
-                        && GetSpecificLine(sources[fileIndex], error.Line, out string lineText)
-                        && !string.IsNullOrEmpty(lineText)
-                    )
-                    {
-                        msg.AppendFormat("Error {0}: {1} (at line #{2}: \"{3}\")\n", errorCode, error.ErrorText, error.Line, lineText);
-                    }
-                    else
-                    {
-                        msg.AppendFormat("Error {0}: {1}\n", errorCode, error.ErrorText);
-                    }
+                    string errorCodeText = !string.IsNullOrEmpty(error.ErrorNumber) ? $"CS{error.ErrorNumber}" : string.Empty;
+                    string errorText = error.ErrorText;
+                    string numLineText = $"line#{error.Line}";
+                    string numColumnText = $"column#{error.Column}";
+                    string lineContentText = string.Empty;
+
+                    if (int.TryParse(error.FileName, out int fileIndex) && GetSpecificLine(sources[fileIndex], error.Line, out lineContentText))
+                        lineContentText = $"\"{lineContentText}\"";
+
+                    msg.AppendLine($"Error {errorCodeText}: {errorText}");
+                    msg.AppendLine($"\tat {numLineText} {numColumnText} {lineContentText}");
                 }
 
                 throw new Exception(msg.ToString());

--- a/Assets/Game/Addons/CSharpCompiler/Compiler.cs
+++ b/Assets/Game/Addons/CSharpCompiler/Compiler.cs
@@ -124,12 +124,10 @@ namespace DaggerfallWorkshop.Game.Utility
             bool success;
             var reader = new System.IO.StringReader(text);
             {
-                string nextLine;
                 int i = 0;
-                do nextLine = reader.ReadLine();
-                while (nextLine != null && i++ < lineNumber);
+                do line = reader.ReadLine();
+                while (line != null && ++i < lineNumber);
                 success = i == lineNumber;
-                line = success ? nextLine : string.Empty;
             }
             reader.Close();
             return success;

--- a/Assets/Game/Addons/ModSupport/Mod.cs
+++ b/Assets/Game/Addons/ModSupport/Mod.cs
@@ -971,7 +971,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
                 if (stringSource.Count > 0)
                 {
-                    assembly = ModManager.CompileFromSourceAssets(stringSource.ToArray());
+                    assembly = ModManager.CompileFromSourceAssets(stringSource.ToArray(), $"{this.ModInfo.ModTitle} {this.ModInfo.ModVersion}");
                     if (assembly != null)
                         assemblies.Add(assembly);
                 }

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -754,7 +754,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// </summary>
         /// <param name="source">The content of source files.</param>
         /// <returns>The compiled assembly or null.</returns>
-        public static Assembly CompileFromSourceAssets(string[] source)
+        public static Assembly CompileFromSourceAssets(string[] source, string modName = "(no mod name)")
         {
             if (source == null || source.Length < 1)
             {
@@ -771,7 +771,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             }
             catch (Exception ex)
             {
-                Debug.LogError(ex.Message);
+                Debug.LogError($"[{modName}] {ex.Message}");
                 return null;
             }
         }


### PR DESCRIPTION
# What
A change in `DaggerfallWorkshop.Game.Utility.Compiler` to help fellow mod developers fix mod compilation errors more easily.

> edit: since [1911297](https://github.com/Interkarma/daggerfall-unity/pull/2432/commits/191129724181daa3a962435e2fcdec9f9d9d265b) this includes minimal changes in `Mod.cs` and `ModManager.cs` so compilation API can pass mod title+version as an optional parameter.

# Why
I compiled a mod, ran the game, mod failed to load. Saw this error message:
![Screenshot 2022-09-19 160736 b](https://user-images.githubusercontent.com/3066539/191048748-d716ec33-5f88-4654-af59-99f7f39cf130.png)

<p>
    <img src="https://user-images.githubusercontent.com/3066539/191051095-5fd8197a-3272-436e-a8eb-cd13fc9b1d95.jpg" height="140px">
</p>

# Results

Now I can see this:

![Screenshot 2022-09-20 162939](https://user-images.githubusercontent.com/3066539/191293130-d19352c4-c85d-4deb-b9c2-e6307b201f0d.png)

<p>
    <img src="https://user-images.githubusercontent.com/3066539/191051193-4ed5cf08-23ee-4a21-ac6b-123fd11d9f34.jpg" height="140px">
</p>
