### PR TITLE
Fix for RuntimeMaterials to pick the right ground texture in Woodland Hills

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/RuntimeMaterials.cs
@@ -198,10 +198,28 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             int archive = runtimeMaterial.Archive;
             int record = runtimeMaterial.Record;
 
+            ClimateTextureInfo ci = ClimateSwaps.GetClimateTextureInfo(archive);
             if (dungeonTextureTable != null)
+            {
                 archive = DungeonTextureTables.ApplyTextureTable(archive, dungeonTextureTable, climateBaseType);
+            }
             else if (runtimeMaterial.ApplyClimate)
-                archive = ClimateSwaps.ApplyClimate(archive, record, climate, season);
+            {
+                if (ci.textureSet == DFLocation.ClimateTextureSet.Exterior_Terrain)
+                {
+                    // For exterior terrain, always apply the ground based on climate settings, not climate swap
+                    // Most climates match, except Woodland Hills, which is Temperate with Mountain ground
+                    archive = GameManager.Instance.PlayerGPS.ClimateSettings.GroundArchive;
+                    if (season == ClimateSeason.Winter && ci.supportsWinter)
+                        archive += (int)DFLocation.ClimateWeather.Winter;
+                    else if (season == ClimateSeason.Rain && ci.supportsRain)
+                        archive += (int)DFLocation.ClimateWeather.Rain;
+                }
+                else
+                {
+                    archive = ClimateSwaps.ApplyClimate(archive, record, climate, season);
+                }
+            }
 
             return DaggerfallUnity.Instance.MaterialReader.GetMaterial(archive, record);
         }


### PR DESCRIPTION
A user was having a mismatch in RuntimeMaterials when replacing ground textures according to climate/season/weather.

In this example:
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/16ddf733-6ecc-481a-9a92-aa0d499ec73c)

The bright green of the hill clashes with the dark green of the rest of the area. This is because the hill has been made to use archive 302-304, and Woodland Hills uses archive 102-104 for ground.

A concrete climate's ground archive is defined in `MapsFile.GetWorldClimateSettings`, along with its base climate setting. Without the concrete climate, we can get a default ground archive matching the base climate as defined in `ClimateSwaps` logic (either in `ApplyClimate` or `GetGroundArchive`).
In the latter case, we have for the ground:
- Desert = archive 2
- Mountain = archive 102
- Temperate = archive 302
- Swamp = archive 402
With winter variants at x03 and rain variants at x04.

For the most part, the climates in `MapsFile.GetWorldClimateSettings` have a ground archive matching the base climate's in `ClimateSwaps.GetGroundArchive`. We only have one exception: `Climates.MountainWoods` (aka "Woodland Hills") has a Temperate base climate (normally ground archive 302), but with a specific ground archive of 102 (the mountain one).
102 is the archive used by the terrain generator. Therefore, any ground generated in this climate needs to match 102, not 302.

This fix adds an explicit check in RuntimeMaterials for whether we're replacing a ground archive, and if so, use the climate settings' ground archive, not the naive climate-based swap.

And the result is a more natural hill
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/c917f901-3725-4f35-a355-20603905f728)

Similarly, `DaggerfallMesh.SetClimate` uses `MaterialReader.ChangeClimate` which also relies on `ClimateSwaps` logic to customize by weather. However, I'm not sure whether a `DaggerfallMesh` ever uses the ground archive, so I did not insert this fix in this PR.