### PR TITLE
RMB Block Editor bugfixing

### DIFF
--- a/Assets/Game/Addons/RmbBlockEditor/Editor/RmbBlockEditorWindow.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Editor/RmbBlockEditorWindow.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using DaggerfallConnect;
-using DaggerfallWorkshop.Game.Utility.ModSupport;
 using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 
@@ -39,6 +38,8 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
         private ClimateSettingsEditor climateSettingsEditor;
 
         private bool keepViewOnSelectionChange;
+
+        private readonly PositionUpdater positionUpdater = new PositionUpdater();
 
         [MenuItem("Daggerfall Tools/RMB Block Editor")]
         public static void ShowWindow()
@@ -407,6 +408,8 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                 loadedBlock.RmbBlock.MiscFlatObjectRecords[i] = record;
             }
 
+            // Flats, People and Doors have a "position" property that needs to be unique in the RMB block.
+            loadedBlock = positionUpdater.UpdateDuplicatedPositions(loadedBlock);
             RmbBlockHelper.SaveBlockFile(loadedBlock, path);
         }
 

--- a/Assets/Game/Addons/RmbBlockEditor/Editor/Utils/PositionUpdater.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Editor/Utils/PositionUpdater.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using DaggerfallConnect;
+
+namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
+{
+    public class PositionUpdater
+    {
+        private readonly Random random = new Random();
+
+        public DFBlock UpdateDuplicatedPositions(DFBlock loadedBlock)
+        {
+            var existingPositions = new HashSet<long>();
+
+            // RMB Flats
+            for (var i = 0; i < loadedBlock.RmbBlock.MiscFlatObjectRecords.Length; i++)
+            {
+                var record = loadedBlock.RmbBlock.MiscFlatObjectRecords[i];
+                if (existingPositions.Contains(record.Position))
+                {
+                    record.Position = GenerateUniquePosition(existingPositions);
+                }
+                existingPositions.Add(record.Position);
+                loadedBlock.RmbBlock.MiscFlatObjectRecords[i] = record;
+            }
+
+            // Buildings
+            for (var buildingIndex = 0; buildingIndex < loadedBlock.RmbBlock.SubRecords.Length; buildingIndex++)
+            {
+                var building = loadedBlock.RmbBlock.SubRecords[buildingIndex];
+                // Exterior Flats
+                for (var extFlatIndex = 0;
+                     extFlatIndex < building.Exterior.BlockFlatObjectRecords.Length;
+                     extFlatIndex++)
+                {
+                    var extFlat = building.Exterior.BlockFlatObjectRecords[extFlatIndex];
+                    if (existingPositions.Contains(extFlat.Position))
+                    {
+                        extFlat.Position = GenerateUniquePosition(existingPositions);
+                    }
+                    existingPositions.Add(extFlat.Position);
+                    building.Exterior.BlockFlatObjectRecords[extFlatIndex] = extFlat;
+                }
+
+                // Exterior People
+                for (var extPeopleIndex = 0;
+                     extPeopleIndex < building.Exterior.BlockPeopleRecords.Length;
+                     extPeopleIndex++)
+                {
+                    var extPerson = building.Exterior.BlockPeopleRecords[extPeopleIndex];
+                    if (existingPositions.Contains(extPerson.Position))
+                    {
+                        extPerson.Position = GenerateUniquePosition(existingPositions);
+                    }
+                    existingPositions.Add(extPerson.Position);
+                    building.Exterior.BlockPeopleRecords[extPeopleIndex] = extPerson;
+                }
+
+                // Exterior Doors
+                for (var extDoorsIndex = 0;
+                     extDoorsIndex < building.Exterior.BlockDoorRecords.Length;
+                     extDoorsIndex++)
+                {
+                    var extDoor = building.Exterior.BlockDoorRecords[extDoorsIndex];
+                    if (existingPositions.Contains(extDoor.Position))
+                    {
+                        extDoor.Position = GenerateUniquePosition(existingPositions);
+                    }
+                    existingPositions.Add(extDoor.Position);
+                    building.Exterior.BlockDoorRecords[extDoorsIndex] = extDoor;
+                }
+
+                // Internal Flats
+                for (var intFlatIndex = 0;
+                     intFlatIndex < building.Interior.BlockFlatObjectRecords.Length;
+                     intFlatIndex++)
+                {
+                    var intFlat = building.Interior.BlockFlatObjectRecords[intFlatIndex];
+                    if (existingPositions.Contains(intFlat.Position))
+                    {
+                        intFlat.Position = GenerateUniquePosition(existingPositions);
+                    }
+                    existingPositions.Add(intFlat.Position);
+                    building.Interior.BlockFlatObjectRecords[intFlatIndex] = intFlat;
+                }
+
+                // Interior People
+                for (var intPeopleIndex = 0;
+                     intPeopleIndex < building.Interior.BlockPeopleRecords.Length;
+                     intPeopleIndex++)
+                {
+                    var intPerson = building.Interior.BlockPeopleRecords[intPeopleIndex];
+                    if (existingPositions.Contains(intPerson.Position))
+                    {
+                        intPerson.Position = GenerateUniquePosition(existingPositions);
+                    }
+                    existingPositions.Add(intPerson.Position);
+                    building.Interior.BlockPeopleRecords[intPeopleIndex] = intPerson;
+                }
+
+                // Interior Doors
+                for (var intDoorsIndex = 0;
+                     intDoorsIndex < building.Interior.BlockDoorRecords.Length;
+                     intDoorsIndex++)
+                {
+                    var intDoor = building.Interior.BlockDoorRecords[intDoorsIndex];
+                    if (existingPositions.Contains(intDoor.Position))
+                    {
+                        intDoor.Position = GenerateUniquePosition(existingPositions);
+                    }
+                    existingPositions.Add(intDoor.Position);
+                    building.Interior.BlockDoorRecords[intDoorsIndex] = intDoor;
+                }
+
+                loadedBlock.RmbBlock.SubRecords[buildingIndex] = building;
+            }
+
+            return loadedBlock;
+        }
+
+        private int GenerateUniquePosition(HashSet<long> existingIds)
+        {
+            int newId;
+            do
+            {
+                newId = random.Next();
+            } while (existingIds.Contains(newId));
+
+            return newId;
+        }
+    }
+}

