### PR TITLE
Raise an event when a crime is committed

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -2346,6 +2346,20 @@ namespace DaggerfallWorkshop.Game.Entity
             bool suppressCrime = racialOverride != null && racialOverride.SuppressCrime;
 
             crimeCommitted = (!suppressCrime) ? crime : Crimes.None;
+
+            RaiseOnCrimeUpdateEvent(crimeCommitted);
+        }
+
+        // Allows modders to easily detect if a crime has been committed
+        public delegate void OnCrimeUpdateHandler(Crimes crime);
+        public event OnCrimeUpdateHandler OnCrimeUpdate;
+        protected void RaiseOnCrimeUpdateEvent(Crimes crime)
+        {
+            if (SaveLoadManager.Instance.LoadInProgress)
+                return;
+
+            if (OnCrimeUpdate != null)
+                OnCrimeUpdate(crime);
         }
 
         #endregion

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -2351,6 +2351,8 @@ namespace DaggerfallWorkshop.Game.Entity
         }
 
         // Allows modders to easily detect if a crime has been committed
+        // This will raise when the player's crime is set to None!
+        // Make sure to account for that when necessary.
         public delegate void OnCrimeUpdateHandler(Crimes crime);
         public event OnCrimeUpdateHandler OnCrimeUpdate;
         protected void RaiseOnCrimeUpdateEvent(Crimes crime)


### PR DESCRIPTION
Modding support.

This may be a useful event for a number of future mods - it's necessary for mine. I made a crime system overhaul the allows the player to accrue multiple counts of a single crime/multiple crimes, and they're all tracked by region.

An event wasn't necessary before, but a breaking change was added in a DFU commit since I last worked on my mods that de-spawns guards when the player's crime is set to "None" (this is probably for the best).

Unfortunately, I relied on setting the player's crime to "None" as soon as a crime was committed, as I kept track of all crimes committed via a dictionary. The reason why it was necessary to set the crime to "None" is because the counts will add up very quickly over Update() calls.

Storing the last time a crime was committed and keeping track that way will not work if a player commits the same crime twice in a row, as playerEntity.crimeCommitted's value doesn't change, so there's no way to tell if the player has committed the crime only once or ten times in a row.

Hopefully, this is low impact enough to be rolled in at this stage of DFU development. Alternately, I'm open to other suggestions if someone has a solution, but I feel like this event is something that has potential for others to find quite useful.