### PR TITLE
Enemy component access

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -325,7 +325,7 @@ namespace DaggerfallWorkshop.Game
         void ApplyGravity()
         {
             // Apply gravity
-            if (entity.IsSlowFalling && !flies && !swims && !controller.isGrounded)
+            if (entity.IsSlowFalling && !flies && !swims && !controller.isGrounded && !IsLevitating)
             {
                 Vector3 velocity = controller.velocity * 0.97f; //gradually slow x/z movement
                 velocity.y = -1; //slow downward fall
@@ -344,10 +344,7 @@ namespace DaggerfallWorkshop.Game
                     CanAct = false;
             }
 
-            if (IsLevitating || entity.IsSlowFalling)
-                LastGroundedY = transform.position.y;
-
-            if (flyerFalls && flies && !IsLevitating)
+            if (flyerFalls && flies && !IsLevitating && !entity.IsSlowFalling)
             {
                 controller.SimpleMove(Vector3.zero);
                 Falls = true;
@@ -1418,6 +1415,9 @@ namespace DaggerfallWorkshop.Game
             // For flying enemies, "lastGroundedY" is really "lastAltitudeControlY"
             else if (flies && !flyerFalls)
                 LastGroundedY = transform.position.y;
+            else if (IsLevitating || entity.IsSlowFalling)
+                LastGroundedY = transform.position.y;
+
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -98,7 +98,8 @@ namespace DaggerfallWorkshop.Game
         public float LastGroundedY { get; set; }    // Used for fall damage
         public bool Falls { get; private set; }
 
-        //Delegates to allow mods to extend motor behaviour.
+        //============Delegates to allow mods to extend motor behaviour.
+        //==When setting a new handler, it may be desired to store the original and call it before/after your own logic.
         public delegate void TakeActionCallback();
         public TakeActionCallback TakeActionHandler { get; set; }
 
@@ -1412,12 +1413,11 @@ namespace DaggerfallWorkshop.Game
                 LastGroundedY = transform.position.y;
             }
             // For flying enemies, "lastGroundedY" is really "lastAltitudeControlY"
-            else if (flies && !flyerFalls)
-                LastGroundedY = transform.position.y;
-            else if (IsLevitating || entity.IsSlowFalling)
+            else if ((flies && !flyerFalls) || IsLevitating || entity.IsSlowFalling)
                 LastGroundedY = transform.position.y;
 
         }
+
 
         /// <summary>
         /// Open doors that are in the way.

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -15,6 +15,7 @@ using DaggerfallWorkshop.Game.MagicAndEffects;
 using System.Collections.Generic;
 using DaggerfallWorkshop.Utility;
 using System.Linq;
+using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -48,7 +49,6 @@ namespace DaggerfallWorkshop.Game
         bool retreating;                            // Is retreating
         bool backingUp;                             // Is backing up
         bool fallDetected;                          // Detected a fall in front of us, so don't move there
-        bool obstacleDetected;
         bool foundUpwardSlope;
         bool foundDoor;
         Vector3 lastPosition;                       // Used to track whether we have moved or not
@@ -69,10 +69,7 @@ namespace DaggerfallWorkshop.Game
         int searchMult;
         int ignoreMaskForShooting;
         int ignoreMaskForObstacles;
-        bool canAct;
-        bool falls;
         bool flyerFalls;
-        float lastGroundedY;                        // Used for fall damage
         float originalHeight;
 
         EnemySenses senses;
@@ -84,7 +81,6 @@ namespace DaggerfallWorkshop.Game
         DaggerfallEntityBehaviour entityBehaviour;
         EnemyBlood entityBlood;
         EntityEffectManager entityEffectManager;
-        EntityEffectBundle selectedSpell;
         EnemyAttack attack;
         EnemyEntity entity;
         #endregion
@@ -97,6 +93,22 @@ namespace DaggerfallWorkshop.Game
         public Vector3 KnockbackDirection { get; set; } // Direction to travel while being knocked back
         public bool Bashing { get; private set; }   // Is this enemy bashing a door
         public int GiveUpTimer { get; set; }        // Timer for enemy giving up pursuit of target
+        public bool ObstacleDetected { get; private set; }
+        public EntityEffectBundle SelectedSpell { get; set; }
+        public bool CanAct { get; set; }
+        public float LastGroundedY { get; set; }    // Used for fall damage
+        public bool Falls { get; private set; }
+
+        //Delegates to allow mods to extend motor behaviour.
+        public delegate void TakeActionCallback();
+        public TakeActionCallback TakeAction { get; set; }
+
+        public delegate bool CanCastRangedSpellCallback();
+        public CanCastRangedSpellCallback CanCastRangedSpell { get; set; }
+
+        public delegate bool CanCastTouchSpellCallback();
+        public CanCastTouchSpellCallback CanCastTouchSpell { get; set; }
+
         #endregion
 
         #region Unity Methods
