### PR TITLE
Extended max "terrain distance" to 6

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -373,7 +373,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Advanced settings
             AddSectionTitle(rightPanel, "advanced");
             fovSlider = AddSlider(rightPanel, "fovSlider", 60, 120, DaggerfallUnity.Settings.FieldOfView);
-            terrainDistance = AddSlider(rightPanel, "terrainDistance", 1, 4, DaggerfallUnity.Settings.TerrainDistance);
+            terrainDistance = AddSlider(rightPanel, "terrainDistance", 1, 6, DaggerfallUnity.Settings.TerrainDistance);
             shadowResolutionMode = AddSlider(rightPanel, "shadowResolutionMode",
                 DaggerfallUnity.Settings.ShadowResolutionMode, "Low", "Medium", "High", "Very High");
             dungeonLightShadows = AddCheckbox(rightPanel, "dungeonLightShadows", DaggerfallUnity.Settings.DungeonLightShadows);

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -513,7 +513,7 @@ namespace DaggerfallWorkshop
             StartCellY = GetInt(sectionStartup, "StartCellY", 2, 497);
             StartInDungeon = GetBool(sectionStartup, "StartInDungeon");
 
-            TerrainDistance = GetInt(sectionExperimental, "TerrainDistance", 1, 4);
+            TerrainDistance = GetInt(sectionExperimental, "TerrainDistance", 1, 6);
             TerrainHeightmapPixelError = GetFloat(sectionExperimental, "TerrainHeightmapPixelError", 1, 10);
             SmallerDungeons = GetBool(sectionExperimental, "SmallerDungeons");
             AssetCacheThreshold = GetInt(sectionExperimental, "AssetCacheThreshold", 0, 120);

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -52,7 +52,9 @@ namespace DaggerfallWorkshop
         // 2 : ( 2 * 2 + 1 ) * ( 2 * 2 + 1 ) = 25 tiles
         // 3 : ( 2 * 3 + 1 ) * ( 2 * 3 + 1 ) = 49 tiles
         // 4 : ( 2 * 4 + 1 ) * ( 2 * 4 + 1 ) = 81 tiles
-        [Range(1, 4)]
+        // 5 : ( 2 * 5 + 1 ) * ( 2 * 5 + 1 ) = 121 tiles
+        // 6 : ( 2 * 6 + 1 ) * ( 2 * 6 + 1 ) = 169 tiles
+        [Range(1, 6)]
         public int TerrainDistance = 3;
 
         // This controls central map pixel for streaming world


### PR DESCRIPTION
I've seen players use a custom DFU build to run terrain distance at 6. Seems viable on some PCs. 
For a while, people have been running Distant Terrain, which adds an extra 4 low-quality tiles around the terrain, which kind of looks like a distance of 8.
However, users have reported memory and other issues with DT in recent versions. Running DFU with a higher terrain distance seems easier for them.

So, I don't think allowing this is harmful. Users can experiment and see what they prefer.

I could consider letting the max go to 8, not sure if that's something anyone would run.