### PR TITLE
Fixed Temple music errors

### DIFF
--- a/Assets/Scripts/Game/SongManager.cs
+++ b/Assets/Scripts/Game/SongManager.cs
@@ -65,6 +65,7 @@ namespace DaggerfallWorkshop.Game
             public PlayerMusicWeather weather;
             public PlayerMusicTime time;
             public uint gameDays; // How many days since playthrough started. Each day gives a new song in a playlist
+            public int locationIndex;
             public bool arrested;
 
             //minimize GC alloc of struct.Equals(object o) with this method instead
@@ -73,6 +74,7 @@ namespace DaggerfallWorkshop.Game
                         && weather == pmc.weather
                         && time == pmc.time
                         && gameDays == pmc.gameDays
+                        && locationIndex == pmc.locationIndex
                         && arrested == pmc.arrested;
             }
         }
@@ -207,6 +209,7 @@ namespace DaggerfallWorkshop.Game
             if (!currentContext.Equals(lastContext) || (!songPlayer.IsPlaying && playSong))
             {
                 bool dayChanged = currentContext.gameDays != lastContext.gameDays;
+                bool locationChanged = currentContext.locationIndex != lastContext.locationIndex;
                 lastContext = currentContext;
 
                 SongFiles[] lastPlaylist = currentPlaylist;
@@ -215,7 +218,8 @@ namespace DaggerfallWorkshop.Game
 
                 // If current playlist is different from last playlist, pick a song from the current playlist
                 // For many interiors, changing days will give you a new song
-                if (currentPlaylist != lastPlaylist || dayChanged)
+                // For dungeons, changing locations will give you a new song
+                if (currentPlaylist != lastPlaylist || dayChanged || locationChanged)
                 {
                     PlayAnotherSong();
                     return;
@@ -400,6 +404,8 @@ namespace DaggerfallWorkshop.Game
         {
             if (!playerEnterExit || !LocalPlayerGPS || !dfUnity)
                 return;
+
+            currentContext.locationIndex = LocalPlayerGPS.CurrentLocationIndex; // -1 for "no location"
 
             // Exteriors
             if (!playerEnterExit.IsPlayerInside)


### PR DESCRIPTION
Temple music is handled differently from other playlists in SongManager. The selected song is based on the faction of the building (the manager checks for both the "Temple" faction id and the "God" faction id). The songs are as follows:

| God       | Song    |
|-----------|---------|
| Arkay     | Good    |
| Z'en      | Bad     |
| Mara      | Good    |
| Akatosh   | Neutral |
| Julianos  | Bad     |
| Dibella   | Good    |
| Stendarr  | Bad     |
| Kynareth  | Neutral |

I found two errors in how we handle this.

First, we use separate SongPlayer objects for Exterior and Interior. This means that when moving from an Interior to outside, the Interior SongPlayer is not updated until we enter a new interior. Therefore, if we move from one temple to outside to another temple, from the perspective of the Interior SongPlayer, the context never changed, and the music is not updated, even if the FactionID would cause a different song.

This can be tested in the Daggerfall region's Chesterwick Hamlet (not Chesterwick), which has both a Julianos and Kynareth temple. Both temples should have a different music, but if you enter one then directly enter the other, then the music is preserved from the first temple. The music is properly updated if you enter a non-temple interior then go to the temple.

So, I added "factionID" to the music context, which is only updated for temples since only that playlist actually checks it. When the playlist is the same as previously but the factionID changes, we update the song only if the playlist is Temples.

The second issue is what I initially investigated. DFU was throwing an exception if a Temple location did not have a proper Temple/God faction id, which occurs in DF data in those Fighter Trainers halls in Hammerfell. I checked in classic DF, and the music that plays is actually the "unused" Knight Order music - yes, that music is actually used. This can be checked in the Abibon-Gora capital. 

So, I fixed both the error handling in the Temple music selection, and added a new music context for FighterTrainers so its classic DF music plays. 