### PR TITLE
Dim backgound for DaggerfallEffectSettingsEditorWindow

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallEffectSettingsEditorWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallEffectSettingsEditorWindow.cs
@@ -139,6 +139,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Setup native panel background
             NativePanel.BackgroundTexture = baseTexture;
+            NativePanel.BackgroundColor = new Color(0, 0, 0, 0.65f);
 
             // Setup controls
             SetupEffectDescriptionPanels();


### PR DESCRIPTION
The background panel of the DaggerfallEffectSettingsEditorWindow should be dimmed like in the original DF.