### PR TITLE
Immediate Ambient Light Updating To Prevent Flicker On Transition To …

### DIFF
--- a/Assets/Scripts/Game/PlayerAmbientLight.cs
+++ b/Assets/Scripts/Game/PlayerAmbientLight.cs
@@ -48,6 +48,7 @@ namespace DaggerfallWorkshop.Game
         
         private void OnTransitionToExterior(PlayerEnterExit.TransitionEventArgs args)
         {
+            sunlightManager.Update(); // Ensure that SunlightManager is in a ready state
             UpdateAmbientLight();
         }
 
@@ -73,7 +74,7 @@ namespace DaggerfallWorkshop.Game
             }
             else if (playerEnterExit.IsPlayerInside && !playerEnterExit.IsPlayerInsideDungeon)
             {
-                if (DaggerfallUnity.Instance.WorldTime.Now.IsNight && !playerEnterExit.IsPlayerInsideTavern) // Interiors of taverns are always welcomingly bright
+                if (DaggerfallUnity.Instance.WorldTime.Now.IsNight)
                     targetAmbientLight = (DaggerfallUnity.Settings.AmbientLitInteriors) ? InteriorNightAmbientLight_AmbientOnly : InteriorNightAmbientLight;
                 else
                     targetAmbientLight = (DaggerfallUnity.Settings.AmbientLitInteriors) ? InteriorAmbientLight_AmbientOnly : InteriorAmbientLight;

--- a/Assets/Scripts/Game/PlayerAmbientLight.cs
+++ b/Assets/Scripts/Game/PlayerAmbientLight.cs
@@ -39,14 +39,16 @@ namespace DaggerfallWorkshop.Game
         Color targetAmbientLight;
         bool fadeRunning;
 
-        public static PlayerAmbientLight Instance = null;
-
         void Start()
         {
-            Instance = this;
-
+            PlayerEnterExit.OnTransitionExterior += OnTransitionToExterior;
             playerEnterExit = GetComponent<PlayerEnterExit>();
             sunlightManager = GameManager.Instance.SunlightManager;
+        }
+        
+        private void OnTransitionToExterior(PlayerEnterExit.TransitionEventArgs args)
+        {
+            UpdateAmbientLight();
         }
 
         void Update()

--- a/Assets/Scripts/Game/PlayerAmbientLight.cs
+++ b/Assets/Scripts/Game/PlayerAmbientLight.cs
@@ -38,7 +38,6 @@ namespace DaggerfallWorkshop.Game
         SunlightManager sunlightManager;
         Color targetAmbientLight;
         bool fadeRunning;
-        float timeOfLastAmbientLightUpdate;
 
         public static PlayerAmbientLight Instance = null;
 
@@ -54,16 +53,17 @@ namespace DaggerfallWorkshop.Game
         {
             if (UnityEngine.RenderSettings.ambientLight != targetAmbientLight && !fadeRunning)
                 StartCoroutine(ChangeAmbientLight());
-            else if (Time.realtimeSinceStartup - timeOfLastAmbientLightUpdate > 1f / 3f) // Might be better to update every frame instead of periodically
-                UpdateAmbientLight();
+        }
+        
+        void LateUpdate()
+        {
+            UpdateAmbientLight(); // Would be better to call this just prior to world frame rendering
         }
 
         public void UpdateAmbientLight()
         {
             if (!playerEnterExit)
                 return;
-
-            timeOfLastAmbientLightUpdate = Time.realtimeSinceStartup;
 
             if (!playerEnterExit.IsPlayerInside && !playerEnterExit.IsPlayerInsideDungeon)
             {

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -841,6 +841,9 @@ namespace DaggerfallWorkshop.Game
             // Perform transition
             BuildingTransitionExteriorLogic();
 
+            // Immediately update ambient lighting (called again in SaveLoadManager.RestoreCachedSceneNextFrame method)
+            PlayerAmbientLight.Instance.UpdateAmbientLight(true);
+
             // Increase fade time if outside world not ready
             // This indicates a first-time transition on fresh load
             float fadeTime = 0.7f;

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -880,7 +880,7 @@ namespace DaggerfallWorkshop.Game
             // Fire event
             RaiseOnTransitionExteriorEvent();
 
-            // Immediately update ambient lighting for this frame (called again in SaveLoadManager.RestoreCachedSceneNextFrame method)
+            // Immediately update ambient lighting
             PlayerAmbientLight.Instance.UpdateAmbientLight();
         }
 

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -879,9 +879,6 @@ namespace DaggerfallWorkshop.Game
 
             // Fire event
             RaiseOnTransitionExteriorEvent();
-
-            // Immediately update ambient lighting
-            PlayerAmbientLight.Instance.UpdateAmbientLight();
         }
 
         #endregion

--- a/Assets/Scripts/Game/PlayerEnterExit.cs
+++ b/Assets/Scripts/Game/PlayerEnterExit.cs
@@ -841,9 +841,6 @@ namespace DaggerfallWorkshop.Game
             // Perform transition
             BuildingTransitionExteriorLogic();
 
-            // Immediately update ambient lighting (called again in SaveLoadManager.RestoreCachedSceneNextFrame method)
-            PlayerAmbientLight.Instance.UpdateAmbientLight(true);
-
             // Increase fade time if outside world not ready
             // This indicates a first-time transition on fresh load
             float fadeTime = 0.7f;
@@ -882,6 +879,9 @@ namespace DaggerfallWorkshop.Game
 
             // Fire event
             RaiseOnTransitionExteriorEvent();
+
+            // Immediately update ambient lighting for this frame (called again in SaveLoadManager.RestoreCachedSceneNextFrame method)
+            PlayerAmbientLight.Instance.UpdateAmbientLight();
         }
 
         #endregion

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -588,7 +588,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             // Restore the scene from cache
             stateManager.RestoreCachedScene(sceneName);
 
