### PR TITLE
Add ability to declare QuestLists in .dfmod file.

### DIFF
--- a/Assets/Editor/.Schemas/ModInfo.schema.json
+++ b/Assets/Editor/.Schemas/ModInfo.schema.json
@@ -65,6 +65,15 @@
                     },
                     "uniqueItems": true
                 },
+                "QuestLists": {
+                    "type": "array",
+                    "description": "Names of additional quest lists to be automatically imported.",
+                    "items": {
+                        "type": "string",
+                        "description": "The name of a quest list file without extension and without 'QuestList' prefix."
+                    },
+                    "uniqueItems": true
+                },
                 "SpellIcons": {
                     "type": "array",
                     "description": "Names of spell icon packs. See https://www.dfworkshop.net/projects/daggerfall-unity/modding/additional-resources/#spell-icons for details.",

--- a/Assets/Game/Addons/ModSupport/Editor/CreateModEditorWindow.cs
+++ b/Assets/Game/Addons/ModSupport/Editor/CreateModEditorWindow.cs
@@ -64,6 +64,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         GUIContent documentationGUIContent;
         GUIContent targetInfoGUIContent;
         bool isSupportedEditorVersion;
+        bool automaticallyRegisterQuestLists;
 
         void OnEnable()
         {
@@ -78,6 +79,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                 buildTargetsToggles[i] = EditorPrefs.GetBool($"ModBuildTarget:{buildTargets[i]}", buildTargetsToggles[i]);
 
             modInfo = ReadModInfoFile(currentFilePath);
+            ResetRegisterQuestListsValue();
+
             titleStyle.fontSize = 15;
             fieldStyle.fontSize = 12;
             minSize = new Vector2(1280, 600);
@@ -175,6 +178,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                         }
 
                         modInfo = ReadModInfoFile(currentFilePath);
+                        ResetRegisterQuestListsValue();
                         Debug.Log(string.Format("opened mod file for: {0}", modInfo.ModTitle));
 
                     }
@@ -368,6 +372,8 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             compressionOption = (ModCompressionOptions)EditorGUILayout.EnumPopup("", compressionOption, GUILayout.MaxWidth(125));
             EditorGUILayout.EndVertical();
 
+            EditorGUILayout.BeginVertical();
+            GUILayout.Label("Dependencies:\n", titleStyle);
             if(GUILayout.Button("Collect Dependencies", GUILayout.MaxWidth(200)) && ModInfoReady)
             {
                 foreach(var assetPath in Assets.ToArray())
@@ -379,8 +385,13 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                     }
                 }
             }
+            EditorGUILayout.EndVertical();
 
-            GUILayout.Space(100);
+            EditorGUILayout.BeginVertical();
+            GUILayout.Label("\tQuestLists:\n", titleStyle);
+            automaticallyRegisterQuestLists = EditorGUILayout.ToggleLeft(new GUIContent("Automatically Register QuestLists", "Automatically discover Quest Lists and register them in game."), automaticallyRegisterQuestLists, GUILayout.ExpandWidth(true));
+            EditorGUILayout.EndVertical();
+
             EditorGUILayout.EndHorizontal();
             EditorGUILayout.Space();
             EditorGUILayout.Space();
@@ -436,7 +447,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
 
         bool SaveModFile(bool supressWindow = false)
         {
-            ModManager.SeekModContributes(modInfo);
+            ModManager.SeekModContributes(modInfo, automaticallyRegisterQuestLists);
 
             string path = currentFilePath;
             fsData fsData;
@@ -516,6 +527,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                     }
                 }
             }
+        }
+
+        // Check if there is already added Quest Lists in the ModInfo
+        void ResetRegisterQuestListsValue()
+        {
+            automaticallyRegisterQuestLists = modInfo.Contributes?.QuestLists?.Length > 0;
         }
 
         bool AddAssetToMod(string assetPath)

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -942,13 +942,14 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// Seeks asset contributes for the target mod, reading the folder name of each asset.
         /// </summary>
         /// <param name="modInfo">Manifest data for a mod, which will be filled with retrieved contributes.</param>
+        /// <param name="automaticallyRegisterQuestLists">Optional parameter that triggers Quest Lists declaration</param>
         /// <remarks>
         /// Assets are imported from loose files according to folder name,
         /// for example all textures inside `SpellIcons` are considered icon atlases.
         /// This method replicates the same behaviour for mods, doing all the hard work at build time.
         /// Results are stored to json manifest file for performant queries at runtime.
         /// </remarks>
