### PR TITLE
Set castInProgress to false when loading game (EntityEffectManager.cs)

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -1806,6 +1806,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             lastSpell = null;
             readySpell = null;
             readySpellDoesNotCostSpellPoints = false;
+            castInProgress = false;
         }
 
         public int GetCastSoundID(ElementTypes elementType)


### PR DESCRIPTION
Original problem: If a game is loaded immediately after casting spell, spellcasting will be locked up.
Setting castInProgress to false when EntityEffectManager.ClearReadySpellHistory() is called.

