### PR TITLE
PcAt : ActionTemplate support dungeons

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/PcAt.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PcAt.cs
@@ -81,7 +81,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                 {
                     // Store values
                     int p1 = Place.CustomParseInt(placesTable.GetValue("p1", name));
-                    if(p1 != 0 && p1 != 1)
+                    if(p1 != 0)
                     {
                         throw new Exception("PcAt: This trigger condition can only be used with building types (p1=0) in Quests-Places table.");
                     }

--- a/Assets/Scripts/Game/Questing/Actions/PcAt.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PcAt.cs
@@ -9,13 +9,9 @@
 // Notes:
 //
 
-using UnityEngine;
-using System.Collections;
 using System.Text.RegularExpressions;
 using System;
-using DaggerfallConnect;
 using FullSerializer;
-
 using DaggerfallWorkshop.Utility;
 
 namespace DaggerfallWorkshop.Game.Questing.Actions
@@ -30,6 +26,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
         int textId;
         bool textShown;
         // Place type parameters
+        int p1;                     // Parameter 1
         int p2;                     // Parameter 2
         int p3;                     // Parameter 3
 
@@ -80,11 +77,12 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
                 if (placesTable.HasValue(name))
                 {
                     // Store values
-                    int p1 = Place.CustomParseInt(placesTable.GetValue("p1", name));
-                    if(p1 != 0)
+                    var p_1 = Place.CustomParseInt(placesTable.GetValue("p1", name));
+                    if(p_1 != 0 && p_1 != 1)
                     {
-                        throw new Exception("PcAt: This trigger condition can only be used with building types (p1=0) in Quests-Places table.");
+                        throw new Exception("PcAt: This trigger condition can only be used with building types (p1=0) and dungeon types (p1=1) in Quests-Places table.");
                     }
+                    pcat.p1 = p_1;
                     pcat.p2 = Place.CustomParseInt(placesTable.GetValue("p2", name));
                     pcat.p3 = Place.CustomParseInt(placesTable.GetValue("p3", name));
                 }
@@ -119,7 +117,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             }
             else
             {
-                result = Place.IsPlayerAtBuildingType(p2, p3);
+                result = p1 == 0 ? Place.IsPlayerAtBuildingType(p2, p3) : Place.IsPlayerAtDungeonType(p2);
             }
 
             // Handle positive check
@@ -145,25 +143,27 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
 
         #region Serialization
 
-        [fsObject("v1")]
-        public struct SaveData_v1
+        [fsObject("v2")]
+        public struct SaveData_v2
         {
             public Symbol placeSymbol;
             public Symbol taskSymbol;
             public int textId;
             public bool textShown;
             // Place type parameters
+            public int p1;
             public int p2;
             public int p3;
         }
 
         public override object GetSaveData()
         {
-            SaveData_v1 data = new SaveData_v1();
+            SaveData_v2 data = new SaveData_v2();
             data.placeSymbol = placeSymbol;
             data.taskSymbol = taskSymbol;
             data.textId = textId;
             data.textShown = textShown;
+            data.p1 = p1;
             data.p2 = p2;
             data.p3 = p3;
 
@@ -175,11 +175,12 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             if (dataIn == null)
                 return;
 
-            SaveData_v1 data = (SaveData_v1)dataIn;
+            SaveData_v2 data = (SaveData_v2)dataIn;
             placeSymbol = data.placeSymbol;
             taskSymbol = data.taskSymbol;
             textId = data.textId;
             textShown = data.textShown;
+            p1 = data.p1;
             p2 = data.p2;
             p3 = data.p3;
         }

--- a/Assets/Scripts/Game/Questing/Actions/PcAt.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PcAt.cs
@@ -117,7 +117,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             }
             else
             {
-                result = p1 == 0 ? Place.IsPlayerAtBuildingType(p2, p3) : Place.IsPlayerAtDungeonType(p2);
+                result = p1 == 1 ? Place.IsPlayerAtDungeonType(p2) : Place.IsPlayerAtBuildingType(p2, p3);
             }
 
             // Handle positive check
