### PR TITLE
Bug when giving the totem to Gothryd

### DIFF
--- a/Assets/StreamingAssets/Quests/S0000008.txt
+++ b/Assets/StreamingAssets/Quests/S0000008.txt
@@ -540,12 +540,6 @@ EadwyreGotTotem _S.36_
 	create foe _F.01_ every 1 minutes 5 times with 100% success 
 	say 1051 
 
-_S.37_ task:
-	when _S.46_ and _S.07_ 
-	get item _goldgoth_ from _Gothryd_ 
-	say 1053 
-	make _goldgoth_ permanent 
-
 _S.38_ task:
 	give pc totemLetter6 notify 1070 
 
@@ -579,5 +573,8 @@ _S.45_ task:
 	end quest 
 
 _S.46_ task:
-	toting _totem_ and _Gothryd_ clicked 
+	toting _totem_ and _Gothryd_ clicked
+    get item _goldgoth_ from _Gothryd_ 
+    say 1053 
+    make _goldgoth_ permanent  
 	start task _S.31_ 


### PR DESCRIPTION
Removes the requirement to be outside the castle (S.07) before Gothryd will "thank" and reward you for giving him the Totem.

Fix for https://forums.dfworkshop.net/viewtopic.php?t=4845