### PR TITLE
Fast travel gold fix

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -325,6 +325,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             RaiseOnPreFastTravelEvent();
 
+            DeductFastTravelGold();
+
             // Cache scene first, if fast travelling while on ship.
             if (GameManager.Instance.TransportManager.IsOnShip())
                 SaveLoadManager.CacheScene(GameManager.Instance.StreamingWorld.SceneName);
@@ -460,13 +462,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 showNotEnoughGoldPopup();
                 return;
             }
-            else
-            {
-                GameManager.Instance.PlayerEntity.GoldPieces -= travelTimeCalculator.PiecesCost;
-                GameManager.Instance.PlayerEntity.DeductGoldAmount(travelTimeCalculator.TotalCost - travelTimeCalculator.PiecesCost);
-            }
-
+            
             doFastTravel = true; // initiate fast travel (Update() function will perform fast travel when this flag is true)
+        }
+
+        private void DeductFastTravelGold()
+        {
+            GameManager.Instance.PlayerEntity.GoldPieces -= travelTimeCalculator.PiecesCost;
+            GameManager.Instance.PlayerEntity.DeductGoldAmount(travelTimeCalculator.TotalCost - travelTimeCalculator.PiecesCost);
         }
 
         public virtual void ExitButtonOnClickHandler(BaseScreenComponent sender, Vector2 position)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -323,9 +323,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         // perform fast travel actions
         private void performFastTravel()
         {
-            RaiseOnPreFastTravelEvent();
-
             DeductFastTravelGold();
+
+            RaiseOnPreFastTravelEvent();
 
             // Cache scene first, if fast travelling while on ship.
             if (GameManager.Instance.TransportManager.IsOnShip())


### PR DESCRIPTION
This PR fixes the following issue: #2591 (Fast Travel deducts gold even if travel is canceled)

Pretty straight forward. Moved the code to deduct the gold into a separate method, `DaggerfallTravelPopUp.DeductFastTravelGold`. Rather than invoking directly from update, I opted to do so in `DaggerfallTravelPopUp.performFastTravel`, as that method seemed to be where most of the other related changes to `GameManager.Instance.PlayerEntity` state occur. The only concern I have is related to the `DaggerfallTravelPopUp.OnPreFastTravel` and `DaggerfallTravelPopUp.OnPostFastTravel` events. Previously, the gold was deducted prior to either event being fired. In `performFastTravel`, I put it after `OnPreFastTravel`, as that seemed to make the most sense. Looking at the codebase, I did not see any subscribers to `OnPreFastTravel`, so I don't think this will break anything.