### PR TITLE
Changed save data in Questing Foe to allow for custom foe ids

### DIFF
--- a/Assets/Scripts/Game/Questing/Foe.cs
+++ b/Assets/Scripts/Game/Questing/Foe.cs
@@ -58,7 +58,7 @@ namespace DaggerfallWorkshop.Game.Questing
 
         public override Genders Gender
         {
-            get { return ((int)foeType < 128) ? Genders.Male : humanoidGender; }
+            get { return DaggerfallEntity.IsClassEnemyId((int)foeType) ? humanoidGender : Genders.Male; }
         }
 
         public int SpawnCount
@@ -314,11 +314,40 @@ namespace DaggerfallWorkshop.Game.Questing
             public ItemData_v1[] itemQueue;
         }
 
+        [fsObject("v2", typeof(SaveData_v1))]
+        public struct SaveData_v2
+        {
+            public int spawnCount;
+            public int foeId; // allows for custom foes
+            public Genders humanoidGender;
+            public bool injuredTrigger;
+            public bool restrained;
+            public int killCount;
+            public string displayName;
+            public string typeName;
+            public List<SpellReference> spellQueue;
+            public ItemData_v1[] itemQueue;
+
+            public SaveData_v2(SaveData_v1 v1)
+            {
+                spawnCount = v1.spawnCount;
+                foeId = (int)v1.foeType;
+                humanoidGender = v1.humanoidGender;
+                injuredTrigger = v1.injuredTrigger;
+                restrained = v1.restrained;
+                killCount = v1.killCount;
+                displayName = v1.displayName;
+                typeName = v1.typeName;
+                spellQueue = v1.spellQueue;
+                itemQueue = v1.itemQueue;
+            }
+        }
+
         public override object GetSaveData()
         {
-            SaveData_v1 data = new SaveData_v1();
+            SaveData_v2 data = new SaveData_v2();
             data.spawnCount = spawnCount;
-            data.foeType = foeType;
+            data.foeId = (int)foeType;
             data.humanoidGender = humanoidGender;
             data.injuredTrigger = injuredTrigger;
             data.restrained = restrained;
@@ -337,9 +366,19 @@ namespace DaggerfallWorkshop.Game.Questing
             if (dataIn == null)
                 return;
 
-            SaveData_v1 data = (SaveData_v1)dataIn;
+            SaveData_v2 data;
+
+            if (dataIn is SaveData_v1)
+            {
+                data = new SaveData_v2((SaveData_v1) dataIn);
+            }
+            else
+            {
+                data = (SaveData_v2)dataIn;
+            }
+
             spawnCount = data.spawnCount;
-            foeType = data.foeType;
+            foeType = (MobileTypes)data.foeId;
             humanoidGender = data.humanoidGender;
             injuredTrigger = data.injuredTrigger;
             restrained = data.restrained;


### PR DESCRIPTION
After looking into this issue: https://forums.dfworkshop.net/viewtopic.php?t=6357

Normally, we can store any `int` value in a `MobileTypes` enum, which occurs when using custom enemies with ids not defined in the `enum`. This works as long as we don't rely on features that require a field to be defined, such as serialization to and from string.

I found that in fsSerializer, enum values are serialized as strings, based on the matching enum field name.

In the `Foe.SaveData_v1` struct, we have `foeType` as a `MobileTypes` enum. This shows in the save like this
```
                    "resourceSpecific": {
                        "spawnCount": 3,
                        "foeType": "Knight",
                        ...
                    },
```
If a field is not defined for this value (ex: custom enemy ids), this gets saved as `"foeType": null`, which will default to 0 when loaded back in (hence the rat mentioned in the linked thread). 

To work around this issue, I've used an `int` with the id value. I have considered using a string to retain legibility, but I was not sure if it would still work once people start localizing custom enemies (we only have the Career name to identify custom enemies, and that string is user facing).

With the new save data
```
                    "resourceSpecific": {
                        "spawnCount": 1,
                        "foeId": 277,
                        "humanoidGender": "Male",
                        "injuredTrigger": true,
                        "restrained": false,
                        "killCount": 1,
                        "displayName": "Morkuchas",
                        "typeName": "Ghoul",
                        "spellQueue": null,
                        "itemQueue": null,
                        "$version": "v2",
                        "$type": "DaggerfallWorkshop.Game.Questing.Foe+SaveData_v2"
                    },
```

I have found one other place where a `MobileTypes` is serialized, in `ItemData_v1`, with the field `trappedSoulType`. I have not provided a fix for this one, because:
1) many structs and interface use `ItemData_v1` explicitly. Moving to `ItemData_v2` would require updating all save structures using items to v2 (big change) and the interfaces (breaks mods)
2) custom monsters cannot be soul trapped as of now. we can keep this fix for later if we ever implement it

