### PR TITLE
Added ability to move text labels.

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBankingWindow.cs
@@ -27,10 +27,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
         Panel mainPanel;
 
-        TextLabel accountAmount;
-        TextLabel inventoryAmount;
-        TextLabel loanAmountDue;
-        TextLabel loanDueBy;
+        protected TextLabel accountAmount;
+        protected TextLabel inventoryAmount;
+        protected TextLabel loanAmountDue;
+        protected TextLabel loanDueBy;
 
         Button depoGoldButton;
         Button drawGoldButton;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallCharacterSheetWindow.cs
@@ -50,18 +50,18 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region UI Controls
 
-        PlayerEntity playerEntity;
-        TextLabel nameLabel = new TextLabel();
-        TextLabel raceLabel = new TextLabel();
-        TextLabel classLabel = new TextLabel();
-        TextLabel levelLabel = new TextLabel();
-        TextLabel goldLabel = new TextLabel();
-        TextLabel fatigueLabel = new TextLabel();
-        TextLabel healthLabel = new TextLabel();
-        TextLabel encumbranceLabel = new TextLabel();
-        Panel[] statPanels = new Panel[DaggerfallStats.Count];
-        TextLabel[] statLabels = new TextLabel[DaggerfallStats.Count];
-        PaperDoll characterPortrait = new PaperDoll(showArmorValues: false);
+        protected PlayerEntity playerEntity;
+        protected TextLabel nameLabel = new TextLabel();
+        protected TextLabel raceLabel = new TextLabel();
+        protected TextLabel classLabel = new TextLabel();
+        protected TextLabel levelLabel = new TextLabel();
+        protected TextLabel goldLabel = new TextLabel();
+        protected TextLabel fatigueLabel = new TextLabel();
+        protected TextLabel healthLabel = new TextLabel();
+        protected TextLabel encumbranceLabel = new TextLabel();
+        protected Panel[] statPanels = new Panel[DaggerfallStats.Count];
+        protected TextLabel[] statLabels = new TextLabel[DaggerfallStats.Count];
+        protected PaperDoll characterPortrait = new PaperDoll(showArmorValues: false);
 
         #endregion
 


### PR DESCRIPTION
# Reason

It's not a secret that text in different languages have different lengths. Hence, we need the ability to move labels. At least through mods. But currently we cannot do that easily, because these fields are private. And instead of quick extension of the dialog class we must re-implement the whole window logic. 

To be able to do something simple like 
```cs
protected override void Setup()
{
    base.Setup();
    // Setup labels
    nameLabel.Position = new Vector2(34, 4);
    raceLabel.Position = new Vector2(40, 14);
    classLabel.Position = new Vector2(47, 24);
    levelLabel.Position = new Vector2(54, 34);
    goldLabel.Position = new Vector2(53, 44);
    fatigueLabel.Position = new Vector2(42, 54);
    healthLabel.Position = new Vector2(48, 64);
    encumbranceLabel.Position = new Vector2(68, 74);
}
```

or 
```cs
protected override void Setup()
{
    base.Setup();
    // Setup labels
    accountAmount.Position = new Vector2(126, 14);
    inventoryAmount.Position = new Vector2(141, 24);
    loanAmountDue.Position = new Vector2(71, 34);
    loanDueBy.Position = new Vector2(71, 44);
}
```

we need to change the protection level on these labels.


# Result
## Before:
![Screenshot 2023-12-18 124824](https://github.com/Interkarma/daggerfall-unity/assets/1652113/86bf0b5a-93da-49b5-bd35-917896c0de3e)
![Screenshot 2023-12-18 130222](https://github.com/Interkarma/daggerfall-unity/assets/1652113/e85906be-7580-4d04-b87f-6663db88c63d)

## After
![Screenshot 2023-12-18 124740](https://github.com/Interkarma/daggerfall-unity/assets/1652113/0f1d90ea-fb73-4a69-878b-6f42f704a3ed)
![Screenshot 2023-12-18 131827](https://github.com/Interkarma/daggerfall-unity/assets/1652113/2f4f5418-b81c-4fd5-a1d6-e5321aabc2bd)
