### PR TITLE
Reset seed to ensure magic item shop theft randomization

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -913,6 +913,10 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 int chanceBeingDetected = FormulaHelper.CalculateShopliftingChance(PlayerEntity, buildingDiscoveryData.quality, weightAndNumItems);
                 PlayerEntity.TallySkill(DFCareer.Skills.Pickpocket, 1);
 
+                // Here we ensure that stealing will always be random
+                // DaggerfallGuildServicePopupWindow.cs:231 sets a seed which will keep you from being able to steal from magic item shops, which I don't think is purposeful
+                UnityEngine.Random.InitState(System.DateTime.Now.Millisecond);
+
                 if (Dice100.FailedRoll(chanceBeingDetected))
                 {
                     DaggerfallUI.AddHUDText(TextManager.Instance.GetLocalizedText("stealSuccess"), 2);


### PR DESCRIPTION
DaggerfallGuildServicePopupWindow.cs line 231 (in the GetMerchantMagicItems function) sets a consistent seed when opening the magic items window. This means there is no randomization when you go to steal an item from the magic shop. This change re-randomizes the seed when you're about to steal so that quickload-stealing is possible from the magic shop as I have to assume it was in vanilla.