-            PlayerAmbientLight.Instance.UpdateAmbientLight(true); // Immediately update ambient lighting
+            PlayerAmbientLight.Instance.UpdateAmbientLight();
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -587,6 +587,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             yield return new WaitForEndOfFrame();
             // Restore the scene from cache
             stateManager.RestoreCachedScene(sceneName);
+
+            PlayerAmbientLight.Instance.UpdateAmbientLight(true); // Immediately update ambient lighting
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
+++ b/Assets/Scripts/Game/Serialization/SaveLoadManager.cs
@@ -587,8 +587,6 @@ namespace DaggerfallWorkshop.Game.Serialization
             yield return new WaitForEndOfFrame();
             // Restore the scene from cache
             stateManager.RestoreCachedScene(sceneName);
-
-            PlayerAmbientLight.Instance.UpdateAmbientLight();
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/SunlightManager.cs
+++ b/Assets/Scripts/Game/SunlightManager.cs
@@ -64,7 +64,7 @@ namespace DaggerfallWorkshop.Game
                 myLight.shadows = LightShadows.None;
         }
 
-        void Update()
+        public void Update()
         {
             // Do nothing if not ready
             if (!ReadyCheck())


### PR DESCRIPTION
…Exterior

The purpose of this PR is to eliminate the glitchy flicker you sometimes get when exiting a building.

What the world outside looks like for a few frames before lighting gets updated:
![transition_to_exterior_first_few_frames](https://user-images.githubusercontent.com/115361770/199148073-e6ae9e3c-72d9-4377-9c57-43645da6eaae.png)

And after:
![transition_to_exterior_after](https://user-images.githubusercontent.com/115361770/199148103-6f4f540f-aa00-4a46-a75d-e23c9d591d7a.png)

Immediate calls to PlayerAmbientLight.UpdateAmbientLight solves this.

The proposed code calls that method twice: once in the current frame and again on the next. The combination of the two calls completely eliminates all flickering as far as I can tell (I disabled HUD fade in so I could see every frame).