### PR TITLE
Add an option to hide PersistentDataPath in launcher

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -115,6 +115,7 @@ CanDropQuestItems=False
 EnableQuestDebugger=False
 QuestRumorWeight = 50
 DisableEnemyDeathAlert=False
+HideLoginName=False
 
 [Spells]
 EnableSpellLighting=True

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -510,7 +510,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Add settings path text
             TextLabel settingsPathLabel = new TextLabel();
-            settingsPathLabel.Text = DaggerfallUnity.Settings.PersistentDataPath;
+            if (!DaggerfallUnity.Settings.HideLoginName)
+            {
+                settingsPathLabel.Text = DaggerfallUnity.Settings.PersistentDataPath;
+            }
             settingsPathLabel.Position = new Vector2(0, 170);
             settingsPathLabel.HorizontalAlignment = HorizontalAlignment.Center;
             settingsPathLabel.ShadowPosition = Vector2.zero;

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -239,6 +239,7 @@ namespace DaggerfallWorkshop
         public bool EnableQuestDebugger { get; set; }
         public int QuestRumorWeight { get; set; }
         public bool DisableEnemyDeathAlert { get; set; }
+        public bool HideLoginName { get; set; }
 
         // [Spells]
         public bool EnableSpellLighting { get; set; }
@@ -459,6 +460,7 @@ namespace DaggerfallWorkshop
             EnableQuestDebugger = GetBool(sectionGUI, "EnableQuestDebugger");
             QuestRumorWeight = GetInt(sectionGUI, "QuestRumorWeight", 1, 100);
             DisableEnemyDeathAlert = GetBool(sectionGUI, "DisableEnemyDeathAlert");
+            HideLoginName = GetBool(sectionGUI, "HideLoginName");
 
             EnableSpellLighting = GetBool(sectionSpells, "EnableSpellLighting");
             EnableSpellShadows = GetBool(sectionSpells, "EnableSpellShadows");
@@ -646,6 +648,7 @@ namespace DaggerfallWorkshop
             SetBool(sectionGUI, "EnableQuestDebugger", EnableQuestDebugger);
             SetInt(sectionGUI, "QuestRumorWeight", QuestRumorWeight);
             SetBool(sectionGUI, "DisableEnemyDeathAlert", DisableEnemyDeathAlert);
+            SetBool(sectionGUI, "HideLoginName", HideLoginName);
 
             SetBool(sectionSpells, "EnableSpellLighting", EnableSpellLighting);
             SetBool(sectionSpells, "EnableSpellShadows", EnableSpellShadows);


### PR DESCRIPTION
Some streamers would prefer not to show PersistentDataPath in the launcher because it reveals their login name.

This PR adds a (not published) setting to hide that path. I called the setting "HideLoginName" to match its true intent, it case it becomes necessary in other places.

(I kept this PR minimal given feature freeze).