@@ -130,10 +142,14 @@ namespace DaggerfallWorkshop.Game
             // Also ignore arrows and "Ignore Raycast" layer for obstacles
             ignoreMaskForObstacles = ~(1 << LayerMask.NameToLayer("SpellMissiles") | 1 << LayerMask.NameToLayer("Ignore Raycast"));
 
-            lastGroundedY = transform.position.y;
+            LastGroundedY = transform.position.y;
 
             // Get original height, before any height adjustments
             originalHeight = controller.height;
+
+            TakeAction = TakeActionDefault;
+            CanCastRangedSpell = CanCastRangedSpellDefault;
+            CanCastTouchSpell = CanCastTouchSpellDefault;
         }
 
         void FixedUpdate()
@@ -142,9 +158,9 @@ namespace DaggerfallWorkshop.Game
                 return;
 
             flies = CanFly();
-            canAct = true;
+            CanAct = true;
             flyerFalls = false;
-            falls = false;
+            Falls = false;
 
             HandleParalysis();
             KnockbackMovement();
@@ -152,7 +168,7 @@ namespace DaggerfallWorkshop.Game
             HandleNoAction();
             HandleBashing();
             UpdateTimers();
-            if (canAct)
+            if (CanAct)
                 TakeAction();
             ApplyFallDamage();
             UpdateToIdleOrMoveAnim();
@@ -218,7 +234,7 @@ namespace DaggerfallWorkshop.Game
         /// <param name="y">Amount to increment to fallstart</param>
         public void AdjustLastGrounded(float y)
         {
-            lastGroundedY += y;
+            LastGroundedY += y;
         }
 
         #endregion
@@ -237,7 +253,7 @@ namespace DaggerfallWorkshop.Game
             if (entityBehaviour.Entity.IsParalyzed)
             {
                 mobile.FreezeAnims = true;
-                canAct = false;
+                CanAct = false;
                 flyerFalls = true;
             }
             mobile.FreezeAnims = false;
@@ -298,7 +314,7 @@ namespace DaggerfallWorkshop.Game
                     EvaluateMoveInForAttack();
                 }
 
-                canAct = false;
+                CanAct = false;
                 flyerFalls = true;
             }
         }
@@ -309,22 +325,32 @@ namespace DaggerfallWorkshop.Game
         void ApplyGravity()
         {
             // Apply gravity
-            if (!flies && !swims && !IsLevitating && !controller.isGrounded)
+            if (entity.IsSlowFalling && !flies && !swims && !controller.isGrounded)
+            {
+                Vector3 velocity = controller.velocity * 0.97f; //gradually slow x/z movement
+                velocity.y = -1; //slow downward fall
+                Vector3 move = velocity * Time.deltaTime;
+                controller.Move(move);
+            }
+            else if (!flies && !swims && !IsLevitating && !controller.isGrounded)
             {
                 controller.SimpleMove(Vector3.zero);
-                falls = true;
+                Falls = true;
 
                 // Only cancel movement if actually falling. Sometimes mobiles can get stuck where they are !isGrounded but SimpleMove(Vector3.zero) doesn't help.
                 // Allowing them to continue and attempt a Move() frees them, but we don't want to allow that if we can avoid it so they aren't moving
                 // while falling, which can also accelerate the fall due to anti-bounce downward movement in Move().
                 if (lastPosition != transform.position)
-                    canAct = false;
+                    CanAct = false;
             }
+
+            if (IsLevitating || entity.IsSlowFalling)
+                LastGroundedY = transform.position.y;
 
             if (flyerFalls && flies && !IsLevitating)
             {
                 controller.SimpleMove(Vector3.zero);
-                falls = true;
+                Falls = true;
             }
         }
 
@@ -338,7 +364,7 @@ namespace DaggerfallWorkshop.Game
                 SetChangeStateTimer();
                 searchMult = 0;
 
-                canAct = false;
+                CanAct = false;
             }
         }
 
@@ -356,7 +382,7 @@ namespace DaggerfallWorkshop.Game
                     attack.ResetMeleeTimer();
                 }
 
-                canAct = false;
+                CanAct = false;
             }
         }
 
@@ -372,7 +398,7 @@ namespace DaggerfallWorkshop.Game
                 avoidObstaclesTimer -= Time.deltaTime;
 
             // Set avoidObstaclesTimer to 0 if got close enough to detourDestination. Only bother checking if possible to move.
