### PR TITLE
Fix typo that breaks 3d object scaling in RMBLayout.cs

### DIFF
--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -73,7 +73,7 @@ namespace DaggerfallWorkshop.Utility
         /// <returns>Vector3 with the scaling factors</returns>
         public static Vector3 GetModelScaleVector(DFBlock.RmbBlock3dObjectRecord obj)
         {
-            return new Vector3(obj.XScale == 0 ? 1 : obj.XScale, obj.YScale == 0 ? 1 : obj.YScale, obj.ZScale == 0 ? 1 : obj.YScale);
+            return new Vector3(obj.XScale == 0 ? 1 : obj.XScale, obj.YScale == 0 ? 1 : obj.YScale, obj.ZScale == 0 ? 1 : obj.ZScale);
         }
 
         /// <summary>


### PR DESCRIPTION
Modders working with RMBs have known for a long time that rescaling 3d objects will break them. Either the scale will be wrong or objects will disappear entirely when scaled. The screenshot below demonstrates this bug with a modded RMB but otherwise unmodded game:
![Screenshot from 2024-01-25 20-58-56](https://github.com/Interkarma/daggerfall-unity/assets/73616371/df91b506-2ddc-4464-a30d-c5eb994448ad)

This bug turns out to be caused by a typo in the GetModelScaleVector method, in which obj.ZScale is incorrectly set to obj.YScale on line 76. Correcting this typo fixes the scaling bug:
![Screenshot from 2024-01-25 20-57-23](https://github.com/Interkarma/daggerfall-unity/assets/73616371/afb46c02-18fd-4fb8-a06b-20616a896b8b)
