### PR TITLE
Fix 'unaccepted keys' not being allowed for bindings in control settings

### DIFF
--- a/Assets/Scripts/Game/InputManager.cs
+++ b/Assets/Scripts/Game/InputManager.cs
@@ -1119,30 +1119,30 @@ namespace DaggerfallWorkshop.Game
             get => GetAnyKeyUpIgnoreAxisBinds() != KeyCode.None;
         }
 
-        public KeyCode GetAnyKeyDown()
+        public KeyCode GetAnyKeyDown(bool allowUnaccepted = false)
         {
             foreach (KeyCode k in KeyCodeList)
-                if (!unacceptedAnyKeys.Contains((int)k)
+                if ((allowUnaccepted || !unacceptedAnyKeys.Contains((int)k))
                     && GetUnaryKey(k, getKeyDownMethod, true, false))
                     return k;
 
             return KeyCode.None;
         }
 
-        public KeyCode GetAnyKeyUp()
+        public KeyCode GetAnyKeyUp(bool allowUnaccepted = false)
         {
             foreach (KeyCode k in KeyCodeList)
-                if (!unacceptedAnyKeys.Contains((int)k)
+                if ((allowUnaccepted || !unacceptedAnyKeys.Contains((int)k))
                     && GetUnaryKey(k, getKeyUpMethod, false, false))
                     return k;
 
             return KeyCode.None;
         }
 
-        public KeyCode GetAnyKeyDownIgnoreAxisBinds()
+        public KeyCode GetAnyKeyDownIgnoreAxisBinds(bool allowUnaccepted = false)
         {
             foreach (KeyCode k in KeyCodeList)
-                if (!unacceptedAnyKeys.Contains((int)k)
+                if ((allowUnaccepted || !unacceptedAnyKeys.Contains((int)k))
                     && !IsUsedInAxisBinding(k)
                     && GetUnaryKey(k, getKeyDownMethod, true, false))
                     return k;
@@ -1151,10 +1151,10 @@ namespace DaggerfallWorkshop.Game
         }
 
 
-        public KeyCode GetAnyKeyUpIgnoreAxisBinds()
+        public KeyCode GetAnyKeyUpIgnoreAxisBinds(bool allowUnaccepted = false)
         {
             foreach (KeyCode k in KeyCodeList)
-                if (!unacceptedAnyKeys.Contains((int)k)
+                if ((allowUnaccepted || !unacceptedAnyKeys.Contains((int)k))
                     && !IsUsedInAxisBinding(k)
                     && GetUnaryKey(k, getKeyUpMethod, false, false))
                     return k;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallControlsWindow.cs
@@ -389,7 +389,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             button.Label.Text = "";
             yield return new WaitForSecondsRealtime(0.05f);
 
-            while ((code1 = InputManager.Instance.GetAnyKeyDownIgnoreAxisBinds()) == KeyCode.None)
+            while ((code1 = InputManager.Instance.GetAnyKeyDownIgnoreAxisBinds(true)) == KeyCode.None)
             {
                 setWaitingForInput(true);
                 yield return null;
@@ -397,9 +397,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             yield return new WaitForSecondsRealtime(0.05f);
 
-            while ((code2 = InputManager.Instance.GetAnyKeyDownIgnoreAxisBinds()) == KeyCode.None)
+            while ((code2 = InputManager.Instance.GetAnyKeyDownIgnoreAxisBinds(true)) == KeyCode.None)
             {
-                if (InputManager.Instance.GetAnyKeyUpIgnoreAxisBinds() != KeyCode.None)
+                if (InputManager.Instance.GetAnyKeyUpIgnoreAxisBinds(true) != KeyCode.None)
                     break;
 
                 setWaitingForInput(true);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallJoystickControlsWindow.cs
@@ -552,8 +552,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             button.Label.Text = "";
             yield return new WaitForSecondsRealtime(0.05f);
 
-            while ((!isAxisAction && (code = InputManager.Instance.GetAnyKeyDownIgnoreAxisBinds()) == KeyCode.None)
-                || (isAxisAction && (code = InputManager.Instance.GetAnyKeyDown()) == KeyCode.None))
+            while ((!isAxisAction && (code = InputManager.Instance.GetAnyKeyDownIgnoreAxisBinds(true)) == KeyCode.None)
+                || (isAxisAction && (code = InputManager.Instance.GetAnyKeyDown(true)) == KeyCode.None))
             {
                 SetWaitingForInput(true);
                 yield return null;


### PR DESCRIPTION
From Pango's [comment](https://github.com/Interkarma/daggerfall-unity/issues/2428#issuecomment-1301489156).

My apologies for not checking this earlier! Since it does break binding things as simple as "Shift" back to sprint for example, I'm not sure if this warrants a hotfix release. I do know as a workaround, you can simply rebind in the Keybinds.txt file.