-            if (avoidObstaclesTimer > 0 && canAct)
+            if (avoidObstaclesTimer > 0 && CanAct)
             {
                 Vector3 detourDestination2D = detourDestination;
                 detourDestination2D.y = transform.position.y;
@@ -404,7 +430,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Make decision about what action to take.
         /// </summary>
-        void TakeAction()
+        void TakeActionDefault()
         {
             // Monster speed of movement follows the same formula as for when the player walks
             float moveSpeed = (entity.Stats.LiveSpeed + PlayerSpeedChanger.dfWalkBase) * MeshReader.GlobalScale;
@@ -498,6 +524,7 @@ namespace DaggerfallWorkshop.Game
                 pursuing = false;
                 retreating = false;
             }
+
         }
 
         /// <summary>
@@ -574,7 +601,7 @@ namespace DaggerfallWorkshop.Game
                             }
                         }
                         // Random chance to shoot spell
-                        else if (Random.value < 1/40f && entityEffectManager.SetReadySpell(selectedSpell))
+                        else if (Random.value < 1/40f && entityEffectManager.SetReadySpell(SelectedSpell))
                         {
                             mobile.ChangeEnemyState(MobileStates.Spell);
                         }
@@ -596,7 +623,7 @@ namespace DaggerfallWorkshop.Game
         {
             if (senses.TargetInSight && senses.DetectedTarget && attack.MeleeTimer == 0
                 && senses.DistanceToTarget <= attack.MeleeDistance + senses.TargetRateOfApproach
-                && CanCastTouchSpell() && entityEffectManager.SetReadySpell(selectedSpell))
+                && CanCastTouchSpell() && entityEffectManager.SetReadySpell(SelectedSpell))
             {
                 if (mobile.EnemyState != MobileStates.Spell)
                     mobile.ChangeEnemyState(MobileStates.Spell);
@@ -607,6 +634,7 @@ namespace DaggerfallWorkshop.Game
 
             return false;
         }
+
 
         /// <summary>
         /// Decide whether to strafe, and get direction to strafe to.
@@ -647,7 +675,7 @@ namespace DaggerfallWorkshop.Game
             ObstacleCheck(sphereCastDir2d);
             FallCheck(sphereCastDir2d);
 
-            if (obstacleDetected || fallDetected)
+            if (ObstacleDetected || fallDetected)
                 return false;
 
             RaycastHit hit;
@@ -670,7 +698,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Returns true if can shoot projectile at target.
         /// </summary>
