### PR TITLE
Mod Organizer support in editor

### DIFF
--- a/Assets/Game/Addons/Editor.meta
+++ b/Assets/Game/Addons/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f718d9611e724954b2ed6b85eb1230f6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport.meta
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: afa8553283e44f06a2e6f47b491e9b2b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerData.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerData.cs
@@ -4,14 +4,14 @@ using DaggerfallWorkshop;
 using UnityEngine;
 
 [Serializable]
-public class ModOrganizerData
+internal class ModOrganizerData
 {
     [SerializeField]
     internal string modOrganizerDataPath;
     [SerializeField]
     internal string profileName;
 
-    public ModOrganizerData(string modOrganizerDataPath, string profileName)
+    internal ModOrganizerData(string modOrganizerDataPath, string profileName)
     {
         this.modOrganizerDataPath = modOrganizerDataPath;
         this.profileName = profileName;
@@ -22,12 +22,12 @@ public class ModOrganizerData
     private static string fileName = "mod-organizer-import-settings.json";
     private static string FilePath => Path.Combine(EditorPersistentModData, fileName);
 
-    public static string EditorPersistentModData =>
+    internal static string EditorPersistentModData =>
         Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, "Mods", "EditorData");
 
-    public static string ModInstallPath => Path.Combine(EditorPersistentModData, "mod-organizer-mod-installs");
+    internal static string ModInstallPath => Path.Combine(EditorPersistentModData, "mod-organizer-mod-installs");
 
-    public static void Save(ModOrganizerData modOrganizerData)
+    internal static void Save(ModOrganizerData modOrganizerData)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(FilePath));
         File.WriteAllText(FilePath,JsonUtility.ToJson(modOrganizerData, true));
@@ -42,7 +42,7 @@ public class ModOrganizerData
         return JsonUtility.FromJson<ModOrganizerData>(fileContents);
     }
 
