### PR TITLE
Use Redguard names in Redguard lands for named residences

### DIFF
--- a/Assets/Scripts/API/MapsFile.cs
+++ b/Assets/Scripts/API/MapsFile.cs
@@ -17,6 +17,7 @@ using DaggerfallConnect.Utility;
 using DaggerfallWorkshop;
 using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.Questing;
+using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Utility.AssetInjection;
 #endregion
 
@@ -319,6 +320,19 @@ namespace DaggerfallConnect.Arena2
         #endregion
 
         #region Static Public Methods
+
+        /// <summary>
+        /// Gets NameHelper.BankType in given region.
+        /// In practice this will always be Redguard/Breton.
+        /// Supporting other name banks for possible diversity later.
+        /// </summary>
+        public static NameHelper.BankTypes GetNameBankOfRegion(int regionIndex)
+        {
+            if (regionIndex > -1)
+                return (NameHelper.BankTypes)RegionRaces[regionIndex];
+
+            return NameHelper.BankTypes.Breton;
+        }
 
         /// <summary>
         /// Converts longitude and latitude to map pixel coordinates.

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -15,15 +15,12 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Linq;
-using DaggerfallWorkshop;
 using DaggerfallWorkshop.Utility;
 using DaggerfallConnect;
-using DaggerfallConnect.Arena2;
-using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using FullSerializer;
 using DaggerfallWorkshop.Game.Banking;
+using DaggerfallWorkshop.Game.Entity;
 using DaggerfallWorkshop.Game.Guilds;
-using DaggerfallWorkshop.Game.Serialization;
 
 namespace DaggerfallWorkshop.Game.Questing
 {
@@ -1284,8 +1281,13 @@ namespace DaggerfallWorkshop.Game.Questing
             if (RMBLayout.IsResidence(buildingType))
             {
                 // Generate a random surname for this residence
-                //DFRandom.srand(Time.renderedFrameCount);
-                string surname = DaggerfallUnity.Instance.NameHelper.Surname(Utility.NameHelper.BankTypes.Breton);
+                string surname = DaggerfallUnity.Instance.NameHelper.Surname(GameManager.Instance.PlayerGPS.GetNameBankOfRegion(location.RegionIndex));
+                if (string.IsNullOrEmpty(surname))
+                {
+                    // Redguards have just a single name
+                    surname = DaggerfallUnity.Instance.NameHelper.FirstName(GameManager.Instance.PlayerGPS.GetNameBankOfRegion(location.RegionIndex), (Genders)UnityEngine.Random.Range(0, 1));
+                }
+
                 buildingName = TextManager.Instance.GetLocalizedText("theNamedResidence").Replace("%s", surname);
             }
             else

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DaggerfallWorkshop.Utility;
 using DaggerfallConnect;
+using DaggerfallConnect.Arena2;
 using FullSerializer;
 using DaggerfallWorkshop.Game.Banking;
 using DaggerfallWorkshop.Game.Entity;
@@ -1281,11 +1282,11 @@ namespace DaggerfallWorkshop.Game.Questing
             if (RMBLayout.IsResidence(buildingType))
             {
                 // Generate a random surname for this residence
-                string surname = DaggerfallUnity.Instance.NameHelper.Surname(GameManager.Instance.PlayerGPS.GetNameBankOfRegion(location.RegionIndex));
+                string surname = DaggerfallUnity.Instance.NameHelper.Surname(MapsFile.GetNameBankOfRegion(location.RegionIndex));
                 if (string.IsNullOrEmpty(surname))
                 {
                     // Redguards have just a single name
-                    surname = DaggerfallUnity.Instance.NameHelper.FirstName(GameManager.Instance.PlayerGPS.GetNameBankOfRegion(location.RegionIndex), (Genders)UnityEngine.Random.Range(0, 1));
+                    surname = DaggerfallUnity.Instance.NameHelper.FirstName(MapsFile.GetNameBankOfRegion(location.RegionIndex), (Genders)UnityEngine.Random.Range(0, 1));
                 }
 
                 buildingName = TextManager.Instance.GetLocalizedText("theNamedResidence").Replace("%s", surname);

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -427,19 +427,6 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
-        /// Gets NameHelper.BankType in given region.
-        /// In practice this will always be Redguard/Breton.
-        /// Supporting other name banks for possible diversity later.
-        /// </summary>
-        public NameHelper.BankTypes GetNameBankOfRegion(int regionIndex)
-        {
-            if (regionIndex > -1)
-                return (NameHelper.BankTypes) MapsFile.RegionRaces[regionIndex];
-
-            return NameHelper.BankTypes.Breton;
-        }
-
-        /// <summary>
         /// Gets the dominant race in player's current region.
         /// </summary>
         public Races GetRaceOfCurrentRegion()

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -427,7 +427,7 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
-        /// Gets NameHelper.BankType in player's current region.
+        /// Gets NameHelper.BankType in given region.
         /// In practice this will always be Redguard/Breton.
         /// Supporting other name banks for possible diversity later.
         /// </summary>

--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -427,6 +427,19 @@ namespace DaggerfallWorkshop
         }
 
         /// <summary>
+        /// Gets NameHelper.BankType in player's current region.
+        /// In practice this will always be Redguard/Breton.
+        /// Supporting other name banks for possible diversity later.
+        /// </summary>
+        public NameHelper.BankTypes GetNameBankOfRegion(int regionIndex)
+        {
+            if (regionIndex > -1)
+                return (NameHelper.BankTypes) MapsFile.RegionRaces[regionIndex];
+
+            return NameHelper.BankTypes.Breton;
+        }
+
+        /// <summary>
         /// Gets the dominant race in player's current region.
         /// </summary>
         public Races GetRaceOfCurrentRegion()


### PR DESCRIPTION
So, most of the Daggerfall is Breton lands. But not all. But in quests, we always see the named residences of Bretons. Even in the Redguard lands. We should use Redguard names in Redguard lands.

Original DOS:
![image](https://github.com/Interkarma/daggerfall-unity/assets/1652113/ba2b03f4-1b23-4800-b5da-6670bc41d2df)

PR effect:
Sentinel
![Screenshot 2024-03-02 222339](https://github.com/Interkarma/daggerfall-unity/assets/1652113/b5b31b67-8a11-4d44-9551-9315027cee3f)

Wayrest
![Screenshot 2024-03-02 222558](https://github.com/Interkarma/daggerfall-unity/assets/1652113/c9e93f08-0bd5-485a-b968-c70c6eb1da55)
