### PR TITLE
Localize "USE"d maps

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1825,9 +1825,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 if (string.IsNullOrEmpty(revealedLocation.Name))
                     throw new Exception();
 
-                playerGPS.LocationRevealedByMapItem = revealedLocation.Name;
+                string localizedLocation = TextManager.Instance.GetLocalizedLocationName(revealedLocation.MapTableData.MapId, revealedLocation.Name);
+                playerGPS.LocationRevealedByMapItem = localizedLocation;
                 GameManager.Instance.PlayerEntity.Notebook.AddNote(
-                    TextManager.Instance.GetLocalizedText("readMap").Replace("%map", revealedLocation.Name));
+                    TextManager.Instance.GetLocalizedText("readMap").Replace("%map", localizedLocation));
 
                 DaggerfallMessageBox mapText = new DaggerfallMessageBox(uiManager, this);
                 mapText.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRandomTokens(mapTextId));


### PR DESCRIPTION
Translate the location written on maps used from the inventory (usually maps found in loot).
Tested to translate correctly the dialog box, the notes, and the regional map.

Screenshot before PR:
![Capture d’écran du 2023-05-22 01-18-01](https://github.com/Interkarma/daggerfall-unity/assets/1211431/15f52c76-90ab-4bf9-b052-c8cc2443af47)
