### PR TITLE
Fixed TalkManager issue causing missing people

### DIFF
--- a/Assets/Scripts/Game/Questing/Person.cs
+++ b/Assets/Scripts/Game/Questing/Person.cs
@@ -475,6 +475,18 @@ namespace DaggerfallWorkshop.Game.Questing
         }
 
         /// <summary>
+        /// Returns the assigned or home symbol.
+        /// </summary>
+        /// <returns>
+        /// If the most recent Place symbol assigned if not null, otherwise returns
+        /// home symbol (which might be null as well).
+        /// </returns>
+        public Symbol GetAssignedOrHomePlaceSymbol()
+        {
+            return lastAssignedPlaceSymbol ?? homePlaceSymbol;
+        }
+
+        /// <summary>
         /// Checks if player in same world cell as Place this Person was assigned to.
         /// Does not care about specific building/dungeon or interior/exterior, just matching location mapID.
         /// Does not care if player actually inside bounds, just if inside same world cell.

--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -2317,7 +2317,7 @@ namespace DaggerfallWorkshop.Game
 
         public SiteDetails GetPersonSiteDetails(ref Person person)
         {
-            Symbol assignedPlaceSymbol = person.GetAssignedPlaceSymbol();
+            Symbol assignedPlaceSymbol = person.GetAssignedOrHomePlaceSymbol();
             if (assignedPlaceSymbol == null)
                 throw new Exception(string.Format("GetBuildingKeyForPersonResource(): Resource is not of type Person but was expected to be"));
 
@@ -3446,7 +3446,7 @@ namespace DaggerfallWorkshop.Game
                             {
                             }*/
 
-                            Symbol assignedPlaceSymbol = person.GetAssignedPlaceSymbol();
+                            Symbol assignedPlaceSymbol = person.GetAssignedOrHomePlaceSymbol();
 
                             if (assignedPlaceSymbol != null)
                             {


### PR DESCRIPTION
This PR covers the following issue: #2604 (1.0: Person fails to appear in "where is" talk UI for quest)

A few details related to the issue can be found in my comments on the bug. The appears to stem from `Person.GetAssignedPlaceSymbol` returning `null`. Diving a little deeper, apart from the serialization code, the assigned place symbol is only set via the `Person.SetAssignedPlaceSymbol` method. In turn, that method is called in two spots:

1. The `PlaceNpc` `ActionTemplate`, which handles `place npc` statements.
2. In `Person.PlaceAtHome`, which is itself called in two spots:
a. In `Person.Tick` when `home.IsPlayerHere` returns true. This explains the NPC begins resolving once the player enters its home.
b. The `CreateNpc` `ActionTemplate`, which handles `create npc` statements.

Both `T0C00Y00` and `10C00Y00` (and maybe others) lack `place npc` or `create npc` statements for the NPC in question, thus their assigned place is always `null`.

While this is apparently a regression, searching through the history, I was not able to easily identify the exact revision that introduced this behavior, so was not entirely sure how this case was meant to be handled. Reviewing the code, I noted that `Person.homePlaceSymbol` was set, despite the NPC not being created. As this value is not public, I added the `Person.GetAssignedOrHomePlaceSymbol` method, which `null` coalesces the values. I then updated the appropriate calls in `TalkManager`, replacing `Person.GetAssignedPlaceSymbol` with `Person.GetAssignedOrHomePlaceSymbol`. This appears to work as expected, with the NPC being resolved by map id.