### PR TITLE
Fixed Knightly_Guard faction resolve bug.

### DIFF
--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -20,6 +20,7 @@ using DaggerfallWorkshop.Game.Utility;
 using DaggerfallConnect.Arena2;
 using FullSerializer;
 using DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects;
+using DaggerfallWorkshop.Game.Guilds;
 
 namespace DaggerfallWorkshop.Game.Questing
 {
@@ -980,9 +981,10 @@ namespace DaggerfallWorkshop.Game.Questing
                     return GetRandomFactionOfType(factionType);
 
                 // Type 10 Knightly_Guard does not exist in FACTION.TXT but IS used in some quests
-                // Redirecting this to "Generic Knightly Order" #844 to ensure NPC is created
+                // Redirecting this to a random knightly order to ensure NPC is created and faction is properly resolved
                 case FactionFile.FactionTypes.KnightlyGuard:
-                    return 844;
+                    var knightlyOrderIds = (int[])Enum.GetValues(typeof(KnightlyOrder.Orders));
+                    return knightlyOrderIds[UnityEngine.Random.Range(0, knightlyOrderIds.Length)];
 
                 // Type 11 Magic_User does not exist in FACTION.TXT and is not used in any quests
                 // Redirecting this to "Mages Guild" #40 to ensure NPC is created


### PR DESCRIPTION
This PR (hopefully) fixes the following bug: #2510 (0.14.5: "Generic Knightly Order" used as faction in quest dialogue). The update makes `Knightly_Guard` resolve to a random knightly order, which should fix the faction resolution issue in `Q0C20Y02`. Since the knightly orders are already hardcoded in the `DaggerfallWorkshop.Game.Guilds.KnightlyOrder.Orders` `enum`, the `enum` values were used instead of adding another hardcoded set of knightly order ids.