### PR TITLE
Remove delay between asset unloads

### DIFF
--- a/Assets/Scripts/Game/UserInterface/UserInterfaceWindow.cs
+++ b/Assets/Scripts/Game/UserInterface/UserInterfaceWindow.cs
@@ -128,7 +128,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             uiManager.PopWindow();
             RaiseOnCloseHandler();
-            DaggerfallGC.ThrottledUnloadUnusedAssets();
+            DaggerfallGC.ForcedUnloadUnusedAssets();
         }
 
         public void PopWindow()

--- a/Assets/Scripts/Internal/DaggerfallGC.cs
+++ b/Assets/Scripts/Internal/DaggerfallGC.cs
@@ -4,33 +4,20 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Pango (petchema@concept-micro.com)
-// Contributors:    
+// Contributors:    Numidium
 // 
 // Notes:
 //
 
-using System;
 using UnityEngine;
 
 namespace DaggerfallWorkshop
 {
     public static class DaggerfallGC
     {
-        // Min time between two unused assets collections
-        private const float uuaThrottleDelay = 180f;
-
-        private static float uuaTimer = Time.realtimeSinceStartup;
-
-        public static void ThrottledUnloadUnusedAssets()
-        {
-            if (Time.realtimeSinceStartup >= uuaTimer)
-                ForcedUnloadUnusedAssets();
-        }
-
         public static void ForcedUnloadUnusedAssets()
         {
             Resources.UnloadUnusedAssets();
-            uuaTimer = Time.realtimeSinceStartup + uuaThrottleDelay;
         }
     }
 }

--- a/Assets/Scripts/Terrain/StreamingWorld.cs
+++ b/Assets/Scripts/Terrain/StreamingWorld.cs
@@ -679,7 +679,7 @@ namespace DaggerfallWorkshop
             if (init)
             {
                 DaggerfallUnity.Instance.PruneCache();
-                DaggerfallGC.ThrottledUnloadUnusedAssets();
+                DaggerfallGC.ForcedUnloadUnusedAssets();
             }
 
             // Set terrain neighbours


### PR DESCRIPTION
The addition of incremental GC makes asset unloads less jarring in my experience. Waiting less time between asset unloads should give the GC less work to do when it is called. Incremental GC was enabled here: #2390