### PR TITLE
Fixed VitalChangeDetector UI synchronization issue.

### DIFF
--- a/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
+++ b/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
@@ -9,6 +9,7 @@
 // Notes:
 //
 
+using System;
 using UnityEngine;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
@@ -24,6 +25,7 @@ namespace DaggerfallWorkshop.Game
         protected int previousHealth;
         protected int previousFatigue;
         protected int previousMagicka;
+        public event EventHandler HealthChanged, FatigueChanged, MagickaChanged;
         public float HealthLostPercent { get; private set; }
         public float FatigueLostPercent { get; private set; }
         public float MagickaLostPercent { get; private set; }
@@ -96,6 +98,23 @@ namespace DaggerfallWorkshop.Game
 
             MagickaLost = previousMagicka - currentMagicka;
             MagickaLostPercent = (float)MagickaLost / maxMagicka;
+
+            // Invoking these events after values are set to ensure
+            // subscribers see the changes in a synchronized manner.
+            if (HealthLost != 0 && HealthChanged != null)
+            {
+                HealthChanged(this, EventArgs.Empty);
+            }
+
+            if (FatigueLost != 0 && FatigueChanged != null)
+            {
+                FatigueChanged(this , EventArgs.Empty);
+            }
+
+            if (MagickaLost != 0 && MagickaChanged != null)
+            {
+                MagickaChanged(this, EventArgs.Empty);
+            }
 
             // reset previous health to detect next health loss
             previousHealth = currentHealth;

