### PR TITLE
Crouch to Stand Eye-height Bug, Quick Fix

### DIFF
--- a/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
+++ b/Assets/Scripts/Game/Player/PlayerHeightChanger.cs
@@ -268,7 +268,7 @@ namespace DaggerfallWorkshop.Game
 
             if (playerMotor.IsCrouching)
             {
-                standingHeightAdjustment = 0;
+                standingHeightAdjustment = 0 - eyeHeight * 2; // Subtracting eyeHeight * 2 fixes crouch->stand height increase bug
                 float targetHeight = CurrentControllerStandingHeight;
                 prevCamLevel = prevHeight / 2f;
                 targetCamLevel = ControllerHeightChange(targetHeight - prevHeight);


### PR DESCRIPTION
When character crouches then stands the camera is raised to full height instead of eye height.

A quick fix for this is to subtract eyeHeight * 2 from standingHeightAdjustment in PlayerHeightChanger.cs line 271:

standingHeightAdjustment = 0 - eyeHeight * 2;