### PR TITLE
Fixed "work question" sticking while moving from "Where Is?"

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTalkWindow.cs
@@ -1221,7 +1221,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
         protected virtual void UpdateQuestion(int index)
         {
             TalkManager.ListItem listItem;
-            if (selectedTalkCategory == TalkCategory.Work)
+            if (selectedTalkOption == TalkOption.WhereIs && selectedTalkCategory == TalkCategory.Work)
             {
                 listItem = new TalkManager.ListItem();
                 listItem.questionType = TalkManager.QuestionType.Work;


### PR DESCRIPTION
When transitioning from asking about "Where Is? Work" to "Tell Me About", the question at the top of the screen remains about work.

https://github.com/Interkarma/daggerfall-unity/assets/5789925/c38badb1-79e7-4b77-9f92-40d35bdebb7d

The "Where Is?" talk category is preserved when moving to "Tell Me About" so it can be restored when going back to "Where Is?". 
The problem is that `UpdateQuestion` only checks the talk category "Work", not if we're actually in the "Where Is?" talk option.

I fixed this to also check the talk option