### PR TITLE
Fix painting description for paintingRecord #70

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -46,6 +46,14 @@ namespace DaggerfallWorkshop.Game.Items
                 dataSource.paintingFilename = paintingFileChar + "PAINT.CIF";
 
                 byte[] paintingRecord = DaggerfallUnity.Instance.ContentReader.PaintFileReader.Read(paintingIndex);
+                if (paintingIndex == 70 && // Known buggy paintingRecord
+                    paintingRecord[30] == 0xFF) // not fixed in PAINT.DAT
+                {
+                    // That paintingRecord is used for Wayrest Painting, whose non-magic look resembles the fog on Cryngaine Field.
+                    paintingRecord[30] = 3; // summer
+                    paintingRecord[31] = 8; // afternoon
+                    paintingRecord[32] = 10; // Highrock
+                }
                 Debug.LogFormat("painting file: {0}, index: {1}, cif idx: {2}, record: {3} {4} {5}", dataSource.paintingFilename, paintingIndex, dataSource.paintingFileIdx, paintingRecord[0], paintingRecord[1], paintingRecord[2]);
 
                 dataSource.paintingSub = GetPaintingRecordPart(paintingRecord, 0, 9) + 6100; // for %sub macro

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItemMCP.cs
@@ -49,10 +49,10 @@ namespace DaggerfallWorkshop.Game.Items
                 if (paintingIndex == 70 && // Known buggy paintingRecord
                     paintingRecord[30] == 0xFF) // not fixed in PAINT.DAT
                 {
-                    // That paintingRecord is used for Wayrest Painting, whose non-magic look resembles the fog on Cryngaine Field.
                     paintingRecord[30] = 3; // summer
-                    paintingRecord[31] = 8; // afternoon
-                    paintingRecord[32] = 10; // Highrock
+                    paintingRecord[31] = 6; // spring
+                    paintingRecord[32] = 8; // afternoon
+                    paintingRecord[33] = 10; // Highrock
                 }
                 Debug.LogFormat("painting file: {0}, index: {1}, cif idx: {2}, record: {3} {4} {5}", dataSource.paintingFilename, paintingIndex, dataSource.paintingFileIdx, paintingRecord[0], paintingRecord[1], paintingRecord[2]);
 


### PR DESCRIPTION
PAINT.DAT's #70 paintingRecord alternatives list for %pp2 is empty, raising an exception.

Runtime patch a list for this macro, compatible with painting gfx. In case this paintingRecord is hardcoded to be used for Wayrest Painting, it will also be compatible with the "fog over Cryngaine Fields" event.

It is also possible that classic does not generate text (%pp2 expands to the empty string) instead.

Forums: https://forums.dfworkshop.net/viewtopic.php?t=6336