### PR TITLE
Add prohibited action event for DaggerfallEntity and Callbacks in ItemEquip and ReadySpell

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -209,6 +209,7 @@ namespace DaggerfallWorkshop.Game.Entity
             OnExhausted += PlayerEntity_OnExhausted;
             PlayerGPS.OnExitLocationRect += PlayerGPS_OnExitLocationRect;
             DaggerfallTravelPopUp.OnPostFastTravel += DaggerfallTravelPopUp_OnPostFastTravel;
+            OnProhibitedAction += PlayerEntity_OnProhibitedInventoryMessage;
         }
 
         #endregion
@@ -2436,6 +2437,22 @@ namespace DaggerfallWorkshop.Game.Entity
         {
             // Clear crime state post fast travel
             CrimeCommitted = Crimes.None;
+        }
+
+        public static void PlayerEntity_OnProhibitedInventoryMessage(DaggerfallEntity entity, object sender)
+        {
+            if (sender.GetType() == typeof(DaggerfallUnityItem))
+            {
+                const int forbiddenEquipmentTextId = 1068;
+                TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(forbiddenEquipmentTextId);
+                if (tokens != null && tokens.Length > 0)
+                {
+                    DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.Instance.UserInterfaceManager, DaggerfallUI.Instance.UserInterfaceManager.TopWindow);
+                    messageBox.SetTextTokens(tokens);
+                    messageBox.ClickAnywhereToClose = true;
+                    messageBox.Show();
+                }
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1319,7 +1319,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected void EquipItem(DaggerfallUnityItem item)
         {
             const int itemBrokenTextId = 29;
-            const int forbiddenEquipmentTextId = 1068;
 
             if (item.ItemGroup == ItemGroups.Weapons && item.TemplateIndex == (int)Weapons.Arrow)
                 return;
@@ -1331,46 +1330,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
                     messageBox.SetTextTokens(tokens, item);
-                    messageBox.ClickAnywhereToClose = true;
-                    messageBox.Show();
-                }
-                return;
-            }
-
-            bool prohibited = false;
-
-            if (item.ItemGroup == ItemGroups.Armor)
-            {
-                // Check for prohibited shield
-                if (item.IsShield && ((1 << (item.TemplateIndex - (int)Armor.Buckler) & (int)playerEntity.Career.ForbiddenShields) != 0))
-                    prohibited = true;
-
-                // Check for prohibited armor type (leather, chain or plate)
-                else if (!item.IsShield && (1 << (item.NativeMaterialValue >> 8) & (int)playerEntity.Career.ForbiddenArmors) != 0)
-                    prohibited = true;
-
-                // Check for prohibited material
-                else if (((item.nativeMaterialValue >> 8) == 2)
-                    && (1 << (item.NativeMaterialValue & 0xFF) & (int)playerEntity.Career.ForbiddenMaterials) != 0)
-                    prohibited = true;
-            }
-            else if (item.ItemGroup == ItemGroups.Weapons)
-            {
-                // Check for prohibited weapon type
-                if ((item.GetWeaponSkillUsed() & (int)playerEntity.Career.ForbiddenProficiencies) != 0)
-                    prohibited = true;
-                // Check for prohibited material
-                else if ((1 << item.NativeMaterialValue & (int)playerEntity.Career.ForbiddenMaterials) != 0)
-                    prohibited = true;
-            }
-
-            if (prohibited)
-            {
-                TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(forbiddenEquipmentTextId);
-                if (tokens != null && tokens.Length > 0)
-                {
-                    DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
-                    messageBox.SetTextTokens(tokens);
                     messageBox.ClickAnywhereToClose = true;
                     messageBox.Show();
                 }


### PR DESCRIPTION
Mod extension for prohibited items and and spell silence/disabled check event

This creates a callback in DaggerfallEntity for "prohibited actions", and changes the bool checks within a few functions to be events with a bool return type. When a function is made to complete early due to a check failing, an OnProhibitedAction event is raised.

The main behavioral changes in the commit:
1. Any player equip OnDisableEquip events that fail now produce the prohibited message. Before this change, only the EquipItem method within DaggerfallInventoryWindow would display the prohibited message.
2. Check events which fail produce another callback, potentially creating 2 callbacks total if they fail. I believe the additional complexity and small computational cost for the callbacks are worth it in exchange for mod accessibility.

Minor differences are:
- UnequipItem now has a disabled check event. However, the current result of event always unequips the item like before.
- UnequipItem with 2 params slot EquipSlot and list, now returns a bool, which was previously void. Since this was only a helper function used within ItemsEquipTable, it seemed fine to do and it was necessary for prohibited unequips to work properly.


The reason for this change is exposing these prohibited checks to modders for custom behavior and a new event modders can use when prohibited action has occurred. I intend to use some of these myself in upcoming mods I am creating.

This commit opens:
- Prohibited weapons and armor equips and OnProhibitedAction callback for enemies and non-player classes inheriting DaggerfallEntity
- Prohibited spells based on any arbitrary condition
- More fine detail prohibited rules for item equips
- Prohibited unequips for weapons, cursed items
- Callback events when any prohibited action occurs

While there were more changes than I originally expected, a good chunk of these changes are cut and paste reorganization. The second commit with OnDisableReadySpell shows how few lines are needed when replacing an if statement and how simple the changes can be.

I think the prohibited action event for daggerfall entities is a useful extension. It can be expanded to include other types of behavior/systems in the future. I wouldn't know of another way to expose this functionality for modders without being mod incompatible. One thing I decided to not modify was the special weapon handling for arrows. Since arrows in EquipItem always return null, you could argue it's part of the OnDisabledEquip check. It wasn't necessary to modify as part these commits, although it could be added in the future.