### PR TITLE
Rewrite of CSV regex parsing to avoid exponential behavior

### DIFF
--- a/Assets/Scripts/Game/StringTableCSVParser.cs
+++ b/Assets/Scripts/Game/StringTableCSVParser.cs
@@ -102,10 +102,12 @@ public class StringTableCSVParser
         // First row will be accepted if any other key/value pair is present instead
         if (rows.Count > 0 && rows[0].Key == keyString && rows[0].Value == valueString)
             rows.RemoveAt(0);
+
         return rows.ToArray();
     }
 
-    static string UnescapeCSVvalue(string value) {
+    static string UnescapeCSVvalue(string value)
+    {
         if (value.Length > 0 && value[0] == '"')
         {
             return value.Substring(1, value.Length - 2)

--- a/Assets/Scripts/Game/StringTableCSVParser.cs
+++ b/Assets/Scripts/Game/StringTableCSVParser.cs
@@ -36,7 +36,7 @@ public class StringTableCSVParser
     /// </summary>
     /// <param name="filename">Filename of StringTable CSV file.</param>
     /// <returns>KeyValuePair for each row if successful, otherwise null.</returns>
-    public static KeyValuePair<string, string>[] Load(string filename)
+    public static List<KeyValuePair<string, string>> Load(string filename)
     {
         string csvText = null;
 
@@ -64,7 +64,7 @@ public class StringTableCSVParser
             return null;
 
         // Parse into CSV rows
-        KeyValuePair<string, string>[] rows = null;
+        List<KeyValuePair<string, string>> rows;
         try
         {
             rows = ParseCSVRows(csvText);
@@ -84,7 +84,7 @@ public class StringTableCSVParser
     /// </summary>
     /// <param name="csvText">Source CSV data.</param>
     /// <returns>KeyValuePair for each row.</returns>
-    static KeyValuePair<string, string>[] ParseCSVRows(string csvText)
+    static List<KeyValuePair<string, string>> ParseCSVRows(string csvText)
     {
         // Regex pattern inspired by https://gist.github.com/awwsmm/886ac0ce0cef517ad7092915f708175f
         // but without the exponential behavior
@@ -97,14 +97,14 @@ public class StringTableCSVParser
                 m.Groups[1].Value.Trim(trimChars),
                 UnescapeCSVvalue(m.Groups[2].Value).Trim(trimChars)
                 )
-            ).ToList();
-        // Remove first row if it contains "Key" as key and "Value" as value
-        // This is the expected header row but doesn't need to be present
-        // First row will be accepted if any other key/value pair is present instead
-        if (rows.Count > 0 && rows[0].Key == keyString && rows[0].Value == valueString)
-            rows.RemoveAt(0);
+            )
+            // Remove first row if it contains "Key" as key and "Value" as value
+            // This is the expected header row but doesn't need to be present
+            // First row will be accepted if any other key/value pair is present instead
+            .Where((pair, index) => !(index == 0 && pair.Key == keyString && pair.Value == valueString))
+            .ToList();
 
-        return rows.ToArray();
+        return rows;
     }
 
     static string UnescapeCSVvalue(string value)

--- a/Assets/Scripts/Game/StringTableCSVParser.cs
+++ b/Assets/Scripts/Game/StringTableCSVParser.cs
@@ -84,35 +84,34 @@ public class StringTableCSVParser
     /// <returns>KeyValuePair for each row.</returns>
     static KeyValuePair<string, string>[] ParseCSVRows(string csvText)
     {
-        // Regex pattern from https://gist.github.com/awwsmm/886ac0ce0cef517ad7092915f708175f
-        const string linePattern = "(?:,|\\n|^)(\"(?:(?:\"\")*[^\"]*)*\"|[^\",\\n]*|(?:\\n|$))";
+        // Regex pattern inspired by https://gist.github.com/awwsmm/886ac0ce0cef517ad7092915f708175f
+        // but without the exponential behavior
+        const string linePattern = "(?:\\n|^)([^\",\\n]*),((?:\"[^\"]*\")+|[^\",\\n]*)";
 
         // Split source CSV based on regex matches
-        char[] trimChars = { '\r', '\n', '\"', ',' };
-        List<KeyValuePair<string, string>> rows = new List<KeyValuePair<string, string>>();
-        string[] matches = (from Match m in Regex.Matches(csvText, linePattern, RegexOptions.ExplicitCapture) select m.Groups[0].Value).ToArray();
-        int pos = 0;
-        while (pos < matches.Length)
-        {
-            if (pos + 1 == matches.Length)
-            {
-                // Exit if no valid pair at end of csv (likely an empty line at end of source data)
-                break;
-            }
-            string key = matches[pos++].Trim(trimChars);
-            string value = matches[pos++].Trim(trimChars);
-            value = value.Replace("\"\"", "\""); // Replace escaped quotes in value with single quote marks
-            KeyValuePair<string, string> kvp = new KeyValuePair<string, string>(key, value);
-            rows.Add(kvp);
-        }
-
+        char[] trimChars = { '\r', '\n' };
+        List<KeyValuePair<string, string>> rows = (from Match m in
+            Regex.Matches(csvText, linePattern)
+            select new KeyValuePair<string, string>(
+                m.Groups[1].Value.Trim(trimChars),
+                UnescapeCSVvalue(m.Groups[2].Value).Trim(trimChars)
+                )
+            ).ToList();
         // Remove first row if it contains "Key" as key and "Value" as value
         // This is the expected header row but doesn't need to be present
         // First row will be accepted if any other key/value pair is present instead
         if (rows.Count > 0 && rows[0].Key == keyString && rows[0].Value == valueString)
             rows.RemoveAt(0);
-
         return rows.ToArray();
+    }
+
+    static string UnescapeCSVvalue(string value) {
+        if (value.Length > 0 && value[0] == '"')
+        {
+            return value.Substring(1, value.Length - 2)
+                .Replace("\"\"", "\""); // unescape quote marks
+        }
+        return value;
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/StringTableCSVParser.cs
+++ b/Assets/Scripts/Game/StringTableCSVParser.cs
@@ -97,12 +97,13 @@ public class StringTableCSVParser
                 m.Groups[1].Value.Trim(trimChars),
                 UnescapeCSVvalue(m.Groups[2].Value).Trim(trimChars)
                 )
-            )
-            // Remove first row if it contains "Key" as key and "Value" as value
-            // This is the expected header row but doesn't need to be present
-            // First row will be accepted if any other key/value pair is present instead
-            .Where((pair, index) => !(index == 0 && pair.Key == keyString && pair.Value == valueString))
-            .ToList();
+            ).ToList();
+
+        // Remove first row if it contains "Key" as key and "Value" as value
+        // This is the expected header row but doesn't need to be present
+        // First row will be accepted if any other key/value pair is present instead
+        if (rows.Count > 0 && rows[0].Key == keyString && rows[0].Value == valueString)
+            rows.RemoveAt(0);
 
         return rows;
     }

