### PR TITLE
Fixed climate-swap changes in DaggerfallLocation not respecting the billboard's "AlignToBase"

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallLocation.cs
+++ b/Assets/Scripts/Internal/DaggerfallLocation.cs
@@ -253,8 +253,20 @@ namespace DaggerfallWorkshop
             {
                 if (db.Summary.FlatType == FlatTypes.Nature)
                 {
+                    // Billboard is already aligned to base
+                    // But we're potentially changing the archive
+                    // Because the summary size can change, we have to cancel
+                    // the "base" alignment and reapply it after
+                    Vector3 offset = Vector3.zero;
+                    offset.y = (db.Summary.Size.y / 2);
+                    db.transform.position -= offset;
+
                     // Apply recalculated nature archive
                     db.SetMaterial(natureArchive, db.Summary.Record);
+
+                    // Re-align to base
+                    offset.y = (db.Summary.Size.y / 2);
+                    db.transform.position += offset;
                 }
                 else
                 {


### PR DESCRIPTION
Billboards always float in the air, so the bottom touches the ground. In `DaggerfallLocation.ApplyClimateSettings`, we have a procedure to apply climate swap on child billboards, but it fails to account for the change in billboard height.

This issue only affects nature used in RMB "misc block flats". In normal Daggerfall data, nature is in the ground scenery, which applies the climate swap directly in `RMBLayout.AddNatureFlats`, before the billboard's been aligned to base. However, ground scenery is bound to a 16x16 grid and has fixed elevation, so mods prefer to use "misc flats" for better control (like putting a tree on a hill).

This issue was reported by carademono here: https://github.com/Interkarma/daggerfall-unity/pull/2545#issuecomment-1820286381

Without climate swap:
![284473002-19c8ef5a-6cfd-403c-81ef-ab392fb65b4d](https://github.com/Interkarma/daggerfall-unity/assets/5789925/bab4dcc2-b5ce-41e2-a21a-1d299daeacdc)

With climate swap:
![284473016-fb1d70cc-6b7b-4956-9242-b76ba28c88f0](https://github.com/Interkarma/daggerfall-unity/assets/5789925/a16cb618-2618-4662-87c2-13aadb905c7d)

My suggested fix is to cancel out the "AlignToBase" in DaggerfallLocation using the original size, then realign to base using the new size.

Now, trees keep the correct elevation.
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/d15a49e4-27e6-47b9-bab1-3d440d271b95)

Other potential solutions:
We could apply the climate swap in `RMBLayout.AddMiscBlockFlats` similarly to what we already have for the ground scenery. However, DaggerfallLocation is intended to have control of whether climate swap is applied, and I figured this might have side effects of forcing climate swaps in contexts where it's not intended.