### PR TITLE
Travel Map: Discrepancy between Find results and discovered location …

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelMapWindow.cs
@@ -1517,6 +1517,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     // only make location searchable if it is already discovered
                     if (!checkLocationDiscovered(findLocationSummary))
                         continue;
+                        
+                    if (GetPixelColorIndex(findLocationSummary.LocationType) == -1) // Filter out locations with invalid color indices
+                        continue;
 
                     if (cutoff == null)
                     {


### PR DESCRIPTION
…dots

To reproduce issue:

1. Open Travel Map 'v'
2. Select Isle of Betony
3. Start location search 'f'
4. Type 'a' and press Enter
5. Select 'The Wickcroft Cabin' (fourth entry)
6. Notice that you can travel to 'The Wickcroft Cabin' even though its location dot is not being shown on the map

Why it's happening:

The Wickcroft Cabin has 'discovered' status but it also has a pixel color index of -1 which prevents it from being displayed on the region map.

The offered code gives parity between FindLocation() and UpdateMapLocationDotsTexture().

This may or may not be the correct solution as I am not sure why 'The Wickcroft Cabin' (and many other locations) are 'discovered' but have a color index of -1.