--- a/Assets/Scripts/Game/StringTableCSVParser.cs
+++ b/Assets/Scripts/Game/StringTableCSVParser.cs
@@ -28,6 +28,8 @@ public class StringTableCSVParser
     const string keyString = "Key";
     const string valueString = "Value";
 
+    static readonly char[] trimChars = { '\r', '\n' };
+
     /// <summary>
     /// Loads a CSV patch file for in-game text.
     /// Seeks mods first then StreamingAssets/Text folder.
@@ -89,7 +91,6 @@ public class StringTableCSVParser
         const string linePattern = "(?:\\n|^)([^\",\\n]*),((?:\"[^\"]*\")+|[^\",\\n]*)";
 
         // Split source CSV based on regex matches
-        char[] trimChars = { '\r', '\n' };
         List<KeyValuePair<string, string>> rows = (from Match m in
             Regex.Matches(csvText, linePattern)
             select new KeyValuePair<string, string>(

--- a/Assets/Scripts/Game/StringTablePatcher.cs
+++ b/Assets/Scripts/Game/StringTablePatcher.cs
@@ -32,8 +32,8 @@ public class StringTablePatcher : ITablePostprocessor
             return;
 
         // Load table patch data (if present)
-        KeyValuePair<string, string>[] rows = StringTableCSVParser.Load(table.TableCollectionName);
-        if (rows == null || rows.Length == 0)
+        List<KeyValuePair<string, string>> rows = StringTableCSVParser.Load(table.TableCollectionName);
+        if (rows == null || rows.Count == 0)
             return;
 
         // Patch string table from patch data


### PR DESCRIPTION
Problem was discovered after DFU froze (busy-looping) while parsing a CSV with a faulty

    1554,"%it, Le Protecteur

(missing closing quotes) line in Text/Internal_MagicItems.csv

Nested star operators - like here, `(a*b*)*` - can take exponential time under the right conditions.
Minimal fix is to replace this pattern with `(a+|b+)*`, assuming a and b share no common prefix.

I did not stop there and removed the intermediate `matches` array by directly parsing key and value columns together in the regex.

Another potential bug fix, `.Trim("\"")` may remove more than the quotes surrounding quoted strings, ex.

    """Approach"" said the King" -> Approach" said the King

so I replaced it with a more explicit removal of surrounding quotes.