### PR TITLE
Logs changes

### DIFF
--- a/Assets/Scripts/DaggerfallUnityApplication.cs
+++ b/Assets/Scripts/DaggerfallUnityApplication.cs
@@ -1,0 +1,107 @@
+// Project:         Daggerfall Unity
+// Copyright:       Copyright (C) 2009-2024 Daggerfall Workshop
+// Web Site:        http://www.dfworkshop.net
+// License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
+// Source Code:     https://github.com/Interkarma/daggerfall-unity
+// Original Author: kaboissonneault
+// Contributors:    
+// 
+// Notes:
+//
+
+//#define SEPARATE_DEV_PERSISTENT_PATH
+
+using System;
+using System.IO;
+using UnityEngine;
+
+public static class DaggerfallUnityApplication
+{
+    static string persistentDataPath;
+    public static string PersistentDataPath { get { return persistentDataPath; } }
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void SubsystemInit()
+    {
+#if UNITY_EDITOR && SEPARATE_DEV_PERSISTENT_PATH
+        persistentDataPath = String.Concat(Application.persistentDataPath, ".devenv");
+        Directory.CreateDirectory(persistentDataPath);
+#else
+        persistentDataPath = Application.persistentDataPath;
+#endif
+
+        InitLog();
+    }
+
+
+    public class LogHandler : ILogHandler, IDisposable
+    {
+        private FileStream fileStream;
+        private StreamWriter streamWriter;
+
+        public LogHandler()
+        {
+            string filePath = Path.Combine(PersistentDataPath, "Player.log");
+
+            try
+            {
+                if(File.Exists(filePath))
+                {
+                    string prevPath = Path.Combine(PersistentDataPath, "Player-prev.log");
+                    File.Delete(prevPath);
+                    File.Move(filePath, prevPath);
+                }
+            }
+            catch { }
+
+            fileStream = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite);
+            streamWriter = new StreamWriter(fileStream);
+        }
+
+        public void LogException(Exception exception, UnityEngine.Object context)
+        {
+            streamWriter.WriteLine(exception.ToString());
+            streamWriter.Flush();
+        }
+
+        public void LogFormat(LogType logType, UnityEngine.Object context, string format, params object[] args)
+        {
+            string prefix = "";
+            switch(logType)
+            {
+                case LogType.Error:
+                    prefix = "[Error] ";
+                    break;
+
+                case LogType.Warning:
+                    prefix = "[Warning] ";
+                    break;
+
+                case LogType.Assert:
+                    prefix = "[Assert] ";
+                    break;
+
+                case LogType.Exception:
+                    prefix = "[Exception] ";
+                    break;
+            }
+
+            streamWriter.WriteLine(prefix + string.Format(format, args));
+            streamWriter.Flush();
+        }
+
+        public void Dispose()
+        {
+            streamWriter.Close();
+            fileStream.Close();
+        }
+    }
+
+    static void InitLog()
+    {
+        if (Application.isPlaying && Application.installMode != ApplicationInstallMode.Editor)
+        {
+            Debug.unityLogger.logHandler = new LogHandler();
+        }
+    }
+}

--- a/Assets/Scripts/DaggerfallUnityApplication.cs.meta
+++ b/Assets/Scripts/DaggerfallUnityApplication.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 198abb558b24b5644b1043b7179b6b7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -9,8 +9,6 @@
 // Notes:
 //
 
-//#define SEPARATE_DEV_PERSISTENT_PATH
-
 using UnityEngine;
 using System;
 using System.Globalization;
@@ -53,23 +51,14 @@ namespace DaggerfallWorkshop
         IniData defaultIniData = null;
         IniData userIniData = null;
 
-        string persistentPath = null;
         string distributionSuffix = null;
 
+        // Legacy way to get the persistent path. Better to just go through DaggerfallUnityApplication now
         public string PersistentDataPath
         {
             get
             {
-                if (string.IsNullOrEmpty(persistentPath))
-                {
-#if UNITY_EDITOR && SEPARATE_DEV_PERSISTENT_PATH
-                    persistentPath = String.Concat(Application.persistentDataPath, ".devenv");
-                    Directory.CreateDirectory(persistentPath);
-#else
-                    persistentPath = Application.persistentDataPath;
-#endif
-                }
-                return persistentPath;
+                return DaggerfallUnityApplication.PersistentDataPath;
             }
         }
 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -84,7 +84,7 @@ PlayerSettings:
   deferSystemGesturesMode: 0
   hideHomeButton: 0
   submitAnalytics: 1