-    public static bool Delete()
+    internal static bool Delete()
     {
         bool deleted = false;
         if (File.Exists(FilePath))

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerData.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerData.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO;
+using DaggerfallWorkshop;
+using UnityEngine;
+
+[Serializable]
+public class ModOrganizerData
+{
+    [SerializeField]
+    internal string modOrganizerDataPath;
+    [SerializeField]
+    internal string profileName;
+
+    public ModOrganizerData(string modOrganizerDataPath, string profileName)
+    {
+        this.modOrganizerDataPath = modOrganizerDataPath;
+        this.profileName = profileName;
+    }
+
+    internal string SelectedProfilePath => Path.Combine(modOrganizerDataPath, "profiles", profileName);
+
+    private static string fileName = "mod-organizer-import-settings.json";
+    private static string FilePath => Path.Combine(EditorPersistentModData, fileName);
+
+    public static string EditorPersistentModData =>
+        Path.Combine(DaggerfallUnity.Settings.PersistentDataPath, "Mods", "EditorData");
+
+    public static string ModInstallPath => Path.Combine(EditorPersistentModData, "mod-organizer-mod-installs");
+
+    public static void Save(ModOrganizerData modOrganizerData)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(FilePath));
+        File.WriteAllText(FilePath,JsonUtility.ToJson(modOrganizerData, true));
+    }
+
+    internal static ModOrganizerData Load()
+    {
+        if (!File.Exists(FilePath)) return null;
+
+        string fileContents = File.ReadAllText(FilePath);
+        Debug.Log($"<color=orange>Loaded {nameof(ModOrganizerData)}</color> from {FilePath}");
+        return JsonUtility.FromJson<ModOrganizerData>(fileContents);
+    }
+
+    public static bool Delete()
+    {
+        bool deleted = false;
+        if (File.Exists(FilePath))
+        {
+            File.Delete(FilePath);
+            deleted = true;
+        }
+
+        if (Directory.Exists(ModInstallPath))
+        {
+            Directory.Delete(ModInstallPath, true);
+            deleted = true;
+        }
+
+        return deleted;
+    }
+}

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerData.cs.meta
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f6fffeb251564cd09f0fcc50d4feae27
+timeCreated: 1673909865

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerLoader.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerLoader.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport
@@ -9,21 +10,23 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport
     internal static class ModOrganizerLoader
     {
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
-        private static void LoadMO2Mods()
+        internal static void LoadMO2Mods()
         {
-            #if !UNITY_EDITOR
-            return;
-            #endif
-
             var pathData = ModOrganizerData.Load();
             if (pathData is null) return;
 
-            var modManager = UnityEngine.Object.FindObjectOfType<ModManager>();
-
-            if (modManager is null)
+            if (Application.isPlaying)
             {
-                Debug.LogError($"Failed to find Mod Manager. Make sure you're starting from the DaggerfallUnityStartup scene if you wish to load mods.");
-                return;
+                var modManager = UnityEngine.Object.FindObjectOfType<ModManager>();
+
+                if (modManager is null)
+                {
+                    Debug.LogError($"Failed to find Mod Manager. Make sure you're starting from the " +
+                                   $"DaggerfallUnityStartup scene if you wish to load mods from Mod Organizer.");
+                    return;
+                }
+
+                modManager.ModDirectory = ModOrganizerData.ModInstallPath;
             }
 
             if (string.IsNullOrWhiteSpace(pathData.modOrganizerDataPath) ||
@@ -34,7 +37,6 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport
             }
 
             // we copy our mods to a path elsewhere to avoid Unity attempting to import everything
-            modManager.ModDirectory = ModOrganizerData.ModInstallPath;
 
             var modOrganizerModPath = Path.Combine(pathData.modOrganizerDataPath, "mods");
             modOrganizerModPath = Path.GetFullPath(modOrganizerModPath);

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerLoader.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerLoader.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using UnityEngine;
+
+namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport
+{
+    internal static class ModOrganizerLoader
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void LoadMO2Mods()
+        {
+            #if !UNITY_EDITOR
+            return;
+            #endif
+
+            var pathData = ModOrganizerData.Load();
+            if (pathData is null) return;
+
+            var modManager = UnityEngine.Object.FindObjectOfType<ModManager>();
+
+            if (modManager is null)
+            {
+                Debug.LogError($"Failed to find Mod Manager. Make sure you're starting from the DaggerfallUnityStartup scene if you wish to load mods.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(pathData.modOrganizerDataPath) ||
+                string.IsNullOrWhiteSpace(pathData.SelectedProfilePath))
+            {
+                Debug.LogWarning($"No ModOrganizer data");
+                return;
+            }
+
+            // we copy our mods to a path elsewhere to avoid Unity attempting to import everything
+            modManager.ModDirectory = ModOrganizerData.ModInstallPath;
+
+            var modOrganizerModPath = Path.Combine(pathData.modOrganizerDataPath, "mods");
+            modOrganizerModPath = Path.GetFullPath(modOrganizerModPath);
+
+            string profileModList = Path.Combine(pathData.SelectedProfilePath, "modlist.txt");
+            var rawModList = File.ReadAllLines(profileModList).Where(x => !x.StartsWith("#")).ToArray();
+            var modList = rawModList.Where(x => x.StartsWith("+")).Select(x => x.Remove(0, 1)).Reverse()
+                .ToArray();
+
+            var loadedModPath = new DirectoryInfo(ModOrganizerData.ModInstallPath);
+            var streamingAssetsDirectory = new DirectoryInfo(Application.streamingAssetsPath);
+            foreach (string modName in modList)
+            {
+                DirectoryInfo modDir = new DirectoryInfo(Path.Combine(modOrganizerModPath, modName));
+                foreach (DirectoryInfo subDirectory in modDir.GetDirectories())
+                {
+                    DirectoryInfo target = IsModSubdirectory(subDirectory) ? loadedModPath : streamingAssetsDirectory;
+                    target = target.CreateSubdirectory(subDirectory.Name);
+                    Debug.Log($"<color=green>Found Mod Organizer mod: {modName}.</color><color=grey> Copying files if necessary.</color>" +
+                              $"\n<color=grey>{subDirectory.FullName}</color> => {target.FullName}\n");
+                    CopyAll(subDirectory, target);
+                }
+
+                foreach (FileInfo strayFile in modDir.GetFiles())
+                {
+                    string target = Path.Combine(loadedModPath.FullName, strayFile.Name);
+                    Console.WriteLine($"Copying stray files\n<color=grey>{strayFile.FullName}</color> => {loadedModPath.FullName}\n");
+                    strayFile.CopyTo(target, true);
+                }
+            }
+        }
+
+        private static bool IsModSubdirectory(DirectoryInfo subDirectory)
+        {
+            return subDirectory.Name.ToLowerInvariant() == "mods";
+        }
+
+        /// <summary>
+        /// Adapted from https://stackoverflow.com/questions/9053564/c-sharp-merge-one-directory-with-another
+        /// Copies files from source to target
+        /// </summary>
+        private static void CopyAll(DirectoryInfo source, DirectoryInfo target)
+        {
+            var sameDirectory = string.Equals(source.FullName, target.FullName, StringComparison.CurrentCultureIgnoreCase);
+            if (sameDirectory)
+            {
+                Debug.LogWarning($"Attempting to copy a directory into itself.\n<color=grey>What were you thinking?</color>\n");
+                return;
+            }
+
+            var files = source.GetFiles();
+            var subdirectories = source.GetDirectories();
+
+            var empty = files.Length == 0 && subdirectories.Length == 0;
+            if (empty)
+                return;
+
+            // Check if the target directory exists, if not, create it.
+            if (Directory.Exists(target.FullName) == false)
+            {
+                Directory.CreateDirectory(target.FullName);
+            }
+
+            // Copy each file into it's new directory.
+            var fileLogs = string.Empty;
+            foreach (FileInfo file in files)
+            {
+                var targetFilePath = Path.Combine(target.FullName, file.Name);
+
+                if (File.Exists(targetFilePath))
+                {
+                    var targetFile = new FileInfo(targetFilePath);
+                    if (targetFile.LastWriteTimeUtc >= file.LastWriteTimeUtc)
+                        continue;
+                }
+
+                fileLogs += $"\n<color=grey>{file.FullName}</color> => {target.FullName}/{file.Name}";
+                file.CopyTo(targetFilePath, true);
+            }
+
+            if(fileLogs != string.Empty)
+                Debug.Log($"Copied files:{fileLogs}\n");
+
+            // Copy each subdirectory using recursion.
+            foreach (DirectoryInfo diSourceSubDir in subdirectories)
+            {
+                DirectoryInfo nextTargetSubDir = target.CreateSubdirectory(diSourceSubDir.Name);
+                CopyAll(diSourceSubDir, nextTargetSubDir);
+            }
+        }
+    }
+}

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerLoader.cs.meta
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerLoader.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cba6d6a319134492af3d00dcad4fb135
+timeCreated: 1673960135

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using DaggerfallWorkshop.Game.Utility.ModSupport;
 using DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport;
 using UnityEditor;
@@ -16,10 +17,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport
         private const string FullMenu = ParentMenu + "/" + SubMenu + "/";
 
         [MenuItem(FullMenu + "Locate Data")]
-        static void Select()
+        static async void Select()
         {
             Debug.Log($"<color=orange>Select your Mod Organizer data directory.</color> " +
                       $"This path should contain your `profiles` and `mods` subfolders.");
+
+            await Task.Delay(500);
 
             string dataPath = EditorUtility.OpenFolderPanel("Select Mod Organizer data path",
                 String.Empty, String.Empty);
@@ -54,6 +57,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport
             {
 
                 Debug.Log($"<color=orange>Select your profile directory.</color>");
+                await Task.Delay(500);
+
                 profilePath = EditorUtility.OpenFolderPanel("Select profile",
                     Path.Combine(dataPath, "profiles"), String.Empty);
 

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using UnityEngine;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using Directory = System.IO.Directory;
+
+public class ModOrganizerMenuItems
+{
+    [MenuItem("Daggerfall Tools/Mod Organizer Import/Locate Data")]
+    static void Select()
+    {
+        // Get existing open window or if none, make a new one:
+        string dataPath = EditorUtility.OpenFolderPanel("Select Mod Organizer data path",
+            String.Empty, String.Empty);
+
+        if (string.IsNullOrWhiteSpace(dataPath))
+        {
+            return;
+        }
+
+        var requiredDirectories = new string[] { "profiles", "mods" };
+        bool missingPath = false;
+
+        foreach (var subfolder in requiredDirectories)
+        {
+            var directory = Path.Combine(dataPath, subfolder);
+            if (Directory.Exists(directory)) continue;
+
+            Debug.LogError(
+                $"Selected mod organizer data path either does not exist or does not have a \"{subfolder}\" subdirectory.\n" +
+                $"Has it moved? Reselect your mod organizer data path or fix your data.");
+            missingPath = true;
+        }
+
+        if (missingPath)
+        {
+            return;
+        }
+
+        string profilePath = string.Empty;
+
+        while (profilePath == string.Empty)
+        {
+            profilePath = EditorUtility.OpenFolderPanel("Select profile",
+            Path.Combine(dataPath, "profiles"), String.Empty);
+
+            // user exited
+            if (string.IsNullOrWhiteSpace(profilePath))
+                return;
+
+            const string modListFileName = "modlist.txt";
+            var hasModList = new DirectoryInfo(profilePath).GetFiles().Select(x => x.Name).Contains(modListFileName);
+            if (hasModList) continue;
+
+            Debug.LogError($"No mod list by the name of {modListFileName} found in {profilePath}");
+            profilePath = string.Empty;
+        }
+
+        var data = new ModOrganizerData(dataPath, new DirectoryInfo(profilePath).Name);
+        ModOrganizerData.Save(data);
+
+        Debug.Log($"<color=green>Mod Organizer setup succeeded!</color>\n" +
+                  $"Note that this means any mods in your StreamingAssets/Mods folder will be ignored. " +
+                  $"Please bear in mind that Load Priority configured in ModOrganizer is not respected.");
+    }
+
+    [MenuItem("Daggerfall Tools/Mod Organizer Import/Clear Data")]
+    static void Clear()
+    {
+        var deleted = ModOrganizerData.Delete();
+        if (!deleted)
+        {
+            Debug.Log($"No Mod Organizer files to delete");
+            return;
+        }
+
+        Debug.LogWarning($"<color=orange>Mod Organizer copies deleted.</color>\n" +
+                         $"Any files not present within a mod's \"Mods\" subdirectory or root folder remain in the StreamingAssets " +
+                         $"folder and must be cleaned manually to avoid deleting wanted files.");
+    }
+}

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs
@@ -2,106 +2,137 @@
 using UnityEngine;
 using System.IO;
 using System.Linq;
+using DaggerfallWorkshop.Game.Utility.ModSupport;
 using DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport;
 using UnityEditor;
 using Directory = System.IO.Directory;
 
-internal class ModOrganizerMenuItems
+namespace DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport
 {
-    [MenuItem("Daggerfall Tools/Mod Organizer Import/Locate Data")]
-    static void Select()
+    internal class ModOrganizerMenuItems
     {
-        Debug.Log($"<color=orange>Select your Mod Organizer data directory.</color> " +
-                  $"This path should contain your `profiles` and `mods` subfolders.");
+        private const string ParentMenu = "Daggerfall Tools";
+        private const string SubMenu = "Mod Organizer Import";
+        private const string FullMenu = ParentMenu + "/" + SubMenu + "/";
 
-        string dataPath = EditorUtility.OpenFolderPanel("Select Mod Organizer data path",
-            String.Empty, String.Empty);
-
-        if (string.IsNullOrWhiteSpace(dataPath))
+        [MenuItem(FullMenu + "Locate Data")]
+        static void Select()
         {
-            return;
-        }
+            Debug.Log($"<color=orange>Select your Mod Organizer data directory.</color> " +
+                      $"This path should contain your `profiles` and `mods` subfolders.");
 
-        var requiredDirectories = new string[] { "profiles", "mods" };
-        bool missingPath = false;
+            string dataPath = EditorUtility.OpenFolderPanel("Select Mod Organizer data path",
+                String.Empty, String.Empty);
 
-        foreach (var subfolder in requiredDirectories)
-        {
-            var directory = Path.Combine(dataPath, subfolder);
-            if (Directory.Exists(directory)) continue;
-
-            Debug.LogError(
-                $"Selected mod organizer data path either does not exist or does not have a \"{subfolder}\" subdirectory.\n" +
-                $"Has it moved? Reselect your mod organizer data path or fix your data.");
-            missingPath = true;
-        }
-
-        if (missingPath)
-        {
-            return;
-        }
-
-        string profilePath = string.Empty;
-
-        while (profilePath == string.Empty)
-        {
-
-            Debug.Log($"<color=orange>Select your profile directory.</color>");
-            profilePath = EditorUtility.OpenFolderPanel("Select profile",
-            Path.Combine(dataPath, "profiles"), String.Empty);
-
-            // user exited
-            if (string.IsNullOrWhiteSpace(profilePath))
+            if (string.IsNullOrWhiteSpace(dataPath))
+            {
                 return;
+            }
 
-            const string modListFileName = "modlist.txt";
-            var hasModList = new DirectoryInfo(profilePath).GetFiles().Select(x => x.Name).Contains(modListFileName);
-            if (hasModList) continue;
+            var requiredDirectories = new string[] { "profiles", "mods" };
+            bool missingPath = false;
 
-            Debug.LogError($"No mod list by the name of {modListFileName} found in {profilePath}");
-            profilePath = string.Empty;
+            foreach (var subfolder in requiredDirectories)
+            {
+                var directory = Path.Combine(dataPath, subfolder);
+                if (Directory.Exists(directory)) continue;
+
+                Debug.LogError(
+                    $"Selected mod organizer data path either does not exist or does not have a \"{subfolder}\" subdirectory.\n" +
+                    $"Has it moved? Reselect your mod organizer data path or fix your data.");
+                missingPath = true;
+            }
+
+            if (missingPath)
+            {
+                return;
+            }
+
+            string profilePath = string.Empty;
+
+            while (profilePath == string.Empty)
+            {
+
+                Debug.Log($"<color=orange>Select your profile directory.</color>");
+                profilePath = EditorUtility.OpenFolderPanel("Select profile",
+                    Path.Combine(dataPath, "profiles"), String.Empty);
+
+                // user exited
+                if (string.IsNullOrWhiteSpace(profilePath))
+                    return;
+
+                const string modListFileName = "modlist.txt";
+                var hasModList = new DirectoryInfo(profilePath).GetFiles().Select(x => x.Name)
+                    .Contains(modListFileName);
+                if (hasModList) continue;
+
+                Debug.LogError($"No mod list by the name of {modListFileName} found in {profilePath}");
+                profilePath = string.Empty;
+            }
+
+            var data = new ModOrganizerData(dataPath, new DirectoryInfo(profilePath).Name);
+            ModOrganizerData.Save(data);
+            ModOrganizerLoader.DeleteModInstalls();
+            ModOrganizerLoader.LoadMO2Mods();
+
+            Debug.Log($"<color=green>Mod Organizer setup succeeded!</color>\n" +
+                      $"Note that this means any mods in your StreamingAssets/Mods folder will be ignored. " +
+                      $"Please bear in mind that Load Priority configured in ModOrganizer is not respected.");
         }
 
-        var data = new ModOrganizerData(dataPath, new DirectoryInfo(profilePath).Name);
-        ModOrganizerData.Save(data);
-
-        ModOrganizerLoader.LoadMO2Mods();
-
-        Debug.Log($"<color=green>Mod Organizer setup succeeded!</color>\n" +
-                  $"Note that this means any mods in your StreamingAssets/Mods folder will be ignored. " +
-                  $"Please bear in mind that Load Priority configured in ModOrganizer is not respected.");
-    }
-
-    [MenuItem("Daggerfall Tools/Mod Organizer Import/Clear Data")]
-    static void Clear()
-    {
-        var deleted = ModOrganizerData.Delete();
-        if (!deleted)
+        [MenuItem(FullMenu + "Clear Data")]
+        static void Clear()
         {
-            Debug.Log($"No Mod Organizer files to delete");
-            return;
+            var deleted = ModOrganizerLoader.DeleteModInstalls();
+            if (!deleted)
+            {
+                Debug.Log($"No Mod Organizer files to delete");
+                return;
+            }
+
+            Debug.LogWarning($"<color=orange>Mod Organizer copies deleted.</color>\n" +
+                             $"Any files not present within a mod's \"Mods\" subdirectory or root folder remain in the StreamingAssets " +
+                             $"folder and must be cleaned manually to avoid deleting wanted files.");
         }
 
-        Debug.LogWarning($"<color=orange>Mod Organizer copies deleted.</color>\n" +
-                         $"Any files not present within a mod's \"Mods\" subdirectory or root folder remain in the StreamingAssets " +
-                         $"folder and must be cleaned manually to avoid deleting wanted files.");
-    }
-
-    [MenuItem("Daggerfall Tools/Mod Organizer Import/Update mods from current profile")]
-    static void Refresh()
-    {
-        ModOrganizerLoader.LoadMO2Mods();
-    }
-
-    [MenuItem("Daggerfall Tools/Mod Organizer Import/Open Imported Mod Install Path")]
-    static void OpenModPath()
-    {
-        if (!Directory.Exists(ModOrganizerData.ModInstallPath))
+        [MenuItem("Daggerfall Tools/Mod Organizer Import/Update mods from current profile")]
+        static void Refresh()
         {
-            Debug.LogError($"No Mod Organizer mods are currently installed.");
-            return;
+            ModOrganizerLoader.DeleteModInstalls();
+            ModOrganizerLoader.LoadMO2Mods();
         }
 
-        Application.OpenURL($"file:///{ModOrganizerData.ModInstallPath}");
+        [MenuItem(FullMenu + "Open Imported Mod Install Path")]
+        static void OpenModPath()
+        {
+            if (!Directory.Exists(ModOrganizerLoader.ModInstallPath))
+            {
+                Debug.LogError($"No Mod Organizer mods are currently installed.");
+                return;
+            }
+
+            Application.OpenURL($"file:///{ModOrganizerLoader.ModInstallPath}");
+        }
+
+        private const string EnabledMenuName = FullMenu + "Enable";
+
+        private static bool IsEnabled
+        {
+            get => ModOrganizerData.Enabled;
+            set => ModOrganizerData.SetEnabled(value);
+        }
+
+        [MenuItem(EnabledMenuName)]
+        private static void ToggleAction()
+        {
+            IsEnabled = !IsEnabled;
+        }
+
+        [MenuItem(EnabledMenuName, true)]
+        private static bool ToggleActionValidate()
+        {
+            Menu.SetChecked(EnabledMenuName, IsEnabled);
+            return true;
+        }
     }
 }

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs
@@ -2,15 +2,18 @@
 using UnityEngine;
 using System.IO;
 using System.Linq;
+using DaggerfallWorkshop.Game.Utility.ModSupport.ModOrganizerSupport;
 using UnityEditor;
 using Directory = System.IO.Directory;
 
-public class ModOrganizerMenuItems
+internal class ModOrganizerMenuItems
 {
     [MenuItem("Daggerfall Tools/Mod Organizer Import/Locate Data")]
     static void Select()
     {
-        // Get existing open window or if none, make a new one:
+        Debug.Log($"<color=orange>Select your Mod Organizer data directory.</color> " +
+                  $"This path should contain your `profiles` and `mods` subfolders.");
+
         string dataPath = EditorUtility.OpenFolderPanel("Select Mod Organizer data path",
             String.Empty, String.Empty);
 
@@ -42,6 +45,8 @@ public class ModOrganizerMenuItems
 
         while (profilePath == string.Empty)
         {
+
+            Debug.Log($"<color=orange>Select your profile directory.</color>");
             profilePath = EditorUtility.OpenFolderPanel("Select profile",
             Path.Combine(dataPath, "profiles"), String.Empty);
 
@@ -59,6 +64,8 @@ public class ModOrganizerMenuItems
 
         var data = new ModOrganizerData(dataPath, new DirectoryInfo(profilePath).Name);
         ModOrganizerData.Save(data);
+
+        ModOrganizerLoader.LoadMO2Mods();
 
         Debug.Log($"<color=green>Mod Organizer setup succeeded!</color>\n" +
                   $"Note that this means any mods in your StreamingAssets/Mods folder will be ignored. " +
@@ -78,5 +85,23 @@ public class ModOrganizerMenuItems
         Debug.LogWarning($"<color=orange>Mod Organizer copies deleted.</color>\n" +
                          $"Any files not present within a mod's \"Mods\" subdirectory or root folder remain in the StreamingAssets " +
                          $"folder and must be cleaned manually to avoid deleting wanted files.");
+    }
+
+    [MenuItem("Daggerfall Tools/Mod Organizer Import/Update mods from current profile")]
+    static void Refresh()
+    {
+        ModOrganizerLoader.LoadMO2Mods();
+    }
+
+    [MenuItem("Daggerfall Tools/Mod Organizer Import/Open Imported Mod Install Path")]
+    static void OpenModPath()
+    {
+        if (!Directory.Exists(ModOrganizerData.ModInstallPath))
+        {
+            Debug.LogError($"No Mod Organizer mods are currently installed.");
+            return;
+        }
+
+        Application.OpenURL($"file:///{ModOrganizerData.ModInstallPath}");
     }
 }

--- a/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs.meta
+++ b/Assets/Game/Addons/ModSupport/Editor/ModOrganizerSupport/ModOrganizerMenuItems.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f5567189f1631f4db8602920d4b9cc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A simple tool for debugging mods and mod compatibility, and also profiling daggerfall engine functions that the mods rely on. Efforts were made to make this simple to use and largely non-destructive

I'm new to ModOrganizer (and this repo of course. and daggerfall) so I don't know if this will work with non-portable Mod Organizer data folders. I only have familiarity with a portable data folder. Though in theory it should.