### PR TITLE
Force clickAnyWhereToClose behavior on message boxes with no buttons

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -657,7 +657,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             {
                 if (nextMessageBox != null)
                     nextMessageBox.Show();
-                else if (clickAnywhereToClose)
+                else if (clickAnywhereToClose || buttons == null || buttons.Count == 0)
                     CloseWindow();
             }
         }


### PR DESCRIPTION
Currently, if you create a message box with `clickAnywhereToClose` set to `false` (the default), there's no way to get rid of the message box if it doesn't have a button that closes it. Unless there's a reason why this behavior is needed, here's a very small change that will allow the player to close buttonless message boxes that neglected to set `clickAnywhereToClose` to `true`.