### PR TITLE
Make the "Settings" folder more obvious and clickable

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnitySetupGameWizard.cs
@@ -486,8 +486,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             optionsPanel.BackgroundColor = backgroundColor;
             optionsPanel.HorizontalAlignment = HorizontalAlignment.Center;
             //optionsPanel.VerticalAlignment = VerticalAlignment.Middle;
-            optionsPanel.Position = new Vector2(0, 8);
-            optionsPanel.Size = new Vector2(318, 165);
+            optionsPanel.Position = new Vector2(0, 4);
+            optionsPanel.Size = new Vector2(318, 180);
             NativePanel.Components.Add(optionsPanel);
 
             // Add title text
@@ -509,17 +509,34 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             optionsPanel.Components.Add(versionLabel);
 
             // Add settings path text
-            TextLabel settingsPathLabel = new TextLabel();
             if (!DaggerfallUnity.Settings.HideLoginName)
             {
-                settingsPathLabel.Text = DaggerfallUnity.Settings.PersistentDataPath;
+                Panel settingsPanel = new Panel();
+                settingsPanel.Position = new Vector2(0, 130);
+                settingsPanel.Size = new Vector2(318, 16);
+                settingsPanel.HorizontalAlignment = HorizontalAlignment.Center;
+
+                {
+                    TextLabel settingsPathHeaderLabel = new TextLabel();
+                    settingsPathHeaderLabel.Text = GetText("settingsFolder");
+                    settingsPathHeaderLabel.HorizontalAlignment = HorizontalAlignment.Center;
+
+                    TextLabel settingsPathLabel = new TextLabel();
+                    settingsPathLabel.Position = new Vector2(0, 8);
+                    settingsPathLabel.Text = DaggerfallUnity.Settings.PersistentDataPath;
+                    settingsPathLabel.HorizontalAlignment = HorizontalAlignment.Center;
+                    settingsPathLabel.ToolTip = defaultToolTip;
+                    settingsPathLabel.ToolTipText = GetText("settingsFolderInfo");
+                    settingsPathLabel.OnMouseDoubleClick += SettingsPathLabel_OnMouseClick;
+                    settingsPathLabel.ShadowPosition = Vector2.zero;
+                    settingsPathLabel.TextColor = secondaryTextColor;
+
+                    settingsPanel.Components.Add(settingsPathHeaderLabel);
+                    settingsPanel.Components.Add(settingsPathLabel);
+                }
+
+                optionsPanel.Components.Add(settingsPanel);
             }
-            settingsPathLabel.Position = new Vector2(0, 170);
-            settingsPathLabel.HorizontalAlignment = HorizontalAlignment.Center;
-            settingsPathLabel.ShadowPosition = Vector2.zero;
-            settingsPathLabel.TextColor = secondaryTextColor;
-            settingsPathLabel.BackgroundColor = backgroundColor;
-            optionsPanel.Components.Add(settingsPathLabel);
 
             // Setup options checkboxes
             float x = 8;
@@ -545,12 +562,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             enableController.OnToggleState += EnableController_OnToggleState;
 
             weaponSwingMode = AddSlider(x, "weaponSwingMode", "weaponSwingModeInfo", DaggerfallUnity.Settings.WeaponSwingMode, TextManager.Instance.GetLocalizedTextList("weaponSwingModes", TextCollections.TextSettings));
-
-            // Add mod note
-            TextLabel modNoteLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(0, 130), GetText("modNote"), optionsPanel);
-            modNoteLabel.HorizontalAlignment = HorizontalAlignment.Center;
-            modNoteLabel.ShadowPosition = Vector2.zero;
-
+                        
             // Confirm button
             Button optionsConfirmButton = new Button();
             optionsConfirmButton.Position = new Vector2(0, optionsPanel.InteriorHeight - 15);
@@ -566,7 +578,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Restart button
             Button restartButton = new Button();
             restartButton.Size = new Vector2(45, 12);
-            restartButton.Label.Text = string.Format("< {0}", GetText("restart"));
+            restartButton.Label.Text = string.Format(" < {0}", GetText("restart"));
             restartButton.Label.ShadowPosition = DaggerfallUI.DaggerfallDefaultShadowPos;
             restartButton.Label.TextColor = DaggerfallUI.DaggerfallDefaultTextColor;
             restartButton.Label.HorizontalAlignment = HorizontalAlignment.Left;
@@ -586,6 +598,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             if (DaggerfallUnity.Settings.LypyL_ModSystem)
             {
+                // Add mod note
+                TextLabel modNoteLabel = DaggerfallUI.AddTextLabel(DaggerfallUI.DefaultFont, new Vector2(4, optionsPanel.InteriorHeight - 24), GetText("modNote"), optionsPanel);
+                modNoteLabel.ShadowPosition = Vector2.zero;
+
+                // Mod button
                 Button ShowModsButton = new Button();
                 ShowModsButton.Label.Text = GetText("mods");
                 ShowModsButton.Position = new Vector2(3, optionsConfirmButton.Position.y);
@@ -610,6 +627,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             AdvancedSettingsButton.OnMouseClick += AdvancedSettingsButton_OnOnMouseBlick;
             AdvancedSettingsButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.GameSetupAdvancedSettings);
 
+        }
+
+        private void SettingsPathLabel_OnMouseClick(BaseScreenComponent sender, Vector2 position)
+        {
+            // Open the persistent data path
+            System.Diagnostics.Process.Start(DaggerfallUnity.Settings.PersistentDataPath);
         }
 
         private void SDFFontRendering_OnToggleState()

--- a/Assets/StreamingAssets/Text/MainMenu.txt
+++ b/Assets/StreamingAssets/Text/MainMenu.txt
@@ -12,6 +12,8 @@ restart,                    Restart
 restartInfo,                Restart setup from beginning
 exit,                       Exit
 modNote,                    Note: Enabling mods can increase performance requirements
+settingsFolder,             Settings Folder
+settingsFolderInfo,         Double-click to open folder
 
 alwayShowOptions,           Always show this window
 alwayShowOptionsInfo,       Always show this window on startup\rOtherwise use settings.ini to configure


### PR DESCRIPTION
Trying to debug any user issue with DFU or a mod usually runs into this conversation.

"Hey, my game is broken."
"Can you post logs?"
"Where?"
"... Wait a second" _searches a bit_ "Should be in `C:\<User>\AppData\LocalLow\Daggerfall Workshop\Daggerfall Unity`, replace `<User>` with your Windows username. Or you can try copy-pasting `%USERPROFILE%\AppData\LocalLow\Daggerfall Workshop\Daggerfall Unity` in your Explorer. Then..."
_user disappears_

With this change, I'm trying to reduce it to:
"Open DFU, double-click on your Settings Folder, copy-paste Player.log"

This would apply for all other settings and mod data concerns.

Current Title Screen for comparison:
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/3cf73eda-fab8-4e4d-bcbd-8fe82b4be74e)

New Title Screen:
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/91ec2452-307f-498b-8557-dcff192ed727)

New Title Screen, with Hide Login Name setting enabled:
![image-1](https://github.com/Interkarma/daggerfall-unity/assets/5789925/41462406-b3a2-4aaf-80b4-1bb038cf503f)

I wanted to add "Settings Folder" to emphasize what this path was. I couldn't put it on the left, because localization would make the alignment a mess for this screen (mods can't move labels on this screen). But I was running out of vertical space, so I move things around a bit.

The path has a tooltip telling you to double-click, and double-clicking opens the folder. I avoided going to single click, since it's in the middle of the screen and easy to misclick.

I tested on all aspect ratios on Unity, no issues.