### PR TITLE
Adjust arrow position relative to camera rotation

### DIFF
--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -231,10 +231,10 @@ namespace DaggerfallWorkshop.Game
                 }
                 else
                 {
-                    // Offset forward to avoid collision with player
-                    adjust = GameManager.Instance.MainCamera.transform.forward * 0.6f;
                     // Adjust slightly downward to match bow animation
-                    adjust.y -= 0.11f;
+                    adjust = (GameManager.Instance.MainCamera.transform.rotation * -Caster.transform.up) * 0.11f;
+                    // Offset forward to avoid collision with player
+                    adjust += GameManager.Instance.MainCamera.transform.forward * 0.6f;
                     // Adjust to the right or left to match bow animation
                     if (!GameManager.Instance.WeaponManager.ScreenWeapon.FlipHorizontal)
                         adjust += GameManager.Instance.MainCamera.transform.right * 0.15f;


### PR DESCRIPTION
Prevents arrows spawning off-center from player perspective.

**Problem:**
When player aims the bow far enough up or down, arrows spawn noticeably off-center from the camera's perspective.

**Solution:**
Adjust the arrow origin "down" from the camera's perspective instead of moving it down the Y-axis.