--- a/Assets/Game/Addons/RmbBlockEditor/Editor/Utils/PositionUpdater.cs.meta
+++ b/Assets/Game/Addons/RmbBlockEditor/Editor/Utils/PositionUpdater.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3a09ab91d4404e2d8bbad1195cb4b2ea
+timeCreated: 1708856092

--- a/Assets/Game/Addons/RmbBlockEditor/MiscFlat.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/MiscFlat.cs
@@ -29,11 +29,14 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
         private Billboard dfBillboard;
         private Vector3 flatOffset;
 
-        public void CreateObject(DFBlock.RmbBlockFlatObjectRecord data)
+        public void Awake()
         {
             dfBillboard = GetComponent<Billboard>();
             flatOffset = new Vector3(0, (dfBillboard.Summary.Size.y / 2) - 0.1f, 0);
+        }
 
+        public void CreateObject(DFBlock.RmbBlockFlatObjectRecord data)
+        {
             Position = data.Position;
             TextureArchive = data.TextureArchive;
             TextureRecord = data.TextureRecord;


### PR DESCRIPTION
Fixed a couple of bugs.
1. Fixed a problem where the position of MiscFlatObjectRecords billboards would be calculated incorrectly, when the billboard is duplicated through the editor.
2. MiscFlatObjectRecords and BlockFlatObjectRecords, BlockPeopleRecords and BlockDoorRecords in Interior and Exterior subrecords need to have unique "position" values. This "position" property is used to identify the objects.