### PR TITLE
Fixed messagebox painting scaling issue.

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallMessageBox.cs
@@ -527,7 +527,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             float imagePanelHeight = 0;
             if (imagePanel != null && imagePanel.BackgroundTexture != null)
             {
-                imagePanelHeight = imagePanel.BackgroundTexture.height;
+                imagePanelHeight = imagePanel.Size.y;
                 finalSize.y += imagePanelHeight;
                 imagePanel.VerticalAlignment = VerticalAlignment.Top;
                 label.VerticalAlignment = VerticalAlignment.Bottom;


### PR DESCRIPTION
This PR fixes the following bug: #2511 (Painting info window scales improperly with higher resolution images). The issue appears to be caused because the messagebox size is being calculated using the texture height, rather than the actual image panel height. 

Before:
![image](https://github.com/Interkarma/daggerfall-unity/assets/7999934/6e924a7f-d52d-4a4e-8d52-56d505bace43)

After:
![image](https://github.com/Interkarma/daggerfall-unity/assets/7999934/289a11a4-02ca-47a8-bab0-703e02451d27)
