### PR TITLE
RAII compliance for all static events

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
@@ -34,6 +34,11 @@ namespace Wenzil.Console
             DaggerfallWorkshop.Game.InputManager.OnSavedKeyBinds += GetConsoleKeyBind;
         }
 
+        void OnDestroy()
+        {
+            DaggerfallWorkshop.Game.InputManager.OnSavedKeyBinds -= GetConsoleKeyBind;
+        }
+
         void OnEnable()
         {
             DaggerfallWorkshop.Game.InputManager.OnLoadedKeyBinds += GetConsoleKeyBind;

--- a/Assets/Scripts/Game/AmbientEffectsPlayer.cs
+++ b/Assets/Scripts/Game/AmbientEffectsPlayer.cs
@@ -93,6 +93,15 @@ namespace DaggerfallWorkshop.Game
             DaggerfallVidPlayerWindow.OnVideoEnd += AmbientEffectsPlayer_OnVideoEnd;
         }
 
+        void OnDestroy()
+        {
+            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
+            PlayerGPS.OnExitLocationRect -= PlayerGPS_OnExitLocationRect;
+
+            DaggerfallVidPlayerWindow.OnVideoStart -= AmbientEffectsPlayer_OnVideoStart;
+            DaggerfallVidPlayerWindow.OnVideoEnd -= AmbientEffectsPlayer_OnVideoEnd;
+        }
+
         void OnDisable()
         {
             rainLoop = null;

--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -365,6 +365,11 @@ namespace DaggerfallWorkshop.Game
             SetupSingleton();
         }
 
