### PR TITLE
Fix TextLabel metrics in 4:3 mode for MultiFormatTextLabel and ListBox.

### DIFF
--- a/Assets/Scripts/Game/UserInterface/ListBox.cs
+++ b/Assets/Scripts/Game/UserInterface/ListBox.cs
@@ -544,7 +544,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             TextLabel textLabel = new TextLabel();
 
             textLabel.Parent = this; //Establish parent early.
-            _ = textLabel.Rectangle; //Call GetRectangle() early to establish LocalScale, discard return value
 
             if (UseRestrictedRenderArea)
             {
@@ -586,7 +585,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             }
 
             textLabel.Parent = this; //Establish parent early.
-            _ = textLabel.Rectangle; //Call GetRectangle() early to establish LocalScale, discard return value
 
             if (UseRestrictedRenderArea)
             {

--- a/Assets/Scripts/Game/UserInterface/ListBox.cs
+++ b/Assets/Scripts/Game/UserInterface/ListBox.cs
@@ -542,6 +542,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 font = DaggerfallUI.DefaultFont;
 
             TextLabel textLabel = new TextLabel();
+
+            textLabel.Parent = this; //Establish parent early.
+            _ = textLabel.Rectangle; //Call GetRectangle() early to establish LocalScale, discard return value
+
             if (UseRestrictedRenderArea)
             {
                 textLabel.RectRestrictedRenderArea = RectRestrictedRenderArea;
@@ -558,7 +562,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             textLabel.MaxCharacters = maxCharacters;
             textLabel.Text = text;
             textLabel.TextScale = textScale;
-            textLabel.Parent = this;
             textLabel.WrapText = wrapTextItems;
             textLabel.WrapWords = wrapWords;
 
@@ -582,6 +585,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 return;
             }
 
+            textLabel.Parent = this; //Establish parent early.
+            _ = textLabel.Rectangle; //Call GetRectangle() early to establish LocalScale, discard return value
+
             if (UseRestrictedRenderArea)
             {
                 textLabel.RectRestrictedRenderArea = RectRestrictedRenderArea;
@@ -592,7 +598,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 textLabel.MaxWidth = (int)Size.x;
             else if (horizontalScrollMode == HorizontalScrollModes.PixelWise)
                 textLabel.MaxWidth = -1;
-            textLabel.Parent = this;
             textLabel.WrapText = wrapTextItems;
             textLabel.WrapWords = wrapWords;
 

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -212,6 +212,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
         public TextLabel AddTextLabel(string text, DaggerfallFont font, Color color)
         {
             TextLabel textLabel = new TextLabel();
+
+            textLabel.Parent = this; //Establish parent early.
+            _ = textLabel.Rectangle; //Call GetRectangle() early to establish LocalScale, discard return value
+
             textLabel.AutoSize = AutoSizeModes.None;
             textLabel.MinTextureDim = minTextureDimTextLabel;
             textLabel.Font = font;
@@ -224,7 +228,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             if (maxTextWidth > 0)
                 textLabel.MaxWidth = maxTextWidth;
             textLabel.Text = text;
-            textLabel.Parent = this;
             textLabel.TextColor = color;
             textLabel.ShadowColor = ShadowColor;
             textLabel.ShadowPosition = ShadowPosition;

--- a/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/MultiFormatTextLabel.cs
@@ -214,7 +214,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
             TextLabel textLabel = new TextLabel();
 
             textLabel.Parent = this; //Establish parent early.
-            _ = textLabel.Rectangle; //Call GetRectangle() early to establish LocalScale, discard return value
 
             textLabel.AutoSize = AutoSizeModes.None;
             textLabel.MinTextureDim = minTextureDimTextLabel;

--- a/Assets/Scripts/Game/UserInterface/TextLabel.cs
+++ b/Assets/Scripts/Game/UserInterface/TextLabel.cs
@@ -460,6 +460,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
             // Start a new layout
             glyphLayout.Clear();
 
+            if (Parent != null)
+                _ = Rectangle; //Calling GetRectangle() to establish LocalScale; discarding return value
+
             // Set a local maxWidth that compensates for textScale
             int maxWidth = (int)(this.maxWidth / textScale);
 


### PR DESCRIPTION
Fix for MultiFormatTextLabel and ListBox TextLabel wrapping issues spotted in 4:3 mode.

I originally noticed an issue with wrapping TextLabels when constructing a MultiFormatTextLabel while running in 4:3 mode.
Wrapped text would overlap the following line. 
In the TextLabel.CreateNewLabelLayoutWrapped() method, the LocalScale was (1,1), causing some bad line metric calculations.

More recently I noticed the bottom line of the npc conversation window was often not shown in 4:3 mode.
This appears to be the same problem.

This fix calls GetRectangle() on the TextLabel early to establish the correct LocalScale prior to other operations.