### PR TITLE
Pacified-Enemy-Not-Attack-Allies

### DIFF
--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -765,6 +765,10 @@ namespace DaggerfallWorkshop.Game
                     if ((GameManager.Instance.PlayerEntity.NoTargetMode || !motor.IsHostile || enemyEntity.MobileEnemy.Team == MobileTeams.PlayerAlly) && targetBehaviour == player)
                         continue;
 
+                    //Pacified enemies should not attack player allies.
+                    if (!motor.IsHostile && targetEntity != null && targetEntity.Team == MobileTeams.PlayerAlly)
+                        continue;
+
                     //Player allies should not attack pacified enemies.
                     if (enemyEntity.Team == MobileTeams.PlayerAlly && targetBehaviour != player)
                     {


### PR DESCRIPTION
In a previous PR I had added code to prevent allies from attacking pacified enemies but forgot to prevent pacified enemies from attacking player allies.

Added check to prevent pacified enemies from attacking player allies.