### PR TITLE
added: `StreamingWorld` unregisters events on `OnDestroy()`

### DIFF
--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -232,6 +232,12 @@ namespace DaggerfallWorkshop
             StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
         }
 
+        void OnDestroy()
+        {
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
         void Update()
         {
             // Cannot proceed until ready and player is set


### PR DESCRIPTION
# What

`OnDestroy()` added so `StreamingWorld` can unregister it's events. That's all.

# Why

`StreamingWorld` registers events (`+=`) on `Awake` but was never unregistering them back (`-=`). This was probably never an issue until #2442 where `DaggerfallUnityGame` scene can be loaded and unloaded back and forth for testing purposes.

# Results

`StreamingWorld` cleans up after itself.