### PR TITLE
Scale sky panels according to current fov relative to start-up fov

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -526,7 +526,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.GUIFilterMode = guiFilterMode.ScrollIndex;
             DaggerfallUnity.Settings.VideoFilterMode = videoFilterMode.ScrollIndex;
 
-            DaggerfallUnity.Settings.FieldOfView = fovSlider.Value;
+            GameManager.Instance.MainCamera.fieldOfView = DaggerfallUnity.Settings.FieldOfView = fovSlider.Value;
             DaggerfallUnity.Settings.TerrainDistance = terrainDistance.Value;
             DaggerfallUnity.Settings.ShadowResolutionMode = shadowResolutionMode.ScrollIndex;
             DaggerfallUnity.Settings.DungeonLightShadows = dungeonLightShadows.IsChecked;

--- a/Assets/Scripts/Internal/DaggerfallSky.cs
+++ b/Assets/Scripts/Internal/DaggerfallSky.cs
@@ -199,9 +199,11 @@ namespace DaggerfallWorkshop
 
         private void UpdateSkyRects()
         {
+            float relativeZoom = Mathf.Tan((DaggerfallUnity.Settings.FieldOfView * 0.50f) * Mathf.Deg2Rad) / Mathf.Tan((mainCamera.fieldOfView * 0.50f) * Mathf.Deg2Rad);
+
             Vector3 angles = mainCamera.transform.eulerAngles;
-            float width = (int)(Screen.width * skyScale);
-            float height = Screen.height * skyScale;
+            float width = (int)(Screen.width * skyScale * relativeZoom);
+            float height = Screen.height * skyScale * relativeZoom;
             float halfScreenWidth = Screen.width * 0.5f;
 
             // Scroll left-right

--- a/Assets/Scripts/Internal/DaggerfallSky.cs
+++ b/Assets/Scripts/Internal/DaggerfallSky.cs
@@ -56,7 +56,8 @@ namespace DaggerfallWorkshop
         const int skyNativeWidth = 512;         // Native image width of sky image
         const int skyNativeHalfWidth = 256;     // Half native image width
         const int skyNativeHeight = 220;        // Native image height
-        const float skyScale = 1.3f;            // Scale of sky image relative to display area
+        const float minSkyScale = 1.3f;         // Minimum scale of sky image relative to display area
+        float skyScale = minSkyScale;           // Current scale of sky image relative to display area
 
         DaggerfallUnity dfUnity;
         WeatherManager weatherManager;
@@ -91,6 +92,15 @@ namespace DaggerfallWorkshop
         public Camera SkyCamera
         {
             get { return myCamera; }
+        }
+
+        /// <summary>
+        /// Gets or sets scale of sky image relative to display area.
+        /// </summary>
+        public float SkyScale
+        {
+            get { return skyScale; }
+            set { skyScale = Mathf.Clamp(value, minSkyScale, minSkyScale * 100); }
         }
 
         void Start()


### PR DESCRIPTION
The `DaggerfallSky.skyScale` member needs to be accessible for mods that would like to alter zoom level.

For example, if a modder wanted to apply zoom while bow is drawn and held the skywall backdrop needs to be scaled in addition to modifying the fov for proper zoom effect.

A more compete solution for this would be the addition of an FPSZoom class to provide an obvious API for zoom behavior.

I would be interested in implementing such a class just let me know if there's an interest.

**UPDATE:**

Actually, exposing that field probably isn't necessary.

DaggerfallSky can scale its panels according to fov in a way that doesn't change the way the backdrop looks when no fov modifiers are applied.

This can be done by scaling the panels by the following factor:

```
float relativeZoom = Mathf.Tan((DaggerfallUnity.Settings.FieldOfView * 0.50f) * Mathf.Deg2Rad) / Mathf.Tan((mainCamera.fieldOfView * 0.50f) * Mathf.Deg2Rad);

float width = (int)(Screen.width * skyScale * relativeZoom); // Panel width
float height = Screen.height * skyScale * relativeZoom; // Panel height

```
This works because when main camera fov is the same as game settings (initial) fov you get a `relativeZoom` of 1.0f (no change). The only limitation is on zooming out because the panels get smaller, but zooming in from initial pov is unlimited and accurate.