### PR TITLE
added: `ModManager.OnDestroy()` to unload loaded asset bundles

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -158,6 +158,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             }
         }
 
+        void OnDestroy()
+        {
+            foreach (Mod mod in mods)
+                mod.UnloadAssetBundle(unloadAllObjects: true);
+        }
+
         #endregion
 
         #region Public Methods


### PR DESCRIPTION
# What

 `OnDestroy()` added to unload asset bundles from `List<Mod> mods;`. That's all.

# Why
#2442, for better or worse, requires that all scripts clean up after themselves

# Results

Destroying a `ModManager` will unload asset bundles associated with loaded mods.