### PR TITLE
Allow access to tagged spells even without a spellbook

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -572,7 +572,13 @@ namespace DaggerfallWorkshop.Game
                 case DaggerfallUIMessages.dfuiOpenSpellBookWindow:
                     if (!GameManager.Instance.PlayerSpellCasting.IsPlayingAnim)
                     {
-                        if (GameManager.Instance.PlayerEntity.Items.Contains(Items.ItemGroups.MiscItems, (int)Items.MiscItems.Spellbook))
+                        bool hasSpellbook = GameManager.Instance.PlayerEntity.Items.Contains(Items.ItemGroups.MiscItems, (int)Items.MiscItems.Spellbook);
+                        bool hasTaggedSpells()
+                        {
+                            EffectBundleSettings[] spells = GameManager.Instance.PlayerEntity.GetSpells();
+                            return spells == null ? false : spells.Any(spell => spell.Tag != null);
+                        }
+                        if (hasSpellbook || hasTaggedSpells())
                             uiManager.PushWindow(dfSpellBookWindow);
                         else
                             AddHUDText(TextManager.Instance.GetLocalizedText("noSpellbook"));

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -240,6 +240,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     spellBookIndices = new List<int>();
                     PopulateSpellsList(spellbook.ToList(), GameManager.Instance.PlayerEntity.CurrentMagicka);
+                    // in case a mod overrode PopulateSpellsList() with a method that doesn't update spellBookIndices
+                    if (spellBookIndices.Count == 0)
+                    {
+                        for (int i = 0; i < spellsListBox.Count; i++)
+                            spellBookIndices.Add(i);
+                    }
                 }
             }
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallSpellBookWindow.cs
@@ -238,7 +238,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 EffectBundleSettings[] spellbook = GameManager.Instance.PlayerEntity.GetSpells();
                 if (spellbook != null)
                 {
-                    spellBookIndices = PopulateSpellsList(spellbook.ToList(), GameManager.Instance.PlayerEntity.CurrentMagicka);
+                    spellBookIndices = new List<int>();
+                    PopulateSpellsList(spellbook.ToList(), GameManager.Instance.PlayerEntity.CurrentMagicka);
                 }
             }
 
@@ -255,11 +256,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
         }
 
-        protected virtual List<int> PopulateSpellsList(List<EffectBundleSettings> spells, int? availableSpellPoints = null)
+        protected virtual void PopulateSpellsList(List<EffectBundleSettings> spells, int? availableSpellPoints = null)
         {
             bool hasSpellbook = GameManager.Instance.PlayerEntity.Items.Contains(Items.ItemGroups.MiscItems, (int)Items.MiscItems.Spellbook);
             int spellIndex = 0;
-            List<int> spellIndices = new List<int>();
 
             foreach (EffectBundleSettings spell in spells)
             {
@@ -278,7 +278,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     // Display spell name and cost
                     ListBox.ListItem listItem;
                     spellsListBox.AddItem(string.Format("{0} - {1}", spellPointCost, spell.Name), out listItem);
-                    spellIndices.Add(spellIndex);
+                    spellBookIndices?.Add(spellIndex);
                     if (availableSpellPoints != null && availableSpellPoints < spellPointCost)
                     {
                         // Desaturate unavailable spells
@@ -291,7 +291,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 }
                 spellIndex++;
             }
-            return spellIndices;
         }
 
         protected virtual void LoadSpellsForSale()


### PR DESCRIPTION

Fix would be relatively simple if DaggerfallSpellBookWindow.spellListBox and PlayerEntity.spellbook didn't use the same indices.
To be able to only show a subset of the known spells, some index mapping (spellBookIndices list) has been added.

Forums: https://forums.dfworkshop.net/viewtopic.php?t=5924