-        bool HasClearPathToShootProjectile(float speed, float originDistance, float radius)
+        public bool HasClearPathToShootProjectile(float speed, float originDistance, float radius)
         {
             // Check that there is a clear path to shoot projectile
             Vector3 sphereCastDir = senses.PredictNextTargetPos(speed);
@@ -731,7 +759,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Selects a ranged spell from this enemy's list and returns true if it can be cast.
         /// </summary>
-        bool CanCastRangedSpell()
+        bool CanCastRangedSpellDefault()
         {
             if (entity.CurrentMagicka <= 0)
                 return false;
@@ -753,9 +781,9 @@ namespace DaggerfallWorkshop.Game
                 return false;
 
             EffectBundleSettings selectedSpellSettings = rangeSpells[Random.Range(0, count)];
-            selectedSpell = new EntityEffectBundle(selectedSpellSettings, entityBehaviour);
+            SelectedSpell = new EntityEffectBundle(selectedSpellSettings, entityBehaviour);
 
-            if (EffectsAlreadyOnTarget(selectedSpell))
+            if (EffectsAlreadyOnTarget(SelectedSpell))
                 return false;
 
             // Check that there is a clear path to shoot a spell
@@ -766,7 +794,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Selects a touch spell from this enemy's list and returns true if it can be cast.
         /// </summary>
-        bool CanCastTouchSpell()
+        bool CanCastTouchSpellDefault()
         {
             if (entity.CurrentMagicka <= 0)
                 return false;
@@ -801,9 +829,9 @@ namespace DaggerfallWorkshop.Game
                 return false;
 
             EffectBundleSettings selectedSpellSettings = rangeSpells[Random.Range(0, count)];
-            selectedSpell = new EntityEffectBundle(selectedSpellSettings, entityBehaviour);
+            SelectedSpell = new EntityEffectBundle(selectedSpellSettings, entityBehaviour);
 
-            if (EffectsAlreadyOnTarget(selectedSpell))
+            if (EffectsAlreadyOnTarget(SelectedSpell))
                 return false;
 
             return true;
@@ -822,7 +850,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Checks whether the target already is affected by all of the effects of the given spell.
         /// </summary>
-        bool EffectsAlreadyOnTarget(EntityEffectBundle spell)
+        public bool EffectsAlreadyOnTarget(EntityEffectBundle spell)
         {
             if (senses.Target)
             {
@@ -956,7 +984,7 @@ namespace DaggerfallWorkshop.Game
             ObstacleCheck(direction2d);
             FallCheck(direction2d);
 
-            if (fallDetected || obstacleDetected)
+            if (fallDetected || ObstacleDetected)
             {
                 if (!strafe && !backAway)
                     FindDetour(direction2d);
@@ -993,13 +1021,13 @@ namespace DaggerfallWorkshop.Game
                 testMove = (direction2d + upOrDown).normalized;
 
                 ObstacleCheck(testMove);
-                if (obstacleDetected)
+                if (ObstacleDetected)
                 {
                     upOrDown.y *= -1;
                     testMove = (direction2d + upOrDown).normalized;
                     ObstacleCheck(testMove);
                 }
-                if (!obstacleDetected)
+                if (!ObstacleDetected)
                     foundUpDown = true;
             }
 
@@ -1025,7 +1053,7 @@ namespace DaggerfallWorkshop.Game
                     ObstacleCheck(testMove);
                     FallCheck(testMove);
 
-                    if (!obstacleDetected && !fallDetected)
+                    if (!ObstacleDetected && !fallDetected)
                     {
                         // First direction was clear, use that way
                         if (angle == 45)
@@ -1044,7 +1072,7 @@ namespace DaggerfallWorkshop.Game
                         ObstacleCheck(testMove);
                         FallCheck(testMove);
 
-                        if (!obstacleDetected && !fallDetected)
+                        if (!ObstacleDetected && !fallDetected)
                         {
                             if (angle == 45)
                             {
@@ -1102,7 +1130,7 @@ namespace DaggerfallWorkshop.Game
                         break;
                     }
                 }
-                while (obstacleDetected || fallDetected);
+                while (ObstacleDetected || fallDetected);
             }
 
             detourDestination = transform.position + testMove * 2;
@@ -1114,7 +1142,7 @@ namespace DaggerfallWorkshop.Game
 
         void ObstacleCheck(Vector3 direction)
         {
-            obstacleDetected = false;
+            ObstacleDetected = false;
             // Rationale: follow walls at 45° incidence; is that optimal? At least it seems very good
             float checkDistance = controller.radius / Mathf.Sqrt(2f);
             foundUpwardSlope = false;
@@ -1129,7 +1157,7 @@ namespace DaggerfallWorkshop.Game
             if (Physics.CapsuleCast(p1, p2, controller.radius / 2, direction, out hit, checkDistance, ignoreMaskForObstacles))
             {
                 // Debug.DrawRay(transform.position, direction, Color.red, 2.0f);
-                obstacleDetected = true;
+                ObstacleDetected = true;
                 DaggerfallEntityBehaviour entityBehaviour2 = hit.transform.GetComponent<DaggerfallEntityBehaviour>();
                 DaggerfallActionDoor door = hit.transform.GetComponent<DaggerfallActionDoor>();
                 DaggerfallLoot loot = hit.transform.GetComponent<DaggerfallLoot>();
@@ -1137,11 +1165,11 @@ namespace DaggerfallWorkshop.Game
                 if (entityBehaviour2)
                 {
                     if (entityBehaviour2 == senses.Target)
-                        obstacleDetected = false;
+                        ObstacleDetected = false;
                 }
                 else if (door)
                 {
-                    obstacleDetected = false;
+                    ObstacleDetected = false;
                     foundDoor = true;
                     if (senses.TargetIsWithinYawAngle(22.5f, door.transform.position))
                     {
@@ -1151,7 +1179,7 @@ namespace DaggerfallWorkshop.Game
                 }
                 else if (loot)
                 {
-                    obstacleDetected = false;
+                    ObstacleDetected = false;
                 }
                 else if (!swims && !flies && !IsLevitating)
                 {
@@ -1165,7 +1193,7 @@ namespace DaggerfallWorkshop.Game
 
                     if (!Physics.CapsuleCast(p1, p2, controller.radius / 2, direction, checkDistance))
                     {
-                        obstacleDetected = false;
+                        ObstacleDetected = false;
                         foundUpwardSlope = true;
                     }
                 }
@@ -1178,7 +1206,7 @@ namespace DaggerfallWorkshop.Game
 
         void FallCheck(Vector3 direction)
         {
-            if (flies || IsLevitating || swims || obstacleDetected || foundUpwardSlope || foundDoor)
+            if (flies || IsLevitating || swims || ObstacleDetected || foundUpwardSlope || foundDoor)
             {
                 fallDetected = false;
                 return;
@@ -1365,9 +1393,9 @@ namespace DaggerfallWorkshop.Game
             if (controller.isGrounded)
             {
                 // did enemy just land?
-                if (falls)
+                if (Falls)
                 {
-                    float fallDistance = lastGroundedY - transform.position.y;
+                    float fallDistance = LastGroundedY - transform.position.y;
                     if (fallDistance > fallingDamageThreshold)
                     {
                         int damage = (int)(HPPerMetre * (fallDistance - fallingDamageThreshold));
@@ -1385,11 +1413,11 @@ namespace DaggerfallWorkshop.Game
                     }
                 }
 
-                lastGroundedY = transform.position.y;
+                LastGroundedY = transform.position.y;
             }
             // For flying enemies, "lastGroundedY" is really "lastAltitudeControlY"
             else if (flies && !flyerFalls)
-                lastGroundedY = transform.position.y;
+                LastGroundedY = transform.position.y;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -15,7 +15,6 @@ using DaggerfallWorkshop.Game.MagicAndEffects;
 using System.Collections.Generic;
 using DaggerfallWorkshop.Utility;
 using System.Linq;
-using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop.Game
 {

--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -101,13 +101,13 @@ namespace DaggerfallWorkshop.Game
 
         //Delegates to allow mods to extend motor behaviour.
         public delegate void TakeActionCallback();
-        public TakeActionCallback TakeAction { get; set; }
+        public TakeActionCallback TakeActionHandler { get; set; }
 
         public delegate bool CanCastRangedSpellCallback();
-        public CanCastRangedSpellCallback CanCastRangedSpell { get; set; }
+        public CanCastRangedSpellCallback CanCastRangedSpellHandler { get; set; }
 
         public delegate bool CanCastTouchSpellCallback();
-        public CanCastTouchSpellCallback CanCastTouchSpell { get; set; }
+        public CanCastTouchSpellCallback CanCastTouchSpellHandler { get; set; }
 
         #endregion
 
@@ -147,9 +147,9 @@ namespace DaggerfallWorkshop.Game
             // Get original height, before any height adjustments
             originalHeight = controller.height;
 
-            TakeAction = TakeActionDefault;
-            CanCastRangedSpell = CanCastRangedSpellDefault;
-            CanCastTouchSpell = CanCastTouchSpellDefault;
+            TakeActionHandler = TakeAction;
+            CanCastRangedSpellHandler = CanCastRangedSpell;
+            CanCastTouchSpellHandler = CanCastTouchSpell;
         }
 
         void FixedUpdate()
@@ -169,7 +169,7 @@ namespace DaggerfallWorkshop.Game
             HandleBashing();
             UpdateTimers();
             if (CanAct)
-                TakeAction();
+                TakeActionHandler();
             ApplyFallDamage();
             UpdateToIdleOrMoveAnim();
             OpenDoors();
@@ -430,7 +430,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Make decision about what action to take.
         /// </summary>
-        void TakeActionDefault()
+        void TakeAction()
         {
             // Monster speed of movement follows the same formula as for when the player walks
             float moveSpeed = (entity.Stats.LiveSpeed + PlayerSpeedChanger.dfWalkBase) * MeshReader.GlobalScale;
@@ -573,7 +573,7 @@ namespace DaggerfallWorkshop.Game
         bool DoRangedAttack(Vector3 direction, float moveSpeed, float distance, bool isPlayingOneShot)
         {
             bool inRange = senses.DistanceToTarget > EnemyAttack.minRangedDistance && senses.DistanceToTarget < EnemyAttack.maxRangedDistance;
-            if (inRange && senses.TargetInSight && senses.DetectedTarget && (CanShootBow() || CanCastRangedSpell()))
+            if (inRange && senses.TargetInSight && senses.DetectedTarget && (CanShootBow() || CanCastRangedSpellHandler()))
             {
                 if (DaggerfallUnity.Settings.EnhancedCombatAI && senses.TargetIsWithinYawAngle(22.5f, destination) && strafeTimer <= 0)
                 {
@@ -623,7 +623,7 @@ namespace DaggerfallWorkshop.Game
         {
             if (senses.TargetInSight && senses.DetectedTarget && attack.MeleeTimer == 0
                 && senses.DistanceToTarget <= attack.MeleeDistance + senses.TargetRateOfApproach
-                && CanCastTouchSpell() && entityEffectManager.SetReadySpell(SelectedSpell))
+                && CanCastTouchSpellHandler() && entityEffectManager.SetReadySpell(SelectedSpell))
             {
                 if (mobile.EnemyState != MobileStates.Spell)
                     mobile.ChangeEnemyState(MobileStates.Spell);
@@ -759,7 +759,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Selects a ranged spell from this enemy's list and returns true if it can be cast.
         /// </summary>
-        bool CanCastRangedSpellDefault()
+        bool CanCastRangedSpell()
         {
             if (entity.CurrentMagicka <= 0)
                 return false;
@@ -794,7 +794,7 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// Selects a touch spell from this enemy's list and returns true if it can be cast.
         /// </summary>
-        bool CanCastTouchSpellDefault()
+        bool CanCastTouchSpell()
         {
             if (entity.CurrentMagicka <= 0)
                 return false;

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -197,22 +197,22 @@ namespace DaggerfallWorkshop.Game
         public BlockedByIllusionEffectCallback BlockedByIllusionEffectHandler { get; set; }
 
         public delegate bool CanSeeTargetCallback(DaggerfallEntityBehaviour target);
-        public CanSeeTargetCallback CanSeeTarget { get; set; }
+        public CanSeeTargetCallback CanSeeTargetHandler { get; set; }
 
         public delegate bool CanHearTargetCallback();
-        public CanHearTargetCallback CanHearTarget { get; set; }
+        public CanHearTargetCallback CanHearTargetHandler { get; set; }
 
         public delegate bool CanDetectOtherwiseCallback(DaggerfallEntityBehaviour target);
-        public CanDetectOtherwiseCallback CanDetectOtherwise { get; set; }
+        public CanDetectOtherwiseCallback CanDetectOtherwiseHandler { get; set; }
 
 
         void Start()
         {
             //Initialize delegates to standard defaults
             BlockedByIllusionEffectHandler = BlockedByIllusionEffect;
-            CanSeeTarget = CanSeeTargetDefault;
-            CanHearTarget = CanHearTargetDefault;
-            CanDetectOtherwise = delegate (DaggerfallEntityBehaviour target) { return false; };
+            CanSeeTargetHandler = CanSeeTarget;
+            CanHearTargetHandler = CanHearTarget;
+            CanDetectOtherwiseHandler = delegate (DaggerfallEntityBehaviour target) { return false; };
 
             mobile = GetComponent<DaggerfallEnemy>().MobileUnit;
             entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
@@ -381,7 +381,7 @@ namespace DaggerfallWorkshop.Game
                 {
                     distanceToTarget = distanceToPlayer;
                     directionToTarget = toPlayer.normalized;
-                    playerInSight = CanSeeTarget(player);
+                    playerInSight = CanSeeTargetHandler(player);
                 }
 
                 if (classicTargetUpdateTimer > 5)
@@ -417,20 +417,20 @@ namespace DaggerfallWorkshop.Game
                 {
                     distanceToTarget = distanceToPlayer;
                     directionToTarget = toPlayer.normalized;
-                    targetInSight = CanSeeTarget(player);
+                    targetInSight = CanSeeTargetHandler(player);
                 }
                 else
                 {
                     Vector3 toTarget = target.transform.position - transform.position;
                     distanceToTarget = toTarget.magnitude;
                     directionToTarget = toTarget.normalized;
-                    targetInSight = CanSeeTarget(target);
+                    targetInSight = CanSeeTargetHandler(target);
                 }
 
                 // Classic stealth mechanics would be interfered with by hearing, so only enable
                 // hearing if the enemy has detected the target. If target is visible we can omit hearing.
                 if (detectedTarget && !targetInSight)
-                    targetInEarshot = CanHearTarget();
+                    targetInEarshot = CanHearTargetHandler();
                 else
                     targetInEarshot = false;
 
@@ -463,7 +463,7 @@ namespace DaggerfallWorkshop.Game
                     if (lastHadLOSTimer <= 0)
                         lastKnownTargetPos = target.transform.position;
                 }
-                else if (CanDetectOtherwise(target))
+                else if (CanDetectOtherwiseHandler(target))
                     detectedTarget = true;
                 else
                     detectedTarget = false;
@@ -803,7 +803,7 @@ namespace DaggerfallWorkshop.Game
                     directionToTarget = toTarget.normalized;
                     distanceToTarget = toTarget.magnitude;
 
-                    bool see = CanSeeTarget(targetBehaviour);
+                    bool see = CanSeeTargetHandler(targetBehaviour);
 
                     // Is potential target neither visible nor in area around player? If so, reject as target.
                     if (targetSenses && !targetSenses.WouldBeSpawnedInClassic && !see)
@@ -858,7 +858,7 @@ namespace DaggerfallWorkshop.Game
             }
         }
 
-        bool CanSeeTargetDefault(DaggerfallEntityBehaviour target)
+        bool CanSeeTarget(DaggerfallEntityBehaviour target)
         {
             bool seen = false;
             actionDoor = null;
@@ -908,7 +908,7 @@ namespace DaggerfallWorkshop.Game
             return seen;
         }
 
-        bool CanHearTargetDefault()
+        bool CanHearTarget()
         {
             float hearingScale = 1f;
 

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -202,8 +202,8 @@ namespace DaggerfallWorkshop.Game
         public delegate bool CanHearTargetCallback();
         public CanHearTargetCallback CanHearTarget { get; set; }
 
-        public delegate bool CanSeePlayerLightCallback();
-        public CanSeePlayerLightCallback CanSeePlayerLight { get; set; }
+        public delegate bool CanDetectPlayerOtherCallback();
+        public CanDetectPlayerOtherCallback CanDetectPlayerOther { get; set; }
 
 
         void Start()
@@ -212,7 +212,7 @@ namespace DaggerfallWorkshop.Game
             BlockedByIllusionEffect = BlockedByIllusionEffectDefault;
             CanSeeTarget = CanSeeTargetDefault;
             CanHearTarget = CanHearTargetDefault;
-            CanSeePlayerLight = delegate () { return false; };
+            CanDetectPlayerOther = delegate () { return false; };
 
             mobile = GetComponent<DaggerfallEnemy>().MobileUnit;
             entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
@@ -463,7 +463,7 @@ namespace DaggerfallWorkshop.Game
                     if (lastHadLOSTimer <= 0)
                         lastKnownTargetPos = target.transform.position;
                 }
-                else if (target == player && CanSeePlayerLight())
+                else if (target == player && CanDetectPlayerOther())
                     detectedTarget = true;
                 else
                     detectedTarget = false;

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -202,7 +202,7 @@ namespace DaggerfallWorkshop.Game
         public delegate bool CanHearTargetCallback();
         public CanHearTargetCallback CanHearTarget { get; set; }
 
-        public delegate bool CanDetectOtherwiseCallback();
+        public delegate bool CanDetectOtherwiseCallback(DaggerfallEntityBehaviour target);
         public CanDetectOtherwiseCallback CanDetectOtherwise { get; set; }
 
 
@@ -212,7 +212,7 @@ namespace DaggerfallWorkshop.Game
             BlockedByIllusionEffect = BlockedByIllusionEffectDefault;
             CanSeeTarget = CanSeeTargetDefault;
             CanHearTarget = CanHearTargetDefault;
-            CanDetectOtherwise = delegate () { return false; };
+            CanDetectOtherwise = delegate (DaggerfallEntityBehaviour target) { return false; };
 
             mobile = GetComponent<DaggerfallEnemy>().MobileUnit;
             entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
@@ -463,7 +463,7 @@ namespace DaggerfallWorkshop.Game
                     if (lastHadLOSTimer <= 0)
                         lastKnownTargetPos = target.transform.position;
                 }
-                else if (CanDetectOtherwise())
+                else if (CanDetectOtherwise(target))
                     detectedTarget = true;
                 else
                     detectedTarget = false;

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -194,7 +194,7 @@ namespace DaggerfallWorkshop.Game
         //Delegates to allow mods to replace or extend senses logic.
         //Mods can potentially save the original value before replacing it, if access to default behaviour is still desired.
         public delegate bool BlockedByIllusionEffectCallback();
-        public BlockedByIllusionEffectCallback BlockedByIllusionEffect { get; set; }
+        public BlockedByIllusionEffectCallback BlockedByIllusionEffectHandler { get; set; }
 
         public delegate bool CanSeeTargetCallback(DaggerfallEntityBehaviour target);
         public CanSeeTargetCallback CanSeeTarget { get; set; }
@@ -209,7 +209,7 @@ namespace DaggerfallWorkshop.Game
         void Start()
         {
             //Initialize delegates to standard defaults
-            BlockedByIllusionEffect = BlockedByIllusionEffectDefault;
+            BlockedByIllusionEffectHandler = BlockedByIllusionEffect;
             CanSeeTarget = CanSeeTargetDefault;
             CanHearTarget = CanHearTargetDefault;
             CanDetectOtherwise = delegate (DaggerfallEntityBehaviour target) { return false; };
@@ -442,7 +442,7 @@ namespace DaggerfallWorkshop.Game
                 // to know where the player is.
                 if (GameManager.ClassicUpdate)
                 {
-                    blockedByIllusionEffect = BlockedByIllusionEffect();
+                    blockedByIllusionEffect = BlockedByIllusionEffectHandler();
                     if (lastHadLOSTimer > 0)
                         lastHadLOSTimer--;
                 }
@@ -655,7 +655,7 @@ namespace DaggerfallWorkshop.Game
             return Dice100.FailedRoll(stealthChance);
         }
 
-        public bool BlockedByIllusionEffectDefault()
+        public bool BlockedByIllusionEffect()
         {
             // In classic if the target is another AI character true is always returned.
 

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -202,8 +202,8 @@ namespace DaggerfallWorkshop.Game
         public delegate bool CanHearTargetCallback();
         public CanHearTargetCallback CanHearTarget { get; set; }
 
-        public delegate bool CanDetectPlayerOtherCallback();
-        public CanDetectPlayerOtherCallback CanDetectPlayerOther { get; set; }
+        public delegate bool CanDetectOtherwiseCallback();
+        public CanDetectOtherwiseCallback CanDetectOtherwise { get; set; }
 
 
         void Start()
@@ -212,7 +212,7 @@ namespace DaggerfallWorkshop.Game
             BlockedByIllusionEffect = BlockedByIllusionEffectDefault;
             CanSeeTarget = CanSeeTargetDefault;
             CanHearTarget = CanHearTargetDefault;
-            CanDetectPlayerOther = delegate () { return false; };
+            CanDetectOtherwise = delegate () { return false; };
 
             mobile = GetComponent<DaggerfallEnemy>().MobileUnit;
             entityBehaviour = GetComponent<DaggerfallEntityBehaviour>();
@@ -463,7 +463,7 @@ namespace DaggerfallWorkshop.Game
                     if (lastHadLOSTimer <= 0)
                         lastKnownTargetPos = target.transform.position;
                 }
-                else if (target == player && CanDetectPlayerOther())
+                else if (CanDetectOtherwise())
                     detectedTarget = true;
                 else
                     detectedTarget = false;

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -765,6 +765,14 @@ namespace DaggerfallWorkshop.Game
                     if ((GameManager.Instance.PlayerEntity.NoTargetMode || !motor.IsHostile || enemyEntity.MobileEnemy.Team == MobileTeams.PlayerAlly) && targetBehaviour == player)
                         continue;
 
+                    //Player allies should not attack pacified enemies.
+                    if (enemyEntity.Team == MobileTeams.PlayerAlly && targetBehaviour != player)
+                    {
+                        EnemyMotor targetMotor = targetBehaviour.GetComponent<EnemyMotor>();
+                        if (targetMotor && !targetMotor.IsHostile)
+                            continue;
+                    }
+
                     // Can't target ally
                     if (targetBehaviour == player && enemyEntity.Team == MobileTeams.PlayerAlly)
                         continue;

--- a/Assets/Scripts/Game/Entities/EntityConcealmentBehaviour.cs
+++ b/Assets/Scripts/Game/Entities/EntityConcealmentBehaviour.cs
@@ -53,7 +53,7 @@ namespace DaggerfallWorkshop.Game.Entity
             meshRenderer = GetComponentInChildren<MeshRenderer>();
         }
 
-        protected void MakeConcealed(bool concealed)
+        protected virtual void MakeConcealed(bool concealed)
         {
             if (meshRenderer)
             {

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -144,6 +144,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             get { return GetPoisonBundles(); }
         }
 
+        //The original Daggerfall apparently did it this way (original bug?)
         public bool UsePlayerCharacterSkillsForEnemyMagicCost { get; set; } = true;
 
         #endregion

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -144,6 +144,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             get { return GetPoisonBundles(); }
         }
 
+        public bool UsePlayerCharacterSkillsForEnemyMagicCost { get; set; } = true;
+
         #endregion
 
         #region Unity
@@ -316,8 +318,12 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             if (spell == null || spell.Settings.Version < minAcceptedSpellVersion)
                 return false;
 
+            //By default, enemy spell costs are calculated using player-character skill levels.
+            //Mods can alter this to use enemy skills instead.
+            DaggerfallEntity casterEntity = UsePlayerCharacterSkillsForEnemyMagicCost ? null : entityBehaviour.Entity;
+
             // Get spellpoint costs of this spell
-            (int _, int spellPointCost) = FormulaHelper.CalculateTotalEffectCosts(spell.Settings.Effects, spell.Settings.TargetType, null, spell.Settings.MinimumCastingCost);
+            (int _, int spellPointCost) = FormulaHelper.CalculateTotalEffectCosts(spell.Settings.Effects, spell.Settings.TargetType, casterEntity, spell.Settings.MinimumCastingCost);
             readySpellCastingCost = spellPointCost;
 
             // Allow casting spells of any cost if entity is player and godmode enabled


### PR DESCRIPTION
Replaces some method calls in enemy components with delegates so mods can inject additional logic.

Also includes a change to prevent player allies from attacking pacified creatures. (EnemySenses)
Also changes ApplyGravity in EnemyMotor to allow enemies to slowfall.
Also adds option to base enemy spell cost on enemy skills rather than player skills. (EntityEffectManager)