### PR TITLE
Added "ActiveGameObjectDatabase" to replace FindObjectsOfType

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/DefaultCommands.cs
@@ -1488,13 +1488,13 @@ namespace Wenzil.Console
                     return error;
                 else
                 {
-                    DaggerfallActionDoor[] doors = GameObject.FindObjectsOfType<DaggerfallActionDoor>();
                     int count = 0;
-                    for (int i = 0; i < doors.Length; i++)
+                    IEnumerable<DaggerfallActionDoor> doors = ActiveGameObjectDatabase.GetActiveActionDoors();
+                    foreach (DaggerfallActionDoor door in doors)
                     {
-                        if (!doors[i].IsOpen)
+                        if (!door.IsOpen)
                         {
-                            doors[i].SetOpen(true, false, true);
+                            door.SetOpen(true, false, true);
                             count++;
                         }
                     }
@@ -1574,11 +1574,9 @@ namespace Wenzil.Console
 
             public static string Execute(params string[] args)
             {
-                DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
                 int count = 0;
-                for (int i = 0; i < entityBehaviours.Length; i++)
+                foreach(DaggerfallEntityBehaviour entityBehaviour in ActiveGameObjectDatabase.GetActiveEnemyBehaviours())
                 {
-                    DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
                     if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
                     {
                         entityBehaviour.Entity.SetHealth(0);

--- a/Assets/Scripts/ActiveGameObjectDatabase.cs
+++ b/Assets/Scripts/ActiveGameObjectDatabase.cs
@@ -200,6 +200,7 @@ namespace DaggerfallWorkshop
         static GameObjectCache foeSpawnerCache = new GameObjectCache("Foe Spawner");
         static GameObjectCache staticNpcCache = new GameObjectCache("Static NPC");
         static GameObjectCache actionDoorCache = new GameObjectCache("Action Door");
+        static GameObjectCache rdbCache = new GameObjectCache("RDB");
 
         // Gets all the active enemy GameObjects. Must be registered as Enemy (see below)
         public static IEnumerable<GameObject> GetActiveEnemyObjects()
@@ -334,6 +335,24 @@ namespace DaggerfallWorkshop
             actionDoorCache.AddObject(door);
         }
 
+        // Gets all the active RDB GameObjects. Must be registered as RDB (see below)
+        public static IEnumerable<GameObject> GetActiveRDBObjects()
+        {
+            return rdbCache.GetActiveObjects();
+        }
+
+        // Gets all the enabled DaggerfallStaticDoors components from active registered RDBs
+        public static IEnumerable<DaggerfallStaticDoors> GetActiveRDBStaticDoors()
+        {
+            return rdbCache.GetActiveComponents<DaggerfallStaticDoors>();
+        }
+
+        // Registers a Daggerfall dungeon block "RDB" game object to the RDB cache. Does not have to be active
+        public static void RegisterRDB(GameObject rdb)
+        {
+            rdbCache.AddObject(rdb);
+        }
+
         // Used for debugging
         public static IEnumerable<string> GetCacheDebugLines()
         {
@@ -343,6 +362,7 @@ namespace DaggerfallWorkshop
             yield return foeSpawnerCache.GetDebugString();
             yield return staticNpcCache.GetDebugString();
             yield return actionDoorCache.GetDebugString();
+            yield return rdbCache.GetDebugString();
         }
     }
 }

--- a/Assets/Scripts/ActiveGameObjectDatabase.cs
+++ b/Assets/Scripts/ActiveGameObjectDatabase.cs
@@ -1,0 +1,345 @@
+using DaggerfallWorkshop.Game;
+using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Questing;
+using DaggerfallWorkshop.Game.Utility;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+
+namespace DaggerfallWorkshop
+{
+    // Generic GameObject cache
+    // To be used as Singleton storage, to replace "FindObjectsOfType" lookups
+    // From https://docs.unity3d.com/ScriptReference/Object.FindObjectsOfType.html
+    // "This function is very slow. It is not recommended to use this function every frame. In most cases you can use the singleton pattern instead."
+    // In addition, DFU has historically had crashes associated to frequent "FindObjectsOfType" lookups
+    //
+    // We can register inactive GameObjects, but the cache will only return active GameObjects.
+    public class GameObjectCache
+    {
+        string cacheName;
+        ReaderWriterLockSlim cacheLock = new ReaderWriterLockSlim();
+        List<WeakReference<GameObject>> cachedObjects = new List<WeakReference<GameObject>>();
+
+        public GameObjectCache(string name)
+        {
+            cacheName = name;
+        }
+
+        // Returns all the active GameObjects in the cache
+        // If a system calls SetActive(false) on an object without destroying it, it will not be returned here
+        public IEnumerable<GameObject> GetActiveObjects()
+        {
+            cacheLock.EnterReadLock();
+            try
+            {
+                List<GameObject> gameObjects = new List<GameObject>();
+                foreach (var weakObject in cachedObjects)
+                {
+                    if (weakObject.TryGetTarget(out GameObject activeObject))
+                    {
+                        // A null check on a GameObject does more than C#'s reference check,
+                        // it also checks if the object has been destroyed
+                        // Like Object.FindObjectsOfType, we should only include active objects 
+                        if (activeObject != null && activeObject.activeInHierarchy)
+                            gameObjects.Add(activeObject);
+                    }
+                }
+
+                return gameObjects;
+            }
+            finally
+            {
+                cacheLock.ExitReadLock();
+            }
+        }
+
+        // Returns all the enabled components of active GameObjects in the cache
+        // If a system calls SetActive(false) on an object without destroying it, it will not be returned here
+        public IEnumerable<T> GetActiveComponents<T>() where T : MonoBehaviour
+        {
+            foreach (GameObject gameObject in GetActiveObjects())
+            {
+                var t = gameObject.GetComponent<T>();
+                if (t != null && t.isActiveAndEnabled)
+                    yield return t;
+            }
+        }
+
+        // Adds a GameObject to the cache
+        // Input GameObject can be inactive in the scene. It will not be removed from the cache until Destroyed
+        public void AddObject(GameObject gameObject)
+        {
+#if UNITY_EDITOR
+            // Editor-only test:
+            // Check if the object is already there before adding
+            cacheLock.EnterUpgradeableReadLock();
+            try
+            {
+                foreach(WeakReference<GameObject> weakObject in cachedObjects)
+                {
+                    if(weakObject.TryGetTarget(out GameObject cachedObject))
+                    {
+                        // Already added
+                        if (cachedObject == gameObject)
+                            throw new ArgumentException($"GameObject '{gameObject.name}' was already registered in cache '{cacheName}'");
+                    }
+                }
+#endif                
+                // We're not already in the cache
+                cacheLock.EnterWriteLock();
+                try
+                {
+                    ClearDestroyedObjects();
+                    cachedObjects.Add(new WeakReference<GameObject>(gameObject));
+                }
+                finally
+                {
+                    cacheLock.ExitWriteLock();
+                }
+#if UNITY_EDITOR
+            }
+            finally
+            {
+                cacheLock.ExitUpgradeableReadLock();
+            }
+#endif
+        }
+
+        // Adds a GameObjects to the cache. More efficient if multiple objects can be added at the same time.
+        // Input GameObjects can be inactive in the scene. They will not be removed from the cache until Destroyed
+        public void AddObjects(IEnumerable<GameObject> newActiveObjects)
+        {
+            cacheLock.EnterWriteLock();
+            try
+            {
+                ClearDestroyedObjects();
+                foreach (GameObject gameObject in newActiveObjects)
+                {
+                    cachedObjects.Add(new WeakReference<GameObject>(gameObject));
+                }
+            }
+            finally
+            {
+                cacheLock.ExitWriteLock();
+            }
+        }
+
+        void ClearDestroyedObjects()
+        {
+            // We assume we already have the write lock
+
+#if UNITY_EDITOR
+            int previousCachedObjectCount = cachedObjects.Count;
+#endif
+
+            // Clear only null or destroyed objects
+            // Objects may be inactive, but we are keeping them, in case they get activated
+            cachedObjects.RemoveAll(weakRef => !weakRef.TryGetTarget(out GameObject target) || target == null);
+
+#if UNITY_EDITOR
+            int newCachedObjectCount = cachedObjects.Count;
+            if (newCachedObjectCount < previousCachedObjectCount)
+            {
+                Debug.Log($"Removed {previousCachedObjectCount - newCachedObjectCount} entries from cache '{cacheName}'");
+            }
+#endif
+        }
+
+        public string GetDebugString()
+        {
+            int activeCount = 0;
+            int destroyedCount = 0;
+            int inactiveCount = 0;
+
+            cacheLock.EnterReadLock();
+            try
+            {
+                foreach (var weakObject in cachedObjects)
+                {
+                    if (weakObject.TryGetTarget(out GameObject activeObject))
+                    {
+                        if(activeObject == null)
+                        {
+                            ++destroyedCount;
+                        }
+                        else if(!activeObject.activeInHierarchy)
+                        {
+                            ++inactiveCount;
+                        }
+                        else
+                        {
+                            ++activeCount;
+                        }
+                    }
+                    else
+                    {
+                        ++destroyedCount;
+                    }
+                }
+            }
+            finally
+            {
+                cacheLock.ExitReadLock();
+            }
+
+            return $"{cacheName}: {activeCount} active, {destroyedCount} destroyed, {inactiveCount} inactive";
+        }
+    }
+
+    // Namespace for DFU object lookups
+    // We keep separate caches for different GameObject types
+    // For example, we have an Enemy cache, for entities of type EntityMonster or EntityClass
+    // Even though Civilian Mobile NPCs are also similar entities, they are tracked separately
+    public static class ActiveGameObjectDatabase
+    {
+        static GameObjectCache enemyCache = new GameObjectCache("Enemy");
+        static GameObjectCache civilianCache = new GameObjectCache("Civilian Mobile");
+        static GameObjectCache lootCache = new GameObjectCache("Loot");
+        static GameObjectCache foeSpawnerCache = new GameObjectCache("Foe Spawner");
+        static GameObjectCache staticNpcCache = new GameObjectCache("Static NPC");
+        static GameObjectCache doorCache = new GameObjectCache("Door");
+
+        // Gets all the active enemy GameObjects. Must be registered as Enemy (see below)
+        public static IEnumerable<GameObject> GetActiveEnemyObjects()
+        {
+            return enemyCache.GetActiveObjects();
+        }
+
+        // Gets all the enabled DaggerfallEntityBehaviour components from active registered enemies
+        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveEnemyBehaviours()
+        {
+            return enemyCache.GetActiveComponents<DaggerfallEntityBehaviour>();
+        }
+
+        // Gets all the enabled DaggerfallEnemy components from active registered enemies
+        public static IEnumerable<DaggerfallEnemy> GetActiveEnemyEntities()
+        {
+            return enemyCache.GetActiveComponents<DaggerfallEnemy>();
+        }
+
+        // Gets all the enabled QuestResourceBehaviour components from active registered enemies
+        public static IEnumerable<QuestResourceBehaviour> GetActiveEnemyQuestResourceBehaviours()
+        {
+            return enemyCache.GetActiveComponents<QuestResourceBehaviour>();
+        }
+
+        // Gets all the enabled EnemyMotor components from active registered enemies
+        public static IEnumerable<EnemyMotor> GetActiveEnemyMotors()
+        {
+            return enemyCache.GetActiveComponents<EnemyMotor>();
+        }
+
+        // Registers an enemy (monster or class) to the enemy cache. Does not have to be active
+        public static void RegisterEnemy(GameObject enemy)
+        {
+            enemyCache.AddObject(enemy);
+        }
+
+        // Gets all the active Civilian Mobile GameObjects. Must be registered as Civilian Mobile (see below)
+        public static IEnumerable<GameObject> GetActiveCivilianMobileObjects()
+        {
+            return civilianCache.GetActiveObjects();
+        }
+
+        // Gets all the enabled DaggerfallEntityBehaviour components from active registered Civilian Mobiles
+        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveCivilianMobileBehaviours()
+        {
+            return civilianCache.GetActiveComponents<DaggerfallEntityBehaviour>();
+        }
+
+        // Registers a mobile civilian NPC to the civilian cache. Does not have to be active
+        public static void RegisterCivilianMobile(GameObject civilian)
+        {
+            civilianCache.AddObject(civilian);
+        }
+
+        // Gets all the active loot GameObjects. Must be registered as Loot (see below)
+        public static IEnumerable<GameObject> GetActiveLootObjects()
+        {
+            return lootCache.GetActiveObjects();
+        }
+
+        // Gets all the enabled DaggerfallLoot components from active registered loot
+        public static IEnumerable<DaggerfallLoot> GetActiveLoot()
+        {
+            return lootCache.GetActiveComponents<DaggerfallLoot>();
+        }
+
+        // Registers a loot object to the loot cache. Does not have to be active
+        public static void RegisterLoot(GameObject loot)
+        {
+            lootCache.AddObject(loot);
+        }
+
+        // Gets all the active Foe Spawner GameObjects. Must be registered as Foe Spawner (see below)
+        public static IEnumerable<GameObject> GetActiveFoeSpawnerObjects()
+        {
+            return foeSpawnerCache.GetActiveObjects();
+        }
+
+        // Gets all the enabled FoeSpawner components from active registered foe spawners
+        public static IEnumerable<FoeSpawner> GetActiveFoeSpawners()
+        {
+            return foeSpawnerCache.GetActiveComponents<FoeSpawner>();
+        }
+
+        // Registers a foe spawner object to the foe spawner cache. Does not have to be active
+        public static void RegisterFoeSpawner(GameObject foeSpawner)
+        {
+            foeSpawnerCache.AddObject(foeSpawner);
+        }
+
+        // Gets all the active Static NPC GameObjects. Must be registered as a Static NPC (see below)
+        public static IEnumerable<GameObject> GetActiveStaticNPCObjects()
+        {
+            return staticNpcCache.GetActiveObjects();
+        }
+
+        // Gets all the enabled StaticNPC components from active registered static NPCs
+        public static IEnumerable<StaticNPC> GetActiveStaticNPCs()
+        {
+            return staticNpcCache.GetActiveComponents<StaticNPC>();
+        }
+
+        public static IEnumerable<QuestResourceBehaviour> GetActiveStaticNPCQuestResourceBehaviours()
+        {
+            return staticNpcCache.GetActiveComponents<QuestResourceBehaviour>();
+        }
+
+        // Registers a static NPC object to the Static NPC cache. Does not have to be active
+        public static void RegisterStaticNPC(GameObject staticNPC)
+        {
+            staticNpcCache.AddObject(staticNPC);
+        }
+
+        // Gets all the active Door GameObjects. Must be registered as Door (see below)
+        public static IEnumerable<GameObject> GetActiveDoorObjects()
+        {
+            return doorCache.GetActiveObjects();
+        }
+
+        // Gets all the enabled DaggerfallActionDoor components from active registered doors
+        public static IEnumerable<DaggerfallActionDoor> GetActiveActionDoors()
+        {
+            return doorCache.GetActiveComponents<DaggerfallActionDoor>();
+        }
+
+        // Registers a Door object to the Door cache. Does not have to be active
+        public static void RegisterDoor(GameObject door)
+        {
+            doorCache.AddObject(door);
+        }
+
+        public static IEnumerable<string> GetCacheDebugLines()
+        {
+            yield return enemyCache.GetDebugString();
+            yield return civilianCache.GetDebugString();
+            yield return lootCache.GetDebugString();
+            yield return foeSpawnerCache.GetDebugString();
+            yield return staticNpcCache.GetDebugString();
+            yield return doorCache.GetDebugString();
+        }
+    }
+}

--- a/Assets/Scripts/ActiveGameObjectDatabase.cs
+++ b/Assets/Scripts/ActiveGameObjectDatabase.cs
@@ -199,7 +199,7 @@ namespace DaggerfallWorkshop
         static GameObjectCache lootCache = new GameObjectCache("Loot");
         static GameObjectCache foeSpawnerCache = new GameObjectCache("Foe Spawner");
         static GameObjectCache staticNpcCache = new GameObjectCache("Static NPC");
-        static GameObjectCache doorCache = new GameObjectCache("Door");
+        static GameObjectCache actionDoorCache = new GameObjectCache("Action Door");
 
         // Gets all the active enemy GameObjects. Must be registered as Enemy (see below)
         public static IEnumerable<GameObject> GetActiveEnemyObjects()
@@ -303,6 +303,7 @@ namespace DaggerfallWorkshop
             return staticNpcCache.GetActiveComponents<StaticNPC>();
         }
 
