### PR TITLE
Prevent missile collision from moving entity

### DIFF
--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -184,10 +184,12 @@ namespace DaggerfallWorkshop.Game
             // Setup collider
             myCollider = GetComponent<SphereCollider>();
             myCollider.radius = ColliderRadius;
+            myCollider.isTrigger = true;
 
             // Setup rigidbody
             myRigidbody = GetComponent<Rigidbody>();
             myRigidbody.useGravity = false;
+            myRigidbody.isKinematic = true;
 
             // Use payload when available
             if (payload != null)
@@ -331,16 +333,6 @@ namespace DaggerfallWorkshop.Game
             // Missile collision should only happen once
             if (impactDetected)
                 return;
-
-            // Set my collider to trigger and rigidbody to kinematic immediately after impact
-            // This helps prevent mobiles from walking over low missiles or the missile bouncing off in some other direction
-            // Seems to eliminate the combined worst-case scenario where mobile will "ride" a missile bounce, throwing them high into the air
-            // Now the worst that seems to happen is mobile will "bump" over low missiles occasionally
-            // TODO: Review later and find a better way to eliminate issue other than this quick workaround
-            if (myCollider)
-                myCollider.isTrigger = true;
-            if (myRigidbody)
-                myRigidbody.isKinematic = true;
 
             // Play spell impact animation, this replaces spell missile animation
             if (elementType != ElementTypes.None && targetType != TargetTypes.ByTouch)


### PR DESCRIPTION
In some cases spell or arrow missiles could cause their targets to bump over them as mentioned in the code comment. Setting the collider to trigger and the rigid body to kinematic at start seemed to fix this without causing any other issues in my tests.