### PR TITLE
Fix exception thrown during Lycanthropy transition

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1713,7 +1713,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             // Run all bundles
             activeMagicItemsInRound.Clear();
             uint currentTime = DaggerfallUnity.Instance.WorldTime.DaggerfallDateTime.ToClassicDaggerfallTime();
-            foreach (LiveEffectBundle bundle in instancedBundles)
+            var currentInstancedBundles = new List<LiveEffectBundle>(instancedBundles); // use a copy, as ending an effect can add new bundles (ex: wereworlf infection -> werewolf effect)
+            foreach (LiveEffectBundle bundle in currentInstancedBundles)
             {
                 // Run effects for this bundle
                 bool hasRemainingEffectRounds = false;


### PR DESCRIPTION
A user on Discord sent me this error during gameplay.

![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/ff5600c8-2ef5-47d5-97cb-b4bdd14805fa)

This error is easy to reproduce.

1. Load any save
2. Use console command `diseaseplayer werewolf` to get Lycanthropy Infection
3. Wait 1 day (ex: travel anywhere), get the dream sequence
4. Wait 2 another day (ex: travel anywhere 2+ days away)
5. See error in logs / console

So, during `EntityEffectManager.DoMagicRound()`, we have this loop
```
foreach (LiveEffectBundle bundle in instancedBundles)
{
    // Run effects for this bundle 
    bool hasRemainingEffectRounds = false;
    foreach (IEntityEffect effect in bundle.liveEffects)
    {
        // Update effects with remaining rounds, item effects are always ticked
        // All other effects with a duration will be ended at zero rounds remaining
        hasRemainingEffectRounds = hasRemainingEffectRounds || effect.RoundsRemaining > 0;
        if (effect.RoundsRemaining > 0 || bundle.fromEquippedItem != null)
            effect.MagicRound();
        else if (effect.Properties.SupportDuration)
            effect.End();
    }
   ...
```

For the `LycanthropyInfection` effect, `MagicRound` updates the disease progress, until 3 days have passed and the dream sequence has been watched. This will call `DeployFullBlownLycanthropy()`, which is implemented by `WereboarInfection` and `WerewolfInfection` as this
```
protected override void DeployFullBlownLycanthropy()
{
    // Start permanent wereboar lycanthropy effect stage two
    EntityEffectBundle bundle = GameManager.Instance.PlayerEffectManager.CreateLycanthropyCurse();
    GameManager.Instance.PlayerEffectManager.AssignBundle(bundle, AssignBundleFlags.BypassSavingThrows);
    LycanthropyEffect lycanthropyEffect = (LycanthropyEffect)GameManager.Instance.PlayerEffectManager.FindIncumbentEffect<LycanthropyEffect>();
    if (lycanthropyEffect != null)
        lycanthropyEffect.InfectionType = LycanthropyTypes.Wereboar;
}
```

This is all happening still in the middle of the foreach loop above. As you can see, we're assigning a new bundle to the player's effect manager, which modifies `instancedBundles` if the bundle has any "live" effects (which Lycanthropy curse does). Modifying collections during iteration is not supported, so the error occurs.

While the error does not break anything permanently as far as we know, it still prevents other effects from being processed for the rest of this magic round. This could happen more often with mods.