### PR TITLE
Added checkbox to show hidden folders during Daggerfall setup

### DIFF
--- a/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
+++ b/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
@@ -28,6 +28,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
     /// </summary>
     public class FolderBrowser : Panel
     {
+        private const string parentDirectory = "..";
+
         int confirmButtonWidth = 35;
         int drivePanelWidth = 40;
         int pathPanelHeight = 12;
@@ -209,6 +211,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
         {
             folders.Clear();
             folderList.ClearItems();
+
+            // Add return path
+            if (currentPath != drives[driveList.SelectedIndex])
+                folderList.AddItem(parentDirectory);
+
             try
             {
                 string[] directoryList = Directory.GetDirectories(currentPath);
@@ -332,7 +339,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
             // Get new path
             string newPath = string.Empty;
-            if (folderList.SelectedItem == "..")
+            if (folderList.SelectedItem == parentDirectory)
             {
                 // Handle return path
                 DirectoryInfo info = new DirectoryInfo(currentPath);
@@ -351,13 +358,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 currentPath = newPath;
                 RefreshFolders();
                 RaisePathChangedEvent();
-
-                // Add return path
-                if (currentPath != drives[driveList.SelectedIndex])
-                    folderList.AddItem("..", 0);
-
-                // Update scroller units
-                folderScroller.TotalUnits = folderList.Count;
 
                 UpdatePathText();
             }

--- a/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
+++ b/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
@@ -45,6 +45,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         VerticalScrollBar folderScroller = new VerticalScrollBar();
         TextLabel pathLabel = new TextLabel();
         Button confirmButton = new Button();
+        Checkbox showHiddenFilesCheck = new Checkbox();
         Vector2 lastSize;
 
         Color unselectedColor = new Color(0.8f, 0.8f, 0.8f, 1.0f);
@@ -136,6 +137,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Components.Add(folderPanel);
             Components.Add(pathPanel);
             Components.Add(confirmButton);
+            Components.Add(showHiddenFilesCheck);
             AdjustPanels();
 
             // Setup drive list
@@ -163,6 +165,12 @@ namespace DaggerfallWorkshop.Game.UserInterface
             folderScroller.OnScroll += FolderScroller_OnScroll;
             //folderScroller.OnScrollUp += FolderScroller_OnScrollUp;
             //folderScroller.OnScrollDown += FolderScroller_OnScrollDown;
+
+            showHiddenFilesCheck.Label.Text = TextManager.Instance.GetText("MainMenu", "hiddenFolders");
+            showHiddenFilesCheck.Label.TextColor = unselectedColor;
+            showHiddenFilesCheck.CheckBoxColor = unselectedColor;
+            showHiddenFilesCheck.IsChecked = false;
+            showHiddenFilesCheck.OnToggleState += HiddenFileCheck_OnToggleState;
 
             // Setup initial folder conditions
             RefreshDrives();
@@ -208,7 +216,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 foreach (var directory in directoryList)
                 {
                     DirectoryInfo info = new DirectoryInfo(directory);
-                    if ((info.Attributes & FileAttributes.Hidden) == 0)
+                    if (showHiddenFilesCheck.IsChecked || (info.Attributes & FileAttributes.Hidden) == 0)
                     {
                         string name = Path.GetFileName(directory);
                         folders.Add(name);
@@ -280,6 +288,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             confirmButton.Outline.Enabled = true;
             confirmButton.Label.Text = confirmButtonText;
             //confirmButton.Label.ShadowPosition = Vector2.zero;
+
+            showHiddenFilesCheck.Position = new Vector2(pathPanel.Position.x, pathPanel.Position.y + pathPanel.Size.y + 4);
         }
 
         void UpdatePathText()
@@ -369,6 +379,11 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 RaiseOnConfirmPathEvent();
             else
                 FolderList_OnUseSelectedItem();
+        }
+
+        private void HiddenFileCheck_OnToggleState()
+        {
+            RefreshFolders();
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -244,7 +244,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Add help text
             findArena2Tip = GetText("findArena2Tip");
             pathValidated = GetText("pathValidated");
-            helpLabel.Position = new Vector2(0, 145);
+            helpLabel.Position = new Vector2(0, 150);
             helpLabel.HorizontalAlignment = HorizontalAlignment.Center;
             helpLabel.ShadowPosition = Vector2.zero;
             helpLabel.Text = findArena2Tip;

--- a/Assets/StreamingAssets/Text/MainMenu.txt
+++ b/Assets/StreamingAssets/Text/MainMenu.txt
@@ -45,6 +45,7 @@ missingWoods,               it's missing WOODS.WLD
 missingVideos,              it's missing one or more .VID files
 justNotValid,               it does not appear to be valid
 pathValidated,              Great! This looks like a valid Daggerfall folder :)
+hiddenFolders,              Show Hidden Folders
 testText,                   Test
 okText,                     OK
 keepSetting,                Keep this setting? Changes will revert in 8 seconds.


### PR DESCRIPTION
Fixes #2487. Steam installs DF in a hidden folder by default on Linux, so it's pretty essential for these users.

![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/fbdff2a5-de71-4119-9c1f-95d24eed106c)

![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/2bab65c6-a98a-4a2d-aafd-152b45df8c20)

I can find a DF installation in AppData just fine :)

![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/c5e9bb5c-eb7f-4fed-880e-1fd07fab3cb4)

