### PR TITLE
Fixed PlayerGPS loading ContentReader maps before mods ready

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -64,6 +64,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         public bool LoadVirtualMods = true;
 #endif
 
+        // Returns whether the ModManager has been through Init
+        // Before Initialized is true, disabled mods are not filtered out
+        // Systems that run on launch should ensure this is true before touching systems involving mods
+        public bool Initialized { get { return alreadyStartedInit; } }
+
         #endregion
 
         #region Properties

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -24,6 +24,7 @@ using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.Banking;
 using DaggerfallWorkshop.Game.MagicAndEffects;
+using DaggerfallWorkshop.Game.Utility.ModSupport;
 
 namespace DaggerfallWorkshop
 {
@@ -725,6 +726,12 @@ namespace DaggerfallWorkshop
 
             // Do nothing until DaggerfallUnity is ready
             if (!dfUnity.IsReady)
+                return false;
+
+            // When running the game, wait for the mod manager to be initialized
+            // Updating the player location too early causes the region loading to read WorldData
+            // locations from disabled mods
+            if (ModManager.Instance != null && !ModManager.Instance.Initialized)
                 return false;
 
             return true;


### PR DESCRIPTION
Fixes #2573 . Most of the details should be on the issue, but in summary:

1. PlayerGPS updates the world info
2. This causes the ContentReader to fill its "MapDict" cache with all the regions
3. Loading a region also loads the WorldDataReplacement location data from mods

Before the fix, this could happen before disabled mods were removed (this occurs in ModManager.Init). Now, PlayerGPS waits for the ModManager to be Initialized before running.

As an aside, for performance reasons, I'd like if ContentReader did not read _all_ the regions on boot, since it slows down when mods try adding thousands of new locations (carademono has a vision, okay). But I'm not ready to change that yet - maybe I'll send cara a custom build to see if simply having independent caches per region works.

But this simple change fixes the issue, and increases performance when running disabled mods with WorldData.