-        public static void SeekModContributes(ModInfo modInfo, bool automaticallyRegisterQuestLists)
+        public static void SeekModContributes(ModInfo modInfo, bool automaticallyRegisterQuestLists = false)
         {
             List<string> spellIcons = null;
             List<string> booksMapping = null;
@@ -958,15 +959,15 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             {
                 var directory = Path.GetDirectoryName(file);
 
-                if (directory != null && directory.EndsWith("SpellIcons"))
+                if (!string.IsNullOrEmpty(directory) && directory.EndsWith("SpellIcons"))
                     AddNameToList(ref spellIcons, file);
-                else if (directory != null && directory.EndsWith("Books/Mapping"))
+                else if (!string.IsNullOrEmpty(directory) && directory.EndsWith("Books/Mapping"))
                     AddNameToList(ref booksMapping, file);
 
                 if (automaticallyRegisterQuestLists)
                 {
                     var name = Path.GetFileNameWithoutExtension(file);
-                    if (name.StartsWith("QuestList-"))
+                    if (!string.IsNullOrEmpty(name) && name.StartsWith("QuestList-"))
                         AddNameToList(ref questLists, name.Substring(10));
                 }
             }

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -948,27 +948,36 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// This method replicates the same behaviour for mods, doing all the hard work at build time.
         /// Results are stored to json manifest file for performant queries at runtime.
         /// </remarks>
-        public static void SeekModContributes(ModInfo modInfo)
+        public static void SeekModContributes(ModInfo modInfo, bool automaticallyRegisterQuestLists)
         {
             List<string> spellIcons = null;
             List<string> booksMapping = null;
+            List<string> questLists = null;
 
-            foreach (string file in modInfo.Files)
+            foreach (var file in modInfo.Files)
             {
-                string directory = Path.GetDirectoryName(file);
+                var directory = Path.GetDirectoryName(file);
 
-                if (directory.EndsWith("SpellIcons"))
+                if (directory != null && directory.EndsWith("SpellIcons"))
                     AddNameToList(ref spellIcons, file);
-                else if (directory.EndsWith("Books/Mapping"))
+                else if (directory != null && directory.EndsWith("Books/Mapping"))
                     AddNameToList(ref booksMapping, file);
+
+                if (automaticallyRegisterQuestLists)
+                {
+                    var name = Path.GetFileNameWithoutExtension(file);
+                    if (name.StartsWith("QuestList-"))
+                        AddNameToList(ref questLists, name.Substring(10));
+                }
             }
 
-            if (spellIcons != null || booksMapping != null)
-            {
-                var contributes = modInfo.Contributes ?? (modInfo.Contributes = new ModContributes());
-                contributes.SpellIcons = spellIcons != null ? spellIcons.ToArray() : null;
-                contributes.BooksMapping = booksMapping != null ? booksMapping.ToArray() : null;
-            }
+            if (spellIcons == null && booksMapping == null && questLists == null)
+                return;
+
+            var contributes = modInfo.Contributes ?? (modInfo.Contributes = new ModContributes());
+            contributes.SpellIcons = spellIcons?.ToArray();
+            contributes.BooksMapping = booksMapping?.ToArray();
+            contributes.QuestLists = questLists?.ToArray();
         }
 
         private static void AddNameToList(ref List<string> names, string path)

--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -951,6 +951,9 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// </remarks>
         public static void SeekModContributes(ModInfo modInfo, bool automaticallyRegisterQuestLists = false)
         {
+            // Reset contributions before rebuilding it
+            modInfo.Contributes = null;
+
             List<string> spellIcons = null;
             List<string> booksMapping = null;
             List<string> questLists = null;
@@ -975,10 +978,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
             if (spellIcons == null && booksMapping == null && questLists == null)
                 return;
 
-            var contributes = modInfo.Contributes ?? (modInfo.Contributes = new ModContributes());
-            contributes.SpellIcons = spellIcons?.ToArray();
-            contributes.BooksMapping = booksMapping?.ToArray();
-            contributes.QuestLists = questLists?.ToArray();
+            modInfo.Contributes = new ModContributes
+            {
+                SpellIcons = spellIcons?.ToArray(),
+                BooksMapping = booksMapping?.ToArray(),
+                QuestLists = questLists?.ToArray()
+            };
         }
 
         private static void AddNameToList(ref List<string> names, string path)

--- a/Assets/Game/Addons/ModSupport/ModTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModTypes.cs
@@ -55,8 +55,7 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         /// Automatic asset injections defined by manifest .json file.
         /// These values are not available for edits from mods at runtime.
         /// </summary>
-        [SerializeField]
-        internal ModContributes Contributes;
+        public ModContributes Contributes { get; internal set; }
 #pragma warning restore 649
 
         /// <summary>
@@ -81,26 +80,23 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
     /// This class can be expanded over time as necessary but breaking changes should be avoided.
     /// <remarks/>
     [Serializable]
-    internal sealed class ModContributes
+    public sealed class ModContributes
     {
         /// <summary>
         /// Look-up maps that announce additional books to be imported.
         /// </summary>
-        [SerializeField]
-        internal string[] BooksMapping;
+        public string[] BooksMapping { get; internal set; }
 
         /// <summary>
         /// Names of additional quest lists to be automatically imported
         /// </summary>
-        [SerializeField]
-        internal string[] QuestLists;
+        public string[] QuestLists { get; internal set; }
 
         /// <summary>
         /// Names of spell icon packs; each name corresponds to a <see cref="Texture2D"/>
         /// asset and a <see cref="TextAsset"/> with `.json` extension.
         /// </summary>
-        [SerializeField]
-        internal string[] SpellIcons;
+        public string[] SpellIcons { get; internal set; }
     }
 
     /// <summary>

--- a/Assets/Game/Addons/ModSupport/ModTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModTypes.cs
@@ -90,6 +90,12 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         internal string[] BooksMapping;
 
         /// <summary>
+        /// Names of additional quest lists to be automatically imported
+        /// </summary>
+        [SerializeField]
+        internal string[] QuestLists;
+
+        /// <summary>
         /// Names of spell icon packs; each name corresponds to a <see cref="Texture2D"/>
         /// asset and a <see cref="TextAsset"/> with `.json` extension.
         /// </summary>

--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -11,6 +11,7 @@ using System;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 using DaggerfallWorkshop.Game.Utility.ModSupport;
 using DaggerfallWorkshop.Game.Entity;
@@ -110,6 +111,22 @@ namespace DaggerfallWorkshop.Game.Questing
             foreach (string listFile in listFiles)
                 if (!RegisterQuestList(listFile))
                     Debug.LogErrorFormat("QuestList already registered. {0}", listFile);
+
+            if (ModManager.Instance == null)
+            {
+                return;
+            }
+
+            foreach (var mod in ModManager.Instance.GetAllModsWithContributes(x => x.QuestLists != null))
+            {
+                foreach (var questList in mod.ModInfo.Contributes.QuestLists)
+                {
+                    if (!RegisterQuestList(questList))
+                    {
+                        Debug.LogErrorFormat("QuestList {0} is already registered.", questList);
+                    }
+                }
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -11,7 +11,6 @@ using System;
 using DaggerfallConnect.Arena2;
 using DaggerfallWorkshop.Utility;
 using System.IO;
-using System.Linq;
 using UnityEngine;
 using DaggerfallWorkshop.Game.Utility.ModSupport;
 using DaggerfallWorkshop.Game.Entity;


### PR DESCRIPTION
Currently you can activate new Quest Pack (quest list) by adding the file to StreamingAssets\QuestPacks\ folder.

In case of packing quests in .dfmod file, you must call `QuestListsManager.RegisterQuestList("MyQuests")`.

It is not possible to ship quests in .dfmod without C# script.

I propose to register them in "Contributes" ModInfo section, the same way as BooksMappings 

Example:

```json

{
    "ModTitle": "QuestPack",
    "ModVersion": "1.0.0",
    "Files": [
        "QUEST1.txt",
        "QUEST2.txt",
        "QUEST3.txt",
        "QuestList-MyQuests.txt"
    ],
    "Contributes": {
        "QuestLists": [
            "MyQuests"
        ]
    }
}

```
![image](https://github.com/Interkarma/daggerfall-unity/assets/1652113/876ed8a1-2e75-4bda-8898-5f0bc29123a1)


![image](https://github.com/Interkarma/daggerfall-unity/assets/1652113/e514407f-c90b-45f7-858e-073865b90816)


![Screenshot 2024-02-10 212729](https://github.com/Interkarma/daggerfall-unity/assets/1652113/ee919e19-4c39-4725-86df-26aae8375096)
