### PR TITLE
re-work caching, de-couple gfx change from caching

### DIFF
--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -652,28 +652,22 @@ namespace DaggerfallWorkshop.Game
                 usingRightHand = true;
                 holdingShield = true;
                 leftHandItem = null;
+                if (currentLeftHandWeapon == null || !currentLeftHandWeapon.IsShield)
+                    UpdateLeftHandGfxCache(null); // Cache melee graphics in case shield is unequipped later.
             }
 
             // Right-hand item changed
             if (!DaggerfallUnityItem.CompareItems(currentRightHandWeapon, rightHandItem))
             {
                 currentRightHandWeapon = rightHandItem;
-                if (rightHandItem != null && !rightHandItem.IsShield)
-                    ScreenWeapon.TryCacheReadiedWeaponAtlas(DaggerfallUnity.Instance.ItemHelper.ConvertItemMaterialToAPIMetalType(rightHandItem),
-                                                            DaggerfallUnity.Instance.ItemHelper.ConvertItemToAPIWeaponType(rightHandItem));
-                else if (rightHandItem == null)
-                    ScreenWeapon.TryCacheReadiedWeaponAtlas(MetalTypes.None, WeaponTypes.Melee);
+                UpdateRightHandGfxCache(rightHandItem);
             }
 
             // Left-hand item changed
             if (!DaggerfallUnityItem.CompareItems(currentLeftHandWeapon, leftHandItem))
             {
                 currentLeftHandWeapon = leftHandItem;
-                if (leftHandItem != null && !leftHandItem.IsShield)
-                    ScreenWeapon.TryCacheReadiedWeaponAtlas(DaggerfallUnity.Instance.ItemHelper.ConvertItemMaterialToAPIMetalType(leftHandItem),
-                                                            DaggerfallUnity.Instance.ItemHelper.ConvertItemToAPIWeaponType(leftHandItem));
-                else if (leftHandItem == null)
-                    ScreenWeapon.TryCacheReadiedWeaponAtlas(MetalTypes.None, WeaponTypes.Melee);
+                UpdateLeftHandGfxCache(leftHandItem);
             }
 
             if (EquipCountdownRightHand > 0)
@@ -765,6 +759,7 @@ namespace DaggerfallWorkshop.Game
             target.MetalType = MetalTypes.None;
             target.DrawWeaponSound = SoundClips.None;
             target.SwingWeaponSound = SoundClips.SwingHighPitch;
+            target.SpecificWeapon = null;
         }
 
         void SetWeapon(FPSWeapon target, DaggerfallUnityItem weapon)
@@ -917,6 +912,33 @@ namespace DaggerfallWorkshop.Game
                     hitEnemy = WeaponDamage(strikingWeapon, false, false, hit.transform, hit.point, mainCamera.transform.forward);
                 }
             }
+        }
+
+        private void UpdateRightHandGfxCache(DaggerfallUnityItem rightHandItem)
+        {
+            ScreenWeapon.SpecificWeapon = currentRightHandWeapon;
+            if (rightHandItem != null)
+            {
+                ScreenWeapon.TryCacheReadiedWeaponAtlas(DaggerfallUnity.Instance.ItemHelper.ConvertItemMaterialToAPIMetalType(rightHandItem),
+                                                        DaggerfallUnity.Instance.ItemHelper.ConvertItemToAPIWeaponType(rightHandItem), true);
+                if (rightHandItem.GetItemHands() == ItemHands.Both)
+                {
+                    ScreenWeapon.SpecificWeapon = currentLeftHandWeapon;
+                    ScreenWeapon.TryCacheReadiedWeaponAtlas(MetalTypes.None, WeaponTypes.Melee, false); // Left hand becomes melee if 2H.
+                }
+            }
+            else
+                ScreenWeapon.TryCacheReadiedWeaponAtlas(MetalTypes.None, WeaponTypes.Melee, true);
+        }
+
+        private void UpdateLeftHandGfxCache(DaggerfallUnityItem leftHandItem)
+        {
+            ScreenWeapon.SpecificWeapon = currentLeftHandWeapon;
+            if (leftHandItem != null)
+                ScreenWeapon.TryCacheReadiedWeaponAtlas(DaggerfallUnity.Instance.ItemHelper.ConvertItemMaterialToAPIMetalType(leftHandItem),
+                                                        DaggerfallUnity.Instance.ItemHelper.ConvertItemToAPIWeaponType(leftHandItem), false);
+            else
+                ScreenWeapon.TryCacheReadiedWeaponAtlas(MetalTypes.None, WeaponTypes.Melee, false);
         }
 
         public void ToggleSheath()


### PR DESCRIPTION
Had to work through multiple issues.
1. SpecificWeapon needed to be set right before the caching routine so proper cache keys can be referenced.
2. Used a pigeon-hole cache instead of a queue for the right/left hands. The queue couldn't cache for both hands in every case.
3. Modified GetWeaponTextureAtlas to not alter the screen weapon's current custom textures. The caching routine uses this method so I opted to put the newly loaded textures in an output parameter where it can be assigned to customTextures as needed.

I went through the steps to reproduce the bug outlined in https://forums.dfworkshop.net/viewtopic.php?t=5954. I do not have DREAM installed but I have another texture replacer (Diverse Weapons). I was seeing similar issues before while using it but they are now resolved with these changes.