### PR TITLE
Allow custom sound indices in SoundReader.GetAudioClip. 

### DIFF
--- a/Assets/Scripts/API/BsaFile.cs
+++ b/Assets/Scripts/API/BsaFile.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Unity
+// Project:         Daggerfall Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -208,7 +208,7 @@ namespace DaggerfallConnect.Arena2
         public int GetRecordLength(int record)
         {
             // Validate
-            if (record >= header.DirectoryCount)
+            if (record < 0 || record >= header.DirectoryCount)
                 return 0;
 
             // Return length of this record
@@ -231,7 +231,7 @@ namespace DaggerfallConnect.Arena2
         public string GetRecordName(int record)
         {
             // Validate
-            if (record >= header.DirectoryCount)
+            if (record < 0 || record >= header.DirectoryCount)
                 return string.Empty;
 
             // Return name of this record
@@ -254,7 +254,7 @@ namespace DaggerfallConnect.Arena2
         public uint GetRecordId(int record)
         {
             // Validate
-            if (record >= header.DirectoryCount || header.DirectoryType != DirectoryTypes.NumberRecord)
+            if (record < 0 || record >= header.DirectoryCount || header.DirectoryType != DirectoryTypes.NumberRecord)
                 return 0;
 
             return numberRecordDirectory[record].RecordId;
@@ -268,7 +268,7 @@ namespace DaggerfallConnect.Arena2
         public byte[] GetRecordBytes(int record)
         {
             // Validate
-            if (record >= header.DirectoryCount)
+            if (record < 0 || record >= header.DirectoryCount)
                 return null;
 
             // Read record data into buffer

--- a/Assets/Scripts/SoundReader.cs
+++ b/Assets/Scripts/SoundReader.cs
@@ -60,8 +60,8 @@ namespace DaggerfallWorkshop
         {
             const float divisor = 1.0f / 128.0f;
 
-            // Must be ready and have a valid input index
-            if (!ReadyCheck() || !soundFile.IsValidIndex(soundIndex))
+            // Must be ready
+            if (!ReadyCheck())
                 return null;
 
             // Look for clip in cache
@@ -78,6 +78,10 @@ namespace DaggerfallWorkshop
             }
             else
             {
+                // Must have a valid index
+                if (!soundFile.IsValidIndex(soundIndex))
+                    return null;
+
                 // Get sound data
                 DFSound dfSound;
                 if (!soundFile.GetSound(soundIndex, out dfSound))


### PR DESCRIPTION
This can be used for custom enemies to pass new sounds in EnemySounds (ex: by providing `1000.mp3` and using `1000` as the attack sound in its Mobile structure). The value is forwarded to `SoundReplacement`, which handles non-standard values just fine.

I added some extra sanitization for negative numbers in BsaFile, because `SoundClips.None` is `-1`, which is often used as a default.