### PR TITLE
Remove ! prefix from spell bundles in Active Spells HUD tooltips

### DIFF
--- a/Assets/Scripts/Game/UserInterface/HUDActiveSpells.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDActiveSpells.cs
@@ -301,7 +301,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 // And offensive spells the player catches themselves with
                 // Will need to refine how this works as more effects and situations become available
                 ActiveSpellIcon item = new ActiveSpellIcon();
-                item.displayName = bundle.name;
+                item.displayName = bundle.name.TrimStart('!'); // Non-vendor spells start with !, don't show this on the UI
                 item.iconIndex = bundle.iconIndex;
                 item.icon = bundle.icon;
                 item.poolIndex = poolIndex++;


### PR DESCRIPTION
I've recently learned that spell bundle names are user-facing

![image](https://user-images.githubusercontent.com/5789925/236647147-5b3be30a-8b1e-45b4-83bb-dca4047a5796.png)

There's an existing practice in DF data that spells that shouldn't be sold at the Mages Guild start with ! (ex: `!Lycanthropy`). Having one of these as an active effect is not really possible in classic. With mods, it's desirable to give enemies custom spell bundles without filling up the vendor.
So, this change just removes the ! prefix of spells in the active spells HUD, making the name look less like a debug placeholder