### PR TITLE
better exception message for `SerializableStateManager.GetStatefulGameObjectType`

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableStateManager.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableStateManager.cs
@@ -27,7 +27,6 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         const string invalidLoadIDExceptionText = "serializableObject does not have a valid LoadID";
         const string duplicateLoadIDErrorText = "Duplicate LoadID {1} detected for {0} object. This object will not be serialized.";
-        const string typeNotImplementedExeptionText = "ISerializableGameObject type not implemented for ";
 
         private static int numStatefulGameObjectTypes = Enum.GetNames(typeof(StatefulGameObjectTypes)).Length;
 
@@ -486,16 +485,18 @@ namespace DaggerfallWorkshop.Game.Serialization
 
         private StatefulGameObjectTypes GetStatefulGameObjectType(ISerializableGameObject sgObj)
         {
-            if (sgObj is SerializableActionDoor)
-                return StatefulGameObjectTypes.ActionDoor;
-            else if (sgObj is SerializableActionObject)
-                return StatefulGameObjectTypes.ActionObject;
-            else if (sgObj is SerializableEnemy)
-                return StatefulGameObjectTypes.Enemy;
-            else if (sgObj is SerializableLootContainer)
-                return StatefulGameObjectTypes.LootContainer;
-
-            throw new Exception(typeNotImplementedExeptionText + sgObj.GetType().ToString());
+            if (sgObj is SerializableActionDoor) return StatefulGameObjectTypes.ActionDoor;
+            else if (sgObj is SerializableActionObject) return StatefulGameObjectTypes.ActionObject;
+            else if (sgObj is SerializableEnemy) return StatefulGameObjectTypes.Enemy;
+            else if (sgObj is SerializableLootContainer) return StatefulGameObjectTypes.LootContainer;
+            else
+            {
+                // type is not accounted for
+                if (sgObj is ISerializableGameObject)
+                    throw new NotImplementedException($"{nameof(GetStatefulGameObjectType)} does not know what to do with {sgObj.GetType().FullName}");
+                else
+                    throw new Exception($"{nameof(ISerializableGameObject)} type not implemented for {sgObj.GetType().FullName}");
+            }
         }
 
         #endregion


### PR DESCRIPTION
# What

More precise exception message for `SerializableStateManager.GetStatefulGameObjectType` method

# Why

Misleading `Exception: ISerializableGameObject type not implemented for DaggerfallWorkshop.Game.Serialization.SerializablePlayer` appeared while working on #2442

# Results

This PR does not resolve the underlying issue but fixes the messaging to clear out confusion first.

A new message is:
```
NotImplementedException: GetStatefulGameObjectType does not know what to do with DaggerfallWorkshop.Game.Serialization.SerializablePlayer
DaggerfallWorkshop.Game.Serialization.SerializableStateManager.GetStatefulGameObjectType (DaggerfallWorkshop.Game.Serialization.ISerializableGameObject sgObj) (at Assets/Scripts/Game/Serialization/SerializableStateManager.cs:495)
DaggerfallWorkshop.Game.Serialization.SerializableStateManager.DeregisterStatefulGameObject (DaggerfallWorkshop.Game.Serialization.ISerializableGameObject serializableObject) (at Assets/Scripts/Game/Serialization/SerializableStateManager.cs:263)
DaggerfallWorkshop.Game.Serialization.SaveLoadManager.DeregisterSerializableGameObject (DaggerfallWorkshop.Game.Serialization.ISerializableGameObject serializableObject) (at Assets/Scripts/Game/Serialization/SaveLoadManager.cs:553)
DaggerfallWorkshop.Game.Serialization.SerializablePlayer.OnDestroy () (at Assets/Scripts/Game/Serialization/SerializablePlayer.cs:88)
```

I am not familiar with this segment of the codebase atm to resolve this further on my own so I will leave that to the professionals to decide.