+        void OnDestroy()
+        {
+            Questing.Actions.GivePc.OnOfferPending -= GivePc_OnOfferPending;
+        }
+
         void Start()
         {
             // Post start message

--- a/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
+++ b/Assets/Scripts/Game/Entities/DaggerfallEntity.cs
@@ -292,6 +292,16 @@ namespace DaggerfallWorkshop.Game.Entity
 
         #endregion
 
+        #region Destructors
+
+        ~DaggerfallEntity()
+        {
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
+        #endregion
+
         #region Abstract Methods
 
         /// <summary>

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -213,6 +213,18 @@ namespace DaggerfallWorkshop.Game.Entity
 
         #endregion
 
+        #region Destructors
+
+        ~PlayerEntity()
+        {
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+            OnExhausted -= PlayerEntity_OnExhausted;
+            PlayerGPS.OnExitLocationRect -= PlayerGPS_OnExitLocationRect;
+            DaggerfallTravelPopUp.OnPostFastTravel -= DaggerfallTravelPopUp_OnPostFastTravel;
+        }
+
+        #endregion
+
         #region Public Methods
 
         public bool GetSkillRecentlyIncreased(DFCareer.Skills skill)

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -50,6 +50,11 @@ namespace DaggerfallWorkshop.Game.Guilds
             GuildConsoleCommands.RegisterCommands();
         }
 
+        ~GuildManager()
+        {
+            QuestMachine.OnQuestEnded -= QuestMachine_OnQuestEnded;
+        }
+
         public void QuestMachine_OnQuestEnded(Quest quest)
         {
             if (quest.QuestSuccess)

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectBroker.cs
@@ -103,6 +103,19 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
         #endregion
 
+        #region Destructors
+
+        ~EntityEffectBroker()
+        {
+            SaveLoadManager.OnLoad -= SaveLoadManager_OnLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+            StartGameBehaviour.OnStartGame -= StartGameBehaviour_OnStartGame;
+            DaggerfallTravelPopUp.OnPostFastTravel -= DaggerfallTravelPopUp_OnPostFastTravel;
+            DaggerfallCourtWindow.OnEndPrisonTime -= DaggerfallCourtWindow_OnEndPrisonTime;
+        }
+
+        #endregion
+
         #region Unity
 
         void Start()

--- a/Assets/Scripts/Game/Player/CameraRecoiler.cs
+++ b/Assets/Scripts/Game/Player/CameraRecoiler.cs
@@ -61,6 +61,13 @@ namespace DaggerfallWorkshop.Game
             DaggerfallCourtWindow.OnCourtScreen += DaggerfallCourtWindow_OnCourtScreen;
         }
 
+        void OnDestroy()
+        {
+            StreamingWorld.OnInitWorld -= StreamingWorld_OnInitWorld;
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            DaggerfallCourtWindow.OnCourtScreen -= DaggerfallCourtWindow_OnCourtScreen;
+        }
+
         void Update()
         {
             if (GetRecoilSetting(DaggerfallUnity.Settings.CameraRecoilStrength) == CameraRecoilSetting.Off ||

--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -119,6 +119,11 @@ namespace DaggerfallWorkshop.Game
             SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
         }
 
+        void OnDestroy()
+        {
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+        }
+
         /// <summary>
         /// Determines what Height-changing action should be taken based on player's input and PlayerMotor.IsRiding
         /// </summary>

--- a/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
+++ b/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
@@ -61,6 +61,14 @@ namespace DaggerfallWorkshop.Game
             DaggerfallHUD.OnLargeHUDToggle += DaggerfallHUD_OnLargeHUDToggle;
         }
 
+        void OnDestroy()
+        {
+            StreamingWorld.OnInitWorld -= StreamingWorld_OnInitWorld;
+            SaveLoadManager.OnLoad -= SaveLoadManager_OnLoad;
+            DaggerfallCourtWindow.OnCourtScreen -= DaggerfallCourtWindow_OnCourtScreen;
+            DaggerfallHUD.OnLargeHUDToggle -= DaggerfallHUD_OnLargeHUDToggle;
+        }
+
         void Update()
         {
             if (GameManager.IsGamePaused)

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -322,6 +322,12 @@ namespace DaggerfallWorkshop.Game
             underwaterFog = new UnderwaterFog();
         }
 
+        void OnDestroy()
+        {
+            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
+            EntityEffectBroker.OnNewMagicRound -= EntityEffectBroker_OnNewMagicRound;
+        }
+
         void Update()
         {            
             // Track which dungeon block player is inside of

--- a/Assets/Scripts/Game/PlayerMotor.cs
+++ b/Assets/Scripts/Game/PlayerMotor.cs
@@ -271,6 +271,12 @@ namespace DaggerfallWorkshop.Game
             SaveLoadManager.OnStartLoad += SaveLoadManager_OnStartLoad;
             StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
         }
+
+        void OnDestroy()
+        {
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
       
         void FixedUpdate()
         {

--- a/Assets/Scripts/Game/Questing/Actions/CreateFoe.cs
+++ b/Assets/Scripts/Game/Questing/Actions/CreateFoe.cs
@@ -58,6 +58,15 @@ namespace DaggerfallWorkshop.Game.Questing
             StreamingWorld.OnInitWorld += StreamingWorld_OnInitWorld;
         }
 
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            PlayerEnterExit.OnTransitionDungeonExterior -= PlayerEnterExit_OnTransitionExterior;
+            PlayerEnterExit.OnTransitionExterior -= PlayerEnterExit_OnTransitionExterior;
+            StreamingWorld.OnInitWorld -= StreamingWorld_OnInitWorld;
+        }
+
         public override void InitialiseOnSet()
         {
             lastSpawnTime = 0;

--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -85,6 +85,11 @@ namespace DaggerfallWorkshop.Game.Questing
             QuestMachine.OnQuestStarted += QuestMachine_OnQuestStarted;
         }
 
+        ~QuestListsManager()
+        {
+            QuestMachine.OnQuestStarted -= QuestMachine_OnQuestStarted;
+        }
+
         public void QuestMachine_OnQuestStarted(Quest quest)
         {
             // Record that this quest was accepted so it doesn't get offered again.

--- a/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
+++ b/Assets/Scripts/Game/Serialization/PrintScreenManager.cs
@@ -60,6 +60,11 @@ namespace DaggerfallWorkshop.Game.Serialization
             GetPrintScreenKeyBind();
         }
 
+        void OnDestroy()
+        {
+            DaggerfallWorkshop.Game.InputManager.OnSavedKeyBinds -= GetPrintScreenKeyBind;
+        }
+
         void Update ()
         {
             if (DaggerfallUI.Instance.HotkeySequenceProcessed == HotkeySequence.HotkeySequenceProcessStatus.NotFound)

--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -179,6 +179,11 @@ namespace DaggerfallWorkshop.Game
             PlayerEnterExit.OnTransitionDungeonInterior += PlayerEnterExit_OnTransitionDungeonInterior;
         }
 
+        void OnDestroy()
+        {
+            PlayerEnterExit.OnTransitionDungeonInterior -= PlayerEnterExit_OnTransitionDungeonInterior;
+        }
+
         void Update()
         {
             UpdateSong(false);

--- a/Assets/Scripts/Game/StateManager.cs
+++ b/Assets/Scripts/Game/StateManager.cs
@@ -62,6 +62,15 @@ namespace DaggerfallWorkshop.Game
             PlayerDeath.OnPlayerDeath               += PlayerDeath_OnPlayerDeathHandler;
         }
 
+        ~StateManager()
+        {
+            DaggerfallUI.UIManager.OnWindowChange   -= UIManager_OnWindowChangeHandler;
+            StartGameBehaviour.OnStartMenu          -= StartGameBehaviour_OnStartMenuHandler;
+            StartGameBehaviour.OnStartGame          -= StartGameBehaviour_OnStartGameHandler;
+            SaveLoadManager.OnLoad                  -= SaveLoadManager_OnLoadHandler;
+            PlayerDeath.OnPlayerDeath               -= PlayerDeath_OnPlayerDeathHandler;
+        }
+
         public enum StateTypes
         {
             None,

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -191,7 +191,12 @@ namespace DaggerfallWorkshop.Game
             neighClip = dfAudioSource.GetAudioClip((int)horseSound);
 
             // Init event listener for transitions.
-            PlayerEnterExit.OnPreTransition += new PlayerEnterExit.OnPreTransitionEventHandler(HandleTransition);
+            PlayerEnterExit.OnPreTransition += HandleTransition;
+        }
+
+        void OnDestroy()
+        {
+            PlayerEnterExit.OnPreTransition -= HandleTransition;
         }
 
         // Handle interior/exterior transition events by setting transport mode to Foot.

--- a/Assets/Scripts/Game/UserInterface/HUDActiveSpells.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDActiveSpells.cs
@@ -101,6 +101,17 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #region Public Methods
 
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            EntityEffectBroker.OnNewMagicRound -= UpdateIcons;
+            GameManager.Instance.PlayerEffectManager.OnAssignBundle -= UpdateIcons;
+            GameManager.Instance.PlayerEffectManager.OnRemoveBundle -= UpdateIcons;
+            GameManager.Instance.PlayerEffectManager.OnAddIncumbentState -= UpdateIcons;
+            SaveLoadManager.OnLoad -= SaveLoadManager_OnLoad;
+        }
+
         public override void Update()
         {
             base.Update();

--- a/Assets/Scripts/Game/UserInterface/HUDCompass.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDCompass.cs
@@ -75,6 +75,14 @@ namespace DaggerfallWorkshop.Game.UserInterface
             LoadAssets();
         }
 
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
         public override void Update()
         {
             if (Enabled)

--- a/Assets/Scripts/Game/UserInterface/HUDEscortingNPCFaces.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDEscortingNPCFaces.cs
@@ -53,6 +53,15 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         #region Overrides
 
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            QuestMachine.OnQuestEnded -= QuestMachine_OnQuestEnded;
+            Serialization.SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
         public override void Update()
         {
             base.Update();

--- a/Assets/Scripts/Game/UserInterface/HUDLarge.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDLarge.cs
@@ -135,6 +135,14 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Utility.StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
         }
 
+        public override void Dispose()
+        {
+            base.Dispose();
+            
+            Serialization.SaveLoadManager.OnLoad -= SaveLoadManager_OnLoad;
+            Utility.StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
         void LoadAssets()
         {
             // Main large HUD background

--- a/Assets/Scripts/Game/UserInterface/HUDPlaceMarker.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDPlaceMarker.cs
@@ -46,6 +46,18 @@ namespace DaggerfallWorkshop.Game.UserInterface
             StreamingWorld.OnFloatingOriginChange += StreamingWorld_OnFloatingOriginChange;
         }
 
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            QuestMachine.OnQuestStarted -= QuestMachine_OnQuestStarted;
+            QuestMachine.OnQuestEnded -= QuestMachine_OnQuestEnded;
+            PlayerGPS.OnEnterLocationRect -= PlayerGPS_OnEnterLocationRect;
+            PlayerGPS.OnExitLocationRect -= PlayerGPS_OnExitLocationRect;
+            PlayerGPS.OnMapPixelChanged -= PlayerGPS_OnMapPixelChanged;
+            StreamingWorld.OnFloatingOriginChange -= StreamingWorld_OnFloatingOriginChange;
+        }
+
         public override void Update()
         {
             base.Update();

--- a/Assets/Scripts/Game/UserInterface/HUDQuestDebugger.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDQuestDebugger.cs
@@ -129,6 +129,17 @@ namespace DaggerfallWorkshop.Game.UserInterface
             QuestMachine.OnTick += QuestMachine_OnTick;
         }
 
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            QuestMachine.OnQuestStarted -= QuestMachine_OnQuestStarted;
+            QuestMachine.OnQuestEnded -= QuestMachine_OnQuestEnded;
+            SaveLoadManager.OnLoad -= SaveLoadManager_OnLoad;
+
+            QuestMachine.OnTick -= QuestMachine_OnTick;
+        }
+
         public override void Update()
         {
             base.Update();

--- a/Assets/Scripts/Game/UserInterface/HUDVitals.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDVitals.cs
@@ -121,6 +121,13 @@ namespace DaggerfallWorkshop.Game.UserInterface
             VitalsChangeDetector.OnReset += VitalChangeDetector_OnReset;
         }
 
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            VitalsChangeDetector.OnReset -= VitalChangeDetector_OnReset;
+        }
+
         public void SetAllHorizontalAlignment(HorizontalAlignment alignment)
         {
             healthBar.HorizontalAlignment = alignment;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -283,6 +283,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #endregion
 
+        #region Destructors
+
+        ~DaggerfallInventoryWindow()
+        {
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
+        #endregion
+
         #region Setup Methods
 
         protected override void Setup()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -70,6 +70,16 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #endregion
 
+        #region Destructors
+
+        ~DaggerfallUnityMouseControlsWindow()
+        {
+            // note: is this the the best spot to unregister this event? idk
+            DaggerfallWorkshop.Game.InputManager.OnSavedKeyBinds -= OnUpdateValues;
+        }
+
+        #endregion
+
         #region Unity
 
         public override void Update()

--- a/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
+++ b/Assets/Scripts/Game/Utility/StartGameBehaviour.cs
@@ -121,6 +121,11 @@ namespace DaggerfallWorkshop.Game.Utility
             SaveLoadManager.OnLoad += SaveLoadManager_OnLoad;
         }
 
+        void OnDestroy()
+        {
+            SaveLoadManager.OnLoad -= SaveLoadManager_OnLoad;
+        }
+
         void Update()
         {
             // Restart game using method provided

--- a/Assets/Scripts/Game/WeatherManager.cs
+++ b/Assets/Scripts/Game/WeatherManager.cs
@@ -119,6 +119,7 @@ namespace DaggerfallWorkshop.Game
         {
             StreamingWorld.OnInitWorld -= StreamingWorld_OnInitWorld;
             SaveLoadManager.OnLoad -= SaveLoadManager_OnLoad;
+            PlayerEnterExit.OnRespawnerComplete -= PlayerEnterExit_OnRespawnerComplete;
             PlayerEnterExit.OnTransitionInterior -= OnTransitionToInterior;
             PlayerEnterExit.OnTransitionExterior -= OnTransitionToExterior;
             PlayerEnterExit.OnTransitionDungeonInterior -= OnTransitionToDungeon;

--- a/Assets/Scripts/Internal/DaggerfallSongPlayer.cs
+++ b/Assets/Scripts/Internal/DaggerfallSongPlayer.cs
@@ -77,6 +77,12 @@ namespace DaggerfallWorkshop
             DaggerfallVidPlayerWindow.OnVideoEnd += DaggerfallVidPlayerWindow_OnVideoEnd;
         }
 
+        void OnDestroy()
+        {
+            DaggerfallVidPlayerWindow.OnVideoStart -= DaggerfallVidPlayerWindow_OnVideoStart;
+            DaggerfallVidPlayerWindow.OnVideoEnd -= DaggerfallVidPlayerWindow_OnVideoEnd;
+        }
+
         void Update()
         {
             if (!isImported)

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -266,6 +266,17 @@ namespace DaggerfallWorkshop
 
         #endregion
 
+        #region Destructors
+
+        ~PlayerGPS()
+        {
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            DaggerfallTravelPopUp.OnPostFastTravel -= DaggerfallTravelPopUp_OnPostFastTravel;
+        }
+
+        #endregion
+
         #region Unity
 
         void Awake()

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -232,6 +232,12 @@ namespace DaggerfallWorkshop
             StartGameBehaviour.OnNewGame += StartGameBehaviour_OnNewGame;
         }
 
+        void OnDestroy()
+        {
+            SaveLoadManager.OnStartLoad -= SaveLoadManager_OnStartLoad;
+            StartGameBehaviour.OnNewGame -= StartGameBehaviour_OnNewGame;
+        }
+
         void Update()
         {
             // Cannot proceed until ready and player is set

--- a/Assets/Scripts/Utility/FloatingOrigin.cs
+++ b/Assets/Scripts/Utility/FloatingOrigin.cs
@@ -89,6 +89,11 @@ namespace DaggerfallWorkshop.Utility
             StreamingWorld.OnInitWorld += StreamingWorld_OnInitWorld;
         }
 
+        void OnDestroy()
+        {
+            StreamingWorld.OnInitWorld -= StreamingWorld_OnInitWorld;
+        }
+
         void FixedUpdate()
         {
             // Must have streaming world reference


### PR DESCRIPTION
# What

I scanned the entire codebase for classes that register `static event`s `+=` but never bother to unregister them `-=` once class is destroyed etc. and made sure they do that.

![Screenshot 2022-10-13 233742](https://user-images.githubusercontent.com/3066539/195726984-ce8d2bee-890c-47ba-b64b-e953e0d8e987.png)

# Why

1. I need this for #2442
2. I am 100% positive this caused errors in the past and will cause them in the future, if not fixed

At first I needed this for test setup only. But after digging into the codebase and realizing how prevalent this issue is I convinced myself that this is serious.

I am definitely no fan of programming dogma but RAII makes sense even if we call it differently or none at all. Making sure that resource is allocated (here: event registered) on object construction and then deallocated (here: event unregistered) makes sense on a very practical level - there are always errors somewhere eventually if we don't fancy doing that.

# Results

This PR spans across many files over different domains unfortunately so it will require some additional attention to make sure this wont break anything when merged. If you read the code changes you can see that these are not invasive changes, thankfully. All are either `OnDestroy` or destructor additions - so are vastly safer that most code changes as they won't break existing code execution loops (these calls are managed by Unity engine and CLR).