--- a/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
+++ b/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
@@ -18,6 +18,7 @@ namespace DaggerfallWorkshop.Game
 {
     public class VitalsChangeDetector : MonoBehaviour
     {
+        private bool waitingForUnpause = false;
         protected int previousMaxHealth;
         protected int previousMaxFatigue;
         protected int previousMaxMagicka;
@@ -64,7 +65,15 @@ namespace DaggerfallWorkshop.Game
         void Update()
         {
             if (GameManager.IsGamePaused)
+            {
+                waitingForUnpause = true;
                 return;
+            }
+            else if (waitingForUnpause)
+            {
+                waitingForUnpause = false;
+                return;
+            }
 
             // Check max vitals hasn't changed - this can indicate user has loaded a different character
             // or current character has levelled up or changed in some way and the cached vital values need to be refreshed.

--- a/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
+++ b/Assets/Scripts/Game/Player/VitalsChangeDetector.cs
@@ -18,7 +18,6 @@ namespace DaggerfallWorkshop.Game
 {
     public class VitalsChangeDetector : MonoBehaviour
     {
-        private bool waitingForUnpause = false;
         protected int previousMaxHealth;
         protected int previousMaxFatigue;
         protected int previousMaxMagicka;
@@ -65,15 +64,7 @@ namespace DaggerfallWorkshop.Game
         void Update()
         {
             if (GameManager.IsGamePaused)
-            {
-                waitingForUnpause = true;
                 return;
-            }
-            else if (waitingForUnpause)
-            {
-                waitingForUnpause = false;
-                return;
-            }
 
             // Check max vitals hasn't changed - this can indicate user has loaded a different character
             // or current character has levelled up or changed in some way and the cached vital values need to be refreshed.

--- a/Assets/Scripts/Game/UserInterface/HUDVitals.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDVitals.cs
@@ -26,8 +26,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
         const int nativeBarHeight = 32;
         public const int borderSize = 10;
 
-        float previousHealth, previousFatigue, previousMagicka;
-
         VitalsChangeDetector vitalsDetector = GameManager.Instance.VitalsChangeDetector;
         VerticalProgressSmoother healthBar = new VerticalProgressSmoother();
         VerticalProgressSmoother fatigueBar = new VerticalProgressSmoother();
@@ -121,6 +119,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
             Components.Add(magickaBar);
 
             VitalsChangeDetector.OnReset += VitalChangeDetector_OnReset;
+            vitalsDetector.HealthChanged += VitalsDetector_HealthChanged;
+            vitalsDetector.FatigueChanged += VitalsDetector_FatigueChanged;
+            vitalsDetector.MagickaChanged += VitalsDetector_MagickaChanged;
         }
 
         public void SetAllHorizontalAlignment(HorizontalAlignment alignment)
@@ -278,56 +279,82 @@ namespace DaggerfallWorkshop.Game.UserInterface
             healthBarGain.Amount = playerEntity.CurrentHealth / (float)playerEntity.MaxHealth;
             fatigueBarGain.Amount = playerEntity.CurrentFatigue / (float)playerEntity.MaxFatigue;
             magickaBarGain.Amount = playerEntity.CurrentMagicka / (float)playerEntity.MaxMagicka;
-
-            float target;
-            // if there's any change in health... Smooth update the Loss bar, and
-            // decide if should smooth update or instant update the progress bar
-            if (vitalsDetector.HealthLost != 0 || previousHealth != Health)
-            {
-                if (vitalsDetector.HealthLost > 0)
-                    healthBar.Amount -= vitalsDetector.HealthLostPercent;              
-                else // assumed gaining health
-                    healthBarLoss.Amount += vitalsDetector.HealthGainPercent;
-
-                target = healthBarGain.Amount;
-                healthBar.BeginSmoothChange(target);
-                healthBarLoss.BeginSmoothChange(target);
-            }
-            // if there's any change in fatigue...
-            if (vitalsDetector.FatigueLost != 0 || previousFatigue != Fatigue)
-            {
-                if (vitalsDetector.FatigueLost > 0)
-                    fatigueBar.Amount -= vitalsDetector.FatigueLostPercent;
-                else // assumed gaining health
-                    fatigueBarLoss.Amount += vitalsDetector.FatigueGainPercent;
-
-                target = fatigueBarGain.Amount;
-                fatigueBar.BeginSmoothChange(target);
-                fatigueBarLoss.BeginSmoothChange(target);
-            }
-            // if there's any change in magicka...
-            if (vitalsDetector.MagickaLost != 0 || previousMagicka != Magicka)
-            {
-                if (vitalsDetector.MagickaLost > 0)
-                    magickaBar.Amount -= vitalsDetector.MagickaLostPercent;
-                else // assumed gaining health
-                    magickaBarLoss.Amount += vitalsDetector.MagickaGainPercent;
-
-                target = magickaBarGain.Amount;
-                magickaBar.BeginSmoothChange(target);
-                magickaBarLoss.BeginSmoothChange(target);
-            }
-
             healthBarLoss.Cycle();
             fatigueBarLoss.Cycle();
             magickaBarLoss.Cycle();
             healthBar.Cycle();
             fatigueBar.Cycle();
             magickaBar.Cycle();
+        }
 
-            previousHealth = Health;
-            previousFatigue = Fatigue;
-            previousMagicka = Magicka;
+        private void VitalsDetector_HealthChanged(object sender, System.EventArgs e)
+        {
+            if (!DaggerfallUnity.Settings.EnableVitalsIndicators)
+            {
+                return;
+            }
+
+            healthBarGain.Amount = playerEntity.CurrentHealth / (float)playerEntity.MaxHealth;
+
+            // if there's any change in health... Smooth update the Loss bar, and
+            // decide if should smooth update or instant update the progress bar
+            if (vitalsDetector.HealthLost != 0)
+            {
+                if (vitalsDetector.HealthLost > 0)
+                    healthBar.Amount -= vitalsDetector.HealthLostPercent;
+                else // assumed gaining health
+                    healthBarLoss.Amount += vitalsDetector.HealthGainPercent;
+
+                var target = healthBarGain.Amount;
+                healthBar.BeginSmoothChange(target);
+                healthBarLoss.BeginSmoothChange(target);
+            }
+        }
+
+        private void VitalsDetector_FatigueChanged(object sender, System.EventArgs e)
+        {
+            if (!DaggerfallUnity.Settings.EnableVitalsIndicators)
+            {
+                return;
+            }
+
+            fatigueBar.Amount = playerEntity.CurrentFatigue / (float)playerEntity.MaxFatigue;
+
+            // if there's any change in fatigue...
+            if (vitalsDetector.FatigueLost != 0)
+            {
+                if (vitalsDetector.FatigueLost > 0)
+                    fatigueBar.Amount -= vitalsDetector.FatigueLostPercent;
+                else // assumed gaining health
+                    fatigueBarLoss.Amount += vitalsDetector.FatigueGainPercent;
+
+                var target = fatigueBarGain.Amount;
+                fatigueBar.BeginSmoothChange(target);
+                fatigueBarLoss.BeginSmoothChange(target);
+            }
+        }
+
+        private void VitalsDetector_MagickaChanged(object sender, System.EventArgs e)
+        {
+            if (!DaggerfallUnity.Settings.EnableVitalsIndicators)
+            {
+                return;
+            }
+
+            magickaBarGain.Amount = playerEntity.CurrentMagicka / (float)playerEntity.MaxMagicka;
+
+            // if there's any change in magicka...
+            if (vitalsDetector.MagickaLost != 0)
+            {
+                if (vitalsDetector.MagickaLost > 0)
+                    magickaBar.Amount -= vitalsDetector.MagickaLostPercent;
+                else // assumed gaining health
+                    magickaBarLoss.Amount += vitalsDetector.MagickaGainPercent;
+
+                var target = magickaBarGain.Amount;
+                magickaBar.BeginSmoothChange(target);
+                magickaBarLoss.BeginSmoothChange(target);
+            }
         }
 
         private void VitalChangeDetector_OnReset()

--- a/Assets/Scripts/Game/UserInterface/HUDVitals.cs
+++ b/Assets/Scripts/Game/UserInterface/HUDVitals.cs
@@ -26,6 +26,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
         const int nativeBarHeight = 32;
         public const int borderSize = 10;
 
+        float previousHealth, previousFatigue, previousMagicka;
+
         VitalsChangeDetector vitalsDetector = GameManager.Instance.VitalsChangeDetector;
         VerticalProgressSmoother healthBar = new VerticalProgressSmoother();
         VerticalProgressSmoother fatigueBar = new VerticalProgressSmoother();
@@ -280,7 +282,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             float target;
             // if there's any change in health... Smooth update the Loss bar, and
             // decide if should smooth update or instant update the progress bar
-            if (vitalsDetector.HealthLost != 0)
+            if (vitalsDetector.HealthLost != 0 || previousHealth != Health)
             {
                 if (vitalsDetector.HealthLost > 0)
                     healthBar.Amount -= vitalsDetector.HealthLostPercent;              
@@ -292,7 +294,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 healthBarLoss.BeginSmoothChange(target);
             }
             // if there's any change in fatigue...
-            if (vitalsDetector.FatigueLost != 0)
+            if (vitalsDetector.FatigueLost != 0 || previousFatigue != Fatigue)
             {
                 if (vitalsDetector.FatigueLost > 0)
                     fatigueBar.Amount -= vitalsDetector.FatigueLostPercent;
@@ -304,7 +306,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 fatigueBarLoss.BeginSmoothChange(target);
             }
             // if there's any change in magicka...
-            if (vitalsDetector.MagickaLost != 0)
+            if (vitalsDetector.MagickaLost != 0 || previousMagicka != Magicka)
             {
                 if (vitalsDetector.MagickaLost > 0)
                     magickaBar.Amount -= vitalsDetector.MagickaLostPercent;
@@ -322,6 +324,10 @@ namespace DaggerfallWorkshop.Game.UserInterface
             healthBar.Cycle();
             fatigueBar.Cycle();
             magickaBar.Cycle();
+
+            previousHealth = Health;
+            previousFatigue = Fatigue;
+            previousMagicka = Magicka;
         }
 
         private void VitalChangeDetector_OnReset()


### PR DESCRIPTION
This PR fixes the following issue: #2593 (Changing Vitals while HUDVitals is not Active)

RCA can be found in my comment on the issue. This was the least hacky fix I could think of without resorting to updating `HUDVitals` every tick from `DaggerfallUI.Update`, or doing more complicated state tracking in `VitalsChangeDetector` to ensure `VitalsChangeDetector.HealthLost` wasn't missed. The latter approach would have been difficult to make generic to cover all of the states that can be missed e.g. `FatigueLost`, `MagickaLost`, etc., and may have involved modifications to referencing code as well.

Instead, I opted to modify `VitalsChangeDetector` to delay updates a single tick after each unpause. This should cover cases like those observed in #2593, where only a single tick passes between pauses, wherein a window is pushed to the front that causes `HUDVitals` to miss the `VitalsChangeDetector` update. This approach also has the added benefit of triggering the view bob, which probably wouldn't occur if side channels such as `HUDVitals.SynchronizeImmediately` were used instead.

In code review and testing, nothing seemed to stick out to me, and everything worked as expected. However, this probably warrants careful review of somebody more familiar with the code. If there's a better way of doing this that I missed, let me know and I will update appropriately.