+        // Gets all the enabled QuestResourceBehaviour components from active registered static NPCs
         public static IEnumerable<QuestResourceBehaviour> GetActiveStaticNPCQuestResourceBehaviours()
         {
             return staticNpcCache.GetActiveComponents<QuestResourceBehaviour>();
@@ -314,24 +315,26 @@ namespace DaggerfallWorkshop
             staticNpcCache.AddObject(staticNPC);
         }
 
-        // Gets all the active Door GameObjects. Must be registered as Door (see below)
-        public static IEnumerable<GameObject> GetActiveDoorObjects()
+        // Gets all the active Action Door GameObjects. Must be registered as Action Door (see below)
+        public static IEnumerable<GameObject> GetActiveActionDoorObjects()
         {
-            return doorCache.GetActiveObjects();
+            return actionDoorCache.GetActiveObjects();
         }
 
         // Gets all the enabled DaggerfallActionDoor components from active registered doors
         public static IEnumerable<DaggerfallActionDoor> GetActiveActionDoors()
         {
-            return doorCache.GetActiveComponents<DaggerfallActionDoor>();
+            return actionDoorCache.GetActiveComponents<DaggerfallActionDoor>();
         }
 
-        // Registers a Door object to the Door cache. Does not have to be active
-        public static void RegisterDoor(GameObject door)
+        // Registers an Action Door object to the Action Door cache. Does not have to be active
+        // Action Doors are not to be confused with static doors, which exist on RDBs and Interiors on their DaggerfallStaticDoors component
+        public static void RegisterActionDoor(GameObject door)
         {
-            doorCache.AddObject(door);
+            actionDoorCache.AddObject(door);
         }
 
