### PR TITLE
Serialize PlayerTeleportedInsideDungeon

### DIFF
--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -235,6 +235,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public bool insideOpenShop;
         public bool insideTavern;
         public bool insideResidence;
+        public bool playerTeleportedIntoDungeon;
         public string terrainSamplerName;
         public int terrainSamplerVersion;
         public QuestSmallerDungeonsState smallerDungeonsState;

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -185,6 +185,10 @@ namespace DaggerfallWorkshop.Game.Serialization
                 data.playerPosition.exteriorDoors = playerEnterExit.ExteriorDoors;
                 data.playerPosition.buildingDiscoveryData = playerEnterExit.BuildingDiscoveryData;
             }
+            if (playerEnterExit.IsPlayerInsideDungeon)
+            {
+                data.playerPosition.playerTeleportedIntoDungeon = playerEnterExit.PlayerTeleportedIntoDungeon;
+            }
             // Store guild memberships
             data.guildMemberships = GameManager.Instance.GuildManager.GetMembershipData();
             data.vampireMemberships = GameManager.Instance.GuildManager.GetMembershipData(true);
@@ -393,6 +397,11 @@ namespace DaggerfallWorkshop.Game.Serialization
                 playerEnterExit.IsPlayerInsideOpenShop = data.playerPosition.insideOpenShop;
                 playerEnterExit.IsPlayerInsideTavern = data.playerPosition.insideTavern;
                 playerEnterExit.IsPlayerInsideResidence = data.playerPosition.insideResidence;
+            }
+
+            if (data.playerPosition.insideDungeon)
+            {
+                playerEnterExit.PlayerTeleportedIntoDungeon = data.playerPosition.playerTeleportedIntoDungeon;
             }
 
             // Lower player position flag if inside with no doors


### PR DESCRIPTION
Serialize PlayerTeleportedInsideDungeon so that dungeon doors can be opened from inside, even if player has saved/reloaded the game.

Problem of doors not always opening from inside after teleport mentioned by Aina the Khajiit on Discord:
https://discord.com/channels/559842137374457876/599345625569689620/1042632093072625845
Strictly speaking she couldn't tell if it stops working for her because of save/reload cycle.

PlayerTeleportedInsideDungeon flag and discussion about this very PR: 
see commit e81b2d7283cbc1d8c9ac56d6ad3d1e06d201af80