### PR TITLE
Fixed Q0C20Y02 faction type bug.

### DIFF
--- a/Assets/StreamingAssets/Quests/Q0C20Y02.txt
+++ b/Assets/StreamingAssets/Quests/Q0C20Y02.txt
@@ -125,7 +125,7 @@ Item _reward_ gem
 Item _magicitem_ magic_item
 
 Person _questgiver_ face 112 group Questor anyInfo 1011
-Person _other_ factiontype Knightly_Guard remote
+Person _other_ factiontype Daedra remote
 
 Clock _1stparton_ 00:00 0 flag 17 range 1 4
 


### PR DESCRIPTION
This PR fixes the following bug: #2510 (0.14.5: "Generic Knightly Order" used as faction in quest dialogue). The issue appears to be caused by the incorrect `factiontype` value for `_other_` in `Q0C20Y02.txt`. `factiontype` should be set to `Daedra`, not `Knightly_Guard`.