+        // Used for debugging
         public static IEnumerable<string> GetCacheDebugLines()
         {
             yield return enemyCache.GetDebugString();
@@ -339,7 +342,7 @@ namespace DaggerfallWorkshop
             yield return lootCache.GetDebugString();
             yield return foeSpawnerCache.GetDebugString();
             yield return staticNpcCache.GetDebugString();
-            yield return doorCache.GetDebugString();
+            yield return actionDoorCache.GetDebugString();
         }
     }
 }

--- a/Assets/Scripts/ActiveGameObjectDatabase.cs.meta
+++ b/Assets/Scripts/ActiveGameObjectDatabase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d565014c03b96f740af893081909bf65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/External/FPSDisplay.cs
+++ b/Assets/Scripts/External/FPSDisplay.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+using DaggerfallWorkshop;
+using UnityEngine;
 
 /// <summary>
 /// Simple FPS counter using OnGui(), taken from here:
@@ -33,15 +34,36 @@ public class FPSDisplay : MonoBehaviour
 
         int w = Screen.width, h = Screen.height;
 
-        GUIStyle style = new GUIStyle();
+        // Show FPS
+        {
+            GUIStyle style = new GUIStyle();
 
-        Rect rect = new Rect(w / 2, 0, w, h * 2 / 100);
-        style.alignment = TextAnchor.UpperLeft;
-        style.fontSize = h * 2 / 100;
-        style.normal.textColor = Color.white;  //new Color(0.0f, 0.0f, 0.5f, 1.0f);
-        float msec = deltaTime * 1000.0f;
-        float fps = 1.0f / deltaTime;
-        string text = string.Format("{0:0.0} ms ({1:0.} fps)", msec, fps);
-        GUI.Label(rect, text, style);
+            Rect rect = new Rect(w / 2, 0, w, h * 2 / 100);
+            style.alignment = TextAnchor.UpperLeft;
+            style.fontSize = h * 2 / 100;
+            style.normal.textColor = Color.white;  //new Color(0.0f, 0.0f, 0.5f, 1.0f);
+            float msec = deltaTime * 1000.0f;
+            float fps = 1.0f / deltaTime;
+            string text = string.Format("{0:0.0} ms ({1:0.} fps)", msec, fps);
+            GUI.Label(rect, text, style);
+        }
+
+        // Show Game Objects
+        {
+            GUIStyle style = new GUIStyle();
+            style.normal.textColor = Color.black;
+
+            Rect rect = new Rect(10, 82, 800, 24);
+            Rect rectShadow = new Rect(8, 80, 800, 24);
+
+
+            foreach (string line in ActiveGameObjectDatabase.GetCacheDebugLines())
+            {
+                GUI.Label(rect, line, style);
+                GUI.Label(rectShadow, line);
+                rect.y += 16;
+                rectShadow.y += 16;
+            }            
+        }
     }
 }

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -16,6 +16,7 @@ using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallConnect;
 using DaggerfallWorkshop.Game.Questing;
 using DaggerfallWorkshop.Game.Utility;