-  usePlayerLog: 1
+  usePlayerLog: 0
   bakeCollisionMeshes: 0
   forceSingleInstance: 0
   useFlipModelSwapchain: 1


### PR DESCRIPTION
This is my last DFU 1.1 item and the more controversial one, and the one I'm most willing to budge on.

In addition to log reachability (addressed by #2606), I have determined three issues with the default Unity logs.

1. They are extremely noisy. Each line has this appended `(Filename: C:\buildslave\unity\build\Runtime/Export/Debug/Debug.bindings.h Line: 39)` and an extra newline, making logs extremely long and hard to get through
2. There is nothing indicating a normal log from a warning from an error, unless the message repeats that information
3. We cannot relocate the logs to a folder other than `Application.persistentDataPath`. This is an issue for https://github.com/Interkarma/daggerfall-unity/pull/2556

So this changelist aims to make going through user issues easier, and unblocking the Portable Install feature. But it is not without downsides unfortunately.

Concretely, what this changelist does is disable Unity's Player.log, and adds a log handler to the Debug class to create and manage this file ourselves. Doing so is mostly necessary for point 3, we could get the benefits of point 1 and 2 by simply creating a second log file, and leave the normal Unity Player.log untouched. We'll see the downsides of supporting point 3 below.

First, here's what the old logs look like
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/0b391ef7-786f-4d25-af96-acb18073a4d2)

Here's what they look like now
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/0dfa600c-34a5-48d3-a269-f8a24a380333)

Errors and warnings are shown with a little tag
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/a33b0037-b839-470a-9704-36ef6054fe78)

This token is both searchable _and_ can be parsed by code. I saw someone claim they were working on a log viewer for DFU, and this could help them.

Now, for the differences in logs content. Unfortunately, we're losing all the Engine logs, logs of systems that come from the engine. They just don't go through the Debug log handler, and therefore do not appear in our new Player.log file.

I passed two logs through a diff software to show exactly which lines are missing.

We have this header at the top of every log file
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/addecda2-e46e-4654-9511-587ff98989b7)

and we have some of the periodic Garbage Collection messages all over
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/424b8c0c-6971-415e-88bb-0e1035b550d5)

Here's the warning and error tags again
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/d9360929-775d-4654-8df0-8c522eedede6)

Exceptions look slightly different for some reason, but not really meaningfully
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/a3851e79-1eb9-4e3d-892f-f6e6785596de)

There was also this message when I closed the game that was gone
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/3a1b580c-b975-4bee-a636-527613b3eb06)

So this is what this changelist does for now. I personally don't care much for those Engine logs, so I'm comfortable with this change, but maybe other people might have a different idea.

I was to emphasize that I think supporting the Portable Install feature is good. Without being able to put the log feature in the portable install, the feature is a failure, in my opinion. Through Googling, I could not find anyone researching solutions for portable installs of a Unity game, just the Unity Editor itself. But users do desire it, if only to have different settings for the many DFU versions they run (1.0, test builds, multiplayer, etc). It also helps people who are on a computer they don't own, from a temporary folder that they can easily backup and move around.

So yeah, drop your feedback in the meantime. I'll probably make another test build with all the unmerged DFU 1.1 PRs to get user feedback on a candidate build for 1.1.

PS: I do think we can also get point 1 benefits in other ways than creating a second log file. There's a big thread on this problem here: https://forum.unity.com/threads/debug-log-stacktrace-spam.489858/ (I find it kind of funny)
I think we might have to replace all the calls to `Debug.Log` in the project with `Debug.LogFormat(...)` with the "NoStackTrace" option. Or maybe that Stack Trace setting here
![image](https://github.com/Interkarma/daggerfall-unity/assets/5789925/dfaf6d6b-ac72-433e-a617-0a14541565d2)
