### PR TITLE
Ensure GetMerchantMagicItems preserves seed (alternative to #2529)

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -224,6 +224,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             ItemCollection items = new ItemCollection();
             int numOfItems = (buildingDiscoveryData.quality / 2) + 1;
 
+            // Store state of random sequence
+            UnityEngine.Random.State prevState = UnityEngine.Random.state;
+
             // Seed random from game time to rotate magic stock every 24 game hours
             // This more or less resolves issue of magic item stock not being deterministic every time player opens window
             // Doesn't match classic exactly as classic stocking method unknown, but should be "good enough" for now
@@ -262,6 +265,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                     items.AddItem(magicItem);
                 }
             }
+            UnityEngine.Random.state = prevState;   // Restore random state
             return items;
         }
 


### PR DESCRIPTION
GetMerchantMagicItems() sets the random seed based on the current day. Any activity reliant on random sequence which occurs after opening the mages item seller will always have the same set of outcomes. Preserve the seed to avoid this.

This is an alternative fix to the one contributed in PR #2529 to limit the effect the change may have on the rest of the codebase. I am pretty sure there would be no ill effects from the other approach, but it's possible and given how close to release of v1.0 I am very cautious.

All credit to @chloelcdev for finding the issue, and contributing a perfectly fine fix. 