### PR TITLE
Taverns too dim at night when using Simplified Interior Lighting option

### DIFF
--- a/Assets/Scripts/Game/PlayerAmbientLight.cs
+++ b/Assets/Scripts/Game/PlayerAmbientLight.cs
@@ -65,7 +65,10 @@ namespace DaggerfallWorkshop.Game
                 }
                 else if (playerEnterExit.IsPlayerInside && !playerEnterExit.IsPlayerInsideDungeon)
                 {
-                    if (DaggerfallUnity.Instance.WorldTime.Now.IsNight)
+                    // Forced brightness when Simplified Interior Lighting is enabled and player is inside a tavern at night
+                    bool forceBright = DaggerfallUnity.Settings.AmbientLitInteriors && playerEnterExit.IsPlayerInsideTavern;
+
+                    if (DaggerfallUnity.Instance.WorldTime.Now.IsNight && !forceBright)
                         targetAmbientLight = (DaggerfallUnity.Settings.AmbientLitInteriors) ? InteriorNightAmbientLight_AmbientOnly : InteriorNightAmbientLight;
                     else
                         targetAmbientLight = (DaggerfallUnity.Settings.AmbientLitInteriors) ? InteriorAmbientLight_AmbientOnly : InteriorAmbientLight;


### PR DESCRIPTION
Taverns are lively places that should be well lit and welcoming all hours of the day.

![tavern_dim](https://user-images.githubusercontent.com/115361770/199843435-1ce73072-9e4e-4e0c-8db4-eed2a7c15a71.png)
Inside of tavern at night when Simplified Interior Lighting is enabled

![tavern_lit](https://user-images.githubusercontent.com/115361770/199843477-1ccc23e1-b4b2-4d88-bd00-cfd64b18274c.png)
How it should look (in my opinion) so players feel like taverns are a safe haven from the night