@@ -143,8 +143,8 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
 
         #region Serialization
 
-        [fsObject("v2")]
-        public struct SaveData_v2
+        [fsObject("v1")]
+        public struct SaveData_v1
         {
             public Symbol placeSymbol;
             public Symbol taskSymbol;
@@ -158,7 +158,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
 
         public override object GetSaveData()
         {
-            SaveData_v2 data = new SaveData_v2();
+            SaveData_v1 data = new SaveData_v1();
             data.placeSymbol = placeSymbol;
             data.taskSymbol = taskSymbol;
             data.textId = textId;
@@ -175,7 +175,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             if (dataIn == null)
                 return;
 
-            SaveData_v2 data = (SaveData_v2)dataIn;
+            SaveData_v1 data = (SaveData_v1)dataIn;
             placeSymbol = data.placeSymbol;
             taskSymbol = data.taskSymbol;
             textId = data.textId;

--- a/Assets/Scripts/Game/Questing/Place.cs
+++ b/Assets/Scripts/Game/Questing/Place.cs
@@ -671,6 +671,25 @@ namespace DaggerfallWorkshop.Game.Questing
             }
         }
 
+        /// For dungeon types check StreamingAssets\Tables\Quests-Places.txt
+        public static bool IsPlayerAtDungeonType(int p2)
+        {
+            // Get component handling player world status and transitions
+            PlayerEnterExit playerEnterExit = GameManager.Instance.PlayerEnterExit;
+            if (!playerEnterExit)
+                return false;
+
+            // Only dungeons
+            if (!playerEnterExit.IsPlayerInsideDungeon)
+                return false;
+
+            // Any dungeon will do
+            if (p2 == -1)
+                return true;
+
+            return p2 == (int)GameManager.Instance.PlayerEnterExit.Dungeon.Summary.DungeonType;
+        }
+
         #endregion
 
         #region Local Site Methods

--- a/Assets/StreamingAssets/Tables/Quests-Places.txt
+++ b/Assets/StreamingAssets/Tables/Quests-Places.txt
@@ -108,26 +108,47 @@ shop,               0, -1, 2
 house,              0, -1, 1
 random,             0, -1, 0
 dungeon,            1, -1, 0
+-- Crypt
 dungeon0,           1, 0 , 0
+-- Orc Stronghold
 dungeon1,           1, 1 , 0
+-- Human Stronghold
 dungeon2,           1, 2 , 0
+-- Prison
 dungeon3,           1, 3 , 0
+-- Desecrated Temple
 dungeon4,           1, 4 , 0
+-- Mine
 dungeon5,           1, 5 , 0
+-- Natural Cave
 dungeon6,           1, 6 , 0
+-- Coven
 dungeon7,           1, 7 , 0
+-- Vampire Haunt
 dungeon8,           1, 8 , 0
+-- Laboratory
 dungeon9,           1, 9 , 0
+-- Harpy Nest
 dungeon10,          1, 10, 0
+-- Ruined Castle
 dungeon11,          1, 11, 0
+-- Spider Nest
 dungeon12,          1, 12, 0
+-- Giant Stronghold
 dungeon13,          1, 13, 0
+-- Dragon's Den
 dungeon14,          1, 14, 0
+-- Barbarian Stronghold
 dungeon15,          1, 15, 0
+-- Volcanic Caves
 dungeon16,          1, 16, 0
+
 --	Dungeons17-18 contain no quest or item markers
 --	Can only be used with "remote dungeon exterior"
+
+-- Scorpion Nest
 dungeon17,          1, 17, 0
+-- Cemetery
 dungeon18,          1, 18, 0
 ---
 ---	Exterior location types


### PR DESCRIPTION
In `Quests-Places.txt` records with `p1 == 0` are dungeons but function Place.IsPlayerAtBuildingType() forbids using anything but buildings.
```cs
if (!playerEnterExit.IsPlayerInsideBuilding)
    return false;
```