+using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -735,6 +736,18 @@ namespace DaggerfallWorkshop.Game
 
         #region Private Methods
 
+        // Enemies consider only other enemies and the player
+        // Civilian Mobile NPCs are not handled here
+        IEnumerable<DaggerfallEntityBehaviour> GetActiveTargetEntityBehaviours()
+        {
+            foreach(DaggerfallEntityBehaviour behaviour in ActiveGameObjectDatabase.GetActiveEnemyBehaviours())
+            {
+                yield return behaviour;
+            }
+
+            yield return player;
+        }
+
         void GetTargets()
         {
             DaggerfallEntityBehaviour highestPriorityTarget = null;
@@ -745,10 +758,8 @@ namespace DaggerfallWorkshop.Game
             Vector3 directionToTargetHolder = directionToTarget;
             float distanceToTargetHolder = distanceToTarget;
 
-            DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
-            for (int i = 0; i < entityBehaviours.Length; i++)
+            foreach (DaggerfallEntityBehaviour targetBehaviour in GetActiveTargetEntityBehaviours())
             {
-                DaggerfallEntityBehaviour targetBehaviour = entityBehaviours[i];
                 EnemyEntity targetEntity = null;
                 if (targetBehaviour != player)
                     targetEntity = targetBehaviour.Entity as EnemyEntity;

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -687,10 +687,8 @@ namespace DaggerfallWorkshop.Game
             const float restingDistance = 12f;
 
             bool areEnemiesNearby = false;
-            DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
-            for (int i = 0; i < entityBehaviours.Length; i++)
+            foreach (DaggerfallEntityBehaviour entityBehaviour in ActiveGameObjectDatabase.GetActiveEnemyBehaviours())
             {
-                DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
                 if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
                 {
                     EnemySenses enemySenses = entityBehaviour.GetComponent<EnemySenses>();
@@ -720,11 +718,10 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Also check for enemy spawners that might emit an enemy
-            FoeSpawner[] spawners = FindObjectsOfType<FoeSpawner>();
-            for (int i = 0; i < spawners.Length; i++)
+            foreach (FoeSpawner spawner in ActiveGameObjectDatabase.GetActiveFoeSpawners())
             {
                 // Is a spawner inside min distance?
-                if (Vector3.Distance(spawners[i].transform.position, PlayerController.transform.position) < spawnDistance)
+                if (Vector3.Distance(spawner.transform.position, PlayerController.transform.position) < spawnDistance)
                 {
                     areEnemiesNearby = true;
                     break;
@@ -743,10 +740,8 @@ namespace DaggerfallWorkshop.Game
         public int HowManyEnemiesOfType(MobileTypes type, bool stopLookingIfFound = false, bool includingPacified = false)
         {
             int numberOfEnemies = 0;
-            DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
-            for (int i = 0; i < entityBehaviours.Length; i++)
-            {
-                DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
+            foreach (DaggerfallEntityBehaviour entityBehaviour in ActiveGameObjectDatabase.GetActiveEnemyBehaviours())
+            { 
                 if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
                 {
                     EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
@@ -765,11 +760,10 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Also check for enemy spawners that might emit an enemy
-            FoeSpawner[] spawners = FindObjectsOfType<FoeSpawner>();
-            for (int i = 0; i < spawners.Length; i++)
+            foreach (FoeSpawner spawner in ActiveGameObjectDatabase.GetActiveFoeSpawners())
             {
                 // Is a spawner inside min distance?
-                if (spawners[i].FoeType == type)
+                if (spawner.FoeType == type)
                 {
                     numberOfEnemies++;
                     if (stopLookingIfFound)
@@ -785,18 +779,12 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         public void ClearEnemies()
         {
-            DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
-            for (int i = 0; i < entityBehaviours.Length; i++)
-            {
-                DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
-                if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
-                    Destroy(entityBehaviour.gameObject);
-            }
+            foreach (GameObject enemyObject in ActiveGameObjectDatabase.GetActiveEnemyObjects())
+                Destroy(enemyObject);
 
             // Also check for enemy spawners that might emit an enemy
-            FoeSpawner[] spawners = FindObjectsOfType<FoeSpawner>();
-            for (int i = 0; i < spawners.Length; i++)
-                Destroy(spawners[i].gameObject);
+            foreach (GameObject spawnerObject in ActiveGameObjectDatabase.GetActiveFoeSpawnerObjects())
+                Destroy(spawnerObject);
         }
 
         /// <summary>
@@ -804,10 +792,8 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         public void MakeEnemiesHostile()
         {
-            DaggerfallEntityBehaviour[] entityBehaviours = FindObjectsOfType<DaggerfallEntityBehaviour>();
-            for (int i = 0; i < entityBehaviours.Length; i++)
-            {
-                DaggerfallEntityBehaviour entityBehaviour = entityBehaviours[i];
+            foreach (DaggerfallEntityBehaviour entityBehaviour in ActiveGameObjectDatabase.GetActiveEnemyBehaviours())
+            { 
                 if (entityBehaviour.EntityType == EntityTypes.EnemyMonster || entityBehaviour.EntityType == EntityTypes.EnemyClass)
                 {
                     EnemyMotor enemyMotor = entityBehaviour.GetComponent<EnemyMotor>();

--- a/Assets/Scripts/Game/MobilePersonNPC.cs
+++ b/Assets/Scripts/Game/MobilePersonNPC.cs
@@ -125,6 +125,14 @@ namespace DaggerfallWorkshop.Game
 
         #endregion
 
+        #region Unity
+        private void Awake()
+        {
+            // Register this object as a Civilian Mobile NPC object
+            ActiveGameObjectDatabase.RegisterCivilianMobile(gameObject);
+        }
+        #endregion
+
         #region Public Methods
 
         /// <summary>

--- a/Assets/Scripts/Game/Questing/Actions/ChangeFoeInfighting.cs
+++ b/Assets/Scripts/Game/Questing/Actions/ChangeFoeInfighting.cs
@@ -58,7 +58,7 @@ namespace DaggerfallWorkshop.Game.Questing
             if (foe == null)
                  return;
 
-            foreach (DaggerfallEnemy enemy in UnityEngine.Object.FindObjectsOfType<DaggerfallEnemy>())
+            foreach (DaggerfallEnemy enemy in ActiveGameObjectDatabase.GetActiveEnemyEntities())
             {
                 if (enemy.QuestSpawn)
                 {

--- a/Assets/Scripts/Game/Questing/Actions/ChangeFoeTeam.cs
+++ b/Assets/Scripts/Game/Questing/Actions/ChangeFoeTeam.cs
@@ -74,7 +74,7 @@ namespace DaggerfallWorkshop.Game.Questing
             if (foe == null)
                 return;
 
-            foreach (DaggerfallEnemy enemy in UnityEngine.Object.FindObjectsOfType<DaggerfallEnemy>())
+            foreach (DaggerfallEnemy enemy in ActiveGameObjectDatabase.GetActiveEnemyEntities())
             {
                 if (enemy.QuestSpawn)
                 {

--- a/Assets/Scripts/Game/Questing/Quest.cs
+++ b/Assets/Scripts/Game/Questing/Quest.cs
@@ -481,8 +481,7 @@ namespace DaggerfallWorkshop.Game.Questing
             // Dynamically relink individual NPC and associated QuestResourceBehaviour (if any) in current scene
             if (person.IsIndividualNPC)
             {
-                QuestResourceBehaviour[] behaviours = GameObject.FindObjectsOfType<QuestResourceBehaviour>();
-                foreach (var questResourceBehaviour in behaviours)
+                foreach (QuestResourceBehaviour questResourceBehaviour in ActiveGameObjectDatabase.GetActiveStaticNPCQuestResourceBehaviours())
                 {
                     // Get StaticNPC if present
                     StaticNPC npc = questResourceBehaviour.GetComponent<StaticNPC>();

--- a/Assets/Scripts/Game/StaticNPC.cs
+++ b/Assets/Scripts/Game/StaticNPC.cs
@@ -121,6 +121,12 @@ namespace DaggerfallWorkshop.Game
 
         #region Unity
 
+        private void Awake()
+        {
+            // Register game object as Static NPC
+            ActiveGameObjectDatabase.RegisterStaticNPC(gameObject);
+        }
+
         private void Start()
         {
             // Get runtime-available data on start

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1100,13 +1100,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             const float proximityWagonAccessDistance = 5f;
 
             // Get all static doors
-            DaggerfallStaticDoors[] allDoors = GameObject.FindObjectsOfType<DaggerfallStaticDoors>();
-            if (allDoors != null && allDoors.Length > 0)
+            IEnumerable<DaggerfallStaticDoors> allRdbDoors = ActiveGameObjectDatabase.GetActiveRDBStaticDoors();
+            if (allRdbDoors != null && allRdbDoors.Count() > 0)
             {
                 Vector3 playerPos = GameManager.Instance.PlayerObject.transform.position;
                 // Find closest door to player
                 float closestDoorDistance = float.MaxValue;
-                foreach (DaggerfallStaticDoors doors in allDoors)
+                foreach (DaggerfallStaticDoors doors in allRdbDoors)
                 {
                     int doorIndex;
                     Vector3 doorPos;

--- a/Assets/Scripts/Game/Utility/FoeSpawner.cs
+++ b/Assets/Scripts/Game/Utility/FoeSpawner.cs
@@ -44,6 +44,12 @@ namespace DaggerfallWorkshop.Game.Utility
         int pendingFoesSpawned = 0;
         bool spawnInProgress = false;
 
+        void Awake()
+        {
+            // Register as Foe Spawner object
+            ActiveGameObjectDatabase.RegisterFoeSpawner(gameObject);
+        }
+
         void Update()
         {
             // Create new foe list when changed in editor

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -113,7 +113,7 @@ namespace DaggerfallWorkshop
                 meshCollider = GetComponent<MeshCollider>();
 
             // Register object as Door
-            ActiveGameObjectDatabase.RegisterDoor(gameObject);
+            ActiveGameObjectDatabase.RegisterActionDoor(gameObject);
         }
 
         void Start()

--- a/Assets/Scripts/Internal/DaggerfallActionDoor.cs
+++ b/Assets/Scripts/Internal/DaggerfallActionDoor.cs
@@ -111,6 +111,9 @@ namespace DaggerfallWorkshop
                 boxCollider = GetComponent<BoxCollider>();
             if ((boxCollider?.enabled != true) && (meshCollider == null))
                 meshCollider = GetComponent<MeshCollider>();
+
+            // Register object as Door
+            ActiveGameObjectDatabase.RegisterDoor(gameObject);
         }
 
         void Start()

--- a/Assets/Scripts/Internal/DaggerfallEnemy.cs
+++ b/Assets/Scripts/Internal/DaggerfallEnemy.cs
@@ -45,6 +45,9 @@ namespace DaggerfallWorkshop
         private void Awake()
         {
             MobileUnit = FindMobileUnit();
+
+            // Register GameObject as Enemy object
+            ActiveGameObjectDatabase.RegisterEnemy(gameObject);
         }
 
         private void Start()

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -59,6 +59,12 @@ namespace DaggerfallWorkshop
             get { return items; }
         }
 
+        public void Awake()
+        {
+            // Register as Loot object
+            ActiveGameObjectDatabase.RegisterLoot(gameObject);
+        }
+
         public static int CreateStockedDate(DaggerfallDateTime date)
         {
             return (date.Year * 1000) + date.DayOfYear;

--- a/Assets/Scripts/Internal/DaggerfallRDBBlock.cs
+++ b/Assets/Scripts/Internal/DaggerfallRDBBlock.cs
@@ -39,6 +39,11 @@ namespace DaggerfallWorkshop
             get { return enterMarkers; }
         }
 
+        private void Awake()
+        {
+            ActiveGameObjectDatabase.RegisterRDB(gameObject);
+        }
+
         public void SetMarkers(GameObject[] startMarkers, GameObject[] enterMarkers)
         {
             this.startMarkers = startMarkers;

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -748,41 +748,31 @@ namespace DaggerfallWorkshop
         {
             nearbyObjects.Clear();
 
-            // Get entities
-            DaggerfallEntityBehaviour[] entities = FindObjectsOfType<DaggerfallEntityBehaviour>();
-            if (entities != null)
+            // Get enemy and civilian entities
+            foreach (DaggerfallEntityBehaviour entity in ActiveGameObjectDatabase.GetActiveEnemyBehaviours()
+                .Concat(ActiveGameObjectDatabase.GetActiveCivilianMobileBehaviours()))
             {
-                for (int i = 0; i < entities.Length; i++)
+                NearbyObject no = new NearbyObject()
                 {
-                    if (entities[i] == GameManager.Instance.PlayerEntityBehaviour)
-                        continue;
+                    gameObject = entity.gameObject,
+                    distance = Vector3.Distance(transform.position, entity.transform.position),
+                    flags = GetEntityFlags(entity)
+                };
 
-                    NearbyObject no = new NearbyObject()
-                    {
-                        gameObject = entities[i].gameObject,
-                        distance = Vector3.Distance(transform.position, entities[i].transform.position),
-                    };
-
-                    no.flags = GetEntityFlags(entities[i]);
-                    nearbyObjects.Add(no);
-                }
+                nearbyObjects.Add(no);
             }
 
-            // Get treasure - this assumes loot containers will never carry entity component
-            DaggerfallLoot[] lootContainers = FindObjectsOfType<DaggerfallLoot>();
-            if (lootContainers != null)
+            // Get treasure
+            foreach (DaggerfallLoot loot in ActiveGameObjectDatabase.GetActiveLoot())
             {
-                for (int i = 0; i < lootContainers.Length; i++)
+                NearbyObject no = new NearbyObject()
                 {
-                    NearbyObject no = new NearbyObject()
-                    {
-                        gameObject = lootContainers[i].gameObject,
-                        distance = Vector3.Distance(transform.position, lootContainers[i].transform.position),
-                    };
+                    gameObject = loot.gameObject,
+                    distance = Vector3.Distance(transform.position, loot.transform.position),
+                    flags = GetLootFlags(loot)
+                };
 
-                    no.flags = GetLootFlags(lootContainers[i]);
-                    nearbyObjects.Add(no);
-                }
+                nearbyObjects.Add(no);
             }
         }
 

--- a/Assets/Scripts/Utility/FloatingOrigin.cs
+++ b/Assets/Scripts/Utility/FloatingOrigin.cs
@@ -127,7 +127,7 @@ namespace DaggerfallWorkshop.Utility
 
                 // Offset loaded enemies
                 // Not that many in DFU, but it happens in mods
-                foreach (EnemyMotor enemy in FindObjectsOfType<EnemyMotor>())
+                foreach (EnemyMotor enemy in ActiveGameObjectDatabase.GetActiveEnemyMotors())
                     enemy.AdjustLastGrounded(offset.y);
 
                 // Raise event


### PR DESCRIPTION
# Intro

My solution for https://github.com/Interkarma/daggerfall-unity/issues/2355 crashes.

I have personally observed some users struggling with DFU crashes multiple times a day. The callstacks are almost always somewhere in the middle of a specific Unity function: FindObjectsOfType. DFU uses these in many places, often on every frame, for each object in the scene (see EnemySenses).

From the Unity docs: https://docs.unity3d.com/ScriptReference/Object.FindObjectsOfType.html
> Note: This function is very slow. It is not recommended to use this function every frame. In most cases you can use the singleton pattern instead.

And this is precisely what this changelist does.

I have personally never reproduced these crashes. They seem to require extensive gameplay sessions on a very specific mod setup. Avoiding calls to FindObjectsOfType should for sure avoid crashes in that function - we'll see if it doesn't end up crashing somewhere else.

One thing is for sure, the performance should be better no matter what. Doing a lookup on a limited list of objects should always be faster than doing a lookup on the entire scene.

# The Database
`ActiveGameObjectDatabase` is the namespace where we store the GameObject caches for DFU objects. I have created a new utility class, `GameObjectCache`, which is designed with specific performance characteristics and safety concerns. I have made this class public, since mods might want to reuse it for similar lookups on their own objects (see the Mods section below).

## GameObjectCache

I don't actually suspect that the crashes we've been seeing are caused by multiple threads touching the scene at the same time. DFU does use parallel threads for jobs in the terrain system, for example, and while Unity does not actually support creating GameObjects from such parallel jobs, I have seen mods like Interesting Eroded Terrains try to do GameObject lookups from terrain jobs. Therefore, I decided to be safe and find the minimal overhead solution to make such lookups safe for any code.

`GameObjectCache` has two data members: a `List<WeakReference<GameObject>>`, and a `ReaderWriterLockSlim`. 

For the List part, the WeakReference is there to ensure that 1) the cache does not keep objects alive for longer than necessary 2) we can safely detect destroyed objects long after Unity has cleaned them. I suspect this is not actually necessary for Unity GameObjects, maybe I went overkill on this aspect, but I don't think the cost has been an issue so far.

For the Lock part, here's the C# documentation: https://learn.microsoft.com/en-us/dotnet/api/system.threading.readerwriterlockslim. 

The Cache is used in two ways: multiple systems do frequent reads to the cache, and a few system do infrequent additions to the cache. A "Reader Writer Lock" allows multiple readers to read at the same time without blocking each other, while a single writer can still claim exclusive ownership for actual modifications. This means that while we're not spawning objects, the cache has no interference.
The RWLockSlim also has an "upgradable" lock feature, which I somewhat used for reading whether an object was already there before committing to the write. I still kept this check only in Editor, we shouldn't have this in real code.

For Registration, I first experimented with having factory functions like GameObjectHelper handle registration. This is because registering multiple objects at once would be faster than doing it once per object. However, I could not find a way to do it in a way that would guarantee that mods that spawn objects are also covered. So I went with the per-object registration in one of their component's Awake.

One detail of note here is that I don't "unregister" objects. I could easily add an `OnDestroy` event on all components where I do the register on `Awake` and remove them from the cache there. However, I find that this would cause many unnecessary write locks, so I decided not to do that. Instead, whenever we write to the cache, we take the opportunity to remove any destroyed objects.

Whenever a gameplay system needs to lookup all the GameObjects of a certain type, the cache will not only avoid returning destroyed objects, but it will also not return inactive objects. Similarly, when trying to get a specific component type on the objects, objects where the component is disabled will also be skipped. Both of these behaviors reproduce how FindObjectsOfType works. 

## DFU's caches

In the end, `ActiveGameObjectCache` currently has 6 caches: Enemy, Civilian Mobile NPC, Loot, Foe Spawner, Action Door, and Static NPC. These correspond to six GameObject types where FindObjectsOfType lookups are frequently made, and happen to match six different prefabs in Assets/Prefabs/Scene.
For each of these GameObject types, we identify a primary component (where the registration is made) and some secondary components which are frequently used in lookups.

Enemy:
- Primary: `DaggerfallEnemy`
- Secondaries: `DaggerfallEntityBehaviour`, `QuestResourceBehaviour`
Civilian Mobile NPC:
- Primary: `MobilePersonNPC`
- Secondaries: `DaggerfallEntityBehaviour`
Loot:
- Primary: `DaggerfallLoot`
Foe Spawner
- Primary: `FoeSpawner`
Action Door:
- Primary: `DaggerfallActionDoor`
Static NPC:
- Primary: `StaticNPC`
- Secondaries; `QuestResourceBehaviour`

Two cases stand out here. Some `DaggerfallEntityBehaviour` lookups can be intended to grab more than one GameObject type. `EnemySenses` wants the behaviour from both other enemies and the player. `PlayerGPS` wants the behaviours of both enemies and static NPCs. Fortunately, it's pretty easy to concat two `IEnumerable<DaggerfallEntityBehaviour>` together, the changes were minimal. `QuestResourceBehaviour` can also be either for enemies or for static NPCs. 

Ultimately, the flow looks like one of two things.
Registration:
```diff
// ObjectComponent.cs
+ void Awake()
+ {
+   ActiveGameObjectDatabase.RegisterThing(gameObject);
+ }
```
Lookups:
```diff
// PlayerObjectComponentHandler.cs
- foreach(ObjectComponent component in FindObjectsOfType<ObjectComponent>())
+ foreach(ObjectComponent component in ActivateGameObjectDatabase.GetActiveThingObjectComponents())
{
  if(component.Type == ComponentType.Thing)
    ...
}
```

This is done all over for our 6 object types.

# Performance

I wanna update this PR with more specific benchmarks for key DFU cases of lookups and object registration. In practice, I'm pretty confident all lookups with be faster, though object creation has extra overhead. I estimate the impact to be minimal.

Anecdotally, I made a quest that spawns hundreds of harpies, and I found the performance better with my changes (due to the many EnemySenses lookups).

Key tests:
- Walking around town (PopulationManager spawning Civilian Mobile NPCs)
- Transition in and out of Interiors
- Transition in and out of Scourg Barrow
- Transition in and out of Daggerfall Palace
- Tedious Traveling with Travel Options on a World of Daggerfall save (lots of enemy and loot spawning from nearby bandit camps)

# Debugging

Such a change requires some form of debugging for when we suspect issues. Two primary tools I've implemented are:
- Editor-only check against double registration. If mods all follow the same "Awake" pattern on their objects, it should never be an issue, so I don't think we should add such a check in normal gameplay. 
- New visualizers in the `tdbg` console command (see `FPSDisplay.cs`). Whenever a user has an issue we suspect could be related, we can ask them to run `tdbg` and post a screenshot

![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/71068feb-3fd6-4a22-b5fb-44f431e1ead9)

Some more reference numbers from my tests running around:
Entering Scourg Barrow
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/da57e40e-da65-4e8c-a565-7039b6a51a45)

Leaving Scourg Barrow
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/cbfb8f50-0bc7-4fac-82eb-387d4dfd6807)

Running around Daggerfall City during the day
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/1eabc75a-e7f7-4da3-8f25-15e716552172)

Inside a house
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/0c154f18-d7f3-41c6-a5de-959a0d9bdf42)

Daggerfall City at night
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/a956d17f-6d54-4f0c-bdd1-906800d24b93)

Daggerfall Palace
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/ab739476-7c19-4568-9dc1-4165c78606df)

# Mod
Mod compatibility is always a concern in post 1.0. I had to reject my initial approach to object registration because mods can easily spawn DFU GameObjects in any way (Location Loader from WoD sure does). I believe the current solution should be safe from any sort of weird spawning patterns mods might have.

The crash and performance benefits on lookups will need be applied manually by mods. For example, I had users report crashes with Horrible Hordes when entering main quest dungeons, and this was due to a StaticNPC lookup. In 1.1, we will be able to use `ActiveGameObjectDatabase.GetActiveStaticNPCs()` instead.

One thing I did not take into account yet are DFU objects that mods might do lookups on but not DFU itself. RDBBlocks, Interiors, RMBBlocks, Lights... I did not want to overreach into object types that I couldn't test properly. Mods will have to manifest their interest if they need DFU to track more of its object types.

# Improvements

## Garbage collection

While I mentioned that I deliberately don't clear objects as they are destroyed, I do think we could use some points where we clear objects _before_ a new one is added. For example, leaving a large dungeon will leave lots of dead enemies, loot, action doors, and potentially static NPCs. Lookups in PlayerGPS will still traverse these big lists to check if the object is alive, which could be avoided if we cleared the list.

@numidium Do you have suggestions for clear places where we can "collect garbage" on this system? My current idea is to do it on dungeon transitions, but I'm not sure when GameObjects are all properly destroyed after a dungeon exit.

## Remaining FindObjectsOfType

I left a few FindObjectsOfType lookups. 

I ignored all the FindObjectOfType (singular) lookups for DaggerfallUnity scene objects. These are often just done once on scene load for one object and cached. We don't need a separate cache.

I did not cover `DaggerfallStaticDoors`, which is a component on Interior and RDB objects. I was mostly concerned with having to introduce two new caches for one lookup, but maybe the caches would be useful for certain mods.
I also did not cover `DaggerfallMarker`. It's an obscure object, I'm not sure how to test it.
There is one lookup for `QuestResourceBehaviour` that uses `Resources.FindObjectsOfTypeAll`, which covers inactive objects. It's a weird unique case, I did not cover it for now.
There is one lookup for `SongPlayer` in DefaultCommands. Commands run while the game is paused, not really an issue for crashes.

# Conclusion
This is a big change to DFU, but given that the crashes really ruin some users, I believe it is necessary to integrate as soon as possible. I will block version 1.1 on this. In addition, the earlier we deploy this, the more mods can benefit from the improvements.

I will probably deploy a test build with this change (and some others) before it gets approved. We can check for regressions, and see if users get other forms of weird crashes.