### PR TITLE
added: `DaggerfallStaticDoors.OnDrawGizmosSelected()` to debug door trigger placements

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
+++ b/Assets/Scripts/Internal/DaggerfallStaticDoors.cs
@@ -32,26 +32,6 @@ namespace DaggerfallWorkshop
 
         void Start()
         {
-            //// Debug trigger placement at start
-            //for (int i = 0; i < Doors.Length; i++)
-            //{
-            //    Quaternion buildingRotation = GameObjectHelper.QuaternionFromMatrix(Doors[i].buildingMatrix);
-            //    Vector3 doorNormal = buildingRotation * Doors[i].normal;
-            //    Quaternion facingRotation = Quaternion.LookRotation(doorNormal, Vector3.up);
-
-            //    GameObject go = new GameObject();
-            //    go.name = "DoorTrigger";
-
-            //    BoxCollider c = go.AddComponent<BoxCollider>();
-            //    c.size = Doors[i].size;
-            //    go.transform.parent = transform;
-            //    go.transform.position = transform.rotation * Doors[i].buildingMatrix.MultiplyPoint3x4(Doors[i].centre);
-            //    go.transform.position += transform.position;
-            //    go.transform.rotation = facingRotation;
-            //    c.isTrigger = true;
-            //}
-            //Debug.LogFormat("Added {0} door triggers to scene", Doors.Length);
-
             // Promote dungeon exit doors to full physical colliders rather than just virtual trigger volumes
             // This step is based on the following:
             //  * Daggerfall uses a mixture of discrete exit quads (modelid 70300) and exits baked into surrounding geometry (e.g. modelid 58051)
@@ -86,6 +66,32 @@ namespace DaggerfallWorkshop
                 }
             }
         }
+
+#if UNITY_EDITOR
+        void OnDrawGizmosSelected()
+        {
+            // Debug door trigger placement
+            var popMatrix = Gizmos.matrix;
+            {
+                Gizmos.color = new Color(0, 1, 1, 0.5f);
+                int length = Doors.Length;
+                for (int i = 0; i < length; i++)
+                {
+                    StaticDoor door = Doors[i];
+                    Quaternion buildingRotation = GameObjectHelper.QuaternionFromMatrix(door.buildingMatrix);
+                    Vector3 doorNormal = buildingRotation * door.normal;
+                    Quaternion facingRotation = Quaternion.LookRotation(doorNormal, Vector3.up);
+                    Vector3 doorPos = transform.rotation * door.buildingMatrix.MultiplyPoint3x4(door.centre) + transform.position;
+                    
+                    Gizmos.matrix = Matrix4x4.TRS(doorPos, facingRotation, door.size);
+                    Gizmos.DrawCube(Vector3.zero, new Vector3(1, 1, 0));
+                    Gizmos.DrawWireCube(Vector3.zero, new Vector3(1, 1, 0));
+                    Gizmos.DrawRay(Vector3.zero, new Vector3(0, 0, 0.5f));
+                }
+            }
+            Gizmos.matrix = popMatrix;
+        }
+#endif
 
         /// <summary>
         /// Check for a door hit in world space.


### PR DESCRIPTION
# What

> This is small and unimportant PR. You can close it rn if you see it of no worth to the project.

Moves commented out "Debug trigger placement at start" code block from `Start()` and puts it into `OnDrawGizmosSelected()`

# Why

I needed to see where the door triggers were... the code was ready written already, so.

# Results

Door gizmos shows up when `DaggerfallStaticDoors` instance is selected only, so it wont pollute the screen nor slow down the editor everywhere. `#if UNITY_EDITOR` makes sure this won't ever end up in a build.

![Screenshot 2022-10-18 232154](https://user-images.githubusercontent.com/3066539/196818826-0cbe166c-2281-4c33-a8f7-d70b14d06827.png)

