### PR TITLE
Fix for buildings names macro expand

### DIFF
--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -1293,8 +1293,8 @@ namespace DaggerfallWorkshop.Game.Questing
                     buildingSummary[buildingIndex].NameSeed,
                     buildingSummary[buildingIndex].BuildingType,
                     buildingSummary[buildingIndex].FactionId,
-                    location.Name,
-                    location.RegionName);
+                    TextManager.Instance.GetLocalizedLocationName(location.MapTableData.MapId, location.Name),
+                    TextManager.Instance.GetLocalizedRegionName(location.RegionIndex));
             }
 
             return buildingName;

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -1169,7 +1169,7 @@ namespace DaggerfallWorkshop
                     buildingSummary.NameSeed,
                     buildingSummary.BuildingType,
                     buildingSummary.FactionId,
-                    buildingDirectory.LocationData.Name,
+                    TextManager.Instance.GetLocalizedLocationName(buildingDirectory.LocationData.MapTableData.MapId, buildingDirectory.LocationData.Name),
                     TextManager.Instance.GetLocalizedRegionName(buildingDirectory.LocationData.RegionIndex));
 
                 // Schedule name change

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -1319,7 +1319,7 @@ namespace DaggerfallWorkshop
                     buildingSummary.NameSeed,
                     buildingSummary.BuildingType,
                     buildingSummary.FactionId,
-                    buildingDirectory.LocationData.Name,
+                    TextManager.Instance.GetLocalizedLocationName(buildingDirectory.LocationData.MapId, buildingDirectory.LocationData.Name),
                     TextManager.Instance.GetLocalizedRegionName(buildingDirectory.LocationData.RegionIndex));
             }
             buildingDiscoveryData.factionID = buildingSummary.FactionId;

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -1319,7 +1319,7 @@ namespace DaggerfallWorkshop
                     buildingSummary.NameSeed,
                     buildingSummary.BuildingType,
                     buildingSummary.FactionId,
-                    TextManager.Instance.GetLocalizedLocationName(buildingDirectory.LocationData.MapId, buildingDirectory.LocationData.Name),
+                    buildingDirectory.LocationData.Name,
                     TextManager.Instance.GetLocalizedRegionName(buildingDirectory.LocationData.RegionIndex));
             }
             buildingDiscoveryData.factionID = buildingSummary.FactionId;

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -843,7 +843,7 @@ namespace DaggerfallWorkshop.Utility
                 buildingData.NameSeed,
                 buildingData.BuildingType,
                 buildingData.FactionId,
-                location.Name,
+                TextManager.Instance.GetLocalizedLocationName(location.MapTableData.MapId, location.Name),
                 TextManager.Instance.GetLocalizedRegionName(location.RegionIndex));
         }
 


### PR DESCRIPTION
Fix for `%cn` macro not expanded in all cases 

Before:

![Screenshot 2023-12-16 191130](https://github.com/Interkarma/daggerfall-unity/assets/1652113/2cbf97e9-aff0-42bb-9e35-e89e18694266)
![Screenshot 2023-12-16 191224](https://github.com/Interkarma/daggerfall-unity/assets/1652113/c337b5ec-b544-4c54-a2fd-a23838708c6e)
![Screenshot 2023-12-16 191246](https://github.com/Interkarma/daggerfall-unity/assets/1652113/83387307-6dfd-4a0b-a470-537cba1157ff)

<hr/>

After:
![Screenshot 2023-12-16 193256](https://github.com/Interkarma/daggerfall-unity/assets/1652113/a36dc5b5-5a74-4de0-98af-471278ea85fb)
![Screenshot 2023-12-16 193238](https://github.com/Interkarma/daggerfall-unity/assets/1652113/751dd5e5-4e24-4e5d-87da-cfe0875ae95b)
