### PR TITLE
Fix regression caused by #1861

### DIFF
--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -37,6 +37,7 @@ namespace DaggerfallWorkshop.Game
 
         public float MovementSpeed = 25.0f;                     // Speed missile moves through world
         public float ColliderRadius = 0.45f;                    // Radius of missile contact sphere
+        public static float ArmLength = 0.9f;                   // Distance of cast origin, >= ColliderRadius
         public float ExplosionRadius = 4.0f;                    // Radius of area of effect explosion
         public bool EnableLight = true;                         // Show a light with this missile - player can force disable from settings
         public bool EnableShadows = true;                       // Light will cast shadows - player can force disable from settings
@@ -430,7 +431,7 @@ namespace DaggerfallWorkshop.Game
         void DoMissile()
         {
             direction = GetAimDirection();
-            transform.position = GetAimPosition() + direction * ColliderRadius;
+            transform.position = GetAimPosition() + direction * ArmLength;
             missileReleased = true;
         }
 

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -35,7 +35,6 @@ namespace DaggerfallWorkshop.Game
         const float attackSpeedDivisor = 2f;        // How much to slow down during attack animations
         float stopDistance = 1.7f;                  // Used to prevent orbiting
         const float doorCrouchingHeight = 1.65f;    // How low enemies dive to pass thru doors
-        const float armLength = 1f;                 // Distance of cast spells origin
         bool flies;                                 // The enemy can fly
         bool swims;                                 // The enemy can swim
         bool pausePursuit;                          // pause to wait for the player to come closer to ground
@@ -690,7 +689,9 @@ namespace DaggerfallWorkshop.Game
                 // Exclude enemy collider from CheckSphere test
                 myCollider.enabled = false;
             }
-            bool isSpaceInsufficient = Physics.CheckSphere(transform.position + sphereCastDir * armLength, radius, ignoreMaskForShooting);
+
+            Vector3 shootOrigin = transform.position + sphereCastDir * radius;
+            bool isSpaceInsufficient = Physics.CheckSphere(shootOrigin, radius, ignoreMaskForShooting);
             if (myCollider)
                 myCollider.enabled = myColliderWasEnabled;
 
@@ -698,7 +699,7 @@ namespace DaggerfallWorkshop.Game
                 return false;
 
             RaycastHit hit;
-            if (Physics.SphereCast(transform.position, radius, sphereCastDir, out hit, sphereCastDist, ignoreMaskForShooting))
+            if (Physics.SphereCast(shootOrigin, radius, sphereCastDir, out hit, sphereCastDist, ignoreMaskForShooting))
             {
                 DaggerfallEntityBehaviour hitTarget = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
 

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -35,6 +35,7 @@ namespace DaggerfallWorkshop.Game
         const float attackSpeedDivisor = 2f;        // How much to slow down during attack animations
         float stopDistance = 1.7f;                  // Used to prevent orbiting
         const float doorCrouchingHeight = 1.65f;    // How low enemies dive to pass thru doors
+        const float armLength = 1f;                 // Distance of cast spells origin
         bool flies;                                 // The enemy can fly
         bool swims;                                 // The enemy can swim
         bool pausePursuit;                          // pause to wait for the player to come closer to ground
@@ -677,6 +678,9 @@ namespace DaggerfallWorkshop.Game
             if (sphereCastDir == EnemySenses.ResetPlayerPos)
                 return false;
 
+            float sphereCastDist = (sphereCastDir - transform.position).magnitude;
+            sphereCastDir = (sphereCastDir - transform.position).normalized;
+
             // No point blank shooting special handling here, makes enemies favor other attack types (melee, touch spells,...)
 
             bool myColliderWasEnabled = false;
@@ -686,15 +690,12 @@ namespace DaggerfallWorkshop.Game
                 // Exclude enemy collider from CheckSphere test
                 myCollider.enabled = false;
             }
-            bool isSpaceInsufficient = Physics.CheckSphere(transform.position, radius, ignoreMaskForShooting);
+            bool isSpaceInsufficient = Physics.CheckSphere(transform.position + sphereCastDir * armLength, radius, ignoreMaskForShooting);
             if (myCollider)
                 myCollider.enabled = myColliderWasEnabled;
 
             if (isSpaceInsufficient)
                 return false;
-
-            float sphereCastDist = (sphereCastDir - transform.position).magnitude;
-            sphereCastDir = (sphereCastDir - transform.position).normalized;
 
             RaycastHit hit;
             if (Physics.SphereCast(transform.position, radius, sphereCastDir, out hit, sphereCastDist, ignoreMaskForShooting))

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -670,7 +670,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Returns true if can shoot projectile at target.
         /// </summary>
-        bool HasClearPathToShootProjectile(float speed, float radius)
+        bool HasClearPathToShootProjectile(float speed, float originDistance, float radius)
         {
             // Check that there is a clear path to shoot projectile
             Vector3 sphereCastDir = senses.PredictNextTargetPos(speed);
@@ -690,7 +690,7 @@ namespace DaggerfallWorkshop.Game
                 myCollider.enabled = false;
             }
 
-            Vector3 shootOrigin = transform.position + sphereCastDir * radius;
+            Vector3 shootOrigin = transform.position + sphereCastDir * originDistance;
             bool isSpaceInsufficient = Physics.CheckSphere(shootOrigin, radius, ignoreMaskForShooting);
             if (myCollider)
                 myCollider.enabled = myColliderWasEnabled;
@@ -725,7 +725,7 @@ namespace DaggerfallWorkshop.Game
 
             // Check that there is a clear path to shoot an arrow
             // All arrows are currently 35 speed.
-            return HasClearPathToShootProjectile(35f, 0.15f);
+            return HasClearPathToShootProjectile(35f, 0f, 0.15f);
         }
 
         /// <summary>
@@ -760,7 +760,7 @@ namespace DaggerfallWorkshop.Game
 
             // Check that there is a clear path to shoot a spell
             // All range spells are currently 25 speed and 0.45f radius
-            return HasClearPathToShootProjectile(25f, 0.45f);
+            return HasClearPathToShootProjectile(25f, DaggerfallMissile.ArmLength, 0.45f);
         }
 
         /// <summary>


### PR DESCRIPTION
PR #1861 was added to prevent caster enemies from nuking themselves with spells at range in the presence of low obstacles.

A side effect of this PR however, is that daedra lords in the "crossbow room" near the end of Mantellan Crux stopped shooting at the player altogether, making this room much less threatening.

This new PR checks for obstacles a bit in front of the enemies, so they can still cast from behind thin obstacles (rationale: spells start from arm's reach). It's a bit crude, for example it doesn't change from where the spells will be really cast. While some spells get thru, daedra lords sometimes nuke themselves.