### PR TITLE
Reformat books, use the built-in book formatting.

### DIFF
--- a/Assets/StreamingAssets/Text/Books/BOK00000-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00000-LOC.txt
@@ -3,191 +3,52 @@ Author: Arkan
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
 
-
 [/font=2]
-
 [/center]The First Scroll of Baan Dar
 
-
-
 [/font=4]
+ What follows is a translation of the first fragment from a series of vellum scrolls found in 3 Alabaster jars sealed in a cave. The discoverer was a nomad wanderer somewhere on the shores of Lake Vread in the Province of Elswyer. I can neither vouch for nor deny its authenticity or veracity - only that the scrolls, as such, DO exist. Read and judge for yourself:
 
- What follows is a translation of the first fragment from a
-series of vellum scrolls found in 3 Alabaster jars sealed
-in a cave. The discoverer was a nomad wanderer somewhere on
-the shores of Lake Vread in the Province of Elswyer. I can
-neither vouch for nor deny its authenticity or veracity -
-only that the scrolls, as such, DO exist. Read and judge for
-yourself:
+ Baan Dar, The Legend... Thief, Warlock, ShadowMaster, Ruthless Assassin, Undying Avenger, Dark God, Robber Baron, MasterMind of Nefarious Plots. All these things and more are the Legendary Baan Dar, he who is called The Bandit God. But what is the Truth?
 
-         Baan Dar, The Legend... Thief, Warlock,
-ShadowMaster, Ruthless Assassin, Undying Avenger, Dark
-God, Robber Baron, MasterMind of Nefarious Plots. All
-these things and more are the Legendary Baan Dar, he who is
-called The Bandit God. But what is the Truth?         Baan Dar,
-The Man is a much more simple and complex being. I pen this
-tale as I slowly die of old age and a mortifying arrow
-wound. I cannot decide if the truth will add to or subtract
-from the legend that is Baan Dar, nor if the original Baan
-Dar would want the truth to be known. Therefore, I will
-leave this tale hidden when I am done and gone, and let Fate
-(which was ever Baan Dar's true master and motivator)
-decide.         I was a child of 12 Seasons when I first met
-Baan Dar. Orphan of a Slaver raid during one of the many
-inter-provincial border wars. Living by my quick wits,
-nimble fingers, and the grace of Lady Luck in the back alleys
-and byways of my birth city. I had just "liberated" a loaf
-of bread and a few small apples from a local street vendor
-in the Bazaar on the edge of the city near the tumbled outer
-wall, and had withdrawn down an ill-lit alley to feast on
-my bounty when I was beset by an older band of my ilk. The
-older and lazier variety which were want to engage in the
-easier and less dangerous art of stealing from the
-stealers.         There were 5 of the bully boys who had decided
-they were more deserving of my booty than I, and they were
-beating me half to death with staves in between bites and
-laughter at the time. Lying on the ground curled up into as
-tight a ball as I could manage, trying to protect my head
-and groin, I heard a quiet voice ask if they were not "more
-suited to go down to the wharf and take food from your
-brother rats, or would you care to try your tricks on game a
-bit more your size and number?"         Since my "companions"
-had become otherwise engaged with the newcomer and had for the
-nonce ceased thumping, kicking and cuffing at me, I looked up
-to see a dark shadow of boots, cloak, and chainmail hood
-leaning against the wall at the end of the alleyway.        
-The others, being what they were, took this as a challenge to
-their manhood - and easy prey to their superior number with a
-promise of coin of the realm as added reward (else the first
-part would have been overlooked). The leader of my band of
-playmates suggested that the stranger take a leap off the
-mentioned wharf unless he wished to join me there when they
-were done with their evening meal.         Having drawn
-chuckles and courage from his underlings, he then proceeded forward with staff at high
-port. I'm not quite sure exactly what followed, but within a
-short space of time, Lead Bully was lying in the dirt with a
-thrown dagger in his chest, number two bully had lost three
-teeth to a boot (I still carry them in a leather pouch as a
-keepsake), and number three bully was brought short by his
-own staff applied forcefully up between his toes (the two
-big ones!). Bullies four and five thought better of the
-entertainment and departed rapidly for parts unknown.        
-Baan Dar picked me up, dusted me off, and dragged me round
-to a near tavern where we shared a meal and a mug. I
-attempted to thank him for saving my life. How can I ever
-repay this favor, I asked? His reply was short, to the point,
-and has driven my actions in life ever since...
+ Baan Dar, The Man is a much more simple and complex being. I pen this tale as I slowly die of old age and a mortifying arrow wound. I cannot decide if the truth will add to or subtract from the legend that is Baan Dar, nor if the original Baan Dar would want the truth to be known. Therefore, I will leave this tale hidden when I am done and gone, and let Fate (which was ever Baan Dar's true master and motivator) decide.
+
+ I was a child of 12 Seasons when I first met Baan Dar. Orphan of a Slaver raid during one of the many inter-provincial border wars. Living by my quick wits, nimble fingers, and the grace of Lady Luck in the back alleys and byways of my birth city. I had just "liberated" a loaf of bread and a few small apples from a local street vendor in the Bazaar on the edge of the city near the tumbled outer wall, and had withdrawn down an ill-lit alley to feast on my bounty when I was beset by an older band of my ilk. The older and lazier variety which were want to engage in the easier and less dangerous art of stealing from the stealers.
+
+ There were 5 of the bully boys who had decided they were more deserving of my booty than I, and they were beating me half to death with staves in between bites and laughter at the time. Lying on the ground curled up into as tight a ball as I could manage, trying to protect my head and groin, I heard a quiet voice ask if they were not "more suited to go down to the wharf and take food from your brother rats, or would you care to try your tricks on game a bit more your size and number?"
+
+ Since my "companions" had become otherwise engaged with the newcomer and had for the nonce ceased thumping, kicking and cuffing at me, I looked up to see a dark shadow of boots, cloak, and chainmail hood leaning against the wall at the end of the alleyway. The others, being what they were, took this as a challenge to their manhood - and easy prey to their superior number with a promise of coin of the realm as added reward (else the first part would have been overlooked). The leader of my band of playmates suggested that the stranger take a leap off the mentioned wharf unless he wished to join me there when they were done with their evening meal.
+
+ Having drawn chuckles and courage from his underlings, he then proceeded forward with staff at high port. I'm not quite sure exactly what followed, but within a short space of time, Lead Bully was lying in the dirt with a thrown dagger in his chest, number two bully had lost three teeth to a boot (I still carry them in a leather pouch as a keepsake), and number three bully was brought short by his own staff applied forcefully up between his toes (the two big ones!). Bullies four and five thought better of the entertainment and departed rapidly for parts unknown. Baan Dar picked me up, dusted me off, and dragged me round to a near tavern where we shared a meal and a mug. I attempted to thank him for saving my life. How can I ever repay this favor, I asked? His reply was short, to the point, and has driven my actions in life ever since...
 
 
+[/center]"THE PROPER WAY TO REPAY A FAVOR, IS NOT TO - PASS IT ON INSTEAD."
 
-[/center]"THE PROPER WAY TO REPAY A FAVOR, IS NOT TO - PASS IT
-ON INSTEAD."
+ Things having not progressed well along the lines of health, wealth and welfare for me until that point in my life came upon a sudden change that night. I later learned (along with MANY other things) that Baan Dar had decided to take a direct and immediate interest in me because my situation reminded him very much of the bad start his own life had taken, and the odds he had faced to survive it. On that night he took me under his wing as a kind of apprentice. He saw to it that I learned weaponcraft and stealth, that I learned to read and write! He took me along when he traveled for the next year. I served as messenger, valet, packmule, lookout, cook - many things. I saw other towns, cities, races, provinces, and broadened my view and knowledge of the world far beyond belief. He taught me both morals and coldhearted ruthlessness - and when and how to apply each as the ethics of the situation required.
 
-         Things having not progressed well along the lines of
-health, wealth and welfare for me until that point in my
-life came upon a sudden change that night. I later learned
-(along with MANY other things) that Baan Dar had decided to
-take a direct and immediate interest in me because my
-situation reminded him very much of the bad start his own life
-had taken, and the odds he had faced to survive it. On that
-night he took me under his wing as a kind of apprentice. He saw
-to it that I learned weaponcraft and stealth, that I
-learned to read and write! He took me along when he traveled
-for the next year. I served as messenger, valet, packmule,
-lookout, cook - many things. I saw other towns, cities, races,
-provinces, and broadened my view and knowledge of the world
-far beyond belief. He taught me both morals and coldhearted
-ruthlessness - and when and how to apply each as the ethics of
-the situation required.         At the end of the year, he gave me
-good dagger, and decent horse, the 3 teeth, and leave (nay,
-Command) to make my own way in the world from that day
-forward - but to remember all I had been given, and to
-attempt to pass such a gift to another when and where I
-should find need and opportunity. That I have done, several
-times... as I assume he has also, and as I hope my various
-charges have after me (and they theirs).         Thus has the
-Legendary Baan Dar been seen time and again in various
-lands of our world at numerous and the same times in days of
-need. Thus also is the description so very hard to obtain
-and track - for in truth, there have been, and continue to
-be, many Baan Dars in the world. The most valuable lesson he
-ever taught me was that "for Evil to triumph required not so
-much that many bad men to do wrong, as for One good man to
-fail to do what was right." We only hope that our combined
-and concatenated efforts have produced enough single men
-and women that will not fail to do the right thing,
-regardless of current local, morals, laws, religion,
-creed, or lure of coin of the realm.         The Legend grows
-still. Of the Dark Avenging Blade on the Wings of Night that
-make no sound. The Patron Saint of the Lone Wolf. The
-Thousand Eyes and Ears, the Hundred Arms direspectful of
-Time or Distance. Undying, Master of Disguise, Man of a
-Thousand Faces, Shapes and Sizes, Gentle, Rough-Edged,
-Gay, Stern. All the Mystery of the "Man Unknown and
-Undying"... not a single man nor God at all, but a string
-of seeds sown upon the land and left to grow into a forest.
-How to reconcile this truth with the tales of cruelty and the
-gangs of "Baan Dars" or "Bandits"? Some are jealous
-Thieves who take the name only for the cloak of mystery and
-hope of hiding in it's Shadow. Others are tales twisted to
-reverse by those justly served by Baan Dar's unfettered by
-technicalities of law and custom. Some are backsliders drawn of the true path by temptation and returning to
-their old ways. Many are the things that any one Baan Dar
-cannot answer for, as others did the deeds in the same name.
-Some are tales of fishwives, made up to scare the child into
-doing what is wanted. Some are left as part of the
-"Mystery" that is both cloak and shield to the hidden
-purposes - a case where the fear of the tale serves to save the
-need of arms or action.         But, by and large, the true
-Baan Dar is a string of beings taught to act upon what they
-believe in, and stand to take the yoke of needed action upon
-their own shoulders.          Don't fight if you can avoid
-blood or war, But if you must make War, do so with all your
-Heart and Might.
+ At the end of the year, he gave me good dagger, and decent horse, the 3 teeth, and leave (nay, Command) to make my own way in the world from that day forward - but to remember all I had been given, and to attempt to pass such a gift to another when and where I should find need and opportunity. That I have done, several times... as I assume he has also, and as I hope my various charges have after me (and they theirs).
 
+ Thus has the Legendary Baan Dar been seen time and again in various lands of our world at numerous and the same times in days of need. Thus also is the description so very hard to obtain and track - for in truth, there have been, and continue to be, many Baan Dars in the world. The most valuable lesson he ever taught me was that "for Evil to triumph required not so much that many bad men to do wrong, as for One good man to fail to do what was right." We only hope that our combined and concatenated efforts have produced enough single men and women that will not fail to do the right thing, regardless of current local, morals, laws, religion, creed, or lure of coin of the realm.
 
-Leave it at Threats if Threats be enough - but never make
-threats you are unwilling to carry to conclusion if
-required.
+ The Legend grows still. Of the Dark Avenging Blade on the Wings of Night that make no sound. The Patron Saint of the Lone Wolf. The Thousand Eyes and Ears, the Hundred Arms direspectful of Time or Distance. Undying, Master of Disguise, Man of a Thousand Faces, Shapes and Sizes, Gentle, Rough-Edged, Gay, Stern. All the Mystery of the "Man Unknown and Undying"... not a single man nor God at all, but a string of seeds sown upon the land and left to grow into a forest. How to reconcile this truth with the tales of cruelty and the gangs of "Baan Dars" or "Bandits"? Some are jealous Thieves who take the name only for the cloak of mystery and hope of hiding in it's Shadow. Others are tales twisted to reverse by those justly served by Baan Dar's unfettered by technicalities of law and custom. Some are backsliders drawn of the true path by temptation and returning to their old ways. Many are the things that any one Baan Dar cannot answer for, as others did the deeds in the same name. Some are tales of fishwives, made up to scare the child into doing what is wanted. Some are left as part of the "Mystery" that is both cloak and shield to the hidden purposes - a case where the fear of the tale serves to save the need of arms or action.
 
+ But, by and large, the true Baan Dar is a string of beings taught to act upon what they believe in, and stand to take the yoke of needed action upon their own shoulders.
 
-Use all the arts at hand.
+ Don't fight if you can avoid blood or war, But if you must make War, do so with all your Heart and Might.
 
+ Leave it at Threats if Threats be enough - but never make threats you are unwilling to carry to conclusion if required.
 
-But ever keep the true purpose in mind.
+ Use all the arts at hand.
 
+ But ever keep the true purpose in mind.
 
-Stand Tall, but never forget how to bend your knee to
-help another.
+ Stand Tall, but never forget how to bend your knee to help another.
 
-         Note:
+ Note:
 
-
-The rest of the scrolls are tales and tellings of various
-parts of the Legend, some as passed from Bard to Bard, some
-as the true tales underlying the Ballads. These fragments
-are still to be translated and debated. This fragment,
-however, contains the kernel of the Revelation and the true
-source of the questions surrounding the Baan Dar Legend.
-What Say You, Reader? For myself, I do not know... but God
-or unrelated string of linked souls as laid out here... I do
-know that Baan Dar IS a force in our Land and Lives, and one
-that gives Hope to many that need it, and pause to many I
-despise.
-
-
+The rest of the scrolls are tales and tellings of various parts of the Legend, some as passed from Bard to Bard, some as the true tales underlying the Ballads. These fragments are still to be translated and debated. This fragment, however, contains the kernel of the Revelation and the true source of the questions surrounding the Baan Dar Legend. What Say You, Reader? For myself, I do not know... but God or unrelated string of linked souls as laid out here... I do know that Baan Dar IS a force in our Land and Lives, and one that gives Hope to many that need it, and pause to many I despise.
 
 [/center]-- Arkan, Scribe of Daggerfall in the year 2E24
-
-
-
-
-
-
-
-
-
- 

--- a/Assets/StreamingAssets/Text/Books/BOK00001-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00001-LOC.txt
@@ -3,425 +3,137 @@ Author: Vegepythicus, editor
 IsNaughty: False
 Price: 312
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
 
-
 [/font=2]
-
 [/center]Tales of Kieran
 
-
-
 [/font=4]
-
-
-
 [/center]Librarian's Note ...
 
- The recorded tales of Kieran the Bard fall into three
-categories: the Woodland Cycle, Castles and Kings, and an
-unnamed cycle of lusty tales (recently destroyed by
-mysterious accident). Some are in the bard's own hand, while
-others, mere shadows of the originals, remain only as bedtime
-tales for children. The structure exemplifies the helical
-form favoured by listeners about the hearth on a long
-winter's eve. As to whether they describe real events, be
-allegory, or be mere entertaining fancy, the reader must
-decide.
-
-
+ The recorded tales of Kieran the Bard fall into three categories: the Woodland Cycle, Castles and Kings, and an unnamed cycle of lusty tales (recently destroyed by mysterious accident). Some are in the bard's own hand, while others, mere shadows of the originals, remain only as bedtime tales for children. The structure exemplifies the helical form favoured by listeners about the hearth on a long winter's eve. As to whether they describe real events, be allegory, or be mere entertaining fancy, the reader must decide.
 
 [/center]***
 
-
-
-
-
 [/center]I.
 
- Kieran was on the road from Wren to Fairtree, when he grew
-weary from the midday sun. His boots were tight and he thought
-to remove them for a bit in the shade of a nearby oak (oaks
-being a favourite of bards). This particular oak was
-venerable and gnarled, with sturdy branches that dipped
-and swooped, nearly touching the ground in spots. From its
-shade Kieran watched the forest creatures playing in the
-warm sun. But for the rustling of leaves, high above, the
-only sounds were of butterfly wings and birdsong.
+ Kieran was on the road from Wren to Fairtree, when he grew weary from the midday sun. His boots were tight and he thought to remove them for a bit in the shade of a nearby oak (oaks being a favourite of bards). This particular oak was venerable and gnarled, with sturdy branches that dipped and swooped, nearly touching the ground in spots. From its shade Kieran watched the forest creatures playing in the warm sun. But for the rustling of leaves, high above, the only sounds were of butterfly wings and birdsong.
 
- "What a peaceful day," Kieran thought as he watched a
-butterfly drift by, "What a beautiful day! In truth, since
-bards first told tales, has there ever been a day more
-peaceful and beautiful than this?"
+ "What a peaceful day," Kieran thought as he watched a butterfly drift by, "What a beautiful day! In truth, since bards first told tales, has there ever been a day more peaceful and beautiful than this?"
 
- He drank from his waterskin and, taking his lute from its sack,
-cleared his throat and began to sing:
+ He drank from his waterskin and, taking his lute from its sack, cleared his throat and began to sing:
 
- "Oh, the maidens of Wren are passing fair ...  ...with
-breasts like melons, and flaxen hair ..."
+[/center]"Oh, the maidens of Wren are passing fair ...
+[/center]...with breasts like melons, and flaxen hair ..."
 
- He had just taken a deep breath to bellow the lusty chorus
-when a small, feminine voice said, "Kind sir ..."
+ He had just taken a deep breath to bellow the lusty chorus when a small, feminine voice said, "Kind sir ..."
 
- He leaped to his stockinged feet, his face flaming red. "Who's
-there?" he cried.
+ He leaped to his stockinged feet, his face flaming red. "Who's there?" he cried.
 
- The small voice repeated, "Please, sir, if you will be so
-kind ..."
+ The small voice repeated, "Please, sir, if you will be so kind ..."
 
- Kieran looked about but saw no person or creature
-addressing him.
+ Kieran looked about but saw no person or creature addressing him.
 
- "Pray thee," he cried. "Show thyself or have cause to fear
-my dagger." (He tried desperately to remember where he had
-last seen it.) "Whether thee be friend or foe, pray thee show
-thyself now."
+ "Pray thee," he cried. "Show thyself or have cause to fear my dagger." (He tried desperately to remember where he had last seen it.) "Whether thee be friend or foe, pray thee show thyself now."
 
- The small voice replied from above him, "Kind sir, thou
-hast no cause to fear me, and I am in need of help. Can thou
-find it in thy heart to aid me?"
+ The small voice replied from above him, "Kind sir, thou hast no cause to fear me, and I am in need of help. Can thou find it in thy heart to aid me?"
 
- He looked up and saw naught but a small robin's nest, three
-branches above him. Climbing swiftly, he found a robin with
-three tiny robinlings, their mouths open wide.
+ He looked up and saw naught but a small robin's nest, three branches above him. Climbing swiftly, he found a robin with three tiny robinlings, their mouths open wide.
 
- "Good mother robin," he asked, "Can it be thee who addresses
-me thus?"
+ "Good mother robin," he asked, "Can it be thee who addresses me thus?"
 
- "Kind sir," she replied, "I have hurt my wing and it will
-be at least a day before I might fly. If my children do not
-eat soon, they will die. Would you be so kind as to bring a
-fat, juicy meal? Would you find a caterpillar or
-earthworm or grub for my children?"
+ "Kind sir," she replied, "I have hurt my wing and it will be at least a day before I might fly. If my children do not eat soon, they will die. Would you be so kind as to bring a fat, juicy meal? Would you find a caterpillar or earthworm or grub for my children?"
 
- Now, Kieran was kind of heart and it was not within him to
-refuse a plea such as this, so off he went into the forest.
-Searching under some mulberry leaves, he soon found a
-small green caterpillar. It seemed a perfect meal for young
-robins.
+ Now, Kieran was kind of heart and it was not within him to refuse a plea such as this, so off he went into the forest. Searching under some mulberry leaves, he soon found a small green caterpillar. It seemed a perfect meal for young robins.
 
- Plucking it from the leaf upon which it fed, he prepared to
-hurry back to the oak when he heard a tiny voice. He opened his
-hand and the caterpillar looked up at him with her big brown
-eyes wide with fear. "Kind sir," she said, "wouldst thou kill
-me so thoughtlessly?"
+ Plucking it from the leaf upon which it fed, he prepared to hurry back to the oak when he heard a tiny voice. He opened his hand and the caterpillar looked up at him with her big brown eyes wide with fear. "Kind sir," she said, "wouldst thou kill me so thoughtlessly?"
 
- Kieran scratched his head in puzzlement and the caterpillar
-continued: "When thou cooled thy feet beneath the oak, didst
-thou not find joy in my parents' beauty as they danced
-before thee in the sun? I, too, am soon to change. Wouldst
-thou deny thy successors the joy of my dancing? And if I do
-not live to have children, how will thine own children find
-such joy? Please, sir, would not an earthworm serve the
-needs of the robinlings just as well?
+ Kieran scratched his head in puzzlement and the caterpillar continued: "When thou cooled thy feet beneath the oak, didst thou not find joy in my parents' beauty as they danced before thee in the sun? I, too, am soon to change. Wouldst thou deny thy successors the joy of my dancing? And if I do not live to have children, how will thine own children find such joy? Please, sir, would not an earthworm serve the needs of the robinlings just as well?
 
- Kieran looked into the eyes of the caterpillar and knew that
-he could not feed her to the robins. Carefully, he placed
-her beneath her mulberry bush and continued his search.
+ Kieran looked into the eyes of the caterpillar and knew that he could not feed her to the robins. Carefully, he placed her beneath her mulberry bush and continued his search.
 
- Near a rushing brook, Kieran found a flat stone that, when
-moved, revealed a juicy earthworm enjoying the cool moist
-earth. "Aha." he thought. "As nice as the caterpillar may
-have been, this truly seems a more fitting meal for young
-robins."
+ Near a rushing brook, Kieran found a flat stone that, when moved, revealed a juicy earthworm enjoying the cool moist earth. "Aha." he thought. "As nice as the caterpillar may have been, this truly seems a more fitting meal for young robins."
 
- He had no sooner plucked the earthworm from it's cool abode
-(where it had been frantically trying to burrow away from
-him), when he heard a voice so faint he might have imagined it:
+ He had no sooner plucked the earthworm from it's cool abode (where it had been frantically trying to burrow away from him), when he heard a voice so faint he might have imagined it:
 
- "Kind sir," he thought he heard, and Kieran looked in his hand.
-The worm continued: "I am but a lowly creature, it's true,
-but might I plead such case that I have?"
+ "Kind sir," he thought he heard, and Kieran looked in his hand. The worm continued: "I am but a lowly creature, it's true, but might I plead such case that I have?"
 
- Kieran rolled his eyes skyward as the worm sat up and seized
-its chance. "I am not a lowborn worm like others you might
-find. No, I am a prince among earthworms. I come from an
-ancient lineage. My ancestors burrowed the earth when fires
-belched from black pits throughout these lands. I command
-millions like myself. Were it not for my loyal followers,
-you, good sir, would be up to your  neck in leaves, tree
-trunks and mouldy carcasses. I'll make a bargain with you.
-If you release me and choose, instead, a pathetic grub for the
-robinlings, I will dispatch an entire clan of earthworms to
-keep your foreyard clean and sweet-smelling for as long as
-ye shall live." The earthworm looked hopefully at Kieran
-(while calculating the distance to the ground). "Good sir,
-what say ye?"
+ Kieran rolled his eyes skyward as the worm sat up and seized its chance. "I am not a lowborn worm like others you might find. No, I am a prince among earthworms. I come from an ancient lineage. My ancestors burrowed the earth when fires belched from black pits throughout these lands. I command millions like myself. Were it not for my loyal followers, you, good sir, would be up to your neck in leaves, tree trunks and mouldy carcasses. I'll make a bargain with you. If you release me and choose, instead, a pathetic grub for the robinlings, I will dispatch an entire clan of earthworms to keep your foreyard clean and sweet-smelling for as long as ye shall live." The earthworm looked hopefully at Kieran (while calculating the distance to the ground). "Good sir, what say ye?"
 
- Kieran was beginning to lose his patience, but, seeing the
-value of the earthworm's offer, decided that a grub would,
-indeed, make a tasty morsel for the young robins. He returned
-the earthworm to its moist haven and carefully replaced the
-flat stone above it. And, true to his desire, a short while
-later, in a forest glade, beneath a wide slab of discarded
-bark, Kieran chanced upon that which he sought: a fat white
-grub that would grow the robinlings into beautiful
-songsters. He plucked it from its hiding place and set forth.
-It was a beautiful day, indeed.
-
-
-
-
+ Kieran was beginning to lose his patience, but, seeing the value of the earthworm's offer, decided that a grub would, indeed, make a tasty morsel for the young robins. He returned the earthworm to its moist haven and carefully replaced the flat stone above it. And, true to his desire, a short while later, in a forest glade, beneath a wide slab of discarded bark, Kieran chanced upon that which he sought: a fat white grub that would grow the robinlings into beautiful songsters. He plucked it from its hiding place and set forth. It was a beautiful day, indeed.
 
 [/center]II.
 
- Nearby, in stately Trowbridge, King Caladan did live with
-his lovely daughter, Einlea. The princess was the apple of
-the old man's eye and the crown jewel of his small kingdom. He
-looked upon her with the blind pride of a doting father, and
-she, for her part, did naught but bask and flourish in his
-bounty.
+ Nearby, in stately Trowbridge, King Caladan did live with his lovely daughter, Einlea. The princess was the apple of the old man's eye and the crown jewel of his small kingdom. He looked upon her with the blind pride of a doting father, and she, for her part, did naught but bask and flourish in his bounty.
 
- Trowbridge was quiet now, the chief sounds being the clatter
-of cart wheels and the cries of street vendors, but it was
-not always so. Three years earlier there had been trouble
-with Carthan to the west. It was not much, a border dispute,
-but the king persuaded a wizard named Loziard to come to
-Trowbridge in his employ, to aid him in the contest. Loziard
-was unknown by all in Trowbridge and kept to himself within
-the palace, coming and going as he pleased. When Trowbridge
-prevailed, with almost no loss of life, there was joyous
-celebration for days and weeks thereafter. Time passed, yet
-Loziard remained. The King, not wanting to seem
-ungrateful, said nothing, but became increasingly
-discomforted with the wizard's presence and wished for his
-departure.
+ Trowbridge was quiet now, the chief sounds being the clatter of cart wheels and the cries of street vendors, but it was not always so. Three years earlier there had been trouble with Carthan to the west. It was not much, a border dispute, but the king persuaded a wizard named Loziard to come to Trowbridge in his employ, to aid him in the contest. Loziard was unknown by all in Trowbridge and kept to himself within the palace, coming and going as he pleased. When Trowbridge prevailed, with almost no loss of life, there was joyous celebration for days and weeks thereafter. Time passed, yet Loziard remained. The King, not wanting to seem ungrateful, said nothing, but became increasingly discomforted with the wizard's presence and wished for his departure.
 
- On Einlea's twentieth birthday, King Caladan called for a
-celebration and holiday through all his land. Unknown to
-his subjects, he intended to proclaim his retirement and the
-transference of his crown to his beautiful daughter. Out of
-politeness, and nothing more, he invited the wizard Loziard
-to aid him in devising a proper speech.
+ On Einlea's twentieth birthday, King Caladan called for a celebration and holiday through all his land. Unknown to his subjects, he intended to proclaim his retirement and the transference of his crown to his beautiful daughter. Out of politeness, and nothing more, he invited the wizard Loziard to aid him in devising a proper speech.
 
- Loziard was furious. He paced his chamber, his black brows
-knitted with intensity that would have soured any cow's milk.
-"Why," he cried aloud, "am I treated so unjustly by the old
-buffoon? Were it not for my skills, the border contest,
-mayhaps even the kingdom itself, might have been lost. I
-deserve more. I deserve the crown. To give it to that
-primping simpering daughter of his, who thinks naught of more
-than her own whim, is a slap more stinging than that of gauntlet. I will have justice. I will demonstrate, amply, for
-all to see, wherein lies true power."
+ Loziard was furious. He paced his chamber, his black brows knitted with intensity that would have soured any cow's milk. "Why," he cried aloud, "am I treated so unjustly by the old buffoon? Were it not for my skills, the border contest, mayhaps even the kingdom itself, might have been lost. I deserve more. I deserve the crown. To give it to that primping simpering daughter of his, who thinks naught of more than her own whim, is a slap more stinging than that of gauntlet. I will have justice. I will demonstrate, amply, for all to see, wherein lies true power."
 
  Thereupon, Loziard made his preparations.
 
- Princess Einlea's birthday came on a summer morning.
-Everyone within the city, and from the farms without,
-gathered to the palace for the festival. Banners waved
-from every rooftop. Fiddlers fiddled and dancers danced.
-Bakers baked wonderful sweets for the occasion. It was a day
-long to be remembered.
+ Princess Einlea's birthday came on a summer morning. Everyone within the city, and from the farms without, gathered to the palace for the festival. Banners waved from every rooftop. Fiddlers fiddled and dancers danced. Bakers baked wonderful sweets for the occasion. It was a day long to be remembered.
 
- At noon, precisely, King Caladan and Princess Einlea
-emerged onto the main balcony to the cheers of the kingdom.
-"Good citizens of Trowbridge," called the King, "We are
-but a tiny kingdom, but we prosper, do we not?"
+ At noon, precisely, King Caladan and Princess Einlea emerged onto the main balcony to the cheers of the kingdom. "Good citizens of Trowbridge," called the King, "We are but a tiny kingdom, but we prosper, do we not?"
 
- Loud hails (mostly) erupted from the crowd below.
-Encouraged, Caladan continued, "But now I am an old man.
-The day has arrived when younger blood can better attend to
-the needs and events of the kingdom. My subjects ... My loyal
-subjects and friends ... It is with honour  ...and pride 
-...and the greatest of expectations  ...that I transfer my
-kingdom and my crown to my loving daughter. To one and
-all, I give you" (a long pause here) "Einlea."
+ Loud hails (mostly) erupted from the crowd below. Encouraged, Caladan continued, "But now I am an old man. The day has arrived when younger blood can better attend to the needs and events of the kingdom. My subjects ... My loyal subjects and friends ... It is with honour ...and pride ...and the greatest of expectations ...that I transfer my kingdom and my crown to my loving daughter. To one and all, I give you" (a long pause here) "Einlea."
 
- As cheers filled the air, Caladan made a grand, sweeping
-gesture with his arm, intending to make the presentation as
-spectacular as the pride that filled him. His robe went
-"swoooosh" and his hand pointed to ... nobody. What was
-this? Where had she gone? Where Einlea had been, moments
-earlier, there now was naught but vacant air.
+ As cheers filled the air, Caladan made a grand, sweeping gesture with his arm, intending to make the presentation as spectacular as the pride that filled him. His robe went "swoooosh" and his hand pointed to ... nobody. What was this? Where had she gone? Where Einlea had been, moments earlier, there now was naught but vacant air.
 
- "Er ...Einlea ...?" he called, uncertainly. But there was
-no response. Silence fell over park and courtyard. People
-glanced at each other nervously.
+ "Er ...Einlea ...?" he called, uncertainly. But there was no response. Silence fell over park and courtyard. People glanced at each other nervously.
 
- Old Loziard clapped his hands in glee. He danced. He hugged
-himself with uncontained laughter. "How wonderful ..." he
-cried. "What a breathtakingly stunning and talented a
-wizard I am.." For what he had done, of course, was to rid
-himself of Einlea for once and for all. With one stroke,
-crafty and evil, he had removed the vain creature from the
-palace. Nought else remained between him and that which he
-desired.
+ Old Loziard clapped his hands in glee. He danced. He hugged himself with uncontained laughter. "How wonderful ..." he cried. "What a breathtakingly stunning and talented a wizard I am.." For what he had done, of course, was to rid himself of Einlea for once and for all. With one stroke, crafty and evil, he had removed the vain creature from the palace. Nought else remained between him and that which he desired.
 
- Now, magic is a tricky thing. Like all forces in the world,
-it must be kept in balance. As surely as day balances night
-and summer balances winter, so too must positive magic
-balance negative. For every hurtful or destructive spell,
-there must be an act of equal goodness or charity lest
-trouble overflow into the world. For every black wizard,
-there must be a white. For every spell of combat
-destruction, there must be healing. Know ye this  ...if all
-who practice magic cast naught but healing or protective
-spells, dark, horrible forces would build up until chaos
-and ruin would burst forth and rain our doom down upon us.
-Thus may spells of healing be broken by harm, and the worst
-of spells be broken by charity.
+ Now, magic is a tricky thing. Like all forces in the world, it must be kept in balance. As surely as day balances night and summer balances winter, so too must positive magic balance negative. For every hurtful or destructive spell, there must be an act of equal goodness or charity lest trouble overflow into the world. For every black wizard, there must be a white. For every spell of combat destruction, there must be healing. Know ye this ...if all who practice magic cast naught but healing or protective spells, dark, horrible forces would build up until chaos and ruin would burst forth and rain our doom down upon us. Thus may spells of healing be broken by harm, and the worst of spells be broken by charity.
 
- Knowing this, Loziard planned well his act of vengeance.
-To permanently rid himself of Einlea (short of killing her
-outright) he must devise a spell so cunning that no act of
-kindness would ever break it. He was pulling lice out of his
-long beard, late one evening, when he burst into laughter. He
-would make her into something  ...disgusting.
+ Knowing this, Loziard planned well his act of vengeance. To permanently rid himself of Einlea (short of killing her outright) he must devise a spell so cunning that no act of kindness would ever break it. He was pulling lice out of his long beard, late one evening, when he burst into laughter. He would make her into something ...disgusting.
 
- "I will make her into a frog." he laughed, then frowned. No
-... that had been done. People might expect it and go
-around, like mindless idiots, seeking frogs, hoping to earn a
-kings ransom.
+ "I will make her into a frog." he laughed, then frowned. No ... that had been done. People might expect it and go around, like mindless idiots, seeking frogs, hoping to earn a kings ransom.
 
  And then, a brilliant plan occurred to him.
 
- "I will make her into a bug, an insect, a WORM ..." He
-almost choked on his wine. "Oh. How perfect.. I will make her
-into something so truly loathsome that she will spend the
-rest of her little bug life in terror of being squashed by the
-first person who sees her." He squealed and his rings jangled
-and his fat jiggled and he snorted wine out his nose in
-laughter. "Oh, how absolutely delicious ..."
+ "I will make her into a bug, an insect, a WORM ..." He almost choked on his wine. "Oh. How perfect.. I will make her into something so truly loathsome that she will spend the rest of her little bug life in terror of being squashed by the first person who sees her." He squealed and his rings jangled and his fat jiggled and he snorted wine out his nose in laughter. "Oh, how absolutely delicious ..."
 
- And that's exactly what he did. While King Caladan and his
-subjects scratched their heads in puzzlement, nobody saw a
-small fat white tree grub plop to the cobblestones beneath
-the main balcony and immediately curl up, glistening and
-quivering.
-
-
-
-
+ And that's exactly what he did. While King Caladan and his subjects scratched their heads in puzzlement, nobody saw a small fat white tree grub plop to the cobblestones beneath the main balcony and immediately curl up, glistening and quivering.
 
 [/center]III.
 
- Einlea was terrified. What had happened? Well, she had seen
-enough of Loziard's magic to know what had happened. But
-why? Why would he do this to her? She didn't have long to
-ponder the question. A huge black hound, hundreds of times her
-size, ran to the cobblestone where she lay, and almost
-gobbled her with one slurp of his tongue. From somewhere, she
-found the wherewithal to roll out of his way and into the
-crevice between the stones. His HUGE slurpy tongue followed
-her, drooling and panting great hurricanes of hot awful
-breath down at her. But just as the tongue was about to lick
-her into the waiting stomach, the hound's owner yanked his
-massive chain and pulled the beast toward home.
+ Einlea was terrified. What had happened? Well, she had seen enough of Loziard's magic to know what had happened. But why? Why would he do this to her? She didn't have long to ponder the question. A huge black hound, hundreds of times her size, ran to the cobblestone where she lay, and almost gobbled her with one slurp of his tongue. From somewhere, she found the wherewithal to roll out of his way and into the crevice between the stones. His HUGE slurpy tongue followed her, drooling and panting great hurricanes of hot awful breath down at her. But just as the tongue was about to lick her into the waiting stomach, the hound's owner yanked his massive chain and pulled the beast toward home.
 
- It is true that Einlea, in her life as a human, was self
-indulgent and not inclined to effort or resource, but that
-was merely because she had no need of either. In the
-following days, she had cause to discover plenty of both
-within her. After the incident with the hound, she knew she must
-go far away from people and dogs. And she knew what kinds of
-creatures dined on grubs, too. She slept out of sight under
-leaves, in places where grubs would not likely be sought.
+ It is true that Einlea, in her life as a human, was self indulgent and not inclined to effort or resource, but that was merely because she had no need of either. In the following days, she had cause to discover plenty of both within her. After the incident with the hound, she knew she must go far away from people and dogs. And she knew what kinds of creatures dined on grubs, too. She slept out of sight under leaves, in places where grubs would not likely be sought.
 
- Even so, Einlea's days were filled with terror and
-adventure. There were circling hawks by day and owls by
-night. A bear, tearing at a rotting tree trunk, gobbled
-grubs, indistinguishable from Einlea, by the hundreds, as she
-watched in horror from behind a nearby rock. The smallest
-stream was now an enormous, gushing torrent, to be crossed
-in a nutshell under the greatest of peril. Einlea passed
-these tests, along with many others, and she passed them
-well.
+ Even so, Einlea's days were filled with terror and adventure. There were circling hawks by day and owls by night. A bear, tearing at a rotting tree trunk, gobbled grubs, indistinguishable from Einlea, by the hundreds, as she watched in horror from behind a nearby rock. The smallest stream was now an enormous, gushing torrent, to be crossed in a nutshell under the greatest of peril. Einlea passed these tests, along with many others, and she passed them well.
 
- It was on her tenth such day that a clumsy boot kicked aside
-the piece of bark under which she had sought shelter from the
-sun. Blinded by the sudden light, she heard an exclamation
-from high above. Then, before she could react, two fingers
-dropped from the sky and plucked her up and deposited her
-firmly inside a huge fist.
+ It was on her tenth such day that a clumsy boot kicked aside the piece of bark under which she had sought shelter from the sun. Blinded by the sudden light, she heard an exclamation from high above. Then, before she could react, two fingers dropped from the sky and plucked her up and deposited her firmly inside a huge fist.
 
- Ten days ago, Einlea would have been paralysed with
-terror. But that was ten days ago.  Her mind raced. "Who is
-this clumsy idiot, anyway??" she thought,  "and what on
-earth does he want with a tree grub? At least he didn't squash
-me on the spot. That's encouraging, isn't it? So he must be
-here to rescue me.."
+ Ten days ago, Einlea would have been paralysed with terror. But that was ten days ago. Her mind raced. "Who is this clumsy idiot, anyway??" she thought, "and what on earth does he want with a tree grub? At least he didn't squash me on the spot. That's encouraging, isn't it? So he must be here to rescue me.."
 
- She wriggled and squirmed in his fist until she could see his
-face, high above her, between two of his fingers. "Ugh. A
-beard. If I'm going to be rescued, why can't it be by a fine
-young prince?" But it then occurred to her that she was speaking from old habit. "I wonder how many of those foppish boys
-could have survived these past ten days?" She laughed,
-thinking of them. "Not many, I bet. Those who wouldn't have
-curled up and died immediately would, by now, be
-whimpering and crying for their mothers." She looked at
-Kieran again. "Well ... maybe he would look better if I
-wasn't looking straight up his nostrils. Ouch.. Why isn't he
-more careful with me??"
+ She wriggled and squirmed in his fist until she could see his face, high above her, between two of his fingers. "Ugh. A beard. If I'm going to be rescued, why can't it be by a fine young prince?" But it then occurred to her that she was speaking from old habit. "I wonder how many of those foppish boys could have survived these past ten days?" She laughed, thinking of them. "Not many, I bet. Those who wouldn't have curled up and died immediately would, by now, be whimpering and crying for their mothers." She looked at Kieran again. "Well ... maybe he would look better if I wasn't looking straight up his nostrils. Ouch.. Why isn't he more careful with me??"
 
- And then it occurred to Einlea that, if this oaf were truly
-rescuing her, he probably would have said something to her.
+ And then it occurred to Einlea that, if this oaf were truly rescuing her, he probably would have said something to her.
 
- "Uh-oh." Einlea's heart raced and she started wriggling
-furiously , imagining the worst of all possible deaths. "He
-must be going fishing."
+ "Uh-oh." Einlea's heart raced and she started wriggling furiously , imagining the worst of all possible deaths. "He must be going fishing."
 
- Einlea couldn't do much in her current state, but she could
-spit. And spit she did. In quantities unimaginable for so
-small a grub. She spit and spit and spit until her tiny
-grub mouth was too dry to spit another drop. She felt
-Kieran's hand squirming and thought, "It's working.."
-
-
-
-
+ Einlea couldn't do much in her current state, but she could spit. And spit she did. In quantities unimaginable for so small a grub. She spit and spit and spit until her tiny grub mouth was too dry to spit another drop. She felt Kieran's hand squirming and thought, "It's working.."
 
 [/center]IV.
 
- Kieran was fair disgusted. Twas bad enough that he had to
-touch the slimy thing, but now it was oozing something and
-becoming truly revolting. Finally, just before he reached
-the robin's oak, he could take it no longer. He stopped and
-examined the creature in his hand. White and plump and
-glistening, it was, in truth, a repellent creature. Yet the
-poor thing was obviously terrified. It gazed up at him with
-what he imagined to be minuscule grub eyes, pleading.
-Kieran thought of the caterpillar and the earthworm, and his
-heart gave in. Heaving a great resigned sigh, he found a nice
-clean root and placed the grub upon it.
+ Kieran was fair disgusted. Twas bad enough that he had to touch the slimy thing, but now it was oozing something and becoming truly revolting. Finally, just before he reached the robin's oak, he could take it no longer. He stopped and examined the creature in his hand. White and plump and glistening, it was, in truth, a repellent creature. Yet the poor thing was obviously terrified. It gazed up at him with what he imagined to be minuscule grub eyes, pleading. Kieran thought of the caterpillar and the earthworm, and his heart gave in. Heaving a great resigned sigh, he found a nice clean root and placed the grub upon it.
 
  And thus was Loziard's spell broken.
 
- None could have been more astonished than Einlea when she
-unexpectedly grew to her former size, except, perhaps for
-Kieran, who nearly died of fright. He was no more than
-catching his breath when Einlea regained her wits. Raising her
-index finger, warning  Kieran not to say even ONE word,
-Einlea snatched Kieran's coat to cover herself. Then, with
-fire in her eyes, and as much dignity as she could muster, she
-was off to Trowbridge, leaving Kieran to stare, open-
-mouthed, at her departing figure.
+ None could have been more astonished than Einlea when she unexpectedly grew to her former size, except, perhaps for Kieran, who nearly died of fright. He was no more than catching his breath when Einlea regained her wits. Raising her index finger, warning Kieran not to say even ONE word, Einlea snatched Kieran's coat to cover herself. Then, with fire in her eyes, and as much dignity as she could muster, she was off to Trowbridge, leaving Kieran to stare, open- mouthed, at her departing figure.
 
- Einlea knew she could not simply enter the city and
-confront Loziard. The moment he saw her, he would but cast another enchantment upon her. So, disguising
-herself as a shepherd, she found an abandoned house on the
-moors and began to make her plans. What happened next is a
-tale worth hearing. But it is a tale for another evening.
-Indeed, it is a tale to be told over many an evening, and
-many a good pot of ale.
+ Einlea knew she could not simply enter the city and confront Loziard. The moment he saw her, he would but cast another enchantment upon her. So, disguising herself as a shepherd, she found an abandoned house on the moors and began to make her plans. What happened next is a tale worth hearing. But it is a tale for another evening. Indeed, it is a tale to be told over many an evening, and many a good pot of ale.
 
+ And what of the baby robins? Having no alternative, Kieran climbed the tree and took from his pack his last piece of fatty mutton. Tearing it into small shreds, he gave it to the grateful mother robin, who fed it to her family.
 
-
- And what of the baby robins? Having no alternative, Kieran
-climbed the tree and took from his pack his last piece of fatty
-mutton. Tearing it into small shreds, he gave it to the
-grateful mother robin, who fed it to her family.
-
- Upon returning to the ground, Kieran looked first toward
-Fairtree, his former destination, then, grinning, set off after the most surprising young lady, for whom he now had many
-questions. "Who knows ..." he called back to the robins, "It
-may be fate. And besides, I need my coat."
+ Upon returning to the ground, Kieran looked first toward Fairtree, his former destination, then, grinning, set off after the most surprising young lady, for whom he now had many questions. "Who knows ..." he called back to the robins, "It may be fate. And besides, I need my coat."
 
  He was heard, late that evening, far down the road, singing:
 
- "Oh, the maidens of Trowbridge are passing fair ...  
-...with breasts like melons, and flaxen hair ..."
-
-
-
- 
+[/center]"Oh, the maidens of Trowbridge are passing fair ...
+[/center]...with breasts like melons, and flaxen hair ..."

--- a/Assets/StreamingAssets/Text/Books/BOK00002-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00002-LOC.txt
@@ -3,98 +3,35 @@ Author: Taurce Anselma
 IsNaughty: False
 Price: 676
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
 
-
 [/font=2]
-
 [/center]Fragment:
 
 [/center]On Artaeum
 
-
-
 [/font=4]
-
- by Taurce il-Anselma, 3E 400
-
-
+by Taurce il-Anselma, 3E 400
 
 [/center]The Isle of Artaeum (ar-TAY-um)
 
- Artaeum is the third largest island in the Sumurset
-archipelago, located south of the Moridunon village of Potansa and west of the mainland village of
-Runcibae. It is best known for being the home to the Psijic
-Order, perhaps the oldest monastic group in Tamriel.
+ Artaeum is the third largest island in the Sumurset archipelago, located south of the Moridunon village of Potansa and west of the mainland village of Runcibae. It is best known for being the home to the Psijic Order, perhaps the oldest monastic group in Tamriel.
 
- The earliest written record of Psijics is from the twentieth
-year of the first era and tells the tale of the author, the renowned Breton sage Voernet, travelling
-to the Isle of Artaeum to meet with the Rite Master of the
-Psijics, Iachesis. Even then, the Psijics were the counselors
-of kings and proponents of the "Elder Way," taught to them
-by the original people of Tamriel. The Elder Way is a
-philosophy of  meditation and study said to bind the forces
-of nature to the individual will. It differs from magicka in
-origin, but the effects are much the same.
+ The earliest written record of Psijics is from the twentieth year of the first era and tells the tale of the author, the renowned Breton sage Voernet, travelling to the Isle of Artaeum to meet with the Rite Master of the Psijics, Iachesis. Even then, the Psijics were the counselors of kings and proponents of the "Elder Way," taught to them by the original people of Tamriel. The Elder Way is a philosophy of meditation and study said to bind the forces of nature to the individual will. It differs from magicka in origin, but the effects are much the same.
 
- That being said, it is perhaps more than coincidence that the
-Isle of Artaeum literally vanished from the shores of
-Sumurset at the beginning of the second era at about the time
-of the founding of the Mages Guild of Tamriel. Various
-historians and scholars have published theories about this,
-but perhaps none but Iachesis and his own could shed light on
-this.
+ That being said, it is perhaps more than coincidence that the Isle of Artaeum literally vanished from the shores of Sumurset at the beginning of the second era at about the time of the founding of the Mages Guild of Tamriel. Various historians and scholars have published theories about this, but perhaps none but Iachesis and his own could shed light on this.
 
- Five hundred years passed and Artaeum returned. The Psijics
-on the Isle consisted of persons, mostly elves, who had
-disappeared and were presumed dead over the second
-era.
-They could not or would not offer an explanation for
-Artaeum's wherebouts during that time or the fate of Iachesis
-and the original council of Artaeum.
+ Five hundred years passed and Artaeum returned. The Psijics on the Isle consisted of persons, mostly elves, who had disappeared and were presumed dead over the second era.
 
- Currently, the Psijics are led by the Lore Master Celarus
-who has presided over the Council of Artaeum for the last
-two hundred and fifty years. The Council's influence in
-world politics is tidal: the kings of Sumurset,
-particularly those of Moridunon, have often sought the
-Psijics' opinion; Uriel V was much influenced by the Council
-in the early, most glorious part of his reign, before his
-disasterous attack on Akavir; it has even been suggested that
-the fleet of King Orghum of Pyandonea was destroyed by a
-joint effort of Emperor Antiochus and the Psijic Order. The
-last four emperors, Uriel VI, Morihatha, Pelagius IV, and
-Uriel VII, have been suspicious of the Psijics, even enough
-to refuse ambassadors for the Isle of Artaeum in the
-Imperial City.
+ They could not or would not offer an explanation for Artaeum's wherebouts during that time or the fate of Iachesis and the original council of Artaeum.
 
- The Isle of Artaeum is difficult to chart geographically.
-It is said that parts of it exist simultaneously in multiple
-dimensions and continuously shift either at random or by
-decree of Council. Visitors to the island are so rare to be
-almost unheard of. Anyone desirous of a meeting with a Psijic
-may find contacts in Potansa and Runcibae as well as many
-of the kingdoms of Sumurset.
+ Currently, the Psijics are led by the Lore Master Celarus who has presided over the Council of Artaeum for the last two hundred and fifty years. The Council's influence in world politics is tidal: the kings of Sumurset, particularly those of Moridunon, have often sought the Psijics' opinion; Uriel V was much influenced by the Council in the early, most glorious part of his reign, before his disasterous attack on Akavir; it has even been suggested that the fleet of King Orghum of Pyandonea was destroyed by a joint effort of Emperor Antiochus and the Psijic Order. The last four emperors, Uriel VI, Morihatha, Pelagius IV, and Uriel VII, have been suspicious of the Psijics, even enough to refuse ambassadors for the Isle of Artaeum in the Imperial City.
 
- Were it more accessible, Artaeum would be a favored
-destination for travellers. I have been to the Isle once
-and still dream of the idylic orchards and pastures, the
-still and silent lagoons, the misty woodlands, and the
-unique Psijic architecture that seems to be as natural but
-wondrous as the surroundings. The Ceporah Tower in
-particular I would study, for it is a ruin from a
-civilization that predates the High Elves by several hundred
-years and is still used in certain rites by the Psijics.
+ The Isle of Artaeum is difficult to chart geographically. It is said that parts of it exist simultaneously in multiple dimensions and continuously shift either at random or by decree of Council. Visitors to the island are so rare to be almost unheard of. Anyone desirous of a meeting with a Psijic may find contacts in Potansa and Runcibae as well as many of the kingdoms of Sumurset.
+
+ Were it more accessible, Artaeum would be a favored destination for travellers. I have been to the Isle once and still dream of the idylic orchards and pastures, the still and silent lagoons, the misty woodlands, and the unique Psijic architecture that seems to be as natural but wondrous as the surroundings. The Ceporah Tower in particular I would study, for it is a ruin from a civilization that predates the High Elves by several hundred years and is still used in certain rites by the Psijics.
 
  Perhaps one day I might return.
 
- Note: The author is currently on the Isle of Artaeum by
-gracious consent of Master Sargenius of the Council of
-Artaeum. 
-
-
-
-
-
- 
+ Note: The author is currently on the Isle of Artaeum by gracious consent of Master Sargenius of the Council of Artaeum.

--- a/Assets/StreamingAssets/Text/Books/BOK00003-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00003-LOC.txt
@@ -3,54 +3,16 @@ Author: Kiergo Chorvak
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]The Wild Elves
 
-
-
 [/font=4]
+ In the wilds of most every province of Tamriel, descended philosophically if not directly from the original inhabitants of the land are the Ayleids, commonly called the Wild Elves. While three races of elven stock, Salache (or High), Boiche (or Wood), and Moriche (or Dark) have assimilated well to the new cultures of Tamriel, the Ayleids and their brethren have remained aloof of our civilization, preferring to practice the old ways far from the eyes of the world.
 
+ The Wild Elves speak a variation of Old Cyrodilic and not Tamrielic, separating themselves further even than their more urbanized Elven cousins. In temperament they are dark-spirited and taciturn, though they doubtless act differently with outsiders (or "Pellani" in their tongue) than within their own tribes. Indeed, one of the finest sages of the University of Gwilym was a civilized Ayleid elf, Tjurhane Fyrre (1E 2790 - 2E 227) whose published work on Wild Elves suggests a lively, vibrant culture. Fyrre is one of the very few Ayleids to speak freely on his people and religion, and even he said "the nature of the tribes of Ayleid are multi-hued, their personalities often wildly different from their neighbor tribes." (Fyrre, T. "Nature of Ayleidic Poesy" p. 8, Univ of Gwilym Press, 2E 12) Like any alien culture, Wild Elves are often feared by the simple people of Tamriel.
 
-
- In the wilds of most every province of Tamriel, descended
-philosophically if not directly from the original
-inhabitants of the land are the Ayleids, commonly called the
-Wild Elves. While three races of elven stock, Salache (or
-High), Boiche (or Wood), and Moriche (or Dark) have
-assimilated well to the new cultures of Tamriel, the
-Ayleids and their brethren have remained aloof of our
-civilization, preferring to practice the old ways far from
-the eyes of the world.
-
- The Wild Elves speak a variation of Old Cyrodilic and not
-Tamrielic, separating themselves further even than their
-more urbanized Elven cousins. In temperament they are
-dark-spirited and taciturn, though they doubtless act
-differently with outsiders (or "Pellani" in their tongue)
-than within their own tribes. Indeed, one of the finest sages
-of the University of Gwilym was a civilized Ayleid elf,
-Tjurhane Fyrre (1E 2790 - 2E 227) whose published work on Wild
-Elves suggests a lively, vibrant culture. Fyrre is one of
-the very few Ayleids to speak freely on his people and
-religion, and even he said "the nature of the tribes of Ayleid
-are multi-hued, their personalities often wildly different
-from their neighbor tribes." (Fyrre, T. "Nature of Ayleidic
-Poesy" p. 8, Univ of Gwilym Press, 2E 12) Like any alien
-culture, Wild Elves are often feared by the simple people
-of Tamriel.
-
- The Ayleids continue to be one of the greatest enigmas of the
-continent of Tamriel. They seldom appear in the pages of
-written history in any role, and then only as a strange sight
-a chronicler stumbles upon before they vanish into the wood.
-When probable fiction is filtered from common legend, we
-are left with almost nothing. The mysterious ways of the
-Ayleids have remained shrouded since before the first era, and
-may well remain so for thousands of years to come.
-
- 
+ The Ayleids continue to be one of the greatest enigmas of the continent of Tamriel. They seldom appear in the pages of written history in any role, and then only as a strange sight a chronicler stumbles upon before they vanish into the wood. When probable fiction is filtered from common legend, we are left with almost nothing. The mysterious ways of the Ayleids have remained shrouded since before the first era, and may well remain so for thousands of years to come.

--- a/Assets/StreamingAssets/Text/Books/BOK00004-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00004-LOC.txt
@@ -3,9 +3,8 @@ Author: Destri Merlarg
 IsNaughty: False
 Price: 728
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,221 +14,53 @@ Content:
 
 [/center]Their Heroes
 
-
-
 [/font=4]
+ Notes on the Redguards, their history and their heroes.
 
- Notes on the Redguards, their history and their heroes. 
+ This is a publishers proof of the initial draft of my book, "REDGUARDS, THEIR HISTORY AND THEIR HEROES".
 
- This is a publishers proof of the initial draft of my book,
-"REDGUARDS, THEIR HISTORY AND THEIR HEROES". 
-
- The following is a collection of the tales, myths and
-history of the Redguards. Much of their history is shrouded in
-mystery and in the mists of time. It is hard to distinguish
-between myths, and real history. 
+ The following is a collection of the tales, myths and history of the Redguards. Much of their history is shrouded in mystery and in the mists of time. It is hard to distinguish between myths, and real history.
 
  Below are the first chapters of the draft by Destri Melarg
 
- Author's note as translated into the Modern Tongue of
-Hammerfell: Frandar Hunding was born in 2356 in the old way
-of reckoning, in our  beloved deserts of the old land.  The
-traditional rule of emperors had been overthrown in 2012,
-and although each successive emperor remained the figurehead
-of the empire, his powers were very much reduced. Since that
-time, our people saw 300 years of almost  continuous civil
-war between the provincial lords, warrior monks and
-brigands, all fighting each other for land and power. Our
-people once  were artisans, poets, and scholars, but the
-ever evolving strife made the way the sword inevitable - the
-song of the blade through the air, through flesh and bone, its
-ring against armor: an answer to our prayers. 
+ Author's note as translated into the Modern Tongue of Hammerfell: Frandar Hunding was born in 2356 in the old way of reckoning, in our beloved deserts of the old land. The traditional rule of emperors had been overthrown in 2012, and although each successive emperor remained the figurehead of the empire, his powers were very much reduced. Since that time, our people saw 300 years of almost continuous civil war between the provincial lords, warrior monks and brigands, all fighting each other for land and power. Our people once were artisans, poets, and scholars, but the ever evolving strife made the way the sword inevitable - the song of the blade through the air, through flesh and bone, its ring against armor: an answer to our prayers.
 
- In the time of Lord Frandar the first Warrior Prince, lords
-called Yokeda built huge stone castles to protect
-themselves and their lands, and castle towns outside the
-walls begin to grow up. In 2245, however, Mansel Sesnit
-came to the fore. He became the Elden Yokeda, or military
-dictator, and for eight years succeeded in gaining control
-of almost the whole empire. When Sesnit was assassinated in
-2253,a commoner took over the government. Randic Torn
-continued the work of unifying the Empire which Sesnit had
-begun, ruthlessly putting down any traces of insurrection.
-He revived the old gulf between the warriors - the sword
-singers - and the commoners by introducing restrictions on
-the wearing of swords. "Torn's Sword-hunt", as it was known,
-meant that only the singers were allowed to wear swords,
-which distinguished  them from the rest of the population. 
+ In the time of Lord Frandar the first Warrior Prince, lords called Yokeda built huge stone castles to protect themselves and their lands, and castle towns outside the walls begin to grow up. In 2245, however, Mansel Sesnit came to the fore. He became the Elden Yokeda, or military dictator, and for eight years succeeded in gaining control of almost the whole empire. When Sesnit was assassinated in 2253,a commoner took over the government. Randic Torn continued the work of unifying the Empire which Sesnit had begun, ruthlessly putting down any traces of insurrection. He revived the old gulf between the warriors - the sword singers - and the commoners by introducing restrictions on the wearing of swords. "Torn's Sword-hunt", as it was known, meant that only the singers were allowed to wear swords, which distinguished them from the rest of the population.
 
- Although Torn did much to settle the empire into its
-pre-strife ways, by the time of his death in 2373 internal
-disturbances still had not been  completely eliminated.
-Upon his death, civil war broke out in earnest; war that made
-the prior 300 year turmoil pale in comparison. It was in
-this period that Frandar Hunding grew up. 
+ Although Torn did much to settle the empire into its pre-strife ways, by the time of his death in 2373 internal disturbances still had not been completely eliminated. Upon his death, civil war broke out in earnest; war that made the prior 300 year turmoil pale in comparison. It was in this period that Frandar Hunding grew up.
 
- Hunding belonged to the sword-singers. This element of empire
-society grew from the desert artisans and was initially
-recruited from the young  sons and daughters of the high
-families.  They built the first temple to the unknown gods of
-War and build a training hall "The Hall of the Virtues  of
-War". Within a few generations the way of the sword - the
-song of the blade - had become their life. The people of the
-blade kept their poetry and artisanship in building
-beautiful swords woven with magic and powers from the
-unknown gods. The greatest among them became known as Ansei
-or "Saints of the Sword". Each of these began their  own
-training schools teaching their individual way of the sword.
-Those Ansei of the highest virtue wandered the country side
-engaging in battle,  righting wrongs, and seeking to end the
-strife. 
+ Hunding belonged to the sword-singers. This element of empire society grew from the desert artisans and was initially recruited from the young sons and daughters of the high families. They built the first temple to the unknown gods of War and build a training hall "The Hall of the Virtues of War". Within a few generations the way of the sword - the song of the blade - had become their life. The people of the blade kept their poetry and artisanship in building beautiful swords woven with magic and powers from the unknown gods. The greatest among them became known as Ansei or "Saints of the Sword". Each of these began their own training schools teaching their individual way of the sword. Those Ansei of the highest virtue wandered the country side engaging in battle, righting wrongs, and seeking to end the strife.
 
- To sum it up. Hunding, was a sword-singer, a master, no, a
-Master Ansei at a time when the peak of the strife was reborn
-out of the chaos of Torn's death. Many singers put up their
-swords and became artists, for the pull of the artisan
-heritage was strong; but others, like Hunding pursued the
-ideal of the warrior searching for enlightenment through the
-perilous paths of the Sword. Duels of revenge and tests of
-skill were common place, and fencing schools multiplied. 
+ To sum it up. Hunding, was a sword-singer, a master, no, a Master Ansei at a time when the peak of the strife was reborn out of the chaos of Torn's death. Many singers put up their swords and became artists, for the pull of the artisan heritage was strong; but others, like Hunding pursued the ideal of the warrior searching for enlightenment through the perilous paths of the Sword. Duels of revenge and tests of skill were common place, and fencing schools multiplied.
 
- Frandar do Hunding Hel Ansei No Shira, or as he is commonly
-known Frandar Hunding, was born in the far desert marches in
-the province of High Desert. Hunding is the name of the High
-Desert region near where he was born. No Shira means noble
-person or person of noble birth and Hel Ansei is his title of
-Sword Sainthood. 
+ Frandar do Hunding Hel Ansei No Shira, or as he is commonly known Frandar Hunding, was born in the far desert marches in the province of High Desert. Hunding is the name of the High Desert region near where he was born. No Shira means noble person or person of noble birth and Hel Ansei is his title of Sword Sainthood.
 
- Hunding's ancestors reach back to the beginning of recorded
-time in the high desert and were artisans and mystics, his
-grandfather was a retainer of the Elden Yokeda, Mansel
-Sesnit, and led many of the battles of unification prior to
-Sesnit's assassination. 
+ Hunding's ancestors reach back to the beginning of recorded time in the high desert and were artisans and mystics, his grandfather was a retainer of the Elden Yokeda, Mansel Sesnit, and led many of the battles of unification prior to Sesnit's assassination.
 
- When he was 14, Hunding's father died in the one of the many
-insurrections, and he was left to support his mother and
-four brothers. His prowess with the sword however, made his
-life both difficult and easy. Easy in that his services came in
-great demand as a guardian and escort. Hard in that his
-reputation preceded him, and many awaited their turn to
-face him in battle and gain instant fame through his defeat. 
+ When he was 14, Hunding's father died in the one of the many insurrections, and he was left to support his mother and four brothers. His prowess with the sword however, made his life both difficult and easy. Easy in that his services came in great demand as a guardian and escort. Hard in that his reputation preceded him, and many awaited their turn to face him in battle and gain instant fame through his defeat.
 
- By the time Hunding was 30 he had fought and won more than 90
-duels killing all his opponents. He became virtually
-invincible with the sword, gaining such skill and mastery
-that he finally stopped using the real swords created
-through the artisanship of his people and began using the
-Shehai or "way of the spirit sword". 
+ By the time Hunding was 30 he had fought and won more than 90 duels killing all his opponents. He became virtually invincible with the sword, gaining such skill and mastery that he finally stopped using the real swords created through the artisanship of his people and began using the Shehai or "way of the spirit sword".
 
- All sword singers learn through their intense training and
-devotion to the gods of war and way of the sword, the forms
-of discipline that allow the  creation of the spirit sword. 
-This is a simple form of magic or mind mastery where by a
-image of a sword is formed from pure thought. The sword
-singer forms the sword by concentrating, and it takes shape
-in his  hand - usually a pale thing of light, misty and
-insubstantial, a thing of beauty perhaps, a symbol of
-devotion to the Way and the gods, but no weapon. However,
-those Ansei of the highest level and sensitivity and those
-with talent in magic, can at times of stress, form a spirit
-sword, the Shehai which is far more than light and air - it is
-an unstoppable weapon of great might, a weapon which can
-never be taken from the owner without also taking his mind. 
+ All sword singers learn through their intense training and devotion to the gods of war and way of the sword, the forms of discipline that allow the creation of the spirit sword. This is a simple form of magic or mind mastery where by a image of a sword is formed from pure thought. The sword singer forms the sword by concentrating, and it takes shape in his hand - usually a pale thing of light, misty and insubstantial, a thing of beauty perhaps, a symbol of devotion to the Way and the gods, but no weapon. However, those Ansei of the highest level and sensitivity and those with talent in magic, can at times of stress, form a spirit sword, the Shehai which is far more than light and air - it is an unstoppable weapon of great might, a weapon which can never be taken from the owner without also taking his mind.
 
- The Shehai became Hunding's weapon, and with this he slew
-bands of brigands and wandering monsters than infested the
-land. Finally upon finishing his 90th duel, defeating the
-evil Lord Janic and his seven lich followers, he was
-satisfied that he was indeed invincible. Hunding then turned
-to formulating his philosophy of"the Way of the Sword". He
-wrote his Learnings down in the BOOK OF CIRCLES while living
-as a hermit in a cave in the mountains of high desert in his
-sixtieth year. 
+ The Shehai became Hunding's weapon, and with this he slew bands of brigands and wandering monsters than infested the land. Finally upon finishing his 90th duel, defeating the evil Lord Janic and his seven lich followers, he was satisfied that he was indeed invincible. Hunding then turned to formulating his philosophy of"the Way of the Sword". He wrote his Learnings down in the BOOK OF CIRCLES while living as a hermit in a cave in the mountains of high desert in his sixtieth year.
 
- In that year Hunding having enlisted in the many battles of
-the empire, defeating all opponents, had thought himself
-ready for death and retired to his cave to capture his
-strategy and mystical visions to share with other Sword
-Singers. It was after his completion of the scroll of the
-Circle that the Singers found him composing his death poem
-and  preparing to join the gods of war in final rest. 
+ In that year Hunding having enlisted in the many battles of the empire, defeating all opponents, had thought himself ready for death and retired to his cave to capture his strategy and mystical visions to share with other Sword Singers. It was after his completion of the scroll of the Circle that the Singers found him composing his death poem and preparing to join the gods of war in final rest.
 
- At sixty he was a vigorous man, who thought himself through
-with life, but his people,the sword-singers needed him. They
-needed him as never before.
+ At sixty he was a vigorous man, who thought himself through with life, but his people,the sword-singers needed him. They needed him as never before.
 
- Torn's Sword Hunt, had separated the Singers from the common
-people, and the rise of the Last Emperor began the last
-great strife of the desert empire. The Emperor and his
-consort Elisa's final effort to wrest control of the empire
-from the people by  destroying the sword-singers. Hira vowed
-to search out every Singer with his Brigand army composed of
-Orcs and castoffs of the wars of the empire, and to scourge
-them from the face of the planet. 
+ Torn's Sword Hunt, had separated the Singers from the common people, and the rise of the Last Emperor began the last great strife of the desert empire. The Emperor and his consort Elisa's final effort to wrest control of the empire from the people by destroying the sword-singers. Hira vowed to search out every Singer with his Brigand army composed of Orcs and castoffs of the wars of the empire, and to scourge them from the face of the planet.
 
- The Sword Singers were never a numerous people. The harsh
-desert kept the births few, and growing up in the
-unforgiving wastes eliminated all but those of iron spirit
-and will. Thus the final strife which became knows as the
-"War of the Singers" found the people of the sword
-unprepared and unready to join together their individually
-great skills into an army that could defend their homes and
-lives. 
+ The Sword Singers were never a numerous people. The harsh desert kept the births few, and growing up in the unforgiving wastes eliminated all but those of iron spirit and will. Thus the final strife which became knows as the "War of the Singers" found the people of the sword unprepared and unready to join together their individually great skills into an army that could defend their homes and lives.
 
- Frandar Hunding was sought out, his death poem interrupted,
-and unceremoniously command of the singers was thrust upon
-him.  To the unknown gods of war great thanks is owed that
-Hunding had the  time in his cave to write down his years of
-accumulated wisdom, of strategy, of the way of the Shehai.
-The singers fled from their camps up  into the desert hills
-and mountains. Fled to the foot of Hattu "the father of
-Mountains" where Hunding had gone to write in peace and to
-die,  and there these remnants formed into the Army of the
-Circle - they learned Hunding's Way, his strategies his
-tactics, and the final great  vision for a master stroke. 
+ Frandar Hunding was sought out, his death poem interrupted, and unceremoniously command of the singers was thrust upon him. To the unknown gods of war great thanks is owed that Hunding had the time in his cave to write down his years of accumulated wisdom, of strategy, of the way of the Shehai. The singers fled from their camps up into the desert hills and mountains. Fled to the foot of Hattu "the father of Mountains" where Hunding had gone to write in peace and to die, and there these remnants formed into the Army of the Circle - they learned Hunding's Way, his strategies his tactics, and the final great vision for a master stroke.
 
- Hunding devised a plan of seven battles leading the Armies
-of Hira further and further into the wilderness to the foot of
-Hattu, where the final battle could be fought. Hunding
-called his plan the "Hammer and the Anvil". With each battle
-Hunding's Singers would further learn his strategies and
-tactics, grow strong in the use of the Shehai, and be ready to
-defeat their opponents in the seventh battle. And thus it
-was, the six first battles were waged, each neither victory
-or defeat, each leading to the next. The larger armies of
-Hira following the small army of  Hunding. Outnumbered
-thirty to one, the singers never faltered from the Way. The
-stage was set, Hira and his Army maneuvered to the base of
-Hattu Mountain, where the hammer blow was delivered. The
-battle was pitched, and many singers fell that day. Hunding
-knew, that the  singers who lived would be few, but Hira and
-his empire of evil would not live and so it went. 
+ Hunding devised a plan of seven battles leading the Armies of Hira further and further into the wilderness to the foot of Hattu, where the final battle could be fought. Hunding called his plan the "Hammer and the Anvil". With each battle Hunding's Singers would further learn his strategies and tactics, grow strong in the use of the Shehai, and be ready to defeat their opponents in the seventh battle. And thus it was, the six first battles were waged, each neither victory or defeat, each leading to the next. The larger armies of Hira following the small army of Hunding. Outnumbered thirty to one, the singers never faltered from the Way. The stage was set, Hira and his Army maneuvered to the base of Hattu Mountain, where the hammer blow was delivered. The battle was pitched, and many singers fell that day. Hunding knew, that the singers who lived would be few, but Hira and his empire of evil would not live and so it went.
 
- At the end Hunding and less that twenty thousand Singers
-survived the day, but no army of evil was left to pillage
-and murder, more than three  hundred thousand fell that day
-on Hattu. Of those who were left to run and live, all were
-scattered to the four winds, and organized force no  more. 
+ At the end Hunding and less that twenty thousand Singers survived the day, but no army of evil was left to pillage and murder, more than three hundred thousand fell that day on Hattu. Of those who were left to run and live, all were scattered to the four winds, and organized force no more.
 
- The singers packed their lives, folded their tents, mourned
-their dead, and followed Hunding to the great port city of
-Arch, in the province of Seawind. There Hunding had a
-flotilla of ships waiting. The Singers left their desert for a
-new land. No longer welcome in the desert empire, they left
-to be sung about and spoken of in legend.  The final great
-warrior, the singers of Shehai, the Book of Circles, all
-leaving that land where their virtue was unappreciated.
-Red, red with blood they were in the eyes of the gentle
-citizenry, never mind that they had saved them  from a great
-evil. 
+ The singers packed their lives, folded their tents, mourned their dead, and followed Hunding to the great port city of Arch, in the province of Seawind. There Hunding had a flotilla of ships waiting. The Singers left their desert for a new land. No longer welcome in the desert empire, they left to be sung about and spoken of in legend. The final great warrior, the singers of Shehai, the Book of Circles, all leaving that land where their virtue was unappreciated. Red, red with blood they were in the eyes of the gentle citizenry, never mind that they had saved them from a great evil.
 
- The singers vowed to learn new ways as they traveled across
-the great ocean to their new land. To adopt a new name, but
-to honor the past. In  honor of their final battle, they
-named their new land Hammerfell and adopted the name
-Redguards.
+ The singers vowed to learn new ways as they traveled across the great ocean to their new land. To adopt a new name, but to honor the past. In honor of their final battle, they named their new land Hammerfell and adopted the name Redguards.
 
- In honor to Hunding the great warrior prince, each household
-in Hammerfell has a place by the hearth an alcove really,
-just a niche, big enough to hold the scroll - The Book of
-Circles.  
+ In honor to Hunding the great warrior prince, each household in Hammerfell has a place by the hearth an alcove really, just a niche, big enough to hold the scroll - The Book of Circles.

--- a/Assets/StreamingAssets/Text/Books/BOK00005-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00005-LOC.txt
@@ -3,92 +3,38 @@ Author: Mymophonus the Scribe
 IsNaughty: False
 Price: 562
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]Arkay The God
 
-
-
 [/font=4]
-
  So be it known that the gods were once as we.
 
- Ark'ay, the god of death and birth, was an ordinary 
-shopkeeper whose only unusual characteristic was a passion
-for knowledge. To indulge his hobby he became an avid
-collector of books on almost any subject he could find in
-print. 
+ Ark'ay, the god of death and birth, was an ordinary shopkeeper whose only unusual characteristic was a passion for knowledge. To indulge his hobby he became an avid collector of books on almost any subject he could find in print.
 
- One day he stumbled across a tome which purported to tell
-the secrets of life, death, and the purpose of existence.
-After  months of studying the convoluted logic, written in
-opaque language, he thought that he was finally beginning to
-understand what the author was saying. 
+ One day he stumbled across a tome which purported to tell the secrets of life, death, and the purpose of existence. After months of studying the convoluted logic, written in opaque language, he thought that he was finally beginning to understand what the author was saying.
 
- During this time he became so intent on understanding the book
-that he ignored everything else: his business started to slide
-towards bankruptcy, his few friends stopped visiting him, he
-ignored the plague which was ravaging the town, and his
-family were ready to leave him.
+ During this time he became so intent on understanding the book that he ignored everything else: his business started to slide towards bankruptcy, his few friends stopped visiting him, he ignored the plague which was ravaging the town, and his family were ready to leave him.
 
- Just as he felt that the book was opening visions of new
-worlds, the plague brought him low. His family tended his
-illness out of a sense of duty, but he slowly sank towards
-death. So, as a last resort, he prayed to Mara the
-mother-goddess to allow him enough time to complete his
-studies of the book.
+ Just as he felt that the book was opening visions of new worlds, the plague brought him low. His family tended his illness out of a sense of duty, but he slowly sank towards death. So, as a last resort, he prayed to Mara the mother-goddess to allow him enough time to complete his studies of the book.
 
- "Why should I make an exception for you, Ark`ay?" asked
-Mara.
+ "Why should I make an exception for you, Ark`ay?" asked Mara.
 
- "Mother Mara, I am finally beginning to understand this
-book and the meaning of life and death" he answered, "and
-with a little more time to study and think, I should be able
-to teach others".
+ "Mother Mara, I am finally beginning to understand this book and the meaning of life and death" he answered, "and with a little more time to study and think, I should be able to teach others".
 
- "Hmmm, it sounds to me like that `teaching others' is an 
-afterthought to appeal to me", she replied. "What is the
-reason for death and birth?"
+ "Hmmm, it sounds to me like that `teaching others' is an afterthought to appeal to me", she replied. "What is the reason for death and birth?"
 
- "There are far more souls in the Universe than there is room
-for in the physical world. But it is in the physical world
-that a soul has an opportunity to learn and progress.
-Without birth, souls would not be able to acquire that
-experience, and without death there would be no room for
-birth."
+ "There are far more souls in the Universe than there is room for in the physical world. But it is in the physical world that a soul has an opportunity to learn and progress. Without birth, souls would not be able to acquire that experience, and without death there would be no room for birth."
 
- "Not a very good explanation, but it does have elements of
-truth. Maybe with more study you could improve it," she
-mused.  "I cannot give you `a little more time.' I can
-only condemn you to Eternal labor in the field you have
-chosen. How say you to that?"
+ "Not a very good explanation, but it does have elements of truth. Maybe with more study you could improve it," she mused. "I cannot give you `a little more time.' I can only condemn you to Eternal labor in the field you have chosen. How say you to that?"
 
  "I do not understand, mother," said Ark'ay.
 
- "Your choice is to either accept the death that is so close
-or to become a god with us. But a god is not an easy nor
-pleasant thing to be. As the god of death and birth you will
-spend eternity making sure that deaths and births stay in
-proper  balance in the physical world. And, in spite of what
-you  believe you understand, you will always agonize over 
-whether your decisions are truly correct. How do you
-decide?"
+ "Your choice is to either accept the death that is so close or to become a god with us. But a god is not an easy nor pleasant thing to be. As the god of death and birth you will spend eternity making sure that deaths and births stay in proper balance in the physical world. And, in spite of what you believe you understand, you will always agonize over whether your decisions are truly correct. How do you decide?"
 
- Ark'ay spent what seemed to him as an eternity in thought
-before answering. "Mother, if my studies are not completely wrong, my only choice is to accept the burden and
-try to  transmit the reasons for death and birth to
-humanity."
+ Ark'ay spent what seemed to him as an eternity in thought before answering. "Mother, if my studies are not completely wrong, my only choice is to accept the burden and try to transmit the reasons for death and birth to humanity."
 
  "So be it, Arkay, God of Birth and Death."
-
-
-
-
-
-
-
- 

--- a/Assets/StreamingAssets/Text/Books/BOK00006-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00006-LOC.txt
@@ -3,65 +3,19 @@ Author: Szun Triop
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
 
-
 [/font=2]
-
 [/center]The Faerie
 
-
-
 [/font=4]
+ Faerie have been on Tamriel, in all probability, long before recorded history, perhaps since or before the days of the Elder Ones. The tales of their mischief are found in every culture, in most every village, town, and city-states in the Empire. Alternately they are called Faerie, Fey, Illyadi, Sprites, Pixies, and Sylphim, and their natures seem to flit from one story to the next with the same variation. It could almost be said that Faeries are anything unpredictable in nature.
 
- Faerie have been on Tamriel, in all probability, long
-before recorded history, perhaps since or before the days of
-the Elder Ones. The tales of their mischief are found in every
-culture, in most every village, town, and city-states in
-the Empire. Alternately they are called Faerie, Fey,
-Illyadi, Sprites, Pixies, and Sylphim, and their natures seem
-to flit from one story to the next with the same variation.
-It could almost be said that Faeries are anything
-unpredictable in nature.
+ The noted scholar Ahrtabazus studying at the time in the Crystal Tower of Sumurset Isle developed an interesting if controversial theory about Faerie. He organized the Fey variants on a chain, beginning with the glimmering sparks called Pixies or Whilloki by the Redguards at one end and the godlike beings such as Gheateus, Chonus, and Sygria at the other. In the middle are human and semi-human beings generating up to intelligent trees, brooks, rocks, even mountains. All of this was a new and completely original theory and would have prompted enthusiastic, if somewhat skeptical response had Ahrtabazus not added this footnote: "It may be that elves as a whole are part of this chain, above whilloki and below nephrine. They certainly have similar features and propensities for magicka as the other Faerie." (Ahrtabazus, "The Faerie Chain" Firsthold, 2E 456)
 
- The noted scholar Ahrtabazus studying at the time in the
-Crystal Tower of Sumurset Isle developed an interesting if
-controversial theory about Faerie. He organized the Fey
-variants on a chain, beginning with the glimmering sparks
-called Pixies or Whilloki by the Redguards at one end and the
-godlike beings such as Gheateus, Chonus, and Sygria at the
-other. In the middle are human and semi-human beings
-generating up to intelligent trees, brooks, rocks, even
-mountains. All of this was a new and completely original
-theory and would have prompted enthusiastic, if somewhat
-skeptical response had Ahrtabazus not added this footnote:
-"It may be that elves as a whole are part of this chain,
-above whilloki and below nephrine. They certainly have
-similar features and propensities for magicka as the other
-Faerie." (Ahrtabazus, "The Faerie Chain" Firsthold, 2E 456)
+ No elf liked to be put in a hierarchy slightly above whimsical pranksters like the whilloki, and Ahrtabazus was challenged on his assumptions based on very slight coincidences. Nevertheless, with modification, his Fairie Chain theory has gained wider and wider acceptance since its publication.
 
- No elf liked to be put in a hierarchy slightly above
-whimsical pranksters like the whilloki, and Ahrtabazus was
-challenged on his assumptions based on very slight
-coincidences. Nevertheless, with modification, his Fairie
-Chain theory has gained wider and wider acceptance since its
-publication. 
+ The hierarchial chain is not, in the strictest sense, an order of command. While Gheateus and Sygria are said to be surrounded by a host of minor Sylphim, faerie on the whole are not followers nor leaders. Their plans and schemes are not governed by a higher purpose, simply by their own whim.
 
- The hierarchial chain is not, in the strictest sense, an order
-of command. While Gheateus and Sygria are said to be
-surrounded by a host of minor Sylphim, faerie on the whole
-are not followers nor leaders. Their plans and schemes are
-not governed by a higher purpose, simply by their own whim.
-
- To this most faerie scholars agree. Because it is based on
-coincidental evidence and supported by auxiliary
-theories, it may very well be wrong.
-
-
-
-
-
-
-
- 
+ To this most faerie scholars agree. Because it is based on coincidental evidence and supported by auxiliary theories, it may very well be wrong.

--- a/Assets/StreamingAssets/Text/Books/BOK00007-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00007-LOC.txt
@@ -3,145 +3,71 @@ Author: Krowle
 IsNaughty: False
 Price: 424
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]Oelander's Hammer:
 
-[/center]
-
 [/center]An Instructive Tale
 
 [/center]For Children
 
-
-
 [/font=4]
 
-
-
- The two children, Froedwig and his younger sister
-Silvanda, had been exploring all morning. The noon sun was
-directly overhead and everything was warm and bright. The
-had left their Redguard village, Granitsta, early that
-morning for a day in the wildnerness, a picnic, and with a
-stern warning from their father to be home before dark. They
-crossed a huge field that was bare save a single rose bush
-right in the middle.
+ The two children, Froedwig and his younger sister Silvanda, had been exploring all morning. The noon sun was directly overhead and everything was warm and bright. The had left their Redguard village, Granitsta, early that morning for a day in the wildnerness, a picnic, and with a stern warning from their father to be home before dark. They crossed a huge field that was bare save a single rose bush right in the middle.
 
  The little girl asked Froedwig about it.
 
- "Well," he said, "according to father a great battle was
-fought in this place many years ago. The battle was visited
-by the God of all warriors, Reymon Ebonarm, who caused the
-leaders to end the battle and return to their homes. It is
-said that the rose bush grows where he stood that day."
+ "Well," he said, "according to father a great battle was fought in this place many years ago. The battle was visited by the God of all warriors, Reymon Ebonarm, who caused the leaders to end the battle and return to their homes. It is said that the rose bush grows where he stood that day."
 
  "Oh, how exciting," giggled Silvanda.
 
- The children continued their trek approaching some woods. As
-they entered the forest the air became very cool and a deep
-quiet seemed to envelope them. 
+ The children continued their trek approaching some woods. As they entered the forest the air became very cool and a deep quiet seemed to envelope them.
 
  "What is that?"
 
- Silvanda pointed to a large hole in the ground from which
-protruded a long, thick pole. Around the hole thorny
-plants had grown into an impenetrable wall.
+ Silvanda pointed to a large hole in the ground from which protruded a long, thick pole. Around the hole thorny plants had grown into an impenetrable wall.
 
- "I don't know," said Froedwig, "but let's see if we can get
-a closer look."
+ "I don't know," said Froedwig, "but let's see if we can get a closer look."
 
  "Stop!"
 
  They did.
 
- Looking beyond the hole, the children saw an elderly
-Redguard of many years. His gray beard, scraggly hair and
-stooped shoulders certainly did not support the
-authoritarian command he gave. But the children stopped
-just the same as he approached.
+ Looking beyond the hole, the children saw an elderly Redguard of many years. His gray beard, scraggly hair and stooped shoulders certainly did not support the authoritarian command he gave. But the children stopped just the same as he approached.
 
- "Who are you?" stammered Froedwig as Silvanda carefully
-tucked herself behind her brother's back.
+ "Who are you?" stammered Froedwig as Silvanda carefully tucked herself behind her brother's back.
 
  "My name is Hoennig Groevinger, and I live in these woods."
 
- "Why can't we examine yon hole, Master Groevinger?" asked
-Froedwig.
+ "Why can't we examine yon hole, Master Groevinger?" asked Froedwig.
 
- "Because, my dear children, it and what it holds are
-cursed. Now just wh-h-h-o are you?" he stuttered, mimicing
-Froedwig.
+ "Because, my dear children, it and what it holds are cursed. Now just wh-h-h-o are you?" he stuttered, mimicing Froedwig.
 
- Finally gaining his composure, Froedwig said, "I am
-Froedwig-aj- Murr of the village Granitsta. This is my sister
-Silvanda. We are on an outing. Can you tell us about this
-mysterious hole?"
+ Finally gaining his composure, Froedwig said, "I am Froedwig-aj- Murr of the village Granitsta. This is my sister Silvanda. We are on an outing. Can you tell us about this mysterious hole?"
 
- "Well," said the old man as he slowly settled to the
-ground, "Why don't you sit here with me for a while and I
-will tell you about Oelander's Hammer. That's the handle of
-the fabled weapon sticking out from yonder chasm."
+ "Well," said the old man as he slowly settled to the ground, "Why don't you sit here with me for a while and I will tell you about Oelander's Hammer. That's the handle of the fabled weapon sticking out from yonder chasm."
 
- With this the children also settled into sitting positions
-in front of the old Redguard ranger.
+ With this the children also settled into sitting positions in front of the old Redguard ranger.
 
- Groevinger began, "Many year's ago there was a huge battle
-fought in this very field ..."
+ Groevinger began, "Many year's ago there was a huge battle fought in this very field ..."
 
- "Oh, yes, I know," said Silvanda, interrupting the old
-man. "It was ended by the Warrior God Reymon Ebonarm, and
-the magic rose bush grows where he stood that day..." she
-continued breathlessly.
+ "Oh, yes, I know," said Silvanda, interrupting the old man. "It was ended by the Warrior God Reymon Ebonarm, and the magic rose bush grows where he stood that day..." she continued breathlessly.
 
- The old man sternly cleared his throat causing the little
-girl to again shrink behind her brother.
+ The old man sternly cleared his throat causing the little girl to again shrink behind her brother.
 
- "Now, if I may continue without interruption... On the day
-that battle ended, a young Redguard soldier stopped in this
-spot as he was leaving to go to his home. He carried the
-equipment he had used on the field which included a
-marvelously fashioned war hammer that had been given to him
-by his father. The weapon  was beautifully made and unknown
-to the young warrior carried an enchantment that had
-protected him through the vicious battle just ended."
+ "Now, if I may continue without interruption... On the day that battle ended, a young Redguard soldier stopped in this spot as he was leaving to go to his home. He carried the equipment he had used on the field which included a marvelously fashioned war hammer that had been given to him by his father. The weapon was beautifully made and unknown to the young warrior carried an enchantment that had protected him through the vicious battle just ended."
 
- "The young man, Oelander by name, rested by this very tree.
-Suddenly he was confronted by a wizard dressed all in black
-from head to toe. Without so much as a how-do-you-do, the
-wizard demanded that Oelander give him his hammer. Still
-flushed from the battle, the young man just looked at the dark
-man and  laughed. The wizard shaking with rage raised his hands
-to cast a horrible spell against the soldier. However, the
-young man was quicker. The huge war hammer whistled through
-the air smiting the wizard a mortal blow just as the spell
-left his fingers. There was a loud explosion."
+ "The young man, Oelander by name, rested by this very tree. Suddenly he was confronted by a wizard dressed all in black from head to toe. Without so much as a how-do-you-do, the wizard demanded that Oelander give him his hammer. Still flushed from the battle, the young man just looked at the dark man and laughed. The wizard shaking with rage raised his hands to cast a horrible spell against the soldier. However, the young man was quicker. The huge war hammer whistled through the air smiting the wizard a mortal blow just as the spell left his fingers. There was a loud explosion."
 
- The children stared at the old man. He surpressed a grin and
-continued.
+ The children stared at the old man. He surpressed a grin and continued.
 
- "Clouds of dusk and smoke covered the forest clearing, and
-when the air settled, yon hole was there with the hammer's
-handle protruding from it. Oelander and the wizard had
-vanished! The thorny vines you see grew up immediately
-around the hole, and to this day no one has been able to
-approach it close enough to remove that marvelous weapon.
-Many have tried and all have failed. It is said that only
-someone of tremendous merit can take it."
+ "Clouds of dusk and smoke covered the forest clearing, and when the air settled, yon hole was there with the hammer's handle protruding from it. Oelander and the wizard had vanished! The thorny vines you see grew up immediately around the hole, and to this day no one has been able to approach it close enough to remove that marvelous weapon. Many have tried and all have failed. It is said that only someone of tremendous merit can take it."
 
- All of a sudden, both children in unison stood and shouted,
-"Oh, look how the day has gone. We must go. If we are late
-getting home, our father will be most unhappy with us."
+ All of a sudden, both children in unison stood and shouted, "Oh, look how the day has gone. We must go. If we are late getting home, our father will be most unhappy with us."
 
- As they turned to leave, Froedwig said to the old man,
-"Thank you, Master Groevinger, for telling us of
-Oelander's Hammer. You know, I may just come back one day and
-try to retrieve it!"
+ As they turned to leave, Froedwig said to the old man, "Thank you, Master Groevinger, for telling us of Oelander's Hammer. You know, I may just come back one day and try to retrieve it!"
 
- As they disappeared from his view, the old man said to
-himself, "Ah, yes, Master Froedrig aj-Murr, you just  might
-do that."  
+ As they disappeared from his view, the old man said to himself, "Ah, yes, Master Froedrig aj-Murr, you just might do that."

--- a/Assets/StreamingAssets/Text/Books/BOK00008-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00008-LOC.txt
@@ -3,58 +3,17 @@ Author: Tyston Bane
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]The Pig Children
 
-
-
 [/font=4]
 
- No one, not the oldest Dark Elf of Mount Dagoth-Ur or the
-Ancient Sage of Solitude, no one can recall a time when the
-Orc did not ravage our fair Tamriel. Whatever foul and
-pestilent daedra of Oblivion conjured them could scarcely
-have created a more constant threat to the well-being of the
- civilized races of Tamriel.
+ No one, not the oldest Dark Elf of Mount Dagoth-Ur or the Ancient Sage of Solitude, no one can recall a time when the Orc did not ravage our fair Tamriel. Whatever foul and pestilent daedra of Oblivion conjured them could scarcely have created a more constant threat to the well-being of the civilized races of Tamriel.
 
- Orcs are thankfully easy to recognize from other humanoids
-by their size, commonly forty pertans in height and fifteen
-thousand angaids in weight, their brutal pig-like features,
-and their stench. They are consistantly belligerant,
-morally grotesque, intellectually moronic, and unclean. By
-all rights, the civilized races of Tamriel should have been
-able to purge our land of their blight eras ago, but their
-ferocity, animal cunning, and curious tribal loyalty has
-made them inevitable as leeches in a stagnant pool.
+ Orcs are thankfully easy to recognize from other humanoids by their size, commonly forty pertans in height and fifteen thousand angaids in weight, their brutal pig-like features, and their stench. They are consistantly belligerant, morally grotesque, intellectually moronic, and unclean. By all rights, the civilized races of Tamriel should have been able to purge our land of their blight eras ago, but their ferocity, animal cunning, and curious tribal loyalty has made them inevitable as leeches in a stagnant pool.
 
- Tales of orcish barbarity preceed written record. When
-Jastyaga wrote of the Order of Diagna joining the armies of
-Daggerfall and Sentinel "to hold the wicked orcs in their
-foul Orsinium tower ... and burn all" in 1E 950, she assumed
-that any reader would be aware of the savagery of the orcs.
-When the siege was completed thirty years later, after the
-death of many heroes including Gaiden Shinji, and the
-destruction of Orsinium scattered the orc survivors
-throughout the Wrothgarian Mountains, Jastyaga wrote, "the
-people rejoiced for their ancient enemy was dispersed."
-Obviously, the orcs had been terrorizing the region of the
-Iliac Bay at least since the early years of the first era.
-
-
-
-  
-
-
-
-
-
-
-
-
-
- 
+ Tales of orcish barbarity preceed written record. When Jastyaga wrote of the Order of Diagna joining the armies of Daggerfall and Sentinel "to hold the wicked orcs in their foul Orsinium tower ... and burn all" in 1E 950, she assumed that any reader would be aware of the savagery of the orcs. When the siege was completed thirty years later, after the death of many heroes including Gaiden Shinji, and the destruction of Orsinium scattered the orc survivors throughout the Wrothgarian Mountains, Jastyaga wrote, "the people rejoiced for their ancient enemy was dispersed." Obviously, the orcs had been terrorizing the region of the Iliac Bay at least since the early years of the first era.

--- a/Assets/StreamingAssets/Text/Books/BOK00009-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00009-LOC.txt
@@ -3,9 +3,8 @@ Author: Celarus
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -17,85 +16,16 @@ Content:
 
 [/center]Council
 
-
-
 [/font=4]
 
+ We who know the Old Ways are well aware of the existence of a spiritual world invisible to the unenlightened. Just as one living in a kingdom but unaware of the political machinations may see a new tax or battle preparation as capricious fortune, many observe floods, famines, and madness with helpless incomprehension. This is deplorable. As the great Cuilean Darnizhaan moaned, "The power of ignorance can truly shatter mithril like glass."
 
+ What, after all, is the origin of these spiritual forces that move the invisible strings of Mundus? Any neophyte of Artaeum knows that the spirits are our ancestors, and that, while living, they too were bewildered by the spirits of their ancestors, and so on to the original Acharyai. The daedra and gods the common people turn to are no more than the spirits of superior men and women whose power and passion granted them great influence in the phantom world. Certainly, this is our truth and our religion, but how does it help us in our sacred duty to seliffrnsae, or "provide grave and faithful counsel"?
 
- We who know the Old Ways are well aware of the
-existence of a spiritual world invisible to the
-unenlightened. Just as one living in a kingdom but
-unaware of the political machinations may see a new tax
-or battle preparation as capricious fortune, many
-observe floods, famines, and madness with helpless
-incomprehension. This is deplorable. As the great Cuilean
-Darnizhaan moaned, "The power of ignorance can truly
-shatter mithril like glass."
+ Firstly, we can easily grasp the necessity of both bringing good men great power and making powerful men good. We recognize the multiple threats that a strong tyrant represents -- he breeds cruelty which feeds the daedra Boethiah and hatred which feeds the daedra Vaernima; if he should he die performing a particularly malevolent act, he may go to rule in Oblivion; worst of all, he inspires other villians to power and other rulers to villiany. Knowing this, we have developed patience in our dealings with such despots. They should be crippled, humiliated, impoverished, imprisoned. Other counselors than we may advocate assassination or warfare, which, aside from its spiritual significance, is expensive, aleatric, and likely to cause at least as much pain to innocents as the brutish dictator was inflicting. No, we are intelligence gathers, dignified diplomats, not revolutionaries.
 
- What, after all, is the origin of these spiritual forces
-that move the invisible strings of Mundus? Any neophyte
-of Artaeum knows that the spirits are our ancestors, and
-that, while living, they too were bewildered by the spirits
-of their ancestors, and so on to the original Acharyai.
-The daedra and gods the common people turn to are no
-more than the spirits of superior men and women whose
-power and passion granted them great influence in the
-phantom world. Certainly, this is our truth and our
-religion, but how does it help us in our sacred duty to
-seliffrnsae, or "provide grave and faithful counsel"?
+ How, then, are our counselors "faithful"? We are faithful only to the Old Ways -- it is essential always to remember the spiritual world in watching our world. Performing the Rites of Moawita on the 2nd of Hearth Fire and the Vigyld on the 1st of Second Seed are essential means of empowering the salutary ghosts and debilitating the unclean spirits. How, then, are we faithful to those we counsel and to the Isle of Artaeum?
 
- Firstly, we can easily grasp the necessity of both
-bringing good men great power and making powerful men
-good. We recognize the multiple threats that a strong
-tyrant represents -- he breeds cruelty which feeds the
-daedra Boethiah and hatred which feeds the daedra
-Vaernima; if he should he die performing a particularly
-malevolent act, he may go to rule in Oblivion; worst of
-all, he inspires other villians to power and other rulers to
-villiany. Knowing this, we have developed patience in our
-dealings with such despots. They should be crippled,
-humiliated, impoverished, imprisoned. Other counselors
-than we may advocate assassination or warfare, which,
-aside from its spiritual significance, is expensive,
-aleatric, and likely to cause at least as much pain to
-innocents as the brutish dictator was inflicting. No, we
-are intelligence gathers, dignified diplomats, not
-revolutionaries.
+ Perhaps the sage Taheritae said it best: "In Mundus, conflict, disparity is what brings change, and change is most sacred of all the eleven forces. Change is the force without focus or origin, and it is the duty of the disciplined Psijic (enlightened one) to dilute change where it brings greed, gluttony, sloth, ignorance, prejudice, cruelty ... (Taheritae lists the 111 Prodigalities) ... and to encourage change where it brings excellence, beauty, happiness, and enlightenment. As such, the faithful counsel has but one master, his mind. If the man the Psijic counsels acts wickedly and brings oegnithr ("bad change") and will not be counselled, it is the Psijics duty to counterbalance the oegnithr by any means necessary."
 
- How, then, are our counselors "faithful"? We are faithful
-only to the Old Ways -- it is essential always to
-remember the spiritual world in watching our world.
-Performing the Rites of Moawita on the 2nd of Hearth
-Fire and the Vigyld on the 1st of Second Seed are
-essential means of empowering the salutary ghosts and
-debilitating the unclean spirits. How, then, are we faithful
-to those we counsel and to the Isle of Artaeum?
-
- Perhaps the sage Taheritae said it best: "In Mundus,
-conflict, disparity is what brings change, and change is
-most sacred of all the eleven forces. Change is the force
-without focus or origin, and it is the duty of the
-disciplined Psijic (enlightened one) to dilute change where
-it brings greed, gluttony, sloth, ignorance, prejudice,
-cruelty ... (Taheritae lists the 111 Prodigalities) ... and
-to encourage change where it brings excellence, beauty,
-happiness, and enlightenment. As such, the faithful
-counsel has but one master, his mind. If the man the
-Psijic counsels acts wickedly and brings oegnithr ("bad
-change") and will not be counselled, it is the Psijics duty
-to counterbalance the oegnithr by any means necessary."
-
- A student of the Old Ways may indeed vassal himself to
-a lord, but it is a risky relationship. Should the lord
-refuse wise counsel and order the Psijic (to use
-Taheritae's out-moded word) to perform an act contrary
-to the teachings of the Old Ways, there are few
-available options. The Psijic may abandon his lord, which
-will bring shame on him and the Isle of Artaeum, and so
-may never be allowed home again. The Psijic may also
-kill himself.
-
-
-
-
+ A student of the Old Ways may indeed vassal himself to a lord, but it is a risky relationship. Should the lord refuse wise counsel and order the Psijic (to use Taheritae's out-moded word) to perform an act contrary to the teachings of the Old Ways, there are few available options. The Psijic may abandon his lord, which will bring shame on him and the Isle of Artaeum, and so may never be allowed home again. The Psijic may also kill himself.

--- a/Assets/StreamingAssets/Text/Books/BOK00016-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00016-LOC.txt
@@ -3,92 +3,39 @@ Author: Mymophonus the Scribe
 IsNaughty: False
 Price: 562
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]Arkay The God
 
-
-
 [/font=4]
 
  So be it known that the gods were once as we.
 
- Ark'ay, the god of death and birth, was an ordinary 
-shopkeeper whose only unusual characteristic was a passion
-for knowledge. To indulge his hobby he became an avid
-collector of books on almost any subject he could find in
-print. 
+ Ark'ay, the god of death and birth, was an ordinary shopkeeper whose only unusual characteristic was a passion for knowledge. To indulge his hobby he became an avid collector of books on almost any subject he could find in print.
 
- One day he stumbled across a tome which purported to tell
-the secrets of life, death, and the purpose of existence.
-After  months of studying the convoluted logic, written in
-opaque language, he thought that he was finally beginning to
-understand what the author was saying. 
+ One day he stumbled across a tome which purported to tell the secrets of life, death, and the purpose of existence. After months of studying the convoluted logic, written in opaque language, he thought that he was finally beginning to understand what the author was saying.
 
- During this time he became so intent on understanding the book
-that he ignored everything else: his business started to slide
-towards bankruptcy, his few friends stopped visiting him, he
-ignored the plague which was ravaging the town, and his
-family were ready to leave him.
+ During this time he became so intent on understanding the book that he ignored everything else: his business started to slide towards bankruptcy, his few friends stopped visiting him, he ignored the plague which was ravaging the town, and his family were ready to leave him.
 
- Just as he felt that the book was opening visions of new
-worlds, the plague brought him low. His family tended his
-illness out of a sense of duty, but he slowly sank towards
-death. So, as a last resort, he prayed to Mara the
-mother-goddess to allow him enough time to complete his
-studies of the book.
+ Just as he felt that the book was opening visions of new worlds, the plague brought him low. His family tended his illness out of a sense of duty, but he slowly sank towards death. So, as a last resort, he prayed to Mara the mother-goddess to allow him enough time to complete his studies of the book.
 
- "Why should I make an exception for you, Ark`ay?" asked
-Mara.
+ "Why should I make an exception for you, Ark`ay?" asked Mara.
 
- "Mother Mara, I am finally beginning to understand this
-book and the meaning of life and death" he answered, "and
-with a little more time to study and think, I should be able
-to teach others".
+ "Mother Mara, I am finally beginning to understand this book and the meaning of life and death" he answered, "and with a little more time to study and think, I should be able to teach others".
 
- "Hmmm, it sounds to me like that `teaching others' is an 
-afterthought to appeal to me", she replied. "What is the
-reason for death and birth?"
+ "Hmmm, it sounds to me like that `teaching others' is an afterthought to appeal to me", she replied. "What is the reason for death and birth?"
 
- "There are far more souls in the Universe than there is room
-for in the physical world. But it is in the physical world
-that a soul has an opportunity to learn and progress.
-Without birth, souls would not be able to acquire that
-experience, and without death there would be no room for
-birth."
+ "There are far more souls in the Universe than there is room for in the physical world. But it is in the physical world that a soul has an opportunity to learn and progress. Without birth, souls would not be able to acquire that experience, and without death there would be no room for birth."
 
- "Not a very good explanation, but it does have elements of
-truth. Maybe with more study you could improve it," she
-mused.  "I cannot give you `a little more time.' I can
-only condemn you to Eternal labor in the field you have
-chosen. How say you to that?"
+ "Not a very good explanation, but it does have elements of truth. Maybe with more study you could improve it," she mused. "I cannot give you `a little more time.' I can only condemn you to Eternal labor in the field you have chosen. How say you to that?"
 
  "I do not understand, mother," said Ark'ay.
 
- "Your choice is to either accept the death that is so close
-or to become a god with us. But a god is not an easy nor
-pleasant thing to be. As the god of death and birth you will
-spend eternity making sure that deaths and births stay in
-proper  balance in the physical world. And, in spite of what
-you  believe you understand, you will always agonize over 
-whether your decisions are truly correct. How do you
-decide?"
+ "Your choice is to either accept the death that is so close or to become a god with us. But a god is not an easy nor pleasant thing to be. As the god of death and birth you will spend eternity making sure that deaths and births stay in proper balance in the physical world. And, in spite of what you believe you understand, you will always agonize over whether your decisions are truly correct. How do you decide?"
 
- Ark'ay spent what seemed to him as an eternity in thought
-before answering. "Mother, if my studies are not completely wrong, my only choice is to accept the burden and
-try to  transmit the reasons for death and birth to
-humanity."
+ Ark'ay spent what seemed to him as an eternity in thought before answering. "Mother, if my studies are not completely wrong, my only choice is to accept the burden and try to transmit the reasons for death and birth to humanity."
 
  "So be it, Arkay, God of Birth and Death."
-
-
-
-
-
-
-
- 

--- a/Assets/StreamingAssets/Text/Books/BOK00020-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00020-LOC.txt
@@ -3,81 +3,21 @@ Author: Tidasus
 IsNaughty: False
 Price: 691
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]Ghraewaj and the Harpies
 
-
-
 [/font=4]
 
- On the twelfth of Hearth Fire every year, the people of the
-Hammerfell township and barony of Lainlyn celebrate
-Riglametha. Riglametha in the Banthan dialect of the ancient
-Redguard tongue means "grateful-offering" and is a
-festival of the graces the gods have granted the people of
-Lainlyn over the centuries. Tradition dictates the
-performance of a number of plays about the great moments
-from Lainlyn's past, and one of the most popular is
-Ghraewaj, which may be translated as "The Crows Who Were
-Punished" or "The Crows Who Punish." Old Redguard is
-somewhat vague with its objective case.
+ On the twelfth of Hearth Fire every year, the people of the Hammerfell township and barony of Lainlyn celebrate Riglametha. Riglametha in the Banthan dialect of the ancient Redguard tongue means "grateful-offering" and is a festival of the graces the gods have granted the people of Lainlyn over the centuries. Tradition dictates the performance of a number of plays about the great moments from Lainlyn's past, and one of the most popular is Ghraewaj, which may be translated as "The Crows Who Were Punished" or "The Crows Who Punish." Old Redguard is somewhat vague with its objective case.
 
- The story of Ghraewaj, as any Lainlyn child will tell you,
-is of the wicked sisterhood of daedra worshippers who craft
-lies, curses, murders, and suicides to hurt the people of
-Lainlyn. Most of all, they use their beauty as a weapon to
-drive men to mayhem. Their leader, the temptress Noctyr-a,
-seduces the unnamed baron of Lainlyn and is about to force
-him to commit suicide to prove his love, when the baroness
-arrives. The baroness tricks Noctyr-a into wearing a
-beautiful white robe from the baroness' closet: "See how the
-robe glows with the lumniscience of pearl, but the inside is
-soft, feathered with down." Noctyr-a puts on the robe and
-the trap is sprung: the robe is magical and transforms
-Noctyr-a into an giant black bird. The baron, no longer
-enchanted, slays the great bird and calls in his cook.
+ The story of Ghraewaj, as any Lainlyn child will tell you, is of the wicked sisterhood of daedra worshippers who craft lies, curses, murders, and suicides to hurt the people of Lainlyn. Most of all, they use their beauty as a weapon to drive men to mayhem. Their leader, the temptress Noctyr-a, seduces the unnamed baron of Lainlyn and is about to force him to commit suicide to prove his love, when the baroness arrives. The baroness tricks Noctyr-a into wearing a beautiful white robe from the baroness' closet: "See how the robe glows with the lumniscience of pearl, but the inside is soft, feathered with down." Noctyr-a puts on the robe and the trap is sprung: the robe is magical and transforms Noctyr-a into an giant black bird. The baron, no longer enchanted, slays the great bird and calls in his cook.
 
- The sisterhood has, by this time, taken over Lainlyn castle
-and turned it into a orgy-filled den of decadence. At the
-height of their frenzied debauch, the cook arrives with an
-enormous roast to keep their energy high. They dig into the
-deliciously prepared meal, and at the crescendo of their
-gorging, the baron and baroness appear to tell them all
-that they have just devoured their leader, Noctyr-a. The
-women scream and caw and suddenly they too are transformed
-by the magic of the robe, into harpies, vicious half-bird
-creatures.
+ The sisterhood has, by this time, taken over Lainlyn castle and turned it into a orgy-filled den of decadence. At the height of their frenzied debauch, the cook arrives with an enormous roast to keep their energy high. They dig into the deliciously prepared meal, and at the crescendo of their gorging, the baron and baroness appear to tell them all that they have just devoured their leader, Noctyr-a. The women scream and caw and suddenly they too are transformed by the magic of the robe, into harpies, vicious half-bird creatures.
 
- The interesting thing about Ghraewaj from a scholarly
-perspective is how much the story has changed and continues to
-change over the years. In some versions of the story,
-Noctyr-a is an innocent peasant seamstress and it is the
-baroness who is the cruel and wicked leader of the harpies.
-Noctyr-a prays to Dibella and is given the charm to make the
-magical robe, and she and the baron live happily ever after
-once the harpies have feasted on the tranformed baroness.
-During the long reign of the virgin baroness of Lainlyn,
-Viana the Pure (2E 120 - 2E 148), the baron was portrayed as a
-willing conspirator of Noctyr-a. The harpies thus have two
-birds to dine on.
+ The interesting thing about Ghraewaj from a scholarly perspective is how much the story has changed and continues to change over the years. In some versions of the story, Noctyr-a is an innocent peasant seamstress and it is the baroness who is the cruel and wicked leader of the harpies. Noctyr-a prays to Dibella and is given the charm to make the magical robe, and she and the baron live happily ever after once the harpies have feasted on the tranformed baroness. During the long reign of the virgin baroness of Lainlyn, Viana the Pure (2E 120 - 2E 148), the baron was portrayed as a willing conspirator of Noctyr-a. The harpies thus have two birds to dine on.
 
- It is unlikely that trying to find the truth in the story is
-profitable research. Harpies are indeed a common nuisance in
-the Iliac Bay, particularly around Lainlyn. They do have
-their own tongue, and the few who have mastered it and not
-been devoured by their interviewees suggest that the harpies
-have no more idea about their origins than we do. In a
-different vein, one of the best known of the Daedra Princes is
-named Nocturnal, who is often portrayed as a beautiful dark
-woman holding two black crows. It is not a difficult
-etymologic trick to derive the name Noctyr-a from
-Nocturnal, or vice-versa.
-
-
-
- 
+ It is unlikely that trying to find the truth in the story is profitable research. Harpies are indeed a common nuisance in the Iliac Bay, particularly around Lainlyn. They do have their own tongue, and the few who have mastered it and not been devoured by their interviewees suggest that the harpies have no more idea about their origins than we do. In a different vein, one of the best known of the Daedra Princes is named Nocturnal, who is often portrayed as a beautiful dark woman holding two black crows. It is not a difficult etymologic trick to derive the name Noctyr-a from Nocturnal, or vice-versa.

--- a/Assets/StreamingAssets/Text/Books/BOK00021-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00021-LOC.txt
@@ -3,9 +3,8 @@ Author: Vondham Barres
 IsNaughty: False
 Price: 770
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,137 +12,44 @@ Content:
 
 [/center]Nymphs
 
-
-
 [/font=4]
 
- I grew up a scholar, an ascetic devoted to knowledge, with
-eyes that saw beauty in a fascinating passage in a dusty
-tome, love in the candle that allowed me to study on
-starless nights, passion in a well-reasoned argument of a
-long dead issue. I was a student who never graduated and was
-never expelled.
+ I grew up a scholar, an ascetic devoted to knowledge, with eyes that saw beauty in a fascinating passage in a dusty tome, love in the candle that allowed me to study on starless nights, passion in a well-reasoned argument of a long dead issue. I was a student who never graduated and was never expelled.
 
- Though I am not defending myself, I should further define
-myself. I am not what you would call a prude. In fact, I
-can speak of subjects in a detached way that would make the
-most debauched strumpet in Skyhawk blush with discovered
-modesty. I wrote an essay the House of Dibella as a scholar
-should, analysing the cult of beauty and physical
-relations as one might study crop rotation or the digestive
-system of an orc. The acquaintances of mine who were
-inclined to wink and giggle I tolerated, but barely.
+ Though I am not defending myself, I should further define myself. I am not what you would call a prude. In fact, I can speak of subjects in a detached way that would make the most debauched strumpet in Skyhawk blush with discovered modesty. I wrote an essay the House of Dibella as a scholar should, analysing the cult of beauty and physical relations as one might study crop rotation or the digestive system of an orc. The acquaintances of mine who were inclined to wink and giggle I tolerated, but barely.
 
- With all that said, the reader will understand that when I
-decided to study the language of the nymphs in order to study
-their character and culture, it was not a decision I made on
-account of prurience or lust. Scholars have historically
-neglected the nymph as a subject worthy of research, and this
-neglect I attribute to prejudice. The sages with whom I have
-spoken on the subject have eloquently and intelligently
-formed sentences which, boiled down, can be translated as:
-"Nymphs look like beautiful, naked women who skip along
-tra-la-la and like to have indisciminate sex. What could they
-have to say that would be of any interest?"
+ With all that said, the reader will understand that when I decided to study the language of the nymphs in order to study their character and culture, it was not a decision I made on account of prurience or lust. Scholars have historically neglected the nymph as a subject worthy of research, and this neglect I attribute to prejudice. The sages with whom I have spoken on the subject have eloquently and intelligently formed sentences which, boiled down, can be translated as: "Nymphs look like beautiful, naked women who skip along tra-la-la and like to have indisciminate sex. What could they have to say that would be of any interest?"
 
- So here I was faced with the most daunting of projects -- to
-study and research a species unstudied is a potentially
-rewarding challenge. If the subject was unstudied because
-the scientific community had deemed it beneath interest, a
-potentially rewarding but decidedly frustrating
-challenge. If I spent months in serious study of their
-language and culture and additional time in their company,
-and discovered nothing more than that the common prejudice
-is correct, the term "laughing stock" would not do me
-justice.
+ So here I was faced with the most daunting of projects -- to study and research a species unstudied is a potentially rewarding challenge. If the subject was unstudied because the scientific community had deemed it beneath interest, a potentially rewarding but decidedly frustrating challenge. If I spent months in serious study of their language and culture and additional time in their company, and discovered nothing more than that the common prejudice is correct, the term "laughing stock" would not do me justice.
 
- So, excited and nervous for reasons unrelated to the
-notoriously promiscuous behavior of my subjects, I began my
-studies. I mastered the language, a melodious tongue that
-sounds like wild elf and faerie but share no vocabulary with
-them. I studied the lore, and found it to be on the whole,
-little more than pornography and crude conjecture.
+ So, excited and nervous for reasons unrelated to the notoriously promiscuous behavior of my subjects, I began my studies. I mastered the language, a melodious tongue that sounds like wild elf and faerie but share no vocabulary with them. I studied the lore, and found it to be on the whole, little more than pornography and crude conjecture.
 
  I next had to find a nymph.
 
- From my centralized location in the Imperial City, I found
-it easy to send word around to several wellknown temples and
-guilds devoted to study in all the provinces. Not all
-replies back were serious in nature, but one, from the School
-of Julianos in Sentinel helped me considerably. To
-Magister Oitos and his disciples, I here offer my sincere
-gratitude.
+ From my centralized location in the Imperial City, I found it easy to send word around to several wellknown temples and guilds devoted to study in all the provinces. Not all replies back were serious in nature, but one, from the School of Julianos in Sentinel helped me considerably. To Magister Oitos and his disciples, I here offer my sincere gratitude.
 
- Nymphs are extremely shy creatures, no matter what the more
-obscene stories will tell you. No one who I've spoken with has
-had one seek him or her out. Thus to speak with a nymph requires
-energy and patience.
+ Nymphs are extremely shy creatures, no matter what the more obscene stories will tell you. No one who I've spoken with has had one seek him or her out. Thus to speak with a nymph requires energy and patience.
 
- Out of courtesy for her privacy, I will not here give the
-location of the little grotto off the coast of Hammerfell
-where I found the nymph. It took three months of patient
-waiting, leaving presents where I knew the nymph would be,
-before the nymph stood still at my approach.
+ Out of courtesy for her privacy, I will not here give the location of the little grotto off the coast of Hammerfell where I found the nymph. It took three months of patient waiting, leaving presents where I knew the nymph would be, before the nymph stood still at my approach.
 
- I remember I was carrying a bouquet of purple and white
-tetias, and she looked at them and then at me, and smiled. The
-effect of her smile was truly magical, I'm convinced. Her
-body was, of course, perfect; her face lovely and serene; her
-hair like silk flame. But until she smiled, she was beautiful
-in the abstract, a perfect statue by a master. The smile made
-her approachable and, thus, terrifying.
+ I remember I was carrying a bouquet of purple and white tetias, and she looked at them and then at me, and smiled. The effect of her smile was truly magical, I'm convinced. Her body was, of course, perfect; her face lovely and serene; her hair like silk flame. But until she smiled, she was beautiful in the abstract, a perfect statue by a master. The smile made her approachable and, thus, terrifying.
 
- "For you," I said, attempting my first utterance of Nymph
-to a real nymph.
+ "For you," I said, attempting my first utterance of Nymph to a real nymph.
 
- Her smile grew into a grin which became a giggle and then a
-laugh. The reader has doubtless heard of the silver laughter
-of the elves. The nymph's laugh is earthy and spontaneous,
-and very ... suggestive.
+ Her smile grew into a grin which became a giggle and then a laugh. The reader has doubtless heard of the silver laughter of the elves. The nymph's laugh is earthy and spontaneous, and very ... suggestive.
 
  "And what do you want from me in return, mortal?" she asked.
 
- "I am," There is no, I should say, known word in the Nymph
-language for scholar, "I am a man who likes to learn things.
-I want to learn things about you."
+ "I am," There is no, I should say, known word in the Nymph language for scholar, "I am a man who likes to learn things. I want to learn things about you."
 
  And I did.
 
- Nymphs are the wisest, most wonderful creatures in Tamriel.
-My nymph, her name is Ayalea (a poor phonetic transcription
-of a word that sounds more like a light wind blowing through
-a small crack in a hollow chamber) and she knows more about
-the behavior and varieties of the deep woodland creatures
-than the greatest wood elf scholar I ever met. She taught me
-of flowers and ghosts and creatures too fast and timid to
-have ever been seen by man.
+ Nymphs are the wisest, most wonderful creatures in Tamriel. My nymph, her name is Ayalea (a poor phonetic transcription of a word that sounds more like a light wind blowing through a small crack in a hollow chamber) and she knows more about the behavior and varieties of the deep woodland creatures than the greatest wood elf scholar I ever met. She taught me of flowers and ghosts and creatures too fast and timid to have ever been seen by man.
 
- Ayalea taught me how to learn for the very first time. How to
-open my mind to all of the possibilities of life and how to
-use that knowledge, not just to hold in my cramped brain like
-a dragon's horde.
+ Ayalea taught me how to learn for the very first time. How to open my mind to all of the possibilities of life and how to use that knowledge, not just to hold in my cramped brain like a dragon's horde.
 
  If you ever meet a nymph, speak to her.
 
+[/center]* * *
 
-
- *    *    *
-
- Editor's note: the writer Vondham Barres is no longer a
-scholar at the Imperial University. He deposited this
-manuscript and disappeared from the civilized world. His
-current wherebouts are unknown.
-
-
-
-
-
-
-
-
-
-
-
-  
-
- 
+ Editor's note: the writer Vondham Barres is no longer a scholar at the Imperial University. He deposited this manuscript and disappeared from the civilized world. His current wherebouts are unknown.

--- a/Assets/StreamingAssets/Text/Books/BOK00022-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00022-LOC.txt
@@ -3,9 +3,8 @@ Author: Makela Leki
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,233 +12,64 @@ Content:
 
 [/center]of Makela Leki
 
-
-
 [/font=4]
 
-[/center]
+[/center]This is a faithful reproduction of the thoughts recorded in Makela Leki's memory stone, found in the Bankorai pass, in the year of reckoning 1E 973. Seven years before the fall of Orsinium due to the combined efforts of the armies of Daggerfall, Sentinel, and the Order of Diagna.
 
-This is a faithful reproduction of
-
-[/center]the thoughts recorded in Makela 
-
-[/center]Leki's memory stone, found in the
-
-[/center]Bankorai pass, in the year of
-
-[/center]reckoning 1E 973.  Seven years
-
-[/center]before the fall of Orsinium due to
-
-[/center]the combined efforts of the armies
-
-[/center]of Daggerfall, Sentinel, and the
-
-[/center]Order of Diagna. 
-
-[/center]
-
-[/center]Almost all of this is in the first
-
-[/center]person, as Makela was unfamiliar
-
-with the protocols and scholarly
-
-[/center]formalities of recording herself
-
-[/center]into a memory stone. None the less,
-
-[/center]her heroism and heroic deeds live
-
-[/center]on, her memories fresh in the stone
-
-[/center]for all to feel and hear.  
-
-
-
-
+[/center]Almost all of this is in the first person, as Makela was unfamiliar with the protocols and scholarly formalities of recording herself into a memory stone. None the less, her heroism and heroic deeds live on, her memories fresh in the stone for all to feel and hear.
 
  " . . . muuu uhh, I wonder if this will really work?"
 
- "The Mages guild took me for 25,000 gold crowns if it
-doesn't.  Imagine?  This stone will record my thoughts? What
-did they say? Just unwrap it from the silver foil and
-leather bag and as soon as it touches my flesh it will begin
-to record.  
+ "The Mages guild took me for 25,000 gold crowns if it doesn't. Imagine? This stone will record my thoughts? What did they say? Just unwrap it from the silver foil and leather bag and as soon as it touches my flesh it will begin to record.
 
- "Ahhhh, the pain, I must block it out, no one would want to
-hold my  stone and hear my thoughts if I let it record my
-pain. Thank the Ebonarm and the training I received in The Hall
-of the Virtues of War.  I CAN block out this pain. Ummm
-just, ah,  there, it's walled off.
+ "Ahhhh, the pain, I must block it out, no one would want to hold my stone and hear my thoughts if I let it record my pain. Thank the Ebonarm and the training I received in The Hall of the Virtues of War. I CAN block out this pain. Ummm just, ah, there, it's walled off.
 
- "Yes I can still see it there just beyond my consciousness
-lurking like a hungry wolf - a wolf that will soon  consume
-me. I see also my inevitable death from these damned wounds. 
-No potions left, the healing crystal and ring are used up,
-and me, with not even magic enough to light a candle.   Oh but
-the gods did give me other gifts, the gift of sword singing,
-the thrill of battle, Frandar  Hunding's Book of Circles,
-THE WAY OF THE SWORD. Ah but then that is my story, I get
-ahead of myself.  
+ "Yes I can still see it there just beyond my consciousness lurking like a hungry wolf - a wolf that will soon consume me. I see also my inevitable death from these damned wounds. No potions left, the healing crystal and ring are used up, and me, with not even magic enough to light a candle. Oh but the gods did give me other gifts, the gift of sword singing, the thrill of battle, Frandar Hunding's Book of Circles, THE WAY OF THE SWORD. Ah but then that is my story, I get ahead of myself.
 
- I am Makela Leki a warrior, a sword-singer, a second level
-Ansei. In  my cradle I could form the Shehai, the spirit sword
-- The mystical blade,  mine formed of pure thought serpents
-intertwined with vines of roses to  form the blade, as
-beautiful as ...  
+ I am Makela Leki a warrior, a sword-singer, a second level Ansei. In my cradle I could form the Shehai, the spirit sword - The mystical blade, mine formed of pure thought serpents intertwined with vines of roses to form the blade, as beautiful as ...
 
- Ah, but I'm about to tell you all about that, to tell you
-my story, a story of valiant battle, of my loves, of my
-wars, of. of betrayal and of this last glorious victory.
-To tell you of how I came to this distant lonely pass me and
-five companions, to fight these men and monsters to  defeat
-the army that would fall on my people like cowards in the
-night, but again I get ahead of myself.  
+ Ah, but I'm about to tell you all about that, to tell you my story, a story of valiant battle, of my loves, of my wars, of. of betrayal and of this last glorious victory. To tell you of how I came to this distant lonely pass me and five companions, to fight these men and monsters to defeat the army that would fall on my people like cowards in the night, but again I get ahead of myself.
 
- I am a simple warrior. I grew up as a Maiden of the Spirit
-Blade.  As early as I can remember I wanted to be a Singer, to
-feel the hunger of  the blade in my hands, to feel it come
-alive and take my enemies. I am  told our people were
-artisans and poets long ago in our desert homes.   Here in new
-home now known as Hammerfell, many of us have returned  to
-those ancient ways, but to me there is but ONE WAY. THE WAY 
-of the SWORD.   
+ I am a simple warrior. I grew up as a Maiden of the Spirit Blade. As early as I can remember I wanted to be a Singer, to feel the hunger of the blade in my hands, to feel it come alive and take my enemies. I am told our people were artisans and poets long ago in our desert homes. Here in new home now known as Hammerfell, many of us have returned to those ancient ways, but to me there is but ONE WAY. THE WAY of the SWORD.
 
- Ah this is hard to tell. I grew up in my noble family, the
-only one of  three brothers and two sisters that felt the
-calling, the Song of the  Sword. Father understood, for he too
-had felt the call. He had become a master, and Ansei long
-before settling down with in our estate to raise a family.
-At eleven, I entered the Hall of the Virtues of War and
-joined the Maidens of the Spirit Sword. In my band there were
-six of us. Daring Julia, solid Patia, big Kati, svelte
-Cegila, wise Zell, and me - all are gone now, save me, and
-soon I will join them. ... Join them in the halls of the
-unknown gods of war.
+ Ah this is hard to tell. I grew up in my noble family, the only one of three brothers and two sisters that felt the calling, the Song of the Sword. Father understood, for he too had felt the call. He had become a master, and Ansei long before settling down with in our estate to raise a family. At eleven, I entered the Hall of the Virtues of War and joined the Maidens of the Spirit Sword. In my band there were six of us. Daring Julia, solid Patia, big Kati, svelte Cegila, wise Zell, and me - all are gone now, save me, and soon I will join them. ... Join them in the halls of the unknown gods of war.
 
- We drank together, we fought, we  wept, we grew in the way of
-the sword. We joined in our learnings in the Hall with our
-Brothers of the Blade. Learning from each other, we all sat
-at the feet of the Hall Master striving to learn the depths of
-the  Shehai - making the spirit blade into a real weapon as
-Frandar Hunding had. Only a few have the purity of heart and
-virtue to be able to take the step and learn the mysteries of
-Ansei. Sword Sainthood.  
+ We drank together, we fought, we wept, we grew in the way of the sword. We joined in our learnings in the Hall with our Brothers of the Blade. Learning from each other, we all sat at the feet of the Hall Master striving to learn the depths of the Shehai - making the spirit blade into a real weapon as Frandar Hunding had. Only a few have the purity of heart and virtue to be able to take the step and learn the mysteries of Ansei. Sword Sainthood.
 
- Somehow, of all the Brothers and the Maidens, I only
-possessed the unique qualities, the faint but strong enough
-flicker of magicka to call forth the Shehai. Many times I
-called it, seldom would it become substantial enough to be a
-weapon. To be a Ansei of the first level you just need to be
-able to call it, and that I could, so I became the first
-Ansei from our local hall in two generations. 
+ Somehow, of all the Brothers and the Maidens, I only possessed the unique qualities, the faint but strong enough flicker of magicka to call forth the Shehai. Many times I called it, seldom would it become substantial enough to be a weapon. To be a Ansei of the first level you just need to be able to call it, and that I could, so I became the first Ansei from our local hall in two generations.
 
- Oh I have so much to tell, so many memories, so many
-treasures to share with you, my unknown companion. How do I
-start?
+ Oh I have so much to tell, so many memories, so many treasures to share with you, my unknown companion. How do I start?
 
- Umhhh, the pain is still out there lurking hungry, slowly
-consuming what's left of me. I guess I had better tell of the
-final battle, the one that has left me here, and then if I
-have the will left tell you of my life, of my love  Raliph.
-OH what a lad he was. What times we shared ... Ebonarm ...
-Forgive me, my mind wanders ...  Let me go to the  Final
-Battle.  
+ Umhhh, the pain is still out there lurking hungry, slowly consuming what's left of me. I guess I had better tell of the final battle, the one that has left me here, and then if I have the will left tell you of my life, of my love Raliph. OH what a lad he was. What times we shared ... Ebonarm ... Forgive me, my mind wanders ... Let me go to the Final Battle.
 
- Umm to start, in the middle humm. Yes. We Maidens grew,
-learned, mastered the Way, and upon completing the
-Walk-About. To you who are not Singers, this is a wilderness
-trek emulating the times of Frandar Hunding - where we each
-wander the country side righting wrongs, defeating monsters,
-performing quests in the name of virtue. Some of us in our
-Hall took years to finish. Always there is danger, we six
-Maidens each returned in our own good time, but many are they
-who do not live to return from the Walk About.   
+ Umm to start, in the middle humm. Yes. We Maidens grew, learned, mastered the Way, and upon completing the Walk-About. To you who are not Singers, this is a wilderness trek emulating the times of Frandar Hunding - where we each wander the country side righting wrongs, defeating monsters, performing quests in the name of virtue. Some of us in our Hall took years to finish. Always there is danger, we six Maidens each returned in our own good time, but many are they who do not live to return from the Walk About.
 
- We returned, each to our own lives, to meet in the hall once
-a week to tell our stories to the new Maidens and Brothers,
-and to perform as instructors in the Way of the sword.  All
-was well till the night of the MidYear Festival.
+ We returned, each to our own lives, to meet in the hall once a week to tell our stories to the new Maidens and Brothers, and to perform as instructors in the Way of the sword. All was well till the night of the MidYear Festival.
 
- All our people were reveling and ...  excuse ... enjoying
-the repast, but for we six Maidens.  It happened that the 
-festival day fell on our day of meeting in the hall, our
-day of prayer and  fasting and honor to the Way of the
-Sword.  
+ All our people were reveling and ... excuse ... enjoying the repast, but for we six Maidens. It happened that the festival day fell on our day of meeting in the hall, our day of prayer and fasting and honor to the Way of the Sword.
 
- As we met, late into the night, a knocking rang on our door. 
-When I opened, it there was a guardian the Bankorai Pass in
-the Wrothgarian Mountains, wounded and near death ... He
-told us of betrayal from the  north, an invasion sponsored
-by the Crystal Tower of High Rock, led by King Joile of
-Daggerfall -- our ally in the war with Orsinium!
+ As we met, late into the night, a knocking rang on our door. When I opened, it there was a guardian the Bankorai Pass in the Wrothgarian Mountains, wounded and near death ... He told us of betrayal from the north, an invasion sponsored by the Crystal Tower of High Rock, led by King Joile of Daggerfall -- our ally in the war with Orsinium!
 
- Quickly we used up a crystal of healing in restoring him to
-vitality. We sent him on to the king, while we six grabbed our
-weapons and armor of power, and as many potions, marks,
-and crystals and rings as we could carry.  
+ Quickly we used up a crystal of healing in restoring him to vitality. We sent him on to the king, while we six grabbed our weapons and armor of power, and as many potions, marks, and crystals and rings as we could carry.
 
- We flew to the pass hoping upon hope that we would not be
-too late. Our journey was not in vain, for we arrived just
-at the very point where the last three guardians were
-overwhelmed by the horde.  Into the pass we ran forming the
-old battle line, six abreast.
+ We flew to the pass hoping upon hope that we would not be too late. Our journey was not in vain, for we arrived just at the very point where the last three guardians were overwhelmed by the horde. Into the pass we ran forming the old battle line, six abreast.
 
  OH did we FIGHT.
 
- The Song of the Sword was a joyous noise slicing through the
-ranks of evil.  We fought for hours. Julia was the first to
-fall, a cowardly poisoned dagger finding a rent in her
-armor. Then one by one all fell, save me.
+ The Song of the Sword was a joyous noise slicing through the ranks of evil. We fought for hours. Julia was the first to fall, a cowardly poisoned dagger finding a rent in her armor. Then one by one all fell, save me.
 
- ... oh cruel Ebonarm ...    Then my beloved sword, the sword
-of my father, the one with the serpent's crest, fashioned by
-the master sword smith Singer Tansal broke in my hands. All
-was lost, our six lives spent in vain. Now, many many of
-them would pour through the pass. I would be easy prey for
-them, like a newborn child. I wept in frustration.  
+ ... oh cruel Ebonarm ... Then my beloved sword, the sword of my father, the one with the serpent's crest, fashioned by the master sword smith Singer Tansal broke in my hands. All was lost, our six lives spent in vain. Now, many many of them would pour through the pass. I would be easy prey for them, like a newborn child. I wept in frustration.
 
- Then I remembered the hearth in our home - the book.  Frandar
-Hunding's Book of Circles, the Way of Strategy.  I reached
-for the Shehai the spirit sword, that which I could never
-reliably form when I needed it, and behold ... it was alive.  
-  Alive with fire. It formed in my hand. Ablaze with power ---
-OH I slew mightily, right and left, like a scythe through
-wheat.  All the way to the Lord of the Tower I fought.  With
-one blow I cut his magical armor asunder, one more took his
-head.
+ Then I remembered the hearth in our home - the book. Frandar Hunding's Book of Circles, the Way of Strategy. I reached for the Shehai the spirit sword, that which I could never reliably form when I needed it, and behold ... it was alive. Alive with fire. It formed in my hand. Ablaze with power --- OH I slew mightily, right and left, like a scythe through wheat. All the way to the Lord of the Tower I fought. With one blow I cut his magical armor asunder, one more took his head.
 
- But to do that deed cost me dearly, wounds by the dozen, for
-although I had magical armor, it was not formed of spirit
-like my blade, it was not as invincible as my blade or my own
-spirit, and I was sorely wounded.  
+ But to do that deed cost me dearly, wounds by the dozen, for although I had magical armor, it was not formed of spirit like my blade, it was not as invincible as my blade or my own spirit, and I was sorely wounded.
 
- With the felling of King Joile, his army crumbled. They fled
-before my wrath. All ran back through the pass not even
-pausing to collect their dead and wounded. All who could
-stand ran for their lives, and I slew all I could reach, but
-my breath was coming short, and the pain ...
+ With the felling of King Joile, his army crumbled. They fled before my wrath. All ran back through the pass not even pausing to collect their dead and wounded. All who could stand ran for their lives, and I slew all I could reach, but my breath was coming short, and the pain ...
 
- Finally I rested, on this rock where you find me now. I don't
-know why I chanced to bring this stone along. I bought it on a
-whim really, with the loot from ... ah well I guess I need to
-really stop and  tell my story in order. I feel able to go
-on to tell you more ... the eternal night is descending more
-slowly than I thought.
+ Finally I rested, on this rock where you find me now. I don't know why I chanced to bring this stone along. I bought it on a whim really, with the loot from ... ah well I guess I need to really stop and tell my story in order. I feel able to go on to tell you more ... the eternal night is descending more slowly than I thought.
 
- Not just yet, am I ready to compose my death poem.  A
-little sip of water and ... well I think I will go back and
-tell you of my life, maybe some details about the battle.
-And Oh yes. About Raliph and our children, humm where will I
-start.  
+ Not just yet, am I ready to compose my death poem. A little sip of water and ... well I think I will go back and tell you of my life, maybe some details about the battle. And Oh yes. About Raliph and our children, humm where will I start.
 
  ... oh ... rrr ...
 
- I am ... a simple warrior ... I grew up as a, a Maiden of the
-Spirit Blade ... As early ... as early as I can ... remember
-...  
-
-
-
- 
+ I am ... a simple warrior ... I grew up as a, a Maiden of the Spirit Blade ... As early ... as early as I can ... remember ...

--- a/Assets/StreamingAssets/Text/Books/BOK00025-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00025-LOC.txt
@@ -1,148 +1,37 @@
 Title: Legal Basics
-Author: Anchivius, M.Z.F. 
+Author: Anchivius, M.Z.F.
 IsNaughty: False
 Price: 636
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
 
-
 [/font=2]
-
 [/center]Legal Basics
 
-
-
 [/font=4]
+ Ignorance of the law is no defense. Be forewarned that the following are but the most universal of Tamrielan laws and regulations. Your own local province or principality may have unique laws of its own. As a citizen of Empire, it is your right and responsibility to know and follow these laws of the land.
 
-[/center]
+ Breaking and Entering: This refers to any act including, but not limited to opening, breaking, incinerating, magically transporting, or in any way causing a door, window, or other portal that has been magically or mundanely locked or which a reasonable person would assume to be so restricted to be passable, and the act (though the act is not required for the definition) of entering the house, business, or public location through said defined portal. The punishment for this crime may include a fine or incarceration, or a fine and incarceration. The fine and incarceration, or both, or neither, may be less in a crime of Attempted Breaking and Entering. A crime of Attempted Breaking and Entering is defined as an any act that a reasonable person would perceive as the preparation for, an attempt (whether successful or not, or perceived to be possibly successful or not) to bring about the opening, breaking, incinerating, magically transporting, or in any way causing a door, window, or other portal that has been magically or mundanely locked or which a reasonable person would assume to be so restricted to be passable, and the act (though the act is not required for the definition) of preparing or attempting (whether successful or not, perceived to be possibly successful or not) entering the house, business, or public location through said defined portal.
 
-[/center]    Ignorance of the law is no defense. Be forewarned that the
-following are but the most universal of Tamrielan laws and
-regulations. Your own local province or principality may
-have unique laws of its own. As a citizen of Empire, it is
-your right and responsibility to know and follow these laws
-of the land.
+ Trespassing: This refers to walking, flying, riding, teleporting, floating, or in any way moving or existing on a property without the explicit written or spoken permission (or permission a reasonable person might infer) of the owner or caretaker of the property. The punishment for this crime may include a fine or incarceration, or a fine and incarceration.
 
-    Breaking and Entering:    This refers to any act including,
-but not limited to opening, breaking, incinerating,
-magically transporting, or in any way causing a door,
-window, or other portal that has been magically or
-mundanely locked or which a reasonable person would assume
-to be so restricted to be passable, and the act (though the
-act is not required for the definition) of entering the house,
-business, or public location through said defined portal.
-The punishment for this crime may include a fine or
-incarceration, or a fine and incarceration.    The fine and
-incarceration, or both, or neither, may be less in a crime of
-Attempted Breaking and Entering. A crime of Attempted
-Breaking and Entering is defined as an any act that a
-reasonable person would perceive as the preparation for,
-an attempt (whether successful or not, or perceived to be
-possibly successful or not) to bring about the opening,
-breaking, incinerating, magically transporting, or in any
-way causing a door, window, or other portal that has been
-magically or mundanely locked or which a reasonable person
-would assume to be so restricted to be passable, and the act
-(though the act is not required for the definition) of
-preparing or attempting (whether successful or not,
-perceived to be possibly successful or not) entering the
-house, business, or public location through said defined
-portal.
+ Assault Any threat or attempt (whether successful or not) to do physical, emotional, mental, or magical harm or injury to another person, group of persons, or entity a reasonable person might assume to be sentient. The punishment for this crime may include a fine or incarceration, or a fine and incarceration.
 
-     Trespassing:     This refers to walking, flying, riding,
-teleporting, floating, or in any way moving or existing on
-a property without the explicit written or spoken
-permission (or permission a reasonable person might infer)
-of the owner or caretaker of the property. The punishment for
-this crime may include a fine or incarceration, or a fine
-and incarceration.
+ Murder Any act of premeditated or malicious or premeditated and malicious (or an act that a reasonable person would call premeditated and malicious or premeditated or malicious) or accidental but criminally intended (or what a reasonable person would call criminally intended) purpose that results directly in the death (or destruction with implied death) of a person, group of persons, or entity a reasonable person might assume to be sentient. The punishment for this crime may include a fine or incarceration, or a fine and incarceration.
 
-     Assault     Any threat or attempt (whether successful or
-not) to do physical, emotional, mental, or magical harm or
-injury to another person, group of persons, or entity a
-reasonable person might assume to be sentient. The
-punishment for this crime may include a fine or
-incarceration, or a fine and incarceration.
+ Criminal Conspiracy Any meeting, communication, or encounter with the purpose (or which a reasonable person might assume had the purpose) of preparing or arranging a crime of any kind (or crimes of any kind) to be commited or caused to be commited. The punishment for this crime may include a fine or incarceration, or a fine and incarceration.
 
-     Murder     Any act of premeditated or malicious or
-premeditated and malicious (or an act that a reasonable
-person would call premeditated and malicious or
-premeditated or malicious) or accidental but criminally
-intended (or what a reasonable person would call
-criminally intended) purpose that results directly in the
-death (or destruction with implied death) of a person,
-group of persons, or entity a reasonable person might
-assume to be sentient. The punishment for this crime may
-include a fine or incarceration, or a fine and
-incarceration.
+ Vagrancy Any act of idleness, disorder, begging, or conduct unbecoming a person with occupation, gold, or a home, (or occupation, gold, and a home, or occupation or gold and home, or occupation and gold or home, or occupation and home or gold), or what a reasonable person would consider idle, disorderly, beggarly, or unbecoming. The punishment for this crime may include a fine or incarceration, or a fine and incarceration.
 
-     Criminal Conspiracy     Any meeting, communication, or
-encounter with the purpose (or which a reasonable person
-might assume had the purpose) of preparing or arranging a
-crime of any kind (or crimes of any kind) to be commited or
-caused to be commited. The punishment for this crime may
-include a fine or incarceration, or a fine and
-incarceration.
+ Smuggling Any act of bringing in, taking out, teleporting, or causing to be brought in, taken out, or teleported an object considered illegal or, if not illegal, requiring an import or export tax which is not paid. The punishment for this crime may include a fine or incarceration, or a fine and incarceration, and will include confiscation of the offensive or illegal object. It may also include, but not be restricted to, execution or banishment, or execution and banishment.
 
-     Vagrancy     Any act of idleness, disorder, begging, or
-conduct unbecoming a person with occupation, gold, or a
-home, (or occupation, gold, and a home, or occupation or
-gold and home, or occupation and gold or home, or
-occupation and home or gold), or what a reasonable person
-would consider idle, disorderly, beggarly, or unbecoming.
-The punishment for this crime may include a fine or
-incarceration, or a fine and incarceration.
+ High Treason Any act against (whether directly or indirectly, or any nonaction which results in circumstances, directly or indirectly, against) a allegiated sovereign or by a vassal to a liege, resulting (or what a reasonable person would assume would result) in physical, emotional, mental, or magical harm or injury in said sovereign or liege. The punishment for this crime will be death.
 
-     Smuggling     Any act of bringing in, taking out,
-teleporting, or causing to be brought in, taken out, or
-teleported an object considered illegal or, if not
-illegal, requiring an import or export tax which is not paid.
-The punishment for this crime may include a fine or
-incarceration, or a fine and incarceration, and will
-include confiscation of the offensive or illegal object. It
-may also include, but not be restricted to, execution or
-banishment, or execution and banishment.
+ Pickpocketing Any act of stealing, taking, or, without explicit written or verbal permission (or what a reasonable person would infer as implied permission) an item or items a person, group of persons, or entity a reasonable person might assume to be sentient has on his, her, its, or their own person. The punishment for this crime may include a fine or incarceration, or a fine and incarceration.
 
-     High Treason     Any act against (whether directly or
-indirectly, or any nonaction which results in
-circumstances, directly or indirectly, against) a
-allegiated sovereign or by a vassal to a liege, resulting
-(or what a reasonable person would assume would result) in
-physical, emotional, mental, or magical harm or injury in
-said sovereign or liege. The punishment for this crime will
-be death.
+ Theft (sometimes called Larceny) Any act of stealing, taking, or, without explicit written or verbal permission (or what a reasonable person would infer as implied permission) an item or items from a person, group of persons, or entity a reasonable person might assume to be sentient's place of residence, business, person, or other location a reasonable person would assume is secured from looting. The punishment for this crime may include a fine or incarceration, or a fine and incarceration.
 
-     Pickpocketing     Any act of stealing, taking, or, without
-explicit written or verbal permission (or what a
-reasonable person would infer as implied permission) an
-item or items a person, group of persons, or entity a
-reasonable person might assume to be sentient has on his,
-her, its, or their own person. The punishment for this crime
-may include a fine or incarceration, or a fine and
-incarceration.
+ These are the usual, day-to-day definitions used by legal experts (like myself), but both the definitions and punishments may fluctuate wildly according to location and situation. In the Imperial City, legal counsel is available by persons like myself, but the provinces have no such system in place. Perhaps that will change in time. We can all hope so.
 
-     Theft     (sometimes called Larceny)     Any act of
-stealing, taking, or, without explicit written or verbal
-permission (or what a reasonable person would infer as
-implied permission) an item or items from a person, group of
-persons, or entity a reasonable person might assume to be
-sentient's place of residence, business, person, or other
-location a reasonable person would assume is secured from
-looting. The punishment for this crime may include a fine or
-incarceration, or a fine and incarceration.
-
-     These are the usual, day-to-day definitions used by legal
-experts (like myself), but both the definitions and
-punishments may fluctuate wildly according to location
-and situation. In the Imperial City, legal counsel is
-available by persons like myself, but the provinces have no
-such system in place. Perhaps that will change in time. We
-can all hope so.
-
-     As a final note: the Tamriel legal system has its basis in
-the civilized, reasonable credo uttered by the prophet
-Marukh in the first era: "All are guilty until they have
-proven themselves innocent." Were truer word ever spoke?
-
- 
+ As a final note: the Tamriel legal system has its basis in the civilized, reasonable credo uttered by the prophet Marukh in the first era: "All are guilty until they have proven themselves innocent." Were truer word ever spoke?

--- a/Assets/StreamingAssets/Text/Books/BOK00026-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00026-LOC.txt
@@ -3,9 +3,8 @@ Author: Pellarne Assi
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,86 +14,24 @@ Content:
 
 [/center]Darkness
 
-
-
 [/font=4]
 
+ As their name suggests, the Dark Brotherhood has a history shrouded in obfuscation. Their ways are secret to those who are not Brothers of the order (Brothers is the generic term: some of the deadliest of the assassins are female, but they are called Brothers as well). How they continue to exist in shadow, but can be easily found by those desparate enough to pay for their services is not the least of their mysteries.
 
+ The Dark Brotherhood sprang from a religious order, the Morag Tong, during the Second Era. The Morag Tong were worshippers of the daedra spirit Mephala, who encouraged them to commit ritual murders. In their early years, they were as disorganized as cultists usually are. There was no one to lead the group, and as a group they dared not murder any of any importance. This changed with the rise of the Night Mother.
 
-[/center]    As their name suggests, the Dark Brotherhood has a history
-shrouded in obfuscation. Their ways are secret to those who
-are not Brothers of the order (Brothers is the generic term:
-some of the deadliest of the assassins are female, but they
-are called Brothers as well). How they continue to exist in
-shadow, but can be easily found by those desparate enough
-to pay for their services is not the least of their mysteries.  
- The Dark Brotherhood sprang from a religious order, the
-Morag Tong, during the Second Era. The Morag Tong were
-worshippers of the daedra spirit Mephala, who encouraged
-them to commit ritual murders. In their early years, they
-were as disorganized as cultists usually are. There was no
-one to lead the group, and as a group they dared not murder
-any of any importance. This changed with the rise of the
-Night Mother.    All leaders of the Morag Tong, and then the
-Dark Brotherhood, have been called the Night Mother. Whether
-the same woman has commanded the Dark Brotherhood since the
-second era is unknown. What is believed is that the original
-Night Mother developed an important belief of the Morag
-Tong.    This first belief is that, while Mephala grows
-stronger with every murder commited in her name, certain
-murders were better than others. Murders that came from hate
-pleased Mephala more than murders commited because of greed.
-Murders of great men and women pleased Mephala more than
-murders of unknowns.    We can approximate the time this
-belief was adopted with the first known murder commited by the
-Morag Tong. In the year 324 of the 2nd Era, the Potentate
-Versidue-Shaie was murdered in his palace in what is today the
-Elsweyr kingdom of Senchal. In a brash move, the Night Mother
-announced the identity of the murderers by painting MORAG
-TONG on the walls in the Potentate's blood.    Previous to
-that time, the Morag Tong existed in relative peace, like a
-witches coven. Occasionally persecuted, but usually
-ignored. In a remarkable syncroncity at a time when the Arena
-was a fractured land, the Morag Tong was outlawed
-throughout the continent. Every sovereign gave the cult's
-elimination his highest priority. Nothing more was
-officially heard of them for a hundred years.    It is more
-difficult to date the era when the Morag Tong re-emerged as
-the Dark Brotherhood. Assassin guilds have sporadically
-appeared throughout the history of Tamriel. The first
-mention of the Dark Brotherhood that I have found is from the journals of the Blood
-Queen Arlimahera of Hegathe: she spoke of slaying her enemies
-by her own hand, or, if necessary, "with the help of the Night
-Mother and her Dark Brotherhood, the secret arsenal my family
-has employed since my grandfather's time." Arlimahera wrote
-this in 2E 412, so one can surmise that the Dark Brotherhood had
-been in existance since at least 360 if her grandfather truly
-used them.    The important distinction between the Dark
-Brotherhood and the Morag Tong was that the Brotherhood was a
-business as much as a cult. Rulers and wealthy merchants now
-used the order as an assassin's guild. The Brotherhood gained
-the obvious benefits of a profitable enterprise, as well as
-the secondary benefit that no longer could rulers actively
-persecute them. They were needed. Even an extremely virtuous leader would be unwise to maltreat the Brotherhood.   
-Not long after Alimahera's journal entry about them was
-penned came perhaps the most famous series of executions in
-the history of the Dark Brotherhood. The Colovian Emperor
-Potentate Savirien-Chorak and every one of his heirs was
-murdered on one bloody night in Sun's Dawn in 430. Within a
-fortnight, the Colovian Dynasty crumbled, to the delight of
-its enemies. For over four hundred years, until the age of
-Tiber Septim, chaos reigned over Tamriel. Though no
-comparably impressive executions have been recorded, the
-Brotherhood must have grown fat with gold during that age.   
-The Dark Brotherhood has no shortage of business
-opportunities -- an accounting, I have been informed, is the
-Brotherhood's favorite euphemism for execution. While they
-are officially an unlawful organization in every corner
-of the Empire, like the Thieves Guild, they are almost
-universally tolerated.
+ All leaders of the Morag Tong, and then the Dark Brotherhood, have been called the Night Mother. Whether the same woman has commanded the Dark Brotherhood since the second era is unknown. What is believed is that the original Night Mother developed an important belief of the Morag Tong.
 
+ This first belief is that, while Mephala grows stronger with every murder commited in her name, certain murders were better than others. Murders that came from hate pleased Mephala more than murders commited because of greed. Murders of great men and women pleased Mephala more than murders of unknowns.
 
+ We can approximate the time this belief was adopted with the first known murder commited by the Morag Tong. In the year 324 of the 2nd Era, the Potentate Versidue-Shaie was murdered in his palace in what is today the Elsweyr kingdom of Senchal. In a brash move, the Night Mother announced the identity of the murderers by painting MORAG TONG on the walls in the Potentate's blood.
 
+ Previous to that time, the Morag Tong existed in relative peace, like a witches coven. Occasionally persecuted, but usually ignored. In a remarkable syncroncity at a time when the Arena was a fractured land, the Morag Tong was outlawed throughout the continent. Every sovereign gave the cult's elimination his highest priority. Nothing more was officially heard of them for a hundred years.
 
+ It is more difficult to date the era when the Morag Tong re-emerged as the Dark Brotherhood. Assassin guilds have sporadically appeared throughout the history of Tamriel. The first mention of the Dark Brotherhood that I have found is from the journals of the Blood Queen Arlimahera of Hegathe: she spoke of slaying her enemies by her own hand, or, if necessary, "with the help of the Night Mother and her Dark Brotherhood, the secret arsenal my family has employed since my grandfather's time." Arlimahera wrote this in 2E 412, so one can surmise that the Dark Brotherhood had been in existance since at least 360 if her grandfather truly used them.
 
- 
+ The important distinction between the Dark Brotherhood and the Morag Tong was that the Brotherhood was a business as much as a cult. Rulers and wealthy merchants now used the order as an assassin's guild. The Brotherhood gained the obvious benefits of a profitable enterprise, as well as the secondary benefit that no longer could rulers actively persecute them. They were needed. Even an extremely virtuous leader would be unwise to maltreat the Brotherhood.
+
+ Not long after Alimahera's journal entry about them was penned came perhaps the most famous series of executions in the history of the Dark Brotherhood. The Colovian Emperor Potentate Savirien-Chorak and every one of his heirs was murdered on one bloody night in Sun's Dawn in 430. Within a fortnight, the Colovian Dynasty crumbled, to the delight of its enemies. For over four hundred years, until the age of Tiber Septim, chaos reigned over Tamriel. Though no comparably impressive executions have been recorded, the Brotherhood must have grown fat with gold during that age.
+
+ The Dark Brotherhood has no shortage of business opportunities -- an accounting, I have been informed, is the Brotherhood's favorite euphemism for execution. While they are officially an unlawful organization in every corner of the Empire, like the Thieves Guild, they are almost universally tolerated.

--- a/Assets/StreamingAssets/Text/Books/BOK00027-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00027-LOC.txt
@@ -3,9 +3,8 @@ Author: Hardin
 IsNaughty: False
 Price: 453
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,75 +14,22 @@ Content:
 
 [/center]Tamriel
 
-
-
 [/font=4]
 
+ Poppies, both black and white, can be found growing wild in the mountains of Hammerfell. Their succulent pods are often the only nourishment of adventurers who find themselves in the wilderness without rations. It is said that the black and white poppies together have magical properties. When they are crushed and mixed with the milk of the agile footed mountain goat, a potion that allows the user to glide safely above the ground can be made.
 
+ Fire Fern, a perennial herb, native to Morrowind. The flowers are inconspicuous and often hidden. The glossy, evergreen foliage and flowers are resistant to the conditions of high heat and bright light. A petal from this plant placed under an adventurer's tongue will provide protection from the heat and fire found in the lava pits and streams found around Dagoth-Ur.
 
-[/center] Poppies, both black and white, can be found growing wild in
-the mountains of Hammerfell. Their succulent pods are often
-the only nourishment of adventurers who find themselves in
-the wilderness without rations. It is said that the black and
-white poppies together have magical properties. When they
-are crushed and mixed with the milk of the agile footed
-mountain goat, a potion that allows the user to glide
-safely above the ground can be made.
+ Dragon's-Tongue, common name for a fern like herb found in Black Marsh. It is especially prolific around the area of Utherus Swamp. It is a beautiful wildflower. Its name comes from the fire red fronds that protect its golden flower. As pretty as it is, it is a deadly poison to most living beings and needs to be avoided by adventurers. It is said, however, that Argonians can pick the plant and use the sap derived from its roots as an enhancement to their endurance.
 
- Fire Fern, a perennial herb, native to Morrowind. The
-flowers are inconspicuous and often hidden. The glossy,
-evergreen foliage and flowers are resistant to the
-conditions of high heat and bright light. A petal from this
-plant placed under an adventurer's tongue will provide
-protection from the heat and fire found in the lava pits and
-streams found around Dagoth-Ur.      Dragon's-Tongue, common
-name for a fern like herb found in Black Marsh. It is
-especially prolific around  the area of Utherus Swamp. It is
-a beautiful wildflower. Its name comes from the fire red
-fronds that protect its golden flower. As pretty as it is,
-it is a deadly poison to most living beings and needs to be
-avoided by adventurers. It is said, however, that Argonians
-can pick the plant and use the sap derived from its roots as
-an enhancement to their endurance. 
+ Domica Redwort is a herb grown by many residents of Valenwood for their beautiful and showy flowers. They attain a height of about three feet and have feathery leaves; the flowers are usually bright red. In addition to their beauty, they are said to have magical abilities to enhance the appearance of anyone who carries or wears one of the flowers.
 
- Domica Redwort is a herb grown by many residents of
-Valenwood for their beautiful and showy flowers. They
-attain a height of about three feet and have feathery leaves;
-the flowers are usually bright red. In addition to their
-beauty, they are said to have magical abilities to enhance
-the appearance of anyone who carries or wears one of the
-flowers.
+ Ironwood Nut, this rare nut comes from the Ironwood trees which grow deep in the forests of Skyrim. The wood from these trees is as hard as the metal for which they are named. The very rare black ironwood tree is said to produce a nut which is very succulent and is believed to enhance the strength of the adventurer who is able to crack its shell.
 
- Ironwood Nut, this rare nut comes from the Ironwood trees
-which grow deep in the forests of Skyrim. The  wood from these
-trees is as hard as the metal for which they are named. The
-very rare black ironwood tree is said to produce a nut which
-is very succulent and is believed to enhance the strength of
-the adventurer who is able to crack its shell.
+ The Ginko leaves which are found along the banks of rivers and lakes in Hammerfell are most inconspicuous, only its peculiar halfmoon shape makes it noticeable. It is very sweet and tasty. Legend has it that when mixed properly with the pulp of the Aloe plant, the potion has the ability to increase one's stamina for a short while.
 
- The Ginko leaves which are found along the banks of rivers and
-lakes in Hammerfell are most inconspicuous, only its
-peculiar halfmoon shape makes it noticeable. It is very sweet
-and tasty. Legend has it that when mixed properly with the
-pulp of the Aloe plant, the potion has the ability to
-increase one's stamina for a short while.
+ The Somnalius Fern can be found in the swamps of Black Marsh. The fronds from this plant are light green and quite delicate. Picking a frond can be very difficult, but once retrieved it can be used to put an enemy to sleep for a short while by passing it under his nose.
 
- The Somnalius Fern can be found in the swamps of Black
-Marsh. The fronds from this plant are light green and quite delicate.
-Picking a frond can be very difficult, but once retrieved it
-can be used to put an enemy to sleep for a short while by
-passing it under his nose.
+ Arrowroot is a thick, rubbery tuber that can be found in the Province of Valenwood. The plant is very difficult to find as its above ground foliage is very meager and scrawny. But the Arrowroot itself can be most beneficial to the gatherer as it has magical properties. The paste made from grinding the root is very tasty and can improve the user's accuracy with a bow and arrow.
 
- Arrowroot is a thick, rubbery tuber that can be found in the
-Province of Valenwood. The plant is very difficult to
-find as its above ground foliage is very meager and
-scrawny. But the Arrowroot itself can be most beneficial to
-the gatherer as it has magical properties. The paste made
-from grinding the root is very tasty and can improve the
-user's accuracy with a bow and arrow.
-
- Nightshade is reputed to be a very poisonous herb. However
-the variety found in many parts of Elsweyr is cherished by
-Khajiits who have followed the career path of thievery. Many
-Khajiits will tuck a piece of Nightshade inside their armor to
-increase their abilities to skulk, hide and become invisible. 
+ Nightshade is reputed to be a very poisonous herb. However the variety found in many parts of Elsweyr is cherished by Khajiits who have followed the career path of thievery. Many Khajiits will tuck a piece of Nightshade inside their armor to increase their abilities to skulk, hide and become invisible.

--- a/Assets/StreamingAssets/Text/Books/BOK00028-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00028-LOC.txt
@@ -3,93 +3,38 @@ Author: Stronach
 IsNaughty: False
 Price: 352
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
 
 [/font=2]
+
 [/center]A Brief History
+
 [/center]of the Empire,
+
 [/center]Part I
 
 [/font=4]
-[/center]
-[/center]    Before the day of Tiber Septim, all Tamriel was chaos.
-The poet Tracizis called that era "the days and nights of
-blood and venom." The kings were a petty lot of grasping
-tyrants, who fought Tiber's attempts to bring order to the
-land. But they were as disorganized as they were dissolute,
-and the strong hand of Septim brought peace forcibly to
-Tamriel. The year was 2E 896. The following year, the
-Emperor declared the beginning of a new era, so we began the
-3rd Era, year aught.    For thirty-eight years, the Emperor
-Tiber reigned: a just, pious, and glorious age, when justice
-was known to one and all, from serf to king. It rained for a
-fortnight after as if the land of Tamriel itself was weeping.    The
-Emperor's eldest living son, Pelagius came to the throne.
-Though his reign was short, he was as strong and resolute as
-his father had been, and we could have enjoyed a continuation
-of the Golden Age. Alas, an unknown enemy of the Septims
-hired the cursed organization of cutthroats, the Dark
-Brotherhood, to kill the Emperor Pelagius I as he knelt at
-prayer at the Temple of the One in the Imperial City.
-Pelagius I's reign lasted less than three years.    Pelagius
-had no living children, so the crown of the Empire passed to
-his first cousin, the daughter of Tiber's brother Agnorith. So did
-Kintyra, former Queen of Silvenar, assume the throne.
-Kintyra I was blessed with a time of prosperity and good
-harvests, and was an avid patroness of art, music, and
-dance.    Kintyra's son was crowned after her death, the first
-Emperor of Tamriel to use the imperial name Uriel. The
-Emperor Uriel I was the great lawmaker of the Septim Dynasty,
-and a promoter of independent organizations and guilds.
-Under his kind hand, the Fighters Guild and the Mages Guild
-increased in prominence throughout Tamriel.    His son Uriel
-II reigned for eighteen years, from the death Uriel I in 3E 64 to 3E 82.
-Tragically, the rule of Uriel II was cursed with blights,
-plagues, and insurrections. His tenderheartedness inherited
-from his father did not serve Tamriel well, and little
-justice was done.    Pelagius II inherited not only the throne from his father, but the debt from the poor
-financial and judicial management. Pelagius dismissed all of the old Elder
-Council, and allowed only those willing to pay great sums
-to return. He encouraged similiar acts of his vassals, the kings of Tamriel, and by the end of his
-seventeen year reign, Tamriel had returned to prosperity.
-His critics, however, have suggested that any advisor of wisdom, but without gold
-had been forcibly ousted. This may have led to some of the
-trouble his son Antiochus faced when he became Emperor.    Antiochus was certainly one of the most
-flamboyant of the usually austere Septim family. He had
-many mistresses and nearly as many wives, and was renowned
-for his grandness of dress and good humor. Unfortunately,
-his reign was rife with civil wars, surpassing even that of his grandfather Uriel II. The
-War of the Isle in 3E 110, twelve years after Antiochus
-assumed the throne, nearly took the province of Sumurset
-Isle away from Tamriel. The united alliance of the kings of
-Sumurset and Antiochus only managed to defeat King Orgnum
-of the island-kingdom of Pyandonea due to a freak storm.
-Legend credits the Psijic Order of the Isle of Artaeum with the magic behind the storm.    The story of Kintyra II, heiress
-of her father's throne, is certainly one of the saddest tales
-in modern history. Her first cousin Uriel, son of Queen
-Potena of Solitude, accused Kintyra of being a bastard,
-alluding to the famous decadence of the Imperial City during
-her father's reign. When this accusation failed to stop her coronation, Uriel bought the support of
-several disgrunted kings of High Rock, Skyrim, and Morrowind,
-and, with Queen Potena's assistance, coordinated three attacks on the Septim Empire.    The first attack
-occured in the Iliac Bay that separates High Rock and
-Hammerfell. Kintyra's entourage was destroyed and the
-Emperess was taken captive. For two years, Kintyra II
-languished in an Imperial prison believed to be somewhere in
-Glenpoint or Glenmoril Wyrd before she was slain in her
-cell.    The second attack was on a series of Imperial
-garrisons along the coastal Morrowind islands. The
-Emperess' consort Kontin Arynx died defending the forts.   
-The third attack was a siege of the Imperial City itself,
-occuring after the Elder Council had divided the army to
-attack western High Rock and eastern Morrowind. The much
-weakened government had little defense against Uriel's attack, and surrendered
-after only a fortnight of resistance. Uriel took the throne
-that night and proclaimed himself Uriel III, Emperor of
-Tamriel. The year was 3E 121.    Thus begins the War of the
-Red Diamond, described in Volume II of this series.
+ Before the day of Tiber Septim, all Tamriel was chaos. The poet Tracizis called that era "the days and nights of blood and venom." The kings were a petty lot of grasping tyrants, who fought Tiber's attempts to bring order to the land. But they were as disorganized as they were dissolute, and the strong hand of Septim brought peace forcibly to Tamriel. The year was 2E 896. The following year, the Emperor declared the beginning of a new era, so we began the 3rd Era, year aught.
 
+ For thirty-eight years, the Emperor Tiber reigned: a just, pious, and glorious age, when justice was known to one and all, from serf to king. It rained for a fortnight after as if the land of Tamriel itself was weeping.
 
+ The Emperor's eldest living son, Pelagius came to the throne. Though his reign was short, he was as strong and resolute as his father had been, and we could have enjoyed a continuation of the Golden Age. Alas, an unknown enemy of the Septims hired the cursed organization of cutthroats, the Dark Brotherhood, to kill the Emperor Pelagius I as he knelt at prayer at the Temple of the One in the Imperial City. Pelagius I's reign lasted less than three years.
 
- 
+ Pelagius had no living children, so the crown of the Empire passed to his first cousin, the daughter of Tiber's brother Agnorith. So did Kintyra, former Queen of Silvenar, assume the throne. Kintyra I was blessed with a time of prosperity and good harvests, and was an avid patroness of art, music, and dance.
+
+ Kintyra's son was crowned after her death, the first Emperor of Tamriel to use the imperial name Uriel. The Emperor Uriel I was the great lawmaker of the Septim Dynasty, and a promoter of independent organizations and guilds. Under his kind hand, the Fighters Guild and the Mages Guild increased in prominence throughout Tamriel.
+
+ His son Uriel II reigned for eighteen years, from the death Uriel I in 3E 64 to 3E 82. Tragically, the rule of Uriel II was cursed with blights, plagues, and insurrections. His tenderheartedness inherited from his father did not serve Tamriel well, and little justice was done.
+
+ Pelagius II inherited not only the throne from his father, but the debt from the poor financial and judicial management. Pelagius dismissed all of the old Elder Council, and allowed only those willing to pay great sums to return. He encouraged similiar acts of his vassals, the kings of Tamriel, and by the end of his seventeen year reign, Tamriel had returned to prosperity. His critics, however, have suggested that any advisor of wisdom, but without gold had been forcibly ousted. This may have led to some of the trouble his son Antiochus faced when he became Emperor.
+
+ Antiochus was certainly one of the most flamboyant of the usually austere Septim family. He had many mistresses and nearly as many wives, and was renowned for his grandness of dress and good humor. Unfortunately, his reign was rife with civil wars, surpassing even that of his grandfather Uriel II. The War of the Isle in 3E 110, twelve years after Antiochus assumed the throne, nearly took the province of Sumurset Isle away from Tamriel. The united alliance of the kings of Sumurset and Antiochus only managed to defeat King Orgnum of the island-kingdom of Pyandonea due to a freak storm. Legend credits the Psijic Order of the Isle of Artaeum with the magic behind the storm.
+
+ The story of Kintyra II, heiress of her father's throne, is certainly one of the saddest tales in modern history. Her first cousin Uriel, son of Queen Potena of Solitude, accused Kintyra of being a bastard, alluding to the famous decadence of the Imperial City during her father's reign. When this accusation failed to stop her coronation, Uriel bought the support of several disgrunted kings of High Rock, Skyrim, and Morrowind, and, with Queen Potena's assistance, coordinated three attacks on the Septim Empire.
+
+ The first attack occured in the Iliac Bay that separates High Rock and Hammerfell. Kintyra's entourage was destroyed and the Emperess was taken captive. For two years, Kintyra II languished in an Imperial prison believed to be somewhere in Glenpoint or Glenmoril Wyrd before she was slain in her cell.
+
+ The second attack was on a series of Imperial garrisons along the coastal Morrowind islands. The Emperess' consort Kontin Arynx died defending the forts. The third attack was a siege of the Imperial City itself, occuring after the Elder Council had divided the army to attack western High Rock and eastern Morrowind. The much weakened government had little defense against Uriel's attack, and surrendered after only a fortnight of resistance. Uriel took the throne that night and proclaimed himself Uriel III, Emperor of Tamriel. The year was 3E 121.
+
+ Thus begins the War of the Red Diamond, described in Volume II of this series.

--- a/Assets/StreamingAssets/Text/Books/BOK00029-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00029-LOC.txt
@@ -3,9 +3,8 @@ Author: Stronach
 IsNaughty: False
 Price: 352
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,107 +14,26 @@ Content:
 
 [/center]Part II
 
-
-
 [/font=4]
 
+ Volume I of this series described in brief the lives of the first eight Emperors of the Septim Dynasty, beginning with the forebear Tiber Septim and ending with his great great great great grandniece Kintyra II. Kintyra's murder in Glenpoint, while in captivity, is considered by some to be the end of the pure strain of Septim blood. Certainly, it marks the end of something.
 
+ Uriel III not only proclaimed himself Emperor of Tamriel, but also proclaimed himself Uriel Septim III, taking a surname as a title. In truth, his surname was Uriel Mantiarco from his father. In time, Uriel III was deposed and his crimes reviled, but the tradition of taking the name Septim as a title for the Emperor of Tamriel did not die with him.
 
-[/center]    Volume I of this series described in brief the lives of the
-first eight Emperors of the Septim Dynasty, beginning with
-the forebear Tiber Septim and ending with his great great
-great great grandniece Kintyra II. Kintyra's murder in
-Glenpoint, while in captivity, is considered by some to be
-the end of the pure strain of Septim blood. Certainly, it
-marks the end of something.    Uriel III not only proclaimed
-himself Emperor of Tamriel, but also proclaimed himself
-Uriel Septim III, taking a surname as a title. In truth, his
-surname was Uriel Mantiarco from his father. In time, Uriel
-III was deposed and his crimes reviled, but the tradition of
-taking the name Septim as a title for the Emperor of Tamriel
-did not die with him.    For six years, the War of the Red
-Diamond tore apart the Empire. The combatants were the three
-surviving children of Pelagius II, Potema, Cephorus, and
-Magnus, and their offspring. Potema, of course, supported
-her son Uriel III, and had the support of all of Skyrim and
-northern Morrowind. With the efforts of Cephorus and
-Magnus, High Rock turned. Hammerfell, Sumurset Isle,
-Valenwood, Elsweyr, and Black Marsh were divided, but most
-kings supported Cephorus and Magnus.    In 3E 127, Uriel III
-was captured at the Battle of Ichidag in Hammerfell. En
-route to his trial in the Imperial City, a mob overtook his
-carriage and burned him alive within it. His captor and
-uncle continued on to the Imperial City, and by common
-acclaim, was proclaimed Cephorus I, Emperor of Tamriel.   
-Cephorus' reign is marked by nothing but war. By all
-accounts, he was a kind and intelligent man, but what
-Tamriel needed was a great warrior, and he was that. It took
-an additional ten years of constant warfare for him to
-defeat his sister Potema. The so-called wolf queen of
-Solitude died in the siege of her city-state in the year 137.
-Cephorus only survived his sister by three years.     Cephorus
-never had the time during the war years to marry, so it was
-his brother, the fourth child of Pelagius II, who assumed the
-throne. The Emperor Magnus was elderly, and the business of
-punishing the traitorous kings of the War of the Red Diamond
-drained much of his health. Legend also accuses Magnus' son
-and heir Pelagius III of murder, but that seems very
-unlikely. For no other reason, Pelagius was King of
-Solitude, following the death of Potema, and seldom visited
-the Imperial City.     Pelagius III, sometimes called
-Pelagius the Mad, was proclaimed Emperor in the 145th year of
-the 3rd Era. Almost from the start, his eccentricities of
-behavior was noted. He embarassed dignitaries, offended his
-vassal kings, and, on one occasion, marked the end of a grand
-ball by attempting to hang himself. His long-suffering wife
-was finally awarding the regency of Tamriel and Pelagius
-III was sent to a series of healers and asylums until his death
-in 3E 153 at the age of thirty-four.     The Emperess Regent of
-Tamriel was proclaimed Emperess Katariah I upon the death of
-her husband. Some who do not mark the end of the Septim
-bloodline with the death of Kintyra II consider the accendancy
-of this dark elf woman as the true mark. Her defenders assert
-that though Katariah was not descended from Tiber, the son she
-had with Pelagius, was, so the chain does continue.    Despite
-the racist assertations to the contrary, Katariah's
-forty-six year reign was one of the most glorious in
-Tamriel's history. Uncomfortable in the Imperial City,
-Katariah travelled extensively throughout the Empire, such
-as no Emperor ever had since Tiber's day. She repaired much
-of the damage the broken alliances and bungled diplomacy
-had created. The people of Tamriel came to love their
-Emperess far more than the nobility did. Katariah's death in
-a minor skirmish in Black Marsh is a favorite source for
-conspiracy-minded historians. The sage Montalius' discovery
-of a disenfranchised branch of the Septim family's
-involvement with the skirmish was a revelation indeed.    When
-Cassynder assumed the throne at the death of his mother, he was
-already middle-aged. Only half-elven, he aged like a Breton.
-In fact, he had left the rule of Wayrest to his half-brother
-Uriel due to poor health. Nevertheless, as the only true
-blood relation of Pelagius, and thus Tiber, he was pressed
-into accepting the throne. To no one's surprise, the Emperor
-Cassynder's reign did not last long. In two years, he was
-dead.    Uriel Lariat, Cassynder's half-brother, the child of
-Katariah I and her Imperial consort Lariat, left the
-kingdom of Wayrest to reign as Uriel IV. Legally, Uriel IV
-was a Septim: Cassynder had adopted him into the family when
-he had become King of Wayrest. Nevertheless, to the Council
-and the people of Tamriel, he was a bastard child of
-Katariah. Uriel did not possess the dynamism of his mother,
-and his long forty-three year reign was a hotbed of sedition. 
-  Uriel IV's story is told in the third volume of this series.
+ For six years, the War of the Red Diamond tore apart the Empire. The combatants were the three surviving children of Pelagius II, Potema, Cephorus, and Magnus, and their offspring. Potema, of course, supported her son Uriel III, and had the support of all of Skyrim and northern Morrowind. With the efforts of Cephorus and Magnus, High Rock turned. Hammerfell, Sumurset Isle, Valenwood, Elsweyr, and Black Marsh were divided, but most kings supported Cephorus and Magnus.
 
+ In 3E 127, Uriel III was captured at the Battle of Ichidag in Hammerfell. En route to his trial in the Imperial City, a mob overtook his carriage and burned him alive within it. His captor and uncle continued on to the Imperial City, and by common acclaim, was proclaimed Cephorus I, Emperor of Tamriel. Cephorus' reign is marked by nothing but war. By all accounts, he was a kind and intelligent man, but what Tamriel needed was a great warrior, and he was that. It took an additional ten years of constant warfare for him to defeat his sister Potema. The so-called wolf queen of Solitude died in the siege of her city-state in the year 137. Cephorus only survived his sister by three years.
 
+ Cephorus never had the time during the war years to marry, so it was his brother, the fourth child of Pelagius II, who assumed the throne. The Emperor Magnus was elderly, and the business of punishing the traitorous kings of the War of the Red Diamond drained much of his health. Legend also accuses Magnus' son and heir Pelagius III of murder, but that seems very unlikely. For no other reason, Pelagius was King of Solitude, following the death of Potema, and seldom visited the Imperial City.
 
+ Pelagius III, sometimes called Pelagius the Mad, was proclaimed Emperor in the 145th year of the 3rd Era. Almost from the start, his eccentricities of behavior was noted. He embarassed dignitaries, offended his vassal kings, and, on one occasion, marked the end of a grand ball by attempting to hang himself. His long-suffering wife was finally awarding the regency of Tamriel and Pelagius III was sent to a series of healers and asylums until his death in 3E 153 at the age of thirty-four.
 
+ The Emperess Regent of Tamriel was proclaimed Emperess Katariah I upon the death of her husband. Some who do not mark the end of the Septim bloodline with the death of Kintyra II consider the accendancy of this dark elf woman as the true mark. Her defenders assert that though Katariah was not descended from Tiber, the son she had with Pelagius, was, so the chain does continue.
 
+ Despite the racist assertations to the contrary, Katariah's forty-six year reign was one of the most glorious in Tamriel's history. Uncomfortable in the Imperial City, Katariah travelled extensively throughout the Empire, such as no Emperor ever had since Tiber's day. She repaired much of the damage the broken alliances and bungled diplomacy had created. The people of Tamriel came to love their Emperess far more than the nobility did. Katariah's death in a minor skirmish in Black Marsh is a favorite source for conspiracy-minded historians. The sage Montalius' discovery of a disenfranchised branch of the Septim family's involvement with the skirmish was a revelation indeed.
 
+ When Cassynder assumed the throne at the death of his mother, he was already middle-aged. Only half-elven, he aged like a Breton. In fact, he had left the rule of Wayrest to his half-brother Uriel due to poor health. Nevertheless, as the only true blood relation of Pelagius, and thus Tiber, he was pressed into accepting the throne. To no one's surprise, the Emperor Cassynder's reign did not last long. In two years, he was dead.
 
+ Uriel Lariat, Cassynder's half-brother, the child of Katariah I and her Imperial consort Lariat, left the kingdom of Wayrest to reign as Uriel IV. Legally, Uriel IV was a Septim: Cassynder had adopted him into the family when he had become King of Wayrest. Nevertheless, to the Council and the people of Tamriel, he was a bastard child of Katariah. Uriel did not possess the dynamism of his mother, and his long forty-three year reign was a hotbed of sedition.
 
-
-
-
-
-
- 
+ Uriel IV's story is told in the third volume of this series.

--- a/Assets/StreamingAssets/Text/Books/BOK00030-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00030-LOC.txt
@@ -3,9 +3,8 @@ Author: Stronach
 IsNaughty: False
 Price: 352
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,95 +14,20 @@ Content:
 
 [/center]Part III
 
-
-
 [/font=4]
 
+ The first volume of this series tells in brief the story of the succession of the first eight emperors of the Septim Dynasty, from Tiber I to Kintyra II. The second volume described the War of the Red Diamond and the six emperors that followed its aftermath, Uriel III to Cassynder I. At the end of that volume, I described how the Emperor Cassynder's half-brother, Uriel IV assumed the throne of the Empire of Tamriel.
 
+ It will be recalled that Uriel IV was not a Septim by birth. His mother, though she reigned as Emperess for many years, was a Dark Elf married to a true Septim Emperor, Pelagius III. His father was Katariah I's consort after Pelagius' death and during her reign, a Breton nobleman named Gallivere Lariat. Before taking the throne of Empire, Cassynder I had ruled the kingdom of Wayrest, but poor health had forced him to retire. Cassynder had no children, so he legally adopted his half-brother Uriel and gave him the kingdom. Seven years later, Cassynder inherited the Empire at the death of his mother. Three years after that, Uriel found himself the recipient of Cassynder's inheritance once again.
 
-[/center]     The first volume of this series tells in brief the story of
-the succession of the first eight emperors of the Septim
-Dynasty, from Tiber I to Kintyra II. The second volume
-described the War of the Red Diamond and the six emperors
-that followed its aftermath, Uriel III to Cassynder I. At
-the end of that volume, I described how the Emperor
-Cassynder's half-brother, Uriel IV assumed the throne of the
-Empire of Tamriel.
+ Uriel IV's reign was difficult and long one. Despite being a legally adopted member of the Septim family, and despite the Lariat family's high position -- indeed, they were distant cousins of the Septims -- few of the Elder Council could be persuaded to accept him fully as a blood relation of Tiber. The Council had assumed much responsibility during Katariah I's long reign and Cassynder I's short reign, and a strong-willed alien monarch like Uriel IV found it impossible to hold their unswerving fealty. Time and time again, the Council and Emperor were at odds; and time and time again, the Council won the battles. Since the days of Pelagius II, the Elder Council had consisted of the wealthiest men and women in the Empire, and the power they wielded was ultimate.
 
-     It will be recalled that Uriel IV was not a Septim by
-birth. His mother, though she reigned as Emperess for many
-years, was a Dark Elf married to a true Septim Emperor,
-Pelagius III. His father was Katariah I's consort after
-Pelagius' death and during her reign, a Breton nobleman
-named Gallivere Lariat. Before taking the throne of Empire,
-Cassynder I had ruled the kingdom of Wayrest, but poor
-health had forced him to retire. Cassynder had no children,
-so he legally adopted his half-brother Uriel and gave him the
-kingdom. Seven years later, Cassynder inherited the Empire
-at the death of his mother. Three years after that, Uriel
-found himself the recipient of Cassynder's inheritance once
-again.
+ The Council's last victory over Uriel IV was posthumous. Andorak, Uriel IV's son, was disinherited by vote of Council, and a cousin more closely related to the original Septim line was proclaimed Cephorus II in 3E 268. Cephorus had been a Nordic king of For the first nine years of Cephorus II's reign, those loyal to Andorak battled the Imperial forces. In an act that the sage Eraintine called "Tiber Septim's heart beating no more," the Council granted Andorak the High Rock kingdom of Shornhelm to end the war. Andorak's descendants still rule that land.
 
-    Uriel IV's reign was difficult and long one. Despite
-being a legally adopted member of the Septim family, and
-despite the Lariat family's high position -- indeed, they were
-distant cousins of the Septims -- few of the Elder Council
-could be persuaded to accept him fully as a blood relation
-of Tiber. The Council had assumed much responsibility
-during Katariah I's long reign and Cassynder I's short
-reign, and a strong-willed alien monarch like Uriel IV found
-it impossible to hold their unswerving fealty. Time and time
-again, the Council and Emperor were at odds; and time and
-time again, the Council won the battles. Since the days of
-Pelagius II, the Elder Council had consisted of the
-wealthiest men and women in the Empire, and the power they
-wielded was ultimate.
+ Of course, Cephorus II had foes that demanded more of his attention than Andorak. "From out of a nightmare," in the words of Eraintine, a man who called himself the Camoran Usurper had led an army of daedra and undead warriors on a rampage through Valenwood, conquering kingdom after kingdom. None could resist his onslaughts, and as month turned to bloody month in the year 3E 249, fewer even tried. Cephorus II sent more and more mercenaries into Hammerfell to stop the Usurper's northward march, but they were bribed, turned into undead, or slaughtered.
 
-    The Council's last victory over Uriel IV was posthumous.
-Andorak, Uriel IV's son, was disinherited by vote of
-Council, and a cousin more closely related to the original
-Septim line was proclaimed Cephorus II in 3E 268. Cephorus
-had been a Nordic king of  For the first nine years of
-Cephorus II's reign, those loyal to Andorak battled the
-Imperial forces. In an act that the sage Eraintine called
-"Tiber Septim's heart beating no more," the Council granted
-Andorak the High Rock kingdom of Shornhelm to end the war.
-Andorak's descendants still rule that land.
+ The story of the Camoran Usurper does deserve a book of its own. I recommend the reader find Palaux Illthre's "The Fall of the Usurper" for more detail. In short, the destruction of the forces of the Usurper had little do with efforts of the Emperor. The results was a great regional victory and an increase in hostility toward the seemingly inefficious Empire.
 
-    Of course, Cephorus II had foes that demanded more of his
-attention than Andorak. "From out of a nightmare," in the
-words of Eraintine, a man who called himself the Camoran
-Usurper had led an army of daedra and undead warriors on a
-rampage through Valenwood, conquering kingdom after
-kingdom. None could resist his onslaughts, and as month
-turned to bloody month in the year 3E 249, fewer even tried.
-Cephorus II sent more and more mercenaries into Hammerfell
-to stop the Usurper's northward march, but they were bribed,
-turned into undead, or slaughtered.
+ Uriel V turned opinion back toward the potential power of the Empire. Turning the attention of Tamriel away from internal strife, Uriel V embarked on a series of invasions beginning almost from the moment he took the throne in 3E 268. Uriel V conquered Roscrea in 271, Cathnoquey in 276, Yneslea in 279, and Esroniet in 284. In 3E 288, he embarked on his most ambitious enterprise, the invasion of the continent kingdom of Akavir. This was ultimately a failure, for two years later Uriel V was killed in Akavir on the battlefield of Ionith. Nevertheless, Uriel V holds a reputation second only to Tiber as the great warrior emperor of Tamriel.
 
-    The story of the Camoran Usurper does deserve a book of its
-own. I recommend the reader find Palaux Illthre's "The
-Fall of the Usurper" for more detail. In short, the
-destruction of the forces of the Usurper had little do with
-efforts of the Emperor. The results was a great regional
-victory and an increase in hostility toward the seemingly
-inefficious Empire.
-
-    Uriel V turned opinion back toward the potential power
-of the Empire. Turning the attention of Tamriel away from
-internal strife, Uriel V embarked on a series of invasions
-beginning almost from the moment he took the throne in 3E
-268. Uriel V conquered Roscrea in 271, Cathnoquey in 276,
-Yneslea in 279, and Esroniet in 284. In 3E 288, he embarked
-on his most ambitious enterprise, the invasion of the
-continent kingdom of Akavir. This was ultimately a failure,
-for two years later Uriel V was killed in Akavir on the
-battlefield of Ionith. Nevertheless, Uriel V holds a
-reputation second only to Tiber as the great warrior
-emperor of Tamriel.
-
-    The last four Emperors, beginning with Uriel V's infant
-son, are described in the fourth and final volume of the
-series.
-
- 
+ The last four Emperors, beginning with Uriel V's infant son, are described in the fourth and final volume of the series.

--- a/Assets/StreamingAssets/Text/Books/BOK00031-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00031-LOC.txt
@@ -3,9 +3,8 @@ Author: Stronach
 IsNaughty: False
 Price: 352
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,121 +14,30 @@ Content:
 
 [/center]Part IV
 
-
-
 [/font=4]
 
+ The first book of this series described, in brief, the first eight emperors of the Septim Dynasty beginning with Tiber I. The second volume described the War of the Red Diamond and the six emperors who followed. The third volume describes the troubles of the next three emperors, the frustrated Uriel IV, the ineffectual Cephorus II, and the the heroic Uriel V. At Uriel V's death across the sea in distant hostile Akavir, Uriel VI was but five years old. In fact, Uriel VI was born only shortly before his father left for Akavir. Uriel V's only other progeny, by a different woman, were the twins Morihatha and Eloisa, who had been born a month after Uriel V left. Uriel VI was coronated in the 290th year of the third era. The consort Thonica as the boy's mother was given a restricted Regency until Uriel VI reached his minority. The Council retained the real power, as they had ever since the days of Katariah I.
 
+ The Council so enjoyed its unlimited and unrestricted freedom to make laws (and profits), Uriel VI was not given full license to rule until 307, when he was 22 years old. He had been slowly assuming positions of responsibility for years, but both the Council and his mother, who enjoyed even her limited regency, were loath to give him reign. By the time he came to the throne, the mechanisms of government gave him little power, but the power to veto.
 
-[/center]     The first book of this series described, in brief, the first
-eight emperors of the Septim Dynasty beginning with Tiber I.
-The second volume described the War of the Red Diamond and
-the six emperors who followed. The third volume describes the
-troubles of the next three emperors, the frustrated Uriel
-IV, the ineffectual Cephorus II, and the the heroic Uriel V.    
-At Uriel V's death across the sea in distant hostile Akavir,
-Uriel VI was but five years old. In fact, Uriel VI was born
-only shortly before his father left for Akavir. Uriel V's
-only other progeny, by a different woman, were the twins
-Morihatha and Eloisa, who had been born a month after Uriel
-V left.  Uriel VI was coronated in the 290th year of the third
-era. The consort Thonica as the boy's mother was given a
-restricted Regency until Uriel VI reached his minority. The
-Council retained the real power, as they had ever since the
-days of Katariah I.     The Council so enjoyed its unlimited
-and unrestricted freedom to make laws (and profits), Uriel
-VI was not given full license to rule until 307, when he was
-22 years old. He had been slowly assuming positions of
-responsibility for years, but both the Council and his
-mother, who enjoyed even her limited regency, were loath to
-give him reign. By the time he came to the throne, the
-mechanisms of government gave him little power, but the
-power to veto.     This power he regularly exercised. By
-313, Uriel VI could boast with conviction that he truly did
-rule Tamriel. He utilized defunct spy networks and guard
-units to bully and coerce the difficult members of the Elder
-Council. His sister was his usual ally, after her marriage to
-Baron Ulfe Gersen of Winterhold brought her considerable
-wealth and influence. As the sage Ugaridge said, "Uriel V
-conquered Esroniet, but Uriel VI conquered the Elder
-Council."     When Uriel VI fell from his horse and could not
-be saved by the finest Imperial healers, his beloved sister
-Morihatha took the throne. At 25 years of age, she had been
-described by (admittedly self-serving) diplomats as the
-most beautiful creature in Tamriel. She was certainly
-well-learned, vivacious, athletic, and a well-practiced
-politician. She brought the Archmagister of Skyrim to the
-Imperial City and created the second Imperial Battlemage
-since the days of Tiber Septim.     Morihatha finished the job
-her brother had begun, and made the Imperial Province truly
-a government under the Emperess. Outside the Imperial
-Province, however, the Empire had been slowly
-disintegrating. Open revolutions and civil wars had raged un
-challenged since the days of her grandfather Cephorus
-II. Carefully coordinating her counterattacks, Morihatha
-slowly took back her rebellious vassals, always avoiding
-overextending herself.     Though Morihatha's military
-campaigns were remarkable successful, the Council was often
-frustrated by her deliberate pace. One Councilman, an
-Argonian named Thoricles Romus, furious at her refusal to
-send troops to his troubled lands, is believed to be the man
-who hired the assassins who claimed her life in 3E 339. Romus
-was tried and executed, though he protested his innocence.    
-Morihatha had no surviving children, and Eloisa had died of
-a fever four years before. Eloisa's 25-year-old son
-Pelagius was crowned Pelagius IV.     Pelagius IV continued
-his aunt's work, slowly bringing back the seditious kingdoms
-of his Empire. He had Morihatha's patience and deliberate pace
-in his endeavors, but, alas, he did not have her success. The
-kingdoms had been free of constraints for so long, even a
-benign Imperial presence was odious. Nevertheless, when
-Pelagius died, after an astonishing forty-nine year reign,
-Tamriel was closer to unity than it had been since the days
-of Uriel I.     Our current Emperor, his Awesome and Terrible
-Majesty, Uriel Septim VII, son of Pelagius IV, has the
-diligence of his great aunt Morihatha, the political skill of
-hallenged since the days of her grandfather Cephorus
-II. Carefully coordinating her counterattacks, Morihatha
-slowly took back her rebellious vassals, always avoiding
-overextending herself.     Though Morihatha's military
-campaigns were remarkable successful, the Council was often
-frustrated by her deliberate pace. One Councilman, an
-Argonian named Thoricles Romus, furious at her refusal to
-send troops to his troubled lands, is believed to be the man
-who hired the assassins who claimed her life in 3E 339. Romus
-was tried and executed, though he protested his innocence.    
-Morihatha had no surviving children, and Eloisa had died of
-a fever four years before. Eloisa's 25-year-old son
-Pelagius was crowned Pelagius IV.     Pelagius IV continued
-his aunt's work, slowly bringing back the seditious kingdoms
-of his Empire. He had Morihatha's patience and deliberate pace
-in his endeavors, but, alas, he did not have her success. The
-kingdoms had been free of constraints for so long, even a
-benign Imperial presence was odious. Nevertheless, when
-Pelagius died, after an astonishing forty-nine year reign,
-Tamriel was closer to unity than it had been since the days
-of Uriel I.     Our current Emperor, his Awesome and Terrible
-Majesty, Uriel Septim VII, son of Pelagius IV, has the
-diligence of his great aunt Morihatha, the political skill of
-his great uncle Uriel VI, and the military prowess of his
-great grand-uncle Uriel V. For twenty-one years he reigned
-and brought justice and order to Tamriel. In the year 3E 389,
-his Imperial Battlemage Jagar Tharn betrayed him.      Uriel
-VII was imprisoned in a dimension of Tharn's creation, and
-Tharn used his magic of illusion to assume the Emperor's
-aspect. For the next ten years, Tharn used Imperial
-priveleges, but did not continue Uriel VII's schedule of
-reconquest. It is not entirely known yet what Tharn's goals
-and personal accomplishments were during the ten years he
-imitated his liege lord. In 3E 399, a mysterious champion
-defeated the Battlemage in the dungeons of the Imperial
-Palace and freed Uriel VII from his other dimensional cell.  
-  Since his release, Uriel VII has worked diligently to renew
-the battle to reunite Tamriel. Tharn's interference broke
-the momentuum, but the years since then have proven that the
-glorious golden age of Tiber Septim may be visited on
-Tamriel once again.     
+ This power he regularly exercised. By 313, Uriel VI could boast with conviction that he truly did rule Tamriel. He utilized defunct spy networks and guard units to bully and coerce the difficult members of the Elder Council. His sister was his usual ally, after her marriage to Baron Ulfe Gersen of Winterhold brought her considerable wealth and influence. As the sage Ugaridge said, "Uriel V conquered Esroniet, but Uriel VI conquered the Elder Council."
 
-     
+ When Uriel VI fell from his horse and could not be saved by the finest Imperial healers, his beloved sister Morihatha took the throne. At 25 years of age, she had been described by (admittedly self-serving) diplomats as the most beautiful creature in Tamriel. She was certainly well-learned, vivacious, athletic, and a well-practiced politician. She brought the Archmagister of Skyrim to the Imperial City and created the second Imperial Battlemage since the days of Tiber Septim.
 
- 
+ Morihatha finished the job her brother had begun, and made the Imperial Province truly a government under the Emperess. Outside the Imperial Province, however, the Empire had been slowly disintegrating. Open revolutions and civil wars had raged un challenged since the days of her grandfather Cephorus II. Carefully coordinating her counterattacks, Morihatha slowly took back her rebellious vassals, always avoiding overextending herself.
+
+ Though Morihatha's military campaigns were remarkable successful, the Council was often frustrated by her deliberate pace. One Councilman, an Argonian named Thoricles Romus, furious at her refusal to send troops to his troubled lands, is believed to be the man who hired the assassins who claimed her life in 3E 339. Romus was tried and executed, though he protested his innocence. Morihatha had no surviving children, and Eloisa had died of a fever four years before. Eloisa's 25-year-old son Pelagius was crowned Pelagius IV.
+
+ Pelagius IV continued his aunt's work, slowly bringing back the seditious kingdoms of his Empire. He had Morihatha's patience and deliberate pace in his endeavors, but, alas, he did not have her success. The kingdoms had been free of constraints for so long, even a benign Imperial presence was odious. Nevertheless, when Pelagius died, after an astonishing forty-nine year reign, Tamriel was closer to unity than it had been since the days of Uriel I.
+
+ Our current Emperor, his Awesome and Terrible Majesty, Uriel Septim VII, son of Pelagius IV, has the diligence of his great aunt Morihatha, the political skill of hallenged since the days of her grandfather Cephorus II. Carefully coordinating her counterattacks, Morihatha slowly took back her rebellious vassals, always avoiding overextending herself.
+
+ Though Morihatha's military campaigns were remarkable successful, the Council was often frustrated by her deliberate pace. One Councilman, an Argonian named Thoricles Romus, furious at her refusal to send troops to his troubled lands, is believed to be the man who hired the assassins who claimed her life in 3E 339. Romus was tried and executed, though he protested his innocence. Morihatha had no surviving children, and Eloisa had died of a fever four years before. Eloisa's 25-year-old son Pelagius was crowned Pelagius IV.
+
+ Pelagius IV continued his aunt's work, slowly bringing back the seditious kingdoms of his Empire. He had Morihatha's patience and deliberate pace in his endeavors, but, alas, he did not have her success. The kingdoms had been free of constraints for so long, even a benign Imperial presence was odious. Nevertheless, when Pelagius died, after an astonishing forty-nine year reign, Tamriel was closer to unity than it had been since the days of Uriel I.
+
+ Our current Emperor, his Awesome and Terrible Majesty, Uriel Septim VII, son of Pelagius IV, has the diligence of his great aunt Morihatha, the political skill of his great uncle Uriel VI, and the military prowess of his great grand-uncle Uriel V. For twenty-one years he reigned and brought justice and order to Tamriel. In the year 3E 389, his Imperial Battlemage Jagar Tharn betrayed him.
+
+ Uriel VII was imprisoned in a dimension of Tharn's creation, and Tharn used his magic of illusion to assume the Emperor's aspect. For the next ten years, Tharn used Imperial priveleges, but did not continue Uriel VII's schedule of reconquest. It is not entirely known yet what Tharn's goals and personal accomplishments were during the ten years he imitated his liege lord. In 3E 399, a mysterious champion defeated the Battlemage in the dungeons of the Imperial Palace and freed Uriel VII from his other dimensional cell.
+
+ Since his release, Uriel VII has worked diligently to renew the battle to reunite Tamriel. Tharn's interference broke the momentuum, but the years since then have proven that the glorious golden age of Tiber Septim may be visited on Tamriel once again.

--- a/Assets/StreamingAssets/Text/Books/BOK00032-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00032-LOC.txt
@@ -3,117 +3,46 @@ Author: Anido Jhone, editor
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
 
-
-[/font=4] As uncovered and translated by Anido Jhone, Royal
-Archaeologist, from an ancient tome: 
-
-[/center]
-
-[/center] This tale comes from sometime in the 2nd Era, most probably
-after the time of the Knahaten Flu, or at least I have so
-surmised due to reasons in the text. Whether or not the tale
-is true, it remains an interesting story of survival.
-
- The reader will, I trust, forgive me if I translated the
-epic somewhat informally. The message, I think, is
-universal, and should not be misread.
-
- Enjoy, gentle reader.
-
- A.J.J.
-
-
-
-[/font=2]
-
-The Epic of
-
-[/center]the Grey Falcon
-
-[/center]
-
-[/center]
-
 [/font=4]
+ The Grey Falcon, a small warship of the Sumurset Isle, Was patrolling deep in the ocean for a pirate That had been looting the coast. The first three weeks out were uneventful. Two hours after sunset, on the 22nd day out of port, The lookout spotted a top of a sail in the moonlight, Just on the horizon.
 
-[/center]
+ "Sail! To starboard, forward quarter!" The lookout of the Grey Falcon cried. The crew and captain of the Grey Falcon were quickly roused, And stumbled to the deck.
 
-[/center]
+ "'Tis the ship we're looking for, Captain," said the lookout. "All hands to battle stations! All archers to their posts,"
 
-      The Grey Falcon , a small warship of the         Sumurset
-Isle, Was patrolling deep in the ocean for a         pirate That
-had been looting the coast. The first three weeks out were
-uneventful. Two hours after sunset, on the 22nd day        
-out of port, The lookout spotted a top of a sail in         the
-moonlight, Just on the horizon. "Sail! To starboard,
-forward quarter!" The lookout of the Grey Falcon cried. The
-crew and captain of the Grey Falcon        were quickly
-roused, And stumbled to the deck.  "'Tis the ship we're looking
-for, Captain,"        said the lookout.  "All hands to battle
-stations! All archers        to their posts," The Captain
-yelled, "Full ahead!" The two ships closed, And a dark figure
-stepped out onto the        forecastle of the pirate ship. The
-figure made a gesture with his hands, And a giant ball of
-fire streaked towards        the Grey Falcon. The ball of fire
-struck the Grey Falcon        in her sails, Quickly catching
-them aflame. The figure made another gesture. Large bolts
-of ice streaked out from his        hands, And hit the Grey
-Falcon just above and below        the water line, Gouging
-large holes in her hull.  The Grey Falcon was mortally
-wounded. The Captain cried, "All hands abandon shi-" As he
-was cut off by a pirate's arrow shot        into his throat.  As
-the Grey Falcon, aflame and listing badly,        plunged
-into the sea, One of her sailors, Darik Seaspit, Managed avoid
-the pirate arrows and spells        to make his way to a
-lifeboat, And lowered it into the darkness below. Just as the
-lifeboat entered the water, a        quick grey shape jumped
-into it. Darik looked, and saw it was Helnor Snarlsbane, A
-Khajiit mercenary assigned to the ship. The two rowed the
-small boat away, As the Grey Falcon finished her descent
-into        the sea. In the darkness, the Pirate ship missed their   
-    small craft. After the two rowed well out of the pirates  
-     possible view, They both collapsed from exhaustion.
-Early morning the next day, They took an inventory of the
-lifeboats stores. Normally the lifeboat carries enough food
-and        water To supply seven  people for at least ten
-days. In place of the food, though, Helnor found a note:   
-"The food in this lifeboat was found  to be        in
-violation     of Sumerset Navy regulation during
-inspection.     In accordance to that article, the food was    
-   taken away     and destroyed.     A replacement may be
-obtained by redeeming        this letter     at the Port Supply
-Office.     Signed, Lt. Inspector Windhollow" Helnor read
-aloud. Said Darik, to his Khajiit Companion, "We have       
-plenty of water, but we are out of food. I don't know what
-we're        going to do. I suppose we could try fishing, but
-we have no        bait. "There's no chance we can make it back to
-land Before we starve to death - 'twill be over a month       
-in this craft" "Wait, I have an idea" said Helnor, with a
-gleam        in his catlike eye. Six weeks later, the lifeboat
-entered the port of        Corwich. As it was tethered to the
-dock, a solitary figure        was pulled out, Looking
-weather beaten and thin. One of the dock workers peered into
-the life raft, After the figure was taken away to the port
-healer        for treatment. "Hmm, what's this", a worker said
-to himself, As he picked up a large bone from the boat, A bone
-bleached white by the sun. After the sole survivor of the
-Grey Falcon recovered        from his ordeal, He was taken to
-the inquest for the death        of Darik Seaspit, And placed on
-a chair before the magistrate.  "We here in High Rock have a dim
-view of cannibalism. You'd better have a good reason for
-your actions," The inquisitor boomed at Helnor Snarlsbane,  
-    "By the Lady, do you?" Helnor stood, and said, "Your
-Honor, I had no choice. There was no food, and it was at
-least two months to       the closest port. We both decided this
-was the only way someone would       make it" "Well, then , I
-suppose that is understandable, If somewhat distasteful,"
-the inquisitor said. "You think it was distasteful?," Helnor
-muttered to       himself, "I didn't have any seasoning."    
-"One final thing, Mr. Snarlsbane, How was it decided that
-you would be the one that       would dine on the other? The
-toss of a coin?" Helnor drew himself up and said, "Your
-honor, it was very simple. Darik Seaspit was       a
-vegetarian" "Case dismissed!" 
+ The Captain yelled, "Full ahead!" The two ships closed, And a dark figure stepped out onto the forecastle of the pirate ship. The figure made a gesture with his hands, And a giant ball of fire streaked towards the Grey Falcon. The ball of fire struck the Grey Falcon in her sails, Quickly catching them aflame. The figure made another gesture. Large bolts of ice streaked out from his hands, And hit the Grey Falcon just above and below the water line, Gouging large holes in her hull. The Grey Falcon was mortally wounded.
+
+ The Captain cried, "All hands abandon shi-" As he was cut off by a pirate's arrow shot into his throat. As the Grey Falcon, aflame and listing badly, plunged into the sea, One of her sailors, Darik Seaspit, managed avoid the pirate arrows and spells to make his way to a lifeboat, And lowered it into the darkness below. Just as the lifeboat entered the water, a quick grey shape jumped into it. Darik looked, and saw it was Helnor Snarlsbane, A Khajiit mercenary assigned to the ship. The two rowed the small boat away, As the Grey Falcon finished her descent into the sea. In the darkness, the pirate ship missed their small craft. After the two rowed well out of the pirates possible view, They both collapsed from exhaustion.
+
+ Early morning the next day, They took an inventory of the lifeboats stores. Normally the lifeboat carries enough food and water to supply seven people for at least ten days. In place of the food, though, Helnor found a note:
+
+ "The food in this lifeboat was found to being [sic] violation of Sumerset Navy regulation during inspection. In accordance to that article, the food was taken away and destroyed. A replacement may be obtained by redeeming this letter at the Port Supply Office. Signed, Lt. Inspector Windhollow" Helnor read aloud.
+
+ Said Darik, to his Khajiit Companion, "We have plenty of water, but we are out of food. I don't know what we're going to do. I suppose we could try fishing, but we have no bait.
+
+ "There's no chance we can make it back to land before we starve to death - 'twill be over a month in this craft."
+
+ "Wait, I have an idea" said Helnor, with a gleam in his catlike eye.
+
+ Six weeks later, the lifeboat entered the port of Corwich. As it was tethered to the dock, a solitary figure was pulled out, Looking weather beaten and thin. One of the dock workers peered into the life raft, After the figure was taken away to the port healer for treatment.
+
+ "Hmm, what's this", a worker said to himself, As he picked up a large bone from the boat, A bone bleached white by the sun.
+
+ After the sole survivor of the Grey Falcon recovered from his ordeal, He was taken to the inquest for the death of Darik Seaspit, And placed on a chair before the magistrate.
+
+ "We here in High Rock have a dim view of cannibalism. You'd better have a good reason for your actions," The inquisitor boomed at Helnor Snarlsbane, "By the Lady, do you?"
+
+ Helnor stood, and said, "Your Honor, I had no choice. There was no food, and it was at least two months to the closest port. We both decided this was the only way someone would make it."
+
+ "Well, then, I suppose that is understandable, If somewhat distasteful," the inquisitor said.
+
+ "You think it was distasteful?," Helnor muttered to himself, "I didn't have any seasoning."
+
+ "One final thing, Mr. Snarlsbane, How was it decided that you would be the one that would dine on the other? The toss of a coin?"
+
+ Helnor drew himself up and said, "Your honor, it was very simple. Darik Seaspit was a vegetarian."
+
+ "Case dismissed!"

--- a/Assets/StreamingAssets/Text/Books/BOK00032-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00032-LOC.txt
@@ -7,6 +7,27 @@ WhenVarSet:
 Content:
 
 [/font=4]
+
+As uncovered and translated by Anido Jhone, Royal Archaeologist, from an ancient tome:
+
+[/center]
+
+ This tale comes from sometime in the 2nd Era, most probably after the time of the Knahaten Flu, or at least I have so surmised due to reasons in the text. Whether or not the tale is true, it remains an interesting story of survival.
+
+ The reader will, I trust, forgive me if I translated the epic somewhat informally. The message, I think, is universal, and should not be misread.
+
+ Enjoy, gentle reader.
+
+ A.J.J.
+
+[/font=2]
+
+[/center]The Epic of
+
+[/center]the Grey Falcon
+
+[/font=4]
+
  The Grey Falcon, a small warship of the Sumurset Isle, Was patrolling deep in the ocean for a pirate That had been looting the coast. The first three weeks out were uneventful. Two hours after sunset, on the 22nd day out of port, The lookout spotted a top of a sail in the moonlight, Just on the horizon.
 
  "Sail! To starboard, forward quarter!" The lookout of the Grey Falcon cried. The crew and captain of the Grey Falcon were quickly roused, And stumbled to the deck.

--- a/Assets/StreamingAssets/Text/Books/BOK00033-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00033-LOC.txt
@@ -3,9 +3,8 @@ Author: Theth-i
 IsNaughty: False
 Price: 379
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,88 +14,18 @@ Content:
 
 [/center]Iliac Bay
 
-
-
 [/font=4]
 
+ The region of the Iliac Bay has a rich history, and not surprisingly, a number of holidays unique to it because of this history. The Breton and the Redguard cultures have many similarities, but just as many distinctions. An analysis of the holidays is one way to study the people.
 
+ As any schoolchild could tell you, the Redguards are a relatively new culture to Tamriel. Their arrival from their homeland is actually well recorded, though it occured several thousand years ago, in the 808th year of the 1st Era. Hammerfell was a great desert encompassed by almost impassable mountains -- unclaimed and unwanted. Many of the holidays extant in modern Hammerfell seem to be direct translations of older Redguard festivals before their migration to Tamriel.
 
-[/center]    The region of the Iliac Bay has a rich history, and not
-surprisingly, a number of holidays unique to it because of
-this history. The Breton and the Redguard cultures have many
-similarities, but just as many distinctions. An analysis of
-the holidays is one way to study the people.
+ The orgiastic seasonal celebrations seem unusual in a province with few changes in the weather from month to month. Yet on the 28th of Suns Dawn, the Redguards of the Banthan jungle celebrate Aduros Nau to relieve the wintertide lethargy; on the 1st of Mid Year, the people of Abibon-Gora celebrate Drigh R'Zimb in honor of the sun, which no normal Redguard worships in this day; similarly, on the 29th of Suns Height, the festival in the Desert called Fiery Night, seems almost perverse in such an environment; the Koomu Alezer'i on the 11th of Last Seed in Sentinel has been translated as a harvest thanksgiving, though many scholars have suggested that it was once a springtide holiday; similarly, the Feast of the Tiger in the Bantha on the 14th of Last Seed was probably once a religious holiday to a Tiger God, instead of a thanksgiving.
 
-    As any schoolchild could tell you, the Redguards are a
-relatively new culture to Tamriel. Their arrival from their
-homeland is actually well recorded, though it occured
-several thousand years ago, in the 808th year of the 1st Era.
-Hammerfell was a great desert encompassed by almost
-impassable mountains -- unclaimed and unwanted. Many of
-the holidays extant in modern Hammerfell seem to be direct
-translations of older Redguard festivals before their
-migration to Tamriel.
+ Other old Redguard holidays have either been acknowledged as part of the old culture or adjusted to fit with the climate of Hammerfell. The Serpent's Dance, for example, of Satakalaam is patently an old festival honoring a Serpent God of the homeland who evidently did not survive the journey to Hammerfell. The significance of the date, the 3rd of Suns Dusk, has been lost with the Serpent Priests. Baranth Do, on the 18th of Evening Star, and Chil'a, on the 24th of the same month, are both New Years festivals. Most likely, they have been moved from their original dates to correspond with the notion of the year defined in Tamriel.
 
-    The orgiastic seasonal celebrations seem unusual in a
-province with few changes in the weather from month to month.
-Yet on the 28th of Suns Dawn, the Redguards of the Banthan
-jungle celebrate Aduros Nau to relieve the wintertide
-lethargy; on the 1st of Mid Year, the people of Abibon-Gora
-celebrate Drigh R'Zimb in honor of the sun, which no normal
-Redguard worships in this day; similarly, on the 29th of Suns
-Height, the festival in the Desert called Fiery Night, seems
-almost perverse in such an environment; the Koomu Alezer'i
-on the 11th of Last Seed in Sentinel has been translated as a
-harvest thanksgiving, though many scholars have suggested
-that it was once a springtide holiday; similarly, the Feast
-of the Tiger in the Bantha on the 14th of Last Seed was
-probably once a religious holiday to a Tiger God, instead of
-a thanksgiving.
+ The Bretons have been in Tamriel since before recorded history. Their holidays have remained almost unchanged since primitive times, though new holidays have been created to replace those which have lost popularity.
 
-     Other old Redguard holidays have either been acknowledged
-as part of the old culture or adjusted to fit with the
-climate of Hammerfell. The Serpent's Dance, for example, of
-Satakalaam is patently an old festival honoring a Serpent
-God of the homeland who evidently did not survive the
-journey to Hammerfell. The significance of the date, the 3rd
-of Suns Dusk, has been lost with the Serpent Priests. Baranth
-Do, on the 18th of Evening Star, and Chil'a, on the 24th of
-the same month, are both New Years festivals. Most likely,
-they have been moved from their original dates to correspond
-with the notion of the year defined in Tamriel.
+ The oldest holidays still observed in High Rock must include Waking Day, on the 18th of Morning Star, when the people of the Yeorth Burrowland wake the spirits of nature after the winter, very nearly in the tradition of their more reverential ancestors. Flower Day, held on the 25th of First Seed in the smaller villages of High Rock is most likely just as older or older. The old cult of the flower is also remembered as Gardtide in Tamarilyn Point on the 1st of Rains Hand. Daggerfall's Day of the Dead, on the 13th of Rains Hand, suggests the ancestor worship that marked the Breton religion of antiquity. Finally, the ancient goddess of the moons, Secunda, is remembered in the Moon Festival in Glenumbra Moors on the 8th of Suns Dusk, just as the nights begin to grow longer.
 
-     The Bretons have been in Tamriel since before recorded
-history. Their holidays have remained almost unchanged since
-primitive times, though new holidays have been created to
-replace those which have lost popularity.
-
-     The oldest holidays still observed in High Rock must
-include Waking Day, on the 18th of Morning Star, when the
-people of the Yeorth Burrowland wake the spirits of nature
-after the winter, very nearly in the tradition of their more
-reverential ancestors. Flower Day, held on the 25th of First
-Seed in the smaller villages of High Rock is most likely just
-as older or older. The old cult of the flower is also
-remembered as Gardtide in Tamarilyn Point on the 1st of
-Rains Hand. Daggerfall's Day of the Dead, on the 13th of
-Rains Hand, suggests the ancestor worship that marked the
-Breton religion of antiquity. Finally, the ancient goddess
-of the moons, Secunda, is remembered in the Moon Festival in
-Glenumbra Moors on the 8th of Suns Dusk, just as the nights
-begin to grow longer.
-
-     The more recently created holidays of High Rock are those
-like Tibedetha, "Tibers Day," celebrated every 24th of Mid
-Year in honor of Alcaire's most famous, son, Tiber Septim.
-Likewise, Othroktide on the 5th of Suns Dawn is held in honor of
-the first and most illustrious Baron of Dwynnen. In quite
-extreme contrast, Marukh's Day on the 9th of Second Seed, is a
-solemn holiday, immortalizing the lessons of the equally
-solemn 1st Era prophet Marukh. My favorite of the modern
-Breton festivals has to be Mad Pelagius, held in mock honor
-of the most eccentric of the Septim Emperors. Pelagius was,
-after all, a prince of Wayrest before he became King of
-Solitude, and then Emperor of Tamriel. The Bretons like to
-boast that it was his time in High Rock that drove him mad.
-
- 
+ The more recently created holidays of High Rock are those like Tibedetha, "Tibers Day," celebrated every 24th of Mid Year in honor of Alcaire's most famous, son, Tiber Septim. Likewise, Othroktide on the 5th of Suns Dawn is held in honor of the first and most illustrious Baron of Dwynnen. In quite extreme contrast, Marukh's Day on the 9th of Second Seed, is a solemn holiday, immortalizing the lessons of the equally solemn 1st Era prophet Marukh. My favorite of the modern Breton festivals has to be Mad Pelagius, held in mock honor of the most eccentric of the Septim Emperors. Pelagius was, after all, a prince of Wayrest before he became King of Solitude, and then Emperor of Tamriel. The Bretons like to boast that it was his time in High Rock that drove him mad.

--- a/Assets/StreamingAssets/Text/Books/BOK00034-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00034-LOC.txt
@@ -3,90 +3,27 @@ Author: Ryston Baylor
 IsNaughty: False
 Price: 340
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]Broken Diamonds
 
-
-
 [/font=4]
 
-[/center]
+ I remember as a young lad in Glenumbra Moors my first Broken Diamonds holiday. The big noisy festivals I remember very well -- Harvests' End, Mid Year, New Year, the Emperor's Day. All of these I have memories of that stretch back before I became truly aware of the meaning of our celebrating. On the 19th of Frost Fall, every year, my family and I would walk to a ruined castle in the middle of the wilderness, together with everyone else we knew in the Moors. Hands clutched in hands, we would form an enormous circle around the ruins, and head reverently bowed we would sing a song, the Sepharve.
 
-[/center] I remember as a young lad in Glenumbra Moors my first Broken
-Diamonds holiday. The big noisy festivals I remember very
-well -- Harvests' End, Mid Year, New Year, the Emperor's Day.
-All of these I have memories of that stretch back before I
-became truly aware of the meaning of our celebrating. On the
-19th of Frost Fall, every year, my family and I would walk
-to a ruined castle in the middle of the wilderness, together
-with everyone else we knew in the Moors. Hands clutched in
-hands, we would form an enormous circle around the ruins,
-and head reverently bowed we would sing a song, the
-Sepharve.
+ For years, we did this and I never asked why. It is an odd thing that normally curious children, from my experience, never ask questions about Broken Diamonds, and adults seldom volunteer information. Gradually, as we learn about our homeland through university or the prattling of ancient relatives, we come to guess and then know the meaning of Broken Diamonds.
 
- For years, we did this and I never asked why. It is an odd
-thing that normally curious children, from my experience,
-never ask questions about Broken Diamonds, and adults seldom
-volunteer information. Gradually, as we learn about our
-homeland through university or the prattling of ancient
-relatives, we come to guess and then know the meaning of
-Broken Diamonds.
+ I cannot be objective as a native of Glenumbra Moors, but visitors have told me that the sorrow -- more often they use the word shame -- of the natives is almost overwhelming. There is a sense that a great and ancient crime still burns in the conscience of the people of the Moors. Though it did not happen in our lifetimes, we know that the debt is not yet paid.
 
- I cannot be objective as a native of Glenumbra Moors, but
-visitors have told me that the sorrow -- more often they use the
-word shame -- of the natives is almost overwhelming. There is
-a sense that a great and ancient crime still burns in the
-conscience of the people of the Moors. Though it did not
-happen in our lifetimes, we know that the debt is not yet
-paid.
+ I refer, of course, to the murder of Her Terrible Majesty, Kintyra II, Emperess of Tamriel, on the frozen morning of the 23rd of Frost Fall, in the year 3E 123.
 
- I refer, of course, to the murder of Her Terrible Majesty,
-Kintyra II, Emperess of Tamriel, on the frozen morning of
-the 23rd of Frost Fall, in the year 3E 123.
+ We do not know the name of the castle where she was held; we do not know the name of her murderer (though the man who ordered the murder was her cousin and usurper, Uriel III); we do not know where she was buried. But our ancestors knew that their rightful ruler was imprisoned somewhere in their land, and did nothing to help her. For that, we bear their shame.
 
- We do not know the name of the castle where she was held; we do
-not know the name of her murderer (though the man who ordered
-the murder was her cousin and usurper, Uriel III); we do not
-know where she was buried. But our ancestors knew that their
-rightful ruler was imprisoned somewhere in their land, and
-did nothing to help her. For that, we bear their shame.
+ On that morning, when our great-great grandparents heard of Kintyra's death, all were stricken with horror and regret at their lack of action. All the people of Glenpoint and Glenumbra Moors searched out those responsible in every Imperial castle. They formed barriers with their bodies to hold the killer within. Flags bearing the Red Diamond of the Septim family were torn and scattered, and broken diamonds littered the snow.
 
- On that morning, when our great-great grandparents heard of
-Kintyra's death, all were stricken with horror and regret at
-their lack of action. All the people of Glenpoint and
-Glenumbra Moors searched out those responsible in every
-Imperial castle. They formed barriers with their bodies to
-hold the killer within. Flags bearing the Red Diamond of the
-Septim family were torn and scattered, and broken diamonds
-littered the snow.
+ The song we sing every Broken Diamonds, as I mentioned before, is the Sephavre. I asked everyone in Glenumbra Moor what the meaning of the song is, for it is in Old Bretic, and each generation only knows it because they were taught by their parents. No one knew the exact meaning of the words, not even the tone and emotion the words can be easily translated. When I later talked to a scholar who gave me an accurate translation of the Sephavre, I began to understand both why our ancestors chose it as the anthem for the great injustice of the murder of Kintyra II and the sorrow that still prevades Glenumbra Moors since that dark morn.
 
- The song we sing every Broken Diamonds, as I mentioned
-before, is the Sephavre. I asked everyone in Glenumbra Moor
-what the meaning of the song is, for it is in Old Bretic, and
-each generation only knows it because they were taught by
-their parents. No one knew the exact meaning of the words,
-not even the tone and emotion the words can be easily
-translated. When I later talked to a scholar who gave me an
-accurate translation of the Sephavre, I began to
-understand both why our ancestors chose it as the anthem for
-the great injustice of the murder of Kintyra II and the sorrow
-that still prevades Glenumbra Moors since that dark morn.
-
- The Sephavre Souls of our fathers, suffer deeply, For you
-have led us to the dark time, When our own souls, filled with
-air, Allowed ignorance and villiany to thrive In what used
-to be our land. Howl, ancestors, howl and bring us Memories
-of our conformance with evil. We do anything we can to
-survive, Giving up our minds and hearts and bodies We will
-not fight, and we will be torn And like flotsam in a
-whirling tide We will be forever the agents of injustice But
-we will mourn it forever.
-
-
-
- 
+ The Sephavre Souls of our fathers, suffer deeply, For you have led us to the dark time, When our own souls, filled with air, Allowed ignorance and villiany to thrive In what used to be our land. Howl, ancestors, howl and bring us Memories of our conformance with evil. We do anything we can to survive, Giving up our minds and hearts and bodies We will not fight, and we will be torn And like flotsam in a whirling tide We will be forever the agents of injustice But we will mourn it forever.

--- a/Assets/StreamingAssets/Text/Books/BOK00035-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00035-LOC.txt
@@ -3,9 +3,8 @@ Author: Croll Baumoval
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,72 +12,26 @@ Content:
 
 [/center]Lovers Lament
 
-
-
 [/font=4]
 
-[/center]
+ The night is very dark. Wind gently ruffles the willow trees. All is quiet, or it so appears, around the shores of the small lake. Tamriel's moons reflect in the slightly rippling surface of the water. An owl's questioning call echoes. No lights are shining from the castle nearby; it appears deserted.
 
- The night is very dark. Wind gently ruffles the willow
-trees. All is quiet, or it so appears, around the shores of
-the small lake. Tamriel's moons reflect in the slightly rippling surface of the water. An owl's questioning
-call echoes. No lights are shining from the castle nearby; it
-appears deserted.
+ As the night wears on and the planet's satellites moves across the heavens, a faint glow appears near the castle. The light slowly moves towards the lake, and upon reaching the shore, stops. A figure, a beautiful woman by any measure, stands looking wistfully into the dark water. Her lantern flickers in the breeze, and illuminates her. Tears are streaming down her cheeks; her gown, once beautiful, is now tattered and stained.
 
- As the night wears on and the planet's satellites moves
-across the heavens, a faint glow appears near the castle.
-The light slowly moves towards the lake, and upon reaching
-the shore, stops. A figure, a beautiful woman by any
-measure, stands looking wistfully into the dark water. Her
-lantern flickers in the breeze, and illuminates her. Tears
-are streaming down her cheeks; her gown, once beautiful, is
-now tattered and stained.
-
- The surface of the lake becomes agitated, but not from a
-wind as the night has become as still as it is dark. Slowly
-from the water emerges the figure of a man, a warrior, fully
-adorned in the armor of a knight on the field of battle. He
-seems to float over the water towards the woman and stop
-just short of her.
+ The surface of the lake becomes agitated, but not from a wind as the night has become as still as it is dark. Slowly from the water emerges the figure of a man, a warrior, fully adorned in the armor of a knight on the field of battle. He seems to float over the water towards the woman and stop just short of her.
 
  "Madylina," the ghostly warrior intones.
 
- "My Lord, Gerthland," whispers the lovely Madylina as she
-kneels. "You have come to me again."
+ "My Lord, Gerthland," whispers the lovely Madylina as she kneels. "You have come to me again."
 
- "Yes," Gerthland responds, "My days are long waiting for
-the night in which I can see my love."
+ "Yes," Gerthland responds, "My days are long waiting for the night in which I can see my love."
 
- The lovers stand looking wistfully at each other, unable
-to touch, unable to kiss, unable to satisfy their unrequited
-love until the first tinges of dawn start to color the
-western sky. Gerthland drops something to the ground as does
-Madylina as each depart. The waters of the lake again take
-possession of the handsome knight and the beautiful maiden
-walks slowly back to the castle. As the waters of the lake
-settle into a gentle ripple and the light of Madylina's
-lantern disappears, dawn breaks over the lake.
+ The lovers stand looking wistfully at each other, unable to touch, unable to kiss, unable to satisfy their unrequited love until the first tinges of dawn start to color the western sky. Gerthland drops something to the ground as does Madylina as each depart. The waters of the lake again take possession of the handsome knight and the beautiful maiden walks slowly back to the castle. As the waters of the lake settle into a gentle ripple and the light of Madylina's lantern disappears, dawn breaks over the lake.
 
- On the shore are two beautiful roses--one crimson and the
-other white as fresh cream. Ripples from the lake overtake the
-two flowers and pull them into the lake leaving the shore
-bare as it was in the hours before darkness fell.
+ On the shore are two beautiful roses--one crimson and the other white as fresh cream. Ripples from the lake overtake the two flowers and pull them into the lake leaving the shore bare as it was in the hours before darkness fell.
 
- ...
+[/center]...
 
- The townfolk around Gerthland Manor tell often of seeing
-these lovers in their nightly meeting. The Boar's Bristle Inn
-is always rumbling with conversation about them. Lord
-Gerthland and Lady Madylina who were betrothed. Lord
-Gerthland called to battle to defend the land. Hergen, the
-castle's resident sorcerer, becoming enflamed with love and
-lust for Madylina only to be rebuked by her. Lord
-Gerthland's death on the field of battle. Lady Madylina's
-death by her own hand at the news. Hergen's curse on both
-their souls that will not allow them to rest until Madylina
-will agree to become Hergen's consort even in death.
+ The townfolk around Gerthland Manor tell often of seeing these lovers in their nightly meeting. The Boar's Bristle Inn is always rumbling with conversation about them. Lord Gerthland and Lady Madylina who were betrothed. Lord Gerthland called to battle to defend the land. Hergen, the castle's resident sorcerer, becoming enflamed with love and lust for Madylina only to be rebuked by her. Lord Gerthland's death on the field of battle. Lady Madylina's death by her own hand at the news. Hergen's curse on both their souls that will not allow them to rest until Madylina will agree to become Hergen's consort even in death.
 
- Hergen, to this day, wanders the deserted halls of Gerthland
-Manor hoping that Madylina will agree to his demands. And
-the lovers continue to meet for a few moments each night on
-the shores of the lake now known as Lover's Lament. 
+ Hergen, to this day, wanders the deserted halls of Gerthland Manor hoping that Madylina will agree to his demands. And the lovers continue to meet for a few moments each night on the shores of the lake now known as Lover's Lament.

--- a/Assets/StreamingAssets/Text/Books/BOK00036-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00036-LOC.txt
@@ -3,150 +3,39 @@ Author: Varnard Karessen
 IsNaughty: False
 Price: 419
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]On Lycanthropy
 
-
-
 [/font=4]
 
-[/center]
+ How does one become interested in studying the disease lycanthropy? I have interviewed a number of my peers, and discovered that to a man, they have all entered the field after a horrifying encounter with a lycanthrope of some variety. I am no exception.
 
-[/center]    How does one become interested in studying the disease
-lycanthropy? I have interviewed a number of my peers, and
-discovered that to a man, they have all entered the field
-after a horrifying encounter with a lycanthrope of some
-variety. I am no exception.
+ In Skyrim, it is an old tradition to rub canis root on the trees surrounding your house as a ward against werebears. When I was young and stupid (as opposed, I guess, to being old and stupid as I am now), I always had hoped to meet a werebear to see if they were as impressive as legend suggested. I would follow strange tracks in the woods until they disappeared, with no fear or even thought about what I would do after I had found my quarry. By Thorig's beard, I was lucky that my investigations were fruitless.
 
-    In Skyrim, it is an old tradition to rub canis root on the
-trees surrounding your house as a ward against werebears.
-When I was young and stupid (as opposed, I guess, to being
-old and stupid as I am now), I always had hoped to meet a
-werebear to see if they were as impressive as legend
-suggested. I would follow strange tracks in the woods until
-they disappeared, with no fear or even thought about what I
-would do after I had found my quarry. By Thorig's beard, I
-was lucky that my investigations were fruitless.
+ When I did finally see a lycanthrope, it was not a werebear. It was a werewolf, the "common" lycanthope, which can be found in every part of Tamriel. My father was a priest and during the coldest part of the winter, he allowed the beggars and riffraff of Falcrenth to stay in the relative warmth of the cellar of his temple. We would even supply warm barley stew. My sisters and brothers and I actually enjoyed this bit of philanthropy, for in the cellars during the winter, it seemed there was a constant party. There were always travellers with interesting stories and eccentricities, and the atmosphere in the cellars was always light and friendly. Until that night.
 
-    When I did finally see a lycanthrope, it was not a werebear. It was a werewolf, the
-"common" lycanthope, which can be found in every part of
-Tamriel. My father was a priest and during the coldest part
-of the winter, he allowed the beggars and riffraff of
-Falcrenth to stay in the relative warmth of the cellar of his
-temple. We would even supply warm barley stew. My sisters
-and brothers and I actually enjoyed this bit of
-philanthropy, for in the cellars during the winter, it seemed there was a constant party. There were always
-travellers with interesting stories and eccentricities, and
-the atmosphere in the cellars was always light and friendly.
-Until that night.
+ By an established tradition, the beggars who were sick or wanted rest more than food and companionship would go to the cots at the farthest, darkest end of the cellar when they could be assured at least relative quiet. We were enjoying a song, and my sister Gethessa was dancing to the amusement of all. The song ended, but a chorus continued from the darkness at the far end of the cellar. As drunk and incomprehensible as most of the carolers were, it took a minute for us to realize that the sound we were hearing was not singing, but screaming.
 
-    By an established tradition, the beggars who were sick or
-wanted rest more than food and companionship would go to
-the cots at the farthest, darkest end of the cellar when they
-could be assured at least relative quiet. We were enjoying
-a song, and my sister Gethessa was dancing to the amusement
-of all. The song ended, but a chorus continued from the
-darkness at the far end of the cellar. As drunk and
-incomprehensible as most of the carolers were, it took a
-minute for us to realize that the sound we were hearing was not
-singing, but screaming.
+ No one was too concerned, for some of the older tramps often suffered from vivid nightmares. Nevertheless, one of father's priests went to silence the screamer and the moment he disappeared into the murk, we heard another sound. The snarl of a wolf. Then we heard the priest screaming as the original scream died off.
 
-    No one was too concerned, for some of the older tramps
-often suffered from vivid nightmares. Nevertheless, one of
-father's priests went to silence the screamer and the moment he
-disappeared into the murk, we heard another sound. The snarl
-of a wolf. Then we heard the priest screaming as the original
-scream died off.
+ "Werewolf!" cried the old bard who had been leading the song. The cellar exploded into chaos.
 
-    "Werewolf!" cried the old bard who had been leading the
-song. The cellar exploded into chaos.
+ I was pushed out the cellar door into the snow with the first wave of panic, but I could see that some of the more brave (or more drunk) hobos were rushing into the darkness to do battle with the lycanthrope. They were all, of course, almost instantly killed.
 
-     I was pushed out the cellar door into the snow with the
-first wave of panic, but I could see that some of the more
-brave (or more drunk) hobos were rushing into the darkness to
-do battle with the lycanthrope. They were all, of course,
-almost instantly killed.
+ My father, upon hearing of his unwelcome visitor, sealed off the cellar after the last survivor of the carnage had left. A seasoned battlemage from the Falcrenth Mages Guild, who owed father a favor, went into the cellar and slew the beast.
 
-     My father, upon hearing of his unwelcome visitor, sealed
-off the cellar after the last survivor of the carnage had
-left. A seasoned battlemage from the Falcrenth Mages Guild,
-who owed father a favor, went into the cellar and slew the
-beast.
+ "Not too tough," he said as he emerged, carrying the carcass with him. "Winter must have been tough on him too." Despite his bold words, the blood on his face and chest did not only come from his foe.
 
-     "Not too tough," he said as he emerged, carrying the
-carcass with him. "Winter must have been tough on him too."
-Despite his bold words, the blood on his face and chest did
-not only come from his foe.
+ Werewolves do not revert to their human forms upon death, despite what legends will tell you. I had the opportunity to look at the monster's steaming body out in the snow before it was carried away to be burned. The teeth, clotted with the flesh of the beggars, were horrifying, but the claws shocked me even more. I have since seen live lycanthropes battle golems, atronachs, and other beings not harmed by mundane weapons, and concluded that they act as naturally enchanted weapons.
 
-     Werewolves do not revert to their human forms upon
-death, despite what legends will tell you. I had the
-opportunity to look at the monster's steaming body out in the
-snow before it was carried away to be burned. The teeth,
-clotted with the flesh of the beggars, were horrifying, but the
-claws shocked me even more. I have since seen live
-lycanthropes battle golems, atronachs, and other beings not
-harmed by mundane weapons, and concluded that they act as
-naturally enchanted weapons.
+ Because the werewolf is the most ubiquitous of lycanthropes, the term lycanthropy has been used since ancient days to describe the disease that transforms men into half-beast, although lycanthrope only strictly should refer to men who change into werewolves. But that is semantics. There are certainly differences between the seven documented forms of lycanthropy in Tamriel, but more similarities.
 
-     Because the werewolf is the most ubiquitous of
-lycanthropes, the term lycanthropy has been used since
-ancient days to describe the disease that transforms men into
-half-beast, although lycanthrope only strictly should
-refer to men who change into werewolves. But that is
-semantics. There are certainly differences between the seven
-documented forms of lycanthropy in Tamriel, but more
-similarities.
+ In Black Marsh and southern Morrowind, werecrocodiles stalk the swamps. Black Marsh also shares with the Imperial Province and the wetter parts of Elsweyr the vile presence of werelions. Valenwood's werevultures are not found in any other province. The wereboar has found both the climates of High Rock and Hammerfell amenable. As I mentioned before, the werebear is the most common lycanthrope in Skyrim, and is also found in the northern parts of High Rock, the Imperial Province, and Morrowind. The werewolf can be found in every province. The seventh lycanthrope, which I have never seen but my trusted peers have assured me exists, is a wereshark that roams the oceans around Tamriel.
 
-     In Black Marsh and southern Morrowind, werecrocodiles
-stalk the swamps. Black Marsh also shares with the Imperial
-Province and the wetter parts of Elsweyr the vile presence of
-werelions. Valenwood's werevultures are not found in any
-other province. The wereboar has found both the climates of
-High Rock and Hammerfell amenable. As I mentioned before, the
-werebear is the most common lycanthrope in Skyrim, and is
-also found in the northern parts of High Rock, the Imperial
-Province, and Morrowind. The werewolf can be found in every
-province. The seventh lycanthrope, which I have never seen
-but my trusted peers have assured me exists, is a wereshark
-that roams the oceans around Tamriel.
+ I have spent my life categorizing and observing lycanthropes, but I sometimes feel that I am still a child trapped in a cellar in my attempts to understand them. I know, for example, that lycanthropy can be cured shortly after infection, but after that time, the victim is doomed. No one of my acquaintance has cured themselves after undergoing the first transformation. On the other hand, I have a colleague investigating a coven of witches in the Glenpoint foothills of High Rock who are rumored to have a cure. I remain dubious.
 
-     I have spent my life categorizing and observing
-lycanthropes, but I sometimes feel that I am still a child
-trapped in a cellar in my attempts to understand them. I
-know, for example, that lycanthropy can be cured shortly
-after infection, but after that time, the victim is doomed.
-No one of my acquaintance has cured themselves after
-undergoing the first transformation. On the other hand, I
-have a colleague investigating a coven of witches in the
-Glenpoint foothills of High Rock who are rumored to have a
-cure. I remain dubious.
-
-     Perhaps it is because they are doomed that makes
-lycanthropes so aggressive. I have removed the contents of a
-werewolf's stomach and found more remnants of roots and
-berries than animal flesh. My conclusion is that they do not
-need to attack and devour humans to survive. Yet, for some
-reason they do. Does lycanthropy drive them mad, or do
-lycanthropes feel the need to spread the disease as a form of
-procreation? I do not know. I am not certain that any of us
-who are not lycanthropes ourselves will ever know. And then,
-of course, it's too late.
-
-
-
-
-
-
-
-
-
-
-
-
-
- 
+ Perhaps it is because they are doomed that makes lycanthropes so aggressive. I have removed the contents of a werewolf's stomach and found more remnants of roots and berries than animal flesh. My conclusion is that they do not need to attack and devour humans to survive. Yet, for some reason they do. Does lycanthropy drive them mad, or do lycanthropes feel the need to spread the disease as a form of procreation? I do not know. I am not certain that any of us who are not lycanthropes ourselves will ever know. And then, of course, it's too late.

--- a/Assets/StreamingAssets/Text/Books/BOK00037-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00037-LOC.txt
@@ -3,9 +3,8 @@ Author: Bresne Smythe
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,77 +14,27 @@ Content:
 
 [/center]Lysirius
 
-
-
 [/font=4]
+ In ancient times, there lived a hero named Lyrisius. He fought agains the Akaviri slavetraders and single-handedly slew hundreds. Despite his valor, Lyrisius' army was routed and scattered to the four winds. Lyrisius fled into the moors to escape the Akaviri chariots.
 
+ Far from the lands of men, Lyrisius entered the blasted lands. At the heart of this forsaken landscape, he met the wyrm. The great scaly beast mocked the mighty blows of Lyrisius' enchanted spear. It melted the shield Fearstruck, gift of the Daedra Boethiah, with a single blast of its fiery breath. Lyrisius, seeing that he could not defeat the creature by force of arms, surrendered.
 
+ The wyrm intended to devour Lyrisius when the hero offered to be its slave and manservant. Ever prideful, the wyrm agreed. Seeing that the wyrm was vulnerable to conceit, Lyrisius spoke, "Oh great wyrm. For my first service, I beg that you allow me to polish your one tarnished scale."
 
-[/center]
+ Indeed, centered between the great wings of the creature was a dull scale, clearly out of reach of its long neck. Its vanity was such that it immediately lowered one wing for Lyrisius to climb upon.
 
-    In ancient times, there lived a hero named Lyrisius. He
-fought agains the Akaviri slavetraders and single-handedly
-slew hundreds. Despite his valor, Lyrisius' army was routed
-and scattered to the four winds. Lyrisius fled into the
-moors to escape the Akaviri chariots.
+ Once astride the great lizard, Lyrisius slid his dagger underneath the scale and into the tender flesh of the beast. Though it spun and twisted in all directions, the wyrm could not get at the hero. Finally it took to the air. Lyrisius clung to the neck with all his strength as the wyrm banked, rolled, and dove.
 
-    Far from the lands of men, Lyrisius entered the blasted
-lands. At the heart of this forsaken landscape, he met the
-wyrm. The great scaly beast mocked the mighty blows of
-Lyrisius' enchanted spear. It melted the shield Fearstruck,
-gift of the Daedra Boethiah, with a single blast of its fiery
-breath. Lyrisius, seeing that he could not defeat the
-creature by force of arms, surrendered.
+ Seeing that Lyrisius could not be shaken free, the wyrm demanded that he remove the stinging blade. Lyrisius answered, "Fly straight on until you see a great army. Destroy that army and I will remove my blade."
 
-    The wyrm intended to devour Lyrisius when the hero offered
-to be its slave and manservant. Ever prideful, the wyrm
-agreed. Seeing that the wyrm was vulnerable to conceit,
-Lyrisius spoke, "Oh great wyrm. For my first service, I beg
-that you allow me to polish your one tarnished scale."
+ With a great roar, the scaled creature set off. The Akavari army had no chance against the fire-breathing beast. They have never plagued Tamriel since.
 
-    Indeed, centered between the great wings of the creature
-was a dull scale, clearly out of reach of its long neck.
-Its vanity was such that it immediately lowered one wing for
-Lyrisius to climb upon.
+ "I have done as you bid. Now sheath your stinger," roared the wyrm.
 
-    Once astride the great lizard, Lyrisius slid his dagger
-underneath the scale and into the tender flesh of the beast.
-Though it spun and twisted in all directions, the wyrm
-could not get at the hero. Finally it took to the air.
-Lyrisius clung to the neck with all his strength as the wyrm
-banked, rolled, and dove.
+ Knowing that he would be devoured or worse, Lyrisius pulled the blade and then leapt from the back of the flying wyrm. Indeed, the foul monster had intended to slay the hero. The wyrm pursued the plummeting Lyrisius. Boethiah appeared beside the falling hero. Praising him for ultimately destroying the army of Akavir, she turned him into a raven. Lyrisius quickly lost the wyrm in the clouds.
 
-    Seeing that Lyrisius could not be shaken free, the wyrm
-demanded that he remove the stinging blade. Lyrisius
-answered, "Fly straight on until you see a great army.
-Destroy that army and I will remove my blade."
+ Legend has it that the wyrm still lives, though this happened in the first era long, long ago. The dragon nurses a grudge against Lyrisius and all of his kind. It has vowed never again to trust two legged bearers of weapons.
 
-    With a great roar, the scaled creature set off. The
-Akavari army had no chance against the fire-breathing beast.
-They have never plagued Tamriel since.
+[/center]* * *
 
-    "I have done as you bid. Now sheath your stinger," roared
-the wyrm.
-
-    Knowing that he would be devoured or worse, Lyrisius
-pulled the blade and then leapt from the back of the flying
-wyrm. Indeed, the foul monster had intended to slay the
-hero. The wyrm pursued the plummeting Lyrisius. Boethiah
-appeared beside the falling hero. Praising him for
-ultimately destroying the army of Akavir, she turned him into
-a raven. Lyrisius quickly lost the wyrm in the clouds.
-
-    Legend has it that the wyrm still lives, though this
-happened in the first era long, long ago. The dragon nurses
-a grudge against Lyrisius and all of his kind. It has vowed
-never again to trust two legged bearers of weapons.
-
-
-
-[/center]*   *   *
-
- Scholar's Note: If this legend has a basis in fact, the
-artifact Fearstruck was utterly destroyed. No other
-reference to it has ever been found.
-
- 
+ Scholar's Note: If this legend has a basis in fact, the artifact Fearstruck was utterly destroyed. No other reference to it has ever been found.

--- a/Assets/StreamingAssets/Text/Books/BOK00038-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00038-LOC.txt
@@ -3,9 +3,8 @@ Author: Salarth
 IsNaughty: False
 Price: 687
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,87 +14,19 @@ Content:
 
 [/center]Mages Guild
 
-
-
 [/font=4]
+ The idea of a collection of Mages, Sorcerors, and assorted Mystics pooling their resources and talents for the purpose of research and public charity was a revolutionary concept in the early years of the 2nd era. The closest organization to what we today know as the Mages Guild was the Psijic Order of the Isle of Artaeum. Magic was something to be learned by individuals, or, at most, in intimate covens; mages were, if not actual hermits, usually quite solitary.
 
+ The Psijic Order served the rulers of the Sumurset Isle as counselors, and chose its members by a complex, ritualized method not understood by the common people. Its purposes and goals were likewise unpublished, and its detractors attributed the worst evil as the source of its power. The religion of the old order could be described as ancestor worship, an increasingly unfashionable philosophy in the 2nd Era.
 
+ When Vanus Galerion, a Psijic of Artaeum and student of the famed Iachesis, began collecting mages from around Sumurset Isle, he attracted the animosity of all. He was operating out of Firsthold, and there was a common (and not entirely unsensible) attitude that magical experiments should be conducted only in unpopulated areas. Even more shocking, Galerion proposed to make magical items, potions, and even spells available to any member of the general public who could pay. No longer was magic to be limited either to the aristocracy or intelligensia.
 
-[/center]    The idea of a collection of Mages, Sorcerors, and
-assorted Mystics pooling their resources and talents for
-the purpose of research and public charity was a
-revolutionary concept in the early years of the 2nd era. The
-closest organization to what we today know as the Mages Guild
-was the Psijic Order of the Isle of Artaeum. Magic was
-something to be learned by individuals, or, at most, in
-intimate covens; mages were, if not actual hermits, usually
-quite solitary.
+ Galerion was brought before Iachesis and the King of Firsthold, Rilis XII, and made to state the intentions of the guild he was forming. The fact that Galerion's speech to Rilis and Iachesis was not recorded for posterity is a tragedy, though it does allow the opportunity for historians to amuse one another with lies and persuasions Galerion might have used to found the ubiquitous organization. The charter was approved.
 
-    The Psijic Order served the rulers of the Sumurset Isle as
-counselors, and chose its members by a complex, ritualized
-method not understood by the common people. Its purposes
-and goals were likewise unpublished, and its detractors
-attributed the worst evil as the source of its power. The
-religion of the old order could be described as ancestor
-worship, an increasingly unfashionable philosophy in the
-2nd Era.
+ Almost immediately after the guild was formed, the question of security had to be answered. The Isle of Artaeum did not have to have a force of arms to shield it from invaders interested in stealing its treasures -- when the Psijic Order does not wish someone to land on the island, the island and all on it become insubstantial. The new Mages Guild had to hire guards. Galerion soon discovered what nobles have known for thousands of years: money alone does not buy loyalty. The knightly Order of the Lamp was formed the following year.
 
-    When Vanus Galerion, a Psijic of Artaeum and student of
-the famed Iachesis, began collecting mages from around
-Sumurset Isle, he attracted the animosity of all. He was
-operating out of Firsthold, and there was a common (and not
-entirely unsensible) attitude that magical experiments
-should be conducted only in unpopulated areas. Even more
-shocking, Galerion proposed to make magical items,
-potions, and even spells available to any member of the
-general public who could pay. No longer was magic to be
-limited either to the aristocracy or intelligensia.
+ Like a tree from an acorn, the Mages Guild grew branches all over Sumurset Isle and then to the mainland of Tamriel. There are many records of superstitious or sensibly fearful rulers forbidding the Guild in their kingdom, but their heirs or their heirs' heirs recognized the wisdom of allowing the Guild to practice. The Mages Guild was a powerful force in Tamriel, a dangerous foe if a somewhat disinterested ally. There have been only a few rare incidents of the Mages Guild actually becoming involved in local politcal struggles. On these occasions, the Guild's participation has been the ultimate decider in the conflict.
 
-    Galerion was brought before Iachesis and the King of
-Firsthold, Rilis XII, and made to state the intentions of the
-guild he was forming. The fact that Galerion's speech to
-Rilis and Iachesis was not recorded for posterity is a
-tragedy, though it does allow the opportunity for historians
-to amuse one another with lies and persuasions Galerion
-might have used to found the ubiquitous organization. The
-charter was approved.
+ By tradition begun by Vanus Galerion, the Mages Guild as a singular institution is presided over by a council of six Archmagisters. Each guild location is run by a Guildmagister, assisted by a counsel of two, the Master of Incunubula and the Master at Arms. The Master of Incunubula presides over a counsel of an additional two mages: the Master of Academia and the Master of the Scrye. The Master at Arms also has a counsel of two: the Master of Initiates and the Palatinus, the leader of the Order of the Lamp.
 
-    Almost immediately after the guild was formed, the
-question of security had to be answered. The Isle of Artaeum
-did not have to have a force of arms to shield it from
-invaders interested in stealing its treasures -- when the
-Psijic Order does not wish someone to land on the island, the
-island and all on it become insubstantial. The new Mages
-Guild had to hire guards. Galerion soon discovered what
-nobles have known for thousands of years: money alone does
-not buy loyalty. The knightly Order of the Lamp was formed
-the following year.
-
-    Like a tree from an acorn, the Mages Guild grew branches
-all over Sumurset Isle and then to the mainland of Tamriel.
-There are many records of superstitious or sensibly fearful
-rulers forbidding the Guild in their kingdom, but their heirs
-or their heirs' heirs recognized the wisdom of allowing the
-Guild to practice. The Mages Guild was a powerful force in
-Tamriel, a dangerous foe if a somewhat disinterested ally.
-There have been only a few rare incidents of the Mages Guild
-actually becoming involved in local politcal struggles.
-On these occasions, the Guild's participation has been the
-ultimate decider in the conflict.
-
-    By tradition begun by Vanus Galerion, the Mages Guild as
-a singular institution is presided over by a council of six
-Archmagisters. Each guild location is run by a
-Guildmagister, assisted by a counsel of two, the Master of
-Incunubula and the Master at Arms. The Master of Incunubula
-presides over a counsel of an additional two mages: the
-Master of Academia and the Master of the Scrye. The Master at
-Arms also has a counsel of two: the Master of Initiates and
-the Palatinus, the leader of the Order of the Lamp.
-
-    One need not be a member of the Mages Guild to know that
-this carefully constructed order is often nothing more than
-an illusion. As Vanus Galerion himself said bitterly,
-leaving Tamriel to travel to other lands, "The Guild has
-become nothing more than an intricate morass of political
-infighting." 
+ One need not be a member of the Mages Guild to know that this carefully constructed order is often nothing more than an illusion. As Vanus Galerion himself said bitterly, leaving Tamriel to travel to other lands, "The Guild has become nothing more than an intricate morass of political infighting."

--- a/Assets/StreamingAssets/Text/Books/BOK00039-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00039-LOC.txt
@@ -3,9 +3,8 @@ Author: Waughin Jarth
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,121 +12,27 @@ Content:
 
 [/center]Asylum Ball
 
-
-
 [/font=4]
+ My great great uncle was a warder at an asylum in Torval (maybe he was my great great great uncle -- it was quite a long time ago), and this is the story that has been passed down in my family from his generation to mine. Perhaps it is purely apocryphal, but when I was told it, it was whispered in such a way that it was meant to be taken seriously. Not having any children of my own to whisper to, and being in need of some gold, I have elected to publish my story.
 
-[/center]
+ The asylum my great great uncle worked in was apparently very posh. Only the right class of lunatics were admitted. Eccentric dukes, mad baronesses, touched lords, and daft ladies filled the asylums tapestried and gilded halls. Still, it was a time of great excitement when the rumor began that the unhinged Emperor of Tamriel, Pelagius III, was transferring there from a resort in Valenwood. When the rumor became a reality, the asylum went into nice, calm, restive chaos. Pelagius was given an entire wing of the asylum for his own use, for, though he was madder than a jackal, he was still His Terrible Majesty, the Emperor of Tamriel.
 
-    My great great uncle was a warder at an asylum in Torval
-(maybe he was my great great great uncle -- it was quite a
-long time ago), and this is the story that has been passed down
-in my family from his generation to mine. Perhaps it is
-purely apocryphal, but when I was told it, it was whispered
-in such a way that it was meant to be taken seriously. Not
-having any children of my own to whisper to, and being in
-need of some gold, I have elected to publish my story.
+ The Emperor was remarkably well behaved, my great great uncle supposedly asserted. Of course, he did not have to face the commoners who came on all sorts of pretenses to gawk at their overlord, the loon. When one of the warders (not, I have been assured, my uncle) forgot himself and let His Terrible Majesty know that people had been there to see him, the Emperor grew very excited. He made up his mind right there and then to have a ball. A huge party with musicians, dancing, and dinner, right at the lunatic asylum. Or precisely, in his wing of the asylum.
 
-    The asylum my great great uncle worked in was apparently
-very posh. Only the right class of lunatics were admitted. Eccentric dukes, mad baronesses, touched lords, and
-daft ladies filled the asylums tapestried and gilded
-halls. Still, it was a time of great excitement when the rumor
-began that the unhinged Emperor of Tamriel, Pelagius III,
-was transferring there from a resort in Valenwood. When the
-rumor became a reality, the asylum went into nice, calm,
-restive chaos. Pelagius was given an entire wing of the
-asylum for his own use, for, though he was madder than a
-jackal, he was still His Terrible Majesty, the Emperor of
-Tamriel.
+ Rumors of the Emperor's interest in holding a ball spread throughout Torval and eventually it reached the ears of the Emperess Regent Katariah, Pelagius' dear wife, in the Imperial City. Eager to make her husband happy, she sent a caravan laden with gold to the asylum so a ball might be held befitting the Imperial dignity.
 
-    The Emperor was remarkably well behaved, my great great
-uncle supposedly asserted. Of course, he did not have to
-face the commoners who came on all sorts of pretenses to
-gawk at their overlord, the loon. When one of the warders
-(not, I have been assured, my uncle) forgot himself and let
-His Terrible Majesty know that people had been there to see him, the Emperor grew very
-excited. He made up his mind right there and then to have a
-ball. A huge party with musicians, dancing, and dinner, right
-at the lunatic asylum. Or precisely, in his wing of the
-asylum.
+ The Emperor picked a date for the ball, and preparations began immediately. The old asylum walls were beautifully decorated, but needed cleaning. A pit had to be constructed to house the orchestra; servants for cooking and serving the food had to be hired; gold and ebony candelebras and matching chandeliers were ordered; the old rugs were destroyed, and new rugs embroidered with gems were weaved; lists of guests had to be compiled, reconsidered and recompiled. The Emperor knew that the guest list had to be very exclusive, and he relied on his advisors to tell him who was alive, who was dead, and who was imaginary.
 
-    Rumors of the Emperor's interest in holding a ball spread
-throughout Torval and eventually it reached the ears of the
-Emperess Regent Katariah, Pelagius' dear wife, in the
-Imperial City. Eager to make her husband happy, she sent a
-caravan laden with gold to the asylum so a ball might be
-held befitting the Imperial dignity.
+ The party was set to begin at nine o'clock. At six, the hairdresser he had hired from Torval finished his Imperial coiffure. At seven, he was fully dressed in the robes he had ordered for the ball: voluminous black silk and piled velvet crusted with red diamonds. At eight, he walked down the newly reconstructed staircase to supervise the final preparations -- the lighting of the candles, the opening of the wine, the murder of the first course. At nine o'clock, he took his seat at the facsimile throne he had ordered and awaited the first guests.
 
-    The Emperor picked a date for the ball, and preparations
-began immediately. The old asylum walls were beautifully
-decorated, but needed cleaning. A pit had to be constructed
-to house the orchestra; servants for cooking and serving the
-food had to be hired; gold and ebony candelebras and
-matching chandeliers were ordered; the old rugs were
-destroyed, and new rugs embroidered with gems were weaved;
-lists of guests had to be compiled, reconsidered and
-recompiled. The Emperor knew that the guest list had to be
-very exclusive, and he relied on his advisors to tell him who
-was alive, who was dead, and who was imaginary. 
+ At nine thirty, his advisor, seeing the royal eyes beginning to glaze over with madness, said, "Your Terrible Majesty surely knows that it is not fashionable to arrive at any ball for at least an hour after the desired time, yes?"
 
-    The party was set to begin at nine o'clock. At six, the
-hairdresser he had hired from Torval finished his Imperial
-coiffure. At seven, he was fully dressed in the robes he had
-ordered for the ball: voluminous black silk and piled
-velvet crusted with red diamonds. At eight, he walked down the
-newly reconstructed staircase to supervise the final
-preparations -- the lighting of the candles, the opening of
-the wine, the murder of the first course. At nine o'clock, he
-took his seat at the facsimile throne he had ordered and awaited
-the first guests.
+ The Emperor just stared.
 
-    At nine thirty, his advisor, seeing the royal eyes
-beginning to glaze over with madness, said, "Your Terrible
-Majesty surely knows that it is not fashionable to arrive at
-any ball for at least an hour after the desired time, yes?"
+ At ten thirty, the Emperor called for some food and wine, and sat at his throne, looking at the open door, eatting. Thirty minutes later, he ordered the orchestra to begin playing. For the next three hours, they played gaily for the empty, candlelit ballroom.
 
-    The Emperor just stared.
+ At one o'clock, the Emperor announced his intention to retire for the evening. My uncle was one of the warders who assisted His Terrible Majesty up the staircase. Halfway to his room, Pelagius threw himself on the floor in a hysteria, screaming and laughing, ordering more wine (my mother was good at this part of the story, rolling her eyes and shreiking, "More wine! More wine! Wine!"), and, in short, imagining that he was possessed by all the revellers at his party that never was.
 
-    At ten thirty, the Emperor called for some food and wine,
-and sat at his throne, looking at the open door, eatting.
-Thirty minutes later, he ordered the orchestra to begin
-playing. For the next three hours, they played gaily for the
-empty, candlelit ballroom.
+ Two days later, he was still not better. He had cut himself and those who tried to grapple him horribly with the red diamonds of his robe. Eventually it was decided that the Torval asylum was not equipped to deal with a lunatic of his severity, and he was sent to a more secure location in Black Marsh. It was only three months later, my uncle heard that the Emperor had died.
 
-    At one o'clock, the Emperor announced his intention to
-retire for the evening. My uncle was one of the warders who
-assisted His Terrible Majesty up the staircase. Halfway to
-his room, Pelagius threw himself on the floor in a hysteria,
-screaming and laughing, ordering more wine (my mother was
-good at this part of the story, rolling her eyes and
-shreiking, "More wine! More wine! Wine!"), and, in short,
-imagining that he was possessed by all the revellers at his
-party that never was.
-
-    Two days later, he was still not better. He had cut himself
-and those who tried to grapple him horribly with the red
-diamonds of his robe. Eventually it was decided that the
-Torval asylum was not equipped to deal with a lunatic of his
-severity, and he was sent to a more secure location in Black
-Marsh. It was only three months later, my uncle heard that
-the Emperor had died.
-
-    One of my uncle's duties was to clear out the personal
-property of the inmates after their death. Being primarily
-landed nobility, the personal property was often quite
-extensive. Several years after the asylum ball, my uncle
-was called to clear out the apartment of a duchess whose
-chief eccentricity was a propensity to pilfer.
-Kleptomania, I believe it's called. Locked away in a secret
-door in her desk, protected by a trap armed with a barbed
-needle, was a variety of jewels, piles of gold, and a five
-large stacks of beautifully engraved invitations signed in
-the Emperor's childlike handwriting.
-
-    
-
-
-
-
-
- 
+ One of my uncle's duties was to clear out the personal property of the inmates after their death. Being primarily landed nobility, the personal property was often quite extensive. Several years after the asylum ball, my uncle was called to clear out the apartment of a duchess whose chief eccentricity was a propensity to pilfer. Kleptomania, I believe it's called. Locked away in a secret door in her desk, protected by a trap armed with a barbed needle, was a variety of jewels, piles of gold, and a five large stacks of beautifully engraved invitations signed in the Emperor's childlike handwriting.

--- a/Assets/StreamingAssets/Text/Books/BOK00040-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00040-LOC.txt
@@ -3,9 +3,8 @@ Author: Tetronius Lor
 IsNaughty: False
 Price: 661
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -17,66 +16,13 @@ Content:
 
 [/center]Voyage
 
-
-
 [/font=4]
+ Mysticism is the school of magic least understood by the magical community, most difficult to explain to novices mages. The spells effects commonly ascribed to the School of Mysticism are as wildly disparate as Soul Trap -- the creation of a cell for a victim's spirit after death -- to Silence -- the extinction of sound. But these effects are simply that: effects. The sorcery behind them is veiled in a mystery that may go back to the oldest civilizations of Tamriel, and beyond.
 
-[/center]
+ The Psijics of the Order of Artaeum's term for Mysticism is the Old Way. The phrase becomes bogged in a semantic quagmire, because the Old Way also refers to the religion and customs of the Psijics which may, or may not, be part of the magic of Mysticism.
 
-[/center]     Mysticism is the school of magic least understood by the
-magical community, most difficult to explain to novices
-mages. The spells effects commonly ascribed to the School
-of Mysticism are as wildly disparate as Soul Trap -- the
-creation of a cell for a victim's spirit after death -- to
-Silence -- the extinction of sound. But these effects are
-simply that: effects. The sorcery behind them is veiled in a
-mystery that may go back to the oldest civilizations of
-Tamriel, and beyond.
+ There are few mages who devote their lives to the study of Mysticism. The other schools are far more predictable and fathomable. Mysticism seems to derive its power from its cunundrums and paradoxes; the act of experimentation, no matter how objectively implemented, can influence the magicka by its very existance. Thus, the Mystic mage must regulate himself to finding consistant patterns in an imbroglio of energy. In the time it takes him to find a source with a consistant trigger and result, his peers researching in other schools may have researched and documented dozens of new spells and effects. The Mystic mage is a patient and uncompetitve scholar.
 
-     The Psijics of the Order of Artaeum's term for Mysticism
-is the Old Way. The phrase becomes bogged in a semantic
-quagmire, because the Old Way also refers to the religion
-and customs of the Psijics which may, or may not, be part of
-the magic of Mysticism.
+ For centuries, mostly during the Second Era, scholarly journals publishes theory after theory about the aspect or aspects of magicka that we call Mysticism. In the tradition of the Mages Guild to find answers to all things, respected researchers suggested the energy source as coming from Aetherius or the Daedra themselves to explain the seemingly random patterns of Mysticism; some ventured to guess that Mysticism comes from unused elements of successfully or unsuccessfully cast spells; discussion with the Order of Artaeum after its reappearance has led some scholars to postulate that Mysticism is more spiritual in nature, either the intellect or emotion of the believer influences the energy pattern and flow.
 
-     There are few mages who devote their lives to the study of
-Mysticism. The other schools are far more predictable and
-fathomable. Mysticism seems to derive its power from its
-cunundrums and paradoxes; the act of experimentation, no
-matter how objectively implemented, can influence the
-magicka by its very existance. Thus, the Mystic mage must
-regulate himself to finding consistant patterns in an
-imbroglio of energy. In the time it takes him to find a source
-with a consistant trigger and result, his peers researching
-in other schools may have researched and documented dozens of
-new spells and effects. The Mystic mage is a patient and
-uncompetitve scholar.
-
-     For centuries, mostly during the Second Era, scholarly
-journals publishes theory after theory about the aspect or
-aspects of magicka that we call Mysticism. In the tradition
-of the Mages Guild to find answers to all things, respected
-researchers suggested the energy source as coming from
-Aetherius or the Daedra themselves to explain the seemingly
-random patterns of Mysticism; some ventured to guess that
-Mysticism comes from unused elements of successfully or
-unsuccessfully cast spells; discussion with the Order of
-Artaeum after its reappearance has led some scholars to
-postulate that Mysticism is more spiritual in nature, either
-the intellect or emotion of the believer influences the
-energy pattern and flow.
-
-     None of these explanations is truly satisfactory. For
-the beginning student of Mysticism, it is best to simple
-learn the patterns distinguished in the maelstrom in the
-centuries past. The more patterns are found, the clearer the
-remaining ones become. Until, of course, they change. And
-then the journey begins anew.
-
-
-
-
-
-
-
- 
+ None of these explanations is truly satisfactory. For the beginning student of Mysticism, it is best to simple learn the patterns distinguished in the maelstrom in the centuries past. The more patterns are found, the clearer the remaining ones become. Until, of course, they change. And then the journey begins anew.

--- a/Assets/StreamingAssets/Text/Books/BOK00041-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00041-LOC.txt
@@ -3,9 +3,8 @@ Author: Palaux Illthre
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,102 +14,22 @@ Content:
 
 [/center]the Usurper
 
-
-
 [/font=4]
 
+ The people of Dwynnen celebrate Othroktide every 5th of Suns Dawn, the date when, according to legent, a man emerged from the wilderness of High Rock and defeated the undead of Castle Wightmoor to become the first Baron of Dwynnen. Few people believe the legend anymore, but there most certainly was a Baron Othrok of Dwynnen who was destined to become one of true heroes of High Rock, if not all Tamriel.
 
+ The legend, as most any Dwynnen child will tell you, is that years and years ago (archivists have agreed to the year 3E 253), the people of Dwynnen were ruled by a lich and its armies of zombies, ghosts, vampires, and skeletons. Othrok was blessed with by gods and given an army of men and animals to destroy the dead. He brought peace and prosperity to the land, growing more powerful as the land improved. Years later, he led the tiny barony against the Camoran Usurper, and saved all of Tamriel.
 
-[/center] The people of Dwynnen celebrate Othroktide every 5th of
-Suns Dawn,  the date when, according to legent, a man
-emerged from the wilderness of High Rock and defeated the
-undead of Castle Wightmoor to become the first Baron of
-Dwynnen. Few people believe the legend anymore, but there
-most certainly was a Baron Othrok of Dwynnen who was
-destined to become one of true heroes of High Rock, if not
-all Tamriel.
+ How much credit the Baron ought to receive for the defeat of the Camoran Usurper has been debated, but it is an uncontestable fact that in the year 3E 267, the Camoran Usurper's relentless move north through High Rock was halted around the area of contemporary Dwynnen. Dwynnen is actually larger than it was in the first Baron's day -- it did not, in fact, have a sea port -- but the Battle of Firewaves was a coastal battle. The fact that the battle probably did not occur in Dwynnen does not in itself belittle the Baron's participation in it.
 
- The legend, as most any Dwynnen child will tell you, is
-that years and years ago (archivists have agreed to the year
-3E 253), the people of Dwynnen were ruled by a lich and its
-armies of zombies, ghosts, vampires, and skeletons. Othrok
-was blessed with by gods and given an army of men and
-animals to destroy the dead. He brought peace and prosperity
-to the land, growing more powerful as the land improved.
-Years later, he led the tiny barony against the Camoran
-Usurper, and saved all of Tamriel.
+ The Camoran Usurper had conquered Hammerfell and Valenwood by means of a large army, which by legend consisted entirely of undead and daedra, but was mostly composed of Redguards and Wood Elves. In all probability, the Usurper summoned the daedra and undead in Arenthia and slowly replaced the original summoned creatures with the armies of his conquered territories. Most armies of Valenwood have been historically mercenary.
 
- How much credit the Baron ought to receive for the defeat of
-the Camoran Usurper has been debated, but it is an
-uncontestable fact that in the year 3E 267, the Camoran
-Usurper's relentless move north through High Rock was halted
-around the area of contemporary Dwynnen. Dwynnen is
-actually larger than it was in the first Baron's day -- it did
-not, in fact, have a sea port -- but the Battle of Firewaves
-was a coastal battle. The fact that the battle probably
-did not occur in Dwynnen does not in itself belittle the
-Baron's participation in it.
+ Word of the Usurper's conquests reached High Rock in early 266, but preparations to repel the invasion did not begin until early the following year. Historians attribute two factors to High Rock's hesistancy. The primary powers of the Bay were ruled by particularly inept monarchs -- Wayrest and Sentinel both had kings in their minority, and Daggerfall was torn by contention between Helena and her cousin Jilathe. The Lord of Reich Gradkeep (now Anticlere) was deathly ill through 266 and finally died at the end of the year. There were, in short, no leaders to unite the province against the Usurper. Of the leaders with any influence, at least eight (the "Eight Traitors" of legend) made secret allegiances with the Usurper to protect their lands.
 
- The Camoran Usurper had conquered Hammerfell and
-Valenwood by means of a large army, which by legend
-consisted entirely of undead and daedra, but was mostly
-composed of Redguards and Wood Elves. In all
-probability, the Usurper summoned the daedra and undead in
-Arenthia and slowly replaced the original summoned
-creatures with the armies of his conquered territories. Most
-armies of Valenwood have been historically mercenary.
+ The secondary reason for the lethargy of High Rock had to do with the depth of relations between the province and the Septim Empire. For the first time since the beginning of the Dynasty, an Emperor ruled Tamriel who was neither Breton nor had spent any of his childhood in High Rock. The difference between Cephorus II and his cousin Uriel IV who preceded him was appalling to the people of High Rock. Even mad Emperors like Pelagius III revered the Bretons over all other races, and cousins and younger siblings of the Emperors have ruled in High Rock since the foundation of the Empire. Cephorus was a Nord, with Skyrim and Morrowind sympathies. The attitude of the common men of High Rock was sympathetic toward the Camoran Usurper as an archfoe of this hated Emperor.
 
- Word of the Usurper's conquests reached High Rock in early
-266, but preparations to repel the invasion did not begin
-until early the following year. Historians attribute two
-factors to High Rock's hesistancy. The primary powers of the
-Bay were ruled by particularly inept monarchs -- Wayrest
-and Sentinel both had kings in their minority, and
-Daggerfall was torn by contention between Helena and her
-cousin Jilathe. The Lord of Reich Gradkeep (now Anticlere)
-was deathly ill through 266 and finally died at the end of
-the year. There were, in short, no leaders to unite the
-province against the Usurper. Of the leaders with any
-influence, at least eight (the "Eight Traitors" of legend)
-made secret allegiances with the Usurper to protect their
-lands.
+ The Baron and his less legendary allies, the rulers of Ykalon, Phrygia, and Kambria, changed this favorable perception. News of the Usurper's barbaric treatment of captives and abuse of conquered lands, mostly true, spread rapidly through their territories, and then to other neutral lands. Within a few months, the greatest navy ever combined organized along the High Rock edge of the Iliac Bay. Only the navy of Uriel V's illfated invasion of Akavir was comparable.
 
- The secondary reason for the lethargy of High Rock had to do
-with the depth of relations between the province and the
-Septim Empire. For the first time since the beginning of the
-Dynasty, an Emperor ruled Tamriel who was neither Breton
-nor had spent any of his childhood in High Rock. The difference
-between Cephorus II and his cousin Uriel IV who preceded him
-was appalling to the people of High Rock. Even mad Emperors
-like Pelagius III revered the Bretons over all other races,
-and cousins and younger siblings of the Emperors have ruled
-in High Rock since the foundation of the Empire. Cephorus was a
-Nord, with Skyrim and Morrowind sympathies. The attitude of
-the common men of High Rock was sympathetic toward the
-Camoran Usurper as an archfoe of this hated Emperor.
+ How the combined forces of High Rock defeated the endless army of the Camoran Usurper is certainly worthy of a lengthy book in itself. And perhaps, it is best left to the public imagination. Certainly the weather worked against the Usurper, which is reason in itself to attribute divine intervention.
 
- The Baron and his less legendary allies, the rulers of
-Ykalon, Phrygia, and Kambria, changed this favorable
-perception. News of the Usurper's barbaric treatment of
-captives and abuse of conquered lands, mostly true, spread
-rapidly through their territories, and then to other neutral
-lands. Within a few months, the greatest navy ever combined
-organized along the High Rock edge of the Iliac Bay. Only the
-navy of Uriel V's illfated invasion of Akavir was
-comparable.
-
- How the combined forces of High Rock defeated the endless army
-of the Camoran Usurper is certainly worthy of a lengthy book
-in itself. And perhaps, it is best left to the public
-imagination. Certainly the weather worked against the
-Usurper, which is reason in itself to attribute divine
-intervention.
-
- Baron Othrok's divine purpose is the central theme to
-Othroktide, after all. And as the poet Braeloque wrote,
-"To find the facts, the wisest always look first to the
-fiction."
-
-
-
- 
+ Baron Othrok's divine purpose is the central theme to Othroktide, after all. And as the poet Braeloque wrote, "To find the facts, the wisest always look first to the fiction."

--- a/Assets/StreamingAssets/Text/Books/BOK00042-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00042-LOC.txt
@@ -3,9 +3,8 @@ Author: Tsathenes
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,179 +12,40 @@ Content:
 
 [/center]Pelagius
 
-
-
 [/font=4]
 
-[/center]
+ The man who would be Emperor of all Tamriel was born Thoriz Pelagius Septim, a prince of the royal family of Wayrest in 3E 119 at the end of the glorious reign of his uncle, Antiochus I. Wayrest had been showered by much preference during the years before Pelagius' birth, for King Magnus was Antiochus' favorite brother.
 
- The man who would be Emperor of all Tamriel was born Thoriz
-Pelagius Septim, a prince of the royal family of Wayrest
-in 3E 119 at the end of the glorious reign of his uncle,
-Antiochus I. Wayrest had been showered by much preference
-during the years before Pelagius' birth, for King Magnus was
-Antiochus' favorite brother.
+ It is hard to say when Pelagius' madness first manifested itself, for, in truth, the first ten years of his life were marked by such insanity in the land itself. When Pelagius was just over a year old, Antiochus died and a daughter, Kintyra, assumed the throne to the acclaim of all. Kintyra II was Pelagius' cousin and an accomplished mystic and sorceress. If she had sufficient means to peer into the future, she would have surely fled the palace.
 
- It is hard to say when Pelagius' madness first manifested
-itself, for, in truth, the first ten years of his life were
-marked by such insanity in the land itself. When Pelagius was
-just over a year old, Antiochus died and a daughter,
-Kintyra, assumed the throne to the acclaim of all. Kintyra
-II was Pelagius' cousin and an accomplished mystic and
-sorceress. If she had sufficient means to peer into the
-future, she would have surely fled the palace.
+ The story of the War of the Red Diamond has been told in many other scholarly journals, but as most historians agree, Kintyra II's reign was usurped by her and Pelagius' cousin Uriel, by the power of his mother, Potema -- the so-called wolf queen of Solitude. The year after her coronation, Kintyra was trapped in Glenpoint and imprisoned in the Imperial dungeons there.
 
- The story of the War of the Red Diamond has been told in many
-other scholarly journals, but as most historians agree,
-Kintyra II's reign was usurped by her and Pelagius' cousin
-Uriel, by the power of his mother, Potema -- the so-called
-wolf queen of Solitude. The year after her coronation,
-Kintyra was trapped in Glenpoint and imprisoned in the
-Imperial dungeons there.
+ All of Tamriel exploded into warfare as Prince Uriel took the throne as Uriel III, and High Rock, because of the imprisoned Empress' presence there, was the location of some of the bloodiest battles. Pelagius' father, King Magnus, allied himself with his brother Cephorus against the usurper Emperor, and brought the wrath of Uriel III and Queen Potema down on Wayrest. Pelagius, his brothers and sisters, and his mother Utheilla fled to the Isle of Balfiera. Utheilla was of the line of Direnni, and her family manse is still located on that ancient isle even to this day.
 
- All of Tamriel exploded into warfare as Prince Uriel took
-the throne as Uriel III, and High Rock, because of the
-imprisoned Empress' presence there, was the location of some
-of the bloodiest battles. Pelagius' father, King Magnus,
-allied himself with his brother Cephorus against the usurper
-Emperor, and brought the wrath of Uriel III and Queen
-Potema down on Wayrest. Pelagius, his brothers and sisters,
-and his mother Utheilla fled to the Isle of Balfiera.
-Utheilla was of the line of Direnni, and her family manse is
-still located on that ancient isle even to this day.
+ There is thankfully much written record of Pelagius' childhood in Balfiera recorded by nurses and visitors. All who met him described him as a handsome, personable boy, interested in sport, magic, and music. Even assuming diplomats' lack of candor, Pelagius seemed like, if anything a blessing to the future of the Septim Dynasty.
 
- There is thankfully much written record of Pelagius'
-childhood in Balfiera recorded by nurses and visitors. All
-who met him described him as a handsome, personable boy,
-interested in sport, magic, and music. Even assuming
-diplomats' lack of candor, Pelagius seemed like, if anything
-a blessing to the future of the Septim Dynasty.
+ When Pelagius was eight, Cephorus slew Uriel III at the Battle of Ichidag and proclaimed himself Emperor Cephorus I. For the next ten years of his reign, Cephorus battled Potema. Pelagius' first battle was the Siege of Solitude, which ended with Potema's death and the final end of the war. In gratitude, Cephorus placed Pelagius on the throne of Solitude.
 
- When Pelagius was eight, Cephorus slew Uriel III at the
-Battle of Ichidag and proclaimed himself Emperor Cephorus
-I. For the next ten years of his reign, Cephorus battled
-Potema. Pelagius' first battle was the Siege of Solitude,
-which ended with Potema's death and the final end of the war.
-In gratitude, Cephorus placed Pelagius on the throne of
-Solitude.
+ As king of Solitude, Pelagius' eccentricities of behavior began to be noticeable. As a favorite nephew of the Emperor, few diplomats to Solitude made critical commentary about Pelagius. For the first two years of his reign, Pelagius was at the very least noted for his alarming shifts in weight. Four months after taking the throne, a diplomat from Ebonheart called Pelagius "a hale and hearty soul with a heart so big, it widens his waist"; five months after that, the visiting princess of Firsthold wrote to her brother that "the king's gripped my hand and it felt like I was being clutched by a skeleton. Pelagius is greatly emaciated, indeed."
 
- As king of Solitude, Pelagius' eccentricities of behavior
-began to be noticeable. As a favorite nephew of the
-Emperor, few diplomats to Solitude made critical
-commentary about Pelagius. For the first two years of his
-reign, Pelagius was at the very least noted for his alarming
-shifts in weight. Four months after taking the throne, a
-diplomat from Ebonheart called Pelagius "a hale and hearty
-soul with a heart so big, it widens his waist"; five months
-after that, the visiting princess of Firsthold wrote to her
-brother that "the king's gripped my hand and it felt like I was
-being clutched by a skeleton. Pelagius is greatly
-emaciated, indeed."
+ Cephorus never married and died childless three years after the Siege of Solitude. As the only surviving sibling, Pelagius' father Magnus left the throne of Wayrest and took residence at the Imperial City as the Emperor Magnus I. Magnus was elderly and Pelagius was his oldest living child, so the attention of Tamriel focused on Sentinel. By this time, Pelagius' bizarrities were becoming infamous. There are many legends about his acts as King of Sentinel, but few well documented cases exist. It is known that Pelagius locked the young princes and princesses of Silvenar in his room with him, only releasing them when an unsigned Declaration of War was slipped under the door. When he tore off his clothes during a speech he was giving at a local festival, his advisors apparently decided to watch him more carefully. On the orders of Magnus, Pelagius was married to the beautiful heiress of an ancient Dark Elf noble family, Katariah Ra'athim.
 
- Cephorus never married and died childless three years after
-the Siege of Solitude. As the only surviving sibling,
-Pelagius' father Magnus left the throne of Wayrest and took
-residence at the Imperial City as the Emperor Magnus I.
-Magnus was elderly and Pelagius was his oldest living
-child, so the attention of Tamriel focused on Sentinel. By
-this time, Pelagius' bizarrities were becoming infamous.
-There are many legends about his acts as King of Sentinel,
-but few well documented cases exist. It is known that
-Pelagius locked the young princes and princesses of
-Silvenar in his room with him, only releasing them when an
-unsigned Declaration of War was slipped under the door.
-When he tore off his clothes during a speech he was giving at
-a local festival, his advisors apparently decided to watch
-him more carefully. On the orders of Magnus, Pelagius was
-married to the beautiful heiress of an ancient Dark Elf
-noble family, Katariah Ra'athim.
+ Nordic kings who marry Dark Elves seldom improve their popularity. There are two reasons most scholars give for the union. Magnus was trying to cement relations with Ebonheart, where the Ra'athim clan hailed. Ebonheart's neighbor, Mournhold, had been a historical ally of the Empire since the very beginning, and the royal consort of Queen Barenziah had won many battles in the War of the Red Diamond. Ebonheart had a poorly-kept secret of aiding Uriel III and Potena.
 
- Nordic kings who marry Dark Elves seldom improve their
-popularity. There are two reasons most scholars give for the
-union. Magnus was trying to cement relations with
-Ebonheart, where the Ra'athim clan hailed. Ebonheart's
-neighbor, Mournhold, had been a historical ally of the
-Empire since the very beginning, and the royal consort of
-Queen Barenziah had won many battles in the War of the Red
-Diamond. Ebonheart had a poorly-kept secret of aiding Uriel
-III and Potena.
+ The other reason for the marriage was more personal: Katariah was as shrewd a diplomat as she was beautiful. If any creature was capable of hiding Pelagius' madness, it was she.
 
- The other reason for the marriage was more personal:
-Katariah was as shrewd a diplomat as she was beautiful. If
-any creature was capable of hiding Pelagius' madness, it
-was she.
+ On the 8th of Second Seed, 3E 145, Magnus I died quietly in his sleep. Jolethe, Pelagius' sister took over the throne of Solitude, and Pelagius and Katariah rode to the Imperial City to be crowned Emperor and Empress of Tamriel. It is said that Pelagius fainted when the crown was placed on his head, but Katariah held him up so only those closest to the thrones could see what had happened. Like so many Pelagius stories, this cannot be verified.
 
- On the 8th of Second Seed, 3E 145, Magnus I died quietly in
-his sleep. Jolethe, Pelagius' sister took over the throne of
-Solitude, and Pelagius and Katariah rode to the Imperial
-City to be crowned Emperor and Empress of Tamriel. It is said
-that Pelagius fainted when the crown was placed on his head,
-but Katariah held him up so only those closest to the thrones
-could see what had happened. Like so many Pelagius stories,
-this cannot be verified.
+ Pelagius III never truly ruled Tamriel. Katariah and the Elder Council made all the decisions and only tried to keep Pelagius from embarassing all. Still, stories of Pelagius III's reign exist.
 
- Pelagius III never truly ruled Tamriel. Katariah and the
-Elder Council made all the decisions and only tried to keep
-Pelagius from embarassing all. Still, stories of Pelagius
-III's reign exist.
+ It was said that when the Argonian ambassador from Blackrose came to court, Pelagius insisted on speaking in all grunts and squeaks, as that was the Argonian's natural language.
 
- It was said that when the Argonian ambassador from Blackrose
-came to court, Pelagius insisted on speaking in all grunts
-and squeaks, as that was the Argonian's natural language.
+ It is known that Pelagius was obsessed with cleanliness, and many guests reported waking to the noise of an early-morning scrubdown of the Imperial Palace. The legend of Pelagius while inspecting the servants' work, suddenly defecating on the floor to give them something to do, is probably apocryphal.
 
- It is known that Pelagius was obsessed with cleanliness, and
-many guests reported waking to the noise of an early-morning
-scrubdown of the Imperial Palace. The legend of Pelagius
-while inspecting the servants' work, suddenly defecating on
-the floor to give them something to do, is probably
-apocryphal.
+ When Pelagius began actually biting and attacking visitors to the Imperial Palace, it was decided to send him to a private asylum. Katariah was proclaimed regent two years after Pelagius took the throne. For the next six years, the Emperor stayed in a series of institutions and asylums.
 
- When Pelagius began actually biting and attacking visitors
-to the Imperial Palace, it was decided to send him to a
-private asylum. Katariah was proclaimed regent two years
-after Pelagius took the throne. For the next six years, the
-Emperor stayed in a series of institutions and asylums.
+ Traitors to the Empire have many lies to spread about this period. Whispered stories of hideous experiments and tortures performed on Pelagius have almost become accepted as fact. The noble lady Katariah became pregnant shortly after the Emperor was sent away, and rumors of infidelity and, even more absurd, conspiracies to keep the sane Emperor locked away ran amok. As Katariah proved, her pregnancy came about after a visit to her husband's cell. With no other evidence, as loyal subjects, we are bound to accept the Emperess' word on the matter. Her second child, who would reign for many years as Uriel IV, was the child of her union with her consort Lariate, and publicly acknowledged as such.
 
- Traitors to the Empire have many lies to spread about this
-period. Whispered stories of hideous experiments and
-tortures performed on Pelagius have almost become accepted
-as fact. The noble lady Katariah became pregnant shortly
-after the Emperor was sent away, and rumors of infidelity
-and, even more absurd, conspiracies to keep the sane Emperor
-locked away ran amok. As Katariah proved, her pregnancy
-came about after a visit to her husband's cell. With no
-other evidence, as loyal subjects, we are bound to accept
-the Emperess' word on the matter. Her second child, who would
-reign for many years as Uriel IV, was the child of her union
-with her consort Lariate, and publicly acknowledged as
-such.
+ On a warm night in Suns Dawn, in his 34th year, Pelagius III died after a brief fever in his cell at the Temple of Kynareth in the Isle of Betony. Katariah I reigned for another forty six years before passing the scepter onto the only child she had with Pelagius, Cassynder.
 
- On a warm night in Suns Dawn, in his 34th year, Pelagius III
-died after a brief fever in his cell at the Temple of
-Kynareth in the Isle of Betony. Katariah I reigned for
-another forty six years before passing the scepter onto the
-only child she had with Pelagius, Cassynder.
-
- Pelagius' wild behavior has made him perversely dear to the
-province of his birth and death. The 2nd of Suns Dawn, which
-may or may not be the anniversary of his death (records are
-not very clear) is celebrated at Mad Pelagius, the time when
-foolishness of all sorts is encouraged. And so, one of the
-least desirable Emperors in the history of the Septim
-Dynasty, has become one of the most famous ones.  
-
-
-
-
-
-
-
-
-
-
-
-  
-
-  
-
- 
+ Pelagius' wild behavior has made him perversely dear to the province of his birth and death. The 2nd of Suns Dawn, which may or may not be the anniversary of his death (records are not very clear) is celebrated at Mad Pelagius, the time when foolishness of all sorts is encouraged. And so, one of the least desirable Emperors in the history of the Septim Dynasty, has become one of the most famous ones.

--- a/Assets/StreamingAssets/Text/Books/BOK00043-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00043-LOC.txt
@@ -1,11 +1,10 @@
-Title: The Real Barenziah
+Title: The Real Barenziah, Part I
 Author: Anonymous
 IsNaughty: True
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,202 +12,66 @@ Content:
 
 [/center]Barenziah
 
-
+[/center]Part I
 
 [/font=4]
 
-[/center]
+ Five hundred years ago in Mournhold, city of gems, there lived a blind widow woman and her only child, a strapping young man. He was a miner, as was his father before him, a common laborer in the king's mines, for his magicka ability was but small. The work was honorable, but poorly paid. His mother made and sold small wildenberry cakes in the market to help eke out their living. They did well enough, his mother said. They had enough to fill their bellies, no one could wear more than one suit of clothing at a time and the roof only leaked when it rained. Symmachus would have liked more. He hoped for a lucky strike in the mines, which would garner him a large bonus. In his free hours he enjoyed hoisting a glass of ale in the tavern with his friends, and gambling with them at cards, and he drew the eyes and sighs of more than one pretty elven girl, although none held his interest for long. In short, Symmachus was a typical young dark elf man, remarkable only for his size. It was rumored that he had a bit of Nord blood in him.
 
+ In Symmachus' thirtieth year there was great rejoicing in Mournhold for a girl child was born to their lord and his lady. A queen, the people sang, a queen is born to us! For among the people of Mournhold, the birth of a female heir is a sure sign of peace and prosperity to come.
 
+ When the time came for royal child's Rite of Naming, the mines were closed and Symmachus rushed home to bathe and dress in his best.
 
+ "I'll come straight home and tell you all about it," he promised his mother, who was not to attend. She had been ailing; besides, there would be a great crush of people as all Mournhold would be there, and being blind she would be unable to see anything anyway.
 
+ "My son," she said. "Ere you go, fetch me a priest or healer, else I may pass from the mortal plane ere you return."
 
- Five hundred years ago in Mournhold, city of gems, there
-lived a blind widow woman and her only child, a strapping
-young man. He was a miner, as was his father before him, a
-common laborer in the king's mines, for his magicka ability
-was but small. The work was honorable, but poorly paid. His
-mother made and sold small wildenberry cakes in the market to
-help eke out their living. They did well enough, his mother
-said. They had enough to fill their bellies, no one could
-wear more than one suit of clothing at a time and the roof
-only leaked when it rained. Symmachus would have liked more.
-He hoped for a lucky strike in the mines, which would garner
-him a large bonus. In his free hours he enjoyed hoisting a
-glass of ale in the tavern with his friends, and gambling
-with them at cards, and he drew the eyes and sighs of more than
-one pretty elven girl, although none held his interest for
-long. In short, Symmachus was a typical young dark elf man,
-remarkable only for his size. It was rumored that he had a bit
-of Nord blood in him.
+ Symmachus crossed to her bed at once and noted anxiously that her head was very hot and her breathing shallow. He pried up the loose floorboard where their small hoard of savings was kept. There wasn't nearly enough to pay a priest for healing. He would have to give what they had and owe the rest. Symmachus snatched up his cloak and rushed away. The streets were full of folk hurrying to the sacred grove, but the mage guild and the temples were locked and barred. "Closed for the ceremony" read the signs. Symmachus elbowed his way through the crowd and managed to overtake a brown-robed monk.
 
- In Symmachus' thirtieth year there was great rejoicing in
-Mournhold for a girl child was born to their lord and his
-lady. A queen, the people sang, a queen is born to us! For
-among the people of Mournhold, the birth of a female heir is
-a sure sign of peace and prosperity to come. 
+ "After the rite, brother," the monk said, "if you have gold I shall gladly to attend your mother. My lord has bade all clerics to attend and I shall not offend him."
 
- When the time came for royal child's Rite of Naming, the
-mines were closed and Symmachus rushed home to bathe and
-dress in his best.
+ "My mother's desperately ill," Symmachus pled. "Surely, my lord will not miss just one lowly monk."
 
- "I'll come straight home and tell you all about it," he
-promised his mother, who was not to attend. She had been
-ailing; besides, there would be a great crush of people as
-all Mournhold would be there, and being blind she would be
-unable to see anything anyway.
+ "The father abbot will," the monk said nervously, tearing his robe loose from Symmachus' grip and vanishing into the crowd.
 
- "My son," she said. "Ere you go, fetch me a priest or healer,
-else I may pass from the mortal plane ere you return."
+ Symmachus tried other monks and mages, too, but with no better result. Armored guards came through the street and pushed him aside with their lances and Symmachus realized that the royal procession was approaching. As the royal carriage drew abreast, Symmachus rushed out from the crowd and shouted, "My lord, my mother's dying--"
 
- Symmachus crossed to her bed at once and noted anxiously
-that her head was very hot and her breathing shallow. He pried
-up the loose floorboard where their small hoard of savings
-was kept. There wasn't nearly enough to pay a priest for
-healing. He would have to give what they had and owe the rest.
-Symmachus snatched up his cloak and rushed away. The streets
-were full of folk hurrying to the sacred grove, but the mage
-guild and the temples were locked and barred. "Closed for
-the ceremony" read the signs. Symmachus elbowed his way
-through the crowd and managed to overtake a brown-robed
-monk.
+ "I forbid her to do so on this glorious night!" the lord shouted, laughing and scattering coin into the throng. Symmachus was close enough to smell wine on the royal breath. On the other side of the carriage his lady clutched her babe to her breast, and stared wide-eyed at Symmachus, her nostrils flared in disdain.
 
- "After the rite, brother," the monk said, "if you have gold I
-shall gladly to attend your mother. My lord has bade all
-clerics to attend and I shall not offend him."
+ "Guards!" she cried. "Remove this oaf." Rough hands seized Symmachus. He was beaten and left dazed by the side of the road.
 
- "My mother's desperately ill," Symmachus pled. "Surely,
-my lord will not miss just one lowly monk."
+ Symmachus, head aching, followed in the wake of the crowd and watched the Rite of Naming from the top of the hill. He could see the brown robed clerics and blue robed mages gathered near the royal folk far below.
 
- "The father abbot will," the monk said nervously, tearing his robe loose from Symmachus' grip and vanishing into the
-crowd.
+ Barenziah. The name came dim to Symmachus ears as the High Priest lifted the naked babe and showed her to the twin moons on either side of the horizon: Jone rising, Jode setting. "Behold the Lady Barenziah, born to the rule of Mournhold! Grant her thy blessings and thy counsel ever that she rule to Mournhold's weal."
 
- Symmachus tried other monks and mages, too, but with no
-better result. Armored guards came through the street and
-pushed him aside with their lances and Symmachus realized
-that the royal procession was approaching. As the royal
-carriage drew abreast, Symmachus rushed out from the crowd
-and shouted, "My lord, my mother's dying--"
+ "Blessings, blessings..." all the people murmured with their lord and lady, hands upraised. Only Symmachus stood silent, head bowed, knowing in his heart that his dear mother was gone. And in his silence he swore a mighty oath, that he should be his lord's bane and in vengeance for his mother's needless death, the child Barenziah he would have as his own bride, that his mother's grandchildren should be born to rule Mournhold.
 
- "I forbid her to do so on this glorious night!" the lord
-shouted, laughing and scattering coin into the throng.
-Symmachus was close enough to smell wine on the royal
-breath. On the other side of the carriage his lady clutched
-her babe to her breast, and stared wide-eyed at Symmachus,
-her nostrils flared in disdain.
+ After the ceremony he watched impassively as the royal procession returned to the palace. He saw the monk to whom he'd spoken first. The man came gladly enough now in return for the gold Symmachus had and a promise of more later.
 
- "Guards!" she cried. "Remove this oaf." Rough hands seized
-Symmachus. He was beaten and left dazed by the side of the
-road. 
+ They found his mother dead, as he had feared. The monk sighed and tucked the bag away. "I'm sorry, brother. Well, you can forget the rest of the gold, as there's naught I can do here. Likely--"
 
- Symmachus, head aching, followed in the wake of the crowd and
-watched the Rite of Naming from the top of the hill. He could
-see the brown robed clerics and blue robed mages gathered
-near the royal folk far below. 
+ "Give me back my gold!" Symmachus snarled. "You've done naught to earn it!" He lifted his right arm threateningly. The priest backed away, beginning a curse, but Symmachus struck him before more than three words had left his mouth. He went down heavily, striking his head sharply on one of the stones that formed the firepit. He died instantly.
 
- Barenziah. The name came dim to Symmachus ears as the High
-Priest lifted the naked babe and showed her to the twin moons
-on either side of the horizon: Jone rising, Jode setting.
-"Behold the Lady Barenziah, born to the rule of Mournhold!
-Grant her thy blessings and thy counsel ever that she rule to
-Mournhold's weal."
+ Symmachus took the gold back and fled the city, muttering the name "Barenziah".
 
- "Blessings, blessings..." all the people murmured with
-their lord and lady, hands upraised. Only Symmachus stood
-silent, head bowed, knowing in his heart that his dear mother
-was gone. And in his silence he swore a mighty oath, that he
-should be his lord's bane and in vengeance for his mother's
-needless death, the child Barenziah he would have as his own
-bride, that his mother's grandchildren should be born to rule
-Mournhold. 
+[/center]* * *
 
- After the ceremony he watched impassively as the royal
-procession returned to the palace. He saw the monk to whom
-he'd spoken first. The man came gladly enough now in return
-for the gold Symmachus had and a promise of more later. 
-
- They found his mother dead, as he had feared. The monk sighed
-and tucked the bag away. "I'm sorry, brother. Well, you can
-forget the rest of the gold, as there's naught I can do here.
-Likely--"
-
- "Give me back my gold!" Symmachus snarled. "You've done
-naught to earn it!" He lifted his right arm threateningly.
-The priest backed away, beginning a curse, but Symmachus
-struck him before more than three words had left his mouth. He
-went down heavily, striking his head sharply on one of the
-stones that formed the firepit. He died instantly.
-
- Symmachus took the gold back and fled the city, muttering the
-name "Barenziah".
-
-
-
-[/center]
-
-[/center] *                                *                                  *
-
-[/center]
-
-[/center]
-
- The child Barenziah stood on the upper balcony of the
-palace, staring down into the courtyard where soldiers
-milled, splendid in their armor. Presently they formed into
-ordered ranks and cheered as her parents, the lord and lady
-emerged from the palace, clad head to toe in ebony armor,
-long purple-dyed fur cloaks flowing behind. Splendidly
-caparisoned shining black horses were brought for them and
-they mounted and rode to the courtyard gates, then turned
-to salute her.
+ The child Barenziah stood on the upper balcony of the palace, staring down into the courtyard where soldiers milled, splendid in their armor. Presently they formed into ordered ranks and cheered as her parents, the lord and lady emerged from the palace, clad head to toe in ebony armor, long purple-dyed fur cloaks flowing behind. Splendidly caparisoned shining black horses were brought for them and they mounted and rode to the courtyard gates, then turned to salute her.
 
  "Barenziah!" they cried. "Barenziah, farewell!"
 
- The little girl blinked back tears and waved bravely with
-one hand, her favorite stuffed toy animal, a gray wolf cub
-she called Wuffen, clutched to her breast with the other. She
-had never been parted from her parents before and had no
-idea what it meant, save that there was war in the west and the
-names Tiber Septim and Symmachus were on everyone's lips,
-spoken with hate and dread.
+ The little girl blinked back tears and waved bravely with one hand, her favorite stuffed toy animal, a gray wolf cub she called Wuffen, clutched to her breast with the other. She had never been parted from her parents before and had no idea what it meant, save that there was war in the west and the names Tiber Septim and Symmachus were on everyone's lips, spoken with hate and dread.
 
- "Barenziah!" The soldiers cried, lifting their lances and
-swords and bows. Then her dear parents turned and rode
-away, soldiers trailing in their wake until the palace was
-near emptied.
+ "Barenziah!" The soldiers cried, lifting their lances and swords and bows. Then her dear parents turned and rode away, soldiers trailing in their wake until the palace was near emptied.
 
- Some time after came a day when Barenziah was shaken awake by
-her nurse, dressed hurriedly and carried from the palace.
-All she remembered of that dreadful time was seeing a huge
-shadow with burning eyes that filled the sky.
+ Some time after came a day when Barenziah was shaken awake by her nurse, dressed hurriedly and carried from the palace. All she remembered of that dreadful time was seeing a huge shadow with burning eyes that filled the sky.
 
- She was passed from hand to hand. Foreign soldiers
-appeared. Her nurse vanished and was replaced by strangers,
-some more strange than others. There were days, or was it
-weeks?, of travel. One morning she woke to step from the
-coach into a cold place with a large gray stone house set
-amid endless empty gray-green and hills patchily covered
-with gray-white snow. She clutched Wuffen to her breast with
-both hands and stood blinking and shivering in the gray dawn,
-feeling very small and very black in all this endless space
-gray-white space.
+ She was passed from hand to hand. Foreign soldiers appeared. Her nurse vanished and was replaced by strangers, some more strange than others. There were days, or was it weeks?, of travel. One morning she woke to step from the coach into a cold place with a large gray stone house set amid endless empty gray-green and hills patchily covered with gray-white snow. She clutched Wuffen to her breast with both hands and stood blinking and shivering in the gray dawn, feeling very small and very black in all this endless space gray-white space.
 
- A large gray-white woman was staring at her with dreadful
-bright blue eyes.
+ A large gray-white woman was staring at her with dreadful bright blue eyes.
 
- "She's very -- black, isn't she?" the woman remarked to her
-companion, a brown skinned, black-haired woman named Hana
-who had been travelling with Barenziah for several days.
-"I've never seen a dark elf before."
+ "She's very -- black, isn't she?" the woman remarked to her companion, a brown skinned, black-haired woman named Hana who had been travelling with Barenziah for several days. "I've never seen a dark elf before."
 
- "I don't know much about them myself," Hana said. "This one's
-got red hair and a temper to match, I can tell you that.
-Take care. She bites. And worse."
+ "I don't know much about them myself," Hana said. "This one's got red hair and a temper to match, I can tell you that. Take care. She bites. And worse."
 
- "I'll soon train her out of that," the other woman sniffed,
-"And what's that filthy thing she's got? Ugh!" The woman
-snatched Wuffen away and cast him into the fire blazing in
-the hearth. Barenziah shrieked and would have flung herself
-into the fire after him, but was forcibly restrained, despite
-her attempts to bite and claw her oppressors while poor
-Wuffen was reduced to a little heap of charred ash. 
+ "I'll soon train her out of that," the other woman sniffed, "And what's that filthy thing she's got? Ugh!" The woman snatched Wuffen away and cast him into the fire blazing in the hearth. Barenziah shrieked and would have flung herself into the fire after him, but was forcibly restrained, despite her attempts to bite and claw her oppressors while poor Wuffen was reduced to a little heap of charred ash.

--- a/Assets/StreamingAssets/Text/Books/BOK00044-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00044-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: True
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,268 +12,83 @@ Content:
 
 [/center]Barenziah
 
-[/center]
-
 [/center]Part II
-
-
 
 [/font=4]
 
-[/center]
+ Barenziah grew like a weed transplanted to a Skyrim garden, a ward of Count Sven and his wife Lady Inga. Outwardly she thrived but there was a cold and empty place within.
 
-[/center]
+ "I've raised her as my own daughter," Lady Inga was wont to sigh when she sat gossiping with neighboring ladies come to visit, "But she's a dark elf. What can you expect?"
 
- Barenziah grew like a weed transplanted to a Skyrim garden,
-a ward of Count Sven and his wife Lady Inga. Outwardly she
-thrived but there was a cold and empty place within. 
+ Barenziah was not meant to overhear these words. At least she thought she was not. Her hearing was far keener than that of her Nord hosts. Other, less desirable dark elf traits included pilfering, lying and a little magic, just a small fire spell and a little levitation. And, as she grew older, a keen interest in boys and men, who could provide very pleasant sensations and, to her astonishment, gifts as well. Inga disapproved of this activity for reasons incomprehensible to Barenziah, so she was careful to keep it as secret as possible.
 
- "I've raised her as my own daughter," Lady Inga was wont to
-sigh when she sat gossiping with neighboring ladies come to
-visit, "But she's a dark elf. What can you expect?"
+ "She's wonderful with the children," Inga added, meaning her five sons, all younger than Barenziah. "She'd never see them come to harm."
 
- Barenziah was not meant to overhear these words. At least she
-thought she was not. Her hearing was far keener than that of her
-Nord hosts. Other, less desirable dark elf traits included
-pilfering, lying and a little magic, just a small fire
-spell and a little levitation. And, as she grew older, a
-keen interest in boys and men, who could provide very
-pleasant sensations and, to her astonishment, gifts as well.
-Inga disapproved of this activity for reasons
-incomprehensible to Barenziah, so she was careful to keep it
-as secret as possible.
+ A tutor was hired when Jonny was six and Barenziah eight, and she studied academic lessons along with him. She would have liked arms training as well, but the very idea of a girl training to arms scandalized Inga and Sven. Barenziah was given a bow and allowed to practice target shooting with the boys. She watched them at arms practice when she could, practiced with them when no grown folk were about, and knew she was as good or better than they.
 
- "She's wonderful with the children," Inga added, meaning
-her five sons, all younger than Barenziah. "She'd never see
-them come to harm." 
+ "She's very proud, isn't she?" the neighbor ladies would whisper, and Barenziah, pretending not to hear, would nod in agreement. She could not help but feel superior to the Count and Countess. There was something about them that encouraged this disdain in her.
 
- A tutor was hired when Jonny was six and Barenziah eight, and
-she studied academic lessons along with him. She would have
-liked arms training as well, but the very idea of a girl
-training to arms scandalized Inga and Sven. Barenziah was
-given a bow and allowed to practice target shooting with
-the boys. She watched them at arms practice when she could,
-practiced with them when no grown folk were about, and knew she was as good or better than they.
+ She grew to learn that Sven and Inga were distant cousins of the last rulers of Darkmoon, and then she began to understand. They were poseurs, imposters, not rulers at all. At least, they were not raised to rule. This thought made her strangely furious at them, a good clean hatred detached from resentment. Barenziah came to see them as disgusting and corrupted insects who could be despised, but never feared.
 
- "She's very proud, isn't she?" the neighbor ladies would
-whisper, and Barenziah, pretending not to hear, would nod
-in agreement. She could not help but feel superior to the
-Count and Countess. There was something about them that
-encouraged this disdain in her.
+ Once a month a courier came from the emperor, bringing a small bag of gold for Inga and Sven and a large bag of dried mushrooms from Morrowind for Barenziah's consumption. She was always made presentable, as presentable as a skinny dark elf girl could be made to look in Inga's eyes, and summoned into the courier's presence for a brief interview. The same courier seldom came twice, but all looked her over rather as a farmer looks over a pig he's readying for market. In the spring of her sixteenth year Barenziah thought the courier looked as if she were at last ready for market.
 
- She grew to learn that Sven and Inga were distant cousins of
-the last rulers of Darkmoon, and then she began to
-understand. They were poseurs, imposters, not rulers at
-all. At least, they were not raised to rule. This thought made
-her strangely furious at them, a good clean hatred detached
-from resentment. Barenziah came to see them as disgusting and
-corrupted insects who could be despised, but never feared.
+ Upon reflection Barenziah decided that she did not wish to be marketed. The stable-boy, Straw, a big blond boy, clumsy, gentle, affectionate and rather simple, had been urging her to run off with him for some weeks. Barenziah stole the bag of gold the courier had left, took the mushrooms from the storeroom, dressed herself as a boy in some of twelve year old Timmy's casual clothing, and one fine spring night they took the two best horses and rode hard through the night toward Whiterun, the nearest city of any size, which was where Straw wanted to go.
 
- Once a month a courier came from the emperor, bringing a
-small bag of gold for Inga and Sven and a large bag of
-dried mushrooms from Morrowind for Barenziah's consumption.
-She was always made presentable, as presentable as a skinny
-dark elf girl could be made to look in Inga's eyes, and
-summoned into the courier's presence for a brief interview.
-The same courier seldom came twice, but all looked her over
-rather as a farmer looks over a pig he's readying for market.
-In the spring of her sixteenth year Barenziah thought the
-courier looked as if she were at last ready for market.
+ But Morrowind also lay east and it drew Barenziah as a lodestone does iron. In the morning they abandoned the horses at Barenziah's insistence. She knew they would be missed and tracked, and she hoped to throw pursuers off the trail. They continued afoot until late afternoon, keeping to side roads, then slept for several hours in an abandoned hut. They went on at dusk and came to the Whiterun city gates just before dawn.
 
- Upon reflection Barenziah decided that she did not wish to be
-marketed. The stable-boy, Straw, a big blond boy, clumsy,
-gentle, affectionate and rather simple, had been urging her
-to run off with him for some weeks. Barenziah stole the bag of
-gold the courier had left, took the mushrooms from the
-storeroom, dressed herself as a boy in some of twelve year
-old Timmy's casual clothing, and one fine spring night they
-took the two best horses and rode hard through the night toward
-Whiterun, the nearest city of any size, which was where Straw
-wanted to go.
+ Barenziah had prepared a pass for Straw, stating an errand to a temple in the city for a local village lord. She herself sneaked over the wall with the help of her levitation spell. She had reasoned that by now the gate guards would have been alerted to look for a young dark elf and a Nord boy traveling together, but country boys like Straw were common enough. Alone and with papers, he would be unlikely to draw their attention.
 
- But Morrowind also lay east and it drew Barenziah as a
-lodestone does iron. In the morning they abandoned the horses
-at Barenziah's insistence. She knew they would be missed and
-tracked, and she hoped to throw pursuers off the trail. They
-continued afoot until late afternoon, keeping to side
-roads, then slept for several hours in an abandoned hut.
-They went on at dusk and came to the Whiterun city gates just
-before dawn.
+ Her simple plan went smoothly. She met Straw at the temple, which was not far from the gate. She had been to Whiterun on a few previous occasions. Straw, however, had never been more than a few miles from Sven's estate, his birthplace. Together they made their way to a run-down inn in the poor quarter of Whiterun. Gloved, cloaked and hooded against the chill of the morning, her dark skin and red eyes were not apparent and no one paid any attention to them. They entered the inn separately. Sven paid the host for a single room, a large meal and a jug of ale, and Barenziah sneaked in a few minutes later.
 
- Barenziah had prepared a pass for Straw, stating an errand
-to a temple in the city for a local village lord. She
-herself sneaked over the wall with the help of her levitation
-spell. She had reasoned that by now the gate guards would
-have been alerted to look for a young dark elf and a Nord
-boy traveling together, but country boys like Straw were
-common enough. Alone and with papers, he would be unlikely
-to draw their attention.
+ They ate and drank together gleefully, celebrating their escape, made love vigorously on the narrow bed, then fell into an exhausted sleep.
 
- Her simple plan went smoothly. She met Straw at the temple,
-which was not far from the gate. She had been to Whiterun on a
-few previous occasions. Straw, however, had never been more
-than a few miles from Sven's estate, his birthplace.
-Together they made their way to a run-down inn in the poor quarter of Whiterun. Gloved, cloaked and hooded
-against the chill of the morning, her dark skin and red eyes were not apparent and no one paid any attention
-to them. They entered the inn separately. Sven paid the host
-for a single room, a large meal and a jug of ale, and
-Barenziah sneaked in a few minutes later.
+ They stayed a week in Whiterun. Straw earned a bit of money running errands and Barenziah robbed a few houses at night. Barenziah continued to dress as a boy. She cut her hair short and dyed her flame-red tresses jet black as a further disguise, and kept out of sight as much as possible for there were few dark elves in Whiterun. Then Straw got them places as guards for a merchant caravan that was traveling east. The sergeant looked her over dubiously. "Heh," he chuckled, "dark elf, ain'tcha? Like setting a wolf to guard the sheep, that is. Still, I need arms, and we ain't going near enough to Morrowind that ye can betray us to yer brothers. Our home-grown bandits will as lief cut yer throat as mine."
 
- They ate and drank together gleefully, celebrating their
-escape, made love vigorously on the narrow bed, then fell
-into an exhausted sleep.
+ The sergeant gave Straw an appraising look, then abruptly spun back to Barenziah, whipping out his short sword. But she had her knife out and was in a defensive stance. Straw drew his own knife and circled to the man's rear. The sergeant dropped his blade and chuckled again, "Not bad, kids, not bad. How are ye with that bow, dark elf?" Barenziah demonstrated her prowess. "Aye, not bad, not bad a'tall. And ye'll be keen of eye by night and of hearing at all times. A trusty dark elf makes as good a fightin' man as any could ask for. I know. I served under Symmachus himself before I lost this arm and got invalided out of the Emperor's forces."
 
- They stayed a week in Whiterun. Straw earned a bit of money
-running errands and Barenziah robbed a few houses at night.
-Barenziah continued to dress as a boy. She cut her hair short
-and dyed her flame-red tresses jet black as a further
-disguise, and kept out of sight as much as possible for there
-were few dark elves in Whiterun. Then Straw got them places
-as guards for a merchant caravan that was traveling east.
-The sergeant looked her over dubiously.   "Heh," he chuckled,
-"dark elf, ain'tcha? Like setting a wolf to guard the sheep,
-that is. Still, I need arms, and we ain't going near enough
-to Morrowind that ye can betray us to yer brothers. Our
-home-grown bandits will as lief cut yer throat as mine."
+ "We could betray them. I know folk who'd pay well," Straw said later, as they bedded down for their last night in the old inn, "Or rob them ourselves. They're very rich, those merchants are, Berry."
 
- The sergeant gave Straw an appraising look, then abruptly
-spun back to Barenziah, whipping out his short sword. But she
-had her knife out and was in a defensive stance. Straw drew
-his own knife and circled to the man's rear. The sergeant
-dropped his blade and chuckled again, "Not bad, kids, not
-bad. How are ye with that bow, dark elf?" Barenziah
-demonstrated her prowess. "Aye, not bad, not bad a'tall.
-And ye'll be keen of eye by night and of hearing at all
-times. A trusty dark elf makes as good a fightin' man as any
-could ask for. I know. I served under Symmachus himself
-before I lost this arm and got invalided out of the
-Emperor's forces."
-
- "We could betray them. I know folk who'd pay well," Straw
-said later, as they bedded down for their last night in the
-old inn, "Or rob them ourselves. They're very rich, those
-merchants are, Berry."
-
- Barenziah chuckled, "What ever would we do with so much
-money? And we need their protection for traveling quite as
-much as they need ours."
+ Barenziah chuckled, "What ever would we do with so much money? And we need their protection for traveling quite as much as they need ours."
 
  "We could buy a little farm and settle down."
 
- Peasant! Barenziah thought scornfully. Straw was a
-peasant and had peasant dreams. But all she said was, "Not
-here, Straw, we're too close to Darkmoor still. We'll have
-more chances farther east."
+ Peasant! Barenziah thought scornfully. Straw was a peasant and had peasant dreams. But all she said was, "Not here, Straw, we're too close to Darkmoor still. We'll have more chances farther east."
 
- The caravan went only as far east as Sunguard. Tiber
-Septim had done much in the way of building relatively safe
-patrolled highways, but his tolls were steep, and this
-particular caravan kept to the side roads as much as
-possible to avoid them. This exposed them to the hazards of
-robber barons, both human and orcish, and roving bands of
-brigands of various races, but such were the perils of trade
-and profit.
+ The caravan went only as far east as Sunguard. Tiber Septim had done much in the way of building relatively safe patrolled highways, but his tolls were steep, and this particular caravan kept to the side roads as much as possible to avoid them. This exposed them to the hazards of robber barons, both human and orcish, and roving bands of brigands of various races, but such were the perils of trade and profit.
 
- They had two such encounters before reaching Sunguard, an
-ambush which Barenziah's keen ears detected in plenty of time
-for them to circle about and surprise the lurkers, and a
-night attack by a mixed band of Khajiiti, humans and wood
-elves. The latter were a skilled band and even Barenziah did
-not hear them sneaking up in time to give much warning.
+ They had two such encounters before reaching Sunguard, an ambush which Barenziah's keen ears detected in plenty of time for them to circle about and surprise the lurkers, and a night attack by a mixed band of Khajiiti, humans and wood elves. The latter were a skilled band and even Barenziah did not hear them sneaking up in time to give much warning.
 
- The fighting was fierce. The attackers were driven off, but
-two of the caravan's guards were killed, and Straw got a
-nasty cut on his thigh before he and Barenziah killed his
-Khajiit assailant.
+ The fighting was fierce. The attackers were driven off, but two of the caravan's guards were killed, and Straw got a nasty cut on his thigh before he and Barenziah killed his Khajiit assailant.
 
- Barenziah rather enjoyed the life. The garrulous sergeant
-had taken a liking to her, and she spent most of her evenings
-sitting around a campfire listening to his tales of
-campaigning in Morrowind with Tiber Septim and Symmachus.
-Symmachus had been made a general after Mournhold fell, the
-sergeant said. "He's a fine soldier, Symmachus is, but there
-was more than soldiery involved in Morrowind, if you take
-my drift. Well, you know about that, I expect."
+ Barenziah rather enjoyed the life. The garrulous sergeant had taken a liking to her, and she spent most of her evenings sitting around a campfire listening to his tales of campaigning in Morrowind with Tiber Septim and Symmachus. Symmachus had been made a general after Mournhold fell, the sergeant said. "He's a fine soldier, Symmachus is, but there was more than soldiery involved in Morrowind, if you take my drift. Well, you know about that, I expect."
 
- "I don't remember," Barenziah said, "I've mostly lived in
-Skyrim. My mother married a Skyrim man. They're both dead,
-though. What happened to the lord and lady of Mournhold?"
+ "I don't remember," Barenziah said, "I've mostly lived in Skyrim. My mother married a Skyrim man. They're both dead, though. What happened to the lord and lady of Mournhold?"
 
- The sergeant shrugged, "I never heard. Dead, I expect. All
-Morrowind's under military rule now. It's pretty quiet.
-Maybe too quiet. Like a calm before a storm. You going back
-there?"
+ The sergeant shrugged, "I never heard. Dead, I expect. All Morrowind's under military rule now. It's pretty quiet. Maybe too quiet. Like a calm before a storm. You going back there?"
 
- "Maybe," Barenziah said. The truth was that she was drawn to
-Morrowind like a magnet. Straw sensed it and was unhappy
-about it. He was unhappy anyway, since they could not bed
-together, as she was supposed to be a boy. Barenziah rather
-missed it too, but not as much as Straw did, seemingly. The
-sergeant wanted them to sign on for the return trip, but
-gave them a bonus when they parted and letters of
-recommendation. 
+ "Maybe," Barenziah said. The truth was that she was drawn to Morrowind like a magnet. Straw sensed it and was unhappy about it. He was unhappy anyway, since they could not bed together, as she was supposed to be a boy. Barenziah rather missed it too, but not as much as Straw did, seemingly. The sergeant wanted them to sign on for the return trip, but gave them a bonus when they parted and letters of recommendation.
 
- Straw wanted to settle permanently near Sunguard, but
-Barenziah insisted on continuing to travel east.
+ Straw wanted to settle permanently near Sunguard, but Barenziah insisted on continuing to travel east.
 
- "I'm the queen of Mournhold by rights," she said, unsure
-whether it was true, or it was a story she had made up as a
-child. "I want to go home. I need to go home."
+ "I'm the queen of Mournhold by rights," she said, unsure whether it was true, or it was a story she had made up as a child. "I want to go home. I need to go home."
 
- That at least was true. She had run out of mushrooms and was
-very hungry for them. She found a few for sale in the
-Sunguard marketplace, but they were not as good or
-satisfying as the ones the courier had brought. After a few
-weeks they managed to get places in a caravan heading east.
-By early winter, they were in Riften, and near the Morrowind
-border, but the weather had grown severe and they were told
-no merchant caravans would set forth until mid-spring.
+ That at least was true. She had run out of mushrooms and was very hungry for them. She found a few for sale in the Sunguard marketplace, but they were not as good or satisfying as the ones the courier had brought. After a few weeks they managed to get places in a caravan heading east. By early winter, they were in Riften, and near the Morrowind border, but the weather had grown severe and they were told no merchant caravans would set forth until mid-spring.
 
- Barenziah stood atop the city walls and stared across the
-deep gorge that separated Riften from the snow-clad
-mountain wall of Morrowind beyond.
+ Barenziah stood atop the city walls and stared across the deep gorge that separated Riften from the snow-clad mountain wall of Morrowind beyond.
 
- "Berry," Straw said gently, "Mournhold's a long way off
-yet, nearly as far as we've come already, and the lands
-between are wild, full of wolves and bandits and orcs and
-still worse creatures. We'll have to wait for spring."
+ "Berry," Straw said gently, "Mournhold's a long way off yet, nearly as far as we've come already, and the lands between are wild, full of wolves and bandits and orcs and still worse creatures. We'll have to wait for spring."
 
- "There's Silgrod Tower," Berry said, referring to the Dark
-Elf town that had grown up around the ancient tower that
-guarded the border between Skyrim and Morrowind.
+ "There's Silgrod Tower," Berry said, referring to the Dark Elf town that had grown up around the ancient tower that guarded the border between Skyrim and Morrowind.
 
- "The bridge guards won't let me across, Berry. They're crack
-Imperial troops. They can't be bribed. If you go, you go
-alone. I won't try to stop you. But what will you do?
-Silgrod Tower is full of Imperial troops. Will you become
-a washerwoman for them? A camp follower?"
+ "The bridge guards won't let me across, Berry. They're crack Imperial troops. They can't be bribed. If you go, you go alone. I won't try to stop you. But what will you do? Silgrod Tower is full of Imperial troops. Will you become a washerwoman for them? A camp follower?"
 
- "No," Barenziah said thoughtfully. Actually the idea was
-not entirely unappealing. She was sure that she could earn
-a modest living by sleeping with the soldiers for money.
-She'd had a few adventures of that sort as they crossed
-Skyrim, when she'd dressed as a woman and slipped away from
-Straw. She'd only been looking for a bit of variety. Straw
-was sweet but dull. She'd been startled, but pleased when
-the men she picked up offered her money afterwards.
+ "No," Barenziah said thoughtfully. Actually the idea was not entirely unappealing. She was sure that she could earn a modest living by sleeping with the soldiers for money. She'd had a few adventures of that sort as they crossed Skyrim, when she'd dressed as a woman and slipped away from Straw. She'd only been looking for a bit of variety. Straw was sweet but dull. She'd been startled, but pleased when the men she picked up offered her money afterwards.
 
- Straw had been unhappy about it though and would shout for
-awhile, then sulk for days afterwards if he caught her at it.
-He was very jealous. He'd even threatened to leave her.
+ Straw had been unhappy about it though and would shout for awhile, then sulk for days afterwards if he caught her at it. He was very jealous. He'd even threatened to leave her.
 
- But the Imperial Guards were a tough and brutal lot by all
-accounts and Barenziah had heard some very ugly stories
-during her travels. The ugliest stories had come from the
-lips of ex-veterans around the caravan campfire and were
-proudly recounted. They'd been trying to shock her and
-Straw, she realized, but she also realized that there was some
-truth behind the wild tales. Straw hated that kind of talk
-and hated having her hear it, but there was a part of him that
-was fascinated by it.
+ But the Imperial Guards were a tough and brutal lot by all accounts and Barenziah had heard some very ugly stories during her travels. The ugliest stories had come from the lips of ex-veterans around the caravan campfire and were proudly recounted. They'd been trying to shock her and Straw, she realized, but she also realized that there was some truth behind the wild tales. Straw hated that kind of talk and hated having her hear it, but there was a part of him that was fascinated by it.
 
- Barenziah had encouraged Straw to seek out other women, but
-he said he didn't want anyone but her. She told him she didn't
-feel that way, but she did like him better than anyone else.
+ Barenziah had encouraged Straw to seek out other women, but he said he didn't want anyone but her. She told him she didn't feel that way, but she did like him better than anyone else.
 
  "Then why do you go with other men?"
 
@@ -282,11 +96,4 @@ feel that way, but she did like him better than anyone else.
 
  Straw sighed. "They say dark elf women are like that."
 
- Barenziah smiled and shrugged. "I know. I guess that's all
-the explanation there is."
-
-
-
-
-
- 
+ Barenziah smiled and shrugged. "I know. I guess that's all the explanation there is."

--- a/Assets/StreamingAssets/Text/Books/BOK00045-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00045-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: True
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,144 +12,63 @@ Content:
 
 [/center]Barenziah
 
-[/center]
-
 [/center]Part III
-
-
 
 [/font=4]
 
-[/center]
-
-[/center]
-
- They settled into Rifton for the winter, taking a cheap room
-in the slums. Barenziah joined the Thieves' Guild, knowing
-there would be trouble if she were caught free-lancing. One
-day in the barroom she caught the eye of a known member of the
-guild, a bold young Khajiit named Therris. She offered to
-bed with him if he would sponsor her for membership. He looked
-her over, grinning, and agreed, but said she'd still have to
-pass a test. 
+ They settled into Rifton for the winter, taking a cheap room in the slums. Barenziah joined the Thieves' Guild, knowing there would be trouble if she were caught free-lancing. One day in the barroom she caught the eye of a known member of the guild, a bold young Khajiit named Therris. She offered to bed with him if he would sponsor her for membership. He looked her over, grinning, and agreed, but said she'd still have to pass a test.
 
  "What sort of test?"
 
- "Ah," Therris said. "Payment first, sweet thing." He put an
-arm around her, leaned over and kissed her, thrusting his
-tongue deep into her mouth and his free hand into her shirt.
+ "Ah," Therris said. "Payment first, sweet thing." He put an arm around her, leaned over and kissed her, thrusting his tongue deep into her mouth and his free hand into her shirt.
 
- "Nice," he said presently, withdrawing his tongue, but not
-his hand. His other hand slid down inside her waistband and
-fondled her buttocks.
+ "Nice," he said presently, withdrawing his tongue, but not his hand. His other hand slid down inside her waistband and fondled her buttocks.
 
- "Let's go upstairs. We can use my room," Barenziah felt
-both embarassed and excited by his boldness.
+ "Let's go upstairs. We can use my room," Barenziah felt both embarassed and excited by his boldness.
 
- Therris grinned insolently. "Why bother? You want me,
-don't you? I'll bet you'd pay me, wouldn't you?"
+ Therris grinned insolently. "Why bother? You want me, don't you? I'll bet you'd pay me, wouldn't you?"
 
  "No," Barenziah said. She did want him, but not that badly.
 
- "No? Well, a bargain's a bargain and Therris keeps his
-word. But here. Now." He hiked her skirt up and pulled her
-onto his lap so she sat astride, facing him. He opened her
-shirt and pulled it down on her shoulders so that her breasts
-were exposed.
+ "No? Well, a bargain's a bargain and Therris keeps his word. But here. Now." He hiked her skirt up and pulled her onto his lap so she sat astride, facing him. He opened her shirt and pulled it down on her shoulders so that her breasts were exposed.
 
- "Nice pair, kid." She was facing the wall but she could
-feel the stares of the other patrons. A hush had fallen over
-the place. Even the bard had stilled. She felt both nausea
-and a hot burning desire. Her hands released his turgid penis
-and then it was inside her and she was screaming in both pain
-and ecstasy. Then everything went black.
+ "Nice pair, kid." She was facing the wall but she could feel the stares of the other patrons. A hush had fallen over the place. Even the bard had stilled. She felt both nausea and a hot burning desire. Her hands released his turgid penis and then it was inside her and she was screaming in both pain and ecstasy. Then everything went black.
 
- When she came to herself again she was sitting beside Therris,
-who was buttoning her shirt.
+ When she came to herself again she was sitting beside Therris, who was buttoning her shirt.
 
  "That hurt!" she said indignantly.
 
- "Always does, kid. Didn't anyone ever tell you about
-Khajiit men? It hurts good though, now doesn't it?"
+ "Always does, kid. Didn't anyone ever tell you about Khajiit men? It hurts good though, now doesn't it?"
 
- Barenziah scowled at him. She was still smarting. His penis
-had tiny little barbs on it.
+ Barenziah scowled at him. She was still smarting. His penis had tiny little barbs on it.
 
  "Well, the deal's off, if you like," he shrugged.
 
- "No, I didn't say that. Only I prefer privacy, and I want
-to wait awhile, like a day or so before the next time."
+ "No, I didn't say that. Only I prefer privacy, and I want to wait awhile, like a day or so before the next time."
 
  Therris laughed. "You're OK, kid."
 
- Straw was going to kill her, and maybe Therris too. What in
-Tamriel had possessed her to do such a thing? She cast an
-anxious look around the room, but the other patrons had lost
-interest and gone back to their own business. She did not
-recognize any of them; this wasn't the inn where she lived.
-With luck it'd be awhile, or never, before Straw found out.
-But Therris was by far the most exciting and attractive man
-she'd yet met.
+ Straw was going to kill her, and maybe Therris too. What in Tamriel had possessed her to do such a thing? She cast an anxious look around the room, but the other patrons had lost interest and gone back to their own business. She did not recognize any of them; this wasn't the inn where she lived. With luck it'd be awhile, or never, before Straw found out. But Therris was by far the most exciting and attractive man she'd yet met.
 
- He not only told her about the skills needed to be a member of
-the Thieves' Guild, but trained her in them himself or
-introduced her to people who could teach her. Among these was
-a Nord woman who knew something about magic. Katisha was
-plump and matronly. She was married to a smith, had two teen
-aged children and was perfectly ordinary and respectable
-except that she was very fond of cats, had a gift for
-certain kinds of magic, and cultivated rather odd friends.
+ He not only told her about the skills needed to be a member of the Thieves' Guild, but trained her in them himself or introduced her to people who could teach her. Among these was a Nord woman who knew something about magic. Katisha was plump and matronly. She was married to a smith, had two teen aged children and was perfectly ordinary and respectable except that she was very fond of cats, had a gift for certain kinds of magic, and cultivated rather odd friends.
 
- She taught Barenziah an Invisibility spell and trained her
-in other forms of stealth and disguise. Katisha mingled
-magical and non-magical talents freely, using one to
-enhance the other. She was not a member of the Thieves' Guild
-but was fond of Therris in a motherly sort of fashion.
-Barenziah warmed to her as she never had to any woman, and
-over the next few weeks she told Katisha all about herself.
-She brought Straw there, too. Straw approved of Katisha
-but not of Therris. Therris found Straw amusing and
-suggested to Barenziah that they arrange what he called a
-threesome.
+ She taught Barenziah an Invisibility spell and trained her in other forms of stealth and disguise. Katisha mingled magical and non-magical talents freely, using one to enhance the other. She was not a member of the Thieves' Guild but was fond of Therris in a motherly sort of fashion. Barenziah warmed to her as she never had to any woman, and over the next few weeks she told Katisha all about herself. She brought Straw there, too. Straw approved of Katisha but not of Therris. Therris found Straw amusing and suggested to Barenziah that they arrange what he called a threesome.
 
- "Indeed not," Barenziah said, grateful that Therris had
-broached the subject in private. "He wouldn't like it. I
-wouldn't like it!"
+ "Indeed not," Barenziah said, grateful that Therris had broached the subject in private. "He wouldn't like it. I wouldn't like it!"
 
- Therris smiled his charming triangular cat-smile and
-sprawled lazily back in his chair, curling his tail. "You
-might both be surprised. Pairing is so boring. Well, would
-you mind if I brought a friend?"
+ Therris smiled his charming triangular cat-smile and sprawled lazily back in his chair, curling his tail. "You might both be surprised. Pairing is so boring. Well, would you mind if I brought a friend?"
 
- "Yes. If you're bored with me you and your friend can find
-someone else." She was a member of the Thieves' Guild now.
-She found Therris useful but not essential. Maybe she was a
-bit bored with him, too. 
+ "Yes. If you're bored with me you and your friend can find someone else." She was a member of the Thieves' Guild now. She found Therris useful but not essential. Maybe she was a bit bored with him, too.
 
- She talked to Katisha about her men problems. Katisha shook
-her head and told her she was looking for love, not sex, that
-she'd know the right man when she found him, and that neither
-Straw nor Therris was the right one for her.
+ She talked to Katisha about her men problems. Katisha shook her head and told her she was looking for love, not sex, that she'd know the right man when she found him, and that neither Straw nor Therris was the right one for her.
 
- Barenziah cocked her head to one side quizzically. "They say
-dark elf women are pro- pro- something. Prostitutes?"
+ Barenziah cocked her head to one side quizzically. "They say dark elf women are pro- pro- something. Prostitutes?"
 
- "You mean promiscuous, although some do become
-prostitutes, I suppose. Elf women are promiscuous when
-they're young. You'll outgrow it. Perhaps you're beginning
-to already," Katisha said hopefully. "You ought to meet
-some nice elven boys, though. If you keep on keeping company
-with Khajiits and humans you'll find yourself pregnant
-soon."
+ "You mean promiscuous, although some do become prostitutes, I suppose. Elf women are promiscuous when they're young. You'll outgrow it. Perhaps you're beginning to already," Katisha said hopefully. "You ought to meet some nice elven boys, though. If you keep on keeping company with Khajiits and humans you'll find yourself pregnant soon."
 
- Barenziah smiled involuntarily at the thought. "I'd like
-that. But it would be inconvenient, wouldn't it?  Babies
-are a lot of trouble, and I don't even have a home yet."
+ Barenziah smiled involuntarily at the thought. "I'd like that. But it would be inconvenient, wouldn't it? Babies are a lot of trouble, and I don't even have a home yet."
 
- "How old are you? Seventeen? Well, you've a year or two
-yet before you'll be fertile, unless you're very unlucky.
-Elves don't have children readily with other elves even after
-that, so you'll be all right if you stick with them."
+ "How old are you? Seventeen? Well, you've a year or two yet before you'll be fertile, unless you're very unlucky. Elves don't have children readily with other elves even after that, so you'll be all right if you stick with them."
 
  "Straw wants to buy a farm and marry me."
 
@@ -158,11 +76,6 @@ that, so you'll be all right if you stick with them."
 
  "No. Not yet. Maybe some day, if I can't be a queen."
 
- "I think Straw will be a very old man before "some day"
-comes, Berry. Elves live a very long time." Katisha's face
-briefly wore the wistful look humans got when contemplating
-the thousand year life span that elves were entitled to by
-nature. True, few ever actually lived that long, as
-disease and violence took a toll, but they could.
+ "I think Straw will be a very old man before "some day" comes, Berry. Elves live a very long time." Katisha's face briefly wore the wistful look humans got when contemplating the thousand year life span that elves were entitled to by nature. True, few ever actually lived that long, as disease and violence took a toll, but they could.
 
- "I like old men, too," Berry said. 
+ "I like old men, too," Berry said.

--- a/Assets/StreamingAssets/Text/Books/BOK00046-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00046-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: True
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,363 +14,148 @@ Content:
 
 [/center]Part IV
 
-
-
 [/font=4]
 
+ Barenziah fidgeted impatiently while Therris sorted through the papers in the desk. He was being meticulous and methodical, careful to replace everything just as he'd found it. They'd entered a nobleman's house, leaving Straw outside as a lookout. Therris had said it was a simple job but very secret. He hadn't even wanted to bring any other Guild members along. He said he knew he could trust Berry and Straw.
 
-
-[/center] Barenziah fidgeted impatiently while Therris sorted through
-the papers in the desk. He was being meticulous and
-methodical, careful to replace everything just as he'd
-found it. They'd entered a nobleman's house, leaving Straw
-outside as a lookout. Therris had said it was a simple job
-but very secret. He hadn't even wanted to bring any other
-Guild members along. He said he knew he could trust Berry and
-Straw.
-
- "Tell me what you're looking for and I'll find it," Berry
-whispered. Therris' night sight wasn't as good as hers and he
-didn't want to make a light. Berry had never been in such a
-luxurious place. She gazed around with wonder as they'd made
-their way through the huge echoing downstairs rooms, but
-Therris didn't seem interested in anything but the desk in the
-small book-lined study on the upper floor.
+ "Tell me what you're looking for and I'll find it," Berry whispered. Therris' night sight wasn't as good as hers and he didn't want to make a light. Berry had never been in such a luxurious place. She gazed around with wonder as they'd made their way through the huge echoing downstairs rooms, but Therris didn't seem interested in anything but the desk in the small book-lined study on the upper floor.
 
  "Ssss't," he hissed angrily.
 
- "Someone's coming!" Berry said, a moment before the door
-opened and two dark figures appeared. Therris gave her a
-violent shove toward them and sprang away toward the window.
-Barenziah's muscles went rigid; she couldn't move or even
-speak. She watched helplessly as a dark figure leaped after
-Therris. There were two quick, silent blue flares of light,
-then Therris folded in a still heap. Outside the study the
-house had come alive with footsteps and voices calling and
-the clank of armor.
+ "Someone's coming!" Berry said, a moment before the door opened and two dark figures appeared. Therris gave her a violent shove toward them and sprang away toward the window. Barenziah's muscles went rigid; she couldn't move or even speak. She watched helplessly as a dark figure leaped after Therris. There were two quick, silent blue flares of light, then Therris folded in a still heap. Outside the study the house had come alive with footsteps and voices calling and the clank of armor.
 
- The big man, a dark elf, half lifted, half dragged Therris
-to the door and thrust him into waiting arms. A jerk of the
-elf's head sent his robed companion after him. The elf came
-over to inspect Barenziah, who was once again able to move,
-although her head throbbed maddeningly when she did so.
+ The big man, a dark elf, half lifted, half dragged Therris to the door and thrust him into waiting arms. A jerk of the elf's head sent his robed companion after him. The elf came over to inspect Barenziah, who was once again able to move, although her head throbbed maddeningly when she did so.
 
  "Open your shirt, Barenziah," the elf said.
 
  Barenziah gaped at him and clutched it closed.
 
- "You are a girl, aren't you, Berry?" he said softly. "You
-should have stopped dressing as a boy a few months ago, you
-know. You were only drawing attention to yourself. And
-calling yourself Berry! Is your friend Straw too stupid to
-remember anything else?"
+ "You are a girl, aren't you, Berry?" he said softly. "You should have stopped dressing as a boy a few months ago, you know. You were only drawing attention to yourself. And calling yourself Berry! Is your friend Straw too stupid to remember anything else?"
 
  "It's a common elf name," Barenziah defended herself.
 
- The man shook his head sadly. "Not among dark elves it isn't,
-my dear, but you really don't know much about dark elves,
-do you? I regret that, but it couldn't be helped. No
-matter. I'll remedy it."
+ The man shook his head sadly. "Not among dark elves it isn't, my dear, but you really don't know much about dark elves, do you? I regret that, but it couldn't be helped. No matter. I'll remedy it."
 
  "Who are you?" Barenziah demanded.
 
- "So much for fame," the man shrugged, smiling wryly. "I am
-Symmachus, my lady, and it's a merry chase you've led me,
-although I'd guessed you'd head for Morrowind. You had a bit
-of luck. A body was found in Whiterun that was thought to be
-Straw's so we stopped looking for the pair. That was
-careless of me, yet I'd not have thought you'd have stayed
-together this long."
+ "So much for fame," the man shrugged, smiling wryly. "I am Symmachus, my lady, and it's a merry chase you've led me, although I'd guessed you'd head for Morrowind. You had a bit of luck. A body was found in Whiterun that was thought to be Straw's so we stopped looking for the pair. That was careless of me, yet I'd not have thought you'd have stayed together this long."
 
  "Where is he? Is he all right?"
 
- "Oh, he's fine for now. In custody, of course. You -- care
-for him, then?" he stared at her with curiosity out of red eyes
-that were so strange to her, except in her own seldom-seen
-image.
+ "Oh, he's fine for now. In custody, of course. You -- care for him, then?" he stared at her with curiosity out of red eyes that were so strange to her, except in her own seldom-seen image.
 
- "He's my friend," Barenziah said. The words came in a tone
-that sounded dull and hopeless in her own ears. Symmachus! A
-general in the Imperial Army, said to have the friendship
-and the ear of Tiber Septim himself. 
+ "He's my friend," Barenziah said. The words came in a tone that sounded dull and hopeless in her own ears. Symmachus! A general in the Imperial Army, said to have the friendship and the ear of Tiber Septim himself.
 
- "Ai. You seem to have several unsuitable friends, if you'll
-forgive my saying so, my lady." As they talked the bustle
-and flurry in the house had died away, although she could
-hear people, presumably the residents, whispering together
-not far off. The tall elf seated himself on a corner of the
-desk. He seemed quite relaxed and prepared to stay awhile. 
+ "Ai. You seem to have several unsuitable friends, if you'll forgive my saying so, my lady." As they talked the bustle and flurry in the house had died away, although she could hear people, presumably the residents, whispering together not far off. The tall elf seated himself on a corner of the desk. He seemed quite relaxed and prepared to stay awhile.
 
  Several? "W-what's going to happen to them? To me?"
 
- "Ah. As you know this house belongs to the commander of the
-Imperial troops in this area." Barenziah gasped and
-Symmachus looked up sharply. "You didn't know? You are
-rash, even for seventeen. You must always know what it is
-you do."
+ "Ah. As you know this house belongs to the commander of the Imperial troops in this area." Barenziah gasped and Symmachus looked up sharply. "You didn't know? You are rash, even for seventeen. You must always know what it is you do."
 
- "B-but the G-guild w-wouldn't -- " Barenziah was trembling.
-The Thieves' Guild would never have attempted a mission that
-involved Imperial policies. No one dared oppose Tiber
-Septim, at least no one she knew of. 
+ "B-but the G-guild w-wouldn't -- " Barenziah was trembling. The Thieves' Guild would never have attempted a mission that involved Imperial policies. No one dared oppose Tiber Septim, at least no one she knew of.
 
- "I daresay. It's unlikely that Therris had Guild approval
-for this job. I wonder--" Symmachus examined the desk
-carefully, pulling out its drawers. He selected one, placed
-its contents on the desk top and removed the false bottom.
-There was a folded sheet of paper inside. It seemed to be a
-map of some sort. Barenziah edged closer to see it.
-Symmachus held it away from her, laughing. "Rash indeed!"
-He glanced it over, then folded and replaced it.
+ "I daresay. It's unlikely that Therris had Guild approval for this job. I wonder--" Symmachus examined the desk carefully, pulling out its drawers. He selected one, placed its contents on the desk top and removed the false bottom. There was a folded sheet of paper inside. It seemed to be a map of some sort. Barenziah edged closer to see it. Symmachus held it away from her, laughing. "Rash indeed!" He glanced it over, then folded and replaced it.
 
  "You advised me to seek knowledge."
 
- "So I did, so I did." Suddenly he seemed to be in high good
-humor. "We must be going, my dear lady."
+ "So I did, so I did." Suddenly he seemed to be in high good humor. "We must be going, my dear lady."
 
- He shepherded her to the door, down the stairs and out into the
-night air. No one was about. Barenziah's eyes darted to the
-shadows. She wondered if she could outrun him, or elude him
-somehow.
+ He shepherded her to the door, down the stairs and out into the night air. No one was about. Barenziah's eyes darted to the shadows. She wondered if she could outrun him, or elude him somehow.
 
- "You're not thinking of attempting to escape, are you?
-Don't you want to hear what my plans for you are first?" He
-sounded a bit hurt.
+ "You're not thinking of attempting to escape, are you? Don't you want to hear what my plans for you are first?" He sounded a bit hurt.
 
  "Yes."
 
  "Perhaps you'd rather hear about your friends first."
 
- "No." He looked pleased. It was the answer he wanted, but it
-was also the truth. While Barenziah was concerned for her
-friends, especially Straw, she was far more concerned for
-herself.
+ "No." He looked pleased. It was the answer he wanted, but it was also the truth. While Barenziah was concerned for her friends, especially Straw, she was far more concerned for herself.
 
- "You will take your rightful place as Queen of
-Mournhold."
+ "You will take your rightful place as Queen of Mournhold."
 
- Her heart leapt. It was really true then! 
+ Her heart leapt. It was really true then!
 
- Symamchus explained that this had been his, and Tiber
-Septim's plan for her all along. That Mournhold, which had
-been under military rule for the dozen years since she had
-left was to be returned, gradually, to civilian
-government, under Imperial guidance, of course, and as a
-part of the Imperial Province of Morrowind.
+ Symamchus explained that this had been his, and Tiber Septim's plan for her all along. That Mournhold, which had been under military rule for the dozen years since she had left was to be returned, gradually, to civilian government, under Imperial guidance, of course, and as a part of the Imperial Province of Morrowind.
 
  "But why was I sent to Darkmoor."
 
  "For safekeeping. Why did you run away?"
 
- Barenziah shrugged. "I saw no reason to stay. I should have
-been told."
+ Barenziah shrugged. "I saw no reason to stay. I should have been told."
 
- "You would have been by now. I had in fact sent for you to
-be removed to Imperial City to spend some time as a part of
-the Emperor's household. As for your destiny, it should have
-been obvious to you. Tiber Septim does not keep those he has
-no use for, and what else could you be that is of use to
-him?"
+ "You would have been by now. I had in fact sent for you to be removed to Imperial City to spend some time as a part of the Emperor's household. As for your destiny, it should have been obvious to you. Tiber Septim does not keep those he has no use for, and what else could you be that is of use to him?"
 
  "I know nothing of him or you."
 
- "Then know this: Tiber Septim rewards friend and foe alike
-according to their deserts."
+ "Then know this: Tiber Septim rewards friend and foe alike according to their deserts."
 
- Barenziah chewed on that for a few moments. "Straw has
-deserved well of me and has never done anyone any harm. He is
-not a member of the Thieves' Guild. He came along to protect
-me. He earns our keep by running errands, and--"
+ Barenziah chewed on that for a few moments. "Straw has deserved well of me and has never done anyone any harm. He is not a member of the Thieves' Guild. He came along to protect me. He earns our keep by running errands, and--"
 
- Symmachus waved her to silence. "I know all about Straw,"
-he said, "and about Therris. So? What would you?"
+ Symmachus waved her to silence. "I know all about Straw," he said, "and about Therris. So? What would you?"
 
- "Straw wants a little farm. If I'm to be rich, then I would
-give that to him."
+ "Straw wants a little farm. If I'm to be rich, then I would give that to him."
 
  "Very well. He shall have it. And Therris?"
 
- "He betrayed me," Barenziah said in a low voice. Therris
-should have told her the risks the job entailed. Further, he'd
-pushed her right into their foes' arms in an attempt to save
-himself.
+ "He betrayed me," Barenziah said in a low voice. Therris should have told her the risks the job entailed. Further, he'd pushed her right into their foes' arms in an attempt to save himself.
 
  "Yes. And?"
 
  "Well, he should be made to suffer for it, shouldn't he?"
 
- "That seems reasonable. What form should the suffering
-take?"
+ "That seems reasonable. What form should the suffering take?"
 
- Barenziah balled her hands into fists. She'd like to beat and
-claw at the Khajiit herself, but that didn't seem very
-queenly. "A whipping. Would twenty stripes be too many do
-you think? I don't want to do him any permanent injury."
+ Barenziah balled her hands into fists. She'd like to beat and claw at the Khajiit herself, but that didn't seem very queenly. "A whipping. Would twenty stripes be too many do you think? I don't want to do him any permanent injury."
 
  "I shall arrange it."
 
- Barenziah spent two days in Symmachus' apartment during
-which she was kept very busy. There was a dark elf woman named
-Drelliane who saw to their needs, although she did not seem to
-be exactly a servant as she took her meals with them. Nor was
-she his wife. Drelliane seemed amused when Barenziah asked her
-about that. She simply said she was in Symmachus' employ and
-did whatever he asked of her. 
+ Barenziah spent two days in Symmachus' apartment during which she was kept very busy. There was a dark elf woman named Drelliane who saw to their needs, although she did not seem to be exactly a servant as she took her meals with them. Nor was she his wife. Drelliane seemed amused when Barenziah asked her about that. She simply said she was in Symmachus' employ and did whatever he asked of her.
 
- With Drelliane's assistance several fine gowns and pairs of
-shoes were ordered for her, plus a riding habit and boots,
-along with other small necessities. Barenziah was given a
-room to herself. Symmachus was out a great deal. She saw him
-at most meals, but he said little about himself or what he
-had been doing, although he was cordial and polite, was
-quite willing to converse on most subjects, and seemed
-interested in anything she had to say. Drelliane was much the
-same. Barenziah found them pleasant enough, but hard to get
-to know, as Katisha would have put it. She felt an odd
-disappointment. These were the first dark elves with whom
-she'd associated closely. She had expected to feel
-comfortable with them, to feel, at last, that this was where
-she belonged. Instead she found herself yearning for her
-Nord friends, Katisha and Straw. When Symmachus told her
-they were to set out for Imperial City on the morrow, she
-asked if she could say goodbye to her friends.
+ With Drelliane's assistance several fine gowns and pairs of shoes were ordered for her, plus a riding habit and boots, along with other small necessities. Barenziah was given a room to herself. Symmachus was out a great deal. She saw him at most meals, but he said little about himself or what he had been doing, although he was cordial and polite, was quite willing to converse on most subjects, and seemed interested in anything she had to say. Drelliane was much the same. Barenziah found them pleasant enough, but hard to get to know, as Katisha would have put it. She felt an odd disappointment. These were the first dark elves with whom she'd associated closely. She had expected to feel comfortable with them, to feel, at last, that this was where she belonged. Instead she found herself yearning for her Nord friends, Katisha and Straw. When Symmachus told her they were to set out for Imperial City on the morrow, she asked if she could say goodbye to her friends.
 
- "Katisha?" he asked. "Well enough. I suppose I owe her
-something. She it was who led me to you by telling me of a
-lonely dark elf girl named Berry who need elven friends --
-and sometimes dressed as a boy. She has no association with
-the Thieves' Guild. And no one associated with the Thieves'
-Guild seems to know your true identity, save Therris. That is
-well. I prefer that your former Guild membership not be
-made public knowledge. You will speak of it to no one. It
-does not become an Imperial queen."
+ "Katisha?" he asked. "Well enough. I suppose I owe her something. She it was who led me to you by telling me of a lonely dark elf girl named Berry who need elven friends -- and sometimes dressed as a boy. She has no association with the Thieves' Guild. And no one associated with the Thieves' Guild seems to know your true identity, save Therris. That is well. I prefer that your former Guild membership not be made public knowledge. You will speak of it to no one. It does not become an Imperial queen."
 
- "No one knows but Straw and Therris. They won't tell
-anyone."
+ "No one knows but Straw and Therris. They won't tell anyone."
 
- "No, they won't." He didn't know that Katisha knew then! 
+ "No, they won't." He didn't know that Katisha knew then!
 
- Straw came to their apartment the morning of their
-departure, and they were left alone in the parlor, although
-Barenziah knew that the other elves were well within hearing.
-Straw looked drawn and pale. They hugged one another
-silently for a few minutes. Straw's shoulders were shaking and
-tears were rolling down his cheeks, but he said nothing.
+ Straw came to their apartment the morning of their departure, and they were left alone in the parlor, although Barenziah knew that the other elves were well within hearing. Straw looked drawn and pale. They hugged one another silently for a few minutes. Straw's shoulders were shaking and tears were rolling down his cheeks, but he said nothing.
 
- Barenziah tried a smile. "So we both get what we want. I'm
-to be Queen of Mournhold and you'll be king of your own
-farm. I'll write you. You must find a scribe so you can
-write me, too." Straw shook his head sadly, and when Barenziah
-persisted, he opened his mouth and pointed inside, making an
-inarticulate noise. His tongue was gone! Barenziah
-collapsed onto a chair and wept noisily. 
+ Barenziah tried a smile. "So we both get what we want. I'm to be Queen of Mournhold and you'll be king of your own farm. I'll write you. You must find a scribe so you can write me, too." Straw shook his head sadly, and when Barenziah persisted, he opened his mouth and pointed inside, making an inarticulate noise. His tongue was gone! Barenziah collapsed onto a chair and wept noisily.
 
- "Why?" she demanded of Symmachus, when Straw had been
-ushered away. "Why?"
+ "Why?" she demanded of Symmachus, when Straw had been ushered away. "Why?"
 
- Symmachus shrugged. "He knows too much of you. He could be
-dangerous. At least he's alive, and he won't need his tongue
-to farm."
+ Symmachus shrugged. "He knows too much of you. He could be dangerous. At least he's alive, and he won't need his tongue to farm."
 
- "I hate you!" Barenziah screamed at him, then leaned over
-and vomited on the floor. She continued to revile him
-between intermittent bouts of nausea. He listened stolidly
-for some time, while Drelliane cleaned up after her.
-Finally, he told her to cease or he would gag her for the
-journey.
+ "I hate you!" Barenziah screamed at him, then leaned over and vomited on the floor. She continued to revile him between intermittent bouts of nausea. He listened stolidly for some time, while Drelliane cleaned up after her. Finally, he told her to cease or he would gag her for the journey.
 
- They stopped at Katisha's house. Symmachus and Drelliane
-didn't dismount. All seemed normal but Barenziah was
-frightened as she knocked on the door. Katisha answered her
-knock. She'd obviously been weeping, but she embraced
-Barenziah.
+ They stopped at Katisha's house. Symmachus and Drelliane didn't dismount. All seemed normal but Barenziah was frightened as she knocked on the door. Katisha answered her knock. She'd obviously been weeping, but she embraced Barenziah.
 
  "Why are you crying?" Barenziah asked.
 
- "For Therris, of course. You haven't heard? He's dead. He was
-caught stealing from the commandant's house. Poor fellow,
-but it was so foolish of him. Oh, Barenziah, he was drawn and
-quartered this very dawn by the commandant's order. I went;
-he asked for me. It was terrible; he suffered so before he
-died. I'll never forget it. I looked for you and Straw but
-no one knew where you'd got to. That's Symmachus you're with,
-isn't it? You know, the moment I saw him, I thought, this is the
-one for Barenziah! I told him about you, you know."
+ "For Therris, of course. You haven't heard? He's dead. He was caught stealing from the commandant's house. Poor fellow, but it was so foolish of him. Oh, Barenziah, he was drawn and quartered this very dawn by the commandant's order. I went; he asked for me. It was terrible; he suffered so before he died. I'll never forget it. I looked for you and Straw but no one knew where you'd got to. That's Symmachus you're with, isn't it? You know, the moment I saw him, I thought, this is the one for Barenziah! I told him about you, you know."
 
- "Yes," Barenziah said. "Katisha, I love you, but please
-don't ever tell anyone else anything about me. Ever. Swear
-you won't. Especially not Symmachus. And look after poor
-Straw for me." Katisha promised, puzzled but willing.
-"Berry, it wasn't somehow because of me that Therris was
-caught? I never said anything about Therris to Symmachus."
+ "Yes," Barenziah said. "Katisha, I love you, but please don't ever tell anyone else anything about me. Ever. Swear you won't. Especially not Symmachus. And look after poor Straw for me." Katisha promised, puzzled but willing. "Berry, it wasn't somehow because of me that Therris was caught? I never said anything about Therris to Symmachus."
 
- Barenziah assured her that it wasn't, that an informer had
-told of the Imperial Guard of Therris' plans, which was
-probably a lie, but Katisha badly needed some kind of
-comfort. 
+ Barenziah assured her that it wasn't, that an informer had told of the Imperial Guard of Therris' plans, which was probably a lie, but Katisha badly needed some kind of comfort.
 
- "Oh, I'm glad of that, if I can be glad of anything just
-now. I'd hate to think-- but how could I have known? And
-Symmachus is very handsome, don't you think? And charming."
+ "Oh, I'm glad of that, if I can be glad of anything just now. I'd hate to think-- but how could I have known? And Symmachus is very handsome, don't you think? And charming."
 
- "I don't know," Barenziah said. "I haven't really thought
-about it. There hasn't been time." She explained about being
-Queen of Mournhold and going to live in Imperial City for
-awhile first. "He was looking for me. I don't think he thinks
-of me as a woman at all. He said I didn't look like a boy,
-though," she added in the face of Katisha's incredulity. She
-knew that Barenziah evaluated every male she saw in terms of
-sexual desirability. "I suppose it's the shock of finding
-out that I really am a queen," she added, and Katisha agreed
-that that must be something of a shock, although one there was
-no likelihood of her experiencing first hand.
+ "I don't know," Barenziah said. "I haven't really thought about it. There hasn't been time." She explained about being Queen of Mournhold and going to live in Imperial City for awhile first. "He was looking for me. I don't think he thinks of me as a woman at all. He said I didn't look like a boy, though," she added in the face of Katisha's incredulity. She knew that Barenziah evaluated every male she saw in terms of sexual desirability. "I suppose it's the shock of finding out that I really am a queen," she added, and Katisha agreed that that must be something of a shock, although one there was no likelihood of her experiencing first hand.
 
- Their party left Rifton by the great south gate. Once
-through Symmachus tapped her shoulder and pointed back to
-the gate. "I thought you might want to say good-bye to
-Therris, too," he said. Barenziah stared briefly but
-steadily at the head impaled on a spike above the gate. The birds
-were at it, but the face was still recognizable.
+ Their party left Rifton by the great south gate. Once through Symmachus tapped her shoulder and pointed back to the gate. "I thought you might want to say good-bye to Therris, too," he said. Barenziah stared briefly but steadily at the head impaled on a spike above the gate. The birds were at it, but the face was still recognizable.
 
- "I think he will not hear me," she said. "Let's be on our
-way, shall we?"
+ "I think he will not hear me," she said. "Let's be on our way, shall we?"
 
- Symmachus was clearly disappointed by her lack of
-reaction. "You heard of this from Katisha?"
+ Symmachus was clearly disappointed by her lack of reaction. "You heard of this from Katisha?"
 
- "Of course. She attended the execution." Barenziah said
-casually. If he didn't know already, he'd find out soon
-enough; she was sure of that. 
+ "Of course. She attended the execution." Barenziah said casually. If he didn't know already, he'd find out soon enough; she was sure of that.
 
  "Did she know Therris belonged to the Guild?"
 
- "Everyone knew that. It's only lower ranking members like me
-who are supposed to keep their membership secret. The ranking
-officers are well known. But you know all that, don't
-you?" She smiled archly at him.
+ "Everyone knew that. It's only lower ranking members like me who are supposed to keep their membership secret. The ranking officers are well known. But you know all that, don't you?" She smiled archly at him.
 
- "So you told her who you were and whence you'd come, but not
-about the Guild."
+ "So you told her who you were and whence you'd come, but not about the Guild."
 
- "The Guild membership was not my secret to tell. The other
-was. There is a difference. Besides, Katisha is a very honest
-person. Had I told her it would have lessened me in her eyes.
-She was always after Therris to take up a more honest line of
-work. I value her good opinion. She also thought I'd be
-happier if I'd settle down with just one man friend, one of
-my own race. You, in fact. Isn't it odd how wishes come true
-sometimes, but not the way you want them to?"
+ "The Guild membership was not my secret to tell. The other was. There is a difference. Besides, Katisha is a very honest person. Had I told her it would have lessened me in her eyes. She was always after Therris to take up a more honest line of work. I value her good opinion. She also thought I'd be happier if I'd settle down with just one man friend, one of my own race. You, in fact. Isn't it odd how wishes come true sometimes, but not the way you want them to?"
 
- "Yes. Very odd." Something about the way he said it made her
-think that she herself was one of his wishes that had come true
-in a way that wasn't altogether to his liking.
-
-
-
-
-
-
-
-
-
- 
+ "Yes. Very odd." Something about the way he said it made her think that she herself was one of his wishes that had come true in a way that wasn't altogether to his liking.

--- a/Assets/StreamingAssets/Text/Books/BOK00047-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00047-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,257 +14,79 @@ Content:
 
 [/center]Part V
 
-
-
 [/font=4]
+ Barenziah felt the weight of sorrow for several days, but by the third day out her spirits had begun to rise a bit. She found that she enjoyed being on the road again, although she missed Straw's companionship more than she would have thought. They were escorted by a troop of Redguard knights, with whom she felt comfortable, although these were much more disciplined than the guards of the merchant caravans. They were cordial but respectful towards her despite her attempts to flirt with the men.
 
-
-
-[/center]
-
- Barenziah felt the weight of sorrow for several days, but
-by the third day out her spirits had begun to rise a bit. She
-found that she enjoyed being on the road again, although she
-missed Straw's companionship more than she would have
-thought. They were escorted by a troop of Redguard knights,
-with whom she felt comfortable, although these were much more
-disciplined than the guards of the merchant caravans. They
-were cordial but respectful towards her despite her
-attempts to flirt with the men.
-
- Symmachus scolded her privately, saying a queen must
-maintain a royal dignity at all times.
+ Symmachus scolded her privately, saying a queen must maintain a royal dignity at all times.
 
  "You mean I'm never to have any fun?"
 
- "Not with such as these. They are beneath you. Graciousness is
-to be desired in those in authority. Familiarity is not. You
-will remain chaste and modest while you are in Imperial
-City."
+ "Not with such as these. They are beneath you. Graciousness is to be desired in those in authority. Familiarity is not. You will remain chaste and modest while you are in Imperial City."
 
- Barenziah screwed up her face. "I might as well be back in
-Black Moor. Elves are promiscuous by nature. Everyone says
-so."
+ Barenziah screwed up her face. "I might as well be back in Black Moor. Elves are promiscuous by nature. Everyone says so."
 
- "'Everyone' is wrong, then. Some are, some aren't. The
-emperor -- and I -- expect you to show both discrimination
-and discretion. Let me remind you that you will hold the
-throne of Mournhold not by right of blood but solely at the
-pleasure of Tiber Septim. If he judges you unsuitable your
-reign will end ere it begins. He requires intelligence,
-obedience, discretion and total loyalty in all his
-appointees, and he favors chastity and modesty in women. I
-suggest you model your deportment after Drelliane."
+ "'Everyone' is wrong, then. Some are, some aren't. The emperor -- and I -- expect you to show both discrimination and discretion. Let me remind you that you will hold the throne of Mournhold not by right of blood but solely at the pleasure of Tiber Septim. If he judges you unsuitable your reign will end ere it begins. He requires intelligence, obedience, discretion and total loyalty in all his appointees, and he favors chastity and modesty in women. I suggest you model your deportment after Drelliane."
 
- "I'd liefer be back in Black Moor," Barenziah said
-indignantly.
+ "I'd liefer be back in Black Moor," Barenziah said indignantly.
 
- "That is not an option. If you are of no use to Tiber
-Septim he will see to it that you are of no use to his enemies
-either," Symmachus said coldly. "If you would keep your
-head upon your shoulders take warning. Let me add that
-power offers pleasures other than those of carnality and
-low company." He spoke of art, literature, drama, music,
-and grand balls. Barenziah listened with interest spurred
-by his threats, but after asked if she might continue her study
-of spellcasting while in Imperial City. Symmachus seemed
-pleased and promised to arrange it. Pleased with this she then
-said that she noted that three of their knights were women, and
-asked if she might train a little in combat with them, just
-for the sake of exercise. Symmachus looked less than pleased,
-but agreed she might, although only with the women.
+ "That is not an option. If you are of no use to Tiber Septim he will see to it that you are of no use to his enemies either," Symmachus said coldly. "If you would keep your head upon your shoulders take warning. Let me add that power offers pleasures other than those of carnality and low company." He spoke of art, literature, drama, music, and grand balls. Barenziah listened with interest spurred by his threats, but after asked if she might continue her study of spellcasting while in Imperial City. Symmachus seemed pleased and promised to arrange it. Pleased with this she then said that she noted that three of their knights were women, and asked if she might train a little in combat with them, just for the sake of exercise. Symmachus looked less than pleased, but agreed she might, although only with the women.
 
- The late winter weather held fair but cold for their
-journey, so that they travelled quickly over firm roads. On
-the last day, spring seemed to come at last for there was a
-thaw, and the road grew sloppy underfoot, and everywhere
-one could faintly hear the sound of water trickling and
-dripping. 
+ The late winter weather held fair but cold for their journey, so that they travelled quickly over firm roads. On the last day, spring seemed to come at last for there was a thaw, and the road grew sloppy underfoot, and everywhere one could faintly hear the sound of water trickling and dripping.
 
- They came to the great bridge that crossed into Imperial
-City at sunset. The rosy glow turned all the stark white
-marble buildings a delicate pink. It all looked very new
-and grand and immaculate. A broad avenue led straight
-north to the Palace. There was a crowd of people of all
-sorts in the streets. Lights winked out in the shops and on in
-the inns as dusk fell and the stars came out one by one. Even
-the side streets were broad and brightly lit. Near the
-palace the towers of a grand Mage Guild reared to the east
-while westward the stained glass windows of a great temple
-glittered. 
+ They came to the great bridge that crossed into Imperial City at sunset. The rosy glow turned all the stark white marble buildings a delicate pink. It all looked very new and grand and immaculate. A broad avenue led straight north to the Palace. There was a crowd of people of all sorts in the streets. Lights winked out in the shops and on in the inns as dusk fell and the stars came out one by one. Even the side streets were broad and brightly lit. Near the palace the towers of a grand Mage Guild reared to the east while westward the stained glass windows of a great temple glittered.
 
- Symmachus had an apartment in a great house two blocks from
-the palace, past the Temple, the Temple of the One, he said,
-as they passed it, an ancient Nordic cult which Tiber Septim
-had revived. He said that Barenziah would be expected to
-become a member, should she prove acceptable to the
-Emperor. 
+ Symmachus had an apartment in a great house two blocks from the palace, past the Temple, the Temple of the One, he said, as they passed it, an ancient Nordic cult which Tiber Septim had revived. He said that Barenziah would be expected to become a member, should she prove acceptable to the Emperor.
 
- Symmachus' apartment was very grand, although little to
-Barenziah's liking. The walls and furnishings were stark
-white, relieved only by touches of bright gold, the floors
-of gleaming black marble. Barenziah's eyes ached for color
-and shadow.
+ Symmachus' apartment was very grand, although little to Barenziah's liking. The walls and furnishings were stark white, relieved only by touches of bright gold, the floors of gleaming black marble. Barenziah's eyes ached for color and shadow.
 
- In the morning Symmachus and Drelliane escorted her to the
-Imperial Palace. Barenziah noted that everyone they met
-greeted Symmachus with a deferential respect which in some
-cases bordered on obsequiousness. He took it quite for
-granted. She and Symmachus were ushered directly into the
-Imperial presence.
+ In the morning Symmachus and Drelliane escorted her to the Imperial Palace. Barenziah noted that everyone they met greeted Symmachus with a deferential respect which in some cases bordered on obsequiousness. He took it quite for granted. She and Symmachus were ushered directly into the Imperial presence.
 
- Morning sun flooded the small room through a large window
-with tiny panes, washing over the breakfast table and the
-single man who sat there, dark against the light. He leapt to
-his feet as they entered and hurried toward them, "Ah,
-Symmachus, my friend, I welcome thy return most gladly."
-His hands touched Symmachus shoulders briefly, fondly,
-interrupting the deep bow the elf had begun. Barenziah
-curtsied as Tiber Septim turned to her.
+ Morning sun flooded the small room through a large window with tiny panes, washing over the breakfast table and the single man who sat there, dark against the light. He leapt to his feet as they entered and hurried toward them, "Ah, Symmachus, my friend, I welcome thy return most gladly." His hands touched Symmachus shoulders briefly, fondly, interrupting the deep bow the elf had begun. Barenziah curtsied as Tiber Septim turned to her.
 
- "Barenziah, my naughty little runaway, how do you, child?
-Here, let me have a look at you. Why, Symmachus, she's
-charming, absolutely charming. Why have you hidden her from
-us all these years? Is the light too much? Shall I draw the
-hangings? Yes, of course." He waved aside Symmachus
-protests and drew the curtains himself, not troubling to
-summon a servant. "You will pardon me for this
-discourtesy to my guests. I've much to think of, but that's
-scant excuse for inhospitality -- ah, pray join me. There's
-some excellent fruit from the Black Marsh."
+ "Barenziah, my naughty little runaway, how do you, child? Here, let me have a look at you. Why, Symmachus, she's charming, absolutely charming. Why have you hidden her from us all these years? Is the light too much? Shall I draw the hangings? Yes, of course." He waved aside Symmachus protests and drew the curtains himself, not troubling to summon a servant. "You will pardon me for this discourtesy to my guests. I've much to think of, but that's scant excuse for inhospitality -- ah, pray join me. There's some excellent fruit from the Black Marsh."
 
- They settled themselves at the table. Barenziah was
-astonished. Tiber Septim was nothing like the grim grey
-giant warrior she'd pictured. He was only of middle height,
-half a head shorter than tall Symmachus, although he was
-well knit of figure and lithe in movement. He had a winning
-smile, bright, indeed piercing, blue eyes, and a full head
-of stark white hair above a lined and weathered face. He might
-have been of any age from forty to sixty.
+ They settled themselves at the table. Barenziah was astonished. Tiber Septim was nothing like the grim grey giant warrior she'd pictured. He was only of middle height, half a head shorter than tall Symmachus, although he was well knit of figure and lithe in movement. He had a winning smile, bright, indeed piercing, blue eyes, and a full head of stark white hair above a lined and weathered face. He might have been of any age from forty to sixty.
 
- He pressed food and drink upon them, then repeated his
-question: why had she left her home? Had her guardians been
-unkind to her?
+ He pressed food and drink upon them, then repeated his question: why had she left her home? Had her guardians been unkind to her?
 
- "No, excellency," Barenziah replied, "in truth, no,
-although I fancied so at times." Symmachus had made up a lie
-for her and Barenziah told it, although with misgivings. The
-stableboy, Straw, had convinced her that her guardians,
-unable to find a suitable husband for her, meant to sell her
-as a concubine in Rihad, and when a Redguard had indeed come,
-she had panicked and fled with him. Tiber Septim seemed
-fascinated and listened raptly as she provided details of
-her life as a merchant caravan guard.
+ "No, excellency," Barenziah replied, "in truth, no, although I fancied so at times." Symmachus had made up a lie for her and Barenziah told it, although with misgivings. The stableboy, Straw, had convinced her that her guardians, unable to find a suitable husband for her, meant to sell her as a concubine in Rihad, and when a Redguard had indeed come, she had panicked and fled with him. Tiber Septim seemed fascinated and listened raptly as she provided details of her life as a merchant caravan guard.
 
- "Why, 'tis like a ballad," he said. "By the One, I'll have
-the court bard set it to music. What a charming boy you must
-have made."
+ "Why, 'tis like a ballad," he said. "By the One, I'll have the court bard set it to music. What a charming boy you must have made."
 
- "Symmachus said--" Barenziah stopped in some confusion, "he
-said, well, that I no longer look much like a boy. I have
-grown in the past few months." She lowered her gaze in what
-she hoped looked like maiden modesty.
+ "Symmachus said--" Barenziah stopped in some confusion, "he said, well, that I no longer look much like a boy. I have grown in the past few months." She lowered her gaze in what she hoped looked like maiden modesty.
 
  "He's a very discerning fellow, is my friend Symmachus."
 
- "I know I've been a very foolish girl. I must crave thy
-pardon, and that of my kind guardians. I -- I realized that
-some time ago, but I was too ashamed to go home. And I do
-long for Morrowind. My soul pines for my own country."
+ "I know I've been a very foolish girl. I must crave thy pardon, and that of my kind guardians. I -- I realized that some time ago, but I was too ashamed to go home. And I do long for Morrowind. My soul pines for my own country."
 
- "My dear. You shall go home, I promise you, but I pray you
-remain with us a little longer, that you may prepare
-yourself for the stern task with which I shall charge you."
-Barenziah gazed at him earnestly, heart beating hard. It was
-all working just as Symmachus had said it would. She felt a
-warm flush of gratitude toward him, but was  careful to keep
-her attention focused on the Emperor. "I am honored,
-Excellency, and wish most earnestly to serve you and this
-great Empire you have forged in any way I can." It was the
-politic thing to say, but Barenziah really meant it. She was
-awed by the magnificence of the city and the discipline and
-order everywhere evident, and was excited at the prospect of
-being a part of it all. Plus she felt quite drawn to Tiber
-Septim.
+ "My dear. You shall go home, I promise you, but I pray you remain with us a little longer, that you may prepare yourself for the stern task with which I shall charge you." Barenziah gazed at him earnestly, heart beating hard. It was all working just as Symmachus had said it would. She felt a warm flush of gratitude toward him, but was careful to keep her attention focused on the Emperor. "I am honored, Excellency, and wish most earnestly to serve you and this great Empire you have forged in any way I can." It was the politic thing to say, but Barenziah really meant it. She was awed by the magnificence of the city and the discipline and order everywhere evident, and was excited at the prospect of being a part of it all. Plus she felt quite drawn to Tiber Septim.
 
- After a few days Symmachus left for Mournhold to take up his
-duties as governor until Barenziah was ready to assume the
-throne, after which he would become her Prime Minister.
-Barenziah, with Drelliane as chaperone, took up residence in
-a suite at the Palace. Several tutors were provided for
-her. During this time she became deeply interested in the
-magical arts, but she found the study of history and
-politics not at all to her taste.
+ After a few days Symmachus left for Mournhold to take up his duties as governor until Barenziah was ready to assume the throne, after which he would become her Prime Minister. Barenziah, with Drelliane as chaperone, took up residence in a suite at the Palace. Several tutors were provided for her. During this time she became deeply interested in the magical arts, but she found the study of history and politics not at all to her taste.
 
- On occasion she met Tiber Septim in the Palace gardens and he
-would unfailingly inquire politely as to her progress, and
-chide her, although with a smile, over her disinterest in
-matters of state. However, he was always happy to instruct
-her on fine points of magic, and he could make even history
-and politics seem interesting after all. "They're people,
-child, not dry facts in a dusty book," he said. As her
-understanding broadened their discussions became longer,
-deeper and more frequent. He spoke to her of his vision of a
-united Tamriel, each race separate and distinct but with
-shared ideals and goals, all contributing to the common
-weal.
+ On occasion she met Tiber Septim in the Palace gardens and he would unfailingly inquire politely as to her progress, and chide her, although with a smile, over her disinterest in matters of state. However, he was always happy to instruct her on fine points of magic, and he could make even history and politics seem interesting after all. "They're people, child, not dry facts in a dusty book," he said. As her understanding broadened their discussions became longer, deeper and more frequent. He spoke to her of his vision of a united Tamriel, each race separate and distinct but with shared ideals and goals, all contributing to the common weal.
 
- "Some things are universal, shared by all sentient folk of
-good will," he said. "So the One teaches us. We must unite
-against the malicious and the brutish, the mis-created, the
-orcs, trolls, goblins and other worse creataures, not
-strive 'gainst one another."
+ "Some things are universal, shared by all sentient folk of good will," he said. "So the One teaches us. We must unite against the malicious and the brutish, the mis-created, the orcs, trolls, goblins and other worse creataures, not strive 'gainst one another."
 
- His blue eyes would light as he stared into his dream, and
-Barenziah was delighted just to sit and listen to him. If he
-drew close to her, the side of her body next to him would glow
-as if he were a fire. If their hands met she would tingle all
-over as if his body were charged with a small shock spell. One
-day, quite unexpectedly, he took her face in his hands and
-kissed her gently on the mouth. She drew back after a few
-moments, astonished by the violence of her feelings, and he
-apologized instantly. "I didn't mean to do that. It's just
--- you are so beautiful, my dear. So very beautiful." He
-was looking at her with a hopeless yearning in his face. She
-turned away, tears streaming down her face. "Are you angry
-with me? Talk to me."
+ His blue eyes would light as he stared into his dream, and Barenziah was delighted just to sit and listen to him. If he drew close to her, the side of her body next to him would glow as if he were a fire. If their hands met she would tingle all over as if his body were charged with a small shock spell. One day, quite unexpectedly, he took her face in his hands and kissed her gently on the mouth. She drew back after a few moments, astonished by the violence of her feelings, and he apologized instantly. "I didn't mean to do that. It's just -- you are so beautiful, my dear. So very beautiful." He was looking at her with a hopeless yearning in his face. She turned away, tears streaming down her face. "Are you angry with me? Talk to me."
 
- Barenziah shook her head. "I could never be angry with you. I
-love you. I know it's wrong, but I can't help it."
+ Barenziah shook her head. "I could never be angry with you. I love you. I know it's wrong, but I can't help it."
 
- "I have a wife," he said. "She is a good and virtuous
-woman, and the mother of my children. I could never put her
-aside, yet there is nothing between us, no sharing of the
-spirit. She would have had me be other than what I am. I am the
-most powerful man in all Tamriel, and, Barenziah, I think I
-am the most lonely as well. Power!" he said with contempt.
-"I'd trade a goodly share of it for youth and love if the
-gods allowed it."
+ "I have a wife," he said. "She is a good and virtuous woman, and the mother of my children. I could never put her aside, yet there is nothing between us, no sharing of the spirit. She would have had me be other than what I am. I am the most powerful man in all Tamriel, and, Barenziah, I think I am the most lonely as well. Power!" he said with contempt. "I'd trade a goodly share of it for youth and love if the gods allowed it."
 
- "But you are strong and vigorous and vital, more than any
-man I've ever known."
+ "But you are strong and vigorous and vital, more than any man I've ever known."
 
- He shook his head. "Today, perhaps. Yet I am less than I was
-yesterday, last year, ten years ago. I feel the sting of my
-mortality and it is painful."
+ He shook his head. "Today, perhaps. Yet I am less than I was yesterday, last year, ten years ago. I feel the sting of my mortality and it is painful."
 
- "If I can ease thy pain, let me do so." Barenziah moved
-towards him, hands outstretched.
+ "If I can ease thy pain, let me do so." Barenziah moved towards him, hands outstretched.
 
  "I would not take thy innocence from thee."
 
  "I'm not that innocent."
 
- "How so?" Tiber Septim's voice grated harshly, his brow
-knitted. Barenziah's mouth went dry. What had she done?
+ "How so?" Tiber Septim's voice grated harshly, his brow knitted. Barenziah's mouth went dry. What had she done?
 
- "There was Straw," she faltered. "I -- I was lonely, too.
-Am lonely. And not so strong as you." She cast her eyes down
-in embarassment. "I'm not worthy--"
+ "There was Straw," she faltered. "I -- I was lonely, too. Am lonely. And not so strong as you." She cast her eyes down in embarassment. "I'm not worthy--"
 
- "No, no, not so. Barenziah, it cannot last for long. You
-have a duty in Mournhold. I must tend my Empire. Shall we
-share what we may and pray the One forgives us our
-frailty?"
+ "No, no, not so. Barenziah, it cannot last for long. You have a duty in Mournhold. I must tend my Empire. Shall we share what we may and pray the One forgives us our frailty?"
 
- Tiber Septim held out his arms and, wordlessly, Barenziah stepped into his embrace. 
+ Tiber Septim held out his arms and, wordlessly, Barenziah stepped into his embrace.

--- a/Assets/StreamingAssets/Text/Books/BOK00048-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00048-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: True
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,141 +14,57 @@ Content:
 
 [/center]Part VI
 
-
-
 [/font=4]
+ "You dance on the edge of a volcano, child," Drelliane scolded, as Barenziah admired the emerald ring her lover had given her to celebrate their one month anniversary.
 
+ "How so? We make one another happy. We harm no one. Symmachus bade me to be discriminate and discreet. Who better could I choose? And we've been most discreet. He treats me as a daughter in public." Tiber Septim's nightly visits were made through a secret passage.
 
+ "He slavers over you like a dog his dinner. Have you not noticed the coolness of the Empress and her son toward you?"
 
-[/center]
+ Barenziah shrugged. Even before she and Septim had become lovers she'd had no more from his family than bare civility. Threadbare civility. "What matter? It is Tiber who holds power."
 
- "You dance on the edge of a volcano, child," Drelliane scolded, as Barenziah
-admired the emerald ring her lover had given her to
-celebrate their one month anniversary.
+ "It is his son who holds the future. Do not hold his mother up to public scorn, I beg you."
 
- "How so? We make one another happy. We harm no one. Symmachus
-bade me to be discriminate and discreet. Who better could I
-choose? And we've been most discreet. He treats me as a
-daughter in public." Tiber Septim's nightly visits were
-made through a secret passage.
+ "Can I help it if that dry stick of a woman cannot hold her husband's interest even in conversation at dinner?"
 
- "He slavers over you like a dog his dinner. Have you not
-noticed the coolness of the Empress and her son toward you?"
+ "Have less to say in public. That is all I ask. She matters little, save that her children love her, and you do not want them as enemies. Tiber Septim has not long to live. I mean," Drelliane amended quickly, at Barenziah's scowl, "Humans are all short-lived. Temporary, as we elves say. They come and go as the seasons do, but the families of the powerful live on for a time. You must be a family friend if you would see lasting profit from your relationship. Ah, how can I make you truly see, you who are so young and human-bred as well! If you take care you and Mournhold are like to live to see the fall of Septim's dynasty, if indeed he has founded one, as you have seen its rise. It is the way of human history. They ebb and flow like the tides. Their cities and even their empires bloom like spring flowers, only to wither and die in the summer sun."
 
- Barenziah shrugged. Even before she and Septim had become
-lovers she'd had no more from his family than bare civility.
-Threadbare civility. "What matter? It is Tiber who holds
-power."
+ Barenziah just laughed. She knew that rumors abounded about her and Tiber Septim. She enjoyed the attention for all save the Empress and her son seemed captivated by her. Bards sang of her dark beauty and her charming ways. She was in fashion and in love and if it was temporary, well, what was not? She was happy for the first time she could remember, each day filled with joy and pleasure, and the nights yet better.
 
- "It is his son who holds the future. Do not hold his mother up
-to public scorn, I beg you."
+ "What is wrong with me?" Barenziah lamented. "Look, not one of my skirts fit? What's become of my waist? Am I getting fat?" Barenziah regarded her thin arms and legs and her undeniably thickened waist in the mirror with displeasure.
 
- "Can I help it if that dry stick of a woman cannot hold her
-husband's interest even in conversation at dinner?"
+ Drelliane shrugged. "You appear to be with child, young as you are. Constant pairing with a human has brought you early to fertility. I see no choice but for you to speak with him about it. You are in his power. It would be best, I think, for you to go directly to Mournhold if he will agree, and bear the child there."
 
- "Have less to say in public. That is all I ask. She matters
-little, save that her children love her, and you do not want
-them as enemies. Tiber Septim has not long to live. I mean,"
-Drelliane amended quickly, at Barenziah's scowl, "Humans are
-all short-lived. Temporary, as we elves say. They come and
-go as the seasons do, but the families of the powerful live
-on for a time. You must be a family friend if you would see lasting profit from your relationship. Ah, how can I
-make you truly see, you who are so young and human-bred as
-well! If you take care you and Mournhold are like to live to
-see the fall of Septim's dynasty, if indeed he has founded
-one, as you have seen its rise. It is the way of human history.
-They ebb and flow like the tides. Their cities and even their
-empires bloom like spring flowers, only to wither and die
-in the summer sun."
+ "Alone?" Barenziah placed her hands on her swollen belly, tears forming in her eyes. Everything in her yearned to share the fruit of her love with her lover. "He'll ne'er agree to that. He won't be parted from me now. You'll see."
 
- Barenziah just laughed. She knew that rumors abounded about
-her and Tiber Septim. She enjoyed the attention for all
-save the Empress and her son seemed captivated by her. Bards
-sang of her dark beauty and her charming ways. She was in
-fashion and in love and if it was temporary, well, what was
-not? She was happy for the first time she could remember,
-each day filled with joy and pleasure, and the nights yet
-better.
+ Drelliane shook her gray head. Although she said no more, a look of sympathy and sorrow had replaced her usual cool scorn.
 
- "What is wrong with me?" Barenziah lamented. "Look, not one
-of my skirts fit? What's become of my waist? Am I getting
-fat?" Barenziah regarded her thin arms and legs and her
-undeniably thickened waist in the mirror with displeasure. 
+ That night Barenziah told Tiber Septim of it when he came to her.
 
- Drelliane shrugged. "You appear to be with child, young as
-you are. Constant pairing with a human has brought you early
-to fertility. I see no choice but for you to speak with him
-about it. You are in his power. It would be best, I think,
-for you to go directly to Mournhold if he will agree, and
-bear the child there."
+ "With child?" He looked shocked. Stunned. "You're sure of it? I was told elves do not bear so young."
 
- "Alone?" Barenziah placed her hands on her swollen belly,
-tears forming in her eyes. Everything in her yearned to share
-the fruit of her love with her lover. "He'll ne'er agree to
-that. He won't be parted from me now. You'll see."
-
- Drelliane shook her gray head. Although she said no more, a
-look of sympathy and sorrow had replaced her usual cool
-scorn.
-
- That night Barenziah told Tiber Septim of it when he came to
-her.
-
- "With child?" He looked shocked. Stunned. "You're sure of
-it? I was told elves do not bear so young."
-
- Barenziah summoned a smile. "How can I be sure? I've never --
-"
+ Barenziah summoned a smile. "How can I be sure? I've never --"
 
  "I'll fetch my healer."
 
- The healer, a high elf of middle years, confirmed that
-Barenziah was indeed pregnant and that such a thing had never
-before been known to happen. It was a testimony to His
-Excellency's potency, the healer said sycophantically.
-Tiber Septim snarled at him. "This must not be," he said.
-"Undo it."
+ The healer, a high elf of middle years, confirmed that Barenziah was indeed pregnant and that such a thing had never before been known to happen. It was a testimony to His Excellency's potency, the healer said sycophantically. Tiber Septim snarled at him. "This must not be," he said. "Undo it."
 
  "Sire," the healer gaped at him. "I cannot--."
 
  "Of course you can," he snapped. "I command you do so."
 
- Barenziah, wide-eyed with sudden terror, sat up in the bed.
-"No!" she screamed. "No! What are you saying?"
+ Barenziah, wide-eyed with sudden terror, sat up in the bed. "No!" she screamed. "No! What are you saying?"
 
- "My dear child," Tiber Septim sat down beside her with his
-winning smile. "I'm so sorry. Truly. But this cannot be.
-Your child could be a threat to my son and his sons. I will
-put it no more plainly than that."
+ "My dear child," Tiber Septim sat down beside her with his winning smile. "I'm so sorry. Truly. But this cannot be. Your child could be a threat to my son and his sons. I will put it no more plainly than that."
 
  "The child I bear is your child!" she wailed.
 
- "No. It's but a possibility, a might be, not yet gifted with
-a soul or quickened into life. I will not have it so." He
-gave the healer another hard stare and the elf began to
-tremble.
+ "No. It's but a possibility, a might be, not yet gifted with a soul or quickened into life. I will not have it so." He gave the healer another hard stare and the elf began to tremble.
 
- "It is her child. Children are few among elves. No woman
-conceives more than four and that is very rare. Two is the
-allotted number. Some bear none, some only one. If I take
-this one from her, she may not conceive again."
+ "It is her child. Children are few among elves. No woman conceives more than four and that is very rare. Two is the allotted number. Some bear none, some only one. If I take this one from her, she may not conceive again."
 
- "You told me she would not bear to me. I've little faith in
-your prognostications."
+ "You told me she would not bear to me. I've little faith in your prognostications."
 
- Barenziah scrambled naked from her bed, and ran for the
-door, not knowing where she was going, only that she could not
-stay. She never reached the door for blackness took her.
+ Barenziah scrambled naked from her bed, and ran for the door, not knowing where she was going, only that she could not stay. She never reached the door for blackness took her.
 
- Barenziah awoke to pain and emptiness. Drelliane was there to
-soothe the pain and clean the blood that pooled between her
-legs, but there was nothing to fill the emptiness. Tiber
-Septim sent gifts and flowers, and came for short visits,
-always well attended. Barenziah received these visits with
-pleasure, but he came no more at night nor did she wish for
-him. After a week, when she was physically recovered, it was
-announced that Symmachus had requested she come to Mournhold
-earlier than planned, and that she would leave forthwith.
-She was given a splendid retinue, a wardrobe befitting a
-queen and a ceremonial departure from the gates of
-Imperial City. 
+ Barenziah awoke to pain and emptiness. Drelliane was there to soothe the pain and clean the blood that pooled between her legs, but there was nothing to fill the emptiness. Tiber Septim sent gifts and flowers, and came for short visits, always well attended. Barenziah received these visits with pleasure, but he came no more at night nor did she wish for him. After a week, when she was physically recovered, it was announced that Symmachus had requested she come to Mournhold earlier than planned, and that she would leave forthwith. She was given a splendid retinue, a wardrobe befitting a queen and a ceremonial departure from the gates of Imperial City.

--- a/Assets/StreamingAssets/Text/Books/BOK00049-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00049-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,177 +14,49 @@ Content:
 
 [/center]Part VII
 
-
-
 [/font=4]
+ "Everything I have ever loved I have lost," Barenziah thought, looking over the mounted knights behind and ahead, the tirewomen near her in a carriage, "yet have I gained a measure of wealth and power, and the promise of more to come. Dearly have I bought it. Now do I better understand Tiber Septim's love of it, if he has oft paid such prices, for surely worth is measured by the price one pays." Barenziah, by her wish, rode mounted on a shining black mare, clad as a warrior in shining chain mail of dark elf making.
 
+ As the slow days slipped by and her train rode a winding road eastward into the setting sun, around her rose the steep-sided mountain slopes of Morrowind. The air was thin and a chill late autumn wind blew constantly, but it was also rich with the sweet spice smell of the late-blooming black rose, which grew in every shadowy nook and crevice, finding nourishment even in the stoniest slopes. In small villages and towns, ragged dark elf folk gathered along the road to cry her name or simply gape. Most of her knightly escort were Redguards with a few dark elves, Nords and Bretons scattered among them. As they wove their way into the heart of Morrowind, these grew increasingly uncomfortable and clung together. Even the dark elf knights seemed somewhat uneasy. Barenziah felt at home, felt the welcome extended to her by this land.
 
+ Symmachus met her at the Mournhold borders with an escort of knights, about half of whom were dark elf in Imperial battle dress, she noted. There was a grand parade into the city and speeches of welcome from elders.
 
-[/center]
+ "I've had the queen's suite refurbished for you," he said, "but you can change anything not to your taste, of course." He went on about details of the coronation ceremony which was to be held in a week. He was his old commanding self, but she sensed something else as well. He was eager for her approval of the arrangements. He asked her nothing about her stay in Imperial City or Tiber Septim, although Barenziah was certain that Drelliane had told him everything in detail.
 
+ The ceremony itself, like so much else, was a mixture of old and new, parts of it dictated by Imperial format, as she was sworn to service of the Empire and Tiber Septim, as well as to the land of Mournhold and its people. She then accepted fealty from the people and the council. The council was composed of a mixture of Imperial representatives, advisors they were called, and native representatives of the people. These latter were mostly elders, in accordance with elven custom. Barenziah found that much of her time was occupied in attempting to reconcile these two forces. And the elders were expected to do most of the conciliating in the name of the reforms introduced by the Empire, such as land ownership and surface farming, which went clean against dark elven tradition, as laid down by their ancient gods and goddesses. Now, Tiber Septim, in the name of the One had decreed a new tradition, and the gods and goddesses themselves were expected to obey.
 
+ Barenziah threw herself into work and study. She was through with love and men for a long, long time, if not forever. There were other pleasures, she discovered, as Symmachus had promised, those of the mind, of power. She developed a love for dark elf history and legend, a hunger to know the people from whom she sprang, proud warriors and craftsmen.
 
- "Everything I have ever loved I have lost," Barenziah
-thought, looking over the mounted knights behind and ahead,
-the tirewomen near her in a carriage, "yet have I gained a
-measure of wealth and power, and the promise of more to
-come. Dearly have I bought it. Now do I better understand
-Tiber Septim's love of it, if he has oft paid such prices,
-for surely worth is measured by the price one pays."
-Barenziah, by her wish, rode mounted on a shining black mare,
-clad as a warrior in shining chain mail of dark elf making.
+ Tiber Septim lived another half century, during which she saw him on a few occasions, as she was bidden to Imperial City for one reason or another. He greeted her with warmth on these occasions and they had long talks together about events. He seemed to have quite forgotten that there had ever been anything more between them. He changed little over the years. Rumor said that his mages had found spells to extend his vitality, and even that the One had granted him immortality. Then one day a messenger came with the news that he was dead, and his son was now Emperor in his place.
 
- As the slow days slipped by and her train rode a winding
-road eastward into the setting sun, around her rose the
-steep-sided mountain slopes of Morrowind. The air was thin
-and a chill late autumn wind blew constantly, but it was
-also rich with the sweet spice smell of the late-blooming
-black rose, which grew in every shadowy nook and crevice,
-finding nourishment even in the stoniest slopes. In small
-villages and towns, ragged dark elf folk gathered along the
-road to cry her name or simply gape. Most of her knightly
-escort were Redguards with a few dark elves, Nords and
-Bretons scattered among them. As they wove their way into the
-heart of Morrowind, these grew increasingly uncomfortable
-and clung together. Even the dark elf knights seemed somewhat
-uneasy. Barenziah felt at home, felt the welcome extended to
-her by this land.
-
- Symmachus met her at the Mournhold borders with an escort of
-knights, about half of whom were dark elf in Imperial battle
-dress, she noted. There was a grand parade into the city and
-speeches of welcome from elders. 
-
- "I've had the queen's suite refurbished for you," he said,
-"but you can change anything not to your taste, of course."
-He went on about details of the coronation ceremony which was
-to be held in a week. He was his old commanding self, but she
-sensed something else as well. He was eager for her approval
-of the arrangements. He asked her nothing about her stay in
-Imperial City or Tiber Septim, although Barenziah was
-certain that Drelliane had told him everything in detail.
-
- The ceremony itself, like so much else, was a mixture of old
-and new, parts of it dictated by Imperial format, as she
-was sworn to service of the Empire and Tiber Septim, as
-well as to the land of Mournhold and its people. She then
-accepted fealty from the people and the council. The
-council was composed of a mixture of Imperial
-representatives, advisors they were called, and native
-representatives of the people. These latter were mostly
-elders, in accordance with elven custom. Barenziah found
-that much of her time was occupied in attempting to
-reconcile these two forces. And the elders were expected to
-do most of the conciliating in the name of the reforms
-introduced by  the Empire, such as land ownership and surface
-farming, which went clean against dark elven tradition, as
-laid down by their ancient gods and goddesses. Now, Tiber
-Septim, in the name of the One had decreed a new tradition,
-and the gods and goddesses themselves were expected to obey.
-
- Barenziah threw herself into work and study. She was through
-with love and men for a long, long time, if not forever.
-There were other pleasures, she discovered, as Symmachus had
-promised, those of the mind, of power. She developed a love
-for dark elf history and legend, a hunger to know the people
-from whom she sprang, proud warriors and craftsmen. 
-
- Tiber Septim lived another half century, during which she
-saw him on a few occasions, as she was bidden to Imperial
-City for one reason or another. He greeted her with warmth on
-these occasions and they had long talks together about
-events. He seemed to have quite forgotten that there had ever
-been anything more between them. He changed little over the
-years. Rumor said that his mages had found spells to extend
-his vitality, and even that the One had granted him
-immortality. Then one day a messenger came with the news that
-he was dead, and his son was now Emperor in his place.
-
- They'd heard the news in private, she and Symmachus. He took
-it stoically, as he took everything.
+ They'd heard the news in private, she and Symmachus. He took it stoically, as he took everything.
 
  "It doesn't seem possible," Barenziah said.
 
- "I told you. It's the way of humans. They are a short-lived
-race. It doesn't really matter. His power lives on, and his
-son now wields it."
+ "I told you. It's the way of humans. They are a short-lived race. It doesn't really matter. His power lives on, and his son now wields it."
 
  "You called him your friend. Do you feel nothing?"
 
- He shrugged. "There was a time when you called him somewhat
-more. What do you feel, Barenziah?" 
+ He shrugged. "There was a time when you called him somewhat more. What do you feel, Barenziah?"
 
- "Emptiness. Loneliness," she said, then she too shrugged.
-"That's not new."
+ "Emptiness. Loneliness," she said, then she too shrugged. "That's not new."
 
- "I know," he said, taking her hand. "Barenziah, let me try to
-fill that lonely place." He turned her face up and kissed
-her. It filled her with astonishment. She couldn't remember
-his ever touching her before. She'd never thought of him in
-that way, and yet, undeniably, an old familiar warmth
-spread through her. She'd forgotten how good it was, that
-warmth. Not the burning heat she'd felt with Tiber Septim,
-but the warmth she associated with, with Straw! Straw, poor
-Straw. She hadn't thought of him in so long. He'd be
-middle-aged now if he still lived. Probably married with a
-dozen children, she hoped, and a wife who could talk for two.
+ "I know," he said, taking her hand. "Barenziah, let me try to fill that lonely place." He turned her face up and kissed her. It filled her with astonishment. She couldn't remember his ever touching her before. She'd never thought of him in that way, and yet, undeniably, an old familiar warmth spread through her. She'd forgotten how good it was, that warmth. Not the burning heat she'd felt with Tiber Septim, but the warmth she associated with, with Straw! Straw, poor Straw. She hadn't thought of him in so long. He'd be middle-aged now if he still lived. Probably married with a dozen children, she hoped, and a wife who could talk for two.
 
- "Marry me, Barenziah," he was saying, "I've worked and
-toiled and waited long enough, haven't I?"
+ "Marry me, Barenziah," he was saying, "I've worked and toiled and waited long enough, haven't I?"
 
- Marriage. "A peasant with peasant dreams." The words
-appeared in her mind, as if from long ago. And yet, why
-not? If not him, who? The great noble families had been
-destroyed in the war and its aftermath. Dark elf rule had
-been restored, but not the old nobility. Most of them were
-upstarts, like Symmachus and not as good as he was. He'd
-fought to keep Mournhold whole and healthy when their
-so-called advisors would have picked their bones, sucked them
-dry as Ebonheart had been sucked dry. He'd fought for
-Mournhold, fought for her, while she and it grew. She felt a
-sudden rush of gratitude, and, undeniably, affection. He
-was steady and reliable. He'd served her well. "Why not?"
-she said, smiling.
+ Marriage. "A peasant with peasant dreams." The words appeared in her mind, as if from long ago. And yet, why not? If not him, who? The great noble families had been destroyed in the war and its aftermath. Dark elf rule had been restored, but not the old nobility. Most of them were upstarts, like Symmachus and not as good as he was. He'd fought to keep Mournhold whole and healthy when their so-called advisors would have picked their bones, sucked them dry as Ebonheart had been sucked dry. He'd fought for Mournhold, fought for her, while she and it grew. She felt a sudden rush of gratitude, and, undeniably, affection. He was steady and reliable. He'd served her well. "Why not?" she said, smiling.
 
- The union was a good one, both in its political and
-personal aspects. While Tiber Septim's son viewed her with a
-jaundiced eye, his trust in his father's old friend was
-absolute. Symmachus, however, was still viewed with
-suspicion by Morrowind's stiff-necked folk, suspicious of his
-peasant ancestry, his close ties to the Empire, while she was
-quite popular. "The Lady's one of our own in her heart," it
-was whispered, "held captive as we are." Barenziah felt
-content. There was work and pleasure and what more could
-one ask of life? The years passed swiftly, with crises to be
-dealt with, storms and famines and failures and successes
-and plots to be foiled. Mournhold prospered well enough.
-Her people were secure and fed, her mines and farms
-productive. All was well save that the marriage produced no
-children. No heirs.
+ The union was a good one, both in its political and personal aspects. While Tiber Septim's son viewed her with a jaundiced eye, his trust in his father's old friend was absolute. Symmachus, however, was still viewed with suspicion by Morrowind's stiff-necked folk, suspicious of his peasant ancestry, his close ties to the Empire, while she was quite popular. "The Lady's one of our own in her heart," it was whispered, "held captive as we are." Barenziah felt content. There was work and pleasure and what more could one ask of life? The years passed swiftly, with crises to be dealt with, storms and famines and failures and successes and plots to be foiled. Mournhold prospered well enough. Her people were secure and fed, her mines and farms productive. All was well save that the marriage produced no children. No heirs.
 
- Now elven children are slow to come, and most demanding of
-their welcome, noble children more so than others, thus many
-decades had passed before they grew concerned.
+ Now elven children are slow to come, and most demanding of their welcome, noble children more so than others, thus many decades had passed before they grew concerned.
 
- "The fault lies with me, husband. I am damaged goods."
-Barenziah said bitterly. "If you want to take another..."
+ "The fault lies with me, husband. I am damaged goods." Barenziah said bitterly. "If you want to take another..."
 
- "I want no other," Symmachus snapped, "nor do I know the
-fault to be thine. Perhaps it is mine. Whichever, we will seek
-a cure. If there is damage, surely it may be repaired?"
+ "I want no other," Symmachus snapped, "nor do I know the fault to be thine. Perhaps it is mine. Whichever, we will seek a cure. If there is damage, surely it may be repaired?"
 
  "How so? When we dare not entrust anyone with my true story? Healer's oaths do not always hold."
 
- "It won't matter if we change the time and circumstances a
-bit. Whate'er we say or fail to say Jephre never rests. His
-inventive mind and quick tongue are ever busy spreading
-gossip and rumor."
+ "It won't matter if we change the time and circumstances a bit. Whate'er we say or fail to say Jephre never rests. His inventive mind and quick tongue are ever busy spreading gossip and rumor."
 
- Priests and Healers came and went, but all their prayers,
-potions and other efforts produced not even a period of
-bloom, let alone a single fruit. Eventually, they put it
-from their minds and left it in the gods' hands. They were yet
-young, with centuries ahead of them. There was time. Elves
-always have time.
-
- 
+ Priests and Healers came and went, but all their prayers, potions and other efforts produced not even a period of bloom, let alone a single fruit. Eventually, they put it from their minds and left it in the gods' hands. They were yet young, with centuries ahead of them. There was time. Elves always have time.

--- a/Assets/StreamingAssets/Text/Books/BOK00050-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00050-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: True
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,296 +14,113 @@ Content:
 
 [/center]Part VIII
 
-
-
 [/font=4]
+ Barenziah sat in the hall at dinner, pushing her food about on her plate, feeling bored and restless. Symmachus was away, having been summoned to Imperial City by Tiber Septim's great-great grandson, Uriel Septim. Or was it his great-great-great grandson? She'd lost count, she realized. Their faces seemed to blur into one another. Perhaps she should have gone with him, but there'd been the delegation from Tear on a tiresome matter that required delicate handling.
 
+ A bard was singing, but Barenziah hadn't been listening. Lately all the songs seemed the same to her, whether new or old. Now a turn of phrase caught her attention. He was singing of freedom, of adventure, of freeing Morrowind from its chains. How dare he! Barenziah sat up straight and turned to glare at him and worse, then realized that he was singing of some ancient war with Skyrim Nords, praising the heroism of King Moraelyn and his brave Companions. That tale was old enough, yet the song was new ... and the meaning...Barenziah wasn't sure. A bold fellow, but with a good voice and an ear for poetry and music. Rather handsome, too, in a raffish way. He didn't look exactly prosperous, nor was he all that young. Certainly he wasn't under a century of age. Why hadn't she heard him before, or at least heard of him?
 
-
-[/center]
-
- Barenziah sat in the hall at dinner, pushing her food about
-on her plate, feeling bored and restless. Symmachus was
-away, having been summoned to Imperial City by Tiber
-Septim's great-great grandson, Uriel Septim. Or was it his
-great-great-great grandson? She'd lost count, she realized.
-Their faces seemed to blur into one another. Perhaps she
-should have gone with him, but there'd been the delegation
-from Tear on a tiresome matter that required delicate
-handling.
-
- A bard was singing, but Barenziah hadn't been listening.
-Lately all the songs seemed the same to her, whether new or
-old. Now a turn of phrase caught her attention. He was
-singing of freedom, of adventure, of freeing Morrowind
-from its chains. How dare he! Barenziah sat up straight and
-turned to glare at him and worse, then realized that he was
-singing of some ancient war with Skyrim Nords, praising the
-heroism of King Moraelyn and his brave Companions. That
-tale was old enough, yet the song was new ... and the
-meaning...Barenziah wasn't sure. A bold fellow, but with a
-good voice and an ear for poetry and music. Rather
-handsome, too, in a raffish way. He didn't look exactly
-prosperous, nor was he all that young. Certainly he wasn't
-under a century of age. Why hadn't she heard him before, or at
-least heard of him?
-
- "Who is he?" she whispered to her dinner companion, who
-shrugged and said, "Calls himself Nightingale. No one seems
-to know anything about him."
+ "Who is he?" she whispered to her dinner companion, who shrugged and said, "Calls himself Nightingale. No one seems to know anything about him."
 
  "Bid him speak with me when he has done."
 
- Nighingale came to her, thanked her for the honor and the
-purse she handed him. His manner wasn't bold, rather quiet and
-unassuming. He was quick enough with gossip about others, but
-she learned nothing about him, for he turned all questions
-away with a joking answer or a wild tale, yet one given so
-charmingly that it was impossible to take offense. "My true
-name? Milady, I am no one. No, no, my parents named me Know
-Wan, or was it, No Buddy? What doth it matter? How can
-parents give name to that which they know not? Ah, I believe
-that was the name, No Not. I have been Nighingale for so
-long I do not quite remember, oh, since last month at the very
-least, or was it last week? All my memory goes into song and
-tales, you see. I've none left for myself. I'm really quite
-boring. Where was I born? Why, Knoweyr. I plan to settle in
-Dunroman when I get there, but I'm in no hurry."
+ Nighingale came to her, thanked her for the honor and the purse she handed him. His manner wasn't bold, rather quiet and unassuming. He was quick enough with gossip about others, but she learned nothing about him, for he turned all questions away with a joking answer or a wild tale, yet one given so charmingly that it was impossible to take offense. "My true name? Milady, I am no one. No, no, my parents named me Know Wan, or was it, No Buddy? What doth it matter? How can parents give name to that which they know not? Ah, I believe that was the name, No Not. I have been Nighingale for so long I do not quite remember, oh, since last month at the very least, or was it last week? All my memory goes into song and tales, you see. I've none left for myself. I'm really quite boring. Where was I born? Why, Knoweyr. I plan to settle in Dunroman when I get there, but I'm in no hurry."
 
  "I see. And will you then marry Atleshur?"
 
- "Very perceptive of you, milady. Perhaps, although I find
-Inaste quite charming, too, at whiles."
+ "Very perceptive of you, milady. Perhaps, although I find Inaste quite charming, too, at whiles."
 
  "Ah, you are fickle, then?"
 
- "Like the wind, milady, I blow hither and yon and hot and
-cold."
+ "Like the wind, milady, I blow hither and yon and hot and cold."
 
  "Stay with us awhile, then, if you will."
 
  "As you wish, milady."
 
- Barenziah found her interest in life rekindled. All that had
-seemed stale seemed fresh and new again. She greeted each day
-with zest, looking forward to conversation and song with
-Nightingale. Unlike other bards he never sang her praises,
-nor other women's but only of high adventure and bold deeds.
-When she asked him about this, he merely said, "What greater
-praise of thy charm couldst thou ask, than what thy own mirror
-gives thee? And if words thou wouldst have, thou hast those of
-the greatest bards of the land? How should I vie with them, I
-who was born but a week gone by?" For once they spoke
-privately, for Barenziah, unable to sleep, had bidden him
-come to her chamber that his music might soothe her.
+ Barenziah found her interest in life rekindled. All that had seemed stale seemed fresh and new again. She greeted each day with zest, looking forward to conversation and song with Nightingale. Unlike other bards he never sang her praises, nor other women's but only of high adventure and bold deeds. When she asked him about this, he merely said, "What greater praise of thy charm couldst thou ask, than what thy own mirror gives thee? And if words thou wouldst have, thou hast those of the greatest bards of the land? How should I vie with them, I who was born but a week gone by?" For once they spoke privately, for Barenziah, unable to sleep, had bidden him come to her chamber that his music might soothe her.
 
- "Thou art lazy and a coward, else I hold no charm for
-thee."
+ "Thou art lazy and a coward, else I hold no charm for thee."
 
- "Milady, to praise thee I must know thee and thy spirit is
-wrapped in clouds of enchantment."
+ "Milady, to praise thee I must know thee and thy spirit is wrapped in clouds of enchantment."
 
- "Not so, 'tis thy words that weave enchantment, and thy
-eyes. Know me if thou wilt, and if thou dare'st." He came to
-her; they lay close, kissed and embraced. "Not even
-Barenziah truly knows herself," he whispered softly. "How
-can I? Barenziah, thou seekest and know it not, nor yet for
-what. What would you have, that you have not?"
+ "Not so, 'tis thy words that weave enchantment, and thy eyes. Know me if thou wilt, and if thou dare'st." He came to her; they lay close, kissed and embraced. "Not even Barenziah truly knows herself," he whispered softly. "How can I? Barenziah, thou seekest and know it not, nor yet for what. What would you have, that you have not?"
 
- "Passion," she whispered, "passion. And children born of
-it."
+ "Passion," she whispered, "passion. And children born of it."
 
- "And for thy children, what? What birthright will you give
-them?"
+ "And for thy children, what? What birthright will you give them?"
 
- "Freedom," she whispered, "freedom to be what they are.
-Where can I find these things?"
+ "Freedom," she whispered, "freedom to be what they are. Where can I find these things?"
 
- "They lie beside you and beneath you if you dare stretch out
-your hand to take them."
+ "They lie beside you and beneath you if you dare stretch out your hand to take them."
 
  "But Symmachus..."
 
- "I tell you, in me lies the answer to part of your quest
-and below us in these very mines, lies that which will grant
-us the power to fulfill achieve it. That which Moraelyn and
-Edward between them used to free High Rock from Nord
-domination of their spirit. Properly used, none can stand
-against it, not e'en that power which the Emperor controls.
-Freedom, Barenziah, freedom from the chains that bind you.
-Think on it, Barenziah." He kissed her again, softly, and
-withdrew.
+ "I tell you, in me lies the answer to part of your quest and below us in these very mines, lies that which will grant us the power to fulfill achieve it. That which Moraelyn and Edward between them used to free High Rock from Nord domination of their spirit. Properly used, none can stand against it, not e'en that power which the Emperor controls. Freedom, Barenziah, freedom from the chains that bind you. Think on it, Barenziah." He kissed her again, softly, and withdrew.
 
- "You're not going?" she cried out, for her body yearned for
-him.
+ "You're not going?" she cried out, for her body yearned for him.
 
- "For now," he said. "Pleasures of the flesh are nothing
-beside what we might have together. I would have you think on
-it."
+ "For now," he said. "Pleasures of the flesh are nothing beside what we might have together. I would have you think on it."
 
- "I don't need to think. What must we do? What preparation
-must we make?"
+ "I don't need to think. What must we do? What preparation must we make?"
 
- "Why, none. You can enter the mines freely. Once below I
-can guide you to where this thing lies and lift it from its
-resting place."
+ "Why, none. You can enter the mines freely. Once below I can guide you to where this thing lies and lift it from its resting place."
 
- "The Horn of Summoning," she whispered. "Is it true? How do
-you know? 'Tis said it's buried 'neath Daggerfall itself."
+ "The Horn of Summoning," she whispered. "Is it true? How do you know? 'Tis said it's buried 'neath Daggerfall itself."
 
- "Nay, long have I studied this matter. Ere his death King
-Edward gave the horn for safekeeping into the hand of his old
-friend King Moraelyn, who secreted it here in Mournhold,
-under the guardianship of the god Ephen, whose birthplace
-this is. Now thou know'st what it hath cost me many long years
-and weary miles to learn."
+ "Nay, long have I studied this matter. Ere his death King Edward gave the horn for safekeeping into the hand of his old friend King Moraelyn, who secreted it here in Mournhold, under the guardianship of the god Ephen, whose birthplace this is. Now thou know'st what it hath cost me many long years and weary miles to learn."
 
  "But the god?"
 
- "Trust me, dear heart. All will be well." Laughing, he
-blew her a last kiss and was gone.
+ "Trust me, dear heart. All will be well." Laughing, he blew her a last kiss and was gone.
 
- On the morrow they passed the guards at the great doors that
-led below. Barenziah made her usual tour of inspection but
-instead of leaving afterwards, she and Nightingale entered
-a long-sealed door that led to an ancient part of the
-workings, long abandoned. The going was treacherous, for
-some of the old passages had collapsed and they had to clear
-a passage or find a way around. Vicious rats and huge
-spiders scurried here and there and sometimes attacked them.
+ On the morrow they passed the guards at the great doors that led below. Barenziah made her usual tour of inspection but instead of leaving afterwards, she and Nightingale entered a long-sealed door that led to an ancient part of the workings, long abandoned. The going was treacherous, for some of the old passages had collapsed and they had to clear a passage or find a way around. Vicious rats and huge spiders scurried here and there and sometimes attacked them.
 
- "We've been gone too long," Barenziah said. "They'll be
-looking for us. What will I tell them?"
+ "We've been gone too long," Barenziah said. "They'll be looking for us. What will I tell them?"
 
- "Whate'er you please," Nightingale laughed. "You are the
-queen, aren't you?"
+ "Whate'er you please," Nightingale laughed. "You are the queen, aren't you?"
 
  "Symmachus--"
 
- "That peasant obeys whoever holds power. Always has,
-always will. We shall hold the power, love." His lips were
-the sweetest wine, every touch of fire and lightning. 
+ "That peasant obeys whoever holds power. Always has, always will. We shall hold the power, love." His lips were the sweetest wine, every touch of fire and lightning.
 
- "Now," she said, "take me now. I'm ready." Her body seemed to
-hum, every nerve and muscle taut.
+ "Now," she said, "take me now. I'm ready." Her body seemed to hum, every nerve and muscle taut.
 
- "Not yet. Not here, not like this." He waved around at the
-ancient dusty rubble and grim rock walls. "Just a little
-longer."
+ "Not yet. Not here, not like this." He waved around at the ancient dusty rubble and grim rock walls. "Just a little longer."
 
- "Here," he said at last, pausing before a blank wall. "Here
-it lies." His hands wove a spell and the wall dissolved to
-reveal the entrance to an ancient shrine. In the midst stood
-a statue of the god, hammer in hand, poised above an
-adamantium anvil.
+ "Here," he said at last, pausing before a blank wall. "Here it lies." His hands wove a spell and the wall dissolved to reveal the entrance to an ancient shrine. In the midst stood a statue of the god, hammer in hand, poised above an adamantium anvil.
 
- "By my blood, Ephen, I bid you wake! Moraelyn's heir of
-Ebonheart am I, last of the royal kin, sharer of thy blood.
-At Morrowind's last need, with all elvendom in peril of
-their souls, release to me that which thou guardst! Now do I
-bid thee strike!"
+ "By my blood, Ephen, I bid you wake! Moraelyn's heir of Ebonheart am I, last of the royal kin, sharer of thy blood. At Morrowind's last need, with all elvendom in peril of their souls, release to me that which thou guardst! Now do I bid thee strike!"
 
- At his words the statue stirred and quickened, and the blank
-stone eyes glowed red. The massive head nodded, and the
-hammer smote the anvil, which split asunder with a
-thunderous crash, and the stone god himself crumbled.
-Barenziah clapped her hands over her ears and crouched down,
-crying aloud. Nightingale strode boldly forward and
-clasped what lay among the ruins with a cry of ecstasy,
-lifting it high.
+ At his words the statue stirred and quickened, and the blank stone eyes glowed red. The massive head nodded, and the hammer smote the anvil, which split asunder with a thunderous crash, and the stone god himself crumbled. Barenziah clapped her hands over her ears and crouched down, crying aloud. Nightingale strode boldly forward and clasped what lay among the ruins with a cry of ecstasy, lifting it high.
 
- "Someone's coming!" Barenziah cried. "Wait, that's not the
-Horn, it -- it's a staff!"
+ "Someone's coming!" Barenziah cried. "Wait, that's not the Horn, it -- it's a staff!"
 
- "Indeed, my dear, you see truly, at last!" Nightingale
-laughed aloud, then -- "I'm sorry, my darling, that I must
-leave you now. Perhaps we'll meet again one day. Until then
--- ah, until then, Symmachus," he said to the mail clad
-figure who'd appeared behind them, "she's yours."
+ "Indeed, my dear, you see truly, at last!" Nightingale laughed aloud, then -- "I'm sorry, my darling, that I must leave you now. Perhaps we'll meet again one day. Until then -- ah, until then, Symmachus," he said to the mail clad figure who'd appeared behind them, "she's yours."
 
- "No!" Barenziah sprang up and ran toward him, but he was
-gone -- winked out of existence -- just as Symmachus, sword
-drawn, reached him. His blade cleaved a single stroke through
-empty air, then he stood as still as if he'd taken the stone
-god's place. Barenziah said nothing, nothing, nothing...
+ "No!" Barenziah sprang up and ran toward him, but he was gone -- winked out of existence -- just as Symmachus, sword drawn, reached him. His blade cleaved a single stroke through empty air, then he stood as still as if he'd taken the stone god's place. Barenziah said nothing, nothing, nothing...
 
- Symmachus told the half dozen elves who had accompanied him
-to say only that Nightingale and the queen had lost their
-way, and had been set upon by spiders. Nightingale had
-fallen into a deep crevice that closed upon him. His body
-could not be recovered. The queen had been badly shaken by the
-encounter and deeply mourned the loss of the friend, who
-had fallen in her defense. Such was his power of command
-that the slack-jawed soldiers, none of whom had caught more
-than a glimpse of the event, were half-convinced that it was
-true.
+ Symmachus told the half dozen elves who had accompanied him to say only that Nightingale and the queen had lost their way, and had been set upon by spiders. Nightingale had fallen into a deep crevice that closed upon him. His body could not be recovered. The queen had been badly shaken by the encounter and deeply mourned the loss of the friend, who had fallen in her defense. Such was his power of command that the slack-jawed soldiers, none of whom had caught more than a glimpse of the event, were half-convinced that it was true.
 
- Barenziah was escorted above and taken to her chamber where
-she dismissed her servants and sat stunned, too shaken even
-to weep. Symmachus stood watching her.
+ Barenziah was escorted above and taken to her chamber where she dismissed her servants and sat stunned, too shaken even to weep. Symmachus stood watching her.
 
  "Do you have any idea what you have done?" he said finally.
 
- "You should have told me," Barenziah whispered, "The Staff
-of Unity and Chaos! I never dreamed it lay here. He said--" A
-mewling moan escaped her lips and she doubled over in
-agony. "What have I done? What now? What's to become of
-me?"
+ "You should have told me," Barenziah whispered, "The Staff of Unity and Chaos! I never dreamed it lay here. He said--" A mewling moan escaped her lips and she doubled over in agony. "What have I done? What now? What's to become of me?"
 
  "You loved him?"
 
- "Yes, yes, yes. Oh, may the gods have mercy on me, I did
-love him."
+ "Yes, yes, yes. Oh, may the gods have mercy on me, I did love him."
 
- Symmachus hard-lined face softened slightly and his eyes
-glittered with a new light, and he sighed softly. "Ahhh, that's
-something then. You will become a mother if it's within my
-power. As for the rest, my dear, I expect you have loosed a
-storm upon the land. It'll be awhile yet in the brewing.
-When it comes we'll weather it together." He stripped her
-clothing from her and carried her to the bed. Out of grief and
-longing, her body responded to his as never before, pouring
-forth all that Nightingale had woken in her. She was emptied,
-and then filled, for a child was planted and grew within
-her. As the babe grew in her womb, so did her feeling for
-patient faithful Symmachus, rooted in long friendship and
-affection, now at last ripen into the fullness of true
-love. Eight years later their love was blessed again with a
-little daughter.
+ Symmachus hard-lined face softened slightly and his eyes glittered with a new light, and he sighed softly. "Ahhh, that's something then. You will become a mother if it's within my power. As for the rest, my dear, I expect you have loosed a storm upon the land. It'll be awhile yet in the brewing. When it comes we'll weather it together." He stripped her clothing from her and carried her to the bed. Out of grief and longing, her body responded to his as never before, pouring forth all that Nightingale had woken in her. She was emptied, and then filled, for a child was planted and grew within her. As the babe grew in her womb, so did her feeling for patient faithful Symmachus, rooted in long friendship and affection, now at last ripen into the fullness of true love. Eight years later their love was blessed again with a little daughter.
 
- Directly after Nighingale's theft of the staff Symmachus
-had sent secret messages to Uriel Septim of the matter, but
-had not gone himself, choosing rather to stay with Barenziah
-during her fertile period and father the child upon her. For
-this, and for the theft, he suffered Uriel Septim's disfavor
-and suspicion. Spies were sent in search of the thief but
-Nighingale seemed to have vanished whence he'd come, wherever
-that was.
+ Directly after Nighingale's theft of the staff Symmachus had sent secret messages to Uriel Septim of the matter, but had not gone himself, choosing rather to stay with Barenziah during her fertile period and father the child upon her. For this, and for the theft, he suffered Uriel Septim's disfavor and suspicion. Spies were sent in search of the thief but Nighingale seemed to have vanished whence he'd come, wherever that was.
 
- "Dark elf, in part, perhaps," said Barenziah, "but part
-human, too, I think, in disguise, else would I not have come
-so quickly to fertility."
+ "Dark elf, in part, perhaps," said Barenziah, "but part human, too, I think, in disguise, else would I not have come so quickly to fertility."
 
- "Part dark elf, for sure, of ancient R'Aathim lineage, else
-he could not have freed the staff," Symmachus reasoned,
-"and I think he would have lain with thee. As elf he did not
-dare, for then he would not have been able to part with thee.
-He knew the Staff lay there, not the Horn, and that he must
-teleport to safety, for the Staff is not a weapon that
-would have seen him clear, unlike the horn. Praise the gods he
-hath not that! It seems all was as he expected, yet how did he
-know? I placed it there myself, with the aid of the rag-tail
-end of the R'Aathim clan who now sits king in Ebonheart as a
-reward. Tiber Septim claimed the Horn, but left the Staff
-for safe-keeping. Nightingale can use the Staff to sow seeds
-of strife and dissension, if he wishes, yet that alone will
-not gain him power. That lies with the Horn and the ability to
-use it."
+ "Part dark elf, for sure, of ancient R'Aathim lineage, else he could not have freed the staff," Symmachus reasoned, "and I think he would have lain with thee. As elf he did not dare, for then he would not have been able to part with thee. He knew the Staff lay there, not the Horn, and that he must teleport to safety, for the Staff is not a weapon that would have seen him clear, unlike the horn. Praise the gods he hath not that! It seems all was as he expected, yet how did he know? I placed it there myself, with the aid of the rag-tail end of the R'Aathim clan who now sits king in Ebonheart as a reward. Tiber Septim claimed the Horn, but left the Staff for safe-keeping. Nightingale can use the Staff to sow seeds of strife and dissension, if he wishes, yet that alone will not gain him power. That lies with the Horn and the ability to use it."
 
- "I'm not so sure it's power that Nighingale seeks,"
-Barenziah said.
+ "I'm not so sure it's power that Nighingale seeks," Barenziah said.
 
- "All seek power," Symmachus retorted, "each in our own
-way."
+ "All seek power," Symmachus retorted, "each in our own way."
 
- "I have found what I sought," Barenziah said. 
+ "I have found what I sought," Barenziah said.

--- a/Assets/StreamingAssets/Text/Books/BOK00051-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00051-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,294 +14,79 @@ Content:
 
 [/center]Part IX
 
-
-
 [/font=4]
+ As Symmachus had predicted, the theft of the Staff of Chaos had few short term consequences. The current emperor, Uriel Septim, sent some rather stiff messages expressing shock and displeasure at the staff's disappearance and urging that Symmachus make every effort to locate its whereabouts and communicate this to the newly appointed Imperial BattleMage, Jagar Tharn, in whose hands the matter had been placed.
 
-
-
-[/center]
-
- As Symmachus had predicted, the theft of the Staff of Chaos
-had few short term consequences. The current emperor, Uriel
-Septim, sent some rather stiff messages expressing shock and
-displeasure at the staff's disappearance and urging that
-Symmachus make every effort to locate its whereabouts and
-communicate this to the newly appointed Imperial
-BattleMage, Jagar Tharn, in whose hands the matter had been
-placed.
-
- "Tharn!" Symmachus snarled in disgust and frustration, as
-he paced about the small chamber where Barenziah, now some
-months pregnant, was sitting serenely, knitting a baby
-blanket. "Jagar Tharn, indeed. I wouldn't give him
-directions for crossing the street."
+ "Tharn!" Symmachus snarled in disgust and frustration, as he paced about the small chamber where Barenziah, now some months pregnant, was sitting serenely, knitting a baby blanket. "Jagar Tharn, indeed. I wouldn't give him directions for crossing the street."
 
  "What have you against this person, husband?"
 
- "I just don't trust that mongrel elf. Part wood elf, part
-dark elf and part only the gods know what. All the worst
-qualities of all his combined races. No one knows much about
-him. Claims he was born in Valenwood, of a wood elf mother.
-Seems to have been everywhere since--"
+ "I just don't trust that mongrel elf. Part wood elf, part dark elf and part only the gods know what. All the worst qualities of all his combined races. No one knows much about him. Claims he was born in Valenwood, of a wood elf mother. Seems to have been everywhere since--"
 
- Barenziah, sunk in the contentment of pregnancy had only
-been humoring Symmachus thus far, but this piqued her
-interest. "Nightingale? Could he have been this Jagar Tharn,
-disguised?"
+ Barenziah, sunk in the contentment of pregnancy had only been humoring Symmachus thus far, but this piqued her interest. "Nightingale? Could he have been this Jagar Tharn, disguised?"
 
- "Nay. Human blood seems to be the one missing component in
-Tharn's  ancestry." To Symmachus, Barenziah knew, that was
-a flaw. Symmachus despised wood elves as lazy thieves and
-high elves as effete intellectuals, but he admired humans,
-especially Bretons, for their combination of pragmatism,
-intelligence and energy.
+ "Nay. Human blood seems to be the one missing component in Tharn's ancestry." To Symmachus, Barenziah knew, that was a flaw. Symmachus despised wood elves as lazy thieves and high elves as effete intellectuals, but he admired humans, especially Bretons, for their combination of pragmatism, intelligence and energy.
 
- "Nightingale's of Ebonheart, of the House of Mora, I'll be
-bound -- that house has had human blood since her time.
-Ebonheart was jealous that the Staff was laid here when
-Tiber Septim took the Horn from us."
+ "Nightingale's of Ebonheart, of the House of Mora, I'll be bound -- that house has had human blood since her time. Ebonheart was jealous that the Staff was laid here when Tiber Septim took the Horn from us."
 
- Barenziah sighed a little. The rivalry between Ebonheart
-and Mournhold reached back almost to the dawn of history.
-Once the two had been one, all the mines within held by Clan
-R'Aathim, whose royal house held the High Kingship of
-Morrowind. Ebonheart had split into two separate city
-states, Ebonheart and Mournhold, when Queen Lian's twin
-sons, Moraelyn's grandsons, had been left as the heirs. At
-the same time the office of High King had been vacated in
-favor of a temporary War Leader to be named by a council in
-times of provincial emergency. Still, Ebonheart remained
-jealous of her prerogatives as the eldest city state of
-Morrowind, still first among equals, and claimed that
-guardianship of the Horn should rightfully be entrusted to
-the elder. Mournhold responded that Moraelyn himself had
-placed the Horn in the keeping of the god Ephen, and Mournhold
-was unarguably the god's birthplace.
+ Barenziah sighed a little. The rivalry between Ebonheart and Mournhold reached back almost to the dawn of history. Once the two had been one, all the mines within held by Clan R'Aathim, whose royal house held the High Kingship of Morrowind. Ebonheart had split into two separate city states, Ebonheart and Mournhold, when Queen Lian's twin sons, Moraelyn's grandsons, had been left as the heirs. At the same time the office of High King had been vacated in favor of a temporary War Leader to be named by a council in times of provincial emergency. Still, Ebonheart remained jealous of her prerogatives as the eldest city state of Morrowind, still first among equals, and claimed that guardianship of the Horn should rightfully be entrusted to the elder. Mournhold responded that Moraelyn himself had placed the Horn in the keeping of the god Ephen, and Mournhold was unarguably the god's birthplace.
 
- "Why not tell Jagar Tharn of your suspicions then? Let him
-recover the thing. As long as it's safe, what does it matter
-where it lies?"
+ "Why not tell Jagar Tharn of your suspicions then? Let him recover the thing. As long as it's safe, what does it matter where it lies?"
 
- Symmachus stared at her without comprehension. "It
-matters," he said softly, "but not that much," he added.
-"Certainly not enough for you to concern yourself further
-over it. You just tend to your -- knitting."
+ Symmachus stared at her without comprehension. "It matters," he said softly, "but not that much," he added. "Certainly not enough for you to concern yourself further over it. You just tend to your -- knitting."
 
- In a few more months Barenziah produced a fine son, whom they
-named Helseth. Nothing more was heard of the Staff or
-"Nightingale." If Ebonheart held it, certainly they did not
-boast of it. The years passed swiftly and happily. Helseth
-grew tall and strong. He was much like his father, whom he
-worshipped. When Helseth was eight years old Barenziah bore a
-second child, a daughter, to Symmachus' great delight.
-Helseth was his pride, yet little Morgiah held his heart.
+ In a few more months Barenziah produced a fine son, whom they named Helseth. Nothing more was heard of the Staff or "Nightingale." If Ebonheart held it, certainly they did not boast of it. The years passed swiftly and happily. Helseth grew tall and strong. He was much like his father, whom he worshipped. When Helseth was eight years old Barenziah bore a second child, a daughter, to Symmachus' great delight. Helseth was his pride, yet little Morgiah held his heart.
 
- Shortly after Morgiah's birth word came that a plot
-against the Emperor had been unmasked and that the chief
-co-conspirators Jagar Tharn and Ria Silmane were dead.
-Symmachus rejoiced at this news. "I told you so," he crowed.
-Yet thereafter relations with the Empire slowly
-deteriorated, for no apparent reason. Taxes were raised and
-quotas increased with each passing year. Symmachus felt that
-the Emperor suspected him of having had a hand in the plot
-and sought to prove his loyalty by making every effort to
-comply with the increasing demands. He lengthened working
-hours and raised taxes and even made up some of the
-difference from both crown funds and their own private
-holdings. Yet still the demands increased and commoners and
-nobles alike grew restless.
+ Shortly after Morgiah's birth word came that a plot against the Emperor had been unmasked and that the chief co-conspirators Jagar Tharn and Ria Silmane were dead. Symmachus rejoiced at this news. "I told you so," he crowed. Yet thereafter relations with the Empire slowly deteriorated, for no apparent reason. Taxes were raised and quotas increased with each passing year. Symmachus felt that the Emperor suspected him of having had a hand in the plot and sought to prove his loyalty by making every effort to comply with the increasing demands. He lengthened working hours and raised taxes and even made up some of the difference from both crown funds and their own private holdings. Yet still the demands increased and commoners and nobles alike grew restless.
 
- "I want you to take the children and journey yourself to
-Imperial City," Symmachus at last said in desperation.
-"You must make the Emperor listen, else all Mournhold will
-be in revolt come spring. You have a way with men, you
-always did." He forced a smile.
+ "I want you to take the children and journey yourself to Imperial City," Symmachus at last said in desperation. "You must make the Emperor listen, else all Mournhold will be in revolt come spring. You have a way with men, you always did." He forced a smile.
 
  Barenziah forced a smile of her own. "Even you."
 
- "Yes, even me," he said dully. 
+ "Yes, even me," he said dully.
 
- "Both children?" Barenziah looked over toward the corner
-windows where Helseth was strumming a lute and singing a duet
-with his little sister. Helseth was fifteen, Morgiah just
-eight. 
+ "Both children?" Barenziah looked over toward the corner windows where Helseth was strumming a lute and singing a duet with his little sister. Helseth was fifteen, Morgiah just eight.
 
- "Perhaps they'll soften his heart. Besides, it's time that
-Helseth was presented at the Imperial Court."
+ "Perhaps they'll soften his heart. Besides, it's time that Helseth was presented at the Imperial Court."
 
- "Perhaps, but that's not your true reason. You do not think
-you can keep them safe here. If that's the case, then you're
-not safe here either. Come with us," Barenziah urged.
+ "Perhaps, but that's not your true reason. You do not think you can keep them safe here. If that's the case, then you're not safe here either. Come with us," Barenziah urged.
 
- He took her hands in his. "Barenziah. Love. Heart of my heart,
-if I leave now, there'll be nothing for us to return to.
-I'll be all right. I can take care of myself, and I can do it
-better if I need not fear for you and our children."
+ He took her hands in his. "Barenziah. Love. Heart of my heart, if I leave now, there'll be nothing for us to return to. I'll be all right. I can take care of myself, and I can do it better if I need not fear for you and our children."
 
- Barenziah laid her head against his chest. "Just remember
-that we need you. We can do without the rest if we have each
-other. Empty hands and empty bellies are easier to bear than
-an empty heart. My foolishness has brought us to this pass."
+ Barenziah laid her head against his chest. "Just remember that we need you. We can do without the rest if we have each other. Empty hands and empty bellies are easier to bear than an empty heart. My foolishness has brought us to this pass."
 
- "If so, 'tis not that so a place to be." His eyes rested
-fondly on their carefree children. "And none of us shall go
-without. I cost you everything once, Barenziah, I and Tiber
-Septim. Without my aid the Septim dynasty would never have
-begun. I helped its rise. I can bring about its fall. You
-may tell Uriel Septim that, and that my patience is
-bounded."
+ "If so, 'tis not that so a place to be." His eyes rested fondly on their carefree children. "And none of us shall go without. I cost you everything once, Barenziah, I and Tiber Septim. Without my aid the Septim dynasty would never have begun. I helped its rise. I can bring about its fall. You may tell Uriel Septim that, and that my patience is bounded."
 
- Barenziah gasped. Symmachus was not given to empty
-threats. She'd no more imagined that he would ever turn
-against the Empire than that the old house wolf lying by the
-hearth would turn on her.
+ Barenziah gasped. Symmachus was not given to empty threats. She'd no more imagined that he would ever turn against the Empire than that the old house wolf lying by the hearth would turn on her.
 
- "How?" she demanded, but he shook his head. "Better that you
-know not," he said. "Just tell him that, if he prove
-recalcitrant, and do not fear. He's Septim enough that he
-will not kill the messengers."
+ "How?" she demanded, but he shook his head. "Better that you know not," he said. "Just tell him that, if he prove recalcitrant, and do not fear. He's Septim enough that he will not kill the messengers."
 
- The late winter journey to Imperial City was an easy one.
-One of the things the Septim Empire had accomplished was the
-building and maintenance of good highways throughout
-Tamriel.
+ The late winter journey to Imperial City was an easy one. One of the things the Septim Empire had accomplished was the building and maintenance of good highways throughout Tamriel.
 
+[/center]* * *
 
+ Barenziah stood before the Emperor's throne, explaining Mournhold's straits. She'd waited weeks for an audience with Uriel Septim, fobbed off on pretext or another. "His Excellency is indisposed." "An urgent matter demands his attention." "I am sorry, your Highness, there must be some mistake. Your appointment is for next week. No, see..." And now it was not going well. He did not even seem to be listening to her. He hadn't invited her to sit, nor had he dismissed the children. Helseth stood still as a carved statue, but little Morgiah had begun to fidget.
 
- *                   *                        *                   *
+ He had first greeted the three of them with a too-bright smile of welcome that did not reach his eyes. Then, as she presented her children, he had gazed at them with a fixed attention that was real, yet inappropriate. Barenziah had been dealing with humans for nearly five hundred years now and had developed skill at reading their expressions and movement that was far beyond that any human ever learned. Try as the Emperor might to conceal it, there was a hunger in his eyes, and something more. Regret. Why? He had several fine children of his own. Why covet hers? And why look at her with an intense, though, brief yearning? Ah, well, perhaps he was tired of his Lady. Humans were fickle minded. But after that one long, burning glance, his gaze had shifted away as she began to speak of her mission, and he sat still as stone.
 
- Barenziah stood before the Emperor's throne, explaining
-Mournhold's straits. She'd waited weeks for an audience with
-Uriel Septim, fobbed off on pretext or another. "His
-Excellency is indisposed." "An urgent matter demands his
-attention." "I am sorry, your Highness, there must be some
-mistake. Your appointment is for next week. No, see..." And
-now it was not going well. He did not even seem to be
-listening to her. He hadn't invited her to sit, nor had he
-dismissed the children. Helseth stood still as a carved
-statue, but little Morgiah had begun to fidget.
+ Puzzled, Barenziah stared into the pale set face, looking for some trace of the Septims she'd known. She hadn't known Uriel Septim well, having met him only once when he was still a child and then at his coronation twenty years before. He'd been stern and dignified then, yet not icily remote as this man was. Despite the physical resemblance, he didn't seem to be the same man at all. Not the same, yet something about him was familiar to her, more familiar than it should be, some trick of posture or gesture ... Suddenly she felt very warm, as if lava had been poured over her. Illusion! She had studied well the arts of illusion since Nightingale had fooled her so badly. She had learned to detect it and she felt it now, as certainly as a blind man could feel the sun on his face.
 
- He had first greeted the three of them with a too-bright smile
-of welcome that did not reach his eyes. Then, as she presented
-her children, he had gazed at them with a fixed attention
-that was real, yet inappropriate. Barenziah had been
-dealing with humans for nearly five hundred years now and had
-developed skill at reading their expressions and movement
-that was far beyond that any human ever learned. Try as the
-Emperor might to conceal it, there was a hunger in his eyes,
-and something more. Regret. Why? He had several fine children
-of his own. Why covet hers? And why look at her with an
-intense, though, brief yearning? Ah, well, perhaps he was
-tired of his Lady. Humans were fickle minded. But after that
-one long, burning glance, his gaze had shifted away as she
-began to speak of her mission, and he sat still as stone.
+ Illusion, but why? Her mind worked furiously even as her mouth went on reciting details about the Mournhold economy. Vanity? Humans were oft as ashamed of the signs of age as elves were proud of them. Yet the face Uriel Septim wore seemed consistent with his age. Barenziah dared use none of her magic arts. Even petty nobles had means of detecting, if not shielding themselves from these in their halls. The use of magic here would bring down his wrath as surely as drawing a knife would. Magic. Illusion. Suddenly she thought of Nightingale and briefly he sat before her, only saddened. Trapped. And then that vision faded and another man sat there, like Nightingale and yet unlike. Pale skin, red eyes and elven ears and about him a fierce glow of concentration, an aura of energy, a shrinking horror. This man was capable of anything! And then, once again she beheld the face of Uriel Septim. How could she be sure she wasn't imagining things? Perhaps her mind was playing tricks on her. She felt a sudden vast weariness, as if she'd been carrying a heavy burden too long and too far.
 
- Puzzled, Barenziah stared into the pale set face, looking
-for some trace of the Septims she'd known. She hadn't known
-Uriel Septim well, having met him only once when he was
-still a child and then at his coronation twenty years before.
-He'd been stern and dignified then, yet not icily remote as
-this man was. Despite the physical resemblance, he didn't
-seem to be the same man at all. Not the same, yet something
-about him was familiar to her, more familiar than it should
-be, some trick of posture or gesture ... Suddenly she felt
-very warm, as if lava had been poured over her. Illusion!
-She had studied well the arts of illusion since Nightingale
-had fooled her so badly. She had learned to detect it and
-she felt it now, as certainly as a blind man could feel the
-sun on his face.
-
- Illusion, but why? Her mind worked furiously even as her
-mouth went on reciting details about the Mournhold economy.
-Vanity? Humans were oft as ashamed of the signs of age as
-elves were proud of them. Yet the face Uriel Septim wore
-seemed consistent with his age. Barenziah dared use none of
-her magic arts. Even petty nobles had means of detecting, if
-not shielding themselves from these in their halls. The use of
-magic here would bring down his wrath as surely as drawing a
-knife would. Magic. Illusion. Suddenly she thought of
-Nightingale and briefly he sat before her, only saddened.
-Trapped. And then that vision faded and another man sat
-there, like Nightingale and yet unlike. Pale skin, red eyes
-and elven ears and about him a fierce glow of
-concentration, an aura of energy, a shrinking horror. This
-man was capable of anything! And then, once again she beheld
-the face of Uriel Septim. How could she be sure she wasn't
-imagining things? Perhaps her mind was playing tricks on her.
-She felt a sudden vast weariness, as if she'd been carrying a
-heavy burden too long and too far.
-
- "Do you remember, Excellency, Symmachus and I had dinner
-with your family shortly after your father's coronation.
-You were no older than little Morgiah here. We were greatly
-honored to be the only guests that evening, except for your
-best friend Justin, of course."
+ "Do you remember, Excellency, Symmachus and I had dinner with your family shortly after your father's coronation. You were no older than little Morgiah here. We were greatly honored to be the only guests that evening, except for your best friend Justin, of course."
 
  "Ah, yes," the Emperor said. "I believe I do recall that."
 
- "You and Justin were such friends. I was told he died not
-long after. A great pity."
+ "You and Justin were such friends. I was told he died not long after. A great pity."
 
- "Indeed. I still do not like to speak of him." His eyes were
-wary. "Ah, as for your request, my lady, we shall take it
-under advisement and let you know."
+ "Indeed. I still do not like to speak of him." His eyes were wary. "Ah, as for your request, my lady, we shall take it under advisement and let you know."
 
- Barenziah bowed, as did her children. A nod dismissed them,
-and they backed away from the presence. Barenziah took a deep
-breath. "Justin" had been an imaginary friend, although
-Uriel had insisted that a place be set for Justin at every
-meal! Not only that, "Justin" had been a girl, despite the
-boy name. Symmachus had kept up the family joke long after
-"Justin" had gone wherever such childhood friends go,
-inquiring seriously after Justin's well-being whenever he and
-Uriel Septim met, and being responded to as seriously. The last Barenziah had heard "Justin", after
-an adventurous youth, had married a high elf and settled in
-Lilandril. The man occupying the Emperor's chair was not
-Uriel Septim! Nightingale! A chord of recognition rang
-through her and Barenziah knew that she was right. It was he,
-indeed! Symmachus had been wrong, so wrong ...
+ Barenziah bowed, as did her children. A nod dismissed them, and they backed away from the presence. Barenziah took a deep breath. "Justin" had been an imaginary friend, although Uriel had insisted that a place be set for Justin at every meal! Not only that, "Justin" had been a girl, despite the boy name. Symmachus had kept up the family joke long after "Justin" had gone wherever such childhood friends go, inquiring seriously after Justin's well-being whenever he and Uriel Septim met, and being responded to as seriously. The last Barenziah had heard "Justin", after an adventurous youth, had married a high elf and settled in Lilandril. The man occupying the Emperor's chair was not Uriel Septim! Nightingale! A chord of recognition rang through her and Barenziah knew that she was right. It was he, indeed! Symmachus had been wrong, so wrong ...
 
- What now, she wondered. What had become of Uriel Septim,
-and, more to the point, what did it mean for her and
-Symmachus and Mournhold? Thinking back, Barenziah guessed
-that their troubles were due to this false emperor,
-Nightingale, or whoever he really was. He must have taken
-Uriel Septim's place shortly before the unreasonable
-demands on Mournhold had begun. That would explain why
-relations had deteriorated so long (as humans judged time)
-after her offense. Nightingale knew of Symmachus' famed
-loyalty to, and knowledge of, the Septims and was making a
-pre-emptive strike. If that were indeed the case they were
-all in terrible danger. She and the children were under his
-hand here in Imperial City and Symmachus left alone to face
-the troubles of Nightingale's brewing. 
+ What now, she wondered. What had become of Uriel Septim, and, more to the point, what did it mean for her and Symmachus and Mournhold? Thinking back, Barenziah guessed that their troubles were due to this false emperor, Nightingale, or whoever he really was. He must have taken Uriel Septim's place shortly before the unreasonable demands on Mournhold had begun. That would explain why relations had deteriorated so long (as humans judged time) after her offense. Nightingale knew of Symmachus' famed loyalty to, and knowledge of, the Septims and was making a pre-emptive strike. If that were indeed the case they were all in terrible danger. She and the children were under his hand here in Imperial City and Symmachus left alone to face the troubles of Nightingale's brewing.
 
- What must she do? Barenziah urged the children ahead of her, a
-hand on each shoulder, her womanservant and guards
-trailing behind. They had reached their waiting carriage --
-even though their apartment was only a few blocks from the
-Palace, royal dignity forbade their walking, and for once,
-Barenziah was glad of that. Even the carriage seemed a kind of
-sanctuary now, false as she knew that feeling to be.
+ What must she do? Barenziah urged the children ahead of her, a hand on each shoulder, her womanservant and guards trailing behind. They had reached their waiting carriage -- even though their apartment was only a few blocks from the Palace, royal dignity forbade their walking, and for once, Barenziah was glad of that. Even the carriage seemed a kind of sanctuary now, false as she knew that feeling to be.
 
- A boy dashed up to one of the guards and handed him a letter,
-then pointed towards the carriage. The guard brought it to
-her. The boy waited, eyes wide. The letter was brief and
-complimentary and simply asked if King Eadwyre of Wayrest,
-High Rock, might be granted an audience with her, as he had
-heard much of her, and would be pleased to make her
-acquaintance. Barenziah's first impulse was to refuse. She
-wanted only to leave this city! Certainly she had no
-inclination for any dalliances with a dazzled human. She
-looked up frowning and one of the guard said, "The boy says
-his master awaits your reply yonder." She looked in the
-direction indicated and saw a handsome elderly man on
-horseback, surrounded by a half-dozen courtiers and guards.
-He caught her eye and bowed respectfully, removing his
-plumed hat.
+ A boy dashed up to one of the guards and handed him a letter, then pointed towards the carriage. The guard brought it to her. The boy waited, eyes wide. The letter was brief and complimentary and simply asked if King Eadwyre of Wayrest, High Rock, might be granted an audience with her, as he had heard much of her, and would be pleased to make her acquaintance. Barenziah's first impulse was to refuse. She wanted only to leave this city! Certainly she had no inclination for any dalliances with a dazzled human. She looked up frowning and one of the guard said, "The boy says his master awaits your reply yonder." She looked in the direction indicated and saw a handsome elderly man on horseback, surrounded by a half-dozen courtiers and guards. He caught her eye and bowed respectfully, removing his plumed hat.
 
- "Very well," Barenziah said to the boy, on impulse. "Tell
-your master he may call on me tonight, after the dinner
-hour." The man looked polite and grave, and rather worried,
-but not in the least lovesick.  
+ "Very well," Barenziah said to the boy, on impulse. "Tell your master he may call on me tonight, after the dinner hour." The man looked polite and grave, and rather worried, but not in the least lovesick.

--- a/Assets/StreamingAssets/Text/Books/BOK00052-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00052-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,83 +14,30 @@ Content:
 
 [/center]Part X
 
-
-
 [/font=4]
+ Barenziah stood at the open tower window, waiting. She could sense her familiar's nearness, but though the night sky was clear as day to her eyes she could not yet see him. Then suddenly he was there, a swift moving dot beneath the wispy night clouds. A few more minutes and the great nighthawk was there, wings folded, talons reaching for her thick leather armband. She carried the bird to its perch where it waited, panting, while her impatient fingers felt for the message secured in a capsule on one leg. It drank, then ruffled its feathers and began to preen, secure in her presence. A tiny part of her consciousness shared its satisfaction with a job well done, rest earned ... yet beneath that was an unease. Things were not right, even to its bird mind.
 
+ Her fingers shook as she unfolded the thin sheet and pored over the sheet of cramped writing. Not Symmachus' bold hand! Barenziah sat, slowly, fingers smoothing the document while she prepared her mind and body to accept disaster calmly.
 
+ The Imperial Guards had deserted Symmachus and joined the rebels. The loyal troops had suffered a decisive defeat. The rebel leader had been recognized as king of Morrowind by the Emperor. Symmachus was dead. Barenziah and the children had been declared traitors of the Empire and a price set on their heads.
 
-[/center]
+ "My lady?" Barenziah jumped, startled at her servant's approach. "The Breton is here. King Eadwyre," the woman added helpfully, noting Barenziah's puzzlement. "Is there news, my lady?" she said, nodding at the nighthawk.
 
- Barenziah stood at the open tower window, waiting. She
-could sense her familiar's nearness, but though the night sky
-was clear as day to her eyes she could not yet see him. Then suddenly he was there, a swift moving dot beneath the wispy night clouds. A few
-more minutes and the great nighthawk  was there, wings folded,
-talons reaching for her thick leather armband. She carried
-the bird to its perch where it waited, panting, while her
-impatient fingers felt for the message secured in a capsule
-on one leg. It drank, then ruffled its feathers and began to
-preen, secure in her presence. A tiny part of her
-consciousness shared its satisfaction with a job well done,
-rest earned ... yet beneath that was an unease. Things were
-not right, even to its bird mind. 
+ "Nothing that will not wait," Barenziah said quickly. "See to the bird."
 
- Her fingers shook as she unfolded the thin sheet and pored over
-the sheet of cramped writing. Not Symmachus' bold hand!
-Barenziah sat, slowly, fingers smoothing the document while
-she prepared her mind and body to accept disaster calmly.
+ King Eadwyre greeted her gravely and courteously, if rather fulsomely. He claimed to be a great admirer of Symmachus, who figured prominently in his family legends. Gradually he turned the conversation to her business with the Emperor. Finding her noncommittal, he suddenly blurted out, "My Lady Queen, you must believe me. The man posing as the Emperor is an impostor! I know it sounds mad, but I -- "
 
- The Imperial Guards had deserted Symmachus and joined the
-rebels. The loyal troops had suffered a decisive defeat. The
-rebel leader had been recognized as king of Morrowind by the
-Emperor. Symmachus was dead. Barenziah and the children had
-been declared traitors of  the Empire and a price set on
-their heads.
+ "No," Barenziah said, with sudden decisiveness. "You are correct. I know."
 
- "My lady?" Barenziah jumped, startled at her servant's
-approach. "The Breton is here. King Eadwyre," the woman
-added helpfully, noting Barenziah's puzzlement. "Is there
-news, my lady?" she said, nodding at the nighthawk.
+ Eadwyre relaxed back into his seat for the first time, eyes shrewd. "You know? You're not just humoring a madman? My lady I -- we -- need your aid."
 
- "Nothing that will not wait," Barenziah said quickly. "See
-to the bird."
+ Barenziah smiled grimly at the irony. "Of what assistance might I be, my lord?"
 
- King Eadwyre greeted her gravely and courteously, if rather fulsomely. He claimed to be a great admirer of
-Symmachus, who figured prominently in his family legends.
-Gradually he turned the conversation to her business with the
-Emperor. Finding her noncommittal, he suddenly blurted
-out, "My Lady Queen, you must believe me. The man posing as
-the Emperor is an impostor! I know it sounds mad, but I -- "
+ Quickly he outlined a plot. The Imperial Sorceress Ria Silmane had been killed and declared a traitor by the false emperor, yet she retained a bit of her power and could yet contact a few of those she had known well on the mortal plane. She had chosen a Champion who would undertake to assemble the missing staff pieces and use the staff's power to destroy Jagar Tharn, who was otherwise invulnerable, and rescue the true Emperor, who was being held prisoner in another plane. However, the chosen Champion languished now in the Imperial Dungeons. Tharn's attention must be diverted while he freed himself with Ria's help. Barenziah had Tharn's ear and eye. Could she provide the necessary distraction?
 
- "No," Barenziah said, with sudden decisiveness. "You are
-correct. I know."
+ "I suppose I could obtain another audience with him. Would that be sufficient? What do you mean, his eye?"
 
- Eadwyre relaxed back into his seat for the first time, eyes
-shrewd. "You know? You're not just humoring a madman? My
-lady I -- we -- need your aid."
-
- Barenziah smiled grimly at the irony. "Of what assistance
-might I be, my lord?"
-
- Quickly he outlined a plot. The Imperial Sorceress Ria
-Silmane had been killed and declared a traitor by the false
-emperor, yet she retained a bit of her power and could yet
-contact a few of those she had known well on the mortal
-plane. She had chosen a Champion who would undertake to
-assemble the missing staff pieces and use the staff's power
-to destroy Jagar Tharn, who was otherwise invulnerable, and
-rescue the true Emperor, who was being held prisoner in
-another plane. However, the chosen Champion languished now
-in the Imperial Dungeons. Tharn's attention must be diverted
-while he freed himself with Ria's help. Barenziah had Tharn's
-ear and eye. Could she provide the necessary distraction?
-
- "I suppose I could obtain another audience with him. Would
-that be sufficient? What do you mean, his eye?"
-
- Eadwyre looked uncomfortable. "It was whispered among the
-servants that Jagar Tharn kept your likeness in a sort of
-shrine in his chambers. That surprises you?"
+ Eadwyre looked uncomfortable. "It was whispered among the servants that Jagar Tharn kept your likeness in a sort of shrine in his chambers. That surprises you?"
 
  "Yes. And no."
 
@@ -99,80 +45,45 @@ shrine in his chambers. That surprises you?"
 
  "You trust me in this? Why?"
 
- "We are desperate, my lady. We have no choice. But yes, I
-do trust you. Symmachus -- "
+ "We are desperate, my lady. We have no choice. But yes, I do trust you. Symmachus -- "
 
  "Is dead." Barenziah explained quickly and coolly.
 
- "My Lady. What dreadful news!" For the first time
-Eadwyre's urbane poise was shaken. "Under the circumstances,
-we can hardly ask -- "
+ "My Lady. What dreadful news!" For the first time Eadwyre's urbane poise was shaken. "Under the circumstances, we can hardly ask -- "
 
- "Nay, my lord king. Under the circumstances I must do what I
-may to avenge myself upon the murderer of my childrens'
-father. In return I ask only that you protect my orphaned
-children as you may."
+ "Nay, my lord king. Under the circumstances I must do what I may to avenge myself upon the murderer of my childrens' father. In return I ask only that you protect my orphaned children as you may."
 
- "Most willingly do I so pledge, most brave and noble
-lady!"
+ "Most willingly do I so pledge, most brave and noble lady!"
 
- Old fool, Barenziah thought. She did not sleep that night,
-but sat in a chair beside her bed, hands folded in her lap,
-thinking long deep thoughts. She would not tell the
-children, not yet, not until she must.
+ Old fool, Barenziah thought. She did not sleep that night, but sat in a chair beside her bed, hands folded in her lap, thinking long deep thoughts. She would not tell the children, not yet, not until she must.
 
- She had no need to seek another audience with the "Emperor"
-for a summons came in the morning. She told the children she
-expected to be gone a few days, bade them give the servants
-no trouble and kissed them goodbye. Morgiah whimpered a bit,
-for she was bored and lonely in Imperial City. Helseth looked
-dour but said nothing. He was very like his father.
+ She had no need to seek another audience with the "Emperor" for a summons came in the morning. She told the children she expected to be gone a few days, bade them give the servants no trouble and kissed them goodbye. Morgiah whimpered a bit, for she was bored and lonely in Imperial City. Helseth looked dour but said nothing. He was very like his father.
 
- At the palace, Barenziah was escorted not into the great
-hall, but to a small parlor where the Emperor sat at a
-solitary breakfast. He nodded a greeting, and waved his hand
-at the window. "Splendid view, isn't it?"
+ At the palace, Barenziah was escorted not into the great hall, but to a small parlor where the Emperor sat at a solitary breakfast. He nodded a greeting, and waved his hand at the window. "Splendid view, isn't it?"
 
- Barenziah stared out over the towers of the great city. It
-dawned on her that this was the very chamber where she'd first
-met Tiber Septim and a strong wave of inchoate feeling
-swept over her. When she turned back at last Uriel Septim had
-vanished and Nightingale sat in his place, laughing.
+ Barenziah stared out over the towers of the great city. It dawned on her that this was the very chamber where she'd first met Tiber Septim and a strong wave of inchoate feeling swept over her. When she turned back at last Uriel Septim had vanished and Nightingale sat in his place, laughing.
 
- "You knew," he said accusingly, scanning her face. "I
-wanted to surprise you. You might at least pretend."
+ "You knew," he said accusingly, scanning her face. "I wanted to surprise you. You might at least pretend."
 
- Barenziah spread her arms, "I'm afraid my skills at pretense
-are no match for yours, my liege."
+ Barenziah spread her arms, "I'm afraid my skills at pretense are no match for yours, my liege."
 
  "You're angry with me." He pretended to pout.
 
- "Just a little," she said icily. "I do find betrayal
-offensive."
+ "Just a little," she said icily. "I do find betrayal offensive."
 
  "How human of you."
 
  "What do you want of me?"
 
- He wiped his mouth and stood erect. "Now you are
-pretending. You know what I want of you, my love."
+ He wiped his mouth and stood erect. "Now you are pretending. You know what I want of you, my love."
 
- "You want to tantalize and torment me. Go ahead. I'm in
-your power."
+ "You want to tantalize and torment me. Go ahead. I'm in your power."
 
- "No, no, no. I don't want that at all, Barenziah." He came
-near, speaking low in the old caressing voice that sent
-shivers over her body. "Don't you see? This was the only
-way." His hands closed on her arms.
+ "No, no, no. I don't want that at all, Barenziah." He came near, speaking low in the old caressing voice that sent shivers over her body. "Don't you see? This was the only way." His hands closed on her arms.
 
- "You could have taken me with you!" Tears gathered in her
-eyes.
+ "You could have taken me with you!" Tears gathered in her eyes.
 
- He shook his head. "I didn't have the power. Ah, but now, now I
-have it all. Mine to have, mine to share -- with you." He
-waved his hand toward the window and the city beyond. "All
-Tamriel to lay at your feet -- and that is only the
-beginning."
+ He shook his head. "I didn't have the power. Ah, but now, now I have it all. Mine to have, mine to share -- with you." He waved his hand toward the window and the city beyond. "All Tamriel to lay at your feet -- and that is only the beginning."
 
  "It's too late. Too late. You left me to him."
 
@@ -180,154 +91,50 @@ beginning."
 
  "The children -- "
 
- "I'll adopt them. We'll have others together, Barenziah. I
-have powers you do not dream of!" He moved to kiss her but she
-slipped his grasp and turned away. 
+ "I'll adopt them. We'll have others together, Barenziah. I have powers you do not dream of!" He moved to kiss her but she slipped his grasp and turned away.
 
  "I don't believe you."
 
- "You do, you know. You're still angry, that's all." His
-smile did not reach his eyes. "What do you want?"
+ "You do, you know. You're still angry, that's all." His smile did not reach his eyes. "What do you want?"
 
  She shrugged. "A walk in the garden. A song or two."
 
  "Ah. You want to be courted."
 
- "Why not? You do it so well. It's been long since I've had
-the pleasure."
+ "Why not? You do it so well. It's been long since I've had the pleasure."
 
- And so they spent their days in courtship, walking, talking,
-singing and laughing together, while the Empire's business
-was left to underlings.
+ And so they spent their days in courtship, walking, talking, singing and laughing together, while the Empire's business was left to underlings.
 
- "I'd like to see the staff," Barenziah said idly one day. "I
-only had a glimpse of it."
+ "I'd like to see the staff," Barenziah said idly one day. "I only had a glimpse of it."
 
- "Nothing would give me greater pleasure, heart's delight,
-but that's impossible."
+ "Nothing would give me greater pleasure, heart's delight, but that's impossible."
 
- "You don't trust me," Barenziah pouted, but she softened her
-lips for his kiss.
+ "You don't trust me," Barenziah pouted, but she softened her lips for his kiss.
 
- "Nonsense, love. It isn't here. In fact, it isn't
-anywhere." He laughed and kissed her again, softly.
+ "Nonsense, love. It isn't here. In fact, it isn't anywhere." He laughed and kissed her again, softly.
 
- "Now you're talking in riddles again. I want to see it. You
-can't have destroyed it."
+ "Now you're talking in riddles again. I want to see it. You can't have destroyed it."
 
  "Ah, you've gained in wisdom, since last we met."
 
- "You piqued my interest somewhat. The staff can't be
-destroyed and it can't be removed from Tamriel, not without
-the direst consequences to the land itself."
+ "You piqued my interest somewhat. The staff can't be destroyed and it can't be removed from Tamriel, not without the direst consequences to the land itself."
 
- "Ahhh. All true. And yet, as a I said, it isn't anywhere.
-Can you solve the riddle?" He pulled her to him and she
-leaned into his embrace. "Here's a greater riddle still," he
-whispered, "how to make one of two. That I can and will show
-you." Their bodies merged, limbs tangled together. Later,
-when they'd drawn a bit apart and dozed, she thought,
-sleepily. "One of two, two of one, three of two...what
-cannot be destroyed or banished might be split apart,
-perhaps..."
+ "Ahhh. All true. And yet, as a I said, it isn't anywhere. Can you solve the riddle?" He pulled her to him and she leaned into his embrace. "Here's a greater riddle still," he whispered, "how to make one of two. That I can and will show you." Their bodies merged, limbs tangled together. Later, when they'd drawn a bit apart and dozed, she thought, sleepily. "One of two, two of one, three of two...what cannot be destroyed or banished might be split apart, perhaps..."
 
- Nightingale kept a diary. He scribbled entries in it each
-night after quick reports from his underlings. It was locked
-but the lock was a simple one, so Barenziah managed to sneak
-quick looks at it while he was occupied in toileting himself.
-She discovered that the first staff piece was hidden in an
-ancient dwarven mine called Fang Lair, although its
-location was given only in vague terms. The diary was
-crammed with jotted events in an odd shorthand, and was
-very hard to decipher.
+ Nightingale kept a diary. He scribbled entries in it each night after quick reports from his underlings. It was locked but the lock was a simple one, so Barenziah managed to sneak quick looks at it while he was occupied in toileting himself. She discovered that the first staff piece was hidden in an ancient dwarven mine called Fang Lair, although its location was given only in vague terms. The diary was crammed with jotted events in an odd shorthand, and was very hard to decipher.
 
- All Tamriel, she thought, in his hands and mine, and more
-perhaps, and yet ...  For all his surface charm there was a
-cold emptiness where his heart should have been, an emptiness
-of which he was quite unaware, she thought. One could glimpse
-it now and then, when his eyes would go blank and hard.
-Peasant dreams, Barenziah thought, and Straw flashed before
-her eyes, looking sad, and then Therris, with a mocking smile
-and empty eye sockets. Symmachus, who did what must be done,
-quietly and efficiently. Nightingale. Nightingale, who
-would rule all, and more, and yet spread chaos in the name
-of control.
+ All Tamriel, she thought, in his hands and mine, and more perhaps, and yet ... For all his surface charm there was a cold emptiness where his heart should have been, an emptiness of which he was quite unaware, she thought. One could glimpse it now and then, when his eyes would go blank and hard. Peasant dreams, Barenziah thought, and Straw flashed before her eyes, looking sad, and then Therris, with a mocking smile and empty eye sockets. Symmachus, who did what must be done, quietly and efficiently. Nightingale. Nightingale, who would rule all, and more, and yet spread chaos in the name of control.
 
- Barenziah got reluctant leave from Nightingale to go to
-her children, who had to be told of their father's death and
-of the emperor's offer of his protection to them. Eadwyre
-called on them while she was there, and she told him what she
-had discovered so far, and explained that she must remain
-awhile yet and learn more as she could.
+ Barenziah got reluctant leave from Nightingale to go to her children, who had to be told of their father's death and of the emperor's offer of his protection to them. Eadwyre called on them while she was there, and she told him what she had discovered so far, and explained that she must remain awhile yet and learn more as she could.
 
- Nightingale teased her about her elderly admirer. He was
-quite aware of Eadwyre's suspicion, although as he said, no
-one took the old fool seriously. Barenziah managed to
-arrange a reconciliation of sorts between them. Eadwyre
-publicly recanted his suspicions and his "old friend"
-forgave him. Thus he was invited to dine with them at least
-once a week. The children liked Eadwyre, even Helseth, who
-disapproved of his mother's liaison with the "Emperor" and
-consequently detested Nightingale. He had become surly and
-temperamental and frequently quarreled with both of them.
+ Nightingale teased her about her elderly admirer. He was quite aware of Eadwyre's suspicion, although as he said, no one took the old fool seriously. Barenziah managed to arrange a reconciliation of sorts between them. Eadwyre publicly recanted his suspicions and his "old friend" forgave him. Thus he was invited to dine with them at least once a week. The children liked Eadwyre, even Helseth, who disapproved of his mother's liaison with the "Emperor" and consequently detested Nightingale. He had become surly and temperamental and frequently quarreled with both of them.
 
- Eadwyre was not happy either and Nightingale delighted in
-publicly displaying his affection for Barenziah. They
-could not marry, of course, for Uriel Septim was already
-married. He had exiled the true Empress shortly after taking
-Septim's place, but had not dared to harm her. She was held
-by the Temple of the One. It had been given out publicly
-that she was in ill health, and rumors had been circulated
-that she had mental problems. The Emperor's children had
-also been dispatched to various prisons disguised as
-"schools".
+ Eadwyre was not happy either and Nightingale delighted in publicly displaying his affection for Barenziah. They could not marry, of course, for Uriel Septim was already married. He had exiled the true Empress shortly after taking Septim's place, but had not dared to harm her. She was held by the Temple of the One. It had been given out publicly that she was in ill health, and rumors had been circulated that she had mental problems. The Emperor's children had also been dispatched to various prisons disguised as "schools".
 
- "She'll grow worse in time," Nightingale said carelessly,
-eying Barenziah's swollen breasts and belly with
-satisfaction. "As for his children ... well, life is full
-of hazards, isn't it? We'll be married. Your child will be
-my true heir." He did want the child. Barenziah was sure of
-that. She was far less sure of his feelings for her. They
-quarrelled, often violently, usually about Helseth, whom
-he wanted to send away to school. Barenziah made no effort
-to avoid these quarrels. Nightingale had no interest in a
-peaceful life and he thoroughly enjoyed making up
-afterwards. Occasionally Barenziah would take the children
-and retreat to their old apartment, declaring she wanted no
-more to do with him. 
+ "She'll grow worse in time," Nightingale said carelessly, eying Barenziah's swollen breasts and belly with satisfaction. "As for his children ... well, life is full of hazards, isn't it? We'll be married. Your child will be my true heir." He did want the child. Barenziah was sure of that. She was far less sure of his feelings for her. They quarrelled, often violently, usually about Helseth, whom he wanted to send away to school. Barenziah made no effort to avoid these quarrels. Nightingale had no interest in a peaceful life and he thoroughly enjoyed making up afterwards. Occasionally Barenziah would take the children and retreat to their old apartment, declaring she wanted no more to do with him.
 
- She was six months pregnant before she finally deciphered
-the location of the last staff piece -- an easy one, since
-every dark elf knew where Dagoth-Ur was. When next she
-quarrelled with Nightingale she simply left the city with
-Eadwyre and they rode hard for High Rock and Wayrest.
+ She was six months pregnant before she finally deciphered the location of the last staff piece -- an easy one, since every dark elf knew where Dagoth-Ur was. When next she quarrelled with Nightingale she simply left the city with Eadwyre and they rode hard for High Rock and Wayrest.
 
- Nightingale was furious, but there was little he could do.
-His assassins were rather inept, and he dared not leave his
-seat of power to pursue them in person, nor could he openly
-declare war on Wayrest. He had no legitimate claim on her on
-her unborn child. The nobility had disapproved of his
-liaison with Barenziah and were glad that she had gone.
-Wayrest was equally disapproving and distrustful of her,
-but Eadwyre was much beloved by his prosperous little city,
-and allowances were readily made for his eccentricities.
+ Nightingale was furious, but there was little he could do. His assassins were rather inept, and he dared not leave his seat of power to pursue them in person, nor could he openly declare war on Wayrest. He had no legitimate claim on her on her unborn child. The nobility had disapproved of his liaison with Barenziah and were glad that she had gone. Wayrest was equally disapproving and distrustful of her, but Eadwyre was much beloved by his prosperous little city, and allowances were readily made for his eccentricities.
 
- Barenziah and Eadwyre were married a year after the birth of
-her son by Jagar Tharn. Eadwyre doted on her. She did not
-love him, but she was fond of him, and that was something. It
-was nice to have someone, and Wayrest was a very pleasant
-place, a good place for children to grow up, while they
-waited, and hoped, and prayed for their Champion's success
-in his long mission.                                                           
-                                                                                        
-                                                                                        
-                                                                                        
-                                                                                        
-                                                                                        
-                                                                                        
-                                                                                        
-                                                                                        
-                                                                                        
-                                                                                        
-                                                                                        
-                          
+ Barenziah and Eadwyre were married a year after the birth of her son by Jagar Tharn. Eadwyre doted on her. She did not love him, but she was fond of him, and that was something. It was nice to have someone, and Wayrest was a very pleasant place, a good place for children to grow up, while they waited, and hoped, and prayed for their Champion's success in his long mission.

--- a/Assets/StreamingAssets/Text/Books/BOK00053-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00053-LOC.txt
@@ -3,9 +3,8 @@ Author: Morian Zenas
 IsNaughty: False
 Price: 559
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,95 +12,26 @@ Content:
 
 [/center]Oblivion
 
-
-
 [/font=4]
 
-[/center]
+ It is improper, though common, to refer to the denizens of the dimension of Oblivion as demons. This practice must probably dates to the Alessian Doctrines of the prophet Marukh which, rather amusingly, forbade traffic with "daimons," and then neglected to explain what demons are. It is most probable that "daimon" is a mispelling of "daedra," the old Elvish word for the strange, powerful creatures of uncertain motivation who come from the dimension of Oblivion. In later tractates by King Hale the Pious of Skyrim, almost a thousand years after the publication of the original Doctrines, the evil of his political enemies is compared to "the wickedness of the demons of Oblivion ... their depravity equals that of Sanguine itself, they are cruel as Boethiah, calculating as Molag Bal, and mad as Sheogorath."
 
- It is improper, though common, to refer to the denizens of
-the dimension of Oblivion as demons. This practice must
-probably dates to the Alessian Doctrines of the prophet
-Marukh which, rather amusingly, forbade traffic with
-"daimons," and then neglected to explain what demons are.
-It is most probable that "daimon" is a mispelling of
-"daedra," the old Elvish word for the strange, powerful
-creatures of uncertain motivation who come from the
-dimension of Oblivion. In later tractates by King Hale the
-Pious of Skyrim, almost a thousand years after the
-publication of the original Doctrines, the evil of his
-political enemies is compared to "the wickedness of the demons
-of Oblivion ... their depravity equals that of Sanguine
-itself, they are cruel as Boethiah, calculating as Molag Bal, and mad
-as Sheogorath."
+ Hale the Pious thus longwindedly introduced four of the daedra lords to the written record.
 
- Hale the Pious thus longwindedly introduced four of the
-daedra lords to the written record.
+ The written record is not, after all, the best way to research Oblivion and the daedra that inhabit it. Those who, in the words of the Alessian Doctrine, "traffic with daimons" seldom wish it to be a matter of public record. Nevertheless, scattered throughout the literature of the first era, are diaries, journals, notices for witch burnings, and guides for daedra-slayers which contain only a few contradictions. These I have used as my primary source material.
 
- The written record is not, after all, the best way to
-research Oblivion and the daedra that inhabit it. Those who,
-in the words of the Alessian Doctrine, "traffic with
-daimons" seldom wish it to be a matter of public record.
-Nevertheless, scattered throughout the literature of the
-first era, are diaries, journals, notices for witch
-burnings, and guides for daedra-slayers which contain only a
-few contradictions. These I have used as my primary source material.
+ They are at least as trustworthy as the daedra lords I have actually summoned and spoken with at length.
 
- They are at least as trustworthy as the daedra lords I have
-actually summoned and spoken with at length.
+ Oblivion is a place composed of many lands, thus the many names for which Oblivion is synonymous: Coldharbour, Quagmire, Moonshadow, and others. It may be supposed that each land of Oblivion is ruled by one prince. The princes whose name appears over and over (though this is not a sure test of their authenticity, to be sure) are the aforementioned Sanguine, Boethiah, Molag Bal, Sheogorath, and Azura, Mephala, Clavicus Vil, Vaernima, Malacath, Hoermius (or Hermaeus or Hormaius, there is no consistant spelling) Mora, Namira, Jyggalag, Nocturnal, Mehrunes Dagon, and Peryite.
 
- Oblivion is a place composed of many lands, thus the many
-names for which Oblivion is synonymous: Coldharbour,
-Quagmire, Moonshadow, and others. It may be supposed that
-each land of Oblivion is ruled by one prince. The princes
-whose name appears over and over (though this is not a sure
-test of their authenticity, to be sure) are the
-aforementioned Sanguine, Boethiah, Molag Bal, Sheogorath,
-and Azura, Mephala, Clavicus Vil, Vaernima, Malacath,
-Hoermius (or Hermaeus or Hormaius, there is no consistant
-spelling) Mora, Namira, Jyggalag, Nocturnal, Mehrunes
-Dagon, and Peryite.
+ From my experience, Daedra are a very mixed lot. It is almost impossible to categorize them as a whole except for their immense power and their penchant for extremism.
 
- From my experience, Daedra are a very mixed lot. It is
-almost impossible to categorize them as a whole except for
-their immense power and their penchant for extremism.
+ Mehrunes Dagon, Molag Bal, Peryite, Boethiah, and Vaernima are among the most consistently "demonic" of the Daedra, in the sense that their spheres seem to be destructive in nature. The other daedra can, of course, be very dangerous, but seldom purely for the sake of destruction, as these five can.
 
- Mehrunes Dagon, Molag Bal, Peryite, Boethiah, and Vaernima
-are among the most consistently "demonic" of the Daedra, in
-the sense that their spheres seem to be destructive in nature.
-The other daedra can, of course, be very dangerous, but
-seldom purely for the sake of destruction, as these five can.
+ Nor are those five aforementioned daedra identical in their destruction. Mehrunes Dagon seems to prefer natural disasters, earthquakes and volcanos, to vent his spleen. Molag Bal prefers employing actual daedralings, and Boethiah inspires the arms of mortal warriors. Peryite sphere seems to be pestilence, and Vaernima's torture.
 
- Nor are those five aforementioned daedra identical in their
-destruction. Mehrunes Dagon seems to prefer natural
-disasters, earthquakes and volcanos, to vent his spleen.
-Molag Bal prefers employing actual daedralings, and
-Boethiah inspires the arms of mortal warriors. Peryite
-sphere seems to be pestilence, and Vaernima's torture.
+ Summoning daedra is not a difficult proposition, but it is usual an expensive one. Most Mages Guilds have a summoning room, but this is most often reserved for the highest echelon of guildmembers. Witches covens are much less class sensitive, and the Necromancers, the Dark Brotherhood, and many secretive kings and queens of Tamriel have private summoning rooms. Daedra princes usually demand some sort of service of those who summon them, though I am fortunate enough to have good relations with some and need not perform.
 
- Summoning daedra is not a difficult proposition, but it is
-usual an expensive one. Most Mages Guilds have a summoning
-room, but this is most often reserved for the highest echelon
-of guildmembers. Witches covens are much less class
-sensitive, and the Necromancers, the Dark Brotherhood, and
-many secretive kings and queens of Tamriel have private
-summoning rooms. Daedra princes usually demand some sort
-of service of those who summon them, though I am fortunate
-enough to have good relations with some and need not
-perform.
+ In preparation for the second chapter of this series, I will be investigating two matters that have intrigued me since I began my career as a daedra researcher. The first is on one particular Daedra Prince, referred to in multiple articles of incunabula as Hircine. Hircine has been called "the huntsman of the Princes" and "the father of manbeasts," but I have yet to find anyone who can summon him.
 
- In preparation for the second chapter of this series, I will
-be investigating two matters that have intrigued me since I
-began my career as a daedra researcher. The first is on one
-particular Daedra Prince, referred to in multiple
-articles of incunabula as Hircine. Hircine has been called
-"the huntsman of the Princes" and "the father of manbeasts,"
-but I have yet to find anyone who can summon him.
-
- The other, and more doubtful goal I have for the next
-chapter is to find a practical means for mortal man to
-pass through to Oblivion. It has always been my philosophy
-that we only need fear that which we do not understand, and
-with that thought in mind, I pursue my goal.
-
- 
+ The other, and more doubtful goal I have for the next chapter is to find a practical means for mortal man to pass through to Oblivion. It has always been my philosophy that we only need fear that which we do not understand, and with that thought in mind, I pursue my goal.

--- a/Assets/StreamingAssets/Text/Books/BOK00054-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00054-LOC.txt
@@ -3,209 +3,51 @@ Author: Aegrothius Goth
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]The Sage
 
-
-
 [/font=4]
 
-[/center]
+ Crackle, snap, hiss ... Flicker, bright, dim ... The fire in the hearth provides light and heat. Neither seem to affect the old man. His reclining figure stares into the flames and flames reflect back from his deep dark eyes. Indigo blue robes reflect and yet absorb the firelight and highlights of golden threads twinkle as the flames flicker. His beard and hair are long and snowy white; in the firelight they almost appear to be ethereal like that of a godling. At his side is a tall pointed hat which is the same color as his robe and also twinkles with highlights of gold. The face is lined with age, yet almost appears youthful; wisdom and intellect exude from his personage. This is the Sage who is known in all of Tamriel as the champion and counselor to all users of magic. His thoughts wander, and he remembers ...
 
-[/center] Crackle, snap, hiss ... Flicker, bright, dim ... The fire in
-the hearth provides light and heat. Neither seem to affect the
-old man. His reclining figure stares into the flames and
-flames reflect back from his deep dark  eyes. Indigo blue
-robes reflect and yet absorb the firelight and highlights of
-golden threads twinkle as the flames flicker. His beard and
-hair are long and snowy white; in the firelight they almost
-appear to be ethereal like that of a godling. At his side is a
-tall pointed hat which is the same color as his robe and also
-twinkles with highlights of gold. The face is lined with age,
-yet almost appears youthful; wisdom and intellect exude
-from his personage. This is the Sage who is known in all of
-Tamriel as the champion and counselor to all users of
-magic. His thoughts wander, and he remembers ...
+[/center]...
 
- ...
+ Gyron Vardengroet was born to a poor and humble Breton family in the village of Moonguard. The only child of Frieda and Horstle Vardengroet entered life during a rare eclipse of Tamriel's moons. It was soon apparent that he was unusually gifted in the magical arts. He was found levitating the family dog when he was only a year old. Most Bretons have a great talent for magic, but as he grew Gyron displayed a talent far greater than that of his peers. The village wizard began to take an interest in young Gyron and soon took him under his wing. In spite of the young man's proclivities for being rowdy, the old Wizard Grungdingler liked him and worked hard to teach him the magical arts to the extent of his own skills.
 
- Gyron Vardengroet was born to a poor and humble Breton
-family in the village of Moonguard. The only  child of
-Frieda and Horstle Vardengroet entered life during a rare
-eclipse of Tamriel's moons. It was soon  apparent that he
-was unusually gifted in the magical arts. He was found
-levitating the family dog when he was only a year old. Most
-Bretons have a great talent for magic, but as he grew Gyron
-displayed a talent  far greater than that of his peers. The
-village wizard began to take an interest in young Gyron and
-soon took  him under his wing. In spite of the young man's
-proclivities for being rowdy, the old Wizard Grungdingler 
-liked him and worked hard to teach him the magical arts to the
-extent of his own skills.
+ Finally the day came when Grungdingler could teach Gyron no more. The young mage had surpassed his master, and he was somewhat unsettled with the apprentice mage's questions about life, death and immortality. Grundingler called Gyron to him and gave him a letter addressed to Morkledder, the Guildmagister of the Mages Guild in Shornhelm. The young mage told his parents of his fortune, packed his meager belongings, and set out for the journey to Shornhelm. After many months of travel through the foothills of the Kurallian Mountains, Gyron arrived at the gates to the great City-State of Shornhelm high in the mountainous terrain of High Rock.
 
- Finally the day came when Grungdingler could teach Gyron
-no more. The young mage had surpassed his  master, and he was
-somewhat unsettled with the apprentice mage's questions
-about life, death and immortality. Grundingler called
-Gyron to him and gave him a letter addressed to Morkledder,
-the Guildmagister of the Mages Guild in Shornhelm. The young
-mage told his parents of his fortune, packed his meager
-belongings, and set out for the journey to Shornhelm. After
-many months of travel through the foothills of the
-Kurallian Mountains, Gyron arrived at the gates to the great
-City-State of Shornhelm high in the mountainous terrain of
-High Rock.
+ After the life of a quiet Breton village, Shornhelm was a wonder to Gyron. He explored the city from one end to the other, and eventually found the Mages Guild. Presenting Grungdingler's letter to Morkledder, Gyron was received warmly. Morkledder explained to Gyron that he would need to be tested before any commitment to further training could be made. After a night of rest and meditation, Gyron was shown into the main hall of the Mages Guild which was now filled with magic users of all kinds. It was very quiet. The young mage felt as if his heart was in his throat as he approached the Council of Three, the leaders of the mages in this City-State. Morkledder rose and explained to Gyron the various tests he would be subjected to to prove his worth as a mage. The youth then turned and left the Council Chamber, the eyes of the many mages on him, and went forth to complete the tasks that had been defined for him.
 
- After the life of a quiet Breton village, Shornhelm was a
-wonder to Gyron. He explored the city from one end to the
-other, and eventually found the Mages Guild. Presenting
-Grungdingler's letter to Morkledder, Gyron was received
-warmly. Morkledder explained to Gyron that he would need
-to be tested before any commitment to further training
-could be made. After a night of rest and meditation, Gyron
-was shown into the main hall of the Mages Guild which was now
-filled with magic users of all kinds. It was very quiet. The
-young mage felt as if his heart was in his throat as he
-approached the Council of Three, the leaders of the mages in
-this City-State. Morkledder rose and explained to Gyron the
-various tests he would be subjected to to prove his worth as
-a mage. The youth then turned and left the Council Chamber,
-the eyes of the many mages on him, and went forth to complete
-the tasks that had been defined for him. 
+ Returning to Shornhelm several years later, Gyron was admitted to the Mages Guild and shown to the Council Chamber where he was met by Morkledder. The ancient mage reviewed the journal entries, the artifacts gathered, and most especially the spellbook entries presented to him by Gyron. An expression of amazement spread across the old wizard's face; there had never been a novice to accomplish what Gyron had during the testing. Morkledder then called a full session of the Guild presenting Gyron as a full Wizard.
 
- Returning to Shornhelm several years later, Gyron was
-admitted to the Mages Guild and shown to the  Council Chamber
-where he was met by Morkledder. The ancient mage reviewed the
-journal entries, the  artifacts gathered, and most
-especially the spellbook entries presented to him by Gyron.
-An expression of  amazement spread across the old wizard's
-face; there had never been a novice to accomplish what Gyron
-had  during the testing. Morkledder then called a full
-session of the Guild presenting Gyron as a full Wizard. 
+ Gyron remained with Morkledder for several years and studied hard. In private session several years after the testing, Morkledder admitted to Gyron that the Guild at Shornhelm could teach him no more and that he should seek further enlightenment at the Crystal Tower on Sumurset Isle.
 
- Gyron remained with Morkledder for several years and
-studied hard. In private session several years after the
-testing, Morkledder admitted to Gyron that the Guild at
-Shornhelm could teach him no more and that he should seek
-further enlightenment at the Crystal Tower on Sumurset
-Isle.
+ After packing his possessions once again, Gyron set off on another long journey. He arrived at the Crystal Tower several years later after having traversed the province of Hammerfell where he had many adventures, met many other mages and shared his experiences and knowledge with them. He heard stories of wonderful plants that when combined with other elements could restore life to those dead, prolong life to those yet living, and in the proper combination bestow immortality on the user. Gyron was always quick to advise and guide mages who were less experienced than himself. He loved being able to help. He made many friends and stories began to spread across the land about this exceptional user of magic.
 
- After packing his possessions once again, Gyron set off on
-another long journey. He arrived at the Crystal Tower
-several years later after having traversed the province
-of Hammerfell where he had many adventures, met many other mages and shared his experiences and knowledge
-with them. He heard stories of wonderful plants that when
-combined with other elements could restore life to those
-dead, prolong life to those yet living, and in the proper
-combination bestow immortality on the user. Gyron was
-always quick to advise and guide mages who were less
-experienced than himself. He loved being able to help. He
-made many friends and stories began to spread across  the
-land about this exceptional user of magic.
+ When he entered the Crystal Tower, he was greeted by several mages all clamoring for his attention. His reputation had preceded him. However, the crowd hushed and parted at the arrival of a very imposing figure dressed all in indigo blue robes trimmed in gold, wearing a high pointed hat and carrying the most beautifully carved staff Gyron had ever seen. The Elder of the Council of Wizards, Esthlainder, looked closely at the young wizard, nodded and turned to walk back into the tower. Without delay, Gyron followed him. The audience that followed stunned the young mage.
 
- When he entered the Crystal Tower, he was greeted by several
-mages all clamoring for his attention. His  reputation had
-preceded him. However, the crowd hushed and parted at the
-arrival of a very imposing figure dressed all in indigo
-blue robes trimmed in gold, wearing a high pointed hat and
-carrying the most beautifully carved staff Gyron had ever
-seen. The Elder of the Council of Wizards, Esthlainder,
-looked closely at the young wizard, nodded and turned to
-walk back into the tower. Without delay, Gyron followed him.
-The audience that followed stunned the young mage.
+ Esthlainder explained to him that Gyron's coming had been foretold for many years, and he had been expected. The mages had been told by the Gods that one of their own would come along to provide guidance, knowledge and aid. Gyron was that promised champion and leader. Gyron was confused and uncertain. How could he be such an extraordinary person? What must he do to fulfill his destiny? Many questions spilled from him to which Esthlainder could not provide the answers. The Elder suggested that Gyron stay with them in the Crystal Tower for a while and study. This he did.
 
- Esthlainder explained to him that Gyron's coming had been
-foretold for many years, and he had been expected. The mages
-had been told by the Gods that one of their own would come
-along to provide guidance, knowledge and aid. Gyron was
-that promised champion and leader. Gyron was confused and
-uncertain. How could he be such an extraordinary person?
-What must he do to fulfill his destiny? Many questions
-spilled from him to which Esthlainder could not provide the
-answers. The Elder suggested that Gyron stay with them in the
-Crystal Tower for a while and study. This he did.
+ The day finally came when The Elder admitted to Gyron that the Crystal Tower could no longer provide anything new and that he needed to travel the lands of Tamriel and seek the wisdom and knowledge. The Elder sighed and told Gyron how sad he was that the Crystal Tower was losing him, but that his destiny must be fulfilled. With this, the Elder presented Gyron with a package wrapped in the same beautiful indigo blue as the Elder's Robes. Gyron was told to take the package with him but open it only when he was at least a day's travel from the Crystal Tower.
 
- The day finally came when The Elder admitted to Gyron that
-the Crystal Tower could no longer provide anything new and
-that he needed to travel the lands of Tamriel and seek the
-wisdom and knowledge. The Elder sighed and told Gyron how
-sad he was that the Crystal Tower was losing him, but that his
-destiny must be fulfilled. With this, the Elder presented
-Gyron with a package wrapped in the same beautiful indigo
-blue as the Elder's Robes. Gyron was told to take the package
-with him but open it only when he was at least a day's travel
-from the Crystal Tower.
+ After a long day's walk, Gyron set up camp in a beautiful glade next to a brook of crystal clear water. Finally, he thought, I can open the Elder's package. As he untied the golden cord that had bound the package, he found that the wrapping was not wrapping at all but an exquisitely tailored robe identical to the one worn by the Elder. As he opened the robe, a high pointed wizard's hat popped out of the package, and with a "whoosh" and "pop," the same intricately carved staff that the Elder had carried appeared. A note from the Elder advised that the garments were indestructible and that the staff had many magical properties for Gyron to discover. It went on further to explain that from this day forward Gyron would be known as The Sage.
 
- After a long day's walk, Gyron set up camp in a beautiful
-glade next to a brook of crystal clear water. Finally, he
-thought, I can open the Elder's package. As he untied the
-golden cord that had bound the package, he found that the
-wrapping was not wrapping at all but an exquisitely
-tailored robe identical to the one worn by the Elder. As he
-opened the robe, a high pointed wizard's hat popped out of
-the package, and with a "whoosh" and "pop," the same
-intricately carved staff that the Elder had carried
-appeared. A note from the Elder advised that the garments
-were indestructible and that the staff had many magical
-properties for Gyron to discover. It went on further to
-explain that from this day forward Gyron would be known as
-The Sage.
+ Tired from his walking and with an inner glow of accomplishment, The Sage settled down for the first night of his long pilgrimage across the lands.
 
- Tired from his walking and with an inner glow of
-accomplishment, The Sage settled down for the first night
-of his long pilgrimage across the lands.
+ After many months of further travels and adventures, The Sage returned to Moonguard and was warmly welcomed by the villagers and most especially by his parents, Frieda and Horstle. News of his coming had preceded him and the whole village had worked hard to build and furnish a cottage for the mage in the pleasant forest just outside the town. After a festive banquet that evening, Gyron retired to his new home.
 
- After many months of further travels and adventures, The 
-Sage returned to Moonguard and was warmly welcomed by the
-villagers and most especially by his parents, Frieda and
-Horstle. News of his coming had preceded him and the whole
-village had worked hard to build and furnish a cottage for the mage in the pleasant forest just outside the town.
-After a festive banquet that evening, Gyron retired to his
-new home.
+ The Sage settled into his life outside Moonguard. He received many visitors who have traveled from near and far to seek his guidance, help, and training. The years passed. It was not long before first Horstle and then Frieda died. The Sage was devastated by his loss. In his grief he swore to dedicate the rest of his life to defeating death so that grief like his could be avoided by others.
 
- The Sage settled into his life outside Moonguard. He received
-many visitors who have traveled from near and far to seek his
-guidance, help, and training. The years passed. It was not
-long before first Horstle and then Frieda died. The Sage was
-devastated by his loss. In his grief he swore to dedicate the
-rest of his life to defeating death so that grief like his
-could be avoided by others.
+ He returned to the Great Library at the Crystal Tower and researched the many flowers, herbs and plants that he had heard about and seen during his travels. In his cottage, he labored tirelessly over the spellbooks, vials and collection of flora from all over the lands. He tested the potions on himself. The years went by, but The Sage seemed not to age anymore. At some point he had found the right combination in his experiments, but could not determine which combination it had been as the change had been most subtle. He had secured a life without end. And the years continued to pass.
 
- He returned to the Great Library at the Crystal Tower and
-researched the many flowers, herbs and plants that he had
-heard about and seen during his travels. In his cottage, he
-labored tirelessly over the spellbooks, vials and
-collection of flora from all over the lands. He tested the
-potions on himself. The years went by, but The Sage seemed
-not to age anymore. At some point he had found the right
-combination in his experiments, but could not determine
-which combination it had been as the change had been most
-subtle. He had secured a life without end. And the years
-continued to pass. 
+ Mages came to him for help which he freely gave. The Sage settled into his life of advising and guiding and the years continued to pass. Unfortunately, his fame became so great that the call for his help was unmanageable. He reluctantly packed his possessions for the last time, and moved far into the Kurallian Mountains and built a magical fortress. Only the most worthy magic user could gain access and help from The Sage.
 
- Mages came to him for help which he freely gave. The Sage
-settled into his life of advising and guiding and  the years
-continued to pass. Unfortunately, his fame became so great
-that the call for his help was unmanageable. He reluctantly
-packed his possessions for the last time, and moved far into
-the Kurallian Mountains and built a magical fortress. Only
-the most worthy magic user could gain access and help from
-The Sage. 
+ However, following his heart, even today The Sage often leaves his mountain abode and travels the land helping young mages gain experience and to grow.
 
- However, following his heart, even today The Sage often
-leaves his mountain abode and travels the land helping
-young mages gain experience and to grow.
+[/center]...
 
- ...
-
- Snap, crackle ... The firelight flickers... The old mage
-stirs as the memories fade and flicker like the firelight.
-Bang, bang, bang... echoes from the pounding knocker on the
-great oaken doors of the fortress... The Sage rises and heads
-for the doors knowing that yet another mage in need has found
-him and is worthy of help.  
+ Snap, crackle ... The firelight flickers... The old mage stirs as the memories fade and flicker like the firelight. Bang, bang, bang... echoes from the pounding knocker on the great oaken doors of the fortress... The Sage rises and heads for the doors knowing that yet another mage in need has found him and is worthy of help.

--- a/Assets/StreamingAssets/Text/Books/BOK00055-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00055-LOC.txt
@@ -3,9 +3,8 @@ Author: Irek Unterge
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,176 +14,46 @@ Content:
 
 [/center]The Dark
 
-
-
 [/font=4]
 
+ "Yes, children, it is no accident that this land of Tamriel has been called 'The Arena'." The old man altered his position on the large rock that bore his weight, and straightened his long gray robe. Rheumy eyes lost their focus as they gazed out over the sun-warmed valley in the mountains of High Rock. For a moment he saw a vision of ancient horrors instead of the fresh greenery of spring. A chill washed over his aged bones.
 
+ "Is this a suitable topic for the young and innocent?" he asked himself. The young must be taught, but must they learn of such things now, when they should be playing in the sunlight? This is a tale for the dreary winter, with the wind howling outside a walled town and the doors and windows closed and bolted against the blast and cold and -- other things.
 
-[/center] "Yes, children, it is no accident that this land of Tamriel
-has been called 'The Arena'." The old man altered his
-position on the large rock that bore his weight, and
-straightened his long gray robe.  Rheumy eyes lost their focus
-as they gazed out over the sun-warmed valley in the
-mountains of High Rock. For a moment he saw a vision of
-ancient horrors instead of the fresh greenery of spring. A
-chill washed over his aged bones.
+ He glanced with affection at his two grandchildren: the little towheaded boy with a hint of mischief dancing in his eyes even on those rare occasions when sitting quietly, and his older sister. A serene lass, the old man thought. Her hair like a dark flame and her slightly pointed ears were the only obvious signs of elven blood. So like her grandmother, the old man thought. The past is past, and I'shira had brought him so much peace and happiness after a lifetime of battle. He forced his thoughts back to the present.
 
- "Is this a suitable topic for the young and innocent?" he
-asked himself.  The young must be taught, but must they
-learn of such things now, when they should be playing in the
-sunlight?  This is a tale for the dreary winter, with the wind
-howling outside a walled town and the doors and windows
-closed and bolted against the blast and cold and -- other
-things.
+ "Sorry, children. I was remembering things. Old people do that, you know."
 
- He glanced with affection at his two grandchildren:  the
-little towheaded boy with a hint of mischief dancing in his eyes
-even on those rare occasions when sitting quietly, and his
-older sister.  A serene lass, the old man thought.  Her hair
-like a dark flame and her slightly pointed ears were the only
-obvious signs of elven blood.  So like her grandmother, the
-old man thought.  The past is past, and I'shira had brought
-him so much peace and happiness after a lifetime of battle.
-He forced his thoughts back to the present.
+ "Are you going to tell us the story of Jagar Tharn and the Emperor and the Eternal Champion?" His grandson asked. "That's my favorite!"
 
- "Sorry, children. I was remembering things. Old people do
-that, you know."
+ "Not exactly, son. They were a part of it, in a way. As are I'ric and Moraelyn and Edward and Reymon and many others. Even the gods play a part. This is a far older story, and even the priests won't tell it my way. They have their own interpretations, and their fears as well. I'm too old and have seen too much to have any fear left, except that our people will forget. And forgetting is dangerous. So I, and a few others, carry this tale and try to spread it among the younger generations. You aren't really old enough to understand it all, but I can feel that my end is not far off. I must ask you to remember anyway. In a few years, perhaps, if I still live, we can discuss it again. If not, well, you must seek out others who know, and compare notes."
 
- "Are you going to tell us the story of Jagar Tharn and the
-Emperor and the Eternal Champion?"  His grandson asked. 
-"That's my favorite!"
+ "You talk as if you are going to die, Granther," his granddaughter spoke up. "That can't happen. You will live forever!"
 
- "Not exactly, son.  They were a part of it, in a way.  As
-are I'ric and Moraelyn and Edward and Reymon and many
-others. Even the gods play a part.  This is a far older
-story, and even the priests won't tell it my way.  They have
-their own interpretations, and their fears as well. I'm too
-old and have seen too much to have any fear left, except
-that our people will forget. And forgetting is dangerous. 
-So I, and a few others, carry this tale and try to spread it
-among the younger generations.  You aren't really old
-enough to understand it all, but I can feel that my end is
-not far off.  I must ask you to remember anyway. In a few
-years, perhaps, if I still live, we can discuss it again. 
-If not, well, you must seek out others who know, and compare
-notes."
+ Chuckling, "I'm afraid not, dear. But I have a little while left, enough for the story".
 
- "You talk as if you are going to die, Granther," his
-granddaughter spoke up.  "That can't happen. You will live
-forever!"
+ The children settled back against the bole of a large oak, knowing that the old man could not be hurried. Leaning forward, he began:
 
- Chuckling, "I'm afraid not, dear. But I have a little while
-left, enough for the story".
-
- The children settled back against the bole of a large oak,
-knowing that the old man could not be hurried.  Leaning
-forward, he began:
-
- "Long, long ago, before there were any people at all; even
-before the gods, Tamriel was chosen as a battleground by
-two -- things. It is difficult to find words that fit them
-well. I call them the Light and the Dark. Others use different
-names.  Good and Evil, Bird and Serpent, Order and Chaos. 
-None of these names really apply. It suffices that they are
-opposites, and totally antithetical.  Neither is really
-good or evil, as we know the words. They are immortal since
-they do not really live, but they do exist.  Even the gods
-and their daedric enemies are pale reflections of the eternal
-conflict between them. It's as though their struggle creates
-energies that distort their surroundings, and those energies
-are so powerful that life can appear, like an eddy in a
-stream."
+ "Long, long ago, before there were any people at all; even before the gods, Tamriel was chosen as a battleground by two -- things. It is difficult to find words that fit them well. I call them the Light and the Dark. Others use different names. Good and Evil, Bird and Serpent, Order and Chaos. None of these names really apply. It suffices that they are opposites, and totally antithetical. Neither is really good or evil, as we know the words. They are immortal since they do not really live, but they do exist. Even the gods and their daedric enemies are pale reflections of the eternal conflict between them. It's as though their struggle creates energies that distort their surroundings, and those energies are so powerful that life can appear, like an eddy in a stream."
 
  "Do demons and trolls come from the Dark, Grandpa?"
 
- "Not exactly, son.  The undead evils we know, and the demons
-that live on Oblivion tend to align with the Dark. Their
-natures are more akin to it.  Humans and the other peoples of
-Tamriel, even the misunderstood Dark Elves, are more
-aligned with the Light. Our evils are not always of the Dark,
-but some are, and these are the truly dangerous ones. Jagar
-Tharn was almost wholly aligned with the Dark, and that is
-really why he was so monstrous.  It was not because he was a
-black mage, as some would have it."
+ "Not exactly, son. The undead evils we know, and the demons that live on Oblivion tend to align with the Dark. Their natures are more akin to it. Humans and the other peoples of Tamriel, even the misunderstood Dark Elves, are more aligned with the Light. Our evils are not always of the Dark, but some are, and these are the truly dangerous ones. Jagar Tharn was almost wholly aligned with the Dark, and that is really why he was so monstrous. It was not because he was a black mage, as some would have it."
 
- "Did his magic come from the Dark, Granther?"  The girl's
-interest was piqued by mention of magic.  Her heritage is
-beginning to show itself, thought the old man.
+ "Did his magic come from the Dark, Granther?" The girl's interest was piqued by mention of magic. Her heritage is beginning to show itself, thought the old man.
 
- "No, magic power comes directly from the energies swirling
-about both entities.  These energies are impersonal and all
-mixed up.  Black magic is more a matter of intent than
-effect.  The Mages' Guild holds that a fireball, say,
-directed against a creature intent on causing harm, is not
-black magic; but the same spell directed at one seeking peace
-is.  In this, they are right. Destruction of a fire daedra
-strengthens the Light and weakens the Dark just a little.  In
-the same manner, destruction of a unicorn strengthens the
-Dark."
+ "No, magic power comes directly from the energies swirling about both entities. These energies are impersonal and all mixed up. Black magic is more a matter of intent than effect. The Mages' Guild holds that a fireball, say, directed against a creature intent on causing harm, is not black magic; but the same spell directed at one seeking peace is. In this, they are right. Destruction of a fire daedra strengthens the Light and weakens the Dark just a little. In the same manner, destruction of a unicorn strengthens the Dark."
 
- "What about the gods?  Do they come from the Light?"  The
-boy's eyes were animated, but tinged with apprehension. He
-adored stories of the gods and goddesses of Tamriel's
-pantheon, and the heroes who served them.
+ "What about the gods? Do they come from the Light?" The boy's eyes were animated, but tinged with apprehension. He adored stories of the gods and goddesses of Tamriel's pantheon, and the heroes who served them.
 
- The old man chuckled.  "The gods have an unusual origin, if
-some of the oldest tales are true.  The oldest inhabitants of
-this world -- no one seems to be sure what race they were -- had a
-system of myths that they believed in for a thousand years.
-The people of et'Ada believed for so long and so well,
-that their beliefs may, just may, have drawn upon the
-energies surrounding Tamriel to bring the gods themselves
-into being. If that is so, the conflict between the Light and
-the Dark provided the energy, and the et'Adans the structure,
-that created the gods of Tamriel.  No one really knows since
-it was so long ago and so little survives from that time. It
-no longer matters; the gods have their own existence now, and
-mostly align with the Light, except for a few who are, shall
-we say, a little ambiguous."
+ The old man chuckled. "The gods have an unusual origin, if some of the oldest tales are true. The oldest inhabitants of this world -- no one seems to be sure what race they were -- had a system of myths that they believed in for a thousand years. The people of et'Ada believed for so long and so well, that their beliefs may, just may, have drawn upon the energies surrounding Tamriel to bring the gods themselves into being. If that is so, the conflict between the Light and the Dark provided the energy, and the et'Adans the structure, that created the gods of Tamriel. No one really knows since it was so long ago and so little survives from that time. It no longer matters; the gods have their own existence now, and mostly align with the Light, except for a few who are, shall we say, a little ambiguous."
 
- "Why do we have to remember, Granther?  What is the danger
-you spoke of?  If the Light and Dark are so big and powerful,
-can we influence them?  Should we try? What should we fight
-for?"
+ "Why do we have to remember, Granther? What is the danger you spoke of? If the Light and Dark are so big and powerful, can we influence them? Should we try? What should we fight for?"
 
- "I see that your critical faculties are developing,
-Solara. That is good. The answer is simple, but quite large
-enough for mere mortals like us. The Light and Dark are
-evenly matched, and perhaps will never resolve their
-conflict.  Mortals and the beings of the Aetherius sometimes
-can perceive traces of them. Therein lies the danger; to most
-of us the Light is more congenial, even inspiring, and moves
-us to behavior that we would call good. To creatures like
-us, the Dark is  --  horrible. Those who have visions of it are
-often driven mad, and the ones who are not would be better
-dead. The Dark is to us a monstrous emptiness, an emptiness
-that sucks the soul toward it -- to be twisted, maimed, and
-ultimately destroyed.  What we can see of it seems utterly
-evil. Perhaps somewhere else this would not be so, but in our
-world, it is."
+ "I see that your critical faculties are developing, Solara. That is good. The answer is simple, but quite large enough for mere mortals like us. The Light and Dark are evenly matched, and perhaps will never resolve their conflict. Mortals and the beings of the Aetherius sometimes can perceive traces of them. Therein lies the danger; to most of us the Light is more congenial, even inspiring, and moves us to behavior that we would call good. To creatures like us, the Dark is -- horrible. Those who have visions of it are often driven mad, and the ones who are not would be better dead. The Dark is to us a monstrous emptiness, an emptiness that sucks the soul toward it -- to be twisted, maimed, and ultimately destroyed. What we can see of it seems utterly evil. Perhaps somewhere else this would not be so, but in our world, it is."
 
- The old man paused to gather his thoughts, gazing once more
-at the fresh new life of spring.
+ The old man paused to gather his thoughts, gazing once more at the fresh new life of spring.
 
- "What we must do is never to forget that the Dark is always
-there, beckoning to the weak-souled among us.  Should it gain
-ascendancy over Tamriel, through agents perverted by its
-awful attraction, terrible things could happen. All that
-we hold beautiful or desirable, even love itself, would be
-swept away. Peace and hope would be no more. For Tamriel,
-that would be the worst possible disaster. What I saw during
-Jagar's reign nearly killed me, almost destroyed my mind. 
-When he was destroyed, I thought the worst was over, but it
-was not.  The forces of the Dark are on the march again, and
-new heroes must rise to join the Eternal Champion in the fight
-against them."
+ "What we must do is never to forget that the Dark is always there, beckoning to the weak-souled among us. Should it gain ascendancy over Tamriel, through agents perverted by its awful attraction, terrible things could happen. All that we hold beautiful or desirable, even love itself, would be swept away. Peace and hope would be no more. For Tamriel, that would be the worst possible disaster. What I saw during Jagar's reign nearly killed me, almost destroyed my mind. When he was destroyed, I thought the worst was over, but it was not. The forces of the Dark are on the march again, and new heroes must rise to join the Eternal Champion in the fight against them."
 
- The old man and the two children sat in silence for several
-minutes.  Finally, the children assisted their grandfather
-to his feet, and they walked slowly away. Toward home, and
-hearth, and lunch.
-
-
-
- 
+ The old man and the two children sat in silence for several minutes. Finally, the children assisted their grandfather to his feet, and they walked slowly away. Toward home, and hearth, and lunch.

--- a/Assets/StreamingAssets/Text/Books/BOK00056-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00056-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: False
 Price: 695
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,74 +14,26 @@ Content:
 
 [/center]Thief
 
-
-
 [/font=4]
 
+ I'm a thief. Now, don't get me wrong. I ain't saying this out of pride, but I ain't ashamed of my occupation neither. Thieves got a perfect right to exist in the Empire. People say we're dishonest. Of course, those people are usually either merchants or priests, which really slays me. Sort of the snake calling the worm legless.
 
+ Rulers like us. Crime in moderation is good for the economy. The trick is to keep it at a good even pace, with a well timed lull and a minor wave to keep the fat bottoms from becoming compacent. Of course, stupid, but talented thieves will keep stealing, empty their pockets, and steal some more. This ain't good for no one. That's where the guilds come in.
 
-[/center]     I'm a thief. Now, don't get me wrong. I ain't saying this
-out of pride, but I ain't ashamed of my occupation neither.
-Thieves got a perfect right to exist in the Empire. People
-say we're dishonest. Of course, those people are usually
-either merchants or priests, which really slays me. Sort of
-the snake calling the worm legless.     Rulers like us. Crime
-in moderation is good for the economy. The trick is to keep it
-at a good even pace, with a well timed lull and a minor
-wave to keep the fat bottoms from becoming compacent. Of
-course, stupid, but talented thieves will keep stealing,
-empty their pockets, and steal some more. This ain't good
-for no one. That's where the guilds come in.     A thieves guild
-is what they call a crime regulator. We protect each other
-and punish the clumsy and greedy. The kings depend on us to
-keep the amateurs out of business.     Yeah, occasionally, a
-king will come down on us. I've even seen my Thieves
-Guildmaster get himself stuck in prison once or twice. Some
-cohort of mine said her first Guildmaster got himself hanged.
-Then the Thieves Guild has to get foul on the king, and, let
-someone who knows tell you, the results ain't pretty.     I
-got into the guild, the way I've seen most thieves do it. It
-was a few years back, when that bully Jagar Tharn was sitting
-on the throne only everyone thought he was the Emperor. My
-parents farm turned into eight acres of dust and rock, and
-they threw me and my brothers out. I was always a skinny
-thing, but by the time I made it to the closest town, I was a
-good deal more skinnier.     Just cause the town had some dirt
-that plants could grow on didn't make them that much richer
-than my folks were. I tried to get all kinds of jobs, but the
-hungrier and more raggedier I got, the quicker anyone who
-might have work would kick me out. When the rainy season
-finally came, it came like a sea, and I didn't have nowhere to
-stay. Lucky I found the unlocked cellar door.     Turns out
-that the owners of the house slept like old dogs, cause I
-robbed them blind (and tripped into things like I was the
-blind one) and they never woke up. I sold all the stuff at a
-dirty pawners I knew and spent the next two days living like a
-potentate. Then I got my first visit from the local thieves
-guild.     I remember what the guy looked like, but not
-exactly what he said. Something like, "Hey, kid, if you want to
-steal in these parts, you're going to have to join the Guild.
-Otherwise, I or someone like me is going to break your skinny
-arms so you can't steal."     I've know some people who've
-refused membership in the Guild and kept on stealing anyhow.
-I've broken someone of their arms. As for me, this was the first
-offer I'd had for a career since my pa told me that if I
-didn't milk the cow, he'd rip my head off. In comparison, this
-guy at the tavern was almost a gentleman. I agreed right
-away.     Sure, I had to prove my worth to the Guild before I
-could join and even now. But having two working arms is only
-part of the benefit. They trained me, taught me, and kept me
-out of prison. How many other guilds can boast a forgery
-expert on the premises?     So the next time you're calling
-some swindling merchant or usurious priest a thief, think
-about it. There is honor among thieves -- I should know. 
+ A thieves guild is what they call a crime regulator. We protect each other and punish the clumsy and greedy. The kings depend on us to keep the amateurs out of business.
 
-     
+ Yeah, occasionally, a king will come down on us. I've even seen my Thieves Guildmaster get himself stuck in prison once or twice. Some cohort of mine said her first Guildmaster got himself hanged. Then the Thieves Guild has to get foul on the king, and, let someone who knows tell you, the results ain't pretty.
 
+ I got into the guild, the way I've seen most thieves do it. It was a few years back, when that bully Jagar Tharn was sitting on the throne only everyone thought he was the Emperor. My parents farm turned into eight acres of dust and rock, and they threw me and my brothers out. I was always a skinny thing, but by the time I made it to the closest town, I was a good deal more skinnier.
 
+ Just cause the town had some dirt that plants could grow on didn't make them that much richer than my folks were. I tried to get all kinds of jobs, but the hungrier and more raggedier I got, the quicker anyone who might have work would kick me out. When the rainy season finally came, it came like a sea, and I didn't have nowhere to stay. Lucky I found the unlocked cellar door.
 
+ Turns out that the owners of the house slept like old dogs, cause I robbed them blind (and tripped into things like I was the blind one) and they never woke up. I sold all the stuff at a dirty pawners I knew and spent the next two days living like a potentate. Then I got my first visit from the local thieves guild.
 
+ I remember what the guy looked like, but not exactly what he said. Something like, "Hey, kid, if you want to steal in these parts, you're going to have to join the Guild. Otherwise, I or someone like me is going to break your skinny arms so you can't steal."
 
+ I've know some people who've refused membership in the Guild and kept on stealing anyhow. I've broken someone of their arms. As for me, this was the first offer I'd had for a career since my pa told me that if I didn't milk the cow, he'd rip my head off. In comparison, this guy at the tavern was almost a gentleman. I agreed right away.
 
+ Sure, I had to prove my worth to the Guild before I could join and even now. But having two working arms is only part of the benefit. They trained me, taught me, and kept me out of prison. How many other guilds can boast a forgery expert on the premises?
 
- 
+ So the next time you're calling some swindling merchant or usurious priest a thief, think about it. There is honor among thieves -- I should know.

--- a/Assets/StreamingAssets/Text/Books/BOK00057-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00057-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: False
 Price: 429
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -17,83 +16,24 @@ Content:
 
 [/center]Part I
 
-
-
 [/font=4]
 
-[/center]
+ There are over one hundred distinct kinds of vampire in Tamriel. The Iliac Bay region alone has nine variations with unique powers and abilities. I have this information not only because I have been researching this blight of the world for the last ten years of my life, but because for the seven years before that, I was one of the creatures.
 
-[/center]     There are over one hundred distinct kinds of vampire in
-Tamriel. The Iliac Bay region alone has nine variations with
-unique powers and abilities. I have this information not
-only because I have been researching this blight of the world
-for the last ten years of my life, but because for the seven
-years before that, I was one of the creatures.
+ Vampirism is a disease, like brain rot or cholera, but far, far more insidious. One can become a vampire through certain magical items or by the curse of a powerful wizard, but the most common cause is the bite or scratch of a vampire. There are no symptoms of vampirism except this -- if the victim sleeps after the attack but before he becomes a vampire, his sleep will be plagued with nightmares.
 
-     Vampirism is a disease, like brain rot or cholera, but
-far, far more insidious. One can become a vampire through
-certain magical items or by the curse of a powerful wizard,
-but the most common cause is the bite or scratch of a vampire.
-There are no symptoms of vampirism except this -- if the
-victim sleeps after the attack but before he becomes a
-vampire, his sleep will be plagued with nightmares.
+ During this two to four day period, when the disease has been spread but the victim is still mortal, most any temple healer can remove the curse of vampirism. There will be no further warning.
 
-     During this two to four day period, when the disease has
-been spread but the victim is still mortal, most any temple
-healer can remove the curse of vampirism. There will be no
-further warning.
+ I do not remember dying. I had been a scout for an order of knights which shall go nameless for this. A daughter of a local nobleman had been kidnapped by a mysterious character, and my captain had located his hideout. Deep in the dank underground chambers, I searched until I found the girl. Or what remained of her, a corpse the color of snow, drained of every drop of blood. I knew what the mystery man was right then, but he found me before I found the exit out. He took a good sized hunk out of my fighting arm before I managed to outrun him. I figured I was lucky to be alive. Some luck.
 
-     I do not remember dying. I had been a scout for an order
-of knights which shall go nameless for this. A daughter of a
-local nobleman had been kidnapped by a mysterious
-character, and my captain had located his hideout. Deep in
-the dank underground chambers, I searched until I found the
-girl. Or what remained of her, a corpse the color of snow,
-drained of every drop of blood. I knew what the mystery man
-was right then, but he found me before I found the exit out.
-He took a good sized hunk out of my fighting arm before I
-managed to outrun him. I figured I was lucky to be alive.
-Some luck.
+ My trip back to the knightly order was a five day journey. I decided to get some rest early to get my arm in better shape in case I found any more trouble. I can't remember the dreams I had that night -- only that I was doing something horrible and I couldn't stop myself. I woke up screaming. The next night, at an inn a little closer to my destination, my sleep was deep and dreamless. On the third night, I died.
 
-     My trip back to the knightly order was a five day journey.
-I decided to get some rest early to get my arm in better shape
-in case I found any more trouble. I can't remember the dreams
-I had that night -- only that I was doing something horrible
-and I couldn't stop myself. I woke up screaming. The next
-night, at an inn a little closer to my destination, my sleep
-was deep and dreamless. On the third night, I died.
+ Of course, I didn't know that I died. I had gone to sleep in a nice warm feathered bed and I woke on a cold wet stone mortuary slab. Dazed, I opened the door to the masoleum I was in, which I think must have been locked. I was in a cemetary not far from a town I knew, so I wandered in. It was late at night, so there were precious few souls in the streets. I paused to read a public notice and noticed the date. The date was two weeks later than I thought it must have been.
 
-     Of course, I didn't know that I died. I had gone to sleep
-in a nice warm feathered bed and I woke on a cold wet stone
-mortuary slab. Dazed, I opened the door to the masoleum I
-was in, which I think must have been locked. I was in a
-cemetary not far from a town I knew, so I wandered in. It
-was late at night, so there were precious few souls in the
-streets. I paused to read a public notice and noticed the
-date. The date was two weeks later than I thought it must have
-been.
+ As I puzzled over that, I saw a girl, a wench at my favorite tavern in that town, wandering toward me. I hailed her. She ignored me. I called her by her name, and she turned to me, smiling, but with an expression that told me she did not know who I was. I had visited her tavern on my way over to the mystery man's hideout, but she didn't know me!
 
-     As I puzzled over that, I saw a girl, a wench at my
-favorite tavern in that town, wandering toward me. I hailed
-her. She ignored me. I called her by her name, and she turned
-to me, smiling, but with an expression that told me she did
-not know who I was. I had visited her tavern on my way over to
-the mystery man's hideout, but she didn't know me!
+ I told her my name. She angrily told me that it was a very poor joke, that I looked nothing like the brave knight who used to visit the town, and that if I didn't know he was dead.
 
-     I told her my name. She angrily told me that it was a very
-poor joke, that I looked nothing like the brave knight who used
-to visit the town, and that if I didn't know he was dead.
+ My emotions were a tangled skein. I could tell she was not joking, that I looked nothing like myself. I was touched by her sorrow at my death, and horrified by the idea dawning on me of what I had become. Suddenly, an overriding instinct overcame all my thoughts -- hunger. Without even thinking about what I was doing, I reached out and tore her throat open. I drained her until she looked like the corpse in the mystery man's dungeon.
 
-     My emotions were a tangled skein. I could tell she was not
-joking, that I looked nothing like myself. I was touched by her
-sorrow at my death, and horrified by the idea dawning on me
-of what I had become. Suddenly, an overriding instinct
-overcame all my thoughts -- hunger. Without even thinking
-about what I was doing, I reached out and tore her throat
-open. I drained her until she looked like the corpse in the
-mystery man's dungeon.
-
-     The rest of my story is told in Vampires of the Bay,
-Chapter II.
-
- 
+ The rest of my story is told in Vampires of the Bay, Chapter II.

--- a/Assets/StreamingAssets/Text/Books/BOK00058-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00058-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: False
 Price: 429
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -17,94 +16,27 @@ Content:
 
 [/center]Part II
 
-
-
 [/font=4]
+ I told in the first chapter of my story how I became a vampire and of my first kill. While it might (and, indeed, should) horrify the reader that my first victim was a friend of the mortal I used to be, it is my understanding that they are not uncommon first kills.
 
-[/center]
+ I left the snow white corpse in the alley and ran to the only place I felt perversely safe, the masoleum. For the first couple days of my undeath, I starved myself while I considered my fate. I relearned what I was capable of doing, and found that I was stronger, faster, tougher, and more agile than before. I had powers that as a knight I had only seen powerful mages wield. Later, I discovered additional abilities, such as a total immunity to disease. Helpful when descending on a plague-stricken city like a jackal.
 
-[/center]     I told in the first chapter of my story how I became a
-vampire and of my first kill. While it might (and, indeed,
-should) horrify the reader that my first victim was a friend
-of the mortal I used to be, it is my understanding that they
-are not uncommon first kills.
+ I also found my weaknesses. I could no longer stand the light of the sun -- exposure to it for longer than a few seconds burned me terribly. It also pained me to enter temples and other places of worship. The worst effect, of course, had to be my blood lust. If I did not kill a warm blooded creature once a night and drink its blood, my hunger would gnaw at me, and any wounds I suffered would not heal no matter how much I rested.
 
-     I left the snow white corpse in the alley and ran to the
-only place I felt perversely safe, the masoleum. For the
-first couple days of my undeath, I starved myself while I
-considered my fate. I relearned what I was capable of
-doing, and found that I was stronger, faster, tougher, and
-more agile than before. I had powers that as a knight I had
-only seen powerful mages wield. Later, I discovered
-additional abilities, such as a total immunity to disease.
-Helpful when descending on a plague-stricken city like a
-jackal.
+ Is this the moment for me to admit that there was a time I loved being a bloodsucking creature of the night? It is not impossible to live only at night, merely occasionally inconvenient. And I wouldn't have to kill humans every night, merely warm-blooded creatures. Orcs have a delicious, rich brothy blood; rats are a little sweet for the only meal of the night; werewolves are a real treat, almost decadent the tincture between human and beast. A real gourmet's delight.
 
-     I also found my weaknesses. I could no longer stand the
-light of the sun -- exposure to it for longer than a few
-seconds burned me terribly. It also pained me to enter
-temples and other places of worship. The worst effect, of
-course, had to be my blood lust. If I did not kill a warm
-blooded creature once a night and drink its blood, my hunger
-would gnaw at me, and any wounds I suffered would not heal
-no matter how much I rested.
+ About a month after I died, I was having the best time of my life. One night, I received a letter from someone who said he was "family." Curious, I went to visit him at his tavern, and was told about the tribe of vampires to which I belonged -- the Montalion. In return for me performing certain duties for the "family," the man at the inn would train my in my vampiric abilities and skills.
 
-     Is this the moment for me to admit that there was a time I
-loved being a bloodsucking creature of the night? It is not
-impossible to live only at night, merely occasionally
-inconvenient. And I wouldn't have to kill humans every
-night, merely warm-blooded creatures. Orcs have a
-delicious, rich brothy blood; rats are a little sweet for the
-only meal of the night; werewolves are a real treat, almost
-decadent the tincture between human and beast. A real
-gourmet's delight.
+ Though I never got very much detail, I surmised that the two main differences between the different vampire clans is geography and powers. Montalion alone have the gift for teleportation, but the other eight have powers of their own.
 
-     About a month after I died, I was having the best time of
-my life. One night, I received a letter from someone who
-said he was "family." Curious, I went to visit him at his
-tavern, and was told about the tribe of vampires to which I
-belonged -- the Montalion. In return for me performing
-certain duties for the "family," the man at the inn would
-train my in my vampiric abilities and skills.
+ My mentor (that is the title he used) would congratulate me after each mission I performed, and came to trust me more and more. If asked, he would tell me about the Montalion's newest alliances, who they were manipulating, who they were stalking. It was then I started to become frightened at last. They, and all of their rival clans, were draining the blood of Tamriel itself.
 
-     Though I never got very much detail, I surmised that the
-two main differences between the different vampire clans is
-geography and powers. Montalion alone have the gift for
-teleportation, but the other eight have powers of their own. 
+ I panicked. I had to find a cure. But nowhere could I find any book or rumor suggesting that vampirism is anything but permanent. So I resolved to kill myself, but I wanted to bring the Montalion down with me. I joined guilds they opposed, and failed any mission given to me spectacularly. I thought my mentor would turn against me, but he only became quieter, less forthcoming with information, never violent. He was not concerned. He had probably seen vampires like me before.
 
-     My mentor (that is the title he used) would congratulate
-me after each mission I performed, and came to trust me more
-and more. If asked, he would tell me about the Montalion's
-newest alliances, who they were manipulating, who they were
-stalking. It was then I started to become frightened at
-last. They, and all of their rival clans, were draining the
-blood of Tamriel itself.
+ Here's why he never attacked me: immortals can afford to be eternally patient.
 
-     I panicked. I had to find a cure. But nowhere could I find
-any book or rumor suggesting that vampirism is anything but
-permanent. So I resolved to kill myself, but I wanted to
-bring the Montalion down with me. I joined guilds they
-opposed, and failed any mission given to me
-spectacularly. I thought my mentor would turn against me,
-but he only became quieter, less forthcoming with
-information, never violent. He was not concerned. He had
-probably seen vampires like me before.
+ At last, he refused to give me any further missions. He wouldn't even talk with me, but he never left his tavern. I could come and go, and he'd watch but never talk. That's when I got another letter.
 
-     Here's why he never attacked me: immortals can afford to be
-eternally patient.
+ There are several of us, you see, former vampires who know what to look for. We're patient too: we learned it in our unlife. We watch and listen, and anonymously contact the vampires we know wish to end the curse.
 
-     At last, he refused to give me any further missions. He
-wouldn't even talk with me, but he never left his tavern. I
-could come and go, and he'd watch but never talk. That's
-when I got another letter.
-
-     There are several of us, you see, former vampires who know
-what to look for. We're patient too: we learned it in our
-unlife. We watch and listen, and anonymously contact the
-vampires we know wish to end the curse.
-
-     Ending the curse is possible, but only just. It is very
-dangerous, but when you are cursed, the only real danger is
-no escape.
-
- 
+ Ending the curse is possible, but only just. It is very dangerous, but when you are cursed, the only real danger is no escape.

--- a/Assets/StreamingAssets/Text/Books/BOK00059-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00059-LOC.txt
@@ -3,9 +3,8 @@ Author: Stem Gamboge, scribe
 IsNaughty: False
 Price: 406
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,73 +14,18 @@ Content:
 
 [/center]Vol. I
 
-
-
 [/font=4]
 
+ Late in the Second Era an heir, a girl child, Barenziah, was born to the rulers of Mournhold in Morrowind. She was reared in all the luxury and security befitting a royal dark elf child until she reached five years of age. At that time, His Excellency Tiber Septim demanded that the decadent rulers of Morrowind yield to him and institute Imperial reforms. Trusting to their vaunted magic, they impudently refused and much of Morrowind was laid waste in the conflict that ensued.
 
+ The little Princess Barenziah and her nurse were found among the wreckage. General Symmachus, himself a dark elf and born in Mournhold, suggested to His Excellency that the child might someday be valuable, and she was placed with a loyal supporter who had recently retired from the Imperial army. On retirement, Sven Advensen had been made Baron of Blackmoor, a small town in central Skyrim. Baron Sven and his wife reared her as their own daughter, saw to it that she was educated appropriately, and more importantly, was taught the Imperial virtues and piety. In short, she was made fit to take her place as a member of the new ruling class of Morrowind.
 
-[/center]      Late in the Second Era an heir, a girl child, Barenziah,
-was born to the rulers of Mournhold in Morrowind. She was
-reared in all the luxury and security befitting a royal
-dark elf child until she reached five years of age. At that
-time, His Excellency Tiber Septim demanded that the decadent
-rulers of Morrowind yield to him and institute Imperial
-reforms. Trusting to their vaunted magic, they impudently
-refused and much of Morrowind was laid waste in the conflict
-that ensued.
+ The girl Barenziah grew in beauty, grace, and intelligence. She was very sweet-tempered, a joy to her adoptive parents and their five young sons, who loved her as their elder sister. Other than her appearance, she differed from young girls of her class only in that she had a strong empathy for the woods and fields, and was wont to escape her household duties to wander there.
 
-      The little Princess Barenziah and her nurse were found
-among the wreckage. General Symmachus, himself a dark elf
-and born in Mournhold, suggested to His Excellency that the
-child might someday be valuable, and she was placed with a
-loyal supporter who had recently retired from the Imperial
-army. On retirement, Sven Advensen had been made Baron of
-Blackmoor, a small town in central Skyrim. Baron Sven and
-his wife reared her as their own daughter, saw to it that she
-was educated appropriately, and more importantly, was
-taught the Imperial virtues and piety. In short, she was
-made fit to take her place as a member of the new ruling
-class of Morrowind.
+ Barenziah was happy and content until her sixteenth year, when a wicked orphan stable boy whom she had befriended out of pity told her that he had overheard a conspiracy of her dear guardian. Baron Sven, said the boy, had dealt with a Redguard visitor to sell her as a concubine in Rihad, as no Nord or Breton would marry her on account of her black skin, and no dark elf would have her because of her foreign upbringing.
 
-     The girl Barenziah grew in beauty, grace, and
-intelligence. She was very sweet-tempered, a joy to her
-adoptive parents and their five young sons, who loved her as
-their elder sister. Other than her appearance, she differed
-from young girls of her class only in that she had a strong
-empathy for the woods and fields, and was wont to escape her
-household duties to wander there.
+ "Whatever shall I do?" the poor girl wept, trembling, for she had been brought up in innocence and trust, and it never occured to her that her friend would lie to her.
 
-     Barenziah was happy and content until her sixteenth year,
-when a wicked orphan stable boy whom she had befriended out of
-pity told her that he had overheard a conspiracy of her dear
-guardian. Baron Sven, said the boy, had dealt with a
-Redguard visitor to sell her as a concubine in Rihad, as no
-Nord or Breton would marry her on account of her black skin,
-and no dark elf would have her because of her foreign
-upbringing.
+ The wicked boy, who was called Straw, said she must run away if she valued her virtue, but he would come with her and protect her. Sorrowfully, Barenziah agreed to this plan and that very night, Barenziah disguised herself as a boy and the pair escaped to the nearby city of Whiterun. After a few days there, they managed to get places as guards in a disreputable merchant caravan. The caravan was heading east by side roads in a dishonest attempt to elude the lawful tolls charged on the highway. Thus they eluded pursuit until they reached the city of Rifton, where they ceased their travels. They felt safe in Rifton, close as they were to the Morrowind border so dark elves were commonly seen.
 
-     "Whatever shall I do?" the poor girl wept, trembling,
-for she had been brought up in innocence and trust, and it
-never occured to her that her friend would lie to her.
-
-     The wicked boy, who was called Straw, said she must run
-away if she valued her virtue, but he would come with her and
-protect her. Sorrowfully, Barenziah agreed to this plan
-and that very night, Barenziah disguised herself as a boy and
-the pair escaped to the nearby city of Whiterun. After a few
-days there, they managed to get places as guards in a
-disreputable merchant caravan. The caravan was heading
-east by side roads in a dishonest attempt to elude the
-lawful tolls charged on the highway. Thus they eluded pursuit
-until they reached the city of Rifton, where they ceased their
-travels. They felt safe in Rifton, close as they were to the
-Morrowind border so dark elves were commonly seen.
-
-     The story of how Barenziah finally came to the throne of
-Mournhold after this fitful start is told in Volume II of
-the Biography of Queen Barenziah.
-
-
-
-
+ The story of how Barenziah finally came to the throne of Mournhold after this fitful start is told in Volume II of the Biography of Queen Barenziah.

--- a/Assets/StreamingAssets/Text/Books/BOK00060-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00060-LOC.txt
@@ -3,9 +3,8 @@ Author: Stem Gamboge
 IsNaughty: False
 Price: 406
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,67 +14,16 @@ Content:
 
 [/center]Vol. II
 
-
-
 [/font=4]
 
+ The first volume of this series told the story of Barenziah's origin, heiress of the throne of Mournhold until her father king rebelled against His Excellency Tiber Septim and brought ruin to the province of Morrowind. Due to the benevolence of the Emperor, the child Barenziah was not destroyed with her parents, but reared by the Baron Sven of Blackmoor. She grew beautiful, pious, and trusting in his care. This trust was exploited by a wicked orphan stable boy at Baron Sven's estate, who with lies, tricked her into fleeing Blackmoor with him. After many adventures on the road, they settled in Rifton, a Skyrim city on the border of Morrowind.
 
+ The stable boy Straw was not altogether evil. He did love Barenziah in his own selfish fashion, and the lie was the only way he could think of that he might have her. She, of course, felt only friendship for him, but he was hopeful that she would change her mind. He wanted to buy a small farm and settle down in marriage, but his earnings were barely enough to feed and shelter them.
 
-[/center]     The first volume of this series told the story of
-Barenziah's origin, heiress of the throne of Mournhold until
-her father king rebelled against His Excellency Tiber Septim
-and brought ruin to the province of Morrowind. Due to the
-benevolence of the Emperor, the child Barenziah was not
-destroyed with her parents, but reared by the Baron Sven of
-Blackmoor. She grew beautiful, pious, and trusting in his
-care. This trust was exploited by a wicked orphan stable boy
-at Baron Sven's estate, who with lies, tricked her into
-fleeing Blackmoor with him. After many adventures on the
-road, they settled in Rifton, a Skyrim city on the border of
-Morrowind.
+ After only a short time in Rifton, Straw fell in with a bold villian of a Khajiit thief named Therris, who proposed that they rob the Imperial commandant's house. Therris said that he had a client, a traitor to the Empire, who would pay well for the information they would find there. Barenziah happened to overhear this plan and was appalled. She stole from their rooms and walked the streets of Rifton in desperation, torn between loyalty to the Empire and to her friend.
 
-     The stable boy Straw was not altogether evil. He did love
-Barenziah in his own selfish fashion, and the lie was the only
-way he could think of that he might have her. She, of course,
-felt only friendship for him, but he was hopeful that she
-would change her mind. He wanted to buy a small farm and
-settle down in marriage, but his earnings were barely enough
-to feed and shelter them.
+ In the end, loyalty to the Empire prevailed over personal friendship, and she approached the commandant's house, revealed her true identity and warned him of her friends' plan. The commandant listened to her tale, praised her courage and assured her that no harm would come to her.
 
-     After only a short time in Rifton, Straw fell in with a
-bold villian of a Khajiit thief named Therris, who proposed
-that they rob the Imperial commandant's house. Therris said
-that he had a client, a traitor to the Empire, who would pay
-well for the information they would find there. Barenziah
-happened to overhear this plan and was appalled. She stole
-from their rooms and walked the streets of Rifton in
-desperation, torn between loyalty to the Empire and to her
-friend.
+ General Symmachus had been scouring the countryside in search of her since her disappearance had just arrived in Rifton, hot in pursuit. He took her into his custody, and informed her that, far from being sold, she was to be instated as Queen of Mournhold as soon as she turned eighteen. Until that time, she was to live with the Imperial family in the new Imperial City, where she would learn something of Imperial government and make the acquaintance of people of importance.
 
-     In the end, loyalty to the Empire prevailed over
-personal friendship, and she approached the commandant's
-house, revealed her true identity and warned him of her
-friends' plan. The commandant listened to her tale, praised
-her courage and assured her that no harm would come to her.
-
-     General Symmachus had been scouring the countryside in
-search of her since her disappearance had just arrived in
-Rifton, hot in pursuit. He took her into his custody, and
-informed her that, far from being sold, she was to be
-instated as Queen of Mournhold as soon as she turned
-eighteen. Until that time, she was to live with the Imperial
-family in the new Imperial City, where she would learn
-something of Imperial government and make the acquaintance
-of people of importance.
-
-     And so it came to pass. In the Imperial City, Barenziah
-became great friends with Tiber Septim during the last years
-of his reign; Tiber's heir Pelagius also came to love her as a
-sister. The ballads of the day praised her beauty, chastity,
-wit, and learning. On her eighteenth birthday, the entire
-Imperial City turned out to watch her procession back to
-Mournhold. Sorrowful as they were at her departure, all
-knew that she was ready to be the glorious sovereign of the
-new kingdom of Mournhold.
-
- 
+ And so it came to pass. In the Imperial City, Barenziah became great friends with Tiber Septim during the last years of his reign; Tiber's heir Pelagius also came to love her as a sister. The ballads of the day praised her beauty, chastity, wit, and learning. On her eighteenth birthday, the entire Imperial City turned out to watch her procession back to Mournhold. Sorrowful as they were at her departure, all knew that she was ready to be the glorious sovereign of the new kingdom of Mournhold.

--- a/Assets/StreamingAssets/Text/Books/BOK00061-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00061-LOC.txt
@@ -3,9 +3,8 @@ Author: Odiva Gallwood
 IsNaughty: False
 Price: 358
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -17,126 +16,28 @@ Content:
 
 [/center]Daggerfall
 
-
-
 [/font=4]
 
-[/center]
+ There is sufficient archaeological evidence for the modern historian to believe that there has been some variety of human settlement in the city-state of Daggerfall starting at least a thousand years before recorded history. The first use of the name Daggerfall to refer to the area around the current capitol was most probably in the 246th year of the 1st Era. The north half of the Iliac Bay, in fact all of the current province of High Rock, was conquered by invading Nords who brought a rough sort of civilization with them. One of the first civilized acts the Nords performed was a census -- the so-called Book of Life. Listed on page 933 of the Book is this entry:
 
-[/center]   There is sufficient archaeological evidence for the modern
-historian to believe that there has been some variety of
-human settlement in the city-state of Daggerfall starting
-at least a thousand years before recorded history. The first
-use of the name Daggerfall to refer to the area around the
-current capitol was most probably in the 246th year of the
-1st Era. The north half of the Iliac Bay, in fact all of the
-current province of High Rock, was conquered by invading
-Nords who brought a rough sort of civilization with them. One
-of the first civilized acts the Nords performed was a census
--- the so-called Book of Life. Listed on page 933 of the Book
-is this entry:
+ "North of the Highest bluffs, south of the moors, west of the hills, and east of the sea is called DAGGERFALL. 110 men, 93 women, 13 children under 8 years of age, 58 cows, 7 bulls, 63 chickens, 11 cocks, 38 hogs live here."
 
- "North of the Highest bluffs, south of the moors, west of the
-hills, and east of the sea is called DAGGERFALL. 110 men, 93
-women, 13 children under 8 years of age, 58 cows, 7 bulls,
-63 chickens, 11 cocks, 38 hogs live here."
+ Nearly four thousand years after this census was taken, we can see that these two hundred and sixteen people have multiplied heartily. The last census, in the year 3E 401, lists the population at over 110,000. It is always difficult to find an exact number, but the capitol city of Daggerfall certainly outnumbers her rivals, Sentinel and Wayrest.
 
-   Nearly four thousand years after this census was taken, we
-can see that these two hundred and sixteen people have
-multiplied heartily. The last census, in the year 3E 401,
-lists the population at over 110,000. It is always difficult
-to find an exact number, but the capitol city of
-Daggerfall certainly outnumbers her rivals, Sentinel and
-Wayrest.
+ It has been a consistant, if not actually helpful amusement of historians to find the origin of placenames. Daggerfall, by tradition, is said to refer to the knife the first chieftain threw to form the borders of his lands. But there are other legends that may have equal validity.
 
-   It has been a consistant, if not actually helpful
-amusement of historians to find the origin of placenames.
-Daggerfall, by tradition, is said to refer to the knife the
-first chieftain threw to form the borders of his lands. But
-there are other legends that may have equal validity.
+ The Daggerfall entry from the Book of Life actually supports one theory about the reason for Daggerfall's longevity. The people were coastal fishermen, but they also found the land itself sufficiently rich to support raising livestock. This inclination of the early citizenry toward reinforcing their principal products brought stability to a fickle land.
 
-   The Daggerfall entry from the Book of Life actually
-supports one theory about the reason for Daggerfall's
-longevity. The people were coastal fishermen, but they also
-found the land itself sufficiently rich to support raising
-livestock. This inclination of the early citizenry toward
-reinforcing their principal products brought stability to
-a fickle land.
+ Daggerfall thrived during the years of the Skyrim occupancy. When the Wild Hunt killed King Borgas of Winterhold in 1E 369, the northlands engaged in the War of Succession and Skyrim, greatly weakened, lost her holdings in High Rock and Morrowind. The Iliac Bay had become important strategically, and Daggerfall began to expand her military.
 
-   Daggerfall thrived during the years of the Skyrim
-occupancy. When the Wild Hunt killed King Borgas of
-Winterhold in 1E 369, the northlands engaged in the War of
-Succession and Skyrim, greatly weakened, lost her holdings in
-High Rock and Morrowind. The Iliac Bay had become important
-strategically, and Daggerfall began to expand her
-military.
+ There were multiple opportunities for her to exercise this army and navy during the Direnni conflicts with the force of the Alessian Reform. The Dirennis were native Bretons, and Bretons are hardly ever given to excessive religion. Daggerfall became a minor base of operations for the Dirennis and their allies. Raven Direnni, the enchantress whose magic helped secure the final victory over the Alessians in the Glenumbria Moors, was one of the earliest occupants of Castle Daggerfall.
 
-   There were multiple opportunities for her to exercise this
-army and navy during the Direnni conflicts with the force of
-the Alessian Reform. The Dirennis were native Bretons, and
-Bretons are hardly ever given to excessive religion.
-Daggerfall became a minor base of operations for the
-Dirennis and their allies. Raven Direnni, the enchantress
-whose magic helped secure the final victory over the
-Alessians in the Glenumbria Moors, was one of the earliest
-occupants of Castle Daggerfall.
+ Over the centuries that followed, the Dirennis felt into obscurity, but Daggerfall continued her growth. In 1E 609, King Thagore of Daggerfall defeated the army of Glenpoint and became the preeminant economic, cultural, and military force in southern High Rock. A position the kingdom has precariously kept ever since.
 
-   Over the centuries that followed, the Dirennis felt into
-obscurity, but Daggerfall continued her growth. In 1E 609,
-King Thagore of Daggerfall defeated the army of Glenpoint
-and became the preeminant economic, cultural, and
-military force in southern High Rock. A position the kingdom has
-precariously kept ever since.
+ Ironically, it was another successful military exercise three hundred and seventy years later that ended Daggerfall's monopoly of Bay trade: the annihilation of the orcish capitol Orsinium by a joint effort of Daggerfall, the new kingdom of Sentinel, and the now extinct Order of Diagna. The scattering of the orcs from southeastern High Rock made the river route to the Bay more accessible. The tiny village of Wayrest grew like a flower that no longer feared the mow. In twenty years, Wayrest's trade profits equalled Daggerfall's. In forty years, Wayrest was the acknowledged master of Iliac Bay trade. In one hundred and twenty years, Wayrest became the Kingdom of Wayrest.
 
-   Ironically, it was another successful military exercise
-three hundred and seventy years later that ended
-Daggerfall's monopoly of Bay trade: the annihilation of the
-orcish capitol Orsinium by a joint effort of Daggerfall,
-the new kingdom of Sentinel, and the now extinct Order of
-Diagna. The scattering of the orcs from southeastern High Rock
-made the river route to the Bay more accessible. The tiny
-village of Wayrest grew like a flower that no longer feared
-the mow. In twenty years, Wayrest's trade profits equalled
-Daggerfall's. In forty years, Wayrest was the acknowledged
-master of Iliac Bay trade. In one hundred and twenty years,
-Wayrest became the Kingdom of Wayrest.
+ The Kingdom of Sentinel did not exhibit Wayrest's aggrandizement during the First Era. The Redguards were warriors learning the ways of the merchants, and their land was enemy enough to keep their population checked. Indeed, the number of people in all areas of the Iliac Bay was halved once in the First Era by the Thrassian Plague, once again by the War of Righteousness, and a third time by the invading Akavari. If Daggerfall had not spent its first thousand years preparing for the battles of the next thousand years, it is indeed conceivable that the Iliac Bay today might be Akavarian.
 
-   The Kingdom of Sentinel did not exhibit Wayrest's
-aggrandizement during the First Era. The Redguards were
-warriors learning the ways of the merchants, and their land
-was enemy enough to keep their population checked. Indeed,
-the number of people in all areas of the Iliac Bay was
-halved once in the First Era by the Thrassian Plague, once
-again by the War of Righteousness, and a third time by the
-invading Akavari. If Daggerfall had not spent its first
-thousand years preparing for the battles of the next
-thousand years, it is indeed conceivable that the Iliac Bay
-today might be Akavarian.
+ The Second Era, like the latter part of the First Era, is a tapestry of wars, insurrections, and plagues. Daggerfall, Sentinel, and Wayrest continued to expand and improve their military and economic positions in the Bay. Daggerfall and Wayrest would transpose positions as major trading center of the Bay, and Daggerfall and Sentinel likewise bandied over which was the superior military power.
 
-   The Second Era, like the latter part of the First Era, is a
-tapestry of wars, insurrections, and plagues. Daggerfall,
-Sentinel, and Wayrest continued to expand and improve
-their military and economic positions in the Bay.
-Daggerfall and Wayrest would transpose positions as major
-trading center of the Bay, and Daggerfall and Sentinel
-likewise bandied over which was the superior military power.
-
-   The Iliac Bay has continued to hold an important position
-in the Imperial government of the Third Era. Rarely allies
-(though the combined armies in opposition to the Camoran
-Usurper in the 3rd century of the 3rd Era is a notable
-exception), but not always enemies, Daggerfall, Sentinel,
-and Wayrest have weathered the storms of contention,
-plague, famine, and pestilence. The recent War of Betony was
-typical of Iliac Bay warfare: sincere, frighteningly
-violent, and peaceably resolved.
-
-
-
-
-
-
-
-
-
-
+ The Iliac Bay has continued to hold an important position in the Imperial government of the Third Era. Rarely allies (though the combined armies in opposition to the Camoran Usurper in the 3rd century of the 3rd Era is a notable exception), but not always enemies, Daggerfall, Sentinel, and Wayrest have weathered the storms of contention, plague, famine, and pestilence. The recent War of Betony was typical of Iliac Bay warfare: sincere, frighteningly violent, and peaceably resolved.

--- a/Assets/StreamingAssets/Text/Books/BOK00062-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00062-LOC.txt
@@ -3,9 +3,8 @@ Author: Bibenus Geon
 IsNaughty: False
 Price: 770
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -17,73 +16,22 @@ Content:
 
 [/center]Crystal Tower
 
-
-
 [/font=4]
 
-[/center]
+ This story was first told to me when I was a neonate, newly studying in the Crystal Tower of Sumurset. I was admiring the famous animal pens of the Tower when I was approached by an older student. The fellow who told me this tale seemed very trustworthy at first, but, as the reader will soon discover, the tale is very dubious indeed. Of course, I have told it since to other neonates of the Tower in the same spirit.
 
-[/center]    This story was first told to me when I was a neonate, newly
-studying in the Crystal Tower of Sumurset. I was admiring
-the famous animal pens of the Tower when I was approached by
-an older student. The fellow who told me this tale seemed
-very trustworthy at first, but, as the reader will soon
-discover, the tale is very dubious indeed. Of course, I have
-told it since to other neonates of the Tower in the same
-spirit.
+ I offer the following for your august consideration, gentle reader.
 
-    I offer the following for your august consideration,
-gentle reader.
+ Many, many years back, a talented but poor bard was passing through Sumurset, looking for work. He could sing, he could dance, he could act, but no one had any use for his performances. The poor bard was lugubrious, but he still visited the taverns and palaces, day after day, begging for a chance to showcase his talents.
 
-    Many, many years back, a talented but poor bard was
-passing through Sumurset, looking for work. He could sing, he
-could dance, he could act, but no one had any use for his
-performances. The poor bard was lugubrious, but he still
-visited the taverns and palaces, day after day, begging for
-a chance to showcase his talents.
+ One day, dejected from more bad luck, he was approached by a tall elf in a long robe. A Magister of the Crystal Tower, in charge of the animal pens. The elf tells the bard of the white ape they made a cell for at the Tower, how it had died en route. There was a royal party from Firsthold visiting who had been promised a glimpse at the rare white ape. The Magister had a costume for the bard if he would deign to act out the part of the ape for the visitors. The bard had promised himself to take the first part that came his way, no matter how minor, so he agreed. The elf promised that the charade would last no longer than a fortnight, when the visitors left.
 
-    One day, dejected from more bad luck, he was approached by
-a tall elf in a long robe. A Magister of the Crystal Tower,
-in charge of the animal pens. The elf tells the bard of the
-white ape they made a cell for at the Tower, how it had died
-en route. There was a royal party from Firsthold visiting
-who had been promised a glimpse at the rare white ape. The
-Magister had a costume for the bard if he would deign to act
-out the part of the ape for the visitors. The bard had
-promised himself to take the first part that came his way, no
-matter how minor, so he agreed. The elf promised that the
-charade would last no longer than a fortnight, when the
-visitors left.
+ For the first several days of the masquerade, the bard did nothing more than sit in the back of the pen. He was afraid to move and show the possible imperfections of the ape costume. In time, he became bored and began walking around. He suddenly noticed that the royal party was watching, fascinated. Happy that the ruse was working, he decided to enliven the act.
 
-    For the first several days of the masquerade, the bard did
-nothing more than sit in the back of the pen. He was afraid to
-move and show the possible imperfections of the ape costume.
-In time, he became bored and began walking around. He
-suddenly noticed that the royal party was watching,
-fascinated. Happy that the ruse was working, he decided to
-enliven the act.
+ Soon he had both a performance and a crowd. Instead of dancing a traditional elven jig, he would swing around the cell with every acrobatic trick he knew. Instead of singing a ballad, he would roar a roar he imagined a rare white ape might roar. The crowd loved it. The party outside his cell grew larger and larger every day.
 
-    Soon he had both a performance and a crowd. Instead of
-dancing a traditional elven jig, he would swing around the
-cell with every acrobatic trick he knew. Instead of singing a
-ballad, he would roar a roar he imagined a rare white ape
-might roar. The crowd loved it. The party outside his cell
-grew larger and larger every day.
+ One day, he was performing for the crowd -- his finest work to date. He swung himself round and round, roaring and bleating. His hand slipped and he went flying through the bar and into the cell next door, where a Snow Wolf was in residence. Hackling its back and growling, the Snow Wolf began to inch toward the bard.
 
-    One day, he was performing for the crowd -- his finest work
-to date. He swung himself round and round, roaring and
-bleating. His hand slipped and he went flying through the bar
-and into the cell next door, where a Snow Wolf was in
-residence. Hackling its back and growling, the Snow Wolf
-began to inch toward the bard.
+ Seeing no other way out, the bard screamed, "Help! Help!"
 
-    Seeing no other way out, the bard screamed, "Help! Help!"
-
-    The Snow Wolf whispered, "Shut up or you'll get us all
-fired."
-
-    
-
-
-
- 
+ The Snow Wolf whispered, "Shut up or you'll get us all fired."

--- a/Assets/StreamingAssets/Text/Books/BOK00063-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00063-LOC.txt
@@ -3,9 +3,8 @@ Author: Brother Hetchfeld
 IsNaughty: False
 Price: 711
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -19,90 +18,22 @@ Content:
 
 [/center]In Tamriel
 
-
-
 [/font=4]
 
-[/center]
+ Editor's Note: Brother Hetchfeld is an Associate Scribe at the Imperial University, Office of Introductory Studies
 
-[/center] Editor's Note: Brother Hetchfeld is an Associate Scribe at the
-Imperial University, Office of Introductory Studies
+ Gods are commonly viewed by the evidence of their interest in worldly matters. A central belief in the active participation of Deities in mundane matters can be challenged by the evidence of apathy on the part of Gods during times of plague or famine.
 
- Gods are commonly viewed by the evidence of their interest in
-worldly matters. A central belief in the active
-participation of Deities in mundane matters can be
-challenged by the evidence of apathy on the part of Gods
-during times of plague or famine.
+ From intervention in legendary quests to manifestations in common daily life, no pattern for the Gods of Tamriel activities is readily apparent. The concerns of Gods in many ways may seem unrelated or at best unconcerned with the daily trials of the mortal realm. The exceptions do exist, however.
 
- From intervention in legendary quests to manifestations in
-common daily life, no pattern for the Gods of Tamriel
-activities is readily apparent. The concerns of Gods in
-many ways may seem unrelated or at best unconcerned with the
-daily trials of the mortal realm. The exceptions do exist,
-however.
+ Many historical records and legends point to the direct intervention of one or more gods at times of great need. Many heroic tales recount blessings of the divinity bestowed upon heroic figures who worked or quested for the good of a Deity or the Deity's temple. Some of the more powerful artifacts in the known world were originally bestowed upon their owners through such reward. It has also been reported that priests of high ranking in their temples may on occasion call upon their Deity for blessings or help in time of need. The exact nature of such contact and the blessings bestowed is given to much speculation, as the temples hold such associations secret and holy. This direct contact gives weight to the belief that the Gods are aware of the mortal realm. In many circumstances, however, these same Gods will do nothing in the face of suffering and death, seeming to feel no need to interfere. It is thus possible to conclude that we, as mortals, may not be capable of understanding more than a small fraction of the reasoning and logic such beings use.
 
- Many historical records and legends point to the direct
-intervention of one or more gods at times of great need.
-Many heroic tales recount blessings of the divinity
-bestowed upon heroic figures who worked or quested for the
-good of a Deity or the Deity's temple. Some of the more
-powerful artifacts in the known world were originally
-bestowed upon their owners through such reward.   It has also
-been reported that priests of high ranking in their temples
-may on occasion call upon their Deity for blessings or help
-in time of need. The exact nature of such contact and the
-blessings bestowed is given to much speculation, as the
-temples hold such associations secret and holy. This direct
-contact gives weight to the belief that the Gods are aware of
-the mortal realm. In many circumstances, however, these same
-Gods will do nothing in the face of suffering and death,
-seeming to feel no need to interfere. It is thus possible to
-conclude that we, as mortals, may not be capable of
-understanding more than a small fraction of the reasoning
-and logic such beings use.
+ One defining characteristic of all Gods and Goddesses is their interest in worship and deeds. Deeds in the form of holy quests are just one of the many things that bring the attention of a Deity. Deeds in everyday life, by conforming to the statutes and obligations of individual temples are commonly supposed to please a Deity. Performance of ceremony in a temple may also bring a Deity's attention. Ceremonies vary according to the individual Deity. The results are not always apparent but sacrifice and offerings are usually required to have any hope of gaining a Deity's attention.
 
- One defining characteristic of all Gods and Goddesses is
-their interest in worship and deeds. Deeds in the form of holy
-quests are just one of the many things that bring the
-attention of a Deity. Deeds in everyday life, by conforming
-to the statutes and obligations of individual temples are
-commonly supposed to please a Deity. Performance of
-ceremony in a temple may also bring a Deity's attention.
-Ceremonies vary according to the individual Deity. The
-results are not always apparent but sacrifice and offerings
-are usually required to have any hope of gaining a Deity's
-attention.
+ While direct intervention in daily temple life has been recorded, the exact nature of the presence of a God in daily mundane life is up to great speculation. A traditional saying of the Wood Elves goes "One mans miracle is another mans accident." While some gods are believed to take an active part of daily life, others are well known for their lack of interest in temporal affairs.
 
- While direct intervention in daily temple life has been
-recorded, the exact nature of the presence of a God in daily
-mundane life is up to great speculation. A traditional
-saying of the Wood Elves goes "One mans miracle is another
-mans accident." While some gods are believed to take an
-active part of daily life, others are well known for their
-lack of interest in temporal affairs.
+ It has been theorized that gods do in fact gain strength from such things as worship through praise, sacrifice and deed. It may even be theorized that the number of worshippers a given Deity has may reflect on His overall position among the other Gods. This my own conjecture, garnered from the apparent ability of the larger temples to attain blessings and assistance from their God with greater ease than smaller religious institutions.
 
- It has been theorized that gods do in fact gain strength from
-such things as worship through praise, sacrifice and deed. It
-may even be theorized that the number of worshippers a given
-Deity has may reflect on His overall position among the
-other Gods. This my own conjecture, garnered from the
-apparent ability of the larger temples to attain blessings
-and assistance from their God with greater ease than smaller
-religious institutions.
+ There are reports of the existence of spirits in our world that have the same capacity to use the actions and deeds of mortals to strengthen themselves as do the Gods. The understanding of the exact nature of such creatures would allow us to understand with more clarity the connection between a Deity and the Deity's worshipers.
 
- There are reports of the existence of spirits in our world
-that have the same capacity to use the actions and deeds of
-mortals to strengthen themselves as do the Gods. The
-understanding of the exact nature of such creatures would
-allow us to understand with more clarity the connection
-between a Deity and the Deity's worshipers.
-
- The implication of the existence of such spirits leads to the
-speculation that these spirits may even be capable of
-raising themselves to the level of a God or Goddess. Motusuo
-of the Imperial Seminary has suggested that these spirits may
-be the remains of Gods and Goddesses who through time lost all
-or most of their following, reverting to their earliest
-most basic form. Practioners of the Old Ways say that there
-are no Gods, just greater and lesser spirits. Perhaps it is
-possible for all three theories to be true. 
+ The implication of the existence of such spirits leads to the speculation that these spirits may even be capable of raising themselves to the level of a God or Goddess. Motusuo of the Imperial Seminary has suggested that these spirits may be the remains of Gods and Goddesses who through time lost all or most of their following, reverting to their earliest most basic form. Practioners of the Old Ways say that there are no Gods, just greater and lesser spirits. Perhaps it is possible for all three theories to be true.

--- a/Assets/StreamingAssets/Text/Books/BOK00064-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00064-LOC.txt
@@ -3,9 +3,8 @@ Author: Sathyr Longleat
 IsNaughty: False
 Price: 348
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -17,95 +16,17 @@ Content:
 
 [/center]Bay
 
-
-
 [/font=4]
+ Wayrest is one of the most glorious cities of western Tamriel: sparkling in her contemporary beauty, lustrous by her past. She is prized above all cities in High Rock -- no other city has contributed, and continues to contribute so much to the culture of the Bretons. The spirits of her genius children continue to haunt the streets; you can see them in the gabled roofs, grand boulevards, aromatic marketplaces. The people of Wayrest have an instictive appreciation of their past, but are not obsessed by it, as the people of Daggerfall seem to be. One feels that one is in a modern city when one visits Wayrest, but there is a magic in the air that could only come from thirty-two centuries of civilization.
 
-[/center]
+ It is difficult for historians to declare a certain date for the foundation of Wayrest. A settlement of some variety had been existence where the Bjoulsae River feeds the Iliac Bay possibly since the 800th year of the First Era. The traders and fishermen of Wayrest were surrounded by hostile parties: the orc capitol Orsinium had grown like a poison weed to the north, and the Akaviri pirates and raiders crowded the islands to the west. There is no mystery to Wayrest's name. After the fighting most travellers had to endure passing through the eastern end of the Iliac Bay, the little fishing village on the Bjoulsae was a welcome rest.
 
-[/center]     Wayrest is one of the most glorious cities of western
-Tamriel: sparkling in her contemporary beauty, lustrous by
-her past. She is prized above all cities in High Rock -- no
-other city has contributed, and continues to contribute so
-much to the culture of the Bretons. The spirits of her genius
-children continue to haunt the streets; you can see them in
-the gabled roofs, grand boulevards, aromatic
-marketplaces. The people of Wayrest have an instictive
-appreciation of their past, but are not obsessed by it, as
-the people of Daggerfall seem to be. One feels that one is in
-a modern city when one visits Wayrest, but there is a magic
-in the air that could only come from thirty-two centuries of
-civilization.
+ Nowhere in the much vaunted censuses of the Skyrim Occupation is Wayrest mentioned. In the Annals of Daggerfall, King Joile's letter to Gaiden Shinji of the Order of Diagna contains the following reference: "The orcs have been much plaguing the Wayresters and impeding traffic to the heart of the land." The date given for the letter was 1E 948.
 
-     It is difficult for historians to declare a certain date
-for the foundation of Wayrest. A settlement of some variety
-had been existence where the Bjoulsae River feeds the Iliac
-Bay possibly since the 800th year of the First Era. The
-traders and fishermen of Wayrest were surrounded by hostile
-parties: the orc capitol Orsinium had grown like a poison
-weed to the north, and the Akaviri pirates and raiders
-crowded the islands to the west. There is no mystery to
-Wayrest's name. After the fighting most travellers had to
-endure passing through the eastern end of the Iliac Bay, the
-little fishing village on the Bjoulsae was a welcome rest.
+ Wayrest only truly bloomed after the razing of Orsinium in 1E 980. The hard-working traders and merchants were instrumental in forming the Masconian Trade Way and thus reducing the pirate activity on the Bay. At this time, Wayrest occupied both banks of the Bjoulsae. A successful mercantile family, the Gardners, built a walled palace on the High Rock side of the river and, over time, allowed banks and other businesses within its walls. It was a Gardner, Farangel, who was proclaimed king when Wayrest accepted ambassadors from the Camorian Empire, and was granted the right to call itself a kingdom in the 1100th year of the 1st Era.
 
-      Nowhere in the much vaunted censuses of the Skyrim
-Occupation is Wayrest mentioned. In the Annals of
-Daggerfall, King Joile's letter to Gaiden Shinji of the
-Order of Diagna contains the following reference: "The orcs
-have been much plaguing the Wayresters and impeding traffic
-to the heart of the land." The date given for the letter was
-1E 948.
+ Although Wayrest became a kingdom under the command of one family, the merchants continued to wield incredible power. Many economists have alleged that Wayrest's eternal wealth, despite all her hardships, comes from this rare relationship between the merchants and the crown. The Gardner Dynasty fell, followed by the Cumberland Dynasty, which was followed by the Horley Dynasty, and finally, in the Third Era, the Septim Dynasty. No citizen of another kingdom of comparable age can, with one hand, name all the families who have ever ruled. Never has a king of Wayrest been deposed by revolution or assassination. Except for those of the Septim family, every king of Wayrest can trace his line back to a merchant prince of Wayrest. The merchants and king respect one another, and this relationship strengthens both.
 
-      Wayrest only truly bloomed after the razing of Orsinium
-in 1E 980. The hard-working traders and merchants were
-instrumental in forming the Masconian Trade Way and thus
-reducing the pirate activity on the Bay. At this time,
-Wayrest occupied both banks of the Bjoulsae. A successful
-mercantile family, the Gardners, built a walled palace on
-the High Rock side of the river and, over time, allowed banks
-and other businesses within its walls. It was a Gardner,
-Farangel, who was proclaimed king when Wayrest accepted
-ambassadors from the Camorian Empire, and was granted the
-right to call itself a kingdom in the 1100th year of the 1st
-Era.
+ One need only walk down the great boulevard of Wayrest to see physical proof of this unique alliance. Going north to south, Wayrest Boulevard suddenly divides, one half going west and the other going east. Both halfs end in identical squares: one at Castle Wayrest, the original palace of Aphren Gardner, and the other at Cumberland Square, where the oldest and wealthiest marketplace in Wayrest. The message here is clear: the king and the merchants are joined and equal.
 
-      Although Wayrest became a kingdom under the command of
-one family, the merchants continued to wield incredible
-power. Many economists have alleged that Wayrest's eternal
-wealth, despite all her hardships, comes from this rare
-relationship between the merchants and the crown. The Gardner
-Dynasty fell, followed by the Cumberland Dynasty, which was
-followed by the Horley Dynasty, and finally, in the Third
-Era, the Septim Dynasty. No citizen of another kingdom of
-comparable age can, with one hand, name all the families who
-have ever ruled. Never has a king of Wayrest been deposed by
-revolution or assassination. Except for those of the Septim
-family, every king of Wayrest can trace his line back to a
-merchant prince of Wayrest. The merchants and king respect
-one another, and this relationship strengthens both.
-
-      One need only walk down the great boulevard of Wayrest
-to see physical proof of this unique alliance. Going north
-to south, Wayrest Boulevard suddenly divides, one half
-going west and the other going east. Both halfs end in
-identical squares: one at Castle Wayrest, the original
-palace of Aphren Gardner, and the other at Cumberland
-Square, where the oldest and wealthiest marketplace in
-Wayrest. The message here is clear: the king and the merchants
-are joined and equal.
-
-      Wayrest has survived blights, droughts, plagues,
-piracy, invasions, and war with good humor and
-practicality. In 1E 2702, the entire population of the city
-was forced to move into the walled estate of the Gardners as
-protection against the pirates, Akaviri raiders, and
-Thrassian plague. A less resourceful community would have
-withered, but the Wayresters have survived to enrich Tamriel
-generation after generation.
-
-
-
-
-
- 
+ Wayrest has survived blights, droughts, plagues, piracy, invasions, and war with good humor and practicality. In 1E 2702, the entire population of the city was forced to move into the walled estate of the Gardners as protection against the pirates, Akaviri raiders, and Thrassian plague. A less resourceful community would have withered, but the Wayresters have survived to enrich Tamriel generation after generation.

--- a/Assets/StreamingAssets/Text/Books/BOK00065-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00065-LOC.txt
@@ -3,73 +3,22 @@ Author: Anonymous
 IsNaughty: False
 Price: 599
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]Wabbajack
 
-
-
 [/font=4]
+ Little boys shouldn't summon up the forces of eternal darkness unless they have an adult supervising, I know, I know. But on that sunny night on the 5th of First Seed, I didn't want an adult. I wanted Hermaeus Mora, the daedra of knowledge, learning, gums, and varnishes. You see, I was told by a beautiful, large breasted man who lived under the library in my home town that the 5th of First Seed was Hermaeus Mora's night. And if I wanted the Oghma Infinium, the book of knowledge, I had to summon him. When you're the new king of Solitude, every bit of knowledge helps.
 
-[/center]
+ Normally, you need a witches coven, or a mages guild, or at least matching pillow case and sheets to invoke a prince of Oblivion. The Man Under the Library showed me how to do it myself. He told me to wait until the storm was at its height before shaving the cat. I've forgotten the rest of the ceremony. It doesn't matter.
 
-[/center]     Little boys shouldn't summon up the forces of eternal
-darkness unless they have an adult supervising, I know, I
-know. But on that sunny night on the 5th of First Seed, I
-didn't want an adult. I wanted Hermaeus Mora, the daedra of
-knowledge, learning, gums, and varnishes. You see, I was
-told by a beautiful, large breasted man who lived under the
-library in my home town that the 5th of First Seed was Hermaeus
-Mora's night. And if I wanted the Oghma Infinium, the book of
-knowledge, I had to summon him. When you're the new king of
-Solitude, every bit of knowledge helps.
+ Someone appeared who I thought was Hermaeus Mora. The only thing that made me somewhat suspicious was Hermaeus Mora, from what I read, was a big blobby multi-eyed clawed monstrosity, and this guy looked like a waistcoated banker. Also, he kept calling himself Sheogorath, not Hermaeus Mora. Still, I was so happy to have successfully summoned Hermaeus Mora, these inconsistencies did not bother me. He had me do some things that didn't make any sense to me (beyond the mortal scope, breadth, and ken, I suppose), and then his servant happily gave me something he called the Wabbajack. Wabbajack. Wabbajack. Wabbajack.
 
-     Normally, you need a witches coven, or a mages guild, or
-at least matching pillow case and sheets to invoke a prince
-of Oblivion. The Man Under the Library showed me how to do it
-myself. He told me to wait until the storm was at its height
-before shaving the cat. I've forgotten the rest of the
-ceremony. It doesn't matter.
+ Wabbajack. Wabbajack. Wabbajack. Wabbajack. Wabbajack. Wabbajack.
 
-     Someone appeared who I thought was Hermaeus Mora. The
-only thing that made me somewhat suspicious was Hermaeus Mora,
-from what I read, was a big blobby multi-eyed clawed
-monstrosity, and this guy looked like a waistcoated banker.
-Also, he kept calling himself Sheogorath, not Hermaeus Mora.
-Still, I was so happy to have successfully summoned
-Hermaeus Mora, these inconsistencies did not bother me. He had
-me do some things that didn't make any sense to me (beyond the
-mortal scope, breadth, and ken, I suppose), and then his
-servant happily gave me something he called the Wabbajack.
-Wabbajack. Wabbajack. Wabbajack.
-
- Wabbajack. Wabbajack. Wabbajack. Wabbajack. Wabbajack.
-Wabbajack.
-
-      Maybe the Wabbajack is the Book of Knowledge. Maybe I'm
-smarter because I know cats can be bats can be rats can be
-hats can be gnats can be thats can be thises. And that doors
-can be boars can be snores can be floors can be roars can be
-spores can be yours can be mine. I must be smart, for the
-interconnective system is very clear to me.  Then why, or
-wherefore do people keep calling me mad?
+ Maybe the Wabbajack is the Book of Knowledge. Maybe I'm smarter because I know cats can be bats can be rats can be hats can be gnats can be thats can be thises. And that doors can be boars can be snores can be floors can be roars can be spores can be yours can be mine. I must be smart, for the interconnective system is very clear to me. Then why, or wherefore do people keep calling me mad?
 
  Wabbajack. Wabbajack. Wabbajack.
-
-
-
-
-
-
-
-
-
-
-
-
-
- 

--- a/Assets/StreamingAssets/Text/Books/BOK00066-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00066-LOC.txt
@@ -3,9 +3,8 @@ Author: Asgrim Kolsgreg
 IsNaughty: False
 Price: 638
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,55 +12,14 @@ Content:
 
 [/center]The Mystic
 
-
-
 [/font=4]
 
-[/center]
+ During the early bloody years of the Second Era, Vanus Galerion was born under the name Trechtus, a serf on the estate of a minor nobleman, Lord Gyrnasse of Sollicich-on-Ker. Trechtus' father and mother were common laborers, but his father had secretly, against the law of Lord Gyrnasse, taught himself and then Trechtus to read. Lord Gyrnasse had been advised that literate serfs were an abomination of nature and dangerous to themselves and their lords, and had closed all bookstalls within Sollicich-on-Ker. All booksellers, poets, and teachers were forbidden, except within Gyrnasse's keep. Nevertheless, a small scale smuggling operation kept a number of books and scrolls in circulation right under Gyrnasse's shadow.
 
-     During the early bloody years of the Second Era, Vanus
-Galerion was born under the name Trechtus, a serf on the
-estate of a minor nobleman, Lord Gyrnasse of
-Sollicich-on-Ker. Trechtus' father and mother were common
-laborers, but his father had secretly, against the law of
-Lord Gyrnasse, taught himself and then Trechtus to read.
-Lord Gyrnasse had been advised that literate serfs were an
-abomination of nature and dangerous to themselves and their
-lords, and had closed all bookstalls within
-Sollicich-on-Ker. All booksellers, poets, and teachers were
-forbidden, except within Gyrnasse's keep. Nevertheless, a small scale smuggling operation kept a number of books and
-scrolls in circulation right under Gyrnasse's shadow.
+ When Trechtus was eight, the smugglers were found and imprisoned. Some said that Trechtus's mother, an ignorant and religious woman fearful of her husband, was the betrayer of the smugglers, but there were other rumors as well. The trial of the smugglers was nonexistant, and the punishment swift. The body of Trechtus' father was kept hanging for weeks during the hottest summer Sollicich-on-Ker had seen in centuries.
 
-     When Trechtus was eight, the smugglers were found and
-imprisoned. Some said that Trechtus's mother, an ignorant
-and religious woman fearful of her husband, was the
-betrayer of the smugglers, but there were other rumors as
-well. The trial of the smugglers was nonexistant, and the
-punishment swift. The body of Trechtus' father was kept
-hanging for weeks during the hottest summer Sollicich-on-Ker
-had seen in centuries.
+ Three months later, Trechtus ran away from Lord Gyrnasse's estate. He made it as far as Alinor, half-way across Sumurset Isle. A band of troubadours found him nearly dead, curled up in a ditch by the side of the road, nursed him to health, and employed him as an errand boy in return for food and shelter. One of the troubadours, a soothsayer named Heliand began testing Trechtus' mind and found the boy, though shy, to be preternaturally intelligent and sophisticated given his circumstances. Heliand recognized in the boy a commonality, for Heliand had been trained on the Isle of Artaeum as a mystic.
 
-     Three months later, Trechtus ran away from Lord
-Gyrnasse's estate. He made it as far as Alinor, half-way
-across Sumurset Isle. A band of troubadours found him
-nearly dead, curled up in a ditch by the side of the road,
-nursed him to health, and employed him as an errand boy in
-return for food and shelter. One of the troubadours, a
-soothsayer named Heliand began testing Trechtus' mind and
-found the boy, though shy, to be preternaturally
-intelligent and sophisticated given his circumstances. Heliand
-recognized in the boy a commonality, for Heliand had been
-trained on the Isle of Artaeum as a mystic.
+ When the troupe was performing in the village of Potansa on the far eastern end of Sumurset, Heliand took Trechtus, then a boy of eleven, to the Isle of Artaeum. The Magister of the Isle, Iachesis, recognized potential in Trechtus and took him on as pupil, giving him the name of Vanus Galarion. Vanus trained his mind on the Isle of Artium, as well as his body.
 
-     When the troupe was performing in the village of Potansa
-on the far eastern end of Sumurset, Heliand took Trechtus,
-then a boy of eleven, to the Isle of Artaeum. The Magister
-of the Isle, Iachesis, recognized potential in Trechtus and
-took him on as pupil, giving him the name of Vanus Galarion.
-Vanus trained his mind on the Isle of Artium, as well as his
-body.
-
-     Thus was the first Archmagister of the Mages Guild
-trained. From the Psijics of the Isle of Artaeum, he received
-his training. From his childhood of want and injustice, he
-received his philosophy of sharing knowledge. 
+ Thus was the first Archmagister of the Mages Guild trained. From the Psijics of the Isle of Artaeum, he received his training. From his childhood of want and injustice, he received his philosophy of sharing knowledge.

--- a/Assets/StreamingAssets/Text/Books/BOK00067-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00067-LOC.txt
@@ -3,77 +3,24 @@ Author: Witten Rol
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]The Ebon Arm
 
-
-
 [/font=4]
+ The ground shakes. The great armies continue to wage their unrelenting battle. The battlefield is red, the rivers flow crimson, the sky reflects a deep pink. In the distance lightning flashes, and thunder sounds. Two huge ravens begin circling the field; their blackness is vibrant against the various shades of red in this vista of death and suffering. The bright flashes of light and rumbling begin to increase. The redness surrounding the battlefield begins giving way to a golden glow from the east, almost like a summer's setting sun. From the false sunset a massive golden stallion and single rider approach. All become suddenly still on the field of battle as both sides recognize Reymon Ebonarm, God of War, and the companion and protector of all warriors, also known as the Black Knight and his mighty steed War Master.
 
-[/center]
+ He rides into the middle of the blood soaked field and dismounts. He is a very imposing figure. His very tall and heavily muscled body is encased in ebony armor. His ebony helmet does not hide the flowing reddish blonde hair and beard which appear almost as shimmering gold, nor does it shield the steel blue eyes that seem to pierce all they fall upon. In his left hand he carries a massive ebony tower shield on which is emblazoned a fiery red rose. As he raises his right arm, all see an arm and a magnificent ebony blade which are extensions of each other. The fused arm and sword are a result and symbol of the wounds suffered by this god during titanic battles in the youth of this world.
 
-[/center] The ground shakes. The great armies continue to wage their
-unrelenting battle. The battlefield is red, the rivers flow
-crimson, the sky reflects a deep pink. In the distance
-lightning flashes, and thunder sounds.  Two huge ravens begin
-circling the field; their blackness is vibrant against the
-various shades of red in this vista of death and suffering.
-The bright flashes of light and rumbling begin to increase.
-The redness surrounding the battlefield begins giving way
-to a golden glow from the east, almost like a summer's
-setting sun. From the false sunset a massive golden stallion
-and single rider approach. All become suddenly still on
-the field of battle as both sides recognize  Reymon Ebonarm,
-God of War, and the companion and protector of all
-warriors, also known as the Black Knight and his mighty steed
-War Master.
+ The ravens come to rest on his shoulders. And, as the point of the ebony blade seemingly touches the sky, lightning flashes, thunder roars. Then total quiet descends and a shudder rolls through both armies.
 
- He rides into the middle of the blood soaked field and
-dismounts. He is a very imposing figure. His very tall  and
-heavily muscled body is encased in ebony armor. His ebony
-helmet does not hide the flowing reddish blonde hair and
-beard which appear almost as shimmering gold, nor does it
-shield the steel blue eyes that seem to pierce all they fall
-upon. In his left hand he carries a massive ebony tower
-shield on which is emblazoned a fiery red rose. As he raises his
-right arm, all see an arm and a magnificent ebony blade
-which are extensions of each other. The fused arm and sword
-are a result and symbol of the wounds suffered by this god
-during titanic battles in the youth of this world.
+ The leaders of both armies approach Reymon Ebonarm and kneel. In turn they tell their reasons for this war. Each asks for the favor of the Black Knight for their cause. Reymon Ebonarm listens, but there is no acknowledgment that he has chosen to favor one side or the other in this fight. However, each of the leaders has heard the other state his position. And, each now knows that this war is baseless. They embrace and turn to their armies. They instruct their forces to bury their dead, tend their wounded and return to their homes.
 
- The ravens come to rest on his shoulders. And, as the point
-of the ebony blade seemingly touches the sky,  lightning
-flashes, thunder roars. Then total quiet descends and a
-shudder rolls through both armies.
+ Reymon Ebonarm mounts his great golden stallion, War Master, and again raises the ebony blade skyward and extends the huge rose emblazoned ebony shield to both armies. A massive chorus of cheers rises from the armies. The ravens again take to the air. Lightning and thunder follow him as he rides into the sunset followed by the two birds.
 
- The leaders of both armies approach Reymon Ebonarm and
-kneel. In turn they tell their reasons for this war. Each asks
-for the favor of the Black Knight for their cause. Reymon
-Ebonarm listens, but there is no  acknowledgment that he has
-chosen to favor one side or the other in this fight. However,
-each of the leaders  has heard the other state his position.
-And, each now knows that this war is baseless. They embrace
-and  turn to their armies. They instruct their forces to bury
-their dead, tend their wounded and return to their  homes.
+ The armies do as they have been bidden. They care for their wounded and bury their dead. As they retreat towards their homes each warrior is sure that the great God Reymon Ebonarm, the Black Knight, has responded to their individual prayers for intervention. Each side has won, neither has lost.
 
- Reymon Ebonarm mounts his great golden stallion, War
-Master, and again raises the ebony blade skyward  and
-extends the huge rose emblazoned ebony shield to both armies.
-A massive chorus of cheers rises from  the armies.  The ravens
-again take to the air. Lightning and thunder follow him as he
-rides into the sunset  followed by the two birds.
-
- The armies do as they have been bidden. They care for their
-wounded and bury their dead. As they retreat  towards their
-homes each warrior is sure that the great God Reymon Ebonarm,
-the Black Knight, has responded to their individual prayers
-for intervention. Each side has won, neither has lost.
-
- As the armies depart the field, the rivers begin to run
-clear, and a single red rose begins to bloom near the  grave
-of a fallen hero. 
+ As the armies depart the field, the rivers begin to run clear, and a single red rose begins to bloom near the grave of a fallen hero.

--- a/Assets/StreamingAssets/Text/Books/BOK00068-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00068-LOC.txt
@@ -3,46 +3,117 @@ Author: Anonymous
 IsNaughty: False
 Price: 513
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]Rude Song
 
-
-
 [/font=4]
+
+[/center]In the spring of the year
+
+[/center]Doth propriety disappear
+
+[/center]In the courts and the ports
+
+[/center]Of the Bay.
+
+[/center]Drinking new beer,
+
+[/center]Everybody feels queer
+
+[/center]And the Earls and the churls
+
+[/center]Go astray.
+
+[/center]The bee and the bird
+
+[/center]Don't have to tell us a word.
+
+[/center]Our bodies for naughtie
+
+[/center]Are prime.
+
+[/center]If you haven't heard,
+
+[/center]You can let yourself be lured
+
+[/center]For the youth, for things uncouth,
+
+[/center]It is time.
+
+[/center]Oh, it's lovely to sit in a field, harvested into rows
+
+[/center]It's lovelier still to do the same not wearing any clothes.
 
 [/center]
 
-[/center] In the spring of the year Doth propriety disappear In the
-courts and the ports Of the Bay. Drinking new beer, Everybody
-feels queer And the Earls and the churls Go astray. The bee and
-the bird Don't have to tell us a word. Our bodies for
-naughties Are prime. If you haven't heard, You can let
-yourself be lured For the youth, for things uncouth, It is
-time. Oh, it's lovely to sit in a field, harvested into rows
-It's lovelier still to do the same not wearing any clothes.
-People of the Bay bless The flowered court of Wayrest For
-showing us the gentle way of sin The bonny Dark Elf queen Likes
-to see and to be seen With cobblers, thieves, And tavernkeeps,
-And slaves, and fish-er-men In the court of Lainlyn, Right
-upon the mainland With sex, the whole place is in a whirl The
-Baroness likes to play With men who come her way, While the
-Baron likes the little boys and girls. Oh, it's lovely to
-give your lady a kiss upon her nose  It's lovelier still to
-do the same not wearing any clothes. In Daggerfall, they
-hold a ball And all of society indulges in a variety Of
-scandal, they can handle -- A lot. The Captain of the Guard Has to search very hard For
-a bean that the Queen Has in her pants. And the Court Sorceress
-Will grant you a wish To cause the King to fling About his
-lance. Oh, it's lovely to give your love a single perfect
-rose It's lovelier still to do the same not wearing any
-clothes. Oh, it's lovely to abandon all your cares and
-fears and woes It's lovelier still to do the same not
-wearing any clothes. Yes sir, it's lovely not wear any
-clothes!"
+[/center]People of the Bay bless
 
- 
+[/center]The flowered court of Wayrest
+
+[/center]For showing us the gentle way of sin
+
+[/center]The bonny Dark Elf queen
+
+[/center]Likes to see and to be seen
+
+[/center]With cobblers, thieves,
+
+[/center]And tavernkeeps,
+
+[/center]And slaves, and fish-er-men
+
+[/center]In the court of Lainlyn,
+
+[/center]Right upon the mainland
+
+[/center]With sex, the whole place is in a whirl
+
+[/center]The Baroness likes to play
+
+[/center]With men who come her way,
+
+[/center]While the Baron likes the little boys and girls.
+
+[/center]Oh, it's lovely to give your lady a kiss upon her nose
+
+[/center]It's lovelier still to do the same not wearing any clothes.
+
+[/center]
+
+[/center]In Daggerfall,
+
+[/center]they hold a ball
+
+[/center]And all of society indulges in a variety
+
+[/center]Of scandal, they can handle -- A lot.
+
+[/center]The Captain of the Guard
+
+[/center]Has to search very hard
+
+[/center]For a bean that the Queen
+
+[/center]Has in her pants.
+
+[/center]And the Court Sorceress
+
+[/center]Will grant you a wish
+
+[/center]To cause the King to fling
+
+[/center]About his lance.
+
+[/center]Oh, it's lovely to give your love a single perfect rose
+
+[/center]It's lovelier still to do the same not wearing any clothes.
+
+[/center]Oh, it's lovely to abandon all your cares and fears and woes
+
+[/center]It's lovelier still to do the same not wearing any clothes.
+
+[/center]Yes sir, it's lovely not wear any clothes!"

--- a/Assets/StreamingAssets/Text/Books/BOK00069-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00069-LOC.txt
@@ -3,148 +3,41 @@ Author: Zhen
 IsNaughty: False
 Price: 484
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]Mara's Tear
 
-
-
 [/font=4]
 
-[/center]
+ Well, children, if you all gather round, and sit quietly, I'll tell you the story of Mara's Tear and Shandar's Sorrow
 
-[/center]
+[/center]...
 
- Well, children, if you all gather round, and sit quietly,
-I'll tell you the story of Mara's Tear and Shandar's Sorrow
-...
+ Long, long ago, long before your grandmother and I were were born, long ago, there were two young children growing up in a village far, far from here. They played together, and ran through the woods together, exploring their little world and learning to see things through each other's eyes. This was very different from their parents because Shandar was the son of Maldor, who was captured in a war and forced to work as a slave for the village baron. Their village and another both needed the land between them to feed the villagers, and fought and fought, until many of the villagers died. Maldor was wounded in battle, and left for dead by his fellows. He was captured and forced to work in the fields as punishment. Shandar was not allowed to play with Mara, but she was very small and the other children didn't like to play with her, so she played with Shandar against her father's command. And they learned that they were really not very different at all. They couldn't understand why their parents hated each other so.
 
- Long, long ago, long before your grandmother and I were
-were born, long ago, there were two young children growing
-up in a village far, far from here. They played together,
-and ran through the woods together, exploring their little
-world and learning to see things through each other's eyes.
-This was very different from their parents because Shandar
-was the son of Maldor, who was captured in a war and forced
-to work as a slave for the village baron. Their village and
-another both needed the land between them to feed the
-villagers, and fought and fought, until many of the
-villagers died. Maldor was wounded in battle, and left for
-dead by his fellows. He was captured and forced to work in
-the fields as punishment. Shandar was not allowed to play
-with Mara, but she was very small and the other children
-didn't like to play with her, so she played with Shandar
-against her father's command. And they learned that they
-were really not very different at all. They couldn't
-understand why their parents hated each other so.
+ Well, Shandar and Mara played together for many years, and learned to love each other as they grew up. They knew that they couldn't let their parents know, because it was forbidden for them ever to marry, since they were from different villages and the war was still going on. They tried and tried to figure out how they could be happy together, and finally decided that they must run away from their village. They would try to make a new life for themselves in another village, far, far away from where they grew up.
 
- Well, Shandar and Mara played together for many years,
-and learned to love each other as they grew up. They knew
-that they couldn't let their parents know, because it was
-forbidden for them ever to marry, since they were from
-different villages and the war was still going on. They
-tried and tried to figure out how they could be happy
-together, and finally decided that they must run away from
-their village. They would try to make a new life for
-themselves in another village, far, far away from where they
-grew up.
+ One night, while planning their escape, they were discovered by the town guards. Shandar tried to fight them, but they tied him up and dragged him away to the prison inside town. Mara was taken home, and her father was very angry with her, and told her that she could not leave their home again. He went to the house of another farmer, and asked if their son would marry Mara, so that she could never see Shandar again. The marriage was planned for the next week.
 
- One night, while planning their escape, they were discovered
-by the town guards. Shandar tried to fight them, but they
-tied him up and dragged him away to the prison inside town.
-Mara was taken home, and her father was very angry with her,
-and told her that she could not leave their home again. He
-went to the house of another farmer, and asked if their son
-would marry Mara, so that she could never see Shandar again.
-The marriage was planned for the next week.
+ Shandar, meanwhile, was to be killed for daring to be with Mara. He was beaten, and placed in a stockade. He was placed in a stockade, and they were to hang him the next day. When Mara found out that Shandar was to be killed, she knew that she could never live without him, and climbed out her window and ran into the woods, crying and crying. She ran and ran, and soon was lost. It was very dark, because back then they did not have any moons in the sky back then to make it safe for little boys and girls. Soon she found herself in a part of the woods she had never been before, and sat down on a rock since she was very tired.
 
- Shandar, meanwhile, was to be killed for daring to be with
-Mara. He was beaten, and placed in a stockade. He was placed
-in a stockade, and they were to hang him the next day. When
-Mara found out that Shandar was to be killed, she knew that
-she could never live without him, and climbed out her
-window and ran into the woods, crying and crying. She ran
-and ran, and soon was lost. It was very dark, because back
-then they did not have any moons in the sky back then to make it
-safe for little boys and girls. Soon she found herself in a
-part of the woods she had never been before, and sat down on
-a rock since she was very tired.
+ Well, the rock was a secret entrance to a cave where a very mean orc lived. When he came back from his hunting, he found Mara curled up asleep on his rock, and thought to himself, "Hmmm, a tasty little girl. I shall save her for my breakfast!"
 
- Well, the rock was a secret entrance to a cave where a very
-mean orc lived. When he came back from his hunting, he found
-Mara curled up asleep on his rock, and thought to himself,
-"Hmmm, a tasty little girl. I shall save her for my
-breakfast!"
+ He grabbed her and took her into his cave, moving the rock back so that she could not escape. She was sure to die, and tried to escape, but the evil orc just laughed and laughed at her, until she finally gave up.
 
- He grabbed her and took her into his cave, moving the rock back
-so that she could not escape. She was sure to die, and tried
-to escape, but the evil orc just laughed and laughed at her,
-until she finally gave up.
+ When the villagers found out that Mara had run off, they were very worried. No one knew the woods very well, and all were afraid of the evil orc that lived there. Only Shandar was not afraid, and he begged and begged for the baron to set him free, so that he could go look for Mara. The Baron finally decided to let Shandar go, for no one else was brave enough to go and rescue Mara. So Shandar was set free, and he set off into the woods to go and rescue her.
 
- When the villagers found out that Mara had run off, they
-were very worried. No one knew the woods very well, and all
-were afraid of the evil orc that lived there. Only Shandar
-was not afraid, and he begged and begged for the baron to
-set him free, so that he could go look for Mara. The Baron
-finally decided to let Shandar go, for no one else was
-brave enough to go and rescue Mara. So Shandar was set free,
-and he set off into the woods to go and rescue her.
+ Shandar searched and searched, but could not find poor Mara. Finally, he sat down on a rock to rest for a moment, and as he sat down, he noticed a piece of cloth under the rock. It was a piece from Mara's cloak! He realized that she must be under the rock somehow, and knew that the orc had captured her. He pushed and pushed on the rock, and finally was able to roll it aside. He climbed down into the orc's cave, but it was very dark, and he could not see anything. The evil orc, when he heard his front door moving, hid in the shadows to see what was coming into his home. When he saw that it was just a little man-boy, he grinned to himself and thought, "Now I have lunch, TOO!"
 
- Shandar searched and searched, but could not find poor
-Mara. Finally, he sat down on a rock to rest for a moment,
-and as he sat down, he noticed a piece of cloth under the rock.
-It was a piece from Mara's cloak! He realized that she must be
-under the rock somehow, and knew that the orc had captured her.
-He pushed and pushed on the rock, and finally was able to
-roll it aside. He climbed down into the orc's cave, but it was
-very dark, and he could not see anything. The evil orc, when
-he heard his front door moving, hid in the shadows to see what
-was coming into his home. When he saw that it was just a
-little man-boy, he grinned to himself and thought, "Now I have
-lunch, TOO!" 
+ When Shandar came near, the orc grabbed him, and began to squeeze the life out of him.
 
- When Shandar came near, the orc grabbed him, and began to
-squeeze the life out of him.
+ Back in the village, the people soon realized that they were foolish to let a young man go off into the woods by himself. They gathered all of their weapons, and set off to find the two lost children. When they finally came upon the clearing near the orcs' cave, they saw a strange and wondrous sight: A slain orc near the entrance to the cave, and Mara holding the head of poor Shandar in her lap. Shandar had killed the orc, but not before the it gave Shandar a mortal wound.
 
- Back in the village, the people soon realized that they were
-foolish to let a young man go off into the woods by himself.
-They gathered all of their weapons, and set off to find the
-two lost children. When they finally came upon the clearing
-near the orcs' cave, they saw a strange and wondrous sight: A
-slain orc near the entrance to the cave, and Mara holding
-the head of poor Shandar in her lap. Shandar had killed the
-orc, but not before the it gave Shandar a mortal wound.
+ Mara's tears flowed freely from her eyes and splashed upon Shandar's face, reflecting the light from the villager's torches. Shandar was filled with sorrow at the thought that he had saved Mara, only to lose her because of his own impending death from the battle with the orc. He cried out to Mara's namesake, the goddess of love, to help them.
 
- Mara's tears flowed freely from her eyes and splashed upon
-Shandar's face, reflecting the light from the villager's
-torches. Shandar was filled with sorrow at the thought that he
-had saved Mara, only to lose her because of his own impending
-death from the battle with the orc. He cried out to Mara's
-namesake, the goddess of love, to help them.
+ The Goddess Mara recognized their true love and wept at their loss. Not having power over death, she could do nothing to save Shandar, but she knew that she could not let their love die. She reached down from the heavens and picked up Mara and Shandar in her arms, and placed them high in the heavens. They could be together always, and provide light in the dark night to others so that they may be safe from the evils in the world. The villagers were amazed at this sight, and vowed to honor the love of Shandar and Mara by learning more about themselves and their neighbors, so that the war that had been going on as long as anyone could remember would end. Shandar's sacrifice for the one he loved showed them that he was worthy of their respect, and that those from his village were just as proud and worthy as themselves.
 
- The Goddess Mara recognized their true love and wept at
-their loss. Not having power over death, she could do
-nothing to save Shandar, but she knew that she could not let
-their love die. She reached down from the heavens and picked
-up Mara and Shandar in her arms, and placed them high in the
-heavens. They could be together always, and provide light
-in the dark night to others so that they may be safe from the
-evils in the world. The villagers were amazed at this sight,
-and vowed to honor the love of Shandar and Mara by
-learning more about themselves and their neighbors, so that
-the war that had been going on as long as anyone could
-remember would end. Shandar's sacrifice for the one he
-loved showed them that he was worthy of their respect, and that
-those from his village were just as proud and worthy as
-themselves.
-
- And, that's why, children, every night we can see Mara's Tear
-and Shandar's Sorrow spending their lives together high in the
-heavens, lighting the way for all the little boys and girls
-like you.
-
- 
+ And, that's why, children, every night we can see Mara's Tear and Shandar's Sorrow spending their lives together high in the heavens, lighting the way for all the little boys and girls like you.

--- a/Assets/StreamingAssets/Text/Books/BOK00070-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00070-LOC.txt
@@ -3,145 +3,103 @@ Author: Butha Sunhous
 IsNaughty: True
 Price: 667
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]Jokes
 
-
-
 [/font=4]
+
+ "How is your wife," asked Zalither.
+
+ "She's in bed with laryngitis," replied Harlyth.
+
+ "Is that Argonian bastard back in town again?"
 
 [/center]
 
-[/center] "How is your wife," asked Zalither. "She's in bed with
-laryngitis," replied Harlyth. "Is that Argonian bastard
-back in town again?"
+ "I keep seeing spots before my eyes."
 
+ "Have you seen a healer?"
 
+ "No, just spots."
 
-[/center] "I keep seeing spots before my eyes." "Have you seen a
-healer?" "No, just spots."
+[/center]
 
+ A big Nord named Julgen was set on by a gang of thieves. He fought them furiously, but in the end, they beat him into semiconsciousness. They searched his pockets and discovered that he only had three gold pieces on him.
 
+ "Do you mean to tell us you fought us like a mad lupe for three lousy gold pieces?" sneered one of the thieves.
 
-[/center] A big Nord named Julgen was set on by a gang of thieves. He
-fought them furiously, but in the end, they beat him into
-semiconsciousness. They searched his pockets and discovered
-that he only had three gold pieces on him.
+ "No," answered Julgen. "I was afraid you were after the four hundred gold pieces in my boot."
 
- "Do you mean to tell us you fought us like a mad lupe for
-three lousy gold pieces?" sneered one of the thieves.
+[/center]
 
- "No," answered Julgen. "I was afraid you were after the
-four hundred gold pieces in my boot."
+ During the War of Betony, the Bretons in the Isle of Craghold were under siege for several days. After the island was liberated, Lord Bridwell found the ruins of the castle where a crowd of survivors were hidden away in the dark. It was going to be a difficult job freeing them, as part of the roof had collapsed trapping them all within. Bridwell stuck his head in the only opening and shouted to the Bretons below: "Are there any expectant mothers down there?"
 
+ "It's hard to say, your Lordship," said a young woman. "We've only been down here for a few days."
 
+[/center]
 
-[/center] During the War of Betony, the Bretons in the Isle of Craghold
-were under siege for several days. After the island was
-liberated, Lord Bridwell found the ruins of the castle where
-a crowd of survivors were hidden away in the dark. It was
-going to be a difficult job freeing them, as part of the
-roof had collapsed trapping them all within. Bridwell
-stuck his head in the only opening and shouted to the Bretons
-below: "Are there any expectant mothers down there?"
-
- "It's hard to say, your Lordship," said a young woman.
-"We've only been down here for a few days."
-
-
-
-[/center] An elderly Breton met with an contemporary of his at a
-guild meeting. "Harryston, old man, I wanted to express my
-sympathy. I hear that you buried your wife last week."
+ An elderly Breton met with an contemporary of his at a guild meeting. "Harryston, old man, I wanted to express my sympathy. I hear that you buried your wife last week."
 
  "Had to, old boy," replied Harryston. "Dead, you know."
 
+[/center]
 
+ Why was the Sentinel army so useless during the War of Betony?
 
-[/center] Why was the Sentinel army so useless during the War of
-Betony? The cannons were too heavy, so all three garbage
-scows sunk.
+ The cannons were too heavy, so all three garbage scows sunk.
 
+[/center]
 
+ What does a new Sentinel private learn first as a combat technique?
 
-[/center] What does a new Sentinel private learn first as a combat
-technique? How to retreat.
+ How to retreat.
 
+[/center]
 
+ What is the thinnest book in the world?
 
-[/center] What is the thinnest book in the world? Redguard Heroes of the
-War of Betony.
+ Redguard Heroes of the War of Betony.
 
+[/center]
 
+ A Dark Elf man killed his wife after catching her making love with another man. When the magistrate asked him why he killed her instead of her lover, the man replied, "I considered it better to kill one woman than a different man every week."
 
-[/center] A Dark Elf man killed his wife after catching her making love
-with another man. When the magistrate asked him why he killed
-her instead of her lover, the man replied, "I considered it
-better to kill one woman than a different man every week."
+[/center]
 
+ A Dark Elf woman was being shown around Daggerfall. When she was shown the magnificent Castle Daggerfall, she smiled sweetly to her guild and whispered, "It reminds me of sex."
 
-
-[/center] A Dark Elf woman was being shown around Daggerfall. When she
-was shown the magnificent Castle Daggerfall, she smiled
-sweetly to her guild and whispered, "It reminds me of sex."
-
- "That's odd," said her guild. "Why does our Castle
-Daggerfall remind you of sex?"
+ "That's odd," said her guild. "Why does our Castle Daggerfall remind you of sex?"
 
  The Dark Elf sighed, "Everything does."
 
+[/center]
 
+ Yelithah told Vathysah that she was having dinner with a Dark Elf named Morleth that night.
 
-[/center] Yelithah told Vathysah that she was having  dinner with a Dark
-Elf named Morleth that night.
+ "I hear he's an animal," said Vathysah. "He'll rip your dress right off you."
 
- "I hear he's an animal," said Vathysah. "He'll rip your
-dress right off you."
+ "Thank you for telling me," said Yelithah, "I'll be sure to wear an old dress."
 
- "Thank you for telling me," said Yelithah, "I'll be sure to
-wear an old dress."
+[/center]
 
+ How do separate sailors in the Khajiiti navy?
 
+ With a hammer and tongs.
 
-[/center] How do separate sailors in the Khajiiti navy? With a hammer
-and tongs.
+[/center]
 
+ "This orchard has sentimental value to me," said Mojhad, the Khajiit, to his friend, Hasillid. "Under that tree, for example, is where I first made love. And that tree, is where her mother stood, watching us."
 
-
- "This orchard has sentimental value to me," said Mojhad, the
-Khajiit, to his friend, Hasillid. "Under that tree, for
-example, is where I first made love. And that tree, is where
-her mother stood, watching us."
-
- "She watched you while you made love to her daughter?" said
-Hasillid, clearly impressed. "Didn't she say anything?"
+ "She watched you while you made love to her daughter?" said Hasillid, clearly impressed. "Didn't she say anything?"
 
  "Meow."
 
+[/center]
 
-
-[/center] What do you call a Wood Elf who doesn't lie or cheat or
-steal?
+ What do you call a Wood Elf who doesn't lie or cheat or steal?
 
  A dead Wood Elf.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- 

--- a/Assets/StreamingAssets/Text/Books/BOK00071-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00071-LOC.txt
@@ -1,11 +1,10 @@
 Title: Ius, Animal God
-Author: Buljursoma 
+Author: Buljursoma
 IsNaughty: False
 Price: 385
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,82 +12,22 @@ Content:
 
 [/center]Animal God
 
-
-
 [/font=4]
 
-[/center]
+ The statues one sees throughout Valenwood and parts of Hammerfell and Elsweyr that seem to be of a misshapen humanoid carrying a rod are of Ius, tHe God of Animals.
 
- The statues one sees throughout Valenwood and parts of
-Hammerfell and Elsweyr that seem to be of a misshapen
-humanoid carrying a rod are of Ius, tHe God of Animals. 
+ The rod He carries has its origin in the tale of The Ox and The Evil Farmer. It seems that one day an evil farmer decided to kill all of his animals and have a big party. As The story unfolds, animal after animal is killed and prepared for a big meal. Lastly the farmer comes to the ox and prepares to slit its throat. The ox, not wishing to be anybody's dinner, prayed very vocally to Ius. This came out as a loud Moo, of course.
 
- The rod He carries has its origin in the tale of The Ox and The
-Evil Farmer. It seems that one day an evil farmer decided to
-kill all of his animals and have a big party. As The story
-unfolds, animal after animal is killed and prepared for a
-big meal. Lastly the farmer comes to the ox and prepares to
-slit its throat. The ox, not wishing to be anybody's dinner,
-prayed very vocally to Ius. This came out as a loud Moo,
-of course.
+ At that very instant Ius appeared carrying a rather large set of balance weights. Without explanation, Ius ate the farmer and vanished. Ever since that day Ius The Extremely Agitated, has always been protrayed as carrying a large set of scales with him. The local Ius worshippers have no idea why and do not seem to care. Although this story has been called fanciful at best, I personally know a racoon who had actually talked to The Ox. That is, before the Ox became filler for the local inn's larder.
 
- At that very instant Ius appeared carrying a rather large
-set of balance weights. Without explanation, Ius ate the
-farmer and vanished. Ever since that day Ius The Extremely
-Agitated, has always been protrayed as carrying a large set
-of scales with him. The local Ius worshippers have no idea
-why and do not seem to care. Although this story has been
-called fanciful at best, I personally know a racoon who had
-actually talked to The Ox. That is, before the Ox became
-filler for the local inn's larder.
+ I do not have any information one way or the other about the validity of this second myth. It is, however, quite traditional.
 
- I do not have any information one way or the other about the
-validity of this second myth. It is, however, quite
-traditional.
+ It seems that many, many years ago, before the reign of Uriel Septim VII, before the reign of Cephorus Septim II, yes, even before the age of Pelagius Septim III (long may his name be praised!), there lived a wombat who was the pet of Lady Greelina, daughter of the Lord Prufrock of Rockcreek. Lady Greelina loved her wombat so, and it loved her too with all the passionate intensity a marsupial can muster.
 
- It seems that many, many years ago, before the reign of Uriel
-Septim VII, before the reign of Cephorus Septim II, yes,
-even before the age of Pelagius Septim III (long may his
-name be praised!), there lived a wombat who was the pet of
-Lady Greelina, daughter of the Lord Prufrock of Rockcreek.
-Lady Greelina loved her wombat so, and it loved her too
-with all the passionate intensity a marsupial can muster.
+ Unfortunately, it was a time of great sorrow in Rockcreek. A pestilence had come through the town, destroying all their cash crops (which consisted of raspberries and a few scraggly odd weeds that caused Argonian women to look very attractive to those who partook); Then a plague had come, inflicting nearly every cobbler with chronic hiccoughs; finally a witch had cursed the townspeople so the only words any could utter were "Hmmm. Precisely." All the businesses, stores, and guilds fled from the town faster than an extremely fast thing.
 
- Unfortunately, it was a time of great sorrow in Rockcreek. A
-pestilence had come through the town, destroying all their
-cash crops (which consisted of raspberries and a few scraggly
-odd weeds that caused Argonian women to look very
-attractive to those who partook); Then a plague had come,
-inflicting nearly every cobbler with chronic hiccoughs;
-finally a witch had cursed the townspeople so the only words
-any could utter were "Hmmm. Precisely." All the businesses,
-stores, and guilds fled from the town faster than an
-extremely fast thing.
+ Lady Greelina saw her father despairing the loss the town was suffering, so she brought her wombat in and told him, "Father, my wombat can save us all, for it is sacred to the god Ius, God of Animals. The only reason I didn't tell you earlier is because I am an early adolescent going through that period when I don't like to communicate. But please, ask a wish of my wombat, and Ius will fulfill it, for my wombat loves me."
 
- Lady Greelina saw her father despairing the loss the town was
-suffering, so she brought her wombat in and told him,
-"Father, my wombat can save us all, for it is sacred to the
-god Ius, God of Animals. The only reason I didn't tell you
-earlier is because I am an early adolescent going through
-that period when I don't like to communicate. But please, ask
-a wish of my wombat, and Ius will fulfill it, for my
-wombat loves me."
+ The king thought this was fairly flakey, but he had nothing to lose so he uttered a modest wish to the wombat, "All I want is for one business to come to Rockcreek that will never leave no matter the calamity."
 
- The king thought this was fairly flakey, but he had nothing to
-lose so he uttered a modest wish to the wombat, "All I want is
-for one business to come to Rockcreek that will never leave
-no matter the calamity."
-
- I probably should have mentioned before that the king had
-always been cruel to the wombat (he used to lick it and try to
-make it stick to walls), so the wombat had Ius create an
-equipment store in front of the palace gate that would
-never go away. The royal family ended up going mad and
-eating one another (and ironically, the wombat was one of
-the first to go). But that is why there is to this day an
-equipment store blocking the palace gate in Rockcreek. If
-you don't believe me, go there and see.
-
-
-
- 
+ I probably should have mentioned before that the king had always been cruel to the wombat (he used to lick it and try to make it stick to walls), so the wombat had Ius create an equipment store in front of the palace gate that would never go away. The royal family ended up going mad and eating one another (and ironically, the wombat was one of the first to go). But that is why there is to this day an equipment store blocking the palace gate in Rockcreek. If you don't believe me, go there and see.

--- a/Assets/StreamingAssets/Text/Books/BOK00072-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00072-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: True
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,60 +12,28 @@ Content:
 
 [/center]Tale
 
-
-
 [/font=4]
 
 [/center]
 
-    For over twenty years, I have been a healer at the Temple
-of Stendarr. As the reader is doubtless aware, we are the
-only temple in the Iliac Bay that offers wound healing and
-illness curing for both the faithful and the heathen alike, for
-Stendarr is the God of Mercy. I have faced people at their
-most miserable and their most terrified. I have seen brave
-knights weep and strong peasants scream. I like to think that
-I've watched the masks drop from faces, and seen people as
-they truly are.
+ For over twenty years, I have been a healer at the Temple of Stendarr. As the reader is doubtless aware, we are the only temple in the Iliac Bay that offers wound healing and illness curing for both the faithful and the heathen alike, for Stendarr is the God of Mercy. I have faced people at their most miserable and their most terrified. I have seen brave knights weep and strong peasants scream. I like to think that I've watched the masks drop from faces, and seen people as they truly are.
 
-    A healer's job, after all, is more than simply binding
-wounds and stopping the flows of poison and disease. We are
-counselors and comforters for those who have given up all
-hope. Sometimes, it seems like our kind words and sympathy do
-more for our patients than our spells.
+ A healer's job, after all, is more than simply binding wounds and stopping the flows of poison and disease. We are counselors and comforters for those who have given up all hope. Sometimes, it seems like our kind words and sympathy do more for our patients than our spells.
 
-    I am reminded of a very sick young man who came to the
-temple, suffering from a variety of maladies. Once I had
-given him an examination, I told him the results, careful
-not to alarm him. I let him decide how he wanted to be told the
-news.
+ I am reminded of a very sick young man who came to the temple, suffering from a variety of maladies. Once I had given him an examination, I told him the results, careful not to alarm him. I let him decide how he wanted to be told the news.
 
-    "I have some good news and some bad news, my child," I
-said.
+ "I have some good news and some bad news, my child," I said.
 
-    "I better hear the bad news first," he said.
+ "I better hear the bad news first," he said.
 
-    "Well," I said, gripping his shoulder in case he should
-faint. "The bad news is that, unless I am wrong, you will
-sicken even more over the next day or two. And unless
-Stendarr choses to be merciful to you, you will pass from
-this existance. I am sorry, my child."
+ "Well," I said, gripping his shoulder in case he should faint. "The bad news is that, unless I am wrong, you will sicken even more over the next day or two. And unless Stendarr choses to be merciful to you, you will pass from this existance. I am sorry, my child."
 
-    As soft as the blow was, it stung nonetheless. The boy was,
-after all, very young. He thought he had his whole life ahead
-of him. Tears streaming down his face, he asked, "And what is
-the good news?"
+ As soft as the blow was, it stung nonetheless. The boy was, after all, very young. He thought he had his whole life ahead of him. Tears streaming down his face, he asked, "And what is the good news?"
 
-    I smiled: "When you came in, did you notice our
-proselytizer? She was the enchanting, voluptuous blonde in
-the antechamber by the foyer?"
+ I smiled: "When you came in, did you notice our proselytizer? She was the enchanting, voluptuous blonde in the antechamber by the foyer?"
 
-    Color returned to the young man's face. He had noticed her
-indeed. "Yes?"
+ Color returned to the young man's face. He had noticed her indeed. "Yes?"
 
-    "I'm sleeping with her," I said.
+ "I'm sleeping with her," I said.
 
-    If more of the healers of Tamriel would consider their
-patients' feelings, not just the quickest way to heal them up
-and get them out, we would have a far, far healthier
-society. I truly believe that. 
+ If more of the healers of Tamriel would consider their patients' feelings, not just the quickest way to heal them up and get them out, we would have a far, far healthier society. I truly believe that.

--- a/Assets/StreamingAssets/Text/Books/BOK00073-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00073-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: False
 Price: 738
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,53 +12,16 @@ Content:
 
 [/center]Jephre
 
-
-
 [/font=4]
 
 [/center]
 
+ When the elven folk walked the land alone and sang songs of power amongst the trees and stars, Jephre the Singer walked with them. Jephre gave heed to the nature of the forests and delighted in the gurgling streams and brooks. It was Jephre who taught the birds to sing their songs of the seasons and He that taught the streams the tinkling ethereal tune. The very trees are said to have moved close to hear him sing on the warm summer nights of those elder days. It was in this time that the first great ballads of the elves were made, crafted from the songs that Jephre taught to the sylvan youth who frolicked to his lively tunes and ballads of nature and the unspoiled forest. In truth, He is worshipped as god of song and forest.
 
+ In Valenwood, Jephre is considered one of the Major Sylvan gods with temples and altars in the deep woodland places. Elven tradition holds that children with a gift for song have been blessed by Jephre himself. Legend has it he blessed the Wood Elves with a natural affinity for nature and particularly the forest. Most Wood Elven Rangers worship Jephre.
 
- When the elven folk walked the land alone and sang songs of
-power amongst the trees and stars, Jephre the Singer walked
-with them. Jephre gave heed to the nature of the forests and
-delighted in the gurgling streams and brooks. It was Jephre
-who taught the birds to sing their songs of the seasons and He
-that taught the streams the tinkling ethereal tune. The very
-trees are said to have moved close to hear him sing on the warm
-summer nights of those elder days. It was in this time that the
-first great ballads of the elves were made, crafted from the
-songs that Jephre taught to the sylvan youth who frolicked to
-his lively tunes and ballads of nature and the unspoiled
-forest. In truth, He is worshipped as god of song and forest.
+ It was his great eagerness for natural beauty that led him to the Isle of Sumurset. He taught the great sea birds to sing and molded the crash of wave against beach into a song of whispers and power It is said by the high elves that Jephre hears and sees all within distance of water, whether it be beach, brook, stream or fall. It is further said that the very birds keep watch for Jephre, in repayment for the songs he taught them. It is fruther said he blessed the high elves with a beauty to match the beauty of their island home.
 
- In Valenwood, Jephre is considered one of the Major Sylvan
-gods with temples and altars in the deep woodland places.
-Elven tradition holds that children with a gift for song have
-been blessed by Jephre himself. Legend has it he blessed the
-Wood Elves with a natural affinity for nature and
-particularly the forest. Most Wood Elven Rangers worship
-Jephre.
+ The dark elves have a legend that Jephre walked the earth before the first day, and in the light of the stars weaved a song so beautiful that the very stars moved to its sway. Some of the stars to this very day still wink and blink in memory of the song of night and darkness. Due to his influence most if not all Elven Bards pay homage to Jephre.
 
- It was his great eagerness for natural beauty that led him to
-the Isle of Sumurset. He taught the great sea birds to sing and
-molded the crash of wave against beach into a song of
-whispers and power  It is said by the high elves that Jephre
-hears and sees all within distance of water, whether it be
-beach, brook, stream or fall. It is further said that the
-very birds keep watch for Jephre, in repayment for the songs
-he taught them. It is fruther said he blessed the high elves
-with a beauty to match the beauty of their island home.
-
- The dark elves have a legend that Jephre walked the earth
-before the first day, and in the light of the stars weaved a
-song so beautiful that the very stars moved to its sway.
-Some of the stars to this very day still wink and blink in
-memory of the song of night and darkness. Due to his influence
-most if not all Elven Bards pay homage to Jephre.
-
- The natural order of things is the basis for Jephre's temples
-in Valenwood and the Sumurset Isle. The one thing Jephre
-will not tolerate is the harmful manipulation of the natural
-order of things.   
+ The natural order of things is the basis for Jephre's temples in Valenwood and the Sumurset Isle. The one thing Jephre will not tolerate is the harmful manipulation of the natural order of things.

--- a/Assets/StreamingAssets/Text/Books/BOK00074-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00074-LOC.txt
@@ -3,9 +3,8 @@ Author: Frincheps
 IsNaughty: True
 Price: 317
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,326 +14,194 @@ Content:
 
 [/center]Oneth
 
-
-
 [/font=4]
 
+[/center]
 
+ Dramatis Personae
 
-[/center] Dramatis Personae
-
- Prologue The Adventurer, A Dark Elf Rascal Komon, A Priest
-of Akatosh Lheban, Another Priest of Akatosh Epilogue Stete, A
-Priest of Julianos Raic, Another Priest of Julianos Shub, A
-Mage Shub, A Different Mage of the Same Name Nephron, A
-Somewhat Sleazy Merchant 5 Armorers Ortho Crunn, Husband of
-Millie A Lusty Contessa Millie, Innkeep and Philosopher
-Gurnsey, Bovine Wench Assorted Wenches and Cads of the
-Taverns Soldiers Dwarves Giants
-
-
+ Prologue; The Adventurer, A Dark Elf Rascal; Komon, A Priest of Akatosh; Lheban, Another Priest of Akatosh; Epilogue; Stete, A Priest of Julianos; Raic, Another Priest of Julianos; Shub, A Mage; Shub, A Different Mage of the Same Name; Nephron, A Somewhat Sleazy Merchant; 5 Armorers; Ortho; Crunn, Husband of Millie; A Lusty Contessa; Millie, Innkeep and Philosopher; Gurnsey, Bovine Wench; Assorted Wenches and Cads of the Taverns; Soldiers; Dwarves; Giants.
 
  Daggerfall and Environs in the Doldrums of the 3rd Era
 
- Part The Oneth - Concerning Priests and Nackles       As
-related at length by two Priests of       Akatosh to the
-Adventurer, who at the        time was not having an
-adventure, and       had nothing better to do. In which some     
- (probably unwanted) light is shed upon       the Priesthood
-and its members, and upon       an old peasant myth of some
-significance,       especially common in High Rock. And in      
-which the mysterious Fools' Ebony       appears, that strange
-material that       could bring either drastic cultural
-change       for the many, or just great profit for a       few,
-or death for a bunch, or have no       result whatsoever.
+ Part The Oneth - Concerning Priests and Nackles
 
- Early in the month of Frostfall. The Dead Daedra Inn. Enter
-Prologue
+ As related at length by two Priests of Akatosh to the Adventurer, who at the time was not having an adventure, and had nothing better to do. In which some (probably unwanted) light is shed upon the Priesthood and its members, and upon an old peasant myth of some significance, especially common in High Rock. And in which the mysterious Fools' Ebony appears, that strange material that could bring either drastic cultural change for the many, or just great profit for a few, or death for a bunch, or have no result whatsoever.
 
-      Prologue: Our poor players will try and remember their
-lines and not trip over our meager set. I beg you, the
-audience, not to heckle, badger, or throw rotten
-foodstuffs. You will only make this short play last longer.
-The Guild of Playwrites, Actors, and Dramatists wish any of
-you who are sensitive or allergic to rambling dialogue,
-wooden acting, incomprehensible exposition, or
-unsatisfying endings that leave one confused and unhappy to
-exit the theatre immediately. Your gold will, alas, not be
-refunded. As a saving grace, this series of vignettes
-contains gratuitous references to all pleasures of the
-flesh. You may enjoy it. Ah, here comes our hero, the roguish
-Dark Elf called the Adventurer. It is time for Prologue to
-trip merrily away.
+ Early in the month of Frostfall.
 
+ The Dead Daedra Inn.
 
-     Exit Prologue Enter the Adventurer
+ (Enter Prologue)
 
-       Adventurer:  What an odd conversation I just heard
-between those two mages. It is best not to speak of such
-matters next to privy hedges.
+ Prologue: Our poor players will try and remember their lines and not trip over our meager set. I beg you, the audience, not to heckle, badger, or throw rotten foodstuffs. You will only make this short play last longer. The Guild of Playwrites, Actors, and Dramatists wish any of you who are sensitive or allergic to rambling dialogue, wooden acting, incomprehensible exposition, or unsatisfying endings that leave one confused and unhappy to exit the theatre immediately. Your gold will, alas, not be refunded. As a saving grace, this series of vignettes contains gratuitous references to all pleasures of the flesh. You may enjoy it. Ah, here comes our hero, the roguish Dark Elf called the Adventurer. It is time for Prologue to trip merrily away.
 
- Enter 2 Priests of Akatosh (Lheban, Komon)
+ (Exit Prologue)
 
-       Lheban: Mind if we join you, fellow? ... Good, need some
-company ourselves. I am named Lheban, my fellow priest
-here is Komon. We both serve Akatosh, all in our own ways,
-of course ...
+ (Enter the Adventurer)
 
-       Adventurer: Make yourselves at home, it's not my bench.
-But I thought that priests ... didn't go to ... er ...
-places like this, Inns. I mean ... unless on duty?
+ Adventurer: What an odd conversation I just heard between those two mages. It is best not to speak of such matters next to privy hedges.
 
-       Lheban: Oh, we're not on duty. Got to regenerate our
-internal vital energies, so we can go on blessing and curing
-...
+ (Enter 2 Priests of Akatosh)
 
-       Komon: We often come here, hike up our robes, kick up our
-heels, as it were. Fill up with some bottled energy ...
+ (Lheban, Komon)
+
+ Lheban: Mind if we join you, fellow? ... Good, need some company ourselves. I am named Lheban, my fellow priest here is Komon. We both serve Akatosh, all in our own ways, of course ...
+
+ Adventurer: Make yourselves at home, it's not my bench. But I thought that priests ... didn't go to ... er ... places like this, Inns. I mean ... unless on duty?
+
+ Lheban: Oh, we're not on duty. Got to regenerate our internal vital energies, so we can go on blessing and curing...
+
+ Komon: We often come here, hike up our robes, kick up our heels, as it were. Fill up with some bottled energy ...
 
  (Komon snickers)
 
-       Lheban: Looking for those in need of comfort and
-blessing, of course ...
+ Lheban: Looking for those in need of comfort and blessing, of course ...
 
-       Komon: Oh, yes, Oh yes ... like that young girl outside the
-other evening ...
+ Komon: Oh, yes, Oh yes ... like that young girl outside the other evening ...
 
  (Lheban kicks Komon)
 
-       Komon: ... and anyway our High Priest told us to get
-lost...
+ Komon: ... and anyway our High Priest told us to get lost...
 
-       Lheban: He means told us to get some air. We've been
-having visions, you see ...
+ Lheban: He means told us to get some air. We've been having visions, you see ...
 
-       Komon: Yes, sort of weird, really ... and we hadn't even
-been taking any of that ...
+ Komon: Yes, sort of weird, really ... and we hadn't even been taking any of that ...
 
  (Lheban kicks Komon)
 
-       Lheban: Both of us been having the same visions -- real
-odd.
+ Lheban: Both of us been having the same visions -- real odd.
 
-       Adventurer: Do tell, I'm not going anywhere in a hurry.
+ Adventurer: Do tell, I'm not going anywhere in a hurry.
 
-       Lheban: Well, we've both been hearing sort of ... words
-... for a start. Like 'Sir Nich' or 'Sain Nack' ...
+ Lheban: Well, we've both been hearing sort of ... words ... for a start. Like 'Sir Nich' or 'Sain Nack' ...
 
-       Adventurer: You said 'Nick' or 'Nack'? Just a minute ...
-let me have a swig from your bottle, Brother ... Ah! That's
-better - high-class stuff you fellows drink! Yes, I recall -
-some story or old legend about an elf, name of Nuckle, I
-think -- from Morrowind?
+ Adventurer: You said 'Nick' or 'Nack'? Just a minute ... let me have a swig from your bottle, Brother ... Ah! That's better - high-class stuff you fellows drink! Yes, I recall - some story or old legend about an elf, name of Nuckle, I think -- from Morrowind?
 
-       Lheban: You know, maybe you're on to something there --
-there is a old legend around these parts, comes from deep in
-High Rock I think ... hmmmm ... Nackles, that's it!
+ Lheban: You know, maybe you're on to something there -- there is a old legend around these parts, comes from deep in High Rock I think ... hmmmm ... Nackles, that's it!
 
-       Adventurer: Nackles, eh! Seems that several Dark Elves
-use that name ... particularly the ... more peculiar
-ones...
+ Adventurer: Nackles, eh! Seems that several Dark Elves use that name ... particularly the ... more peculiar ones...
 
-       Komon: Yes, I guess that the bad ones are into all that
-weapons magicka stuff ... very nasty fellows ...
+ Komon: Yes, I guess that the bad ones are into all that weapons magicka stuff ... very nasty fellows ...
 
-       Lheban:     (to Komon) Komon! This fellow's got pointy
-ears and red eyes ...
+ Lheban: (to Komon) Komon! This fellow's got pointy ears and red eyes ...
 
-       Komon: Pardon me, friend ... it's sort of dark, and I
-didn't ... uh ...          Adventurer: Oh, that's fine. These are
-strange times. You know, live and let live -- or die -- as the
-case may be.  Now ... suppose you tell me about this Nackles
-myth? Here, let me help you with that bottle ... Ah! Thanks.     
-    Lheban: Er ... sure, if you want to put it that way ...
-Here, have another swig! Sure, we've got the time, and I
-recall it clearly now.                Komon: Yes, we've a couple
-hours 'til that little blonde shows up at her lamp ...
+ Komon: Pardon me, friend ... it's sort of dark, and I didn't ... uh ...
+
+ Adventurer: Oh, that's fine. These are strange times. You know, live and let live -- or die -- as the case may be. Now ... suppose you tell me about this Nackles myth? Here, let me help you with that bottle ... Ah! Thanks.
+
+ Lheban: Er ... sure, if you want to put it that way ... Here, have another swig! Sure, we've got the time, and I recall it clearly now.
+
+ Komon: Yes, we've a couple hours 'til that little blonde shows up at her lamp ...
 
  (Lheban kicks Komon)
 
-      Lheban:      (to Komon) Quiet! Remember, we had to tell the
-High Priest her address, so she won't be around for a while!    
- (to all) Very well, here's the story, best as I can recall
-it. This is a tale the peasants up in High Rock tell their kids
-to scare them into being good for a while, I guess. They tell
-it, let me see ... either on Tales and Tallows, or is it
-Witches' Festival? -- just before the kids are sent out to the
-barn or pigsty to sleep. 
+ Lheban: (to Komon) Quiet! Remember, we had to tell the High Priest her address, so she won't be around for a while! (to all) Very well, here's the story, best as I can recall it. This is a tale the peasants up in High Rock tell their kids to scare them into being good for a while, I guess. They tell it, let me see ... either on Tales and Tallows, or is it Witches' Festival? -- just before the kids are sent out to the barn or pigsty to sleep.
 
-       Komon: Nasty cruel peasants!  But then, I'd send them
-all out to the midden ...
+ Komon: Nasty cruel peasants! But then, I'd send them all out to the midden ...
 
-       Lheban: Really, Komon! Remember, those poor souls need
-our compassion and blessing, we are their salvation!
+ Lheban: Really, Komon! Remember, those poor souls need our compassion and blessing, we are their salvation!
 
-       Komon: Now who's in Old High Mucky-Mucks' study?
+ Komon: Now who's in Old High Mucky-Mucks' study?
 
-       Lheban: Er ... anyway. It goes a bit like this.  If the kids
-have been real good during the  year -- filched enough in the
-market, mucked out the stables every day, not gone playing
-with goblins, left the sheep alone, and so on. If they have
-been real good, they've nothing to worry about. But if they
-haven't been real good then there is this nasty, horrid Dark
-Elf spirit called Nackles. Doesn't look like your typical
-Dark Elf -- thinner, taller. Pasty white face, long as your
-arm. Walks like his knees and elbows bend the wrong way.
-Snickers like when you drag your fingernails across slate.
-Wears a tight black suit (not Khajiit, more like a formal
-suit with buttons) but too tight and small. He visits the bad
-girls and --
+ Lheban: Er ... anyway. It goes a bit like this. If the kids have been real good during the year -- filched enough in the market, mucked out the stables every day, not gone playing with goblins, left the sheep alone, and so on. If they have been real good, they've nothing to worry about. But if they haven't been real good then there is this nasty, horrid Dark Elf spirit called Nackles. Doesn't look like your typical Dark Elf -- thinner, taller. Pasty white face, long as your arm. Walks like his knees and elbows bend the wrong way. Snickers like when you drag your fingernails across slate. Wears a tight black suit (not Khajiit, more like a formal suit with buttons) but too tight and small. He visits the bad girls and --
 
-       Komon: Why are you talking about Old High Mucky again,
-Lheban?
+ Komon: Why are you talking about Old High Mucky again, Lheban?
 
- (Komon hiccoughs) (Lheban kicks Komon)
-
-       Lheban: You really must excuse Komon here: overwork, you
-know. Too many curings and conversions ... Anyway, Old
-Nasty Nackles is supposed to wander under our Tamriel, in
-dirty deep dark dwarven tunnels. Everywhere under the
-lands, if you can believe that! Rides in a rusty squeaky old
-mine cart, on old mine tracks ...
-
-       Adventurer: I saw some of those in Fang Lair once, down
-in Hammerfell a long long while ago ...
-
-       Komon:       (to Lheban) What the Sheogorath was he doing in
-Fang Lair!?             Lheban:       (to Komon) Hush! If he's who I
-think he is, you do not want to know!       (to all) Um, yes.
-Well, Nackles gets pulled all around these deep tunnels by
-goblins -- not your usual dirty yellow ones, but nasty
-black things. Anyway, they pull Nackles round and through
-these dark tunnels, and then, late at night, he stops below
-each and every bad child's hovel or house or castle -- makes
-no difference. Then he slides up the drainage pipes ...
-
-       Komon: Creeps up cracks ... crawls through holes ...
-
-       Lheban: Oozes up oubliettes ...
-
-       Komon: Climbs giggling up garderobes ...
-
-       Lheban: Right into the kid's place! Then, if the kid's only
-been sort of bad, Nackles will just mess things up in
-general, so the kid gets blamed. Make greasy dirty marks
-everywhere (more than usual, anyway), break some things,
-steal some things, so on and so forth. Maybe take the sugar
-sweets, leave some lumps of fools' ebony instead ...
-
-       Adventurer: Fools' Ebony - what's that?  Heard mention of
-that, oh, a few hours ago ... Some Mages ...
-
-       Lheban: You did now? Interesting ... Very ... Well,
-lets talk of that in a bit ... just let me finish this Nackles
-thing. Where was I -- Oh yes ... Now, if the little brat has
-been real bad --  then all the little brat's toys get taken.
-The copper dagger, the wooden sword, the little whip, and
-so on. All the usual favorite kids things.
-
-       Komon: Whips? I like those.
-
- (Komon hiccoughs) (Lheban kicks Komon)
-
-       Lheban: Now if that little brat has been very, very bad
-then Nackles grabs the brat. Pops him or her in his dirty
-great sack. Hauls the sack off down the holes and cracks, down
-to his rusty old mine cart!  And away they go!         Komon: Hope
-he leaves some bad little girls behind.
+ (Komon hiccoughs)
 
  (Lheban kicks Komon)
 
-       Lheban: Er ... so we can save them, of course, friend ...
-Well. Sometimes, so I've heard tell, the brat never comes
-back. No great loss, I guess, peasants just breed another.
+ Lheban: You really must excuse Komon here: overwork, you know. Too many curings and conversions ... Anyway, Old Nasty Nackles is supposed to wander under our Tamriel, in dirty deep dark dwarven tunnels. Everywhere under the lands, if you can believe that! Rides in a rusty squeaky old mine cart, on old mine tracks ...
 
-       Komon: Know 'bout that, I do, I do ...
+ Adventurer: I saw some of those in Fang Lair once, down in Hammerfell a long long while ago ...
+
+ Komon: (to Lheban) What the Sheogorath was he doing in Fang Lair!?
+
+ Lheban: (to Komon) Hush! If he's who I think he is, you do not want to know! (to all) Um, yes. Well, Nackles gets pulled all around these deep tunnels by goblins -- not your usual dirty yellow ones, but nasty black things. Anyway, they pull Nackles round and through these dark tunnels, and then, late at night, he stops below each and every bad child's hovel or house or castle -- makes no difference. Then he slides up the drainage pipes ...
+
+ Komon: Creeps up cracks ... crawls through holes ...
+
+ Lheban: Oozes up oubliettes ...
+
+ Komon: Climbs giggling up garderobes ...
+
+ Lheban: Right into the kid's place! Then, if the kid's only been sort of bad, Nackles will just mess things up in general, so the kid gets blamed. Make greasy dirty marks everywhere (more than usual, anyway), break some things, steal some things, so on and so forth. Maybe take the sugar sweets, leave some lumps of fools' ebony instead ...
+
+ Adventurer: Fools' Ebony - what's that? Heard mention of that, oh, a few hours ago ... Some Mages ...
+
+ Lheban: You did now? Interesting ... Very ... Well, lets talk of that in a bit ... just let me finish this Nackles thing. Where was I -- Oh yes ... Now, if the little brat has been real bad -- then all the little brat's toys get taken. The copper dagger, the wooden sword, the little whip, and so on. All the usual favorite kids things.
+
+ Komon: Whips? I like those.
+
+ (Komon hiccoughs)
+
+ (Lheban kicks Komon)
+
+ Lheban: Now if that little brat has been very, very bad then Nackles grabs the brat. Pops him or her in his dirty great sack. Hauls the sack off down the holes and cracks, down to his rusty old mine cart! And away they go!
+
+ Komon: Hope he leaves some bad little girls behind.
+
+ (Lheban kicks Komon)
+
+ Lheban: Er ... so we can save them, of course, friend ... Well. Sometimes, so I've heard tell, the brat never comes back. No great loss, I guess, peasants just breed another.
+
+ Komon: Know 'bout that, I do, I do ...
 
  (Lheban pinches Komon's nose)
 
-       Lheban: But, as the story goes round here anyway, often
-the brat is just put to work, digging out lumps of Fools'
-Ebony, shoveling dirt, bagging it. Extending the tunnels of
-the Nackles. After a while, Brat is pushed back up to where it
-came from. Seems that Brat might think it's spent a year down
-there, but only a day has passed up top ... Brat comes back
-real thin and dirty though, covered in black mess ... You
-know, come to think of it -- on the day past Witches'
-Festival, I've often seen some little brats, scrawny, real
-dirty black mess on them, looking terrified, too. Parents
-drag them into Temples to get blessed and cured, if they have
-the gold. By the Beard of Sheogorath, the wailing and noise!
-Enough to drive a priest to ... er ... well,  never mind ...
-that's our problem ...
+ Lheban: But, as the story goes round here anyway, often the brat is just put to work, digging out lumps of Fools' Ebony, shoveling dirt, bagging it. Extending the tunnels of the Nackles. After a while, Brat is pushed back up to where it came from. Seems that Brat might think it's spent a year down there, but only a day has passed up top ... Brat comes back real thin and dirty though, covered in black mess ... You know, come to think of it -- on the day past Witches' Festival, I've often seen some little brats, scrawny, real dirty black mess on them, looking terrified, too. Parents drag them into Temples to get blessed and cured, if they have the gold. By the Beard of Sheogorath, the wailing and noise! Enough to drive a priest to ... er ... well, never mind ... that's our problem ...
 
-       Komon: Nah ... it's a problem with our suppliers, I tell
-you ...
+ Komon: Nah ... it's a problem with our suppliers, I tell you ...
 
  (Lheben throws Komon through a screen)
 
-       Lheban: Anyway, that's the short of it, this Nackles
-legend up around here. I recall now, it's widespread all
-over Tamriel ...  and knowing the place, probably more
-than a grain of truth in the tale, much, much more ...        
-Adventurer: So, I guess some of the ... er, darker Dark Elves
-sort of identify with this Nackles. Take on the persona, so to
-say ...
+ Lheban: Anyway, that's the short of it, this Nackles legend up around here. I recall now, it's widespread all over Tamriel ... and knowing the place, probably more than a grain of truth in the tale, much, much more ...
 
-       Lheban: Yeah, that sort of sums it up, I guess ... though
-we don't see those types hauling off brats in sacks, now do
-we?
+ Adventurer: So, I guess some of the ... er, darker Dark Elves sort of identify with this Nackles. Take on the persona, so to say ...
 
-       Komon: Nah, that's wot we does, girly brats anyway,
-isn't it not?
+ Lheban: Yeah, that sort of sums it up, I guess ... though we don't see those types hauling off brats in sacks, now do we?
 
- (Komon hiccoughs) (Lheben breaks a bottle over Komon's head)
-(Komon falls unconscious)
+ Komon: Nah, that's wot we does, girly brats anyway, isn't it not?
 
-       Adventurer: Thats a very interesting tale, gentlemen.
-Say, let me repay you with another bottle -- what's that
-you're drinking? Ah, thought so - Innkeep!  More holy wine for
-these holy men!
+ (Komon hiccoughs)
 
-       Lheban: A blessing on you for that kind gesture, friend.   
-       Adventurer: I thank you, I sure could use one or three ...
-Anyway, this 'Fools' Ebony', I've heard mutters and murmurs
-about that of late -- mostly eavesdropping ... pardon me
-... listening ... to Mages and the like. What's with this
-stuff?  Here, have another swig ... good!
+ (Lheben breaks a bottle over Komon's head)
 
-       Lheban: Well, we're not supposed to tell outsiders ...
-but then, you seem to know something already. And if you have
-been hearing Mage gossip ... Why, maybe we can do some
-business. Profit all round! Well ... for the Akatosh
-Chantry, of course, and your fee, good Sir.
+ (Komon falls unconscious)
 
-       Adventurer: More and more interesting -- tell on, I pray
-you.
+ Adventurer: Thats a very interesting tale, gentlemen. Say, let me repay you with another bottle -- what's that you're drinking? Ah, thought so - Innkeep! More holy wine for these holy men!
 
- (Komon staggers to feet) (Komon hiccoughs)
+ Lheban: A blessing on you for that kind gesture, friend.
 
-       Komon: Time for me to go convert that little lamppost
-girl ... no, no, no - not last nights one, but the blonde
-...
+ Adventurer: I thank you, I sure could use one or three ... Anyway, this 'Fools' Ebony', I've heard mutters and murmurs about that of late -- mostly eavesdropping ... pardon me... listening ... to Mages and the like. What's with this stuff? Here, have another swig ... good!
 
- (Exit Komon) (Female squeals from offstage)
+ Lheban: Well, we're not supposed to tell outsiders ... but then, you seem to know something already. And if you have been hearing Mage gossip ... Why, maybe we can do some business. Profit all round! Well ... for the Akatosh Chantry, of course, and your fee, good Sir.
 
-       Lheban: Friend, you'll have to excuse Komon. He's a bit
-... you know strange ... Got these ...
+ Adventurer: More and more interesting -- tell on, I pray you.
 
-       Adventurer: Oh, that's all right, we've all got our own
-...
+ (Komon staggers to feet)
 
- (Exeunt Lheben and the Adventurer) (Enter Epilogue)
+ (Komon hiccoughs)
 
-       Epilogue: Our apologies for the quality of this drama so
-far. If those of you still present will wait for a few
-minutes while our bard plays "Silence Implies Consent," we
-will change the set for the next act, Part the Twoth. Please
-don't forget to tip your wench. Do you believe there's such a
-thing as Fools' Ebony? Maybe we'll find out in Part the
-Twoth. Or maybe not.
+ Komon: Time for me to go convert that little lamppost girl ... no, no, no - not last nights one, but the blonde...
 
- (Flourish) (Exit Epilogue)
+ (Exit Komon)
 
- End of Part the Oneth, Being Mostly Concerned with The
-Legend of Nackles. 
+ (Female squeals from offstage)
+
+ Lheban: Friend, you'll have to excuse Komon. He's a bit... you know strange ... Got these ...
+
+ Adventurer: Oh, that's all right, we've all got our own...
+
+ (Exeunt Lheben and the Adventurer)
+
+ (Enter Epilogue)
+
+ Epilogue: Our apologies for the quality of this drama so far. If those of you still present will wait for a few minutes while our bard plays "Silence Implies Consent," we will change the set for the next act, Part the Twoth. Please don't forget to tip your wench. Do you believe there's such a thing as Fools' Ebony? Maybe we'll find out in Part the Twoth. Or maybe not.
+
+ (Flourish)
+
+ (Exit Epilogue)
+
+ End of Part the Oneth, Being Mostly Concerned with The Legend of Nackles.

--- a/Assets/StreamingAssets/Text/Books/BOK00075-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00075-LOC.txt
@@ -3,9 +3,8 @@ Author: Frincheps
 IsNaughty: True
 Price: 317
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,674 +14,170 @@ Content:
 
 [/center]Twoth
 
-
-
 [/font=4]
 
+[/center]
 
+ Dramatis Personae
 
-[/center] Dramatis Personae
+ Prologue; The Adventurer, A Dark Elf Rascal; Komon, A Priest of Akatosh; Lheban, Another Priest of Akatosh; Epilogue; Stete, A Priest of Julianos; Raic, Another Priest of Julianos; Shub, A Mage; Shub, A Different Mage of the Same Name; Nephron, A Somewhat Sleazy Merchant; 5 Armorers; Ortho; Crunn, Husband of Millie; A Lusty Contessa; Millie, Innkeep and Philosopher; Gurnsey, Bovine Wench; Assorted Wenches and Cads of the Taverns; Soldiers; Dwarves; Giants.
 
- Prologue The Adventurer, A Dark Elf Rascal Komon, A Priest
-of Akatosh Lheban, Another Priest of Akatosh Epilogue Stete, A
-Priest of Julianos Raic, Another Priest of Julianos Shub, A
-Mage Shub, A Different Mage of the Same Name Nephron, A
-Somewhat Sleazy Merchant 5 Armorers Ortho Crunn, Husband of
-Millie A Lusty Contessa Millie, Innkeep and Philosopher
-Gurnsey, Bovine Wench Assorted Wenches and Cads of the Taverns Soldiers Dwarves Giants
+ Part The Twoth - Bearing Mostly on Fools' Ebony and Temples
 
+ Same place, same Inn, A bottle or two later. Enter Prologue, the Adventurer, and Lheben
 
-
-
-
- Part The Twoth - Bearing Mostly on Fools'                  Ebony
-and Temples
-
- Same place, same Inn, A bottle or two later. Enter
-Prologue, the Adventurer, and Lheben
-
- Prologue:   Little has occured so far in our             comedic
-drama. The Adventurer, our
-
-
-    Dark Elf rascal, has bought drinks
-
-
-    for two priests of Akatosh. All
-
-
-    have drunk considerably. One of
-
-
-    the priests has rushed off in
-
-
-    pursuit of his lamp girl. And,
-
-
-    unless I've forgotten something or
-
-
-    something happened when I was
-
-
-    paying attention to something else,
-
-
-    that's a complete synopsis of Part
-
-
-    the Oneth. Ah, here come two more
-
-
-    priests. Humble Prologue must
-
-
-    depart.
+ Prologue: Little has occured [sic] so far in our comedic drama. The Adventurer, our Dark Elf rascal, has bought drinks for two priests of Akatosh. All have drunk considerably. One of the priests has rushed off in pursuit of his lamp girl. And, unless I've forgotten something or something happened when I was paying attention to something else, that's a complete synopsis of Part the Oneth. Ah, here come two more priests. Humble Prologue must depart.
 
  (Enter Raic and Stete)
 
- Raic:       Evening Lheban! Evening stranger. My            
-fellow priest here is Stete, I am Raic.
+ Raic: Evening Lheban! Evening stranger. My fellow priest here is Stete, I am Raic. We are honored to serve Julianos.
 
+ Adventurer: What is this, anyway - Priests night out? And ... I thought that your Temples - Akatosh, Julianos, the rest ... I thought them all cut-throat competitors. In theology and gold, if you will forgive my bluntness. Yet you all seem the best of friends ..? Come to think of it, didn't I have words with Stete earlier, you said you were of the Temple of Stendarr?
 
-    We are honored to serve Julianos.
+ Raic: A common misconception, friend ...
 
- Adventurer: What is this, anyway - Priests night             out?
-And ... I thought that your
+ Lheban: ... but one that we ... encourage ...
 
+ Raic: Really, we all work together closely, move between the Temples as needs dictate ...
 
-    Temples - Akatosh, Julianos, the rest
+ Lheban: ... exchange information ...
 
+ Raic: ... share funds ...
 
-    ... I thought them all cut-throat
+ Stete: ... swap our sisters ...
 
+ (Lheben kicks Stete)
 
-    competitors. In theology and gold, if
+ (Enter Prologue)
 
-
-    you will forgive my bluntness. Yet you
-
-
-    all seem the best of friends ..?              Come to think
-of it, didn't I have
-
-
-    words with Stete earlier, you said
-
-
-    you were of the Temple of Stendarr?
-
- Raic:       A common misconception, friend ...
-
- Lheban:     ... but one that we ... encourage ...
-
- Raic:       Really, we all work together closely,            
-move between the Temples as needs
-
-
-    dictate ...
-
- Lheban:     ... exchange information ... Raic:       ... share
-funds ... Stete:      ... swap our sisters ...
-
- (Lheben kicks Stete) (Enter Prologue)
-
- Prologue:   Sorry to interrupt the merry slapstick,            
-but I neglected to mention earlier that
-
-
-    the Fools' Gold saga -- if that is the
-
-
-    word -- contains gratuitous reference
-
-
-    to priestly misdeeds and sexual excess.
-
-
-    I hope those of you in the audience of
-
-
-    peevish, prudish, sullen, frumpy, or
-
-
-    grumpy demeanors are not offended. Now
-
-
-    then, on with the entertainment.
+ Prologue: Sorry to interrupt the merry slapstick, but I neglected to mention earlier that the Fools' Gold [sic] saga -- if that is the word -- contains gratuitous reference to priestly misdeeds and sexual excess. I hope those of you in the audience of peevish, prudish, sullen, frumpy, or grumpy demeanors are not offended. Now then, on with the entertainment.
 
  (Exit Prologue)
 
- Lheban:     ... and all that ...
+ Lheban: ... and all that ...
 
- Raic:       But it helps in our ... holy work, if             we
-are perceived as separate and, uh,
+ Raic: But it helps in our ... holy work, if we are perceived as separate and, uh, competitive...
 
+ Lheban: Mind you, there are one or two, er ... religious organizations ... well, sort of ... that we do not have anything to do with ...
 
-    competitive...
-
- Lheban:     Mind you, there are one or two, er ...            
-religious organizations ... well, sort
-
-
-    of ... that we do not have anything to
-
-
-    do with ...
-
- Raic:       Nothing at all, nothing at all ...            
-animals, just animals ...
+ Raic: Nothing at all, nothing at all ... animals, just animals ...
 
  Adventurer: Such as ..?
 
- Lheban:     Weeell -- the Dark Brotherhood for one             ...
-nasty bunch of thugs ... and then
+ Lheban: Weeell -- the Dark Brotherhood for one ... nasty bunch of thugs ... and then there's the Afterdark Society ... (aside to Raic) This fellow, seems a decent sort of chap ... seems to know something about Mages and Fools' Ebony ...
 
-
-    there's the Afterdark Society ...             (aside to
-Raic)
-
-
-    This fellow, seems a decent sort of             chap ...
-seems to know something about             Mages and Fools'
-Ebony ...
-
- Raic:       (aside to Lheban)             Really now ... how
-interesting...
-
-
-    (to all)             Hey fellow, have another bottle --
-
-
-    this will bless you throat. My, my, yes
-
-
-    indeed it will...
+ Raic: (aside to Lheban) Really now ... how interesting... (to all) Hey fellow, have another bottle -- this will bless you throat. My, my, yes indeed it will...
 
  Adventurer: Thanks Raic, don't mind a bit ...
 
- Lheban:     But let me continue -- I was explaining            
-about this Fools' Ebony to you ...
+ Lheban: But let me continue -- I was explaining about this Fools' Ebony to you ...
 
- Raic:       Yes, Fools' Ebony ...
+ Raic: Yes, Fools' Ebony ...
 
- Lheban:     Well. Fools' Ebony now. Well, you know            
-about ordinary Ebony, how it's rare,
+ Lheban: Well. Fools' Ebony now. Well, you know about ordinary Ebony, how it's rare, only some dwarven clans dig it and sell it. And not too many, these days and times ...
 
+ Stete: How's that popular song go ..? (singing) Where have all the Old Dwarves gone, Long time ago ...
 
-    only some dwarven clans dig it and sell
+ (Lheben throws Innkeep at Stete)
 
+ (Raic breaks chair on Innkeep and Stete)
 
-    it. And not too many, these days and
+ (Innkeep loses consciousness)
 
+ Lheban: There's a pile of real ebony up in the Wrothgarians somewhere north, I hear tell. You know how that dullish black ebony gets worked over by Mages, by some skilled armorers, made into all kinds of potent weapons, amulets, belts, what have you. All fetch a huge price, when you can find any. And how the best was made long ago, by those old dwarves ...
 
-    times ... 
+ (Stete rises to his feet)
 
- Stete:      How's that popular song go ..?             (singing)
+ (Lheban kicks Stete back down)
 
+ (The Adventurer loosens his tunic)
 
-    Where have all the Old Dwarves gone,
+ Lheban: Oh my! Oh, my apologies, friend, Sir! I see you have -- what's that? An ebony torc? Oh my, and an ebony katana! Oh My! Oh My, My! So, of course, you know all that, sir.
 
+ Adventurer: Oh, that's all right, you didn't know. Here, have another bottle ...
 
-    Long time ago ...
+ Lheban: Many thanks, kind Sir. Well, then you know how every adventurer, even snotty kids, all the dungeon-delvers, are always looking for ebony artifacts, weapons, whatnot. But what you may not know, some of the more experienced delvers hunt for raw ebony lodes, piles, dwarven leavings. That stuff, the raw ebony, is far more valuable.
 
- (Lheben throws Innkeep at Stete) (Raic breaks chair on Innkeep
-and Stete) (Innkeep loses consciousness)
+ Adventurer: The raw unshaped material that provides work ... and power ... for so few? Apparently just loaded with negative magicka?
 
- Lheban:     There's a pile of real ebony up in the            
-Wrothgarians somewhere north, I hear
+ Raic: Right, right!
 
+ Lheban: Yes, right so! Quite so! Well, Fools' Ebony now. Looks just about like the real raw stuff. Runs in veins in the deep rocks. Feels the same, smells almost the same. But the big difference: it's not real ebony. No power at all. If you pick some up, it gets you hands a bit dirty. Softer too, by all accounts. But sort of shiny too. But who can tell all that, deep in some old mine, maybe a ghoul breathing down your neck! So it's just grab and run, I guess, down in those nasty holes. So the fools, the kids, the crazy delvers, are always hauling up a bag, a sack, of Fools' Ebony. And getting laughed at by the merchants, dealers, mages, us ... hence the Fools' part. Stuff just gets thrown into the Bay ...
 
-    tell. You know how that dullish black
+ Adventurer: Yeah, that's sort of what I ... er ... heard from some Mages. But I heard something else, too ...
 
+ Lheban: And just what was that, friend ... if you want to tell us, of course ... Sir.
 
-    ebony gets worked over by Mages, by
+ Adventurer: Oh, of course! I think that we can come to ... er ... an arrangement?
 
+ Lheban and Raic (Together):: Certainly, Oh Yes!
 
-    some skilled armorers, made into all
+ Adventurer: So, yeah, so these mages -- Shub and Shub, they are always called Shub, aren't they? -- anyway, these old guys were saying how this Fools' Ebony can burn. Not magically, but like an ordinary piece of wood. But the flame lasts far longer, gives off lots more heat, makes no smoke to speak of, no noise ... very interesting ... Mages were saying as how the alchemists want it, to heat the retorts and flasks ... How the Mages Guild wants it, to make and sell ... er ... fake amulets and the like ... rotten trick that! And especially the Armorers, they want it bad, for their forges, I guess. And the Alchemists, for their alembics ...
 
+ Lheban: Precisely my information! Now... gets cold up here in the winter, doesn't it? And everyone is cutting down all those trees, making siege engines, boats, all that evil war machinery! All those rich royals and merchants got to heat their great big piles of homes. So their Contessas can run around in next to nothing, instead of furs...
 
-    kinds of potent weapons, amulets,
+ Stete: ... just like my sister ...
 
+ (Lheben bites Stete's arm)
 
-    belts, what have you. All fetch a huge
+ (Stete shreiks and falls unconscious)
 
+ Adventurer: All those armorers got to keep their hearths and furnaces running...
 
-    price, when you can find any. And how
+ Lheban: ... All the Mages got to keep their familiars warm ...
 
+ Raic: ... All those royals got to keep the contessas running ...
 
-    the best was made long ago, by those
+ Lheban: ... All those peasants got to keep their animals warm ...
 
+ Adventurer: And To Sheogorath with the wife and kids, right? Ha! And, I guess, its sort of hard for you Priests to give blessings and cures, when your fingers are all cold and stiff ..? Makes getting corks out a tad hard, to say nothing of opening those little twists of parchment ..?
 
-    old dwarves ...
+ Raic: You speak truly, indeed!
 
- (Stete rises to his feet) (Lheban kicks Stete back down) (The Adventurer loosens
-his tunic)
+ Lheban: A man of wisdom, indeed! Yes!
 
- Lheban:     Oh my! Oh, my apologies, friend, Sir!             I
-see you have -- what's that? An
+ Adventurer: So, where do we find this Fools' Ebony -- in quantity?
 
+ Lheban: You put your finger (you have six, I note -- oh, excuse me, Sir) on the crux of the matter. I have heard rumors, just rumors, mind you, that there are huge enormous veins of this stuff, at one place on the surface, far up in the Wrothgarians. Bad, bad place to go. But, if you can get there and back, cartloads of the stuff!
 
-    ebony torc? Oh my, and an ebony katana!
+ Adventurer: Thats just what I overheard from those Mages -- far up there in the Wrothgarians -- orcs, dragonlings, daedra, Sheogorath only knows what ... Those Mages seemed to know the spot, though. Mages wanted someone to ...
 
+ Raic: You didn't ... talk ... to the Mages. I mean, you haven't ...
 
-    Oh My! Oh My, My! So, of course, you
+ Adventurer: Oh no. They didn't even know I was there ... (aside) Not yet, anyway...
 
+ Lheban: Good, good - can't trust those Mages, you know ... old fossils would turn their own mothers into sludge-toads, just for a bit of gold! Gold-mad, power-mad, Mad-mad, the whole rotten lot of them! But then they don't have mothers!
 
-    know all that, sir.
+ Raic: Excellent. Seems to me, friend -- or, can we call you partner? Yes? Excellent. Seems to me, partner, that my brother priests and you should do some digging and poking around -- see if we can get to those veins, those deposits, eh!
 
- Adventurer: Oh, that's all right, you didn't know.            
-Here, have another bottle ...
+ Adventurer: Yes indeed, partners! But it would cost a fair pile of gold to get up there -- weapons, spells, women, clothing, carts and horses, women, food, potions ... Best go well-prepared, up there.
 
- Lheban:     Many thanks, kind Sir.  Well, then you             know
-how every adventurer, even snotty
+ Lheban: No problem, partner. Our Temples have ... certain resources, such that if we were guaranteed ... sole access, sole knowledge of the location, then we could finance someone ... someone with the requisite skills, such as yourself? Just by happenstance, I am Keeper of the Books ... you see the opportunity?
 
+ Adventurer: Oh yes! Oh yes! Well -- lets split a last bottle, and shake on an agreement?
 
-    kids, all the dungeon-delvers, are
+ Lheban: Indeed, let us! We first need information -- who knows about the site up there, where it is, how to reach it ... Why don't we meet back here in, say, a week, to the hour. And see what we can learn, meanwhile?
 
+ Raic: We need to find a merchant, too. Someone who can handle it for us ... warehouses, distribution ...
 
-    always looking for ebony artifacts,
+ Lheban: And keep a shut mouth!
 
+ Adventurer: I'll make some inquiries about merchants ... got a contact or two ... Trouble is -- well, you know how these things go -- few golds here, few there, before you know it you've bribed half the town, or so it seems. Now, as luck would have it, I don't have much -- got swindled by a wretched Mage, some town south of here, and lost most of my belongings in a shipwreck ...
 
-    weapons, whatnot.             But what you may not know,
-some of the
+ Lheban: Ah Yes! You need some ... seed money as it were.
 
+ Raic: (To Lheban) Let me lift old Stete's purse, he made a lot renting out his sister last week ...
 
-    more experienced delvers hunt for raw
+ Lheban: Thank you, Raic. Here, about 100 gold -- enough ?
 
-
-    ebony lodes, piles, dwarven leavings.             That
-stuff, the raw ebony, is far more
-
-
-    valuable.    Adventurer: The raw unshaped material that
-provides             work ... and power ... for so few?
-
-
-    Apparently just loaded with negative
-
-
-    magicka?
-
- Raic:       Right, right! 
-
- Lheban:     Yes, right so! Quite so! Well, Fools'            
-Ebony now. Looks just about like the
-
-
-    real raw stuff. Runs in veins in the
-
-
-    deep rocks.  Feels the same, smells
-
-
-    almost the same.  But the big
-
-
-    difference: it's not real ebony. No
-
-
-    power at all. If you pick some up, it
-
-
-    gets you hands a bit dirty. Softer
-
-
-    too, by all accounts. But sort of
-
-
-    shiny too. But who can tell all that,
-
-
-    deep in some old mine, maybe a ghoul
-
-
-    breathing down your neck! So it's just
-
-
-    grab and run, I guess, down in those
-
-
-    nasty holes. So the fools, the kids,
-
-
-    the crazy delvers, are always hauling             up a
-bag, a sack, of Fools' Ebony.
-
-
-    And getting laughed at by the merchants,
-
-
-    dealers, mages, us ... hence the Fools'             part.
-Stuff just gets thrown into the
-
-
-    Bay ...
-
- Adventurer: Yeah, that's sort of what I ... er             ...
-heard from some Mages. But I
-
-
-    heard something else, too ...
-
- Lheban:     And just what was that, friend ... if             you
-want to tell us, of course ... Sir.
-
- Adventurer: Oh, of course! I think that we can come            
-to ... er ... an arrangement?   Lheban and Raic (Together): Certainly, Oh Yes!
-
- Adventurer: So, yeah, so these mages -- Shub and Shub,           
- they are always called Shub, aren't they?
-
-
-    -- anyway, these old guys were saying how
-
-
-    this Fools' Ebony can burn. Not magically,
-
-
-    but like an ordinary piece of wood. But
-
-
-    the flame lasts far longer, gives off
-
-
-    lots more heat, makes no smoke to speak
-
-
-    of, no noise ... very interesting ...
-
-
-    Mages were saying as how the alchemists
-
-
-    want it, to heat the retorts and flasks
-
-
-    ... How the Mages Guild wants it, to make
-
-
-    and sell ... er ... fake amulets and the
-
-
-    like ... rotten trick that! And especially
-
-
-    the Armorers, they want it bad, for their
-
-
-    forges, I guess. And the Alchemists, for
-
-
-    their alembics ...
-
- Lheban:     Precisely my information! Now... gets cold        
-    up here in the winter, doesn't it?  And
-
-
-    everyone is cutting down all those trees,            
-making siege engines, boats, all that evil
-
-
-    war machinery! All those rich royals and
-
-
-    merchants got to heat their great big piles
-
-
-    of homes. So their Contessas can run around
-
-
-    in next to nothing, instead of furs...
-
- Stete:      ... just like my sister ...
-
- (Lheben bites Stete's arm) (Stete shreiks and falls
-unconscious)
-
- Adventurer: All those armorers got to keep their            
-hearths and furnaces running...
-
- Lheban:     ... All the Mages got to keep their            
-familiars warm ...
-
- Raic:       ... All those royals got to keep the            
-contessas running ...
-
- Lheban:     ... All those peasants got to keep their            
-animals warm ...
-
- Adventurer: And To Sheogorath with the wife and kids,            
-right? Ha! And, I guess, its sort of hard
-
-
-    for you Priests to give blessings and
-
-
-    cures, when your fingers are all cold and
-
-
-    stiff ..? Makes getting corks out a tad
-
-
-    hard, to say nothing of opening those
-
-
-    little twists of parchment ..?
-
- Raic:       You speak truly, indeed!
-
- Lheban:     A man of wisdom, indeed! Yes!
-
- Adventurer: So, where do we find this Fools' Ebony             --
-in quantity?
-
- Lheban:     You put your finger (you have six, I note            
--- oh, excuse me, Sir) on the crux of the
-
-
-    matter. I have heard rumors, just rumors,
-
-
-    mind you, that there are huge enormous
-
-
-    veins of this stuff, at one place on the
-
-
-    surface, far up in the Wrothgarians.              Bad, bad
-place to go. But, if you can get
-
-
-    there and back, cartloads of the stuff!
-
- Adventurer: Thats just what I overheard from those            
-Mages -- far up there in the Wrothgarians
-
-
-    -- orcs, dragonlings, daedra, Sheogorath
-
-
-    only knows what ... Those Mages seemed to
-
-
-    know the spot, though.  Mages wanted
-
-
-    someone to ...
-
- Raic:       You didn't ... talk ... to the Mages. I            
-mean, you haven't ...
-
- Adventurer: Oh no. They didn't even know I was             there
-...
-
-
-    (aside)             Not yet, anyway...
-
- Lheban:     Good, good - can't trust those Mages,             you
-know ... old fossils would turn
-
-
-    their own mothers into sludge-toads, just
-
-
-    for a bit of gold! Gold-mad, power-mad,
-
-
-    Mad-mad, the whole rotten lot of them!
-
-
-    But then they don't have mothers! 
-
- Raic:       Excellent. Seems to me, friend -- or, can            
-we call you partner?               Yes? Excellent. Seems to
-me, partner,
-
-
-    that my brother priests and you should
-
-
-    do some digging and poking around -- see
-
-
-    if we can get to those veins, those
-
-
-    deposits, eh!
-
- Adventurer: Yes indeed, partners! But it would cost           
- a fair pile of gold to get up there --
-
-
-    weapons, spells, women, clothing, carts
-
-
-    and horses, women, food, potions ...             Best go
-well-prepared, up there.
-
- Lheban:     No problem, partner. Our Temples have ...         
-   certain resources, such that if we were
-
-
-    guaranteed ... sole access, sole knowledge             of
-the location, then we could finance
-
-
-    someone ... someone with the requisite
-
-
-    skills, such as yourself? Just by             happenstance,
-I am Keeper of the Books ...
-
-
-    you see the opportunity?
-
- Adventurer: Oh yes! Oh yes! Well -- lets split a             last
-bottle, and shake on an agreement?
-
- Lheban:     Indeed, let us!  We first need information           
- -- who knows about the site up there,
-
-
-    where it is, how to reach it ...             Why don't we meet
-back here in, say, a
-
-
-    week, to the hour. And see what we can
-
-
-    learn, meanwhile?
-
- Raic:       We need to find a merchant, too. Someone            
-who can handle it for us ... warehouses,
-
-
-    distribution ...
-
- Lheban:     And keep a shut mouth!
-
- Adventurer: I'll make some inquiries about merchants            
-... got a contact or two ... Trouble is
-
-
-    -- well, you know how these things go --
-
-
-    few golds here, few there, before you know             it
-you've bribed half the town, or so it
-
-
-    seems. Now, as luck would have it, I don't
-
-
-    have much -- got swindled by a wretched
-
-
-    Mage, some town south of here, and lost
-
-
-    most of my belongings in a shipwreck ...
-
- Lheban:     Ah Yes!  You need some ... seed money as             it
-were.
-
- Raic:
-    (To Lheban)             Let me lift old Stete's
-purse, he made a
-
-
-    lot renting out his sister last week ...
-
- Lheban:     Thank you, Raic.  Here, about 100 gold             --
-enough ?   Adventurer: Oh yes, more than enough for a start,    
-        Gentlemen. Good, good, good ... so we
-
-
-    have a deal?
+ Adventurer: Oh yes, more than enough for a start, Gentlemen. Good, good, good ... so we have a deal?
 
  Adventurer: Yes! It's agreed. One week!
 
- (Exit Lheban, Raic dragging Stete) (Exit the Adventurer)
-(Enter Epilogue)
+ (Exit Lheban, Raic dragging Stete)
 
- Epilogue:   Ah, things are happening now, I doubt it            
-not. Patrons, I request that you recall
+ (Exit the Adventurer)
 
+ (Enter Epilogue)
 
-    that this is a work of fiction created
-
-
-    by one of the finest writers of the
-
-
-    asylum, Frincheps, Archprince of All
-
-
-    Sumurset. There is no such thing as
-
-
-    Fools' Ebony. Furthermore, Ebony is not
-
-
-    mined as the priests have described the
-
-
-    process. Grasp that please. If you can
-
-
-    still enjoy the play as a rude work of
-
-
-    fiction, stay with us for Part the
-
-
-    Threeth. If you can't, farewell. And
-
-
-    don't forget to tip the wenches.
-
- And so endeth Part the Twoth
-
-                      ------------------------------- 
+ Epilogue: Ah, things are happening now, I doubt it not. Patrons, I request that you recall that this is a work of fiction created by one of the finest writers of the asylum, Frincheps, Archprince of All Sumurset. There is no such thing as Fools' Ebony. Furthermore, Ebony is not mined as the priests have described the process. Grasp that please. If you can still enjoy the play as a rude work of fiction, stay with us for Part the Threeth. If you can't, farewell. And don't forget to tip the wenches. And so endeth Part the Twoth

--- a/Assets/StreamingAssets/Text/Books/BOK00076-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00076-LOC.txt
@@ -3,7 +3,7 @@ Author: Frincheps
 IsNaughty: True
 Price: 317
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
 
 
@@ -15,627 +15,186 @@ Content:
 
 [/center]Threeth
 
-
-
 [/font=4]
-
-
 
 [/center]
 
  Dramatis Personae
 
- Prologue The Adventurer, A Dark Elf Rascal Komon, A Priest
-of Akatosh Lheban, Another Priest of Akatosh Epilogue Stete, A
-Priest of Julianos Raic, Another Priest of Julianos Shub, A
-Mage Shub, A Different Mage of the Same Name Nephron, A
-Somewhat Sleazy Merchant 5 Armorers Ortho Crunn, Husband of
-Millie A Lusty Contessa Millie, Innkeep and Philosopher
-Gurnsey, Bovine Wench Assorted Wenches and Cads of the
-Taverns Soldiers Dwarves Giants
+ Prologue; The Adventurer, A Dark Elf Rascal; Komon, A Priest of Akatosh; Lheban, Another Priest of Akatosh; Epilogue; Stete, A Priest of Julianos; Raic, Another Priest of Julianos; Shub, A Mage; Shub, A Different Mage of the Same Name; Nephron, A Somewhat Sleazy Merchant; 5 Armorers; Ortho; Crunn, Husband of Millie; A Lusty Contessa; Millie, Innkeep and Philosopher; Gurnsey, Bovine Wench; Assorted Wenches and Cads of the Taverns; Soldiers; Dwarves; Giants.
 
-
-
- Part The Threeth - In The Mages' Guild, One                    to
-Three Days Later
+ Part The Threeth - In The Mages' Guild, One to Three Days Later
 
  (Enter Prologue)
 
- Prologue:   We are now at the halfway point of             of
-our disjointed epic. If you are
-
-
-    just arriving, you have missed
-
-
-    little. The Adventurer, our rogue
-
-
-    Dark Elf, has joined with a
-
-
-    quadripartite (that's a triumvirate
-
-
-    plus one) of priests intent on
-
-
-    discovering a burning metal called
-
-
-    Fools' Ebony and becoming wealthy.
-
-
-    The priests have given our hero
-
-
-    some gold for bribing merchants,
-
-
-    but the only people who know where
-
-
-    the Fools' Ebony is are the mages
-
-
-    of the Mages' Guild. As the Epilogue
-
-
-    pointed out at the end of Part the
-
-
-    Twoth, there is no such thing as
-
-
-    Fools' Ebony and real Ebony is not
-
-
-    mined. Something our playwrite
-
-
-    apparently did not research. Well,
-
-
-    accept it as high fantasy, if you
-
-
-    will. Or whatever. Hark, here
-
-
-    comes our hero now. Imagine the
-
-
-    miasma (if that's the word I want)
-
-
-    of magical elixirs, bubbling
-
-
-    cauldrons, hovering balls of
-
-
-    sparkling whatnot. And now, the
-
-
-    Prologue must depart.
+ Prologue: We are now at the halfway point of our disjointed epic. If you are just arriving, you have missed little. The Adventurer, our rogue Dark Elf, has joined with a quadripartite (that's a triumvirate plus one) of priests intent on discovering a burning metal called Fools' Ebony and becoming wealthy. The priests have given our hero some gold for bribing merchants, but the only people who know where the Fools' Ebony is are the mages of the Mages Guild. As the Epilogue pointed out at the end of Part the Twoth, there is no such thing as Fools' Ebony and real Ebony is not mined. Something our playwrite [sic] apparently did not research. Well, accept it as high fantasy, if you will. Or whatever. Hark, here comes our hero now. Imagine the miasma (if that's the word I want) of magical elixirs, bubbling cauldrons, hovering balls of sparkling whatnot. And now, the Prologue must depart.
 
  (Enter the Adventurer and Shub)
 
  Adventurer: Ho! Anyone around?
 
- Shub:       Over here, young man, in the             corner ...      
- Adventurer: Morning. Do I call you ...             Shub ..?      
-Shub:       Oh yes, Shub is my name, Shub it             is ... How
-on Tamriel did you
+ Shub: Over here, young man, in the corner ...
 
+ Adventurer: Morning. Do I call you ... Shub ..?
 
-    know?
+ Shub: Oh yes, Shub is my name, Shub it is ... How on Tamriel did you know?
 
- Adventurer: Can we have some ... privacy ...             I have
-a somewhat ... er ...                   delicate matter to discuss
-..?
+ Adventurer: Can we have some ... privacy ... I have a somewhat ... er ... delicate matter to discuss ..?
 
- Shub:       No need for privacy here! We Mages do             not
-hide anything!
+ Shub: No need for privacy here! We Mages do not hide anything!
 
  Adventurer: Fools' Ebony?
 
- Shub:       Quick through this door ..!             Turn right ...
+ Shub: Quick through this door ..! Turn right ... Turn left ... Ah ... just let me throw a privacy spell around us ...
 
+ (Loud zap sounds)
 
-    Turn left ...             Ah ... just let me throw a
-privacy
+ (Enter Shub)
 
+ Good! Now Sir -- Oh, by the way, meet my fellow Mage, Shub.
 
-    spell around us ...
+ Shub: Mmmm.
 
- (Loud zap sounds) (Enter Shub)
+ Shub: Now, you mentioned Fools' Ebony ..?
 
-             Good! Now Sir -- Oh, by the way, meet
+ Adventurer: Well, I fancy myself a bit of an expert in ebony. Had quite a bit come and go through my hands in my time, I have ...
 
+ Shub: We notice that you have an ebony amulet, and an ebony katana -- Of Lightning, no less! And an ebony belt ... ...mmmm...
 
-    my fellow Mage, Shub.
+ Adventurer: Hands off the toys, gentlemen, please!
 
- Shub:       Mmmm.
+ Shub: Forgive us -- but we so appreciate such fine items ...
 
- Shub:       Now, you mentioned Fools' Ebony ..?
+ Shub: ... collect them too ...
 
- Adventurer: Well, I fancy myself a bit of an            
-expert in ebony. Had quite a bit come
+ Adventurer: Well, the other day, just by chance of course, I just happened to hear two priests of the Temple of ... er ... Stendarr, I think it was ... They were a bit high in their cups, I think, a bit loud, and never noticed me skulking -- I mean, standing -- there. They were going on about this Fools' Ebony - stuff like the real thing, only no magicka at all. None. But it burns like wood, only longer, hotter, no smoke, nice even heat.
 
+ Shub: Yes ... we have heard similar rumors. Seen a bit of that stuff -- lumps from a sack or two that some crazed delver dragged up, that kind of thing. Right, Shub?
 
-    and go through my hands in my time, I             have ...
+ Shub: Oh - Oh yes, right, that kind of thing ... right ... (aside) I must remember to keep the secret, whatever it is.
 
- Shub:       We notice that you have an ebony             amulet,
-and an ebony katana -- Of
+ Adventurer: Well, these fool priests seemed to talk as if they knew a location for lots, I mean piles, of that stuff -- somewhere up in the Wrothgarians ...
 
+ Shub and Shub (Together): Where! Who! Did they say? How? When? Where?Shub: [sic] You didn't let them know you were listening, did you?
 
-    Lightning, no less!  And an ebony
+ Adventurer: Of course not! What do you take me for, a priest lover?
 
+ Shub: Calm yourself, my lord ... that's better...just don't go fiddling with that katana so much. Makes us nervous.
 
-    belt ...
+ Shub: Yes, nervous, very ...
 
+ Shub: Here, sit down. There. Want some mulled wine? No? Oh well, just have to finish it myself.
 
-    ...mmmm...
+ Shub: So they seemed to know the location. (aside) Hmmmm. This means we have to act fast, quickly, speedily, and with great rapidity.
 
- Adventurer: Hands off the toys, gentlemen,             please!
+ Adventurer: Oh yes! They were talking like they were going to get a load in a few weeks or so ...
 
- Shub:       Forgive us -- but we so appreciate             such
-fine items ...
+ Shub: Oh My! Oh Dear Me! Ohhh...
 
- Shub:       ... collect them too ...
+ Shub: Now then. Seems you know a fair amount about this Fools' Ebony. And you realize the potential -- just think, big warm fires in all our study rooms ...
 
- Adventurer: Well, the other day, just by chance             of
-course, I just happened to hear
+ Shub and Shub (Together): ... Selling it to the Palace... selling it to those stupid Alchemists ... the Armorer's Guild would be good for a lot ... ... keep out familiars nice and warm ... ... and our posteriors ..! ... just think how Daedra Seducers love a nice warm fire ... Giving smoldering lumps to the peasants to warm their hovels with -- in return for some gold, of course ...
 
+ Shub: ...just think of all that gold...
 
-    two priests of the Temple of ... er
+ Shub: Trouble is, son - we would like to get that stuff by the cartload, bring it down here ...
 
+ Shub: Have some trustworthy merchant ...
 
-    ... Stendarr, I think it was ...  They
+ Shub: Put a spell on him!
 
+ Shub: ... Have some merchant act as sort of, middleman, for us ...
 
-    were a bit high in their cups, I
+ Adventurer: But ... then why the delay, gentlemen?
 
+ Shub: You seem like an honest fellow. We'll tell you -- mind you, you let out a word of this, and there will be a Fire Daedra in your bed ... but no threats between gentlemen, right!
 
-    think, a bit loud, and never noticed
+ Adventurer: Very well -- I shall be the very soul of discretion.
 
+ Shub: You see, we know where the stuff it, cartloads and cartloads of it. But we can't get there and back ...
 
-    me skulking -- I mean, standing --
+ Shub: We are not the outdoorsy types.
 
+ Shub: Far safer here in town.
 
-    there. They were going on about this
+ Shub: Much warmer too.
 
+ Shub: Think of all the supplies we would have to take.
 
-    Fools' Ebony - stuff like the real             thing, only
-no magicka at all. None.             But it burns like wood,
-only longer,
+ Shub: All those nasty things out there.
 
+ Shub: Did you know that seducers won't come to us in the wilderness?
 
-    hotter, no smoke, nice even heat.
+ Shub: We'd have to hire guards, to keep those awful priests away.
 
- Shub:       Yes ... we have heard similar rumors.             Seen
-a bit of that stuff -- lumps
+ Shub: And the strain of dealing with all those coarse types ... the Merchants.
 
+ Shub: The Armorers.
 
-    from a sack or two that some crazed             delver
-dragged up, that kind of thing.
+ Shub: The Royals.
 
+ Adventurer: Mmm. I think I comprehend. You want some -- experienced explorer-hero type, someone used to the wilderness -- to go get it for you, set up a supply line, so on ..?
 
-    Right, Shub?
+ Shub: Exactly. And find us a nice, useable merchant. Someone we can control.
 
- Shub:       Oh - Oh yes, right, that kind of             thing ...
-right ...
+ Shub: With a big, big warehouse, delivery service, that kind of thing ...
 
+ Adventurer: Well, gentlemen. Let me volunteer my services! I have always admired you Mage gentlemen -- so clever, so sharp. No fooling you in anything, is there?
 
-    (aside)
-
-
-    I must remember to keep the secret,
-
-
-    whatever it is.
-
- Adventurer: Well, these fool priests seemed to             talk
-as if they knew a location for             lots, I mean piles,
-of that stuff --
-
-
-    somewhere up in the Wrothgarians ...
-
- Shub and Shub (Together): Where! Who!  Did they say? How?
-When?             Where?   Shub:       You didn't let them know you
-were             listening, did you?
-
- Adventurer: Of course not! What do you take me for,            
-a priest lover?
-
- Shub:       Calm yourself, my lord ... that's            
-better...just don't go fiddling with
-
-
-    that katana so much. Makes us nervous.
-
- Shub:       Yes, nervous, very ...
-
- Shub:       Here, sit down.               There. Want some mulled
-wine?               No? Oh well, just have to finish it
-
-
-    myself.
-
- Shub:       So they seemed to know the location.            
-(aside)             Hmmmm. This means we have to act fast,
-
-
-    quickly, speedily, and with great
-
-
-    rapidity.
-
- Adventurer: Oh yes! They were talking like they             were
-going to get a load in a few
-
-
-    weeks or so ...
-
- Shub:       Oh My! Oh Dear Me! Ohhh...
-
- Shub:       Now then. Seems you know a fair amount            
-about this Fools' Ebony.  And you
-
-
-    realize the potential -- just think,
-
-
-    big warm fires in all our study rooms ...
-
- Shub and Shub (Together): ... Selling it to the Palace...
-selling             it to those stupid Alchemists ... the
-
-
-    Armorer's Guild would be good for a lot ...             
-... keep out familiars nice and warm ...             ... and our
-posteriors ..! ... just think
-
-
-    how Daedra Seducers love a nice warm
-
-
-    fire ... Giving smoldering lumps to the
-
-
-    peasants to warm their hovels with -- in
-
-
-    return for some gold, of course ... 
-
- Shub:       ...just think of all that gold...
-
- Shub:       Trouble is, son - we would like to get that            
-stuff by the cartload, bring it down here ...
-
- Shub:       Have some trustworthy merchant ... 
-
- Shub:       Put a spell on him!
-
- Shub:       ... Have some merchant act as sort of,            
-middleman, for us ...
-
-
-     Adventurer: But ... then why the delay, gentlemen?  
-Shub:       You seem like an honest fellow.  We'll            
-tell you -- mind you, you let out a word
-
-
-    of this, and there will be a Fire Daedra
-
-
-    in your bed ... but no threats between
-
-
-    gentlemen, right!
-
- Adventurer: Very well -- I shall be the very soul             of
-discretion.
-
- Shub:       You see, we know where the stuff it,            
-cartloads and cartloads of it.  But we
-
-
-    can't get there and back ...
-
- Shub:       We are not the outdoorsy types.
-
- Shub:       Far safer here in town.
-
- Shub:       Much warmer too.
-
- Shub:       Think of all the supplies we would             have to
-take.
-
- Shub:       All those nasty things out there.
-
- Shub:       Did you know that seducers won't come             to us
-in the wilderness?
-
- Shub:       We'd have to hire guards, to keep             those
-awful priests away.
-
- Shub:       And the strain of dealing with all             those
-coarse types ... the
-
-
-    Merchants.
-
- Shub:       The Armorers.
-
- Shub:       The Royals.
-
- Adventurer: Mmm. I think I comprehend.  You want            
-some -- experienced explorer-hero type,
-
-
-    someone used to the wilderness -- to go             get it
-for you, set up a supply line,
-
-
-    so on ..?
-
- Shub:       Exactly. And find us a nice, useable            
-merchant.  Someone we can control. 
-
- Shub:       With a big, big warehouse, delivery            
-service, that kind of thing ...
-
- Adventurer: Well, gentlemen. Let me volunteer my            
-services! I have always admired you Mage
-
-
-    gentlemen -- so clever, so sharp. No
-
-
-    fooling you in anything, is there?
-
- Shub:       No, no fooling us ...
+ Shub: No, no fooling us ...
 
  (Enter Prologue)
 
- Prologue:   This, ladies and gentlemen, is irony.
+ Prologue: This, ladies and gentlemen, is irony.
 
- (Exit Prologue)         Adventurer: Tell you what, I can
-probably arrange             a suitable merchant or you. Take
-some
+ (Exit Prologue)
 
+ Adventurer: Tell you what, I can probably arrange a suitable merchant or [sic] you. Take some gold though -- those thieves know the value of a gold piece! As luck would have it, my last gold was swindled off me by a thieving priest, in some little town south of here. And I lost a lot of good stuff in a shipwreck just before that ...
 
-    gold though -- those thieves know the             value of a
-gold piece! As luck would
+ Shub: Well ... since you have agreed to help us ... we can spare some gold from the treasury, can't we, Shub?
 
+ Shub: Oh! Oh yes, lots there ... always make more ...
 
-    have it, my last gold was swindled off             me by a
-thieving priest, in some
+ Adventurer: Now, I do need to know roughly where this site is, got to pick the right breed of horse, calculate my supplies to the last drop, figure out what weapons I might need ... supplies, like food, little things like that ... diameter of the cart wheels in square yurts ... ambush points for the priests, in case they try to get up there ... mmmmm ...
 
+ Shub: Tell you what - here is 500 gold. Go get things started.
 
-    little town south of here. And I lost
+ Shub: Yes ... we can always make some more.
 
+ Shub: (aside, to Shub) Shut up!
 
-    a lot of good stuff in a shipwreck
+ Shub: (Shub fires a spell at Shub that burns him to a cinder and then reconstitutes him)
 
+ Shub: (to all) Excuse us ... where was I ... Oh ... get a merchant, guards, carts, whatever you think it will take. Come back if you need more.
 
-    just before that ...
+ Shub: But what about those priests?
 
- Shub:       Well ... since you have agreed to             help us
-... we can spare some gold
+ Adventurer: I've an idea or two there. Let me get friendly with them - maybe hire a couple of good lamppost girls, lay in a few cases of holy wine ... I'll have them eating out of my hand in no time. And if you show me where this Fools' Ebony is ... why, I can misdirect them, send them straight into an trolls' den or something.
 
+ Shub: You're the expert! Here, let me show you on a map ... and I don't need to mention Fire Daedras, do I?
 
-    from the treasury, can't we, Shub?
+ Adventurer: So ... seems to be ... hmmmm ... only thirty days there, this time of year. Maybe forty back, with the loads. Let me study this a bit more ...
 
- Shub:       Oh! Oh yes, lots there ... always             make more
-...
+ Shub: Can't take it with you, of course ... don't want this getting out now ...
 
- Adventurer: Now, I do need to know roughly where             this
-site is, got to pick the right
+ Adventurer: Oh no. That's fine. Look, let me have a bit more gold. Going to need some heavy-duty carts. See here, this section ... cut by all these washes ... hmmmm ... the flummox there will be something terrible ... Oh, and these ruins, full of ghosts, I bet ... hmmmm ... and this pass, just full of willies too ...
 
+ Shub: If you say so ... My, seems that we picked the right man, right, Shub!
 
-    breed of horse, calculate my supplies
+ Shub: Oh yes, indeed.
 
+ Adventurer: So -- why don't I make arrangements, get back to you in ... er ... say a week? Say -- sure that you don't want to come with me. After all, there's nothing like the wilderness life. Waking up with the sun, shaking off the frost. Catching an orc for breakfast - ever have orc guts fried over stinkwood? Oh, that's a treat! Checking each stream for dead giant spiders - or live ones! Imp jerky for lunch! Scanning the ridges for dragonlings! Standing guard against Ice Daedra in a blinding snowstorm! Oh, what a life!
 
-    to the last drop, figure out what
+ Shub and Shub (Together): No, no ... we, we better stay here at the Guild. Got our duties after all ... someones got to mind the store ... someones got to get the word out to selected customers ... No, thank you kind Sir, it does sound such a lovely life, but I think we best be here ... yes, indeed ...
 
+ Adventurer: A pity, gentlemen. Well, I'll be about it then. And don't worry if you see me with those priests -- got to mislead and misdirect them, haven't I!
 
-    weapons I might need ... supplies,
+ Shub: One week, then!
 
+ (Exeunt Shub, the Adventurer, and Shub)
 
-    like food, little things like that
+ (Enter Epilogue)
 
-
-    ... diameter of the cart wheels in
-
-
-    square yurts ... ambush points for
-
-
-    the priests, in case they try to get
-
-
-    up there ... mmmmm ...
-
- Shub:       Tell you what - here is 500 gold. Go             get
-things started.
-
- Shub:       Yes ... we can always make some more.
-
- Shub:       (aside, to Shub)             Shut up!
-
- (Shub fires a spell at Shub that burns him to a cinder and
-then reconstitutes him)
-
-             (to all)             Excuse us ... where was I ... Oh ... 
-           get a merchant, guards, carts, whatever
-
-
-    you think it will take. Come back if
-
-
-    you need more.
-
- Shub:       But what about those priests?
-
- Adventurer: I've an idea or two there. Let me             get
-friendly with them - maybe hire             a couple of good
-lamppost girls, lay             in a few cases of holy wine ...
-I'll             have them eating out of my hand in             no
-time. And if you show me where             this Fools' Ebony is
-... why, I can             misdirect them, send them straight
-
-
-    into an trolls' den or something.
-
- Shub:       You're the expert!  Here, let me show             you on
-a map ... and I don't need to
-
-
-    mention Fire Daedras, do I?
-
- Adventurer: So ... seems to be ... hmmmm ... only            
-thirty days there, this time of year.             Maybe forty
-back, with the loads. Let
-
-
-    me study this a bit more ...
-
- Shub:       Can't take it with you, of course ...             don't
-want this getting out now ...
-
- Adventurer: Oh no. That's fine.  Look, let me             have a
-bit more gold. Going to need
-
-
-    some heavy-duty carts. See here, this             section
-... cut by all these washes
-
-
-    ... hmmmm ... the flummox there will
-
-
-    be something terrible ... Oh, and             these ruins,
-full of ghosts, I bet
-
-
-    ... hmmmm ... and this pass, just full
-
-
-    of willies too ...
-
- Shub:       If you say so ... My, seems that we             picked
-the right man, right, Shub!
-
- Shub:       Oh yes, indeed.
-
- Adventurer: So -- why don't I make arrangements,             get
-back to you in ... er ... say a
-
-
-    week?             Say -- sure that you don't want to
-
-
-    come with me. After all, there's
-
-
-    nothing like the wilderness life.
-
-
-    Waking up with the sun, shaking off
-
-
-    the frost. Catching an orc for              breakfast - ever
-have orc guts
-
-
-    fried over stinkwood? Oh, that's a
-
-
-    treat! Checking each stream for
-
-
-    dead giant spiders - or live ones!
-
-
-    Imp jerky for lunch! Scanning the
-
-
-    ridges for dragonlings! Standing
-
-
-    guard against Ice Daedra in a
-
-
-    blinding snowstorm! Oh, what a life!
-
- Shub and Shub (Together): No, no ... we, we better stay here  
-          at the Guild. Got our duties after
-
-
-    all ... someones got to mind the
-
-
-    store ... someones got to get the
-
-
-    word out to selected customers ...             No, thank
-you kind Sir, it does
-
-
-    sound such a lovely life, but I
-
-
-    think we best be here ... yes,
-
-
-    indeed ...
-
- Adventurer: A pity, gentlemen. Well, I'll be            
-about it then. And don't worry if
-
-
-    you see me with those priests --
-
-
-    got to mislead and misdirect them,
-
-
-    haven't I!
-
- Shub:       One week, then!
-
- (Exeunt Shub, the Adventurer, and Shub) (Enter Epilogue)
-
- Epilogue:   Shub and Shub, ladies and gentlemen.            
-Implausibly retarded mages, yes, but  
-    perhaps there's
-something more to
-
-
-    them than this act suggests. Do you
-
-
-    think so, maybe? Well, if you are
-
-
-    not in the theater for Part the
-
-
-    Fourth, you won't know for certain,
-
-
-    will you? Don't forget to tip your
-
-
-    wenches and think on that while we
-
-
-    change the set.
+ Epilogue: Shub and Shub, ladies and gentlemen. Implausibly retarded mages, yes, but perhaps there's something more to them than this act suggests. Do you think so, maybe? Well, if you are not in the theater for Part the Fourth, you won't know for certain, will you? Don't forget to tip your wenches and think on that while we change the set.
 
  So Endeth Part the Three
-
- 

--- a/Assets/StreamingAssets/Text/Books/BOK00077-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00077-LOC.txt
@@ -3,9 +3,8 @@ Author: Frincheps
 IsNaughty: True
 Price: 317
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,391 +14,118 @@ Content:
 
 [/center]Fourth
 
-
-
 [/font=4]
 
+[/center]
 
+ Dramatis Personae
 
-[/center] Dramatis Personae
+ Prologue; The Adventurer, A Dark Elf Rascal; Komon, A Priest of Akatosh; Lheban, Another Priest of Akatosh; Epilogue; Stete, A Priest of Julianos; Raic, Another Priest of Julianos; Shub, A Mage; Shub, A Different Mage of the Same Name; Nephron, A Somewhat Sleazy Merchant; 5 Armorers; Ortho; Crunn, Husband of Millie; A Lusty Contessa; Millie, Innkeep and Philosopher; Gurnsey, Bovine Wench; Assorted Wenches and Cads of the Taverns; Soldiers; Dwarves; Giants.
 
- Prologue The Adventurer, A Dark Elf Rascal Komon, A Priest
-of Akatosh Lheban, Another Priest of Akatosh Epilogue Stete, A
-Priest of Julianos Raic, Another Priest of Julianos Shub, A
-Mage Shub, A Different Mage of the Same Name Nephron, A
-Somewhat Sleazy Merchant 5 Armorers Ortho Crunn, Husband of
-Millie A Lusty Contessa Millie, Innkeep and Philosopher
-Gurnsey, Bovine Wench Assorted Wenches and Cads of the
-Taverns Soldiers Dwarves Giants
-
-
-
- Part The Fourth - Mercantile Dealings,                   The
-Armorers Involve
-
-
-  Themselves. After some
-
-
-  general discussion and
-
-
-  verbal dancing around,
-
-
-  finally the topic of
-
-
-  Fools' Ebony is
-
-
-  explored ...                  Somewhere near the market, in
-the back of a store called "Nephron's General Mercantile".
-
- The day after.
+ Part The Fourth - Mercantile Dealings, The Armorers Involve Themselves. After some general discussion and verbal dancing around, finally the topic of Fools' Ebony is explored ... Somewhere near the market, in the back of a store called "Nephron's General Mercantile". The day after.
 
  (Enter Prologue, the Adventurer, and Nephron)
 
- Prologue:   Whilst the actors playing the Adventurer           
- and the merchant Nephron dramatically
+ Prologue: Whilst the actors playing the Adventurer and the merchant Nephron dramatically move their mouths to pantomime a conversation, it is on poor Prologue's shoulders to update the audience on the play's actions in its first three acts. The Adventurer, a rogue of a Dark Elf, has been hired two different groups -- four inebriated priests and two greedy mages -- to delay the other group, and find the lost cache of Fools' Ebony in the Wrothgarian Mountains. Now, picture this clownishly decorated set as the back room at a prosperous merchant's shop. And before the Adventurer and Nephron develop lockjaw, Prologue will leave you thus.
 
+ Adventurer: So you see, friend Nephron, just what an opportunity we have here. We have this new commodity, for which you agree there will be a huge demand.
 
-    move their mouths to pantomime a
+ Nephron: Especially from the Royals -- once one of them has something new, they all want it, of course.
 
+ Adventurer: And do not forget the Armorers for their forges, and the Alchemists for their retorts and whatnots...
 
-    conversation, it is on poor Prologue's
+ Nephron: You seem to have the Mages lined up nicely, got their location, memorized the access map, and so on - you know, we merchants have had a suspicion for quite some time that those old twits had some deep dark secret of interest to us... Now, the priests - the School of Julianos we already work well with, hand and glove, you might say. But of course we shall cut them out of the major profits -- maybe let them distribute some to their flocks? And their Temples make good, how can I say? -- storehouses? But the Akatosh Chantry is a problem, always running off and doing things on their own initiative, no cooperation, just crazy people ... we really need to do something about them, to ... er ... ensure their cooperation ...
 
+ Adventurer: I have a suggestion that might help ... you recall how old Komon left and apparently dragged off some little blonde lamppost girl ... just suppose, that just by chance, in his state of ... befuddlement ... he dragged off someone important by mistake..? Might be a lot of trouble for the Chantry, if word got out?
 
-    shoulders to update the audience on the
+ Nephron: Hmmm. Indeed ... there's this silly little blonde Royal who's all excited by the 'real life' down in these parts of town. Disguises herself (or so she thinks), comes on down here and plays at being poor. Stupid little twit ... Komon is still in hiding with his blonde, right?
 
+ Adventurer: Yes, in that 'retreat' the Priests have, down near the waterfront.
 
-    play's actions in its first three acts.
+ Nephron: Oh yes, I know that place - often sell them some 'spiritual powders' and so on ... Good ... you see, just imagine what would happen if Komon, by mistake, had grabbed this slumming little Contessa ... Akatosh Chantry would have no end of trouble from the palace if something nasty happened to her ... and then we could move in, offer to 'help' the Chantry during their hard times ... Hmmm. Yes! Leave it to me, I shall contact a few of my ... er ... business associates, as it were ... make some arrangements.
 
+ Adventurer: And I'll keep up chatting with the priests, get them to support our little business venture?
 
-    The Adventurer, a rogue of a Dark Elf,
+ Nephron: Right! And I should introduce you to some of the more senior members of our Brotherhood ... excuse me, Guild. Let me contact you in a few days, when everything is all set. You are here every evening?
 
+ Adventurer: Yes, not particularly safe outside after dark these days.
 
-    has been hired two different groups --
+ Nephron: I see. We shall have to arrange some ... protection for you. Well, in a few days, then.
 
+ (Exit Nephron, inconspicuously)
 
-    four inebriated priests and two greedy
+ (Enter Five Armorers)
 
+ (Armorers and the Adventurer fight)
 
-    mages -- to delay the other group, and
+ (The Adventurer falls)
 
+ (The Armorers tie the Adventurer up and then wake him up)
 
-    find the lost cache of Fools' Ebony in
+ Armorer 1: OK, fellow. Lets not spriggen-foot around! We know about this Fools' Ebony thing. And about the Mages who apparently discovered the location. And we have been watching you dance around with the Priests, the Mages, the Merchants. Just about everyone with two feet!
 
+ Armorer 2: And how you are really working with Nephron.
 
-    the Wrothgarian Mountains. Now, picture
+ Armorer 3: And how you are double-crossing the Priests and Mages ...
 
+ Armorer 2: You and Nephron are really doing a good job on the Akatosh Chantry, we must admit.
 
-    this clownishly decorated set as the
+ Armorer 1: But now, we want that Fool's Ebony supply. We need it to increase our production, our quality -- and our prices. We can work with Nephron and his gang, we need warehouses and distribution anyway.
 
+ Armorer 4: We could torture it out of you ...
 
-    back room at a prosperous merchant's
+ Armorer 3: We could let the Priests know about your plans -- they would throw you to the Afterdark Society in a flash!
 
+ Armorer 5: We could let the Mages know -- they would send you to Oblivion for a very, very long time!
 
-    shop. And before the Adventurer and
+ Armorer 1: But we would rather you 'joined' our Guild. We cannot afford to leave Daggerfall for some hairy wilderness trip. Too much demand these days, for our sevices.
 
+ Armorer 2: But we can send a group of our apprentices along to keep you company.
 
-    Nephron develop lockjaw, Prologue will
+ Armorer 4: Our apprentices usually test all our products ... and will be just itching to test out there.
 
-
-    leave you thus.
-
- Adventurer: So you see, friend Nephron, just what an           
- opportunity we have here. We have this
-
-
-    new commodity, for which you agree there
-
-
-    will be a huge demand.
-
- Nephron:    Especially from the Royals -- once one             of
-them has something new, they all want
-
-
-    it, of course.
-
- Adventurer: And do not forget the Armorers for their            
-forges, and the Alchemists for their
-
-
-    retorts and whatnots...
-
- Nephron:    You seem to have the Mages lined up            
-nicely, got their location, memorized
-
-
-    the access map, and so on - you know,              we
-merchants have had a suspicion for
-
-
-    quite some time that those old twits
-
-
-    had some deep dark secret of interest
-
-
-    to us...             Now, the priests - the School of
-Julianos
-
-
-    we already work well with, hand and
-
-
-    glove, you might say. But of course we
-
-
-    shall cut them out of the major profits
-
-
-    -- maybe let them distribute some to
-
-
-    their flocks?  And their Temples make
-
-
-    good, how can I say? -- storehouses?
-
-
-    But the Akatosh Chantry is a problem,
-
-
-    always running off and doing things on
-
-
-    their own initiative, no cooperation,             just
-crazy people ... we really need to
-
-
-    do something about them, to ... er ...             ensure
-their cooperation ...
-
- Adventurer: I have a suggestion that might help ...            
-you recall how old Komon left and             apparently
-dragged off some little blonde             lamppost girl ...
-just suppose, that just             by chance, in his state of
-...             befuddlement ... he dragged off someone
-
-
-    important by mistake..? Might be a lot of
-
-
-    trouble for the Chantry, if word got out?
-
- Nephron:    Hmmm. Indeed ... there's this silly            
-little blonde Royal who's all excited by
-
-
-    the 'real life' down in these parts of
-
-
-    town. Disguises herself (or so she             thinks), comes
-on down here and plays at             being poor.  Stupid
-little twit ... Komon             is still in hiding with his
-blonde, right?
-
- Adventurer: Yes, in that 'retreat' the Priests have,            
-down near the waterfront.
-
- Nephron:    Oh yes, I know that place - often sell            
-them some 'spiritual powders' and so on
-
-
-    ... Good ... you see, just imagine what             would
-happen if Komon, by mistake, had             grabbed this
-slumming little Contessa             ... Akatosh Chantry would
-have no end of             trouble from the palace if something 
-           nasty happened to her ... and then we             could
-move in, offer to 'help' the Chantry             during their
-hard times ... Hmmm.             Yes! Leave it to me, I shall
-contact a few             of my ... er ... business associates,
-as             it were ... make some arrangements.
-
- Adventurer: And I'll keep up chatting with the            
-priests, get them to support our little             business
-venture?
-
- Nephron:    Right!  And I should introduce you to some           
- of the more senior members of our             Brotherhood ...
-excuse me, Guild.  Let me             contact you in a few days,
-when everything             is all set. You are here every
-evening?
-
- Adventurer: Yes, not particularly safe outside after         
-   dark these days.
-
- Nephron:    I see. We shall have to arrange some ...            
-protection for you. Well, in a few days,
-
-
-    then.
-
- (Exit Nephron, inconspicuously) (Enter Five Armorers)
-(Armorers and the Adventurer fight) (The Adventurer falls)
-(The Armorers tie the Adventurer up and then wake him up)
-
- Armorer 1:  OK, fellow. Lets not spriggen-foot around!      
-      We know about this Fools' Ebony thing. And             about
-the Mages who apparently discovered              the location.
-And we have been watching you             dance around with the
-Priests, the Mages,             the Merchants. Just about
-everyone with two
-
-
-    feet!
-
- Armorer 2:  And how you are really working with Nephron.
-
- Armorer 3:  And how you are double-crossing the Priests         
-   and Mages ...
-
- Armorer 2:  You and Nephron are really doing a good job      
-      on the Akatosh Chantry, we must admit.
-
- Armorer 1:  But now, we want that Fool's Ebony supply.       
-     We need it to increase our production, our            
-quality -- and our prices.  We can work             with Nephron
-and his gang, we need             warehouses and distribution
-anyway.
-
- Armorer 4:  We could torture it out of you ... 
-
- Armorer 3:  We could let the Priests know about your            
-plans -- they would throw you to the
-
-
-    Afterdark Society in a flash!
-
- Armorer 5:  We could let the Mages know -- they would            
-send you to Oblivion for a very, very long
-
-
-    time!
-
- Armorer 1:  But we would rather you 'joined' our            
-Guild. We cannot afford to leave Daggerfall             for
-some hairy wilderness trip. Too much             demand these
-days, for our sevices.
-
- Armorer 2:  But we can send a group of our apprentices        
-    along to keep you company.
-
- Armorer 4:  Our apprentices usually test all our            
-products ... and will be just itching to             test out
-there.
-
- Adventurer: Gentlemen, gentlemen! Please - I really was     
-       going to give the whole deal to you, once I             had
-gotten gold from everyone else.
+ Adventurer: Gentlemen, gentlemen! Please - I really was going to give the whole deal to you, once I had gotten gold from everyone else.
 
  (Armorer 5 slaps the Adventurer with a hot poker)
 
-             Ohhh ... well, I thought of it...
+ Ohhh ... well, I thought of it...
 
- Armorer 5:  Sure!  And I'm a Nymph!
+ Armorer 5: Sure! And I'm a Nymph!
 
- Adventurer: Yes, Yes, Yes, you are very persuasive.            
-I would welcome an ... er ... escort and             guard of
-such tough gentlemen. Be very             handy out there.
+ Adventurer: Yes, Yes, Yes, you are very persuasive. I would welcome an ... er ... escort and guard of such tough gentlemen. Be very handy out there.
 
- Armorer 1:  Good. Thought you would see it our way!            
-Some of our other members are presently             having a
-little ... chat with Nephron. We             can handle him. And
-from now on, two of             our bigger apprentices will
-always be
+ Armorer 1: Good. Thought you would see it our way! Some of our other members are presently having a little ... chat with Nephron. We can handle him. And from now on, two of our bigger apprentices will always be close at hand. Protection, of course -- this town can be quite dangerous at night ...
 
+ Armorer 3: So continue with your arrangements, work with Nephron. You can always leave word about your departure date with any weapons shop. And about any problems you may have ...
 
-    close at hand.  Protection, of course --             this
-town can be quite dangerous at
+ Adventurer: Certainly, gentlemen. Yes, you are indeed very persuasive. I shall keep you up to date. And, er...thanks for the protection.
 
+ (Enter Ortho, the very large apprentice)
 
-    night ...
+ (The Adventurer is untied)
 
- Armorer 3:  So continue with your arrangements, work            
-with Nephron. You can always leave word             about your
-departure date with any weapons             shop.  And about
-any problems you may
-
-
-    have ...
-
- Adventurer: Certainly, gentlemen. Yes, you are indeed        
-    very persuasive. I shall keep you up to             date. 
-And, er...thanks for the protection.
-
- (Enter Ortho, the very large apprentice) (The Adventurer is
-untied) (Exeunt Five Armorers)
+ (Exeunt Five Armorers)
 
  Adventurer: Hello, who are you?
 
- Ortho:      Me am Ortho!
+ Ortho: Me am Ortho!
 
  Adventurer: My ... protection?
 
- Ortho:      Me am Ortho!
+ Ortho: Me am Ortho!
 
- Adventurer: You look very familiar to me for some            
-reason. Have you every been to Morrowind?
+ Adventurer: You look very familiar to me for some reason. Have you every [sic] been to Morrowind?
 
- Ortho:      Me am Ortho!
+ Ortho: Me am Ortho!
 
- Adventurer: Fine then.             (aside)
+ Adventurer: Fine then. (aside) My old man used to say the very worst thing that can happen to a fellow is an evening spent in the company of an earnest politician. This, I think, is a close second.
 
+ (Exeunt the Adventurer and Ortho)
 
-    My old man used to say the very worst
+ (Enter Epilogue)
 
+ Epilogue: Our play has six parts, and we've just finished the fourth. It's interesting I think that the Lusty Contessa has not made an appearance yet. You don't suppose our playwrite [sic] forgot he put her in the Dramatis Personae, do you? Well, you'll only know if you come back for The Fools' Ebony, Part the Fiveth. And if your neighbor decides not to return, don't tell him what happened. We actors have to make a living too, you know. Don't forget to tip your wenches while we change the scene.
 
-    thing that can happen to a fellow is
+ (Exit Epilogue)
 
-
-    an evening spent in the company of an
-
-
-    earnest politician. This, I think, is
-
-
-    a close second.
-
- (Exeunt the Adventurer and Ortho) (Enter Epilogue)
-
- Epilogue:   Our play has six parts, and we've just            
-finished the fourth. It's interesting             I think that the
-Lusty Contessa has
-
-
-    not made an appearance yet. You don't
-
-
-    suppose our playwrite forgot he put her
-
-
-    in the Dramatis Personae, do you? Well,
-
-
-    you'll only know if you come back for
-
-
-    The Fools' Ebony, Part the Fiveth. And
-
-
-    if your neighbor decides not to return,
-
-
-    don't tell him what happened. We actors
-
-
-    have to make a living too, you know.
-
-
-    Don't forget to tip your wenches while
-
-
-    we change the scene.
-
- (Exit Epilogue)     
-
-                    So Endeth Part The Fourth 
+ So Endeth Part The Fourth.

--- a/Assets/StreamingAssets/Text/Books/BOK00078-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00078-LOC.txt
@@ -3,9 +3,8 @@ Author: Frincheps
 IsNaughty: True
 Price: 317
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,624 +14,192 @@ Content:
 
 [/center]Fiveth
 
-
-
 [/font=4]
-
-
 
 [/center]
 
  Dramatis Personae
 
- Prologue The Adventurer, A Dark Elf Rascal Komon, A Priest
-of Akatosh Lheban, Another Priest of Akatosh Epilogue Stete, A
-Priest of Julianos Raic, Another Priest of Julianos Shub, A
-Mage Shub, A Different Mage of the Same Name Nephron, A
-Somewhat Sleazy Merchant 5 Armorers Ortho Crunn, Husband of
-Millie A Lusty Contessa Millie, Innkeep and Philosopher
-Gurnsey, Bovine Wench Assorted Wenches and Cads of the
-Taverns Soldiers Dwarves Giants
+ Prologue; The Adventurer, A Dark Elf Rascal; Komon, A Priest of Akatosh; Lheban, Another Priest of Akatosh; Epilogue; Stete, A Priest of Julianos; Raic, Another Priest of Julianos; Shub, A Mage; Shub, A Different Mage of the Same Name; Nephron, A Somewhat Sleazy Merchant; 5 Armorers; Ortho; Crunn, Husband of Millie; A Lusty Contessa; Millie, Innkeep and Philosopher; Gurnsey, Bovine Wench; Assorted Wenches and Cads of the Taverns; Soldiers; Dwarves; Giants.
 
+ Part The Fiveth - Back With The Priests, Final Plans, and a Killing or Two is Reported... Nearer the middle of the Month of Frostfall, The Inn of the Pink Nymph.
 
+ (Enter Prologue, the Adventurer, Ortho, Nephron, the Five Armorers, and Prologue)
 
- Part The Fiveth - Back With The Priests, Final                  
-Plans, and a Killing or Two
+ Prologue: Our roguish Dark Elf, the Adventurer has plummeted before our stunned eyes, from the king of the spider web of intrigue to a pathetic, crawling lump of Argonian excrement. In the quest for Fools' Ebony, that substance that all would kill for, the Adventurer attempted to play Mage against Priest with the help of the merchant Nephron. Alas, that is to say, alackaday, the five armorers have trapped Nephron and the Adventurer and taken over their scheme. The hulking Ortho now watches the Adventurer's every move. But I get the feeling -- to be honest, don't you? -- that beneath the Adventurer's defeated quivering jelly lurks a jungle cat of such cunning and resource to shatter all his enemies when the time is right. Of course, I could be wrong. Ah, I see one of the priests of Akatosh who believes himself a friend of the Adventurer. I, Prologue must away.
 
+ (Exit Prologue)
 
-  is Reported...          Nearer the middle of the Month of
-Frostfall, The Inn of the Pink Nymph.    (Enter Prologue, the
-Adventurer, Ortho, Nephron, the Five Armorers, and
-Prologue)
+ (Enter Lheban, a Priest of Akatosh.)
 
- Prologue:   Our roguish Dark Elf, the Adventurer has            
-plummeted before our stunned eyes, from
+ Lheban: Evening there, mind if I join you?
 
+ Adventurer: Well ... since you already have - no. And where is our esteemed brother Komon this chill evening?
 
-    the king of the spider web of intrigue
-
-
-    to a pathetic, crawling lump of Argonian
-
-
-    excrement. In the quest for Fools'
-
-
-    Ebony, that substance that all would kill
-
-
-    for, the Adventurer attempted to play
-
-
-    Mage against Priest with the help of the
-
-
-    merchant Nephron. Alas, that is to say,
-
-
-    alackaday, the five armorers have trapped
-
-
-    Nephron and the Adventurer and taken over
-
-
-    their scheme. The hulking Ortho now
-
-
-    watches the Adventurer's every move. But
-
-
-    I get the feeling -- to be honest, don't
-
-
-    you? -- that beneath the Adventurer's
-
-
-    defeated quivering jelly lurks a jungle
-
-
-    cat of such cunning and resource to
-
-
-    shatter all his enemies when the time is
-
-
-    right. Of course, I could be wrong. Ah,
-
-
-    I see one of the priests of Akatosh who
-
-
-    believes himself a friend of the
-
-
-    Adventurer. I, Prologue must away.
-
- (Exit Prologue) (Enter Lheban, a Priest of Akatosh.)
-
- Lheban:     Evening there, mind if I join you?
-
- Adventurer: Well ... since you already have - no.            
-And where is our esteemed brother
-
-
-    Komon this chill evening?
-
- Lheban:     You mean you haven't heard -- Oh, I             guess
-you have been busy with the ...
-
-
-    preparations?
+ Lheban: You mean you haven't heard -- Oh, I guess you have been busy with the ... preparations?
 
  Adventurer: Right, right, very busy...
 
- Lheban:     Then let me tell you -- Oh, what a bad            
-business. What trouble ... Oh Dear ...             Well ... you
-doubtless recall that poor
+ Lheban: Then let me tell you -- Oh, what a bad business. What trouble ... Oh Dear ... Well ... you doubtless recall that poor Komon had this ... er ... problem -- overwork of course!
 
+ Adventurer: Oh yes -- you fellows do work exceeding hard, seems to me.
 
-    Komon had this ... er ... problem --             overwork of
-course!
+ Lheban: Well ... recall how Komon left, somewhat erratically as it were, and ... er ... made off with that young blondie under the lamppost outside? Well -- in his ... er ... state of confusion -- he grabbed the wrong blondie - Oh My, indeed the wrong one ...
 
- Adventurer: Oh yes -- you fellows do work exceeding            
-hard, seems to me.
+ Adventurer: They all look pretty much the same to me, but of course, I do not look too hard!
 
- Lheban:     Well ... recall how Komon left, somewhat            
-erratically as it were, and ... er ...             made off with
-that young blondie under             the lamppost outside?
-Well -- in his ...             er ... state of confusion -- he
-grabbed             the wrong blondie - Oh My, indeed the
+ Lheban: Oh My! Well, to cut a short tale to the bone, old Komon grabbed a Contessa, who had thought to 'disguise herself.' Oh Dear!
 
+ Adventurer: Well -- did she get away? Did they catch Komon? What happened?
 
-    wrong one ...
+ Lheban: Well, old Komon, tipsy as he was, was quick as spit in a gale. Eluded all pursuit, took the lady to a small private ... retreat house that we have. Oh Dear Me! Well, the City Guards, Palace guards, half a dozen Royals, all caught up with Komon 3 days later. One day too late for the poor Contessa -- I hear that they had a hard time locating all the ... er ... bits and pieces. Komon was there, passed out cold. And another body, some common blond lamppost girl. And by now he is cold -- permanently, most likely at the bottom of the Bay.
 
- Adventurer: They all look pretty much the same to me,           
- but of course, I do not look too hard!
+ Adventurer: Oh well. Serves the Contessa right, coming down to this area. But I suppose that there are repercussions?
 
- Lheban:     Oh My! Well, to cut a short tale to the            
-bone, old Komon grabbed a Contessa, who             had thought
-to 'disguise herself.' Oh             Dear!       Adventurer: Well
--- did she get away?  Did they catch             Komon? What
-happened?
+ (Enter two more Priests, Raic and Stete of Julianos, and four armed City Guards)
 
- Lheban:     Well, old Komon, tipsy as he was, was            
-quick as spit in a gale. Eluded all             pursuit, took
-the lady to a small private
+ Raic: Evening, Lheban. Evening, Adventurer. And --
 
+ Ortho: Me am Ortho.
 
-    ... retreat house that we have.  Oh Dear
+ Raic: Yesss. Charmed. And Lheban, you indeed have my sympathies ... if there is anything we can do to help -- our Temple of Julianos, that is ..? But really, you should have kept Komon on a tighter leash - or preferably a noose!
 
+ Adventurer: Hello Raic. And hello to you, Stete - how's your sister?
 
-    Me! Well, the City Guards, Palace guards,
-
-
-    half a dozen Royals, all caught up with
-
-
-    Komon 3 days later. One day too late for
-
-
-    the poor Contessa -- I hear that they had
-
-
-    a hard time locating all the ... er ...
-
-
-    bits and pieces. Komon was there, passed
-
-
-    out cold. And another body, some common
-
-
-    blond lamppost girl. And by now he is cold
-
-
-    -- permanently, most likely at the bottom             of the
-Bay.
-
- Adventurer: Oh well. Serves the Contessa right, coming        
-    down to this area. But I suppose that
-
-
-    there are repercussions?
-
- <Enter two more Priests, Raic and Stete of Julianos, and
-four armed City Guards.)
-
- Raic:       Evening, Lheban. Evening, Adventurer. And --
-
- Ortho:      Me am Ortho.
-
- Raic:       Yesss. Charmed. And Lheban, you indeed have           
- my sympathies ... if there is anything we can
-
-
-    do to help -- our Temple of Julianos, that
-
-
-    is ..?  But really, you should have kept             Komon
-on a tighter leash - or preferably a             noose!
-
- Adventurer: Hello Raic. And hello to you, Stete - how's        
-    your sister?
-
- Stete:      Oh, she's great.
+ Stete:Oh, she's great.
 
  (Raic sets Stete on fire, but it goes out)
 
- Lheban:     Yes, I know I know. Oh the repercussions! Do           
- you know that the Priests of Akatosh to             Daggerfall
-Castle, Wayrest Palace and just             about everywhere
-else have all been thrown out?             That the Royal tax
-exemption for the Chantry
+ Lheban: Yes, I know I know. Oh the repercussions! Do you know that the Priests of Akatosh to Daggerfall Castle, Wayrest Palace and just about everywhere else have all been thrown out? That the Royal tax exemption for the Chantry has been revoked? That the Akatosh Chantry has just received a 'past due taxes' bill? Oh My!
 
+ Adventurer: Well ... I suppose that we could help somewhat, maybe? Maybe a small loan from Julianos for that tax bill? With, say, a Temple as security? Oh -- are not the taxes based on the number of the Priests of Akatosh? So, maybe ... the School of Julianos could take over a ... significant number? Reduce your tax bill? You realize that this is not the best time for this -- just as we need a lot of funds for that expedition that I am arranging for you.
 
-    has been revoked? That the Akatosh Chantry has             
-just received a 'past due taxes' bill? Oh My!
+ Lheban: Oh, I am so sorry about Komon! But, yes, maybe if good brother Raic could -- I hate to say this -- take over a greater share of the financial burden ..? In return, of course, for ... er ... considerations ..?
 
- Adventurer: Well ... I suppose that we could help
-somewhat,             maybe? Maybe a small loan from Julianos
-for             that tax bill? With, say, a Temple as security? 
-           Oh -- are not the taxes based on the number of             
-the Priests of Akatosh? So, maybe ... the School
+ Raic: Hmm. Like a good number of 'permanently' loaned priests? A long look at your books? At your cellar? Your name-lists? A Temple as security on our loan? And, of course, a bigger cut in the proceeds of this ... expedition? Names of your ... er ... suppliers ..?
 
+ Lheban: Oh. I foresaw something like this, talked a bit about it with old Mucky-Muck - livid, he was. But, as I am a Senior Brother, he finally authorized me to 'take care of it.' Those weren't his exact words, mind you, which were quite a bit ...longer, more explicit ... but the gist, at least.
 
-    of Julianos could take over a ... significant
+ Adventurer: Of course, Lheban. If -- and note I say 'if' -- if we are successful, why then you can easily get back into good graces at the Palace. Merely sell them the goods, as a good low rate! With first refusal on any shipment you have? What's one Contessa to them, anyway?
 
+ Lheban: Yes, yes! That could work! Worth a try. But how? Royals will not talk to anyone from the Akatosh Chantry now.
 
-    number?  Reduce your tax bill? You realize that           
-  this is not the best time for this -- just as
+ Adventurer: Leave that to me, I can make ... approaches to certain ones. Yes, I can probably persuade them to let up on the Chantry, in return for ... future favors ...
 
+ Lheban: Oh, Oh how can I thank you?
 
-    we need a lot of funds for that expedition that            
-I am arranging for you.
+ Adventurer: Well, I need a fair amount of gold to finish setting up my little trip. Maybe 10,000? Special horses, reinforced carts, cartiers, guards ... the list goes on and on. And the cost of keeping our little trip quiet is really quite high.
 
- Lheban:     Oh, I am so sorry about Komon! But, yes, maybe     
-       if good brother Raic could -- I hate to say             this
--- take over a greater share of the
+ Lheban: Well, yes, we can afford it, I guess -- you do have the map now, don't you? I know we can afford 8,000 gold. Given the potential profits ...
 
+ Adventurer: Rest easy! - it's all here in my cloak -- show you in a bit. I've also managed to ... hire some good young hefty fellows, like old Ortho here, to manage the carts, dig and load, act as guards, and so on ...
 
-    financial burden ..? In return, of course, for            
-... er ... considerations ..?
+ Lheban: Good, good - I can relax a bit. Oh my, the fellows back at the Chantry will be so relieved. We really owe you, the Brotherhood does -- Oh, I mean the Akatosh Chantry, of course!
 
- Raic:       Hmm. Like a good number of 'permanently' loaned    
-        priests? A long look at your books? At your
+ Stete: Brotherhood ..? What about our sisterhood, eh?
 
+ (Raic grapples Stete, allowing Lheban to hit Stete with a large mallet)
 
-    cellar?  Your name-lists? A Temple as security
+ Adventurer: Well, Raic, what about you and the School? How much are you good for, the extra 2000? And maybe some more - always lots of last minute expenses on a trip like this, you know.
 
+ Raic: Well now. Since we seem to getting a whole extra sect of Priests, and ... other considerations ... Certainly!
 
-    on our loan? And, of course, a bigger cut in
-
-
-    the proceeds of this ... expedition? Names of
-
-
-    your ... er ... suppliers ..?
-
- Lheban:     Oh. I foresaw something like this, talked a bit       
-     about it with old Mucky-Muck - livid, he was.
-
-
-    But, as I am a Senior Brother, he finally            
-authorized me to 'take care of it.' Those             weren't his
-exact words, mind you, which were
-
-
-    quite a bit ...longer, more explicit ... but            
-the gist, at least.
-
- Adventurer: Of course, Lheban. If -- and note I say 'if' --    
-        if we are successful, why then you can easily            
-get back into good graces at the Palace. Merely            
-sell them the goods, as a good low rate! With             first
-refusal on any shipment you have?  What's             one
-Contessa to them, anyway?
-
- Lheban:     Yes, yes! That could work!  Worth a try. But        
-    how? Royals will not talk to anyone from
-
-
-    the Akatosh Chantry now.
-
- Adventurer: Leave that to me, I can make ... approaches to   
-         certain ones. Yes, I can probably persuade            
-them to let up on the Chantry, in return for
-
-
-    ... future favors ...
-
- Lheban:     Oh, Oh how can I thank you?
-
- Adventurer: Well, I need a fair amount of gold to finish     
-       setting up my little trip. Maybe 10,000?            
-Special horses, reinforced carts, cartiers,
-
-
-    guards ... the list goes on and on. And the             cost
-of keeping our little trip quiet is             really quite
-high.
-
- Lheban:     Well, yes, we can afford it, I guess -- you           
- do have the map now, don't you? I know we
-
-
-    can afford 8,000 gold. Given the potential
-
-
-    profits ...
-
- Adventurer: Rest easy! - it's all here in my cloak --            
-show you in a bit. I've also managed to ...
-
-
-    hire some good young hefty fellows, like old
-
-
-    Ortho here, to manage the carts, dig and             load,
-act as guards, and so on ...
-
- Lheban:     Good, good - I can relax a bit. Oh my, the            
-fellows back at the Chantry will be so             relieved. We
-really owe you, the Brotherhood             does -- Oh, I mean the
-Akatosh Chantry, of             course!
-
- Stete:      Brotherhood ..? What about our sisterhood, eh?
-
- (Raic grapples Stete, allowing Lheban to hit Stete with a
-large mallet)
-
- Adventurer:  Well, Raic, what about you and the School?     
-        How much are you good for, the extra 2000?
-
-
-     And maybe some more - always lots of last             
-minute expenses on a trip like this, you know.
-
- Raic:        Well now. Since we seem to getting a whole           
-  extra sect of Priests, and ... other
-
-
-     considerations ... Certainly!
-
- Adventurer:  Well, gentlemen -- Oh, and Stete -- here it        
-     is!
+ Adventurer: Well, gentlemen -- Oh, and Stete -- here it is!
 
  (The Adventurer pulls out a map, gives it to Raic)
 
-
-
-
-     Oh, by the Arms of Zenithar, did I ever have              to
-work hard for this! Those cagey Mages! But,              in the
-end, just greedy old fools! ... Oh,              just in case
-you or your, er, Head Priest,
-
-
-     hasn't seen the goods -- here's a sample.              Play
-with it.
+ Adventurer: Oh, by the Arms of Zenithar, did I ever have to work hard for this! Those cagey Mages! But, in the end, just greedy old fools! ... Oh, just in case you or your, er, Head Priest, hasn't seen the goods -- here's a sample. Play with it.
 
  (The Adventurer hands Raic a small leather bag)
 
- Raic:        Thank you, thank you. I must admit, I had             
-some ... well, some doubts. You know --              dealing
-with a stranger, so on ... No more.              Partner!
+ Raic: Thank you, thank you. I must admit, I had some ... well, some doubts. You know -- dealing with a stranger, so on ... No more. Partner!
 
- Adventurer:  Good, good!
+ Adventurer: Good, good!
 
  (Stete hiccoughs)
 
- Stete:       Say, you fellows ever hear this one --             
-what's a Priest keep under his robe? Haha
+ Stete: Say, you fellows ever hear this one -- what's a Priest keep under his robe? Haha -- His sister! Haheheha!
 
+ (The Adventurer, Lheban, and Raic beat Stete into unconsciousness)
 
-     -- His sister! Haheheha!
+ Raic: You know, I fear that we really have to do something about young Stete here ... his sister thing ... ugh!
 
- (The Adventurer, Lheban, and Raic beat Stete into
-unconsciousness)
+ Adventurer: Yes, he could be another Komon -- just what don't need!
 
- Raic:       You know, I fear that we really have to             do
-something about young Stete here ...
+ Lheban: Hmmmm. This sister of his -- does she really -- exist?
 
+ Raic: Oh yes. My. Oh yes. We know her well -- I mean, we have often seen her ...
 
-    his sister thing ... ugh!    Adventurer: Yes, he could be
-another Komon -- just             what don't need!
+ Lheban: I think, Brother, that she should be made to see the errors of her ways. So she is no longer an influence on Stete ...
 
- Lheban:     Hmmmm. This sister of his -- does she             really
--- exist?
+ Raic: Yes, most certainly ... Hmmm ...
 
- Raic:       Oh yes. My. Oh yes. We know her well --             I
-mean, we have often seen her ...
+ Lheban: A somewhat Dibelytical theological point -- Oh, please excuse the technical discussion here - Raic, if we are to make her see the errors -- well, how shall I put it -- we first have to know just what the ... ways ... are, correct?
 
- Lheban:     I think, Brother, that she should be             made to
-see the errors of her ways. So
+ Raic: Indeed, an astute observation! Hmmm ... so you are suggesting that ... in a nut, we should first determine her ... ways, so as to be able to then show her the ... er ... errors?
 
+ Lheban: Precisely! Mind you, a difficult, ardous, tiring project, I fear. One that will take all our ... will and energy.
 
-    she is no longer an influence on
+ Raic: Hmmm, true. But challenging, eh? Take all our time - but then, we shall have some time, while friend the Adventurer: here is off hauling and carting.
 
+ Lheban: And ... I personally, would feel far safer if we were ... in retreat maybe. Studying the ways ..?
 
-    Stete ...
+ Adventurer: Yeah -- be a good idea for you two to, maybe, disappear? For a while, of course. Cut down on the chances of a ... rival faction catching on? Or catching you?
 
- Raic:       Yes, most certainly ... Hmmm ...
+ Raic: Very well! Lheban, why don't you and I take his sister off with us on a ... theological retreat, as it were? Study the ways in details, and so on ...
 
- Lheban:     A somewhat Dibelytical theological             point
--- Oh, please excuse the technical             discussion here -
-Raic, if we are to             make her see the errors -- well, how
+ Lheban: We could go to that unused little Temple, up on that shoulder of Edward's Mountain... out of the way, quiet ...
 
+ Raic: Door has locks ...
 
-    shall I put it -- we first have to know
+ Lheban: Thick walls ...
 
+ Raic: A big cellar ...
 
-    just what the ... ways ... are, correct?
+ Lheban: Good! It's settled then. A theological retreat! Oh goody!
 
- Raic:       Indeed, an astute observation! Hmmm ...             so
-you are suggesting that ... in a nut,
+ Raic: Of course, once we know the ... er ... ways in detail, we can of course tell old High Mucky-Muck, and let him take care of the ... er ... showing of the errors ..? Yes, that would improve his mood quite a bit ...
 
+ Lheban: Then it's agreed. Let's start, say, day after tomorrow?
 
-    we should first determine her ... ways,
+ Raic: Yes! Adventurer, why don't I meet you at, oh, that horrid ugly statue of ... what on Tamriel is it? - a harpy and a gargoyle? Called something silly like 'Vendigao and Her Lover' or some such? Up in the north west corner of the town. Oh, and can I keep the map?
 
+ Adventurer: Sure, keep it, I have a copy. And you will pass me a small bag, there at that nasty statue?
 
-    so as to be able to then show her the
+ Raic: Have it all ready for you -- say, ten o'clock sharp? Oh, Lheban, another thought about young Stete here. He really needs some ... seasoning in the field, one might say ...?
 
+ Lheban: Hmmm. Good point ... I know! The priest who handles field assignments is coming by tomorrow. We could arrange an ... educational ... assignment for Stete?
 
-    ... er ... errors?
+ Raic: Very good! But where ... hmmm ... Winter's coming soon now. There's a vacancy up in Solitude, far north Skyrim, I believe. Night collections at street corners, or some such. Very Good! Come on, Lheban. We have accounts to work on. Good night to you then, Adventurer. Ten tomorrow morning!
 
- Lheban:     Precisely! Mind you, a difficult,            
-ardous, tiring project, I fear. One that             will take
-all our ... will and energy.
+ (Lheban, Raic rise to leave, picking up Stete)
 
- Raic:       Hmmm, true. But challenging, eh? Take             all
-our time - but then, we shall have             some time, while
-friend the Adventurer
-
-
-    here is off hauling and carting.
-
- Lheban:     And ... I personally, would feel far            
-safer if we were ... in retreat maybe.
-
-
-    Studying the ways ..?
-
- Adventurer: Yeah -- be a good idea for you two to,            
-maybe, disappear? For a while, of course.             Cut down
-on the chances of a ... rival             faction catching on?
-Or catching you?
-
- Raic:       Very well! Lheban, why don't you and I            
-take his sister off with us on a ...
-
-
-    theological retreat, as it were? Study             the ways
-in details, and so on ...
-
- Lheban:     We could go to that unused little            
-Temple, up on that shoulder of Edward's             Mountain
-... out of the way, quiet ...
-
- Raic:       Door has locks ...
-
- Lheban:     Thick walls ...
-
- Raic:       A big cellar ...
-
- Lheban:     Good! It's settled then. A theological            
-retreat! Oh goody!
-
- Raic:       Of course, once we know the ... er ...             ways
-in detail, we can of course tell             old High Mucky-Muck,
-and let him take care              of the ... er ... showing of the
-errors ..?             Yes, that would improve his mood quite a
-
-
-    bit ...
-
- Lheban:     Then it's agreed. Let's start, say, day            
-after tomorrow?
-
- Raic:       Yes! Adventurer, why don't I meet you at,            
-oh, that horrid ugly statue of ... what
-
-
-    on Tamriel is it? - a harpy and a gargoyle?             
-Called something silly like 'Vendigao and
-
-
-    Her Lover' or some such? Up in the north
-
-
-    west corner of the town. Oh, and can I
-
-
-    keep the map?
-
- Adventurer: Sure, keep it, I have a copy. And you will        
-    pass me a small bag, there at that nasty
-
-
-    statue?
-
- Raic:       Have it all ready for you -- say, ten            
-o'clock sharp? Oh, Lheban, another
-
-
-    thought about young Stete here. He really             needs
-some ... seasoning in the field,             one might say ...?
-
- Lheban:     Hmmm. Good point ... I know! The priest            
-who handles field assignments is coming             by
-tomorrow. We could arrange an ...             educational ...
-assignment for Stete?
-
- Raic:       Very good! But where ... hmmm ...             Winter's
-coming soon now. There's a
-
-
-    vacancy up in Solitude, far north Skyrim,
-
-
-    I believe. Night collections at street            
-corners, or some such. Very Good! Come on,             Lheban.
-We have accounts to work on. Good             night to you then,
-Adventurer.  Ten             tomorrow morning!        (Lheban,
-Raic rise to leave, picking up Stete)
-
- Lheban and Raic (Together): ... have to arrange some
-supplies ...             ... leather, rope ... holy wine ....     
-       ... lots of that pink powder ... I
-
-
-    prefer the green, myself ...
+ Lheban and Raic (Together): ... have to arrange some supplies ... ... leather, rope ... holy wine .... ... lots of that pink powder ... I prefer the green, myself ...
 
  (Exeunt Lheban, Raic dragging Stete, and City Guard)
 
- Nephron:    Well?
+ Nephron: Well?
 
- Adventurer: Excellent. Went just as I said it would.          
-  Got 5000 gold from them. And, thanks to             your work
-with that Contessa ... we have              the screws on the
-Chantry. And the School
+ Adventurer: Excellent. Went just as I said it would. Got 5000 gold from them. And, thanks to your work with that Contessa ... we have the screws on the Chantry. And the School of Julianos is going to be ... otherwise engaged ... on a theological retreat. More like a Sanguine retreat!
 
-
-    of Julianos is going to be ... otherwise
-
-
-    engaged ... on a theological retreat.
-
-
-    More like a Sanguine retreat!
-
- Nephron:    And those Mages Shub and Shub seem to             have
-disappeared ...
+ Nephron: And those Mages Shub and Shub seem to have disappeared ...
 
  Adventurer: So we are set?
 
- Nephron:    Yes, you can come by my warehouse            
-tomorrow afternoon. Have the heavy carts             waiting.
+ Nephron: Yes, you can come by my warehouse tomorrow afternoon. Have the heavy carts waiting.
 
- Ortho:      And Ortho ...
+ Ortho: And Ortho ...
 
- Nephron:    Oh yes, must not forget you fellows.             How
-kind of you to ... volunteer your
-
-
-    services ...
+ Nephron: Oh yes, must not forget you fellows. How kind of you to ... volunteer your services ...
 
  Adventurer: Tomorrow, then!
 
- (Exeunt omnes) (Last person to leave looks just like a Royal
-in disguise ...) (Enter Epilogue)
+ (Exeunt omnes)
 
- Epilogue:   Well, we only have one part left to this            
-play and I've run out counting the number
+ (Last person to leave looks just like a Royal in disguise ...)
 
+ (Enter Epilogue)
 
-    of loose strings. Either Part the Sixth
+ Epilogue: Well, we only have one part left to this play and I've run out counting the number of loose strings. Either Part the Sixth is going to be eight hours long, or we're going to leave some parts unsolved. I for one hope that they don't chose to drop the character of the Wanton Contessa. For Jephre's sake, she's been on the Dramatis Personae since Part the Oneth. Ah, well. Nobody leave your seat. Your gold will not be refunded. Any gold you can spare to tip your friendly wenches will be greatly appreciated. We just have a quick costume change and a set to put together and we'll be back. In the meanwhile, enjoy our bard's rendition of the Nordic classic "Alas, The Fleeting Years Glide By."
 
-
-    is going to be eight hours long, or we're
-
-
-    going to leave some parts unsolved. I for
-
-
-    one hope that they don't chose to drop
-
-
-    the character of the Wanton Contessa. For
-
-
-    Jephre's sake, she's been on the Dramatis
-
-
-    Personae since Part the Oneth. Ah, well.
-
-
-    Nobody leave your seat. Your gold will
-
-
-    not be refunded. Any gold you can spare
-
-
-    to tip your friendly wenches will be
-
-
-    greatly appreciated. We just have a quick
-
-
-    costume change and a set to put together
-
-
-    and we'll be back. In the meanwhile, enjoy
-
-
-    our bard's rendition of the Nordic classic
-
-
-    "Alas, The Fleeting Years Glide By."
-
-
-
-                     So Endeth Part The Five
-
- 
+ So Endeth Part The Five

--- a/Assets/StreamingAssets/Text/Books/BOK00079-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00079-LOC.txt
@@ -3,9 +3,8 @@ Author: Erystera Ligen
 IsNaughty: False
 Price: 738
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,109 +12,21 @@ Content:
 
 [/center]Rulers
 
-
-
 [/font=4]
 
 [/center]
+ Because the rules are so complex and the stakes are so high, many people blanche at the thought of speaking with a noble with a title. For starters, it is important to address them correctly, for just as no one likes to be misnamed, no one likes to be mistitled. The problem is that in High Rock, traditions of the peerage differ slightly from region to region. The base rules follow:
 
+ There are eight kingdoms in High Rock in the following regions: Northpoint, Daggerfall, Shornhelm, Camlorn, Farrun, Evermore, Wayrest, and Jehanna. If a woman is ruling one of these areas, she is called the Queen. The husband of a Queen and the wife of a King is not necessarily of equal rank -- they may not be Kings and Queens themselves. Their children are Princes and Princesses. Their grandchildren are also Princes and Princesses. If a male ruler dies, his wife takes the title Dowager Queen, providing there is not a Dowager Queen already. Like all rules, there are exceptions. One noted exception took place recently in Daggerfall, when King Lysandus died. In most regions, his wife Mynisera would not have become Dowager Queen of Daggerfall, because Lysandus' mother, the widow Nulfaga, still lived. In Daggerfall, however, it is permissable for there to be two persons with the same title. Thus, both Nulfaga and Mynisera have the title Dowager Queen.
 
+ If a female ruler, who does not share rank with her husband, dies, there is no male equivalent to the word Dowager. Widowers of Queens usually take another title, either a lesser family title or one given by their children. There have been a few men in the history of High Rock who have fallen from being addressed as King to being addressed as Mister at the death of their wife.
 
-    Because the rules are so complex and the stakes are so high,
-many people blanche at the thought of speaking with a noble
-with a title. For starters, it is important to address them
-correctly, for just as no one likes to be misnamed, no one
-likes to be mistitled. The problem is that in High Rock,
-traditions of the peerage differ slightly from region to
-region. The base rules follow:
+ Other regions are ruled by Dukes and Duchesses, Marquises (or Marquesses) and Marquises (or Marchionesses), Counts and Countesses, Viscounts or Viscountesses, Barons or Baronesses, and Lords or Ladies. This list is theoretically listed from highest to lowest rank, but the ruler of a territory outranks all other nobles, regardless of title. Dwynnen, for example, is a Barony, and the Baron or Baroness of Dwynnen outrank any other noble in that territory, even Dukes and Counts.
 
-    There are eight kingdoms in High Rock in the following
-regions: Northpoint, Daggerfall, Shornhelm, Camlorn,
-Farrun, Evermore, Wayrest, and Jehanna. If a woman is
-ruling one of these areas, she is called the Queen. The husband
-of a Queen and the wife of a King is not necessarily of equal
-rank -- they may not be Kings and Queens themselves. Their
-children are Princes and Princesses. Their grandchildren are
-also Princes and Princesses. If a male ruler dies, his wife
-takes the title Dowager Queen, providing there is not a
-Dowager Queen already. Like all rules, there are
-exceptions. One noted exception took place recently in
-Daggerfall, when King Lysandus died. In most regions, his
-wife Mynisera would not have become Dowager Queen of
-Daggerfall, because Lysandus' mother, the widow Nulfaga,
-still lived. In Daggerfall, however, it is permissable for
-there to be two persons with the same title. Thus, both
-Nulfaga and Mynisera have the title Dowager Queen.
+ In theory, (again, this may not be the case according to local custom) the eldest son or daughter of a noble takes their parents highest family title below their parents. Thus, the Duke of Northmoor, who is also the Marquis of Calder, had a daughter who became the Marchioness of Calder.
 
-    If a female ruler, who does not share rank with her husband,
-dies, there is no male equivalent to the word Dowager.
-Widowers of Queens usually take another title, either a
-lesser family title or one given by their children. There
-have been a few men in the history of High Rock who have fallen
-from being addressed as King to being addressed as Mister at
-the death of their wife.
+ Kings and Queens are always addressed as "Your Majesty" in conversation; Dukes and Duchesses, "Your Grace". All other rulers may be addressed with their title and name, or Lord or Lady and their name.
 
-    Other regions are ruled by Dukes and Duchesses, Marquises
-(or Marquesses) and Marquises (or Marchionesses), Counts and
-Countesses, Viscounts or Viscountesses, Barons or
-Baronesses, and Lords or Ladies. This list is
-theoretically listed from highest to lowest rank, but the
-ruler of a territory outranks all other nobles, regardless
-of title. Dwynnen, for example, is a Barony, and the Baron
-or Baroness of Dwynnen outrank any other noble in that
-territory, even Dukes and Counts.
+ A few hints may be needed to determine exactly who rules a territory. You may rely on people on the streets to make reference to their ruler, but that may not be enough. After all, if the gossip involved Lord Bemmish and Viscountess Byrd, neither or both could be the ruler of the territoy. I have found that a more predictable method is to pay some attention to the names of taverns and shops in a region. By tradition, many of these are called "The Duke's Fox" or "The Lady's Provisions." This, more often than not, is the name of the ruler. If the shop's name is "Lady Annisa's Provisions" or "Lord Boxworth's Fox," that is probably the name of a local titled merchant, not the ruler. A store with a unnamed ruler's title has probably been around for some time, and does not bother to change its name with the new name of the ruler.
 
-    In theory, (again, this may not be the case according to
-local custom) the eldest son or daughter of a noble takes
-their parents highest family title below their parents.
-Thus, the Duke of Northmoor, who is also the Marquis of
-Calder, had a daughter who became the Marchioness of Calder.
-
-    Kings and Queens are always addressed as "Your Majesty"
-in conversation; Dukes and Duchesses, "Your Grace". All
-other rulers may be addressed with their title and name, or
-Lord or Lady and their name.
-
-    A few hints may be needed to determine exactly who rules a
-territory. You may rely on people on the streets to make
-reference to their ruler, but that may not be enough. After
-all, if the gossip involved Lord Bemmish and Viscountess
-Byrd, neither or both could be the ruler of the territoy. I
-have found that a more predictable method is to pay some
-attention to the names of taverns and shops in a region. By
-tradition, many of these are called "The Duke's Fox" or "The
-Lady's Provisions." This, more often than not, is the name
-of the ruler. If the shop's name is "Lady Annisa's
-Provisions" or "Lord Boxworth's Fox," that is probably the
-name of a local titled merchant, not the ruler. A store with
-a unnamed ruler's title has probably been around for some
-time, and does not bother to change its name with the new name
-of the ruler.
-
-    In speaking with any person, a ruler or not, it is best to
-know what sort of a person they are first. Rulers tend to
-stand on ceremony, and prefer that people addressing them
-speak politely and deferentially. There are, of course,
-acceptions to this, particularly among younger rulers, or
-rulers new to their positions. They may prefer a bolder,
-slangy style. If you are unsure, or unsure of your ability
-to adopt the vocubulary of either an aristocrat or a
-criminal, choose to speak as plainly and directly as
-possible. You will seldom charm someone by plain talk, but
-you will also not alienate by mangled politesse or dated
-slang. Alienating a ruler, I need not tell you, can be the
-last mistake one can make.
-
-
-
-
-
-
-
-
-
-
-
-
-
- 
+ In speaking with any person, a ruler or not, it is best to know what sort of a person they are first. Rulers tend to stand on ceremony, and prefer that people addressing them speak politely and deferentially. There are, of course, acceptions to this, particularly among younger rulers, or rulers new to their positions. They may prefer a bolder, slangy style. If you are unsure, or unsure of your ability to adopt the vocubulary of either an aristocrat or a criminal, choose to speak as plainly and directly as possible. You will seldom charm someone by plain talk, but you will also not alienate by mangled politesse or dated slang. Alienating a ruler, I need not tell you, can be the last mistake one can make.

--- a/Assets/StreamingAssets/Text/Books/BOK00080-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00080-LOC.txt
@@ -3,9 +3,8 @@ Author: Sigillah Parate
 IsNaughty: False
 Price: 452
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,96 +12,24 @@ Content:
 
 [/center]Azura
 
-
-
 [/font=4]
 
 [/center]
 
-     For three hundred years, I have been a priestess of Azura,
-the Daedric Prince of Moonshadow, Mother of the Rose, and
-Queen of the Night Sky. Every Hogithum, which we celebrate on
-the 21st of First Seed, we summon her for guidance and to
-give up beautiful things to her majesty. She is a cruel but
-wise mistress. We do not invoke her on any Hogithum troubled
-by thunder storms, for those nights belong to the Mad One,
-Sheogorath, even if they do coincide with Hogithum. Azura
-understands our caution.
+ For three hundred years, I have been a priestess of Azura, the Daedric Prince of Moonshadow, Mother of the Rose, and Queen of the Night Sky. Every Hogithum, which we celebrate on the 21st of First Seed, we summon her for guidance and to give up beautiful things to her majesty. She is a cruel but wise mistress. We do not invoke her on any Hogithum troubled by thunder storms, for those nights belong to the Mad One, Sheogorath, even if they do coincide with Hogithum. Azura understands our caution.
 
-     We may summon her on other dates also, and she quite often
-responds. The only days we are forbidden to invoke her are
-those prescribed to one of the other fifteen Princes: the 1st
-and the 13th of Morning Star, the 2nd and the 16th of Suns
-Dawn, the 5th of First Seed, the 9th of Rains Hand, the 9th of
-Second Seed, the 5th of Mid Year, the 10th of Suns Height, the
-8th of Hearth Fire, the 8th and the 13th of Frost Fall, the
-2nd and 20th of Suns Dusk, and the 20th of Evening Star. I
-know who is summoned on the 8th of Hearth Fire, the 2nd of
-Suns Dusk, and the 20th of Evening Star, but I am not certain
-of the others. It is enough that Azura has forbidden those
-dates.
+ We may summon her on other dates also, and she quite often responds. The only days we are forbidden to invoke her are those prescribed to one of the other fifteen Princes: the 1st and the 13th of Morning Star, the 2nd and the 16th of Suns Dawn, the 5th of First Seed, the 9th of Rains Hand, the 9th of Second Seed, the 5th of Mid Year, the 10th of Suns Height, the 8th of Hearth Fire, the 8th and the 13th of Frost Fall, the 2nd and 20th of Suns Dusk, and the 20th of Evening Star. I know who is summoned on the 8th of Hearth Fire, the 2nd of Suns Dusk, and the 20th of Evening Star, but I am not certain of the others. It is enough that Azura has forbidden those dates.
 
-     Azura's invocation is a very personal one. I have been
-the priestess of three other Daedric Princes, but Azura
-values the quality of her worshippers, the truth behind our
-adoration of her, and the 
+ Azura's invocation is a very personal one. I have been the priestess of three other Daedric Princes, but Azura values the quality of her worshippers, the truth behind our adoration of her, and the
 
-     When I was a Dark Elven maiden of sixteen, I joined my
-grandmother's coven, worshippers of Molag Bal, the Schemer
-Prince. Blackmail, extortion, and bribery are as much the
-weapons of the Witches of Molag Bal as magic is. The
-Invocation of Molag Bal is held on the 20th of Evening Star,
-except in stormy weather. This ceremony is seldom missed,
-but Molag Bal often appears to his cultists in mortal guise
-on other dates. When my grandmother died in an attempt to
-poison the heir of Firewatch, I reexamined my faith in the
-cult.
+ When I was a Dark Elven maiden of sixteen, I joined my grandmother's coven, worshippers of Molag Bal, the Schemer Prince. Blackmail, extortion, and bribery are as much the weapons of the Witches of Molag Bal as magic is. The Invocation of Molag Bal is held on the 20th of Evening Star, except in stormy weather. This ceremony is seldom missed, but Molag Bal often appears to his cultists in mortal guise on other dates. When my grandmother died in an attempt to poison the heir of Firewatch, I reexamined my faith in the cult.
 
-     My brother was a warlock of the cult of Boethiah, and from
-what he told me, the Dark Warrior was closer to my spirit
-than the treacherous Molag Bal. Boethiah is a warrior Prince
-who acts more avertly than any other Daedra. After years of
-skulking and scheming, it felt good to perform acts for my
-mistress which had immediate consequences. Besides, I liked
-that Boethiah is a Daedra of the Dark Elves. Our cult would
-summon her on the day we called the Gauntlet, the 2nd of
-Suns Dusk. Bloody competitions would be held in her honor,
-and the duels and battles would continue until nine
-cultists were killed at the hands of other cultists. Boethiah
-cared little for her cultists -- she only cared about our
-blood. I do think I saw her smile when I accidentally slew my
-brother in a spar. My horror, I think, greatly pleased her.
+ My brother was a warlock of the cult of Boethiah, and from what he told me, the Dark Warrior was closer to my spirit than the treacherous Molag Bal. Boethiah is a warrior Prince who acts more avertly than any other Daedra. After years of skulking and scheming, it felt good to perform acts for my mistress which had immediate consequences. Besides, I liked that Boethiah is a Daedra of the Dark Elves. Our cult would summon her on the day we called the Gauntlet, the 2nd of Suns Dusk. Bloody competitions would be held in her honor, and the duels and battles would continue until nine cultists were killed at the hands of other cultists. Boethiah cared little for her cultists -- she only cared about our blood. I do think I saw her smile when I accidentally slew my brother in a spar. My horror, I think, greatly pleased her.
 
-     I left the cult soon after that. Boethiah was too
-impersonal for me, too cold. I wanted a master of greater
-depth than she. For the next eighteen years of my life, I
-worshipped no one: I read and researched. It was in an old
-and profane tome I came upon the name of Nocturnal.
-Nocturnal the Night Mistress, Nocturnal the Unfathomable.
-As the book prescribed, I called to her on her holy day, the
-8th of Hearth Fire. At last, I had found the personal
-mistress I had so long desired. I strove to understand her
-labyrinthine philosophy, the source of her mysterious pain.
-Everything about her was dark and shrouded, even the way
-she spoke and the acts she required of me.
+ I left the cult soon after that. Boethiah was too impersonal for me, too cold. I wanted a master of greater depth than she. For the next eighteen years of my life, I worshipped no one: I read and researched. It was in an old and profane tome I came upon the name of Nocturnal. Nocturnal the Night Mistress, Nocturnal the Unfathomable. As the book prescribed, I called to her on her holy day, the 8th of Hearth Fire. At last, I had found the personal mistress I had so long desired. I strove to understand her labyrinthine philosophy, the source of her mysterious pain. Everything about her was dark and shrouded, even the way she spoke and the acts she required of me.
 
-     It took years for me to understand the simple fact that I
-could never understand Nocturnal. Her mystery was as
-essential to her as savagery was to Boethiah or treachery was
-to Molag Bal. To understand Nocturnal is to negate her, to
-pull back the curtains in her realm of darkness. As much as I
-loved her, I recognized the futility of unravelling her
-enigmas. I turned instead to her sister, Azura.
+ It took years for me to understand the simple fact that I could never understand Nocturnal. Her mystery was as essential to her as savagery was to Boethiah or treachery was to Molag Bal. To understand Nocturnal is to negate her, to pull back the curtains in her realm of darkness. As much as I loved her, I recognized the futility of unravelling her enigmas. I turned instead to her sister, Azura.
 
-     Azura is the only Daedra Prince I have ever worshipped who
-seems to care about her cultists. Molag Bal wanted my mind,
-Boethiah wanted my arms, and Nocturnal -- perhaps my
-curiousity. Azura wants all of that, and our love. Not our
-abject slavering, but our honest and genuine love in all
-its forms. It is important to her that our emotions are
-engaged. And our love must also be directed inward. If we
-love her and hate ourselves, she feels our pain.
+ Azura is the only Daedra Prince I have ever worshipped who seems to care about her cultists. Molag Bal wanted my mind, Boethiah wanted my arms, and Nocturnal -- perhaps my curiousity. Azura wants all of that, and our love. Not our abject slavering, but our honest and genuine love in all its forms. It is important to her that our emotions are engaged. And our love must also be directed inward. If we love her and hate ourselves, she feels our pain.
 
-     I will have no other mistress.
-
-
+ I will have no other mistress.

--- a/Assets/StreamingAssets/Text/Books/BOK00081-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00081-LOC.txt
@@ -3,9 +3,8 @@ Author: Anonymous
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,53 +14,24 @@ Content:
 
 [/center]Woman
 
-
-
 [/font=4]
 
+[/center]
 
+ I heard this story on good authority from a good and honest friend, whose friend was witness to the incident. I do truly believe it happened, as fantastical as it may seem.
 
-[/center]     I heard this story on good authority from a good and
-honest friend, whose friend was witness to the incident. I do
-truly believe it happened, as fantastical as it may seem.
+ My friend's friend, Terron, was visiting the Elsweyr citystate of Riverhold during a very hot summer and went to the marketplace there. If you have never been to Riverhold, the marketplace is very crowded, much more than in comparably sized city states. People from the countryside flock to the marketplace daily in their wagons and carriages.
 
-     My friend's friend, Terron, was visiting the Elsweyr
-citystate of Riverhold during a very hot summer and went to
-the marketplace there. If you have never been to Riverhold,
-the marketplace is very crowded, much more than in
-comparably sized city states. People from the countryside
-flock to the marketplace daily in their wagons and carriages.
+ Terron was passing one such carriage, and noticed that the sole occupant was a woman, seated with her eyes closed and her hands behind her head. An odd sight, to be sure, but he assumed she must be sleeping. Terron continued on.
 
-     Terron was passing one such carriage, and noticed that
-the sole occupant was a woman, seated with her eyes closed and her hands behind her head. An odd sight, to be
-sure, but he assumed she must be sleeping. Terron continued
-on.
+ A little while later, after Terron had finished shopping in the marketplace, he passed the same carriage. The same woman was sitting in it. Her eyes were open now, but her hands were still behind her head.
 
-     A little while later, after Terron had finished shopping
-in the marketplace, he passed the same carriage. The same
-woman was sitting in it. Her eyes were open now, but her hands
-were still behind her head.
+ "Are you all right, my lady?" he asked.
 
-     "Are you all right, my lady?" he asked.
+ "An arrow shot me in my head and I'm holding my brains in," came the woman's reply.
 
-     "An arrow shot me in my head and I'm holding my brains
-in," came the woman's reply.
+ Terron did not know what to do. He ran into the marketplace and literally bumped into a healer and his knight companion. They were good people and agreed to help.
 
-     Terron did not know what to do. He ran into the
-marketplace and literally bumped into a healer and his
-knight companion. They were good people and agreed to
-help.
+ The carriage door had to be torn off its hinges, as the lady had locked it and feared to move to unlock it. What they found when they finally could get into the carriage was this: the woman was holding barley dough on the back of her head with her hands.
 
-     The carriage door had to be torn off its hinges, as the
-lady had locked it and feared to move to unlock it. What they
-found when they finally could get into the carriage was this:
-the woman was holding barley dough on the back of her head
-with her hands.
-
-     Apparently, in the heat of the day, a jar of barley dough
-had exploded with the thwang of an arrowshot and struck the
-woman in the back of her head. When she reached back to feel
-what had hit her, she felt the dough and reasoned that she was
-feeling her brains.
-
- 
+ Apparently, in the heat of the day, a jar of barley dough had exploded with the thwang of an arrowshot and struck the woman in the back of her head. When she reached back to feel what had hit her, she felt the dough and reasoned that she was feeling her brains.

--- a/Assets/StreamingAssets/Text/Books/BOK00082-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00082-LOC.txt
@@ -3,9 +3,8 @@ Author: Porbert Lyttumly
 IsNaughty: True
 Price: 467
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,142 +12,62 @@ Content:
 
 [/center]Bet
 
-
-
 [/font=4]
 
 [/center]
 
-   It was a perfectly ordinary day at the main office of the
-Bank of Daggerfall. Normal transactions took place:
-deposits were deposited, withdrawals were withdrawn, house
-mortgages were collected, letters of credit were golded.
-When a teller named Clyton J. Wifflington saw the little
-old lady approaching him, dragging two large sacks, each
-nearly as large as her, he changed his mind. It was not to be
-a perfectly ordinary day at the Bank of Daggerfall after
-all.
+ It was a perfectly ordinary day at the main office of the Bank of Daggerfall. Normal transactions took place: deposits were deposited, withdrawals were withdrawn, house mortgages were collected, letters of credit were golded. When a teller named Clyton J. Wifflington saw the little old lady approaching him, dragging two large sacks, each nearly as large as her, he changed his mind. It was not to be a perfectly ordinary day at the Bank of Daggerfall after all.
 
-   "I would like you to take the thirty million gold pieces I
-have in these sacks and open me an account," croaked the
-little old biddy.
+ "I would like you to take the thirty million gold pieces I have in these sacks and open me an account," croaked the little old biddy.
 
-   "Certainly, madam," Wifflington said, eagerly. He
-counted the gold in the sacks and found that it was thirty
-million gold exactly.
+ "Certainly, madam," Wifflington said, eagerly. He counted the gold in the sacks and found that it was thirty million gold exactly.
 
-   "One moment, sonny," the little old lady chirruped.
-"Before I open the account, I would like to meet the man I'm
-trusting it to. I'd like to talk to the president of the bank."
+ "One moment, sonny," the little old lady chirruped. "Before I open the account, I would like to meet the man I'm trusting it to. I'd like to talk to the president of the bank."
 
-    Wifflington wanted the president to know that he was the
-teller who had taken the largest single deposit that year, so
-eagerly sent word to the president's secretary. As it turned
-out, the president was equally eager to meet such a wealthy
-woman, so the old lady was brought to his office that very
-day.
+ Wifflington wanted the president to know that he was the teller who had taken the largest single deposit that year, so eagerly sent word to the president's secretary. As it turned out, the president was equally eager to meet such a wealthy woman, so the old lady was brought to his office that very day.
 
-    "Pleased to make your acquaintance, milady. I am
-Gerander P. Baggledon," said the president, Gerander P.
-Baggledon.
+ "Pleased to make your acquaintance, milady. I am Gerander P. Baggledon," said the president, Gerander P. Baggledon.
 
-    "My name," said the little old lady. "Is Petuva
-Smuthworthy." That was, in fact, her real name. "Thank you
-for seeing me. I like to conduct my business in a more
-personal way."
+ "My name," said the little old lady. "Is Petuva Smuthworthy." That was, in fact, her real name. "Thank you for seeing me. I like to conduct my business in a more personal way."
 
-    "I can certainly appreciate that," said Baggledon
-chucklingly. "It is an appreciable sum of gold. Would it
-be rude of me to ask how you came by it?"
+ "I can certainly appreciate that," said Baggledon chucklingly. "It is an appreciable sum of gold. Would it be rude of me to ask how you came by it?"
 
-    "Not at all," said Mrs. Smuthworthy.
+ "Not at all," said Mrs. Smuthworthy.
 
-    "How came you by it?" asked Baggledon.
+ "How came you by it?" asked Baggledon.
 
-    "I'll let you guess," replied Mrs. Smuthworthy, with a
-trace of unattractive girlish flirtation.
+ "I'll let you guess," replied Mrs. Smuthworthy, with a trace of unattractive girlish flirtation.
 
-    Baggledon was a man of enormous imagination, for a
-banker. He guessed inheritance and longtime thrift, but Mrs.
-Smuthworthy coyly shook her head. Perhaps she had sold a
-large, old mansion? No. In a moment of chumminess,
-Baggledon asked if the gold came as a result of plunder or
-thievery. Mrs. Smuthworthy took no offense, but said no.
-Finally, he admitted defeat.
+ Baggledon was a man of enormous imagination, for a banker. He guessed inheritance and longtime thrift, but Mrs. Smuthworthy coyly shook her head. Perhaps she had sold a large, old mansion? No. In a moment of chumminess, Baggledon asked if the gold came as a result of plunder or thievery. Mrs. Smuthworthy took no offense, but said no. Finally, he admitted defeat.
 
-    "I'm a gambler," she said.      "In arena fights?" he asked,
-interested.
+ "I'm a gambler," she said.
 
-    "No, no, dearie. Different things. For example, I'd be
-willing to wager twenty five thousand gold pieces that at
-this time tomorrow morning, your testicles will be covered
-with feathers."
+ "In arena fights?" he asked, interested.
 
-    Mr. Baggledon was somewhat taken aback by the old woman's
-words. Could she be mad? Could she be a witch? He eliminated
-the latter possibility, for he had a sense for such things. If she were mad, she was still a rich madwoman. And he could
-use twenty five thousand gold pieces. So he took her wager.
+ "No, no, dearie. Different things. For example, I'd be willing to wager twenty five thousand gold pieces that at this time tomorrow morning, your testicles will be covered with feathers."
 
-    For the next twenty-four hours, Mr. Baggledon obsessed
-over his testicles. He checked his pants so often that
-afternoon, his subordinates feared the worse and suggested
-that he not touch anything and go home for the rest of the
-afternoon. He spent the night seated, his pants around his
-ankles, his beady banker's eyes focused on his scrotum. Every
-time he started to doze off, his vision was filled with images
-of Mrs. Smuthworthy plucking feathers from his balls,
-cackling.
+ Mr. Baggledon was somewhat taken aback by the old woman's words. Could she be mad? Could she be a witch? He eliminated the latter possibility, for he had a sense for such things. If she were mad, she was still a rich madwoman. And he could use twenty five thousand gold pieces. So he took her wager.
 
-    Mr. Baggledon arrived at the bank late the next day --
-only moments before Mrs. Smethworthy's arrival.
-Accompanying her was a lean, bespeckled fellow she
-introduced as a barrister from the court. Her son, it turned
-out. Young Mr. Smethworthy always accompanied his mother
-when there was money involved, she explained.
+ For the next twenty-four hours, Mr. Baggledon obsessed over his testicles. He checked his pants so often that afternoon, his subordinates feared the worse and suggested that he not touch anything and go home for the rest of the afternoon. He spent the night seated, his pants around his ankles, his beady banker's eyes focused on his scrotum. Every time he started to doze off, his vision was filled with images of Mrs. Smuthworthy plucking feathers from his balls, cackling.
 
-    "Enough banter," she crowed. "Our bet, dearie?"
+ Mr. Baggledon arrived at the bank late the next day -- only moments before Mrs. Smethworthy's arrival. Accompanying her was a lean, bespeckled fellow she introduced as a barrister from the court. Her son, it turned out. Young Mr. Smethworthy always accompanied his mother when there was money involved, she explained.
 
-    "My dear, dear madam, I can tell you that your gold will
-be quite safe at the Bank of Daggerfall. I hope it will not
-cause you distress to discover that your gold will be safer
-here than in your own hands. My family jewels are quite,
-shall we say, featherless. And you owe me a sum equally
-twenty five thousand gold."
+ "Enough banter," she crowed. "Our bet, dearie?"
 
-    Poor Mrs. Smethworthy's face fell when she heard this. "Are
-you sure?"
+ "My dear, dear madam, I can tell you that your gold will be quite safe at the Bank of Daggerfall. I hope it will not cause you distress to discover that your gold will be safer here than in your own hands. My family jewels are quite, shall we say, featherless. And you owe me a sum equally twenty five thousand gold."
 
-    "Quite, madam."
+ Poor Mrs. Smethworthy's face fell when she heard this. "Are you sure?"
 
-    "Not even one feather?" Her voice suggested doubt. Mr.
-Baggledon could tell she thought he might be lying.
+ "Quite, madam."
 
-    "Not one, I fear, madam."
+ "Not even one feather?" Her voice suggested doubt. Mr. Baggledon could tell she thought he might be lying.
 
-    "It's not that I don't trust you, Mr. Baggledon, but it
-is quite a lot of gold. Might I -- would you -- could I
-possibly see for myself?"
+ "Not one, I fear, madam."
 
-    As he knew he was soon to be a twenty five thousand gold
-pieces richer, and he was still a bit punchy from lack of
-sleep, Mr. Baggledon merely smiled and dropped his breeches
-to the floor. Mrs. Smethworthy examined his testicles very
-carefully, under, to the left, to the right. At last, she was
-satisfied that there was not so much as a down feather
-anywhere in the region. While she was looking under them one
-last time, Mr. Baggledon heard a thwacking noise across the
-office. Young Mr. Smethworthy was banging his head against
-the stone wall.
+ "It's not that I don't trust you, Mr. Baggledon, but it is quite a lot of gold. Might I -- would you -- could I possibly see for myself?"
 
-    "What in the Lady's name is wrong with your son, Mrs.
-Smethworthy?" he asked.
+ As he knew he was soon to be a twenty five thousand gold pieces richer, and he was still a bit punchy from lack of sleep, Mr. Baggledon merely smiled and dropped his breeches to the floor. Mrs. Smethworthy examined his testicles very carefully, under, to the left, to the right. At last, she was satisfied that there was not so much as a down feather anywhere in the region. While she was looking under them one last time, Mr. Baggledon heard a thwacking noise across the office. Young Mr. Smethworthy was banging his head against the stone wall.
 
-    "Nothing, dear," she said. "I merely bet him one hundred
-thousand gold pieces that by this time I would have the
-president of the Bank of Daggerfall by the balls."
+ "What in the Lady's name is wrong with your son, Mrs. Smethworthy?" he asked.
 
-
-
-
-
- 
+ "Nothing, dear," she said. "I merely bet him one hundred thousand gold pieces that by this time I would have the president of the Bank of Daggerfall by the balls."

--- a/Assets/StreamingAssets/Text/Books/BOK00083-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00083-LOC.txt
@@ -3,9 +3,8 @@ Author: Fav'te
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,108 +12,20 @@ Content:
 
 [/center]Betony
 
-
-
 [/font=4]
 
 [/center]
 
-    Could there be a better proof of the natural perversity
-of Bretons than their conduct before, during, and after what
-history will remember as the War of Betony? By the most
-depraved of motivations, the most despicable of tactics,
-and the most ungentlemanly of triumphs, the kingdom of
-Daggerfall changed the nature of warfare in the Iliac Bay
-and perhaps over all of Tamriel. In Sentinel, we call the
-recent carnage the Siege of Betony, but as the book of history
-is writ by the victors, let us speak instead of the War of
-Betony.
+ Could there be a better proof of the natural perversity of Bretons than their conduct before, during, and after what history will remember as the War of Betony? By the most depraved of motivations, the most despicable of tactics, and the most ungentlemanly of triumphs, the kingdom of Daggerfall changed the nature of warfare in the Iliac Bay and perhaps over all of Tamriel. In Sentinel, we call the recent carnage the Siege of Betony, but as the book of history is writ by the victors, let us speak instead of the War of Betony.
 
-    Redguards by their nature are a modest and practical
-people. We are not phlegmatic like the High Elves, nor
-cowardly like the Wood Elves and Khajiiti. But what would
-infuriate and enrage the swaggering, vainglorious Nords and
-Bretons would not merit a shrug from a Redguard. Had any
-Breton kingdom possessed the little island of Betony, it
-would have been covetously guarded. Betony's trade would
-have been seriously restricted; its religion subjugated; its
-people bound by active and constant pledges and duties of
-vassalage. But Betony was not a Breton dominion. Betony was
-part of the Kingdom of Sentinel.
+ Redguards by their nature are a modest and practical people. We are not phlegmatic like the High Elves, nor cowardly like the Wood Elves and Khajiiti. But what would infuriate and enrage the swaggering, vainglorious Nords and Bretons would not merit a shrug from a Redguard. Had any Breton kingdom possessed the little island of Betony, it would have been covetously guarded. Betony's trade would have been seriously restricted; its religion subjugated; its people bound by active and constant pledges and duties of vassalage. But Betony was not a Breton dominion. Betony was part of the Kingdom of Sentinel.
 
-    King Lysandus -- may the Old Ones continue to torment his
-soul for his wickedness! -- saw the prosperous island which is
-closer to his land than to Sentinel, and his black heart
-turned to avarice. Through threats, lies, acts of piracy
-and, finally, invasion, Daggerfall illegally took
-possession of the Island of Betony. His court sorceress, the
-Lady Medora, his enchantress mother, and other experienced
-counselors were horrified by the brutality of his campaign
-and begged him to abandon his tyrannical act of war.
-Gradually, all dissentors were removed from court. None
-but the ignorant and the warmongers remained.
+ King Lysandus -- may the Old Ones continue to torment his soul for his wickedness! -- saw the prosperous island which is closer to his land than to Sentinel, and his black heart turned to avarice. Through threats, lies, acts of piracy and, finally, invasion, Daggerfall illegally took possession of the Island of Betony. His court sorceress, the Lady Medora, his enchantress mother, and other experienced counselors were horrified by the brutality of his campaign and begged him to abandon his tyrannical act of war. Gradually, all dissentors were removed from court. None but the ignorant and the warmongers remained.
 
-    Our late king Camaron tried to employ civil diplomacy
-with Daggerfall, but in the end, he made the former
-declaration of war. Daggerfall and Sentinel have fought
-many times in their two thousand years of coexistance, and
-Camaron knew the black magic and espionage the Bretons
-considered honest warfare. Never debasing the Sentinel
-character by duplicating the Breton villainy, Camaron
-knew best how to combat Lysandus. King Lysandus' knavish
-battle tactics were even more perfidious than his ancestors',
-and the war continue to rage until it began to involve more
-than Sentinel and Daggerfall.
+ Our late king Camaron tried to employ civil diplomacy with Daggerfall, but in the end, he made the former declaration of war. Daggerfall and Sentinel have fought many times in their two thousand years of coexistance, and Camaron knew the black magic and espionage the Bretons considered honest warfare. Never debasing the Sentinel character by duplicating the Breton villainy, Camaron knew best how to combat Lysandus. King Lysandus' knavish battle tactics were even more perfidious than his ancestors', and the war continue to rage until it began to involve more than Sentinel and Daggerfall.
 
-    Lord Graddock, ruler of Reich Gradkeep, acted as
-concilator between Sentinel and Daggerfall, and
-eventually convinced both monarchs to meet and make peace.
-The ill-fated Treaty of Gradkeep began civilly; the terms
-of peace were discussed, agreed on, and set to paper. The
-terms were excessively generous. Camaron had agreed to give
-up some of his rights to Betony in order to placate the
-madness of Lysandus and bring peace back to the Iliac Bay.
-It was not until King Camaron read the Treaty he was about
-to sign that he realized the outrageous perfidy of the
-Bretons: the Treaty had actually been purposefully
-miswritten by the Daggerfall scribe in a desparate and
-ignominious attempt to trick Camaron into signing a
-contract different from the one to which he had agreed. The
-castle of Reich Gradkeep erupted into bloodbath, and the war
-continued.
+ Lord Graddock, ruler of Reich Gradkeep, acted as concilator between Sentinel and Daggerfall, and eventually convinced both monarchs to meet and make peace. The ill-fated Treaty of Gradkeep began civilly; the terms of peace were discussed, agreed on, and set to paper. The terms were excessively generous. Camaron had agreed to give up some of his rights to Betony in order to placate the madness of Lysandus and bring peace back to the Iliac Bay. It was not until King Camaron read the Treaty he was about to sign that he realized the outrageous perfidy of the Bretons: the Treaty had actually been purposefully miswritten by the Daggerfall scribe in a desparate and ignominious attempt to trick Camaron into signing a contract different from the one to which he had agreed. The castle of Reich Gradkeep erupted into bloodbath, and the war continued.
 
-     The Battle of Cryngaine Field was the tragic ending of the
-senseless war of attrition. The Cryngaine Field is located
-in between the Yeorth Burrowland and the Ravennian Forest
-where the armies of Sentinel and Daggerfall respectively
-made camp after the massacre at Reich Gradkeep. As the
-battle began, Daggerfall proved that she had some foul
-daedric magical tricks left by blinding the Redguard army
-with a wall of mist. Lysandus did not have the opportunity
-to gloat over his cozenage for long, for the sure arm of a Sentinel archer struck him in the throat even through the
-thick, swirling fog. Lysandus' son, Gothryd, who had spent
-the battle in lugubrious relaxation, was crowned without
-ceremony, and thereupon demanded a duel with King Camaron.
-Camaron was many years Gothryd's senior, and though a
-superior warrior, was exhausted from the endless warfare the
-boy king had been spared. Nevertheless, as a point of honor,
-our king agreed to the duel. The new king of Daggerfall, by
-dirty trick and black magic, managed to backstab our king
-before the duel ever began. Thus, the victor of Cryngaine
-Field, and the War of Betony, was Daggerfall.
+ The Battle of Cryngaine Field was the tragic ending of the senseless war of attrition. The Cryngaine Field is located in between the Yeorth Burrowland and the Ravennian Forest where the armies of Sentinel and Daggerfall respectively made camp after the massacre at Reich Gradkeep. As the battle began, Daggerfall proved that she had some foul daedric magical tricks left by blinding the Redguard army with a wall of mist. Lysandus did not have the opportunity to gloat over his cozenage for long, for the sure arm of a Sentinel archer struck him in the throat even through the thick, swirling fog. Lysandus' son, Gothryd, who had spent the battle in lugubrious relaxation, was crowned without ceremony, and thereupon demanded a duel with King Camaron. Camaron was many years Gothryd's senior, and though a superior warrior, was exhausted from the endless warfare the boy king had been spared. Nevertheless, as a point of honor, our king agreed to the duel. The new king of Daggerfall, by dirty trick and black magic, managed to backstab our king before the duel ever began. Thus, the victor of Cryngaine Field, and the War of Betony, was Daggerfall.
 
-     Daggerfall's wickedness continued even after her
-inglorious victory. While the widow queen of Sentinel, Her
-Majesty Akorithi, mourned and tried to mend her shattered
-lands, Gothryd demanded the Princess of Sentinel as a
-hostage of war. To save her homeland, the Princess Aubk-i
-agreed to leave Sentinel and even marry the murderer of her
-father. But we true Redguards of Sentinel know where her love
-and honor lies. The Queen of Daggerfall is the Princess of
-Sentinel first and foremost. 
-
-
-
-
-
- 
+ Daggerfall's wickedness continued even after her inglorious victory. While the widow queen of Sentinel, Her Majesty Akorithi, mourned and tried to mend her shattered lands, Gothryd demanded the Princess of Sentinel as a hostage of war. To save her homeland, the Princess Aubk-i agreed to leave Sentinel and even marry the murderer of her father. But we true Redguards of Sentinel know where her love and honor lies. The Queen of Daggerfall is the Princess of Sentinel first and foremost.

--- a/Assets/StreamingAssets/Text/Books/BOK00084-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00084-LOC.txt
@@ -3,9 +3,8 @@ Author: Vulper Newgate
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,134 +14,30 @@ Content:
 
 [/center]Betony
 
-
-
 [/font=4]
 
+[/center]
 
+ The history of the Iliac Bay, if told in its entirety, would horrify readers more than the most gruesome legend of the Underking. In comparison to the wars of the first and second era, our most recent appeal to arms, the War of Betony pales. The Siege of Orsinium lasted from 1E 950 until 1E 980 without a pause. A thousand years later, the Thrassian Plague coupled with the War of Righteousness slayed over half the population of the Iliac Bay. And yet, the War of Betony fascinates us, and not just because of its immediacy.
 
-[/center]    The history of the Iliac Bay, if told in its entirety,
-would horrify readers more than the most gruesome legend of
-the Underking. In comparison to the wars of the first and
-second era, our most recent appeal to arms, the War of
-Betony pales. The Siege of Orsinium lasted from 1E 950 until
-1E 980 without a pause. A thousand years later, the Thrassian
-Plague coupled with the War of Righteousness slayed over half the population of the Iliac Bay. And yet, the War of
-Betony fascinates us, and not just because of its immediacy.
+ Ironically, Lord Mogref of Betony was seeking peace when he asked for Daggerfall's protection on the Isle of Betony. The island had long been independant, but as the piracy in the Bay increased, Mogref truly realized Betony's vulnerability. King Lysandus agreed to be Betony's liege, on advice of many, including his archpriest of Kynareth, Lord Vanech. While Betony is a prosperous fishing island and well-placed strategically, the vassalage of Betony was primarily an act of charity. Lysandus knew that if someone did not help Betony, it would fall to the pirates, if not to someone worse.
 
-    Ironically, Lord Mogref of Betony was seeking peace when
-he asked for Daggerfall's protection on the Isle of Betony.
-The island had long been independant, but as the piracy in
-the Bay increased, Mogref truly realized  Betony's
-vulnerability. King Lysandus agreed to be Betony's liege,
-on advice of many, including his archpriest of Kynareth,
-Lord Vanech. While Betony is a prosperous fishing island and
-well-placed strategically, the vassalage of Betony was
-primarily an act of charity. Lysandus knew that if someone
-did not help Betony, it would fall to the pirates, if not
-to someone worse.
+ Unfortunately, King Camaron of Sentinel did not agree. Citing a two hundred year old contract, obliquely if not illegally written to suggest that Betony was a "traditional holding" of the Kingdom of Sentinel, Camaron declared war. The majority of his advisors, being warlords in a traditionally bellicose country, supported their king in this. The Chief Counselor, a woman called The Oracle, foresaw death and defeat in the war, but her wisdom was stifled and she was banished from court. Camaron should have listened to her.
 
-    Unfortunately, King Camaron of Sentinel did not agree.
-Citing a two hundred year old contract, obliquely if not
-illegally written to suggest that Betony was a "traditional
-holding" of the Kingdom of Sentinel, Camaron declared
-war. The majority of his advisors, being warlords in a
-traditionally bellicose country, supported their king in
-this. The Chief Counselor, a woman called The Oracle,
-foresaw death and defeat in the war, but her wisdom was
-stifled and she was banished from court. Camaron should have
-listened to her.
+ A few scrimages of the War of Betony went to Sentinel, but the major battles were all won by Daggerfall. King Lysandus, his heir Prince Gothryd, and the general of the army Lord Bridwell were fine leaders and warriors as well, and the Battle of the Bluffs and the Siege of Craghold both went to Daggerfall.
 
-    A few scrimages of the War of Betony went to Sentinel, but
-the major battles were all won by Daggerfall. King
-Lysandus, his heir Prince Gothryd, and the general of the
-army Lord Bridwell were fine leaders and warriors as well,
-and the Battle of the Bluffs and the Siege of Craghold both
-went to Daggerfall.
+ The war might have been won with one more victory, but for an unusual domestic incident in King Lysandus' court. The king's mother, the dowager queen Nulfaga, had been uneasy about the war since its beginning, but she now began to have visions of cataclysm. She saw the death of her beloved son should the war continue. Ebullient by his success, King Lysandus refused to listen to her fears until Nulfaga left court. Lysandus then realized how certain she was about his impending death. He began to actively negotiate a peace treaty with Sentinel, using the neutral lordship of Reich Gradkeep as facilitator.
 
-    The war might have been won with one more victory, but for
-an unusual domestic incident in King Lysandus' court. The
-king's mother, the dowager queen Nulfaga, had been uneasy
-about the war since its beginning, but she now began to have
-visions of cataclysm. She saw the death of her beloved son
-should the war continue. Ebullient by his success, King
-Lysandus refused to listen to her fears until Nulfaga left
-court. Lysandus then realized how certain she was about his
-impending death. He began to actively negotiate a peace
-treaty with Sentinel, using the neutral lordship of Reich
-Gradkeep as facilitator.
+ The Treaty of Reich Gradkeep was never to be. King Camaron was initially civil, as the losing side of a war is often civil, but when he realized that the proposed treaty would have included a formal declaration that the kingdoms of Sentinel and Daggerfall would share Betony, he flew into a rage. With no thought for the protocol of attacking a neutral peaceable lordship, Camaron order his army to riot through Reich Gradkeep. First the halls of the palace, and then the streets of the capitol ran red with blood. It was only with the support of the Daggerfall army that the chaos was brought under relative control. The Sentinel army fled to the Yeorth Burrowland, and the Daggerfall army chased them as far as the Ravennian Forest before making camp.
 
-    The Treaty of Reich Gradkeep was never to be. King Camaron
-was initially civil, as the losing side of a war is often
-civil, but when he realized that the proposed treaty would
-have included a formal declaration that the kingdoms of
-Sentinel and Daggerfall would share Betony, he flew into a
-rage. With no thought for the protocol of attacking a
-neutral peaceable lordship, Camaron order his army to riot
-through Reich Gradkeep. First the halls of the palace, and
-then the streets of the capitol ran red with blood. It was
-only with the support of the Daggerfall army that the chaos
-was brought under relative control. The Sentinel army
-fled to the Yeorth Burrowland, and the Daggerfall army
-chased them as far as the Ravennian Forest before making
-camp.
+ One week later, after each had a chance to send for reinforcements and plan their strategies, the armies met in the field that separated them, the flowering meadowland called Cryngaine Field. In the heat of the clash, an unnatural fog spread over the field, blinding all combatants. When the mist finally lifted, King Lysandus' body was found, his throat pierced by an unmarked arrow.
 
-     One week later, after each had a chance to send for
-reinforcements and plan their strategies, the armies met in
-the field that separated them, the flowering meadowland
-called Cryngaine Field. In the heat of the clash, an
-unnatural fog spread over the field, blinding all
-combatants. When the mist finally lifted, King Lysandus'
-body was found, his throat pierced by an unmarked arrow.
+ Daggerfall did not waste any time in mourning; young prince Gothryd, who had shown great bravery in battle and was very popular among the troops, was crowned King of Daggerfall just behind the battle lines, and he ordered the army onward. Perhaps it was the sight of the brave young warrior turned king appearing on the battlefield in full regalia that inspired the Daggerfall army, perhaps the battle would have turned regardless, Sentinel began to panic. King Gothryd met King Camaron before the Redguards had retreated, and the two monarchs fought. Both were excellent warriors, but Gothryd was a more skillful swordsman, and Camaron fell that day. Lord Oresme of Sentinel formally surrendered to Daggerfall, giving up all rights to Betony officially. He later commited suicide on the ship back to Sentinel.
 
-     Daggerfall did not waste any time in mourning; young
-prince Gothryd, who had shown great bravery in battle and
-was very popular among the troops, was crowned King of
-Daggerfall just behind the battle lines, and he ordered the
-army onward. Perhaps it was the sight of the brave young
-warrior turned king appearing on the battlefield in full
-regalia that inspired the Daggerfall army, perhaps the
-battle would have turned regardless, Sentinel began to
-panic. King Gothryd met King Camaron before the Redguards
-had retreated, and the two monarchs fought. Both were
-excellent warriors, but Gothryd was a more skillful
-swordsman, and Camaron fell that day. Lord Oresme of
-Sentinel formally surrendered to Daggerfall, giving up
-all rights to Betony officially. He later commited suicide on
-the ship back to Sentinel.
+ Peace was a difficult process for the cities and towns on both sides of the Iliac Bay. As part of the formal peace treaty, King Gothryd asked for the hand of Princess Aubk-i, only daughter of the late King Camaron and the Queen Regent Akorithi. The request was intended to restore friendship between the kingdoms, and it was partially successful though many in the royal court of Sentinel viewed the princess as more a prisoner of war than a bond to Daggerfall.
 
-     Peace was a difficult process for the cities and towns on
-both sides of the Iliac Bay. As part of the formal peace
-treaty, King Gothryd asked for the hand of Princess Aubk-i,
-only daughter of the late King Camaron and the Queen Regent
-Akorithi. The request was intended to restore friendship
-between the kingdoms, and it was partially successful
-though many in the royal court of Sentinel viewed the
-princess as more a prisoner of war than a bond to
-Daggerfall.
+ The only surviving member of the ruling family of Reich Gradkeep was a sickly infant, so the councilors of state appealed to Lord Auberon Flyte, a cousin of Lord Graddock, to rule the lordship in regency. Lord Flyte accepted, and his strong, almost dictatorial style was just what Reich Gradkeep needed to restore order after the bloody Treaty of Reich Gradkeep. His subjects were grateful that when the infant heir died, they not only elevated his wife Doryanna and him from regents to rulers, they agreed to rename the lordship in his honor. Reich Gradkeep became Anticlere, named after his ancestral home.
 
-     The only surviving member of the ruling family of Reich
-Gradkeep was a sickly infant, so the councilors of state
-appealed to Lord Auberon Flyte, a cousin of Lord
-Graddock, to rule the lordship in regency. Lord Flyte
-accepted, and his strong, almost dictatorial style was
-just what Reich Gradkeep needed to restore order after the
-bloody Treaty of Reich Gradkeep. His subjects were grateful
-that when the infant heir died, they not only elevated his
-wife Doryanna and him from regents to rulers, they agreed to
-rename the lordship in his honor. Reich Gradkeep became
-Anticlere, named after his ancestral home.
+ The horrors of the War of Betony still live on, even in Anticlere. Whether Daggerfall and Sentinel will be able to use the marriage of King Gothryd and Princess Aubk-i as a symbol of peace rather than discord is something that only the future can show.
 
-     The horrors of the War of Betony still live on, even in
-Anticlere. Whether Daggerfall and Sentinel will be able to
-use the marriage of King Gothryd and Princess Aubk-i as a
-symbol of peace rather than discord is something that only
-the future can show.
-
-                         -- 14 Suns Dawn 3E 404
-
-
-
-
-
- 
+[/center]-- 14 Suns Dawn 3E 404

--- a/Assets/StreamingAssets/Text/Books/BOK00085-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00085-LOC.txt
@@ -3,121 +3,43 @@ Author: Enric Milres
 IsNaughty: False
 Price: 580
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]The Alik'r
 
-
-
 [/font=4]
 
 [/center]
 
-[/center]
+ I might never have gone to the Alik'r Desert had I not met Weltan in a little tavern in Sentinel. Weltan is a Redguard poet whose verse I had read, but only in translation. He chooses to write in the old language of the Redguards, not in Tamrielic. I once asked him why.
 
+ "The Tamrielic word for the divinely rich child of rot, silky, pressed sour milk is ... cheese," said Weltan, a huge smile spreading like a tide over his lampblack face. "The Old Redguard word for it is mluo. Tell me, if you were a poet fluent in both languages, which word would you use?"
 
+ I am a child of the cities, and I would tell him tales of the noise and corruption, wild nights and energy, culture and decadence. He listened with awed appreciation of the city of my birth: white-marbled Imperial City where all the citizenry are convinced of their importance because of the proximity of the Emperor and the lustration of the streets. They say that a beggar on the boulevards of the Imperial City is a man living in a palace. Over spiced ale, I regaled Weltan with descriptions of the swarming marketplace of Riverhold; of dark, brooding Mournhold; of the mold-encrusted villas of Lilmoth; the wonderful, dangerous alleys of Helstrom; the stately avenues of grand old Solitude. For all this, he marvelled, inquired, and commented.
 
-     I might never have gone to the Alik'r Desert had I not met
-Weltan in a little tavern in Sentinel. Weltan is a
-Redguard poet whose verse I had read, but only in
-translation. He chooses to write in the old language of the
-Redguards, not in Tamrielic. I once asked him why.
+ "I feel as if I know your home, the Alik'r Desert, from your poems even though I've never been there." I told him.
 
-     "The Tamrielic word for the divinely rich child of rot,
-silky, pressed sour milk is ... cheese," said Weltan, a huge
-smile spreading like a tide over his lampblack face. "The
-Old Redguard word for it is mluo. Tell me, if you were a
-poet fluent in both languages, which word would you use?"
+ "Oh, but you don't. No poem can express the Alik'r. It may prepare you for a visit far better than the best guide book can. But if you want to know Tamriel and be a true citizen of the planet, you must go and feel the desert yourself."
 
-     I am a child of the cities, and I would tell him tales of
-the noise and corruption, wild nights and energy, culture
-and decadence. He listened with awed appreciation of the
-city of my birth: white-marbled Imperial City where all the
-citizenry are convinced of their importance because of the
-proximity of the Emperor and the lustration of the streets.
-They say that a beggar on the boulevards of the Imperial
-City is a man living in a palace. Over spiced ale, I regaled
-Weltan with descriptions of the swarming marketplace of
-Riverhold; of dark, brooding Mournhold; of the
-mold-encrusted villas of Lilmoth; the wonderful,
-dangerous alleys of Helstrom; the stately avenues of grand
-old Solitude. For all this, he marvelled, inquired, and
-commented.
+ It took me a little over a year to break off engagements, save money (my greatest challenge), and leave the urban life for the Alik'r Desert. I brought several books of Weltan's poems as my travel guide.
 
-     "I feel as if I know your home, the Alik'r Desert, from
-your poems even though I've never been there." I told him.
+ "A sacred flame rises above the fire, The ghosts of great men and women without names, Cities long dead rise and fall in the flame, The Dioscori Song of Revelation, Bursting walls and deathless rock, Fiery sand that heals and destroys."
 
-     "Oh, but you don't. No poem can express the Alik'r. It
-may prepare you for a visit far better than the best guide
-book can. But if you want to know Tamriel and be a true
-citizen of the planet, you must go and feel the desert
-yourself."
+ These first six lines from my friend's "On the Immortality of Dust" prepared me for my first image of the Alik'r Desert, though they hardly do it justice. My poor pen cannot duplicate the severity, grandeur, ephemera and permanence of the Alik'r.
 
-     It took me a little over a year to break off engagements,
-save money (my greatest challenge), and leave the urban
-life for the Alik'r Desert. I brought several books of
-Weltan's poems as my travel guide.
+ All the principalities and boundaries the nations have placed on the land dissolve under the moving sand in the desert. I could never tell if I was in Antiphyllos or Bergama, and few of the inhabitants could tell me. For them, and so it came to me, we were simply in the Alik'r. No. We are part of the Alik'r. That is closer to the philosophy of the desert people.
 
-     "A sacred flame rises above the fire, The ghosts of great
-men and women without names, Cities long dead rise and fall
-in the flame, The Dioscori Song of Revelation, Bursting
-walls and deathless rock, Fiery sand that heals and
-destroys."
+ I saw the sacred flame of which Weltan wrote on my first morning in the desert: a vast, red mist that seemed to come from the deep mystery of Tamriel. Long before the noon sun, the mist had disappeared. Then I saw the cities of Weltan. The ruins of the Alik'r rise from the sand by one blast of the unbounded wind and are covered by the next. Nothing in the desert lasts, but nothing dies forever.
 
-     These first six lines from my friend's "On the
-Immortality of Dust" prepared me for my first image of the
-Alik'r Desert, though they hardly do it justice. My poor pen
-cannot duplicate the severity, grandeur, ephemera and
-permanence of the Alik'r.
+ At daylight, I hid myself in tents, and thought about the central character of the Redguards that would cause them to adopt this savage, eternal land. They are warriors by nature. As a group, there are none better. Nothing for them has worth unless they have struggled for it. No one fought them for the desert, but the Alik'r is a great foe. The battle goes on. It is a war without rancor, a holy war in the sense the phrase should always imply.
 
-     All the principalities and boundaries the nations have
-placed on the land dissolve under the moving sand in the
-desert. I could never tell if I was in Antiphyllos or
-Bergama, and few of the inhabitants could tell me. For them,
-and so it came to me, we were simply in the Alik'r. No. We are
-part of the Alik'r. That is closer to the philosophy of the
-desert people.
+ By night, I could contemplate the land itself in its relative serenity. But the serenity was superficial. The stones themselves burned with a heat and a light that comes not from the sun, nor the moons Jone and Jode. The power of the stones comes from the beat of the heart of Tamriel itself.
 
-    I saw the sacred flame of which Weltan wrote on my first
-morning in the desert: a vast, red mist that seemed to come
-from the deep mystery of Tamriel. Long before the noon sun,
-the mist had disappeared. Then I saw the cities of Weltan. The
-ruins of the Alik'r rise from the sand by one blast of the
-unbounded wind and are covered by the next. Nothing in the
-desert lasts, but nothing dies forever.
+ Two years I spent in the Alik'r.
 
-    At daylight, I hid myself in tents, and thought about the
-central character of the Redguards that would cause them to
-adopt this savage, eternal land. They are warriors by
-nature. As a group, there are none better. Nothing for them
-has worth unless they have struggled for it. No one fought
-them for the desert, but the Alik'r is a great foe. The battle
-goes on. It is a war without rancor, a holy war in the sense
-the phrase should always imply.       By night, I could
-contemplate the land itself in its relative serenity. But
-the serenity was superficial. The stones themselves burned
-with a heat and a light that comes not from the sun, nor the
-moons Jone and Jode. The power of the stones comes from the
-beat of the heart of Tamriel itself.
+ As write this, I am back in Sentinel. We are at war with the kingdom of Daggerfall for the possession of a grass-covered rock that belongs to the water of the Iliac Bay. All my fellow poets, writers, and artists are despondent for the greed and pride that brought these people into battle. It is a low point, a tragedy. In the words of Old Redguard, an ajcea, a spiral down.
 
-     Two years I spent in the Alik'r.          As write this, I am
-back in Sentinel. We are at war with the kingdom of
-Daggerfall for the possession of a grass-covered rock that
-belongs to the water of the Iliac Bay. All my fellow poets,
-writers, and artists are despondent for the greed and pride
-that brought these people into battle. It is a low point, a
-tragedy. In the words of Old Redguard, an ajcea, a spiral
-down.
-
-     Yet, I cannot be sorrowful. In the years I spent in the
-glories of the Alik'r, I have seen the eternal stones that live
-on while men go dead. I have found my inner eye in the
-tractless, formless, changeless and changeable land.
-Inspiration and hope, like the stones of the desert, are
-eternal though men be not.
-
- 
+ Yet, I cannot be sorrowful. In the years I spent in the glories of the Alik'r, I have seen the eternal stones that live on while men go dead. I have found my inner eye in the tractless, formless, changeless and changeable land. Inspiration and hope, like the stones of the desert, are eternal though men be not.

--- a/Assets/StreamingAssets/Text/Books/BOK00086-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00086-LOC.txt
@@ -3,9 +3,8 @@ Author: Destri Melarg
 IsNaughty: False
 Price: 684
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,105 +14,30 @@ Content:
 
 [/center]Singer
 
-
-
 [/font=4]
 
+[/center]
 
+ Divad The Singer is in one body, two unique and distinct people. Divad is the most well known of the Redguard heroes. Frandar Hunding's son, probably the most accomplished Ansei who ever lived. Yet early in his life, Divad appeared to thoroughly have rejected The Way of the Sword.
 
-[/center]    Divad The Singer is in one body, two unique and distinct
-people.  Divad is the most well known of the Redguard heroes.
-Frandar Hunding's son, probably the most accomplished Ansei
-who ever lived. Yet early in his life, Divad appeared to
-thoroughly have rejected The Way of the Sword.
+ Divad was the only son of Frandar Hunding, and was born late in Hunding's life (2396 in the old way of reckoning, probably about 1E 760 by the Tamrielic calendar), when he was away most of the time fighting the last of his duels and engaging in the many battles and insurrections of the period. At eleven, Divad entered the Hall of the Virtues of War and began training, but at 16, he finally let his anger at growing up essentially fatherless get the better of him. Divad broke his swords and left the Hall to become an acrobat in a traveling circus.
 
-    Divad was the only son of Frandar Hunding, and was born
-late in Hunding's life (2396 in the old way of reckoning,
-probably about 1E 760 by the Tamrielic calendar), when he
-was away most of the time fighting the last of his duels and
-engaging in the many battles and insurrections of the
-period. At eleven, Divad entered the Hall of the Virtues of
-War and began training, but at 16, he finally let his anger
-at growing up essentially fatherless get the better of him.
-Divad broke his swords and left the Hall to become an acrobat
-in a traveling circus.
+ The life in the circus was unsatisfying to Divad, and after two years, his innate artisan heritage drove him to become a musician and finally a Bard. For two more years he traveled, singing in the cities of the empire -- gaining no small amount of fame and recognition for his stirring and popular songs and music.
 
-    The life in the circus was unsatisfying to Divad, and
-after two years, his innate artisan heritage drove him to
-become a musician and finally a Bard. For two more years he
-traveled, singing in the cities of the empire -- gaining no
-small amount of fame and recognition for his stirring and
-popular songs and music.
+ Although Divad had publicly forsaken the Way of the sword, it would appear that he continued to practice the compulsory forms of training he was taught in the Hall. He carried no sword, but in the late evening, bright lights could be often be seen in his tent (my source says nothing more about this, but it may be assumed that the writer was suggesting that Divad was practicing the form of the Way known as Shehai Shen She Ru -- the Way of the Spirit Sword, or simply the Shehai).
 
-    Although Divad had publicly forsaken the Way of the sword,
-it would appear that he continued to practice the
-compulsory forms of training he was taught in the Hall.  He
-carried no sword, but in the late evening, bright lights
-could be often be seen in his tent (my source says nothing more
-about this, but it may be assumed that the writer was
-suggesting that Divad was practicing the form of the Way
-known as Shehai Shen She Ru -- the Way of the Spirit Sword, or
-simply the Shehai).
+ Divad was very popular with the people of the empire, and his music and concerts were well attended. Still he could not escape his heritage of the sword. When the Last Emperor ascended to power and began to persecute the sword-singers, Divad was among the first to attract his attention.
 
-    Divad was very popular with the people of the empire, and
-his music and concerts were well attended. Still he could
-not escape his heritage of the sword.  When the Last Emperor
-ascended to power and began to  persecute the sword-singers,
-Divad was among the first to attract his attention.
+ Once the Emperor Hira and his consort decided to go to war with the Singers for control of the empire, he moved swiftly against those Singers who were visibly a part of empire society. Most he had killed, but Divad's music and fame were so wide spread that he sent a team of his personal guards to arrest him.
 
-     Once the Emperor Hira and his consort decided to go to war
-with the Singers for control of the empire, he moved swiftly
-against those Singers who were visibly a part of empire
-society.  Most he had killed, but Divad's music and fame were
-so wide spread that he sent a team of his personal guards to
-arrest him. 
+ The Emperor's men were either very lucky or very unlucky depending on how you choose to view it. Being no fool, Hira sent 100 of his best guards, for even an unarmed Singer was a very dangerous foe. The luck was that they were able to capture Divad and place him in chains, for they came at him as he sat dining with his elderly mother. The disaster was that as he surrendered, they rashly struck the pleading old woman. Too hard, it would seem, for she fell dead with that single blow.
 
-    The Emperor's men were either very lucky or very unlucky
-depending on how you choose to view it.  Being no fool, Hira
-sent 100 of his best guards, for even an unarmed Singer was a
-very dangerous foe. The luck  was that they were able to
-capture Divad and place him in chains, for they came at him as
-he sat dining with his elderly mother. The disaster was that as
-he surrendered, they rashly struck the pleading old woman.
-Too hard, it would seem, for she fell dead with that single
-blow.
+ That single thoughtless deed, as is often the case in war, was the one pivotal factor causing their eventual defeat. That act ignited in Divad the spirit of the Way. Up until that careless stroke, Divad was an ordinary artisan, no, an artist, a great artist, but no warrior.
 
-    That single thoughtless deed, as is often the case in war,
-was the one pivotal factor causing their eventual defeat.
-That act ignited in Divad the spirit of the Way. Up until
-that careless stroke, Divad was an ordinary artisan, no, an
-artist, a great artist, but no warrior.  
+ The moment of her death, Divad rose from his seat, took his chains between his two hands and began swinging the heavy chain in a deadly arc. He slew four of the guards, gaining enough space to run and dive through the window and into the river He disappeared into the night
 
-    The moment of her death, Divad rose from his seat, took his
-chains between his two hands and began swinging the heavy
-chain in a deadly arc.  He slew four of the guards, gaining
-enough space to run and dive through the window and into the
-river He disappeared into the night 
+ From that point, Divad was spotted many times and told of in many more rumors all across the empire -- far more places than a mere mortal man could have ever been. At every point where Hira's men gathered to do mischief, the resistance was attributed to Divad.
 
-    From that point, Divad was spotted many times and told of
-in many more rumors all across the empire -- far more places
-than a mere mortal man could have ever been. At every point
-where Hira's men gathered to do mischief, the resistance was
-attributed to Divad.  
+ As Hira moved against the Singers and began forming his army to invade High Desert, it was Divad who carried the news to the Singers. Divad was among those who climbed Hattu to find Hunding in his cave. What is not well known is that Hunding, at first refused to take leadership of the Singers. The first attempt to interrupt him at his death poem cause him to drive the elders from his cave, he even formed the Shehai in his anger. It was Divad who reentered the cave alone to speak with Hunding. To this day, no one knows what was said, what happened in that cave. Scribes of the time reported bright flashes of light and angry voices. Five long hours came and went, then both emerged from the cave, Divad, at Hunding's side. The rest, as they say, is history ...
 
-    As Hira moved against the Singers and began forming his
-army to invade High Desert, it was Divad who carried the news
-to the Singers. Divad was among those who climbed Hattu to
-find Hunding in his cave. What is not well known is that
-Hunding, at first refused to take leadership of the Singers.
-The first attempt to interrupt him at his death poem cause
-him to drive the elders from his cave, he even formed the
-Shehai in his anger. It was Divad who reentered the cave
-alone to speak with Hunding. To this day, no one knows what was
-said, what  happened in that cave. Scribes of the time
-reported bright flashes of light and angry  voices. Five
-long hours came and went, then both emerged from the cave,
-Divad, at Hunding's side. The rest, as they say, is history ...
-
-    Divad, who had not completed training in the Hall of the
-Virtues of War, became an adviser to Hunding and spent his
-time reading the newly completed Book of Circles, but his
-role in the Hammer and Anvil strategy was as a simple
-sword-singer and fighter.  It was not till the Singers fled
-their native empire and landed In New Land that his story
-truly begins. 
+ Divad, who had not completed training in the Hall of the Virtues of War, became an adviser to Hunding and spent his time reading the newly completed Book of Circles, but his role in the Hammer and Anvil strategy was as a simple sword-singer and fighter. It was not till the Singers fled their native empire and landed In New Land that his story truly begins.

--- a/Assets/StreamingAssets/Text/Books/BOK00087-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00087-LOC.txt
@@ -3,9 +3,8 @@ Author: Destri Melarg
 IsNaughty: False
 Price: 597
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -13,146 +12,58 @@ Content:
 
 [/center]Redguard History
 
-
-
 [/font=4]
 
 [/center]
 
- Biographical Note: Destri Melarg was a well-known historian
-and translator of old Redguard verse, born as simply
-Destri in the city-state of Rihad in the 20th year of the 3rd
-Era. At the age of nineteen, he went to the Imperial City to
-study. There were few Redguards who had been to the Imperial
-Province at the time, and it may be that he took the last name
-Melarg in order to assimiliate with the Breton, Nordic, and
-Dark Elf cultures he encountered there. 
+ Biographical Note: Destri Melarg was a well-known historian and translator of old Redguard verse, born as simply Destri in the city-state of Rihad in the 20th year of the 3rd Era. At the age of nineteen, he went to the Imperial City to study. There were few Redguards who had been to the Imperial Province at the time, and it may be that he took the last name Melarg in order to assimiliate with the Breton, Nordic, and Dark Elf cultures he encountered there.
 
- When he died ninety-four years later, he left numerous
-unfinished histories and untranslated verse. Very few of this
-fragmented work has found its way out of collections. What
-follows is an unmailed letter to Melarg's publishers in the
-Imperial City. The insights into the man who put the oral
-traditions of the Redguards to paper impressed me enough to
-seek its publication.
+ When he died ninety-four years later, he left numerous unfinished histories and untranslated verse. Very few of this fragmented work has found its way out of collections. What follows is an unmailed letter to Melarg's publishers in the Imperial City. The insights into the man who put the oral traditions of the Redguards to paper impressed me enough to seek its publication.
 
- Melius, it should be noted, was Melius Kane, Melarg's
-publisher in the Imperial City.
+ Melius, it should be noted, was Melius Kane, Melarg's publisher in the Imperial City.
 
-             --- Vune,
+[/center]--- Vune,
 
+[/center]Redguardic First Scholar
 
-        Redguardic First Scholar
+[/center]Imperial University
 
-
-Imperial University
-
-
-
-
-
-[/center]*    *    *
-
-
+[/center]* * *
 
  Melius,
 
- This is the outline of my final chapter for the series on
-Hammerfell heroes. I condensed Dendle's storytelling. I
-have my notes, but the story gets long with all the quotes.
-She puts a lot of dialog in her storytelling. I am amazed
-that the old stories about the 5 swords keeps cropping up.
-It's been a thousand years since Hellion's time, yet people
-continue to believe in the stories.  
+ This is the outline of my final chapter for the series on Hammerfell heroes. I condensed Dendle's storytelling. I have my notes, but the story gets long with all the quotes. She puts a lot of dialog in her storytelling. I am amazed that the old stories about the 5 swords keeps cropping up. It's been a thousand years since Hellion's time, yet people continue to believe in the stories.
 
- The wagon master sat with me after listening to her story and
-smoked a pipe with me. In discussing the story, he said that his
-storyteller used to say that one of the five swords survived
-the closing of the Goblin gate, and is yet hidden here in
-Hammerfell. It was the least of the five, but the story  has
-it that it exceeds and modern blade magical or ebony by
-several orders of magnitude.
+ The wagon master sat with me after listening to her story and smoked a pipe with me. In discussing the story, he said that his storyteller used to say that one of the five swords survived the closing of the Goblin gate, and is yet hidden here in Hammerfell. It was the least of the five, but the story has it that it exceeds and modern blade magical or ebony by several orders of magnitude.
 
- Of course I take this with a grain of salt, since a ebony
-weapon is unparalleled in its keen cutting ability and
-personally I can't imagine a weapon doing more damage than
-a Claymore of Firestorm or a Saber of Life Steal. Dendle even believes that out in the
-countryside outside of Skaven in one of the Halls of the
-Virtues of War, there are still people who follow the old
-ways and can from  a Shehai or spirit sword.   
+ Of course I take this with a grain of salt, since a ebony weapon is unparalleled in its keen cutting ability and personally I can't imagine a weapon doing more damage than a Claymore of Firestorm or a Saber of Life Steal. Dendle even believes that out in the countryside outside of Skaven in one of the Halls of the Virtues of War, there are still people who follow the old ways and can from a Shehai or spirit sword.
 
- In collecting these stories, I once thought I was seeing a
-Shehai being formed, by an old Hall master, but the thing,
-if it was a spirit sword was so faint that even the sword shape
-was questionable. I didn't want to insult the old man so I
-claimed I saw it too. But if that was a Shehai, I can't 
-imagine it possibly used as a real weapon.     Here's my
-outline of the new story:
+ In collecting these stories, I once thought I was seeing a Shehai being formed, by an old Hall master, but the thing, if it was a spirit sword was so faint that even the sword shape was questionable. I didn't want to insult the old man so I claimed I saw it too. But if that was a Shehai, I can't imagine it possibly used as a real weapon.
 
- At the time of this story, Hammerfell is fully occupied by
-Redguards. All the old cities of the Dwarves (but one - the
-Ghost City of Dwarfhome) are now the cities of today's modern
-Hammerfell. A second invasion of the giant goblins comes.
-Hammerfell is unprepared, except for a few faithful
-followers, all youths in the rural Halls of Virtue.  
+ Here's my outline of the new story:
 
- Hallin, being the only Ansei, rallies the armies of
-Hammerfell. After a defeat, he brings back the old ways by
-telling each warrior to read the Book of Circles. The army
-fights the Goblins to a standstill,  but things look bleak,
-just as in Divad's song. Somehow the goblins keep being
-resupplied both with arms and troops. Eventually the Army
-of Hammerfell will lose.  
+ At the time of this story, Hammerfell is fully occupied by Redguards. All the old cities of the Dwarves (but one - the Ghost City of Dwarfhome) are now the cities of today's modern Hammerfell. A second invasion of the giant goblins comes. Hammerfell is unprepared, except for a few faithful followers, all youths in the rural Halls of Virtue.
 
- The old master of Hallin's Hall of the Virtues of War has an
-ancient copy of  Divad's will and testament, and reads it to
-Hallin. It tells him that the 5 swords aren't lost, just
-hidden and well guarded in 5 caves.  Each cave is home to a
-master guardian, one of the old blind Ansei -- and also a
-maze.  
+ Hallin, being the only Ansei, rallies the armies of Hammerfell. After a defeat, he brings back the old ways by telling each warrior to read the Book of Circles. The army fights the Goblins to a standstill, but things look bleak, just as in Divad's song. Somehow the goblins keep being resupplied both with arms and troops. Eventually the Army of Hammerfell will lose.
 
- According to the will, Derik must, along with a virtuous
-companion of pure heart enter the cave, defeat each Ansei
-Master and retrieve their sword.
+ The old master of Hallin's Hall of the Virtues of War has an ancient copy of Divad's will and testament, and reads it to Hallin. It tells him that the 5 swords aren't lost, just hidden and well guarded in 5 caves. Each cave is home to a master guardian, one of the old blind Ansei -- and also a maze.
 
- Dendle went into great detail here. It seems that each Master
-had an outstanding trait -- one Katrice, possessed feline
-grace, and had become very catlike; another, who had icy
-calm was something much like an Ice Golem.    
+ According to the will, Derik must, along with a virtuous companion of pure heart enter the cave, defeat each Ansei Master and retrieve their sword.
 
- On each blade is inscribed part of an intricate message on
-how to use the power of the swords combined. Derik scours the
-rural Halls for Brothers of the Blade and Maidens of the
-Spirit Sword to accompany him in the quests. He finally one
-by one finds his companions, and wins  each sword.  
+ Dendle went into great detail here. It seems that each Master had an outstanding trait -- one Katrice, possessed feline grace, and had become very catlike; another, who had icy calm was something much like an Ice Golem.
 
- They learn from the blades and together wield the force of
-the 5 swords to seal the rent in space time that the Goblins
-have made and from which springs their invasion. Hallin's
-companions avoided  blinding by the magic swords by hurling
-the swords together into the void, and sealing forever the
-giant Goblins in the void between their world and ours.
+ On each blade is inscribed part of an intricate message on how to use the power of the swords combined. Derik scours the rural Halls for Brothers of the Blade and Maidens of the Spirit Sword to accompany him in the quests. He finally one by one finds his companions, and wins each sword.
 
- The land is saved and Hallin and his companions (3 women and
-2 men) become Ansei and restore the teachings of Frandar
-Hunding to Hammerfell.
+ They learn from the blades and together wield the force of the 5 swords to seal the rent in space time that the Goblins have made and from which springs their invasion. Hallin's companions avoided blinding by the magic swords by hurling the swords together into the void, and sealing forever the giant Goblins in the void between their world and ours.
 
- That's the story in brief. I welcome any comments from you
-or one of the other editors.
+ The land is saved and Hallin and his companions (3 women and 2 men) become Ansei and restore the teachings of Frandar Hunding to Hammerfell.
 
- One other concern of mine. I understand that you are
-considering using a better known writer, Uthilla Abuhk or
-Casmyr Kreestrom, to write the stories I've researched. I can
-understand that a better known writer may mean that a few
-more copies of the books will be sold, but that should not be
-your only concern. Abuhk and Kreestrom, while fine writers
-and poets, will need to be lectured on the true history of
-the Redguards. Even if you are willing to pay me to do that,
-you will have to acknowledge that the books will take longer
-to write than if you just allowed me to do it. Just something
-to consider when you make the decision.
+ That's the story in brief. I welcome any comments from you or one of the other editors.
 
- I hope this letter finds you, your consort, and children to
-good health and humor.
+ One other concern of mine. I understand that you are considering using a better known writer, Uthilla Abuhk or Casmyr Kreestrom, to write the stories I've researched. I can understand that a better known writer may mean that a few more copies of the books will be sold, but that should not be your only concern. Abuhk and Kreestrom, while fine writers and poets, will need to be lectured on the true history of the Redguards. Even if you are willing to pay me to do that, you will have to acknowledge that the books will take longer to write than if you just allowed me to do it. Just something to consider when you make the decision.
 
-              Yours faithfully,              Destri Melarg 
+ I hope this letter finds you, your consort, and children to good health and humor.
+
+[/center]Yours faithfully,
+
+[/center]Destri Melarg

--- a/Assets/StreamingAssets/Text/Books/BOK00088-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00088-LOC.txt
@@ -3,9 +3,8 @@ Author: Frincheps
 IsNaughty: False
 Price: 317
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
@@ -15,878 +14,497 @@ Content:
 
 [/center]Sixth
 
-
-
 [/font=4]
 
+[/center]
 
+ Dramatis Personae
 
-[/center] Dramatis Personae
-
- Prologue The Adventurer, A Dark Elf Rascal Komon, A Priest
-of Akatosh Lheban, Another Priest of Akatosh Epilogue Stete, A
-Priest of Julianos Raic, Another Priest of Julianos Shub, A
-Mage Shub, A Different Mage of the Same Name Nephron, A
-Somewhat Sleazy Merchant 5 Armorers Ortho Crunn, Husband of
-Millie A Lusty Contessa Millie, Innkeep and Philosopher
-Gurnsey, Bovine Wench Assorted Wenches and Cads of the
-Taverns Soldiers Dwarves Giants
-
-
+ Prologue; The Adventurer, A Dark Elf Rascal; Komon, A Priest of Akatosh; Lheban, Another Priest of Akatosh; Epilogue; Stete, A Priest of Julianos; Raic, Another Priest of Julianos; Shub, A Mage; Shub, A Different Mage of the Same Name; Nephron, A Somewhat Sleazy Merchant; 5 Armorers; Ortho; Crunn, Husband of Millie; A Lusty Contessa; Millie, Innkeep and Philosopher; Gurnsey, Bovine Wench; Assorted Wenches and Cads of the Taverns; Soldiers; Dwarves; Giants.
 
  Daggerfall and Environs in the Doldrums of the 3rd Era
 
  Scene 1: In The Adventurer's suite at the Dead Daedra Inn.
 
- Enter Prologue, the Adventurer, and Ortho. Ortho climbs
-into bed.
+ Enter Prologue, the Adventurer, and Ortho. Ortho climbs into bed.
 
-       Prologue: Thank you for allowing us the time to change
-the meager set, while our bard sang that old favorite, "Hail
-and Farewell." Now then, imagine, if you will, the
-luxuriant and langorous suite of that Dark Elven rogue, the
-Adventurer, at the Dead Daedra Inn. The time is shortly
-after the last scene, which if you've forgotten, ended with
-our hero and his partner-in-crime, Nephron, making some
-arrangements to swindle from the mages, priests, and
-armorers. All are interested in getting their hands on a
-lode of Fools' Ebony, a miraculous burning mineral, and the
-priests and mages each consider the Adventurer their ally.
-The Armorers know better and have assigned one of their
-apprentices, Ortho, to watch the Adventurer's movements.
-Now, as Ortho slumbers, the Adventurer has his first moment
-of peace in days. I should mention that in the interest of
-common decency, this scene has been abbreviated from the
-original by order of the Guild of Playwrites, Actors, and
-Dramatists. It now contains little material of relevance.
-A full copy may be obtained from the playwrite after the
-show for a mere 50 g.p. copying fee. Now is the time for
-poor Prologue to shuffle away.
-
- (Exit Prologue) (The Adventurer begins to get undressed)
-(Tap-tap at the door. Adventurer jumps, startled) (Snore
-from Ortho)
-
-       Adventurer: Who's there? I'm coming!
-
- (Opens door - carefully) (Enter Contessa)
-
-       Adventurer: Er, well ... er ... Come In! Please.
-
- (The Adventuer steps back, tripping over his trousers
-around his ankles ...)
-
-       Contessa So sorry to surprise you, but I thought that we
-might find something in common ... Oh! You poor man, you
-have a wound!  Here, let me fix that bandage ... it looks
-very fresh.
-
- (Fixing bandage, properly this time)
-
-       Adventurer: Well, I ... just opened it up again.
-Evening exercises, calisthenics, so on...
-
-       Contessa: How did you get this cut - if you do not mind me
-asking?       
-
-       Adventurer: No, not at all. I was ... in a fight,
-earlier. These three crazy people jumped me.
-
-       Contessa: Really?  This cloth looks like part of a Mage's
-robe.
-
-       Adventurer: Well, yes, two of them were Mages.
-
-       Contessa: Oh My! You must have been very good, to defeat
-them.
-
-       Adventurer: Oh, ah, well, I've been in one or two
-fights. Not to be rude, but who are you?
-
-       Contessa: Oh, I am so sorry, I quite forgot the proper
-introductions. I am the Contessa Aveet Videspreed -- call me
-Ave.  From the Court at Daggerfall.
-
-       Adventurer       (aside) By Oblivion, what now?
-
-       Contessa: Here, help me off with this robe, these inn rooms
-are always ... so hot. And let me check that bandage again,
-poor man. Ooh, you are wearing an ebony belt of stamina,
-and bracers of strength. Ooh, a bracelet of endurance. This
-is my lucky night.
-
-       Adventurer       (aside) Help.
-
-       Contessa: Here, let me help you off with that old shirt -
-got to check you for any more cuts - they can go bad so
-easily, you know.
-
-       Adventurer       (aside) Well, its not the Armorers this
-time. Maybe my luck has turned.
-
-       Contessa: Well, everything seems all right...very all
-right, in fact...
-
-       Adventurer: Er...well, Ave - tell me about ... er ...
-yourself.           Contessa: If you want - just for a bit - 
-
-       Adventurer: Here, have some wine ...
-
- Enter Prologue
-
-       Prologue: Here our worthy playwrite's speech has been
-heavily edited by the Guild of Playwrites, Actors, and
-Dramatists. I will endeavor to fill in those removed
-passages. I should first mention that the Contessa is not
-meant to be a relative of any noble currently in Castle
-Daggerfall. The Contessa Aveet regales the Adventurer with
-tales of the peculiar and hearty members of her royal
-family. She has many brothers and sisters. They are all very
--- close.
-
-       Contessa: I think I must have been a bastard. I was the
-only one with red hair, and an affinity for magicka. Everyone
-else tried to hide this skill of mine. I remember one spanking
-very well ...
-
-       Prologue: The Contessa relates futher differences
-between her siblings.
-
-       Contessa: While my sisters were learning to curtsey in
-ten different modes, and my brothers were learning
-flower-arranging, I used to sneak off into the woods or town.
-I soon learnt how to get what I wanted, from just about
-anyone. Just for example, there was this merchant who had
-three sons ...
-
-       Prologue: The Contessa goes into detail about her
-training.
-
-       Contessa: I became quite good at the school of illusion.
-You never noticed me, downstairs, did you?. I also learned
-how to use some weapons. Let me tell you how I learned
-hand-to-hand ...
-
-       Prologue: The Contessa relates an amusing anecdote, and
-then continues.
-
-       Contessa: And on bad days, I used to dig in my father's
-library. He had a marvelous collection of old texts. I was
-fascinated by Old Dwarvish, managed to learn it quite well,
-I think. Of course, no one has seen or spoken to one in years
-and years. So its probably perfectly useless knowledge.
-But I've always had an interest in collecting new
-knowledge. At the Mages Guild, they taught me an old High
-Elven tradition. You spread this potion all over your body
-...
-
-       Prologue: The Contessa relates her current state of
-boredom.
-
-       Contessa: The life up at the Palace bores me so. My
-sisters ...
-
-       Prologue: The Contessa's sisters are entertaining some
-visitors.
-
-       Contessa: And my brothers are now studying Advanced
-Floral Theory, so I come down here, do a little ... er ...
-business. I keep all my relations supplied with their
-favourite vices -- so I can blackmail the whole rotten lot.
-
-       Adventurer: But is'nt it dangerous, down here? Did I not
-hear that some young Contessa got killed, recently?
-
-       Contessa: That little twit was my cousin, and as far as
-I'm concerned, she got what she deserved. She thought  she could
-just borrow a maids dress, muss up her hair, and pass for s
-commoner. She was spotted the first minute she left the
-Palace gates. Now, I use illusion, craft, guile -- and I
-carry weaponry. By the way, that was a neat scheme you and
-Neph cooked up.
-
-       Adventurer: Well, lets change the subject, can we? ...
-Just what do you carry? I can't see anything ... like a
-weapon, I mean ...
-
-       Contessa: Here, let me show you ...
-
-       Adventurer: Oh my, those are nice ... knives...
-
-       Contessa: And there're more ...             Adventurer: Oh yes
-...
-
-       Contessa: But we don't need these silly nasty weapons
-now, do we?
-
-       Adventurer: My, my -- now those are what I call weapons
-... Oh yes ... heavy duty, high class ones too, my ...
-
-       Contessa: I think its time that we put that ebony to the
-test ... to say nothing of your Mages Staff ...
-
-       Prologue: At this point, extensive material has been
-removed. However, please remember that any scholar who
-truly wishes to peruse this material can obtain a copy for
-only 50 g.p. - hand-drawn illustrations are of course extra.
-The Contessa, after a bit of fun, volunteers to be a part
-of the Adventurer's party to find the fools' ebony lode. I
-know, I know. It didn't make much sense in the original draft
-either, if you want to know the truth.
+ Prologue: Thank you for allowing us the time to change the meager set, while our bard sang that old favorite, "Hail and Farewell." Now then, imagine, if you will, the luxuriant and langorous suite of that Dark Elven rogue, the Adventurer, at the Dead Daedra Inn. The time is shortly after the last scene, which if you've forgotten, ended with our hero and his partner-in-crime, Nephron, making some arrangements to swindle from the mages, priests, and armorers. All are interested in getting their hands on a lode of Fools' Ebony, a miraculous burning mineral, and the priests and mages each consider the Adventurer their ally. The Armorers know better and have assigned one of their apprentices, Ortho, to watch the Adventurer's movements. Now, as Ortho slumbers, the Adventurer has his first moment of peace in days. I should mention that in the interest of common decency, this scene has been abbreviated from the original by order of the Guild of Playwrites, Actors, and Dramatists. It now contains little material of relevance. A full copy may be obtained from the playwrite after the show for a mere 50 g.p. copying fee. Now is the time for poor Prologue to shuffle away.
 
  (Exit Prologue)
 
-       Adventurer: Sure you want to go out there in the wilds?
+ (The Adventurer begins to get undressed)
 
-       Contessa: Oh, yes. I am so bored here. Well, not right
-here and now, but generally. And I can really be of
-assistance. I'm pretty good with woods survival, knife
-work, hand-to-hand ... and it gets cold out there at night,
-even for big ebony-wearing men like you ...
+ (Tap-tap at the door. Adventurer jumps, startled)
 
-       Adventurer: All right, then. Do you know where and why we
-are going?
+ (Snore from Ortho)
 
-       Contessa: Oh, of course. It's all over Daggerfall.
-Everyone is watching and waiting to see what happens. There is
-even a lottery or two running ...
+ Adventurer: Who's there? I'm coming!
 
-       Adventurer: On what ..?
+ (Opens door - carefully)
 
-       Contessa: Oh, your life.
+ (Enter Contessa)
 
-       Adventurer: Oh dear Oh dear! Oh my!
+ Adventurer: Er, well ... er ... Come In! Please.
 
-       Contessa: Look, don't worry -- I know all about the
-double-dealings with mages, priests, merchants, those crude
-armorers. And I intend that we come out on top. I love
-being on top. With the goods and the profits. I'll have yet
-another vice to sell to my stupid relatives in their boring
-palaces.
+ (The Adventuer steps back, tripping over his trousers around his ankles ...)
 
-       Adventurer: But won't it be us two against hordes?
+ Contessa: So sorry to surprise you, but I thought that we might find something in common ... Oh! You poor man, you have a wound! Here, let me fix that bandage ... it looks very fresh.
 
-       Contessa: Oh no. Most everyone is waiting here in town to
-see what and who comes back. And I will have a surprise
-arranged for our 'escorts' - Ortho included. Out in the
-wilderness, they can be dealt with easily.
+ (Fixing bandage, properly this time)
+
+ Adventurer: Well, I ... just opened it up again. Evening exercises, calisthenics, so on...
+
+ Contessa: How did you get this cut - if you do not mind me asking?
+
+ Adventurer: No, not at all. I was ... in a fight, earlier. These three crazy people jumped me.
+
+ Contessa: Really? This cloth looks like part of a Mage's robe.
+
+ Adventurer: Well, yes, two of them were Mages.
+
+ Contessa: Oh My! You must have been very good, to defeat them.
+
+ Adventurer: Oh, ah, well, I've been in one or two fights. Not to be rude, but who are you?
+
+ Contessa: Oh, I am so sorry, I quite forgot the proper introductions. I am the Contessa Aveet Videspreed -- call me Ave. From the Court at Daggerfall.
+
+ Adventurer: (aside) By Oblivion, what now?
+
+ Contessa: Here, help me off with this robe, these inn rooms are always ... so hot. And let me check that bandage again, poor man. Ooh, you are wearing an ebony belt of stamina, and bracers of strength. Ooh, a bracelet of endurance. This is my lucky night.
+
+ Adventurer: (aside) Help.
+
+ Contessa: Here, let me help you off with that old shirt - got to check you for any more cuts - they can go bad so easily, you know.
+
+ Adventurer: (aside) Well, its [sic] not the Armorers this time. Maybe my luck has turned.
+
+ Contessa: Well, everything seems all right...very all right, in fact...
+
+ Adventurer: Er...well, Ave - tell me about ... er ... yourself.
+
+ Contessa: If you want - just for a bit -
+
+ Adventurer: Here, have some wine ...
+
+ (Enter Prologue)
+
+ Prologue: Here our worthy playwrite's speech has been heavily edited by the Guild of Playwrites, Actors, and Dramatists. I will endeavor to fill in those removed passages. I should first mention that the Contessa is not meant to be a relative of any noble currently in Castle Daggerfall. The Contessa Aveet regales the Adventurer with tales of the peculiar and hearty members of her royal family. She has many brothers and sisters. They are all very -- close.
+
+ Contessa: I think I must have been a bastard. I was the only one with red hair, and an affinity for magicka. Everyone else tried to hide this skill of mine. I remember one spanking very well ...
+
+ Prologue: The Contessa relates futher [sic] differences between her siblings.
+
+ Contessa: While my sisters were learning to curtsey in ten different modes, and my brothers were learning flower-arranging, I used to sneak off into the woods or town. I soon learnt how to get what I wanted, from just about anyone. Just for example, there was this merchant who had three sons ...
+
+ Prologue: The Contessa goes into detail about her training.
+
+ Contessa: I became quite good at the school of illusion. You never noticed me, downstairs, did you?. I also learned how to use some weapons. Let me tell you how I learned hand-to-hand ...
+
+ Prologue: The Contessa relates an amusing anecdote, and then continues.
+
+ Contessa: And on bad days, I used to dig in my father's library. He had a marvelous collection of old texts. I was fascinated by Old Dwarvish, managed to learn it quite well, I think. Of course, no one has seen or spoken to one in years and years. So its probably perfectly useless knowledge. But I've always had an interest in collecting new knowledge. At the Mages Guild, they taught me an old High Elven tradition. You spread this potion all over your body ...
+
+ Prologue: The Contessa relates her current state of boredom.
+
+ Contessa: The life up at the Palace bores me so. My sisters ...
+
+ Prologue: The Contessa's sisters are entertaining some visitors.
+
+ Contessa: And my brothers are now studying Advanced Floral Theory, so I come down here, do a little ... er ...business. I keep all my relations supplied with their favourite vices -- so I can blackmail the whole rotten lot.
+
+ Adventurer: But is'nt it dangerous, down here? Did I not hear that some young Contessa got killed, recently?
+
+ Contessa: That little twit was my cousin, and as far as I'm concerned, she got what she deserved. She thought she could just borrow a maids dress, muss up her hair, and pass for some commoner. She was spotted the first minute she left the Palace gates. Now, I use illusion, craft, guile -- and I carry weaponry. By the way, that was a neat scheme you and Neph cooked up.
+
+ Adventurer: Well, lets change the subject, can we? ... Just what do you carry? I can't see anything ... like a weapon, I mean ...
+
+ Contessa: Here, let me show you ...
+
+ Adventurer: Oh my, those are nice ... knives...
+
+ Contessa: And there're more ...
+
+ Adventurer: Oh yes ...
+
+ Contessa: But we don't need these silly nasty weapons now, do we?
+
+ Adventurer: My, my -- now those are what I call weapons ... Oh yes ... heavy duty, high class ones too, my ...
+
+ Contessa: I think its time that we put that ebony to the test ... to say nothing of your Mages Staff ...
+
+ Prologue: At this point, extensive material has been removed. However, please remember that any scholar who truly wishes to peruse this material can obtain a copy for only 50 g.p. - hand-drawn illustrations are of course extra. The Contessa, after a bit of fun, volunteers to be a part of the Adventurer's party to find the fools' ebony lode. I know, I know. It didn't make much sense in the original draft either, if you want to know the truth.
+
+ (Exit Prologue)
+
+ Adventurer: Sure you want to go out there in the wilds?
+
+ Contessa: Oh, yes. I am so bored here. Well, not right here and now, but generally. And I can really be of assistance. I'm pretty good with woods survival, knife work, hand-to-hand ... and it gets cold out there at night, even for big ebony-wearing men like you ...
+
+ Adventurer: All right, then. Do you know where and why we are going?
+
+ Contessa: Oh, of course. It's all over Daggerfall. Everyone is watching and waiting to see what happens. There is even a lottery or two running ...
+
+ Adventurer: On what ..?
+
+ Contessa: Oh, your life.
+
+ Adventurer: Oh dear Oh dear! Oh my!
+
+ Contessa: Look, don't worry -- I know all about the double-dealings with mages, priests, merchants, those crude armorers. And I intend that we come out on top. I love being on top. With the goods and the profits. I'll have yet another vice to sell to my stupid relatives in their boring palaces.
+
+ Adventurer: But won't it be us two against hordes?
+
+ Contessa: Oh no. Most everyone is waiting here in town to see what and who comes back. And I will have a surprise arranged for our 'escorts' - Ortho included. Out in the wilderness, they can be dealt with easily.
 
  (Ortho snores)
 
-       Adventurer: Tell me more.
+ Adventurer: Tell me more.
 
-       Contessa: Certainly. But first ... lets see how many
-uses you have left in that ebony. Mmm, your Mages' Staff is
-in good shape ...
+ Contessa: Certainly. But first ... lets see how many uses you have left in that ebony. Mmm, your Mages' Staff is in good shape ...
 
  (Enter Prologue)
 
-       Prologue: Exactly. Sorry to interrupt again, but
-we're going to have to stop this scene right here. After a
-frenzied night comes the placid dawn, tripping onto the sky
-like a budding rose. And then another day doth dawn, and then
-another. Ten dawns and ten frenzied nights pass as our wily
-Adventurer, the wanton Contessa, the clever and naughty
-Nephron, the loutish Ortho, and an assemblage of randy
-armorers and backsliding maidens take to the road. Imagine
-now that we are in the wildy wilderness of High Rock near the
-Wrothgarian Mountains.
+ Prologue: Exactly. Sorry to interrupt again, but we're going to have to stop this scene right here. After a frenzied night comes the placid dawn, tripping onto the sky like a budding rose. And then another day doth dawn, and then another. Ten dawns and ten frenzied nights pass as our wily Adventurer, the wanton Contessa, the clever and naughty Nephron, the loutish Ortho, and an assemblage of randy armorers and backsliding maidens take to the road. Imagine now that we are in the wildy wilderness of High Rock near the Wrothgarian Mountains.
 
  Scene 2
 
- (Enter Nephron and assorted lads and lasses) (Exit
-Prologue)
+ (Enter Nephron and assorted lads and lasses)
 
-       Contessa: I do so love a bucolic frolic.
+ (Exit Prologue)
 
-       Adventurer: It's getting pretty wild now. I guess the
-dangerous part is coming up tomorrow...?
+ Contessa: I do so love a bucolic frolic.
 
-       Contessa: Yes, one last stop tonight, at that old inn up
-here -- Minnie's Inn.
+ Adventurer: It's getting pretty wild now. I guess the dangerous part is coming up tomorrow...?
 
-       Adventurer: Minnie's Inn? Oh, those two old scholars who
-gave it all up, came to run the inn out here. they must get
-all of two customers a year.
+ Contessa: Yes, one last stop tonight, at that old inn up here -- Minnie's Inn.
 
-       Contessa: I think they like the solitude. It gives them
-time to study. They know a lot about old Dwarvish stuff -- get
-them started on that, they will wear you ears out.
+ Adventurer: Minnie's Inn? Oh, those two old scholars who gave it all up, came to run the inn out here. they must get all of two customers a year.
 
-       Adventurer: Er ... when does your surprise happen? I
-should probably know.
+ Contessa: I think they like the solitude. It gives them time to study. They know a lot about old Dwarvish stuff -- get them started on that, they will wear you ears out.
 
-       Contessa: Don't fret, dear. At the Inn tonight. Just sit
-back and enjoy the show.
+ Adventurer: Er ... when does your surprise happen? I should probably know.
+
+ Contessa: Don't fret, dear. At the Inn tonight. Just sit back and enjoy the show.
 
  (Enter Prologue)
 
- Prologue: Time passes, the carts roll, things happen in the
-backs of the carts. And there are strange furtive movements
-unnoticed by all, on the high ridges around. When next we see
-our players, they are at Minnie's Inn, home of Minnie and
-Crunn, the philosopher- innkeeps. Imagine, if you will, the
-rather dusty dining room of Minnie's Inn.
+ Prologue: Time passes, the carts roll, things happen in the backs of the carts. And there are strange furtive movements unnoticed by all, on the high ridges around. When next we see our players, they are at Minnie's Inn, home of Minnie and Crunn, the philosopher- innkeeps. Imagine, if you will, the rather dusty dining room of Minnie's Inn.
 
- (Enter Minnie, Crunn, and Gurnsey) (Exit Prologue) (Gurnsey
-goes to Orthos' table with more ale for him. She sits down
-suddenly. She stares into Orthos'  eyes, Ortho stares into
-hers. Mouths drop open.)
+ (Enter Minnie, Crunn, and Gurnsey)
 
-       Minnie: ... er ... Crunn ...
+ (Exit Prologue)
 
-       Crunn: ... yes ... Minnie ...
+ (Gurnsey goes to Orthos' table with more ale for him. She sits down suddenly. She stares into Orthos' eyes, Ortho stares into hers. Mouths drop open.)
 
-       Minnie: ... I was thinking ...
+ Minnie: ... er ... Crunn ...
 
-       Crunn: ... yes, you were thinking, Minnie ...
+ Crunn: ... yes ... Minnie ...
 
-       Minnie: ... er .... thinking ...
+ Minnie: ... I was thinking ...
 
-       Crunn: ... yes ...so was I ....
+ Crunn: ... yes, you were thinking, Minnie ...
 
-       Minnie: ... can't remember now ...
+ Minnie: ... er .... thinking ...
 
-       Crunn: ... yes, Minnie ... Minnie ...
+ Crunn: ... yes ...so was I ....
 
-       Minnie: ... Yes ..?
+ Minnie: ... can't remember now ...
 
-       Crunn: ... Shut up ...
+ Crunn: ... yes, Minnie ... Minnie ...
 
-       Gurnsey and Ortho       (Together): Moo ... oooh ... moo.
+ Minnie: ... Yes ..?
 
-       Adventurer: Moo?
+ Crunn: ... Shut up ...
 
-       Contessa: See, Adventurer, Ortho's fixed.
+ Gurnsey and Ortho (Together): Moo ... oooh ... moo.
 
-       Adventurer: Is he?
+ Adventurer: Moo?
 
-       Contessa: You just watch.
+ Contessa: See, Adventurer, Ortho's fixed.
 
-       Adventurer: And what about the other armorers?
+ Adventurer: Is he?
 
-       Contessa: Any minute now.
+ Contessa: You just watch.
 
- (Ortho and serving girl arise, approach Adventurers'
-table. The floor shakes.)
+ Adventurer: And what about the other armorers?
 
-       Ortho: This Gurnsey. Ortho love Gurnsey, oooh.
+ Contessa: Any minute now.
 
-       Gurnsey: Gurnsey love Ortho ... moo ...
+ (Ortho and serving girl arise, approach Adventurers' table. The floor shakes.)
 
-       Ortho: We go get marry, we is.
+ Ortho: This Gurnsey. Ortho love Gurnsey, oooh.
 
-       Adventurer: Well, congratulations! And that was a fine
-long speech, Ortho!
+ Gurnsey: Gurnsey love Ortho ... moo ...
 
-       Ortho: We go raise piggies.
+ Ortho: We go get marry, we is.
 
-       Gurnsey: Grows animals too, farmers be we.
+ Adventurer: Well, congratulations! And that was a fine long speech, Ortho!
+
+ Ortho: We go raise piggies.
+
+ Gurnsey: Grows animals too, farmers be we.
 
  (Exit Ortho and Gurnsey)
 
-       Adventurer: Extraordinary. Ave, I think that you must
-have been up here before.
+ Adventurer: Extraordinary. Ave, I think that you must have been up here before.
 
-       Contessa: Oh yes. I often come up here to get away from
-the Palace and talk dwarves with Minnie and Crunn.         
-Adventurer: You mean that these two ancient ... er, Scholar-I
-nnKeeps can actually talk and about dwarves?
+ Contessa: Oh yes. I often come up here to get away from the Palace and talk dwarves with Minnie and Crunn.
 
- (All but Adventurer, Contessa, Minnie, and Crunn fall
-asleep in their meat pies.)
+ Adventurer: You mean that these two ancient ... er, Scholar-Inn Keeps can actually talk and about dwarves?
 
-       Contessa: Oh yes, you must just be very patient. But look
-over at our other escorts ...
+ (All but Adventurer, Contessa, Minnie, and Crunn fall asleep in their meat pies.)
 
-       Adventurer: By the Lady!
+ Contessa: Oh yes, you must just be very patient. But look over at our other escorts ...
 
-       Contessa: Minnie was an Alchemist before she met Crunn,
-and knows a lot of old forgotten Dwarvish potions.        
-Adventurer: But what do we do with the bodies?        
+ Adventurer: By the Lady!
 
-       Contessa: Wait ...
+ Contessa: Minnie was an Alchemist before she met Crunn, and knows a lot of old forgotten Dwarvish potions.
+
+ Adventurer: But what do we do with the bodies?
+
+ Contessa: Wait ...
 
  (Enter Major)
 
-       Contessa: Adventurer, meet Major Bloodnok, head of my
-own ...private little bodyguard. He's been with me since I
-was a mere girl. Served me very well, haven't you, Major?
+ Contessa: Adventurer, meet Major Bloodnok, head of my own ...private little bodyguard. He's been with me since I was a mere girl. Served me very well, haven't you, Major?
 
-       Major: We give our all, milady.
+ Major: We give our all, milady.
 
-nKeeps can actually talk and about dwarves?
+ Adventurer: Pleased to meet you, Major.
 
- (All but Adventurer, Contessa, Minnie, and Crunn fall
-asleep in their meat pies.)
+ Contessa: How are my other men?
 
-       Contessa: Oh yes, you must just be very patient. But look
-over at our other escorts ...
+ Adventurer: (aside) Other men?
 
-       Adventurer: By the Lady!
+ (Enter Other Men in Khajiit suits)
 
-       Contessa: Minnie was an Alchemist before she met Crunn,
-and knows a lot of old forgotten Dwarvish potions.        
-Adventurer: But what do we do with the bodies?        
+ Major: All present and accounted for, milady. Had a spot of bother with what looked like a party of Merchants following you. But they are out of the picture now, down a ravine. Only one thing.
 
-       Contessa: Wait ...
+ Contessa: Yes?
 
- (Enter Major)
+ Major: Me and my men, we've been noticing sort of furtive movements, up on cliffs, on ridges -- always just out of the corners of our eyes. And we keep getting this feeling of being watched. Now, me and my men, we're the best but there's something out there. Don't like it, not one bit.
 
-       Contessa: Adventurer, meet Major Bloodnok, head of my
-own ...private little bodyguard. He's been with me since I
-was a mere girl. Served me very well, haven't you, Major?
+ Contessa: Oh Dear - and just when it was getting to be fun.
 
-       Major: We give our all, milady.
+ Major: Its not anything human. Not Mages, Armorers, Priests. And its not the usual werewolves, harpies, orcs, daedra. Nothing like that, not at all.
 
-       Adventurer: Pleased to meet you, Major.
+ Minnie: Dwarves!
 
-       Contessa: How are my other men?
+ Crunn: Where? ... oh ... Minnie ... you mean ... up ... there ... here ...
 
-       Adventurer:       (aside) Other men?
+ Minnie: ... Dwarves, up there ...
 
- (Enter Other Men in Khajiit suits)         Major: All present
-and accounted for, milady. Had a spot of bother with what
-looked like a party of Merchants following you. But they are
-out of the picture now, down a ravine. Only one thing.
+ Crunn: ... How exciting ... mmmm ...
 
-       Contessa: Yes?
+ Minnie: ... There, there, Crunn, calm down ... just dwarves ... I knew that one day they would ...
 
-       Major: Me and my men, we've been noticing sort of
-furtive movements, up on cliffs, on ridges -- always just
-out of the corners of our eyes. And we keep getting this
-feeling of being watched. Now, me and my men, we're the best
-but there's something out there. Don't like it, not one bit.
+ Crunn: ... Wake up ..?
 
-       Contessa: Oh Dear - and just when it was getting to be fun.
+ Minnie: ... Come back ...
 
-       Major: Its not anything human. Not Mages, Armorers,
-Priests. And its not the usual werewolves, harpies, orcs,
-daedra. Nothing like that, not at all.
+ Crunn: ... But ... I didn't go anywhere ...
 
-       Minnie: Dwarves!
+ Minnie: ... The dwarves, Crunn ...
 
-       Crunn: Where? ... oh ... Minnie ... you mean ... up ...
-there ... here ...
+ Crunn: ... Oooh ... Back ... So excited ... Dwarves! ... oooh ...
 
-       Minnie: ... Dwarves, up there ...
+ Contessa: Well Major, is it possible?
 
-       Crunn: ... How exciting ... mmmm ...
-
-       Minnie: ... There, there, Crunn, calm down ... just
-dwarves ... I knew that one day they would ...
-
-       Crunn: ... Wake up ..?
-
-       Minnie: ... Come back ...
-
-       Crunn: ... But ... I didn't go anywhere ...
-
-       Minnie: ... The dwarves, Crunn ...
-
-       Crunn: ... Oooh ... Back ... So excited ... Dwarves! ...
-oooh ...
-
-       Contessa: Well Major, is it possible?
-
-       Major: Anything's possible, especially up here.
-Dwarves? I don't know. Me and my men, we'll get rid of this
-lot. There's a good deep mine shaft out back.
+ Major: Anything's possible, especially up here. Dwarves? I don't know. Me and my men, we'll get rid of this lot. There's a good deep mine shaft out back.
 
  (Exit All, but the Adventurer and Contessa)
 
-       Adventurer: Dwarves, Ave! Is that trouble? I mean, they
-sort of own all the ebony down here, don't they?
+ Adventurer: Dwarves, Ave! Is that trouble? I mean, they sort of own all the ebony down here, don't they?
 
-       Contessa: Maybe. I guess we just have to push on, see what
-develops. I can try to talk to them, maybe? Oh, and
-Adventurer, you'll have to drive the first cart. I'll take
-old Nephron's. We'll leave the other here -- Spares for
-later.
+ Contessa: Maybe. I guess we just have to push on, see what develops. I can try to talk to them, maybe? Oh, and Adventurer, you'll have to drive the first cart. I'll take old Nephron's. We'll leave the other here -- Spares for later.
 
-       Adventurer: What, no more bucolic frolics?
+ Adventurer: What, no more bucolic frolics?
 
-       Contessa: Sorry, but we've got to get to the site and
-out again before the weather goes bad.
+ Contessa: Sorry, but we've got to get to the site and out again before the weather goes bad.
 
-       Adventurer: Can't your Major and his men, handle the
-carts?
+ Adventurer: Can't your Major and his men, handle the carts?
 
-       Contessa: Oh, no. They will cover us from all sides and make certain there are no surprises.
+ Contessa: Oh, no. They will cover us from all sides and make certain there are no surprises.
 
-       Adventurer: Oh well. All good things end, I guess.
+ Adventurer: Oh well. All good things end, I guess.
 
-       Contessa: Not quite. If you have any charges left in
-your bracelets of endurance, we can go upstairs and see what
-develops.
+ Contessa: Not quite. If you have any charges left in your bracelets of endurance, we can go upstairs and see what develops.
 
  (Enter Prologue)
 
-       Prologue: Well, I guess we all saw that coming. Scene 3
-takes place some time later at the site. Flanked by the
-Major's men, the Adventurer and the Wanton Contessa
-successfully follow the map of the dear, departed mages.
-Imagine great veins of glistening ebonyesque material
-piercing the surface of the ground, and a nice warm fire of
-Fools Ebony where the Adventurer and the Contessa sprawl.
-To the west are signs that the weather is turning and the first
-major snowstorm of the year is coming. For some time, they
-have been mining and the Adventurer is beginning to feel the
-strain of actual labor.
+ Prologue: Well, I guess we all saw that coming. Scene 3 takes place some time later at the site. Flanked by the Major's men, the Adventurer and the Wanton Contessa successfully follow the map of the dear, departed mages. Imagine great veins of glistening ebonyesque material piercing the surface of the ground, and a nice warm fire of Fools Ebony where the Adventurer and the Contessa sprawl. To the west are signs that the weather is turning and the first major snowstorm of the year is coming. For some time, they have been mining and the Adventurer is beginning to feel the strain of actual labor.
 
  (Exit Prologue)
 
  Scene 3
 
-       Adventurer: I've got blisters on my hands from
-shovelling that black rot, blisters on my rear from that cart
-bench, and we are running out of ale. My bracelet is running
-down and my fingers are getting frostbite.
+ Adventurer: I've got blisters on my hands from shovelling that black rot, blisters on my rear from that cart bench, and we are running out of ale. My bracelet is running down and my fingers are getting frostbite.
 
-       Contessa: What, your bracelet is running down? Oh, now
-that is serious.
+ Contessa: What, your bracelet is running down? Oh, now that is serious.
 
  (Enter Major, running)
 
-       Major: Dwarves! Milady, dwarves, dozens of the little
-buggers caught my men! I'm sorry, milady.
+ Major: Dwarves! Milady, dwarves, dozens of the little buggers caught my men! I'm sorry, milady.
 
  (The Contessa jumps to her feet)
 
-       Contessa: Major, get out of here now. If you get away,
-you can maybe help us later. I'll try to talk to them.
+ Contessa: Major, get out of here now. If you get away, you can maybe help us later. I'll try to talk to them.
 
- (Exit Major) (Enter Dwarves)
+ (Exit Major)
 
-       Contessa: Hhjgys jjvvu klpss Jjqqx zzyzx.
+ (Enter Dwarves)
 
-       Dwarves       (Together): Jjpoo Kalagloo gashnoo bibloo
-franoo Xxnadoo
+ Contessa: Hhjgys jjvvu klpss Jjqqx zzyzx.
 
-       Contessa Jnik? Balpo?
+ Dwarves (Together): Jjpoo Kalagloo gashnoo bibloo franoo Xxnadoo
 
-       Dwarves       (Together) Gabloo! Wazzikoo! Eppapupu!
+ Contessa: Jnik? Balpo?
 
-       Contessa Glooky, glooky, glooky.
+ Dwarves (Together): Gabloo! Wazzikoo! Eppapupu!
 
-       Adventurer: Ave, whats going on?
+ Contessa: Glooky, glooky, glooky.
 
-       Contessa: Relax. I think I've impressed them by talking
-their language. I don't understand everything, but it seems
-that they have only just 'woken up' or something. And that
-they will not let us take any of this Fool's Ebony -- it's
-somehow related to the real stuff or something. And it
-really belongs to the Lords of Oblivion -- the Dwarves are
-just care or something.
+ Adventurer: Ave, whats going on?
 
-       Adventurer: Very interesting. Now, what about us?
+ Contessa: Relax. I think I've impressed them by talking their language. I don't understand everything, but it seems that they have only just 'woken up' or something. And that they will not let us take any of this Fool's Ebony -- it's somehow related to the real stuff or something. And it really belongs to the Lords of Oblivion -- the Dwarves are just care or something.
 
-       Contessa: I made a deal with them the only way I could
-see. I told them about Minnie and Crunn, how those two old
-ones know lots of dwarven tales and legends. The dwarves
-tells me that, having just 'woken up' or something, they want
-three things -- ale, women, and us to leave the Fools' Ebony
-alone.
+ Adventurer: Very interesting. Now, what about us?
 
-       Adventurer: Ah, flog my log.
+ Contessa: I made a deal with them the only way I could see. I told them about Minnie and Crunn, how those two old ones know lots of dwarven tales and legends. The dwarves tells me that, having just 'woken up' or something, they want three things -- ale, women, and us to leave the Fools' Ebony alone.
 
-       Contessa: Well,I told them about all the ale down at
-Minnie's Inn. And about the 2 redheads there. They are going
-there, leaving right now. We may take one empty cart, 2
-horses. And they will keep us guarded all the way there. They
-also said that they will -- I don't know how -- destroy all the
-Fool's Ebony here. It shouldn't be on the surface like this,
-they say.       (aside) Dwarvish is a remarkably compact
-language.
+ Adventurer: Ah, flog my log.
 
-       Adventurer: By the great roaring buttocks of
-Sheogorath! All these blisters and backache for nothing! Ah
-well. At least we are still alive. For now ...
+ Contessa: Well, I told them about all the ale down at Minnie's Inn. And about the 2 redheads there. They are going there, leaving right now. We may take one empty cart, 2 horses. And they will keep us guarded all the way there. They also said that they will -- I don't know how -- destroy all the Fool's Ebony here. It shouldn't be on the surface like this, they say.(aside) Dwarvish is a remarkably compact language.
 
- (Exeunt) (Enter Prologue)
+ Adventurer: By the great roaring buttocks of Sheogorath! All these blisters and backache for nothing! Ah well. At least we are still alive. For now ...
 
- Prologue: Farnoo Lickety Kanoo Gadfloo. Oh, I'm terribly
-sorry. As Scene 4 begins, we are back at Minnie's Inn, where
-the dwarves appear to be on holiday.
+ (Exeunt)
 
- (Enter the Adventurer, the Wanton Contessa, Minnie, Crunn,
-and Dwarves)
+ (Enter Prologue)
+
+ Prologue: Farnoo Lickety Kanoo Gadfloo. Oh, I'm terribly sorry. As Scene 4 begins, we are back at Minnie's Inn, where the dwarves appear to be on holiday.
+
+ (Enter the Adventurer, the Wanton Contessa, Minnie, Crunn, and Dwarves)
 
  (Exit Prologue)
 
  Scene 4
 
-       Minnie: ... ga ... sszx ... spnoo? ...
+ Minnie: ... ga ... sszx ... spnoo? ...
 
-       Crunn: ... glurky ...
+ Crunn: ... glurky ...
 
-       Dwarves       (Together): Jotcha potchka lazzo lanni joopy
-hoopy qui me amat, amat et canem meam
+ Dwarves (Together): Jotcha potchka lazzo lanni joopy hoopy qui me amat, amat et canem meam
 
-       Adventurer: Ave, any ideas? I can't seem to work my
-magical items. And when the ale runs out ...
+ Adventurer: Ave, any ideas? I can't seem to work my magical items. And when the ale runs out ...
 
-       Contessa: Your ebony material is useless against them.
-Dwarves fashion the ebony, so I guess they can suppress it or
-something. Don't worry - just think, these dwarves have been
-asleep or something for hundreds of years. And Minnie has a
-huge stock of ale. Not many customers  come this way, and she
-knows how to salt the ale just right to keep from spoiling
-for decades.
+ Contessa: Your ebony material is useless against them. Dwarves fashion the ebony, so I guess they can suppress it or something. Don't worry - just think, these dwarves have been asleep or something for hundreds of years. And Minnie has a huge stock of ale. Not many customers come this way, and she knows how to salt the ale just right to keep from spoiling for decades.
 
- Adventurer Oh, that's why my tongue always looks like a chunk
-of leather after a pint or two.
+ Adventurer: Oh, that's why my tongue always looks like a chunk of leather after a pint or two.
 
-       Contessa Dwarves apparently love ale. I expect them
-all to pass out in an hour or so. 
+ Contessa: Dwarves apparently love ale. I expect them all to pass out in an hour or so.
 
  (Dwarves fall into comas)
 
-       Contessa: If not sooner. Come on, Adventurer. Grab a
-sack and start collecting! When the dwarves wake up,
-they'll finish the ale, and then us. 
+ Contessa: If not sooner. Come on, Adventurer. Grab a sack and start collecting! When the dwarves wake up, they'll finish the ale, and then us.
 
  (The Wanton Contessa and Adventurer pillage the dwarves)
 
-       Adventurer: South, as fast as our horses will take us in
-this weather.
+ Adventurer: South, as fast as our horses will take us in this weather.
 
-       Contessa: If we make enough distance before they wake up,
-we'll be all right - I don't think that they will leave their
-precious mountains. I hope not.
+ Contessa: If we make enough distance before they wake up, we'll be all right - I don't think that they will leave their precious mountains. I hope not.
 
  (Enter Prologue)
 
-       Prologue: The wailing wintery wind whirls wickedly,
-wafts whipping, wading waist-high, oh never mind. The
-Adventurer and the Contessa get lost in the snow storm.
-Several days later, we find them desperate for warmth and
-exhausted.
+ Prologue: The wailing wintery wind whirls wickedly, wafts whipping, wading waist-high, oh never mind. The Adventurer and the Contessa get lost in the snow storm. Several days later, we find them desperate for warmth and exhausted.
 
  (Exit Prologue)
 
-       Adventurer: The horses have had it. They can't go another
-step and its going to snow again. No ale left, and just one
-loaf.           Contessa: It will have to do.
+ Adventurer: The horses have had it. They can't go another step and its going to snow again. No ale left, and just one loaf.
 
- (Suddenly, a party of giants leaps on our hero and
-heroine. But after some quick work with Bracers of Firestorm,
-really dead giants lie around in heaps)
+ Contessa: It will have to do.
 
-       Adventurer: Anything left, Ave?
+ (Suddenly, a party of giants leaps on our hero and heroine. But after some quick work with Bracers of Firestorm, really dead giants lie around in heaps)
 
-       Contessa: No, no more fire anything - just my daggers
+ Adventurer: Anything left, Ave?
 
-       Adventurer: Same here, just a common shortsword. Curse
-Sheogorath for those dwarves!  Those oafs chewed up our
-horses! Do you think the Major made it out?               
-Contessa: If anyone can, it's him.  Guess we'll find out in
-town. Interesting thought just occured to me. Don't giants
-hunt in several groups? Is that more I hear?
+ Contessa: No, no more fire anything - just my daggers
+
+ Adventurer: Same here, just a common shortsword. Curse Sheogorath for those dwarves! Those oafs chewed up our horses! Do you think the Major made it out?
+
+ Contessa: If anyone can, it's him. Guess we'll find out in town. Interesting thought just occured [sic] to me. Don't giants hunt in several groups? Is that more I hear?
 
  (sound of grumbling and gargling offstage)
 
-       Adventurer: Yes, there are more giants out there. Quick,
-Ave. Help me with this one.
+ Adventurer: Yes, there are more giants out there. Quick, Ave. Help me with this one.
 
  (The Adventurer starts to disembowel a giant's body)
 
-       Contessa: What on Tamriel are you doing? This is not the
-time for studying anatomy!
+ Contessa: What on Tamriel are you doing? This is not the time for studying anatomy!
 
-       Adventurer: Don't argue, climb inside!
+ Adventurer: Don't argue, climb inside!
 
-       Contessa: Poppydash and Baldercock! Inside that smelly
-dead giant? My dear Adventurer, I'm a Lady.
+ Contessa: Poppydash and Baldercock! Inside that smelly dead giant? My dear Adventurer, I'm a Lady.
 
-       Adventurer: It's our only hope! The giant smell will
-hide our scent, and live giants never touch dead ones.
-Quick!
+ Adventurer: It's our only hope! The giant smell will hide our scent, and live giants never touch dead ones. Quick!
 
- (The Adventurer and the Contessa climb inside the steaming
-giant's body)
+ (The Adventurer and the Contessa climb inside the steaming giant's body)
 
-       Adventurer: Here, help me pull the skin shut - and try not
-to throw up. Don't make a sound.
+ Adventurer: Here, help me pull the skin shut - and try not to throw up. Don't make a sound.
 
  (Enter Prologue)
 
-       Prologue: A few hour pass.
+ Prologue: A few hour pass.
 
- (Exit Prologue) (The Adventurer and the Wanton Contessa
-poke their heads out of the giant's belly.) 
+ (Exit Prologue)
 
-       Adventurer: They've all left, but it's snowing hard.
-Definitely getting real cold. We better stay here.
+ (The Adventurer and the Wanton Contessa poke their heads out of the giant's belly.)
 
-       Contessa: It indeed is warm.
+ Adventurer: They've all left, but it's snowing hard. Definitely getting real cold. We better stay here.
 
-       Adventurer: It will keep us warm, safe from the storm
-and giants, for a day or soif we can stand the smell. Here,
-want some bread?
+ Contessa: It indeed is warm.
+
+ Adventurer: It will keep us warm, safe from the storm and giants, for a day or soif we can stand the smell. Here, want some bread?
 
  (The Contessa falls victim to nausea)
 
  (Enter Prologue)
 
-       Prologue: For this, the last scene of the play, please
-forgive us, but we need to change the set. Remove the "giant
-corpses" and whatnot. Please be patient while our bard
-performs the timeless classic "Whither Goest Thou?"
+ Prologue: For this, the last scene of the play, please forgive us, but we need to change the set. Remove the "giant corpses" and what not. Please be patient while our bard performs the timeless classic "Whither Goest Thou?"
 
- (Bard plays "Whither Goest Thou?" If the scenarists take too
-long, he also plays "For Further Consideration.")
+ (Bard plays "Whither Goest Thou?" If the scenarists take too long, he also plays "For Further Consideration.")
 
- Prologue: Ah, here we are, back at the Dead Daedra Inn. The
-Contessa and the Adventurer made it, after all. They had to
-pay three times the normal rate, for they were very dirty and
-stinky. Now poor Prologue will bid you farewell, goodly
-people.
+ Prologue: Ah, here we are, back at the Dead Daedra Inn. The Contessa and the Adventurer made it, after all. They had to pay three times the normal rate, for they were very dirty and stinky. Now poor Prologue will bid you farewell, goodly people.
 
  Scene 6
 
-       Contessa: Thank the Gods for hot water and soap! I
-thought I would smell like a giant forever.
+ Contessa: Thank the Gods for hot water and soap! I thought I would smell like a giant forever.
 
-       Adventurer: Me too. Where did you go while I was
-bathing? And why no mages, priests, armorers, or merchants
-outside yelling for our blood?
+ Adventurer: Me too. Where did you go while I was bathing? And why no mages, priests, armorers, or merchants outside yelling for our blood?
 
-       Contessa: I took a quick trip to the Palace. I've fixed it
-so some cousins have told the armorers and merchants that we
-don't have cartloads of the Fools' Ebony.
+ Contessa: I took a quick trip to the Palace. I've fixed it so some cousins have told the armorers and merchants that we don't have cartloads of the Fools' Ebony.
 
-       Adventurer: Pity that that's actually true.
+ Adventurer: Pity that that's actually true.
 
-       Contessa: But at least no one's interested in us
-anymore. Seems that some priests turned up dead in an old 
-temple, up on Edward's Mountain. They were found with some
-girl, all dead from 'bad green powder' or something. And
-some old mages named Shub have gone missing ...
+ Contessa: But at least no one's interested in us anymore. Seems that some priests turned up dead in an old temple, up on Edward's Mountain. They were found with some girl, all dead from 'bad green powder' or something. And some old mages named Shub have gone missing ...
 
-       Adventurer: Now then, what did you stuff in those sacks
-thats so important?
+ Adventurer: Now then, what did you stuff in those sacks thats so important?
 
-       Contessa: Here, dump them out, take a look.
+ Contessa: Here, dump them out, take a look.
 
-       Adventurer: By the Gods, just look at that!
+ Adventurer: By the Gods, just look at that!
 
-       Contessa: Yes, those dwarves were just loaded with
-ebony. Look. Rings, torcs, bracers, belts, helms All solid
-old ebony.
+ Contessa: Yes, those dwarves were just loaded with ebony. Look. Rings, torcs, bracers, belts, helms All solid old ebony.
 
-       Adventurer: And this stuff feels just loaded with
-magicka. Why, I bet that this ring alone has a thousand uses
-... whatever it does.
+ Adventurer: And this stuff feels just loaded with magicka. Why, I bet that this ring alone has a thousand uses... whatever it does.
 
-       Contessa: Ooh! Look! Bracers of Extreme Endurance and a
-Belt of Strength! Put them on, Adventurer, let's
-celebrate!
+ Contessa: Ooh! Look! Bracers of Extreme Endurance and a Belt of Strength! Put them on, Adventurer, let's celebrate!
 
-       Adventurer       (aside) Help!
+ Adventurer: (aside) Help!
 
  Enter Epilogue
-
-       Epilogue: As I feared, all the loose threads of the play
-were ended by wholesale slaughter. More of the adventures of
-the Adventurer will follow, unless, of course, they don't.
-We thank you for your tempered patience. Don't forget to tip
-your worthy wenches on your way out this evening, and enjoy
-our bard's rendition of the Khajiiti classic, "It's A Matter
-of Luck." Goodnight.
+ Epilogue: As I feared, all the loose threads of the play were ended by wholesale slaughter. More of the adventures of the Adventurer will follow, unless, of course, they don't. We thank you for your tempered patience. Don't forget to tip your worthy wenches on your way out this evening, and enjoy our bard's rendition of the Khajiiti classic, "It's A Matter of Luck." Goodnight.
 
  (Flourish)
 
  (Exeunt Omnes)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- 

--- a/Assets/StreamingAssets/Text/Books/BOK00089-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00089-LOC.txt
@@ -3,103 +3,29 @@ Author: Stem Gamboge, scribe
 IsNaughty: False
 Price: 406
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
 
 [/font=2]
+
 [/center]Biography of
+
 [/center]Queen Barenziah,
+
 [/center]Vol. III
 
 [/font=4]
+
 [/center]
-[/center] Barenziah was welcomed kindly by the Emperor Tiber Septim
-and his family, who treated her like a daughter during her
-stay in the newly built Imperial City. After several happy
-months there learning her duties as a regent under the Empire,
-Symmachus escorted her to Mournhold where she took up her
-duties as Queen of her people, under his wise guidance.
-Gradually they came to love one another and were married
-and crowned in a splendid ceremony at which the Emperor
-himself officiated.
- After several hundred years of marriage a son, Helseth, was
-born to the royal couple, amid rejoicing and prayers to the
-goddess who had at last blessed their marriage. Although it
-was not known at the time, it was shortly before this blessed
-event that the Staff of Chaos was stolen from its hiding
-place deep in the Mournhold mines by a clever bard known
-only as Nightingale.
- Eight years after Helseth's birth, Barenziah bore a daughter,
-Morgiah, named for Symmachus' mother and the royal couple's
-joy was complete. Alas, shortly after that, relations with
-the Empire mysteriously deteriorated, leading to much civil
-unrest in Mournhold. After fruitless inquiries and attempts
-at reconciliation, in desperation Barenziah took her young
-children and travelled to Imperial City herself to seek the
-Emperor's ear. Symmachus remained in Mournhold.
- During her audience with the Emperor, Barenziah, through her
-magical arts, came to realize, to her horror and dismay,
-that the so-called Emperor was an imposter, none other than
-the Bard Nightingale who had stolen the Staff of Chaos.
-Exercising great self control she concealed this realization
-from him. That evening news came that Symmachus had been
-killed in battle and that Mournhold had been taken by the
-rebels. Barenziah knew not where to seek help, when a knock
-sounded at her door. It was Eadwyre, King of Wayrest, and
-an old friend of Uriel Septim and Symmachus. He comforted
-her, pledged his friendship and confirmed her suspicions that
-the Emperor was indeed an impostor, and none other than
-Jagar Tharn, the Imperial Battlemage. Tharn had
-supposedly retired from public work and put his assistant,
-Ria Silmane, in his stead. As it seemed, Tharn had never left
-the Imperial City. Ria was indeed dead, but her ghost had
-appeared in Eadwyre's dreams and revealed that the true
-Emperor had been kidnapped by Tharn and imprisoned in an
-alternate plane. Tharn had then used the Staff of Chaos to
-kill her when she attempted to warn the Council of his
-nefarious plot. 
- Together, Eadwyre and Barenziah plotted to gain the
-imposter's confidence and unmask him with the help of another
-friend of Ria's, who was currently in prison, but to whose
-dreams she had access, and who possessed great, albeit
-untapped, potential. Barenziah charmed and befriended the
-fake Emperor. By reading his secret diary she learned that he
-had broken the Staff into eight pieces and hidden them. She
-managed to obtain a copy of the key to Ria's friend's cell
-and bribed a guard to leave it within the cell, as if by
-accident. Their Champion, whose name was unknown even to
-Barenziah and Eadwyre, made his escape through a shift gate
-Ria had openned in a dark rat infested corner of the prison
-where the cowardly goblin guards feared to venture. It
-took Barenziah several months to learn the hiding places of
-all eight staff pieces through snatches of overheard
-conversation and rare glimpses of the diary. Once she had the
-vital information, she and Eadwyre fled to Wayrest where
-they managed to stave off the sporadic efforts of Tharn's
-henchmen to obtain revenge. Tharn, whatever else might be
-said of him, was no one's fool save perhaps Barenziah's, and
-he concentrated most of his efforts in tracking down and
-destroying the great Champion.
- As all now know, the brave, tireless, and forever nameless
-Champion was successful in reuniting the Staff of Chaos.
-With it, he destroyed Tharn and rescued the true Emperor,
-Uriel Septim VII. Following the Restoration, a grand state
-memorial service was held for Symmachus in the Imperial
-City, befitting the man who had served the Septim family so
-long and so well. Barenziah and good King Eadwyre had come
-to care deeply for one another, and had married in the year
-after their flight from Imperial City. Her children remained
-with her and a regent was appointed to rule Mournhold in her
-absence. She planned to return after Eadwyre's death. He was
-elderly when they wed so she knew that event, alas, could not
-be far off as the elves reckon time.
 
+ Barenziah was welcomed kindly by the Emperor Tiber Septim and his family, who treated her like a daughter during her stay in the newly built Imperial City. After several happy months there learning her duties as a regent under the Empire, Symmachus escorted her to Mournhold where she took up her duties as Queen of her people, under his wise guidance. Gradually they came to love one another and were married and crowned in a splendid ceremony at which the Emperor himself officiated.
 
+ After several hundred years of marriage a son, Helseth, was born to the royal couple, amid rejoicing and prayers to the goddess who had at last blessed their marriage. Although it was not known at the time, it was shortly before this blessed event that the Staff of Chaos was stolen from its hiding place deep in the Mournhold mines by a clever bard known only as Nightingale.
 
+ Eight years after Helseth's birth, Barenziah bore a daughter, Morgiah, named for Symmachus' mother and the royal couple's joy was complete. Alas, shortly after that, relations with the Empire mysteriously deteriorated, leading to much civil unrest in Mournhold. After fruitless inquiries and attempts at reconciliation, in desperation Barenziah took her young children and travelled to Imperial City herself to seek the Emperor's ear. Symmachus remained in Mournhold.
 
+ During her audience with the Emperor, Barenziah, through her magical arts, came to realize, to her horror and dismay, that the so-called Emperor was an imposter, none other than the Bard Nightingale who had stolen the Staff of Chaos. Exercising great self control she concealed this realization from him. That evening news came that Symmachus had been killed in battle and that Mournhold had been taken by the rebels. Barenziah knew not where to seek help, when a knock sounded at her door. It was Eadwyre, King of Wayrest, and an old friend of Uriel Septim and Symmachus. He comforted her, pledged his friendship and confirmed her suspicions that the Emperor was indeed an impostor, and none other than Jagar Tharn, the Imperial Battlemage. Tharn had supposedly retired from public work and put his assistant, Ria Silmane, in his stead. As it seemed, Tharn had never left the Imperial City. Ria was indeed dead, but her ghost had appeared in Eadwyre's dreams and revealed that the true Emperor had been kidnapped by Tharn and imprisoned in an alternate plane. Tharn had then used the Staff of Chaos to kill her when she attempted to warn the Council of his nefarious plot.
 
+ Together, Eadwyre and Barenziah plotted to gain the imposter's confidence and unmask him with the help of another friend of Ria's, who was currently in prison, but to whose dreams she had access, and who possessed great, albeit untapped, potential. Barenziah charmed and befriended the fake Emperor. By reading his secret diary she learned that he had broken the Staff into eight pieces and hidden them. She managed to obtain a copy of the key to Ria's friend's cell and bribed a guard to leave it within the cell, as if by accident. Their Champion, whose name was unknown even to Barenziah and Eadwyre, made his escape through a shift gate Ria had openned in a dark rat infested corner of the prison where the cowardly goblin guards feared to venture. It took Barenziah several months to learn the hiding places of all eight staff pieces through snatches of overheard conversation and rare glimpses of the diary. Once she had the vital information, she and Eadwyre fled to Wayrest where they managed to stave off the sporadic efforts of Tharn's henchmen to obtain revenge. Tharn, whatever else might be said of him, was no one's fool save perhaps Barenziah's, and he concentrated most of his efforts in tracking down and destroying the great Champion.
 
-
-
-
- 
+ As all now know, the brave, tireless, and forever nameless Champion was successful in reuniting the Staff of Chaos. With it, he destroyed Tharn and rescued the true Emperor, Uriel Septim VII. Following the Restoration, a grand state memorial service was held for Symmachus in the Imperial City, befitting the man who had served the Septim family so long and so well. Barenziah and good King Eadwyre had come to care deeply for one another, and had married in the year after their flight from Imperial City. Her children remained with her and a regent was appointed to rule Mournhold in her absence. She planned to return after Eadwyre's death. He was elderly when they wed so she knew that event, alas, could not be far off as the elves reckon time.

--- a/Assets/StreamingAssets/Text/Books/BOK00100-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00100-LOC.txt
@@ -3,264 +3,91 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]King Edward, Part I
 
-
-
 [/font=4]
 
+[/center]
 
+[/center]Departure from Daggerfall
 
+ Long, long ago, when the world was in its springtime, before the Redguards came and the glorious Septim Empire was formed, but after the goblins had driven the dwarves out of Hammerfell, a son, Edward, was born to King Corcyr I of Daggerfall and his Queen, Aliera of Wayrest.
 
+ The young boy lay drowsing in the palace orchard, high on a breezy hill overlooking the deep blue bay of Daggerfall. The constant autumn fog of Daggerfall had blown away for the nonce and the sky was a deep endless blue. Moments like this were rare for young Prince Edward; this afternoon was the result of days of scheming, for he craved solitude as the other nobles he knew craved companionship. Now his tutor believed him engaged in extra arms practice, the master of arms believed him to be chasing deer with the huntmaster, who thought he was studying Elvish. His father had no idea where he was and didn't care, being occupied with his young wife and their sons and other pleasures of noble life ...
 
-[/center]Chapter One:
+ At the plop of an apple barely missing his head, he opened his pale grey eyes; there was a sweet rotten smell in his nostrils. He sighed and stared up into the blue. Why should things fall down instead of up? If you stared at the sky long enough you could feel as if you were falling into it ... his eyes glazed and the pupils grew huge as the dark-ringed irises dilated. He was weightless, drifting ... another apple fell, grazing his ear, and he thudded to earth, crying out as first his rump struck and then his head. A silvery laugh sounded. Edward sat up abruptly and stared around, jaw hanging slack. Two mounted men stood ten feet away, still as if they were carved from stone, regarding him intently. Princes are not easily intimidated, not even the gentle souled kind, but Edward had never seen or imagined anything like this pair. One had golden skin and eyes, was clad in white cloth trimmed with gold and rode a (Edward blinked. It is was still there) a unicorn! Beside the unicorn was a golden dragon, wings neatly folded. And on his back was a man clad in dark chain mail, a long sword at his side. He was bareheaded; his eyes glowed red in his dark face ... and his pointed ears ... "You're elves! What--!"
 
-Departure from Daggerfall
+ "He's a clever child." The dark elf's voice was sardonic. He spoke perfect Bretic, Edward noticed, his mind still working, although something seemed to have gone wrong with the rest of him.
 
- Long, long ago, when the world was in its springtime,
-before the Redguards came and the glorious Septim Empire was
-formed, but after the goblins had driven the dwarves out of
-Hammerfell, a son,  Edward, was born to King Corcyr I of
-Daggerfall and his Queen, Aliera of Wayrest.
+ "So it would seem. He did that mostly of himself. Remarkable for an untrained child. I merely helped him to--- concentrate." The high elf also spoke Bretic, but hesitantly and with a slight singing accent. Edward's tutor said that elves were incapable of human speech.
 
- The young boy lay drowsing in the palace orchard, high on a
-breezy hill overlooking the deep blue bay of Daggerfall.
-The constant autumn fog of Daggerfall had blown away for
-the nonce and the sky was a deep endless blue. Moments like this
-were rare for young Prince Edward; this afternoon was the
-result of days of scheming, for he craved solitude as the
-other nobles he knew craved companionship. Now his tutor
-believed him engaged in extra arms practice, the master of
-arms believed him to be chasing deer with the huntmaster, who
-thought he was studying Elvish. His father had no idea where he
-was and didn't care, being occupied with his young wife and
-their sons and other pleasures of noble life ... 
+ Edward's gaze shifted rapidly over the four beings in front of him, unable to find a comfortable resting place. He hoped briefly, fervently, that he was dreaming. His mind seethed with questions and demands, then quite suddenly his tongue came unstuck. "But I wasn't concentrating at all! My masters all say I'm incapable--." Edward clamped his jaw down hard, suddenly realizing that it might be unwise to argue with beings such as these.
 
- At the plop of an apple barely missing his head, he opened his
-pale grey eyes; there was a sweet rotten smell in his
-nostrils. He sighed and stared up into the blue. Why should
-things fall down instead of up? If you stared at the sky
-long enough you could feel as if you were falling into it
-... his eyes glazed and the pupils grew huge as the dark-ringed
-irises dilated. He was weightless, drifting ... another
-apple fell, grazing his ear, and he thudded to earth, crying
-out as first his rump struck and then his head. A silvery
-laugh sounded. Edward sat up abruptly and stared around,
-jaw hanging slack.
+ But the golden elf smiled broadly, showing perfect white teeth, "Exactly." He radiated such warm approval, that Edward felt his skin tingle pleasantly. It was a feeling that he'd only known with his long-gone mother. But the other elf's face was expressionless; the red eyes bored into Edward as if they would pierce his soul.
 
- Two mounted men stood ten feet away, still as if they were
-carved from stone, regarding him intently. Princes are not
-easily intimidated, not even the gentle souled kind, but
-Edward had never seen or imagined anything like this pair.
-One had golden skin and eyes, was clad in white cloth trimmed
-with gold and rode a (Edward blinked. It is was still there)
-a unicorn! Beside the unicorn was a golden dragon, wings
-neatly folded. And on his back was a man clad in dark chain
-mail, a long sword at his side. He was bareheaded; his eyes
-glowed red in his dark face ... and his pointed ears ...
-"You're elves! What--!"
+ "Moraelyn! You're Moraelyn! The witch-king!" He jumped to his feet and faced the dark elf. "You stole my mother! My father will kill you."
 
- "He's a clever child." The dark elf's voice was sardonic. He
-spoke perfect Bretic, Edward noticed, his mind still
-working, although something seemed to have gone wrong with the
-rest of him.
-
- "So it would seem. He did that mostly of himself. Remarkable
-for an untrained child. I merely helped him to---
-concentrate." The high elf also spoke Bretic, but hesitantly
-and with a slight singing accent. Edward's tutor said that
-elves were incapable of human speech.
-
- Edward's gaze shifted rapidly over the four beings in front
-of him, unable to find a comfortable resting place. He hoped
-briefly, fervently, that he was dreaming. His mind seethed
-with questions and demands, then quite suddenly his tongue
-came unstuck. "But I wasn't concentrating at all! My
-masters all say I'm incapable--." Edward clamped his jaw
-down hard, suddenly realizing that it might be unwise to
-argue with beings such as these.
-
- But the golden elf smiled broadly, showing perfect white
-teeth, "Exactly." He radiated such warm approval, that
-Edward felt his skin tingle pleasantly. It was a feeling
-that he'd only known with his long-gone mother. But the other
-elf's face was expressionless; the red eyes bored into Edward
-as if they would pierce his soul.
-
- "Moraelyn! You're Moraelyn! The witch-king!" He jumped to
-his feet and faced the dark elf. "You stole my mother! My
-father will kill you."
-
- "I am. I did. Will he? Shall we call him and find out?" The
-dark elf straightened and his eyes glowed deeper. A tiny puff
-of steam escaped the dragon's nostrils. A glowing aura
-appeared around his companion. Edward knew he wasn't going
-to call the guard. Why should they be slaughtered? These two
-looked capable of -- anything. Quite suddenly he was no
-longer afraid. If they were here to hurt him, they'd have done
-it by now. But a feeling of impotent rage remained. They'd
-taken his mother. And now--
+ "I am. I did. Will he? Shall we call him and find out?" The dark elf straightened and his eyes glowed deeper. A tiny puff of steam escaped the dragon's nostrils. A glowing aura appeared around his companion. Edward knew he wasn't going to call the guard. Why should they be slaughtered? These two looked capable of -- anything. Quite suddenly he was no longer afraid. If they were here to hurt him, they'd have done it by now. But a feeling of impotent rage remained. They'd taken his mother. And now--
 
  "Why are you here?" he demanded.
 
- "Edward, will you come with us?" The high elf spoke. Hearing
-him was like hearing a harp, cool as a breeze, warm as a
-fireside...
+ "Edward, will you come with us?" The high elf spoke. Hearing him was like hearing a harp, cool as a breeze, warm as a fireside...
 
- The boy stood very still. He wanted very much to say yes, to
-his own amazement. He wanted to ask if he would see his mother,
-but instead: "My father---" he croaked.
+ The boy stood very still. He wanted very much to say yes, to his own amazement. He wanted to ask if he would see his mother, but instead "My father---" he croaked.
 
- "Will miss you no doubt." The irony was back in Moraelyn's
-voice, a voice that make Edward think of icicles sparkling
-and dripping in winter sun. But there was a sort of hunger
-in his glowing eyes, a longing?
+ "Will miss you no doubt." The irony was back in Moraelyn's voice, a voice that make [sic] Edward think of icicles sparkling and dripping in winter sun. But there was a sort of hunger in his glowing eyes, a longing?
 
- His father wouldn't miss him and he knew it. Shame ran through
-the boy, but he looked up at the broad-shouldered elf
-defiantly. "Are you my father?" Edward had meant the
-question to match the elf's sarcasm, but his hand crept to his
-ear as if of itself. He wasn't anything like his short-
-tempered, hearty, red-haired father ... and Roane often said
-he had an elfin look.
+ His father wouldn't miss him and he knew it. Shame ran through the boy, but he looked up at the broad-shouldered elf defiantly. "Are you my father?" Edward had meant the question to match the elf's sarcasm, but his hand crept to his ear as if of itself. He wasn't anything like his short-tempered, hearty, red-haired father ... and Roane often said he had an elfin look.
 
- There was a heavy silence and Edward sensed that Moraelyn
-was taking the question at face value but that truth had
-nothing to do with what Moraelyn would say next. He would
-give the expedient answer. Still--.
+ There was a heavy silence and Edward sensed that Moraelyn was taking the question at face value but that truth had nothing to do with what Moraelyn would say next. He would give the expedient answer. Still--.
 
- "No." It came reluctantly. He might be lying, of course,
-but Edward felt a deep wave of relief.
+ "No." It came reluctantly. He might be lying, of course, but Edward felt a deep wave of relief.
 
- "Does my mother have -- other sons?" Suddenly Edward knew she
-did not and that the question would hurt the dark elf. And
-was glad.
+ "Does my mother have -- other sons?" Suddenly Edward knew she did not and that the question would hurt the dark elf. And was glad.
 
- "Your mother might be dead, for all you know. Or care, it
-seems." The dark elf's narrow nostrils twitched as if
-Edward stank, and the lines around his mouth deepened.
+ "Your mother might be dead, for all you know. Or care, it seems." The dark elf's narrow nostrils twitched as if Edward stank, and the lines around his mouth deepened.
 
- She was not dead. Edward would have known. The bitter
-injustice of Moraelyn's contempt stung. "Did she send you to
-me?"
+ She was not dead. Edward would have known. The bitter injustice of Moraelyn's contempt stung. "Did she send you to me?"
 
- "Do you take me for an errand boy!" he snapped, and spoke to
-his companion: "Let us take him now and be gone; we may
-discuss it at leisure."
+ "Do you take me for an errand boy!" he snapped, and spoke to his companion "Let us take him now and be gone; we may discuss it at leisure."
 
- The golden elf held up his hand, "Patience, my cousin." and,
-to Edward, "Well, youngling, will you come?"
+ The golden elf held up his hand, "Patience, my cousin." and, to Edward, "Well, youngling, will you come?"
 
- Dark tales were told of human children kidnapped by elves,
-who hungered for young humans ... 
+ Dark tales were told of human children kidnapped by elves, who hungered for young humans ...
 
  "I don't know your name," Edward temporized.
 
  "Do you love your life here so much?"
 
- Edward looked at the palace in the distance, the banners
-floating lazily above ... the town below, the sparkling
-bay, the distant mountains. "I love Daggerfall."
+ Edward looked at the palace in the distance, the banners floating lazily above ... the town below, the sparkling bay, the distant mountains. "I love Daggerfall."
 
- "Ah. And you shall return to hold it, Prince Edward. I,
-I'ric Harad Egun the ArchMagister, swear it to you."
-Moraelyn swung about, protesting sharply in Elvish. The
-dragon spat a bit of flame, but the unicorn did not move;
-its golden eyes regarded Edward steadily. "Unicorns do not
-abide any sort of falsity." The words floated through his
-mind in his mother's voice.
+ "Ah. And you shall return to hold it, Prince Edward. I, I'ric Harad Egun the ArchMagister, swear it to you." Moraelyn swung about, protesting sharply in Elvish. The dragon spat a bit of flame, but the unicorn did not move; its golden eyes regarded Edward steadily. "Unicorns do not abide any sort of falsity." The words floated through his mind in his mother's voice.
 
  "I'ric Harad Egun the ArchMagister, I will come with you."
 
- "You must ride with Moraelyn. The Lord Akatosh has
-consented to this--necessity. The elf made a sweeping gesture
-toward the dragon."
+ "You must ride with Moraelyn. The Lord Akatosh has consented to this--necessity. The elf made a sweeping gesture toward the dragon." [sic]
 
- He wasn't fit to touch a unicorn, of course. "Very well,
-then. I--I don't suppose I could bring my dog?" Where was
-he? Shag was always with him. Asleep in the grass! Shag, the
-ever-alert? Edward knelt to touch him. A heated discussion in
-Elvish ensued, during which the dragon scorched the grass.
-Moraelyn swung down and picked Shag up with distaste. "Very
-well, then, but I warn you that Akatosh is at the limit of his
-patience. Mount, then."
+ He wasn't fit to touch a unicorn, of course. "Very well, then. I--I don't suppose I could bring my dog?" Where was he? Shag was always with him. Asleep in the grass! Shag, the ever-alert? Edward knelt to touch him. A heated discussion in Elvish ensued, during which the dragon scorched the grass. Moraelyn swung down and picked Shag up with distaste. "Very well, then, but I warn you that Akatosh is at the limit of his patience. Mount, then."
 
- "Lord Akatosh, I am most deeply obliged by your indulgence.
-If ever I may repay it--".
+ "Lord Akatosh, I am most deeply obliged by your indulgence. If ever I may repay it--".
 
- "You will," Moraelyn interrupted; he seized Edward by the
-belt and tossed him up onto the dragon. Edward settled
-himself between the dragon's neck and wings and the sleeping
-Shag was draped limply in front of him. "There isn't room
-for --" Edward began, and jerked in astonishment as the
-dragon shifted beneath him and grew larger. Much, much, much
-larger. Moraelyn vaulted up behind with a prodigious leap
-for one in armor. The unicorn jumped the nine foot wall,
-clearing it neatly. The dragon's great wings stretched; he
-crouched, then leapt into the air. His riders swayed wildly.
-The dark elf muttered something Edward couldn't understand
-in elvish and they steadied. The wings beat strongly and the
-dragon circled low over the Keep, gaining altitude
-slowly. People were running about now, shouting and
-pointing. Edward saw his old nurse and waved and shouted,
-"Goodbye! Goodbye! I'll be back sometime..." Arrows flew
-through the air as bowmen shot, while the nurse screamed and
-clutched at the arms of those nearest. King Corcyr ran naked
-onto the battlements, screaming and waving his fists. "Child
-of a demon, come back and I'll thrash you within an inch of
-your worthless life. Moraelyn, come down and fight, like the
-man you aren't."
+ "You will," Moraelyn interrupted; he seized Edward by the belt and tossed him up onto the dragon. Edward settled himself between the dragon's neck and wings and the sleeping Shag was draped limply in front of him. "There isn't room for --" Edward began, and jerked in astonishment as the dragon shifted beneath him and grew larger. Much, much, much larger. Moraelyn vaulted up behind with a prodigious leap for one in armor. The unicorn jumped the nine foot wall, clearing it neatly. The dragon's great wings stretched; he crouched, then leapt into the air. His riders swayed wildly. The dark elf muttered something Edward couldn't understand in elvish and they steadied. The wings beat strongly and the dragon circled low over the Keep, gaining altitude slowly. People were running about now, shouting and pointing. Edward saw his old nurse and waved and shouted, "Goodbye! Goodbye! I'll be back sometime..." Arrows flew through the air as bowmen shot, while the nurse screamed and clutched at the arms of those nearest. King Corcyr ran naked onto the battlements, screaming and waving his fists. "Child of a demon, come back and I'll thrash you within an inch of your worthless life. Moraelyn, come down and fight, like the man you aren't."
 
- Moraelyn's loud laughter rang clear as temple bells,
-cascading over the Keep. He shouted, "Be glad I don't,
-little King of the Small Cock!" The dragon circled almost
-lazily and let out a huge gout of flame. Arrows clinked
-harmlessly off his golden scales. "I'm off to see my
-mother!" Edward screamed down, noting the upturned faces
-of his stepmother and her red-haired sons. Roane had a fur-
-trimmed robe clutched round her, but her long hair floated
-wildly. Four pairs of eyes fastened on him, not Moraelyn,
-glittering with fury and hatred. Edward stopped waving and
-clutched Shag tightly with both hands. Moraelyn's mail
-clad arm was securely about his waist. Edward slumped
-against him, feeling quite safe for the first time in a very
-long while. The bowmen had stopped shooting; most of them
-were looking at the royal family. The king danced with rage.
-The great dragon's wings beat harder now and they headed due
-south out over the water.
+ Moraelyn's loud laughter rang clear as temple bells, cascading over the Keep. He shouted, "Be glad I don't, little King of the Small Cock!" The dragon circled almost lazily and let out a huge gout of flame. Arrows clinked harmlessly off his golden scales. "I'm off to see my mother!" Edward screamed down, noting the upturned faces of his stepmother and her red-haired sons. Roane had a fur-trimmed robe clutched round her, but her long hair floated wildly. Four pairs of eyes fastened on him, not Moraelyn, glittering with fury and hatred. Edward stopped waving and clutched Shag tightly with both hands. Moraelyn's mail clad arm was securely about his waist. Edward slumped against him, feeling quite safe for the first time in a very long while. The bowmen had stopped shooting; most of them were looking at the royal family. The king danced with rage. The great dragon's wings beat harder now and they headed due south out over the water.
 
- "Aren't we going to Ebonheart?" the boy twisted round and
-looked up at Moraelyn. "Your mother awaits you at
-Firsthold in Sumurset, little Prince."
+ "Aren't we going to Ebonheart?" the boy twisted round and looked up at Moraelyn. "Your mother awaits you at Firsthold in Sumurset, little Prince."
 
  "Why did you wait so long to fetch me?"
 
- "Querulous child, do you think dragons and unicorns do the
-bidding of elves or men? Your mother came to me full
-willing, but she could not bring you; you were too closely
-guarded by your father's men. Would you have had us lay
-waste your land to take you by force? She thought you would
-be safe and cared for ... and she was desperate. No, this was
-the dragon's plan."
+ "Querulous child, do you think dragons and unicorns do the bidding of elves or men? Your mother came to me full willing, but she could not bring you; you were too closely guarded by your father's men. Would you have had us lay waste your land to take you by force? She thought you would be safe and cared for ... and she was desperate. No, this was the dragon's plan."
 
- Of all the astonishing events of the afternoon, this was the
-most surprising: the notion that a dragon should take an
-interest in him, when not even his own family did. But,
-willing, the elf said, full willing!
+ Of all the astonishing events of the afternoon, this was the most surprising -- the notion that a dragon should take an interest in him, when not even his own family did. But, willing, the elf said, full willing!
 
- "You are the focus of large events, youngling. Your task
-is to prepare yourself to be a king--a king such as your
-people have never known. Our task is to aid you. Sleep now."
+ "You are the focus of large events, youngling. Your task is to prepare yourself to be a king--a king such as your people have never known. Our task is to aid you. Sleep now."
 
- Waves of sleep assaulted Edward's mind, one after another.
-"But--" he meant to ask Moraelyn about his mother, but the
-last wave was too big; it crashed right over him and he
-slipped into dark fire-shot dreams.
-
- 
+ Waves of sleep assaulted Edward's mind, one after another. "But--" he meant to ask Moraelyn about his mother, but the last wave was too big; it crashed right over him and he slipped into dark fire-shot dreams.

--- a/Assets/StreamingAssets/Text/Books/BOK00101-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00101-LOC.txt
@@ -1,531 +1,181 @@
-Title: King Edward, Part 2
+Title: King Edward, Part II
 Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
-[/center]King Edward, Part 2
-
-
+[/center]King Edward, Part II
 
 [/font=4]
 
-
-
-[/center]Chapter 2:
+[/center]
 
 [/center]Reunion at Firsthold
 
- Edward woke to a red sky. The sun was just peeking over the
-western mountains. They were nearing a glittering tower,
-fire flashing from every facet. The dragon veered to fly nearer and shot a long blast of flame. A
-light flashed several times from the tower's top as they
-dropped suddenly. Edward's stomach felt very peculiar. He
-sighed and stirred and felt Moraelyn shift so that his right
-arm now held Edward. He stretched and yawned.
+ Edward woke to a red sky. The sun was just peeking over the western mountains. They were nearing a glittering tower, fire flashing from every facet. The dragon veered to fly nearer and shot a long blast of flame. A light flashed several times from the tower's top as they dropped suddenly. Edward's stomach felt very peculiar. He sighed and stirred and felt Moraelyn shift so that his right arm now held Edward. He stretched and yawned.
 
- "Not much longer now. It's several days by horse from the
-Crystal Tower to Firsthold but I judge that Akatosh will
-have us there within the hour."
+ "Not much longer now. It's several days by horse from the Crystal Tower to Firsthold but I judge that Akatosh will have us there within the hour."
 
  "We're not stopping at the Tower? I'ric---"
 
- "Do not use that name so lightly, not even to me. The
-ArchMagister will not return for days yet. Unicorns are brothers to the wind and travel as fast, even burdened, but
-not as fast as dragons fly. You see the Elven homeland at dawn from the back of a dragon. Count yourself fortunate among men."
+ "Do not use that name so lightly, not even to me. The ArchMagister will not return for days yet. Unicorns are brothers to the wind and travel as fast, even burdened, but not as fast as dragons fly. You see the Elven homeland at dawn from the back of a dragon. Count yourself fortunate among men."
 
- Edward's gaze roamed the deep green woods and rugged hills. T
-here was
-no sign of habitation. "It's lovely," he said politely,
-"but not so beautiful as High Rock," he added out of loyalty and truth. "Are there no towns or villages or
-farms?"
+ Edward's gaze roamed the deep green woods and rugged hills. There was no sign of habitation. "It's lovely," he said politely, "but not so beautiful as High Rock," he added out of loyalty and truth. "Are there no towns or villages or farms?"
 
- "The Firstborn live nestled deep in the trees. And they do
-not tear up the earth and plant anew, but take gladly what
-Auriel offers ... and make return. Ahhh, the green smell of growing things."
+ "The Firstborn live nestled deep in the trees. And they do not tear up the earth and plant anew, but take gladly what Auriel offers ... and make return. Ahhh, the green smell of growing things."
 
- Indeed, the air was as heady as the wine Edward used to sip
-from his father's cup, before ... "I'm hungry."
+ Indeed, the air was as heady as the wine Edward used to sip from his father's cup, before ... "I'm hungry."
 
- "I expect so." A bit of shifting and Moraelyn's left hand
-produced a small leaf-wrapped package. The dusky hand was
-large and strong and looked neither human nor animal. Edward stared at it with revulsion,
-then took the package gingerly so as not to touch the hand. He
-felt Moraelyn stiffen and the hand that held Edward relaxed its grasp
-a bit. Edward felt ashamed of his reaction. It was neither
-kind nor wise to give offense in the circumstances. Moraelyn
-ere was
-no sign of habitation. "It's lovely," he said politely,
-"but not so beautiful as High Rock," he added out of loyalty and truth. "Are there no towns or villages or
-farms?"
+ "I expect so." A bit of shifting and Moraelyn's left hand produced a small leaf-wrapped package. The dusky hand was large and strong and looked neither human nor animal. Edward stared at it with revulsion, then took the package gingerly so as not to touch the hand. He felt Moraelyn stiffen and the hand that held Edward relaxed its grasp a bit. Edward felt ashamed of his reaction. It was neither kind nor wise to give offense in the circumstances. Moraelyn could quite easily drop him overboard. "I need to bathe, but so do you," he said stiffly. Moraelyn was deliberately misinterpreting the reaction, Edward knew. "Yes, I'm very dirty," Edward bit into the cake which proved much better than it looked. "My lady mother's used to seeing me like this--at least she used to be. But perhaps I should bathe first?"
 
- "The Firstborn live nestled deep in the trees. And they do
-not tear up the earth and plant anew, but take gladly what
-Auriel offers ... and make return. Ahhh, the green smell of growing things."
+ "I think you will not be offered that choice. Ah, at last!" The dragon spread his wings, sent a huge gout of flame soaring skyward and dropped to earth in a large clearing. The landing was abrupt and jarring. Elves appeared quite suddenly and arms reached up to take him and Shag, who woke at last, ran frantically in circles, and then sat panting at Edward's feet.
 
- Indeed, the air was as heady as the wine Edward used to sip
-from his father's cup, before ... "I'm hungry."
+ A tall elf with fiery hair like copper greeted them formally. "Greetings, my lord King. Your lady wife awaits you. Prince Edward, I welcome you to the land of the Firstborn on behalf of all its people. May your stay here prove pleasant and productive."
 
- "I expect so." A bit of shifting and Moraelyn's left hand
-produced a small leaf-wrapped package. The dusky hand was
-large and strong and looked neither human nor animal. Edward stared at it with revulsion,
-then took the package gingerly so as not to touch the hand. He
-felt Moraelyn stiffen and the hand that held Edward relaxed its grasp
-a bit. Edward felt ashamed of his reaction. It was neither
-kind nor wise to give offense in the circumstances. Moraelyn
-could quite easily drop him overboard. "I need to bathe,
-but so do you," he said stiffly. Moraelyn was deliberately
-misinterpreting the reaction, Edward knew. "Yes, I'm very
-dirty," Edward bit into the cake which proved much better
-than it looked. "My lady mother's used to seeing me like
-this--at least she used to be. But perhaps I should bathe
-first?"
+ Moraelyn nodded deferentially. "Thank you, my host. My Queen has waited long enough; we will go to her now." Moraelyn's hand on his shoulder steered Edward toward the largest tree he'd ever seen. The trunk was hollow; steps inside led up; openings gave out onto more steps and bridges along and among the mighty branches. They proceeded along these until they reached a large canopied platform, furnished with seats and chests as if it were a room. A golden skinned woman smiled at them and waved them in, then left. A tall slender, pale-skinned, dark-haired human woman paced toward them, her eyes on Edward. Only Edward.
 
- "I think you will not be offered that choice. Ah, at last!"
-The dragon spread his wings, sent a huge gout of flame
-soaring skyward and dropped to earth in a large clearing.
-The landing was abrupt and jarring. Elves appeared quite
-suddenly and arms reached up to take him and Shag, who woke
-at last, ran frantically in circles, and then sat panting
-at Edward's feet.
+ "Why did you leave us!" The cry came from deep inside, ringing through him. It stopped her several paces from him. Now her eyes lifted to Moraelyn, who said in a harsher tone than Edward had yet heard from him. "Thou wilt address thy Mother with respect, cub!" A glancing blow made his eyes water.
 
- A tall elf with fiery hair like copper greeted them
-formally. "Greetings, my lord King. Your lady wife awaits
-you. Prince Edward, I welcome you to the land of the Firstborn on behalf of all its
-people. May your stay here prove pleasant and productive."
+ Aliera crossed quickly to Moraelyn and placed her hands on his chest. "Greeting, my husband. All praise to Notorgo for bringing you and my son safely to me."
 
- Moraelyn nodded deferentially. "Thank you, my host. My
-Queen has waited long enough; we will go to her now."
-Moraelyn's hand on his shoulder steered Edward toward the
-largest tree he'd ever seen. The trunk was hollow; steps inside
-led up; openings gave out onto more steps and bridges
-along and among the mighty branches. They proceeded along
-these until they reached a large canopied platform,
-furnished with seats and chests as if it were a room. A golden
-skinned woman smiled at them and waved them in, then left. A
-tall slender, pale-skinned, dark-haired human woman paced
-toward them, her eyes on Edward. Only Edward.
+ "Thank also the Lord of the Dragons and the Bandit, who could not have lifted the boy more neatly himself. The ArchMagister had somewhat to do with it as well." Moraelyn's dusky hands came up to hold her bare arms lightly and tenderly. He laughed, looking relaxed and happy. But the hands against his chest formed a barrier as much as a caress.
 
- "Why did you leave us!" The cry came from deep inside,
-ringing through him. It stopped her several paces from him.
-Now her eyes lifted to Moraelyn, who said in a harsher tone
-than Edward had yet heard from him. "Thou wilt address thy Mother with respect, cub!" A glancing blow made his eyes water.
+ "I am blessed indeed. But it has been long since my son and I have spoken. We may find words more easily if we seek them alone together."
 
- Aliera crossed quickly to Moraelyn and placed her hands on his chest. "Greeting, my husband.
-All praise to Notorgo for bringing you and my son safely to
-me."
+ Moraelyn's smile vanished instantly. "Are words then a thing which two can find more easily than three? Well. Perhaps. At times. Wife." He turned on his heel and left. The bridge swung and creaked, but his feet made no sound at all.
 
- "Thank also the Lord of the Dragons and the Bandit, who
-could not have lifted the boy more neatly himself. The
-ArchMagister had somewhat to do with it as well."
-Moraelyn's dusky hands came up to hold her bare arms lightly and
-tenderly. He laughed, looking relaxed and happy. But the
-hands against his chest formed a barrier as much as a caress.
+ Aliera watched after him, but he did not look back. Edward felt again the curious mix of satisfaction and regret that came with giving pain to his enemy. "Edward, my son, come and sit by me."
 
- "I am blessed indeed. But it has been long since my son and I
-have spoken. We may find words more easily if we seek them
-alone together."
-
- Moraelyn's smile vanished instantly. "Are words then a
-thing which two can find more easily than three? Well.
-Perhaps. At times. Wife." He turned on his heel and left. The bridge swung and creaked, but his feet made
-no sound at all.
-
- Aliera watched after him, but he did not look back. Edward felt again the curious mix of satisfaction and
-regret that came with giving pain to his enemy. "Edward, my
-son, come and sit by me."
-
- Edward stood where he was, "Madam mother, I have waited many
-years and travelled many leagues to have an answer. I will
-wait no longer, nor go one step further."
+ Edward stood where he was, "Madam mother, I have waited many years and travelled many leagues to have an answer. I will wait no longer, nor go one step further."
 
  "What have you been told?"
 
- "That you were most treacherously kidnapped by night with
-the aid of magic, while my father slept, trusting in the
-honor of his guest."
+ "That you were most treacherously kidnapped by night with the aid of magic, while my father slept, trusting in the honor of his guest."
 
  "Your father told you that. And Moraelyn?"
 
  "Said that you came full willing. I would hear what you say."
 
- "Would you hear why I left your father or why I did not take
-you with me, having chosen to go."
+ "Would you hear why I left your father or why I did not take you with me, having chosen to go."
 
- Edward paused, thinking, "Madam, I would hear the truth, therefore I must
-give the truth. I would hear why you left me behind. The
-other, I think I know, as much as I can or would know, unless you wish to tell me more or
-other."
+ Edward paused, thinking, "Madam, I would hear the truth, therefore I must give the truth. I would hear why you left me behind. The other, I think I know, as much as I can or would know, unless you wish to tell me more or other."
 
- "The truth? Truth is not a single thing existing apart from those who
-apprehend it. But I will tell you my truth and perhaps then
-you may arrive at your truth.
+ "The truth? Truth is not a single thing existing apart from those who apprehend it. But I will tell you my truth and perhaps then you may arrive at your truth.
 
- Aliera walked back to a softly pillowed chair and composed
-herself. Nearby a small ruby colored bird settled on a
-branch and trilled an accompaniment to her soft voice.
+ Aliera walked back to a softly pillowed chair and composed herself. Nearby a small ruby colored bird settled on a branch and trilled an accompaniment to her soft voice.
 
- "My parents arranged my marriage as is the custom of our
-homeland. I did not love Corcyr, but in the beginning I
-respected him and tried to be a good wife. He did not care for
-me, nor did he take care. And so he lost my respect and I died
-a little each day, withering like an untended plant. I was
-happy only with you, but Corcyr thought I was making you too soft. "Womanish," he said, and so, after your third
-birthday I was allowed to spend only an hour each day with
-you. I listened to your cries and sat weeping, without
-heart for anything. Finally, you ceased crying and asking for me, and my heart was left empty. I
-formed the habit of walking and riding much of the time, alone save for a guard or two. Then Moraelyn came. He
-wanted to mine for ebony in the Wrothgarian Mountains. The land he
-wanted to use was part of my dowry. He was willing to train
-our people in the arts of its use and even to give them
-weapons of Dark Elf making. In return our people were to
-aid him in keeping the goblins away, and allow him to form a
-colony of his people in High Rock. Corcyr had no use for the
-land and he wanted the weapons very much indeed -- there are
-none better -- so he favored the proposal. There were many
-details to be discussed and arranged and it fell to me to
-conduct these negotiations. Corcyr despises Dark Elves and he
-was jealous of Moraelyn, who was already famed as the finest fighter in all Tamriel.
+ "My parents arranged my marriage as is the custom of our homeland. I did not love Corcyr, but in the beginning I respected him and tried to be a good wife. He did not care for me, nor did he take care. And so he lost my respect and I died a little each day, withering like an untended plant. I was happy only with you, but Corcyr thought I was making you too soft. "Womanish," he said, and so, after your third birthday I was allowed to spend only an hour each day with you. I listened to your cries and sat weeping, without heart for anything. Finally, you ceased crying and asking for me, and my heart was left empty. I formed the habit of walking and riding much of the time, alone save for a guard or two. Then Moraelyn came. He wanted to mine for ebony in the Wrothgarian Mountains. The land he wanted to use was part of my dowry. He was willing to train our people in the arts of its use and even to give them weapons of Dark Elf making. In return our people were to aid him in keeping the goblins away, and allow him to form a colony of his people in High Rock. Corcyr had no use for the land and he wanted the weapons very much indeed -- there are none better -- so he favored the proposal. There were many details to be discussed and arranged and it fell to me to conduct these negotiations. Corcyr despises Dark Elves and he was jealous of Moraelyn, who was already famed as the finest fighter in all Tamriel.
 
- "But Moraelyn is more than a skilled fighter; he's well-read and interested in everything under the sun. He sang
-and played as if taught by Jeh Free and Jhim Sei both. He was
-a companion such as I'd only dreamed of ... that and no
-more, I swear. We both love to be outside, so our discussions took place while riding and walking, but always
-accompanied by his men and Corcyr's. When all was
-arranged, Corcyr gave a great feast to celebrate the
-treaty. All of High Rock nobility came and many from other
-provinces. At the end Corcyr was deep in his cups and let
-fall an insult that could only be washed out in blood. I had
-long since retired with the other ladies so I know not what it
-was, but I'd heard enough in private to know that Corcyr had a store of such to choose from. Moraelyn gave the
-challenge and gave Corcyr until noon, that he might recover
-such wits as he had.
+ "But Moraelyn is more than a skilled fighter; he's well-read and interested in everything under the sun. He sang and played as if taught by Jeh Free and Jhim Sei both. He was a companion such as I'd only dreamed of ... that and no more, I swear. We both love to be outside, so our discussions took place while riding and walking, but always accompanied by his men and Corcyr's. When all was arranged, Corcyr gave a great feast to celebrate the treaty. All of High Rock nobility came and many from other provinces. At the end Corcyr was deep in his cups and let fall an insult that could only be washed out in blood. I had long since retired with the other ladies so I know not what it was, but I'd heard enough in private to know that Corcyr had a store of such to choose from. Moraelyn gave the challenge and gave Corcyr until noon, that he might recover such wits as he had.
 
- "Then Moraelyn came to me, alone in my chamber, and told
-me what had befallen. 'Milady, I think he will choose your
-brother as his champion; in any case there will be a river of blood between us
-that may not be crossed in this life or any other. I can live
-without your love, but I would not have your enmity. Come
-with me now, as wife or honored guest, as you choose. And you
-shall serve as blood price in stead of your kith or kin.'
+ "Then Moraelyn came to me, alone in my chamber, and told me what had befallen. 'Milady, I think he will choose your brother as his champion; in any case there will be a river of blood between us that may not be crossed in this life or any other. I can live without your love, but I would not have your enmity. Come with me now, as wife or honored guest, as you choose. And you shall serve as blood price in stead of your kith of kin.'
 
- "And there, in the moonlight, in my terror, with my ladies
-sleeping about me, I knew I loved him. Doubted that I could
-live without him. And yet, I loved you more! 'My son,' I
-whispered. 'I can't--'. 'Milady, you must choose. I am
-sorry.' You see, don't you, Edward? If I stayed, it meant
-my brother's death -- his innocent young blood. Or your
-father's! Or possibly that of the man I loved, though I
-counted that most unlikely. Moraelyn's fighting skills alone were supreme, and in an
-affair of this sort he would be entitled to call on magic aid as well. 'We could take him with us.' But
-Moraelyn shook his head sadly, 'That I will not do. It would
-go against my honor to part father and son.'
+ "And there, in the moonlight, in my terror, with my ladies sleeping about me, I knew I loved him. Doubted that I could live without him. And yet, I loved you more! 'My son,' I whispered. 'I can't--'. 'Milady, you must choose. I am sorry.' You see, don't you, Edward? If I stayed, it meant my brother's death -- his innocent young blood. Or your father's! Or possibly that of the man I loved, though I counted that most unlikely. Moraelyn's fighting skills alone were supreme, and in an affair of this sort he would be entitled to call on magic aid as well. 'We could take him with us.' But Moraelyn shook his head sadly, 'That I will not do. It would go against my honor to part father and son.'
 
- "Leaving love alone, I am trained to duty", Aliera said
-proudly. "Should I have robbed you of your father or your
-loving uncle? And I thought it likely that Corcyr, should he
-survive, would somehow blame me for the affair and use it
-as an excuse to put me away. I thought that Corcyr would be
-pleased to have me gone. I knew he wanted the weapons very
-much. I could trade them for time with you, I thought." All
-this passed through my mind while Moraelyn stood waiting, not
-looking at me.
+ "Leaving love alone, I am trained to duty", Aliera said proudly. "Should I have robbed you of your father or your loving uncle? And I thought it likely that Corcyr, should he survive, would somehow blame me for the affair and use it as an excuse to put me away. I thought that Corcyr would be pleased to have me gone. I knew he wanted the weapons very much. I could trade them for time with you, I thought." All this passed through my mind while Moraelyn stood waiting, not looking at me.
 
- "Lady Mara, help me to choose wisely, I prayed. 'You
-truly want me as wife? I--I could bring you nothing but
-trouble.'
+ "Lady Mara, help me to choose wisely, I prayed. 'You truly want me as wife? I--I could bring you nothing but trouble.'
 
- "Aliera, I would have you to wife. And I want nothing but
-yourself." He shed his cloak and wrapped it round my body,
-pulling the bedclothes away.
+ "Aliera, I would have you to wife. And I want nothing but yourself." He shed his cloak and wrapped it round my body, pulling the bedclothes away.
 
  "Moraelyn, wait--is this right, what I do?"
 
- "Milady, if I thought this wrong, I should not be standing
-here! Of the choices you are given, this one seems to me most
-right." He swung me up in his arms and carried me to his horse.
-And so I left your father's house, clad only in his cloak and
-riding before him. And wild joy mixed with my sorrow, so that I scarce knew how
-I felt. That is my truth."
+ "Milady, if I thought this wrong, I should not be standing here! Of the choices you are given, this one seems to me most right." He swung me up in his arms and carried me to his horse. And so I left your father's house, clad only in his cloak and riding before him. And wild joy mixed with my sorrow, so that I scarce knew how I felt. That is my truth."
 
- Edward said quietly, "But he has parted my father and me in
-the end."
+ Edward said quietly, "But he has parted my father and me in the end."
 
- "With great reluctance. And only becaue the dragon says
-that you and your father were in truth already parted in hear
-t. It is only a matter of
-more leagues. Which provide a measure of safety for you.
-Moraelyn insisted that you should freely consent to come.
-You are as free to return any time you wish."
+ "With great reluctance. And only becaue [sic] the dragon says that you and your father were in truth already parted in heart. It is only a matter of more leagues. Which provide a measure of safety for you. Moraelyn insisted that you should freely consent to come. You are as free to return any time you wish."
 
- "Moraelyn would have just taken me! It was I'r--I mean, the ArchMagister, who insisted that I
-must consent."
+ "Moraelyn would have just taken me! It was I'r--I mean, the ArchMagister, who insisted that I must consent."
 
- "He's not a patient man by nature. And he is anxious to do
-Corcyr no harm. Doubtless he felt the discussion could be
-carried on as well elsewhere."
+ "He's not a patient man by nature. And he is anxious to do Corcyr no harm. Doubtless he felt the discussion could be carried on as well elsewhere."
 
- "He called him King of the Small Cock. And laughed. Why?
-Are Daggerfall cockerels smaller than Ebonheart birds? And
-what does it matter, anyway? My father was very angry; I
-think he would have liked to fight. But it's true he hates me. I
-knew that, but I didn't want to know, so I pretended not to.
-I don't suppose Moraelyn would do that."
-
- "No."
-
-. It is only a matter of
-more leagues. Which provide a measure of safety for you.
-Moraelyn insisted that you should freely consent to come.
-You are as free to return any time you wish."
-
- "Moraelyn would have just taken me! It was I'r--I mean, the ArchMagister, who insisted that I
-must consent."
-
- "He's not a patient man by nature. And he is anxious to do
-Corcyr no harm. Doubtless he felt the discussion could be
-carried on as well elsewhere."
-
- "He called him King of the Small Cock. And laughed. Why?
-Are Daggerfall cockerels smaller than Ebonheart birds? And
-what does it matter, anyway? My father was very angry; I
-think he would have liked to fight. But it's true he hates me. I
-knew that, but I didn't want to know, so I pretended not to.
-I don't suppose Moraelyn would do that."
+ "He called him King of the Small Cock. And laughed. Why? Are Daggerfall cockerels smaller than Ebonheart birds? And what does it matter, anyway? My father was very angry; I think he would have liked to fight. But it's true he hates me. I knew that, but I didn't want to know, so I pretended not to. I don't suppose Moraelyn would do that."
 
  "No."
 
  "He'd lie, though. He thought about telling me he was my father. I could see it."
 
- Aliera threw back her head and laughed her pretty rippling
-laugh; he remembered it from long ago, and it sent shivers
-down his back. "He must have wanted to claim it very badly
-indeed if he let you see it; he's usually quicker than that.
-And he does not lie under oath, or to hurt those he loves."
+ Aliera threw back her head and laughed her pretty rippling laugh; he remembered it from long ago, and it sent shivers down his back. "He must have wanted to claim it very badly indeed if he let you see it; he's usually quicker than that. And he does not lie under oath, or to hurt those he loves."
 
  "He doesn't love me; he doesn't even like me."
 
- "But I do, my dear son. You--" Edward thought she was going
-to say he'd grown; adults always remarked on his growth, even
-if he'd just seen them a week ago. Very strange, since he was
-small for his age. Instead she said, "You're just as I
-thought you'd be," with deep maternal satisfaction.
+ "But I do, my dear son. You--" Edward thought she was going to say he'd grown; adults always remarked on his growth, even if he'd just seen them a week ago. Very strange, since he was small for his age. Instead she said, "You're just as I thought you'd be," with deep maternal satisfaction.
 
- "And he loves you. But he said he was no one's errand boy.
-Yet you dismissed him as if he were."
+ "And he loves you. But he said he was no one's errand boy. Yet you dismissed him as if he were."
 
  Aliera's face and neck burned a deep crimson.
 
- "Nay, though I am reduced to serving man, it seems."
-Moraely
-n had entered silently, bearing a huge tray piled high
-with food. "Get me a stool, boy, you can play page if I can
-play server. You must be famished and I thought I'd best
-return before my wife gets round to the rest of my faults.
-Could take her most of the day listing them." He'd shed the mail and bathed and dressed
-in fresh black jerkin and hose with a silvery sash tied round
-his narrow waist. But the black sword still swung by his
-side.
+ "Nay, though I am reduced to serving man, it seems." Moraelyn had entered silently, bearing a huge tray piled high with food. "Get me a stool, boy, you can play page if I can play server. You must be famished and I thought I'd best return before my wife gets round to the rest of my faults. Could take her most of the day listing them." He'd shed the mail and bathed and dressed in fresh black jerkin and hose with a silvery sash tied round his narrow waist. But the black sword still swung by his side.
 
- "Mara help us, you've enough food for a small army. And
-I've broken my fast." Aliera's small hand reached for the
-elf's arm, slid down it caressingly, then clasped his hand
-and squeezed it, lifting it to her still hot cheek, brushing
-it with her lips. Edward looked away quickly, discomforted by
-the sight of his dusky skin against her fairness.
+ "Mara help us, you've enough food for a small army. And I've broken my fast." Aliera's small hand reached for the elf's arm, slid down it caressingly, then clasped his hand and squeezed it, lifting it to her still hot cheek, brushing it with her lips. Edward looked away quickly, discomforted by the sight of his dusky skin against her fairness.
 
- "This's for me, and a bit for the boy. But pray join us, my
-dear. You've grown thin. Pining for me, no doubt." He
-wrapped a lock of her dark curly hair around a finger and
-tugged at it, grinning, then fell on the food like a
-starving wolf, attacking it with small silvery weapons inste
-ad of eating with his
-fingers as humans did. The food was -- wonderful. Edward ate
-until he could eat no more.
+ "This's for me, and a bit for the boy. But pray join us, my dear. You've grown thin. Pining for me, no doubt." He wrapped a lock of her dark curly hair around a finger and tugged at it, grinning, then fell on the food like a starving wolf, attacking it with small silvery weapons instead of eating with his fingers as humans did. The food was -- wonderful. Edward ate until he could eat no more.
 
- "Eavesdropping," he murmured thoughtfully. He'd been
-mulling over a list of Moraelyn's faults while he ate, and realized too late that he'd
-spoken aloud.
 
- "By Zenithar, boy, if you humans will shout your privy conversation all over the tree, d'ye
-expect me to shut my ears with wool?" He tapped one of his
-large pointed ears. Edward hurriedly tried to remember what
-they'd said. What he'd said. Lying. Oh dear. Maybe he hadn't
-heard.
+ "Eavesdropping," he murmured thoughtfully. He'd been mulling over a list of Moraelyn's faults while he ate, and realized too late that he'd spoken aloud.
 
- "So I'm a liar, am I, boy?" Vir Gil help him, Edward felt
-he was drowning. Could the Elf read minds? He hoped that
-wasn't the insult his father had used! "I -- I meant I thought
-that you were thinking about it. You did hesitate," Edward
-gulped. He was making matters worse.
+ "By Zenithar, boy, if you humans will shout your privy conversation all over the tree, d'ye expect me to shut my ears with wool?" He tapped one of his large pointed ears. Edward hurriedly tried to remember what they'd said. What he'd said. Lying. Oh dear. Maybe he hadn't heard.
 
- "Possibly, I was trying to remember ... " the sardonic
- had entered silently, bearing a huge tray piled high
-with food. "Get me a stool, boy, you can play page if I can
-play server. You must be famished and I thought I'd best
-return before my wife gets round to the rest of my faults.
-Could take her most of the day listing them." He'd shed the mail and bathed and dressed
-in fresh black jerkin and hose with a silvery sash tied round
-his narrow waist. But the black sword still swung by his
-side.
+ "So I'm a liar, am I, boy?" Vir Gil help him, Edward felt he was drowning. Could the Elf read minds? He hoped that wasn't the insult his father had used! "I -- I meant I thought that you were thinking about it. You did hesitate," Edward gulped. He was making matters worse.
 
- "Mara help us, you've enough food for a small army. And
-I've broken my fast." Aliera's small hand reached for the
-elf's arm, slid down it caressingly, then clasped his hand
-and squeezed it, lifting it to her still hot cheek, brushing
-it with her lips. Edward looked away quickly, discomforted by
-the sight of his dusky skin against her fairness.
-
- "This's for me, and a bit for the boy. But pray join us, my
-dear. You've grown thin. Pining for me, no doubt." He
-wrapped a lock of her dark curly hair around a finger and
-tugged at it, grinning, then fell on the food like a
-starving wolf, attacking it with small silvery weapons inste
-ad of eating with his
-fingers as humans did. The food was -- wonderful. Edward ate
-until he could eat no more.
-
- "Eavesdropping," he murmured thoughtfully. He'd been
-mulling over a list of Moraelyn's faults while he ate, and realized too late that he'd
-spoken aloud.
-
- "By Zenithar, boy, if you humans will shout your privy conversation all over the tree, d'ye
-expect me to shut my ears with wool?" He tapped one of his
-large pointed ears. Edward hurriedly tried to remember what
-they'd said. What he'd said. Lying. Oh dear. Maybe he hadn't
-heard.
-
- "So I'm a liar, am I, boy?" Vir Gil help him, Edward felt
-he was drowning. Could the Elf read minds? He hoped that
-wasn't the insult his father had used! "I -- I meant I thought
-that you were thinking about it. You did hesitate," Edward
-gulped. He was making matters worse.
-
- "Possibly, I was trying to remember ... " the sardonic
-d of eating with his
-fingers as humans did. The food was -- wonderful. Edward ate
-until he could eat no more.
-
- "Eavesdropping," he murmured thoughtfully. He'd been
-mulling over a list of Moraelyn's faults while he ate, and realized too late that he'd
-spoken aloud.
-
- "By Zenithar, boy, if you humans will shout your privy conversation all over the tree, d'ye
-expect me to shut my ears with wool?" He tapped one of his
-large pointed ears. Edward hurriedly tried to remember what
-they'd said. What he'd said. Lying. Oh dear. Maybe he hadn't
-heard.
-
- "So I'm a liar, am I, boy?" Vir Gil help him, Edward felt
-he was drowning. Could the Elf read minds? He hoped that
-wasn't the insult his father had used! "I -- I meant I thought
-that you were thinking about it. You did hesitate," Edward
-gulped. He was making matters worse.
-
- "Possibly, I was trying to remember ... " the sardonic
-tone was back.
+ "Possibly, I was trying to remember ... " the sardonic tone was back.
 
  "You don't even like me!" Edward burst out.
 
  "That doesn't seem to have stopped your true father from claiming you."
 
- "Moraelyn! Don't!" Aliera interrupted, but the Elf held
-up his hand to quiet her.
+ "Moraelyn! Don't!" Aliera interrupted, but the Elf held up his hand to quiet her.
 
  "I'm not so sure." Edward flashed.
 
  "Why do you say that?"
 
- "I don't know--Roane says--things--and I'm not at all like
-him. Everyone remarks on it. And then stops talking."
+ "I don't know--Roane says--things--and I'm not at all like him. Everyone remarks on it. And then stops talking."
 
  "What--things? Speak, boy!"
 
- "About how fond Mother was of her brother when they were
-young. How sad and angry he was when she was carried off. More
-like a lover, she said, than a brother. She says it very
-sweetly, but like she means something by it. Something too
-dirty to say. Other times she talks about how elfin I look. And how
-quickly after marriage I came. Not as quickly as her first
-son, though."
+ "About how fond Mother was of her brother when they were young. How sad and angry he was when she was carried off. More like a lover, she said, than a brother. She says it very sweetly, but like she means something by it. Something too dirty to say. Other times she talks about how elfin I look. And how quickly after marriage I came. Not as quickly as her first son, though."
 
- Moraelyn leaped up. "By the Avenger, I will go back and
-wring the vixen's neck! The human--", he bit off the insult,
-but his red eyes flamed rage; his muscles swelled and his hair
-stood on end. "You do not look half-elven. I never met your
-mother until four years after your conception. Roane, it
-seems, cannot decide which lie she wishes to use. But incest!
-May Kel strike her down if I may not." The tall elf paced
-furiously about the room, lithe as a Khajiit, hand fondling his sword hilt. The
-platform swayed and dipped.
+ Moraelyn leaped up. "By the Avenger, I will go back and wring the vixen's neck! The human--", he bit off the insult, but his red eyes flamed rage; his muscles swelled and his hair stood on end. "You do not look half-elven. I never met your mother until four years after your conception. Roane, it seems, cannot decide which lie she wishes to use. But incest! May Kel strike her down if I may not." The tall elf paced furiously about the room, lithe as a Khajiit, hand fondling his sword hilt. The platform swayed and dipped.
 
- "She's ambitious for her sons, at Edward's expense. The
-question is, how many will believe her. Not enough if she was
-planning to have him killed instead." Aliera's smooth brow
-wrinkled a bit. "I never disliked her, you know. Nor she me. She
-wanted my place and I was glad enough to let her have it
-save for Edward."
+ "She's ambitious for her sons, at Edward's expense. The question is, how many will believe her. Not enough if she was planning to have him killed instead." Aliera's smooth brow wrinkled a bit. "I never disliked her, you know. Nor she me. She wanted my place and I was glad enough to let her have it save for Edward."
 
- "You want me to be king so I'll let you have the ebon mines."
-Edward had just worked out the puzzle.
+ "You want me to be king so I'll let you have the ebon mines." Edward had just worked out the puzzle.
 
- "Oh, devil take the ebon, which he probably will. I've a better chance
-of getting co-operation from Roane's boys once your
-father's dead. They'd have reason for gratitude and the
-bargain's a good one. Although the chances they could keep a
-civil tongue long enough to sign a contract seem poor, given their parentage."
+ "Oh, devil take the ebon, which he probably will. I've a better chance of getting co-operation from Roane's boys once your father's dead. They'd have reason for gratitude and the bargain's a good one. Although the chances they could keep a civil tongue long enough to sign a contract seem poor, given their parentage."
 
  "Then why? You don't even like me."
 
- "Mara, help me! 'Liking' a person is a human concept. One
-day they like you, the next day they don't. On Tirdas they're
-back to liking you again. My own wife does this to me, but
-claims to love me even when she doesn't like me. Except of
-course on the days when she doesn't do either, and talks about
-joining the Order of Riana. Fortunately that only happens
-once a year or so. I go hunting until she comes to her
-senses."
+ "Mara, help me! 'Liking' a person is a human concept. One day they like you, the next day they don't. On Tirdas they're back to liking you again. My own wife does this to me, but claims to love me even when she doesn't like me. Except of course on the days when she doesn't do either, and talks about joining the Order of Riana. Fortunately that only happens once a year or so. I go hunting until she comes to her senses."
 
- "You exaggerate; that only happened once, and well you
-know it."
+ "You exaggerate; that only happened once, and well you know it."
 
- "I remember enjoying the recovery period. Maybe it should
-happen more often." They grinned at each other.
+ "I remember enjoying the recovery period. Maybe it should happen more often." They grinned at each other.
 
  "But why do you want me to be King?" Edward persisted.
 
- "I told you; it's Akatosh's notion. And the ArchMagister's. I just came along for
-the ride. Ask them."
+ "I told you; it's Akatosh's notion. And the ArchMagister's. I just came along for the ride. Ask them."
 
  "I shall ask the ArchMagister when I see him."
 
- "An excellent plan. You'll spend a few weeks at the Tower
-before heading north with us."
+ "An excellent plan. You'll spend a few weeks at the Tower before heading north with us."
 
  "Only that?"
 
- "Does the prospect of spending the winter with your mother
-and me displease you so much?"
+ "Does the prospect of spending the winter with your mother and me displease you so much?"
 
- "No ... no, sir. But I agreed to go with I'ric." Not you.
-The words hung unsaid between them.
+ "No ... no, sir. But I agreed to go with I'ric." Not you. The words hung unsaid between them.
 
- "You will, in time. A few weeks there now will fit you to
-begin your training in magic; I can teach you spells. But you need
-hardening; your body must catch up to your mind. It is the
-ArchMagister's will."
+ "You will, in time. A few weeks there now will fit you to begin your training in magic; I can teach you spells. But you need hardening; your body must catch up to your mind. It is the ArchMagister's will."
 
- "Fighting magic? I want to learn other things. How to call
-beasts. How to heal. And float..."
+ "Fighting magic? I want to learn other things. How to call beasts. How to heal. And float..."
 
- "You'll learn that, I doubt not. And d'ye think a fighter
-can't Heal? It's the first spell you'll learn. But a King
-must know how to fight."
+ "You'll learn that, I doubt not. And d'ye think a fighter can't Heal? It's the first spell you'll learn. But a King must know how to fight."
 
  "I'm not good at it."
 
@@ -533,26 +183,15 @@ must know how to fight."
 
  "If I cannot?"
 
- "You've courage and a clear head and the potential to
-learn magic; that's more than most people ever have. I can
-teach you the rest."
+ "You've courage and a clear head and the potential to learn magic; that's more than most people ever have. I can teach you the rest."
 
- Edward's head whirled with the unaccustomed praise. "I do? I
-have? You can?"
+ Edward's head whirled with the unaccustomed praise. "I do? I have? You can?"
 
- "D'ye think any of your father's fool court would stand
-naked before a dragon, a unicorn, the ArchMagister, and the
-Champion of Tamriel and demand justice of them? Justice!
-Faced with such, they might have managed to beg for mercy, if
-they could speak at all, which is doubtful."
+ "D'ye think any of your father's fool court would stand naked before a dragon, a unicorn, the ArchMagister, and the Champion of Tamriel and demand justice of them? Justice! Faced with such, they might have managed to beg for mercy, if they could speak at all, which is doubtful."
 
- "I did that? I did, didn't I?" Edward was astonished; he wanted to
-add that he hadn't known, hadn't thought about it ... 
+ "I did that? I did, didn't I?" Edward was astonished; he wanted to add that he hadn't known, hadn't thought about it ...
 
- "Aye, you did. And it's a deed that shall be sung from here
-to Morrowwind; I'll compose the ballad myself--as soon as
-I have a nap. I don't sleep as sound as some on dragon's
-backs."
+ "Aye, you did. And it's a deed that shall be sung from here to Morrowwind [sic]; I'll compose the ballad myself--as soon as I have a nap. I don't sleep as sound as some on dragon's backs."
 
  "You enchanted me and Shag asleep!"
 
@@ -560,54 +199,18 @@ backs."
 
  "Ooooohhhh. Can you levitate? Will you show me?"
 
- "Not so fast. I kept a holding spell on us all night to keep
-us on the dragon's back.  Until I'm rested I couldn't light a
-candle with the aid of a match."
+ "Not so fast. I kept a holding spell on us all night to keep us on the dragon's back. Until I'm rested I couldn't light a candle with the aid of a match."
 
- "Oh. Well, I'd still rather be like the ArchMagister than be
-a fighter."
+ "Oh. Well, I'd still rather be like the ArchMagister than be a fighter."
 
- "Hah! It'll be news to the ArchMagister that he cannot fight! I hope
-he'll find time to show you how to wield a staff. No better
-weapon for early training. And no better trainer. Now, of
-the four you saw before you, which would you say could best
-the others?"
+ "Hah! It'll be news to the ArchMagister that he cannot fight! I hope he'll find time to show you how to wield a staff. No better weapon for early training. And no better trainer. Now, of the four you saw before you, which would you say could best the others?"
 
- Edward thought carefully for several minutes. "Sir, my
-judgement is poor indeed, but if you would still have my
-answer, it would seem that the one who claims the title
-Champion of Tamriel must be the best. Yet must not the
-ArchMagister be your master in magic? And trained to arms as well, it
-seems. So which should prevail? Could any mortal stand
-against the dragon's fire and claws and teeth? And I know
-naught of the unicorn, save that it is fleet and has a very
-sharp horn, and hooves as well. So I will guess the
-unicorn; it had the mildest manner. And since you asked the
-question it seems the unlikely answer may be correct."
+ Edward thought carefully for several minutes. "Sir, my judgement is poor indeed, but if you would still have my answer, it would seem that the one who claims the title Champion of Tamriel must be the best. Yet must not the ArchMagister be your master in magic? And trained to arms as well, it seems. So which should prevail? Could any mortal stand against the dragon's fire and claws and teeth? And I know naught of the unicorn, save that it is fleet and has a very sharp horn, and hooves as well. So I will guess the unicorn; it had the mildest manner. And since you asked the question it seems the unlikely answer may be correct."
 
- "Well answered, youngling! The unicorn would win easily in any
-single close combat. No mortal or even dragon can move
-quickly enough to land a blow and it cannot be burned or
-touched by any magic or elemental power. It's hooves are
-deadly and a single touch of its horn will kill any enemy,
-although the horn itself will burn away. The most powerful can regenerate it
-within moments, however.
+ "Well answered, youngling! The unicorn would win easily in any single close combat. No mortal or even dragon can move quickly enough to land a blow and it cannot be burned or touched by any magic or elemental power. It's hooves are deadly and a single touch of its horn will kill any enemy, although the horn itself will burn away. The most powerful can regenerate it within moments, however.
 
- "And of the four the Champion of Tamriel would probably
-be the loser against any of the others, although the title is
-no idle boast! Moraelyn is not accustomed to being so
-outclassed. My manners may have suffered in consequence."
+ "And of the four the Champion of Tamriel would probably be the loser against any of the others, although the title is no idle boast! Moraelyn is not accustomed to being so outclassed. My manners may have suffered in consequence."
 
- "Milord King, I am most deeply in your debt. You have done me great honor and service. If ever
-I can repay you, I will. Forgive my brash words and ill
-manners. I have dwelt among the rude and boorish. And it seems I have no father, unless I may call you so?" The elf held his hands out to the boy, who placed his own in them. Edward's feeling of
-distaste was quite gone...as if by magic...the thought
-drifted through his mind ... and then he released his hands and
-clasped Moraelyn about his waist. The elf's hands stroked the
-dark hair and clasped the thin shoulders.
+ "Milord King, I am most deeply in your debt. You have done me great honor and service. If ever I can repay you, I will. Forgive my brash words and ill manners. I have dwelt among the rude and boorish. And it seems I have no father, unless I may call you so?" The elf held his hands out to the boy, who placed his own in them. Edward's feeling of distaste was quite gone...as if by magic...the thought drifted through his mind ... and then he released his hands and clasped Moraelyn about his waist. The elf's hands stroked the dark hair and clasped the thin shoulders.
 
- "I thank you, my wife. After only five years of marriage,
-you have presented me with a fine son, nine years of age.
-Remarkable. In fact...magical."
-
- 
+ "I thank you, my wife. After only five years of marriage, you have presented me with a fine son, nine years of age. Remarkable. In fact...magical."

--- a/Assets/StreamingAssets/Text/Books/BOK00102-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00102-LOC.txt
@@ -3,65 +3,32 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]King Edward, Part III
 
-
-
 [/font=4]
 
- Chapter 3: Lessons
+[/center]
 
- The golden days passed swiftly. Edward spent most of his
-time in the company of his parents. He saw few other children.
-None at all lived in 'their' tree, only their wood elf host
-and Moraelyn's six Companions, an oddly assorted, cheerful
-lot. Disrespectful, Edward thought. None of the Daggerfall
-court or servants would dared have addressed his father as
-these did Moraelyn and Aliera with their constant raillery.
-But these weren't servants or courtiers. Just ...
-Companions. Only one was a Dark Elf. There were a Khajiit woman, two wood elves,
-brother and sister, a Nordic man, even bigger than Moraelyn and a strange looking
-lizardlike man, who spoke with such a hissing accent that Edward
-couldn't understand him at all. The Nord man was called
-"Slave of Moraelyn" or just "Slave" for short, although
-Moraelyn usually called him "Mats" of "My-slave." Mats
-tended the group's weapons and gathered wood for the evening fires. But it wasn't unusual for the
-others to bring wood; Moraelyn himself often borrowed Mats' axe and
-fetched and split wood if there was need, or if he  just felt
-like it.
+[/center]Lessons
 
- They spent much of their time roaming the woods and fields,
-hunting and gathering produce, in twos and threes. Usually
-Moraelyn, Aliera and Edward and Shade went off together.
-They carried bows for hunting. When Edward asked Moraelyn
-to teach him to shoot better, he was told to ask his mother, as
-she was the better shot. And it was Aliera's arrow that
-brought down a handsome buck, although both arrows had
-struck, and they quarrelled  over who's arrow had killed as they ran toward
-the buck.
+ The golden days passed swiftly. Edward spent most of his time in the company of his parents. He saw few other children. None at all lived in 'their' tree, only their wood elf host and Moraelyn's six Companions, an oddly assorted, cheerful lot. Disrespectful, Edward thought. None of the Daggerfall court or servants would dared have addressed his father as these did Moraelyn and Aliera with their constant raillery. But these weren't servants or courtiers. Just ... Companions. Only one was a Dark Elf. There were a Khajiit woman, two wood elves, brother and sister, a Nordic man, even bigger than Moraelyn and a strange looking lizardlike man, who spoke with such a hissing accent that Edward couldn't understand him at all. The Nord man was called "Slave of Moraelyn" or just "Slave" for short, although Moraelyn usually called him "Mats" of "My-slave." Mats tended the group's weapons and gathered wood for the evening fires. But it wasn't unusual for the others to bring wood; Moraelyn himself often borrowed Mats' axe and fetched and split wood if there was need, or if he just felt like it.
 
- "Bah!" Moraelyn exclaimed as he pulled his black fletched
-arrow from the hindquarters. "I don't know how I managed to feed myself
-before I married you."
+ They spent much of their time roaming the woods and fields, hunting and gathering produce, in twos and threes. Usually Moraelyn, Aliera and Edward and Shade went off together. They carried bows for hunting. When Edward asked Moraelyn to teach him to shoot better, he was told to ask his mother, as she was the better shot. And it was Aliera's arrow that brought down a handsome buck, although both arrows had struck, and they quarrelled over who's [sic] arrow had killed as they ran toward the buck.
+
+ "Bah!" Moraelyn exclaimed as he pulled his black fletched arrow from the hindquarters. "I don't know how I managed to feed myself before I married you."
 
  "You had the Companions."
 
- "Aye. Mats, Mith and I starved together, before we  met Beech and
-Willow." Moraelyn pulled out his black dagger, Tooth, and
-began to skin the animal's body, calling Edward to come and
-watch. "You want to learn about animals, don't you?"
+ "Aye. Mats, Mith and I starved together, before we met Beech and Willow." Moraelyn pulled out his black dagger, Tooth, and began to skin the animal's body, calling Edward to come and watch. "You want to learn about animals, don't you?"
 
- "Live ones." Edward said with distaste. His dainty mother was
-ripping the skin away with enthusiasm.
+ "Live ones." Edward said with distaste. His dainty mother was ripping the skin away with enthusiasm.
 
- "Such make tough eating," the dark elf said. "Give me your
-cloak; I'll make a package for you to carry."
+ "Such make tough eating," the dark elf said. "Give me your cloak; I'll make a package for you to carry."
 
  "I am a Prince, not a pack horse!"
 
@@ -69,290 +36,114 @@ cloak; I'll make a package for you to carry."
 
  "I won't. I don't want any. You can't make me."
 
- Moraelyn stood erect and appeared to think this over.
-"Can't I?" he taunted.
+ Moraelyn stood erect and appeared to think this over. "Can't I?" he taunted.
 
  "Edward, please--" Aliera appealed to him.
 
- "Tell me, Lord Prince, how then does one get the meat to
-one's table if one may not carry it. If Princes may not
-carry meat then certainly Kings and Queens may not ... or do
-Princes grow out of the incapacity when they  become Kings?"
+ "Tell me, Lord Prince, how then does one get the meat to one's table if one may not carry it. If Princes may not carry meat then certainly Kings and Queens may not ... or do Princes grow out of the incapacity when they become Kings?"
 
  "They have servants!"
 
- "Serve ants? What a clever idea. Only a human could think
-of that! Ants are excellent at carrying, I have noted,
-although I have not the trick of commanding them. Perhaps you
-can teach me."
+ "Serve ants? What a clever idea. Only a human could think of that! Ants are excellent at carrying, I have noted, although I have not the trick of commanding them. Perhaps you can teach me."
 
- "Servants! Like Mats here," Edward shouted. He hated being
-teased. Mats and the other companions had come up, having heard their
-shouts over the kill.
+ "Servants! Like Mats here," Edward shouted. He hated being teased. Mats and the other companions had come up, having heard their shouts over the kill.
 
- "Mats? You think I cannot make you carry deer meat, yet I
-could command Mats to do so?" Moraelyn stared up at the
-blond giant. "Well, one never knows until one tries. Mats,
-carry the deer."
+ "Mats? You think I cannot make you carry deer meat, yet I could command Mats to do so?" Moraelyn stared up at the blond giant. "Well, one never knows until one tries. Mats, carry the deer."
 
- The blond scratched his head and jaw thoughtfully. "Highness,
-nothing would please me more ... .but it is a large deer and
-my old wound is troubling my back ... perhaps if you kill a
-smaller one."
+ The blond scratched his head and jaw thoughtfully. "Highness, nothing would please me more ... but it is a large deer and my old wound is troubling my back ... perhaps if you kill a smaller one."
 
  "Well, Prince, what now?"
 
  "You beat him."
 
- "At what? I can outrun him. Mats, if I reach that oak first,
-will you carry the deer." Mats shook his head slowly.
+ "At what? I can outrun him. Mats, if I reach that oak first, will you carry the deer." Mats shook his head slowly.
 
  "You beat him with a stick!" Edward yelled.
 
- "What promise you show as a Healer, my Prince. You will
-forgive me if I refrain from consulting you until you have
-further training. It is my judgement that  beating with a
-stick will not improve Mats' back. Of  course, I may be in
-error.
+ "What promise you show as a Healer, my Prince. You will forgive me if I refrain from consulting you until you have further training. It is my judgement that beating with a stick will not improve Mats' back. Of course, I may be in error.
 
  "Silk, you carry the deer."
 
- "Me, milord? I am sorry, but I have just remembered that I
-am fourth cousin to the fifth house of Dibella, Queen of
-Heaven. My dignity forbids that I carry anything at all."
+ "Me, milord? I am sorry, but I have just remembered that I am fourth cousin to the fifth house of Dibella, Queen of Heaven. My dignity forbids that I carry anything at all."
 
- Willow and Beech claimed that a mage had forbidden either of them from
-carrying any part of an animal while the moon Jone was risen.
+ Willow and Beech claimed that a mage had forbidden either of them from carrying any part of an animal while the moon Jone was risen.
 
- "Prince, are you truly certain about this rule? It seems to
-make life most inconvenient. We could bring the wood to the
-deer, which will take many  hours and leave us benighted here.
-We could consume the meat raw on the spot, but I own my
-belly is not yet empty enough to make that option attractive.
-Aliera, can you help us? How do the High Rock folk get meat to table?"
+ "Prince, are you truly certain about this rule? It seems to make life most inconvenient. We could bring the wood to the deer, which will take many hours and leave us benighted here. We could consume the meat raw on the spot, but I own my belly is not yet empty enough to make that option attractive. Aliera, can you help us? How do the High Rock folk get meat to table?"
 
- "Milord, when I lived there it was my firm belief that it
-appeared by magic. There were servants, but they were an irritating, lazy lot, more trouble than they were
-worth. Edward, my son, is it possible that this rule applies
-only in High Rock?"
+ "Milord, when I lived there it was my firm belief that it appeared by magic. There were servants, but they were an irritating, lazy lot, more trouble than they were worth. Edward, my son, is it possible that this rule applies only in High Rock?"
 
  "I suppose so ... ."
 
- Edward carried a share of meat that bent his back, but he did
-not complain. And so it was settled, and the meal that night
-was a merry one. But for several days after, if the
-Companions caught him carrying anything at all they would
-inquire anxiously as to whether a High Rock Prince might do so.
+ Edward carried a share of meat that bent his back, but he did not complain. And so it was settled, and the meal that night was a merry one. But for several days after, if the Companions caught him carrying anything at all they would inquire anxiously as to whether a High Rock Prince might do so.
 
- "If Mats is not a servant, then why do they call him
-'Moraelyn's Slave'?" Edward asked one drowsy afternoon.
+ "If Mats is not a servant, then why do they call him 'Moraelyn's Slave'?" Edward asked one drowsy afternoon.
 
- "Well, he is my slave. I paid gold for him, all that Mith
-and I had. We came on a man beating him near Reich Parthkeep. He looked near death; when  Mith and I tried to stop the beating, the
-man said Mats was a runaway slave, and he'd do as he liked with him.
-So I threw down the gold and told him he could take it and
-leave, else I would kill him out of hand. He chose the latter,
-so I told Mats to take the gold as his master's heir and go where he would. He chose to come with us, so we buried the gold with his master and Mats has
-been with us since."
+ "Well, he is my slave. I paid gold for him, all that Mith and I had. We came on a man beating him near Reich Parthkeep. He looked near death; when Mith and I tried to stop the beating, the man said Mats was a runaway slave, and he'd do as he liked with him. So I threw down the gold and told him he could take it and leave, else I would kill him out of hand. He chose the latter, so I told Mats to take the gold as his master's heir and go where he would. He chose to come with us, so we buried the gold with his master and Mats has been with us since."
 
  "Could he leave if he wanted to?"
 
  "Of course."
 
- "May I go pick some of those berries over there?" Edward
-asked, and Moraelyn nodded. 
+ "May I go pick some of those berries over there?" Edward asked, and Moraelyn nodded.
 
- Aliera was sleeping curled on her side. Moraelyn sat next
-to her, leaning back against a tree,  his hand playing with
-her long dark curls. His eyes and skin were sensitive to the
-bright sun. Shade slept stretched in the sun nearby, his  dark
-fur glinting with silver in the light. Edward wandered over
-to the bushes and picked the bright glowberries, so called
-because they glowed at night, although right now they were a
-rather dull gray. But they tasted very good. If he ate
-enough, would he glow at night, he wondered. Or if he smashed them and collected the
-juice ... the bushes caught at him, then he  found a sort of
-tunnel through them and trotted along it, wondering where it
-led.
+ Aliera was sleeping curled on her side. Moraelyn sat next to her, leaning back against a tree, his hand playing with her long dark curls. His eyes and skin were sensitive to the bright sun. Shade slept stretched in the sun nearby, his dark fur glinting with silver in the light. Edward wandered over to the bushes and picked the bright glowberries, so called because they glowed at night, although right now they were a rather dull gray. But they tasted very good. If he ate enough, would he glow at night, he wondered. Or if he smashed them and collected the juice ... the bushes caught at him, then he found a sort of tunnel through them and trotted along it, wondering where it led.
 
- It ended in a small clearing before a pile of rocks. There
-was a hole and something in it. Edward stepped back, making a
-small noise in his  throat. The something heaved and
-presented a tusky snarling face and hooves that pawed at the earth.
-
- The boy backed away slowly. The beast's head went down, the shoulders
-heaved and the immense bulk lumbered into a charge. Edward
-tried to throw himself into the bushes ... there was no room ... and then,
-incredibly, Moraelyn was in front of him, between him and the beast. There was a flash and a
-crash, and the elf seemed to leap  backwards for several
-feet, landing crouched just in front of Edward's face. The
-air whistled as his blade seemed to jump out of the sheath of
-its own accord. There was a sparkle in the air around him, and a burnt smell. Silence.
+ It ended in a small clearing before a pile of rocks. There was a hole and something in it. Edward stepped back, making a small noise in his throat. The something heaved and presented a tusky snarling face and hooves that pawed at the earth. The boy backed away slowly. The beast's head went down, the shoulders heaved and the immense bulk lumbered into a charge. Edward tried to throw himself into the bushes ... there was no room ... and then, incredibly, Moraelyn was in front of him, between him and the beast. There was a flash and a crash, and the elf seemed to leap backwards for several feet, landing crouched just in front of Edward's face. The air whistled as his blade seemed to jump out of the sheath of its own accord. There was a sparkle in the air around him, and a burnt smell. Silence.
 
  "Get out of here, boy! Now!"
 
- Edward fled, yelling for his mother, who was running toward the bushes and calling him. She clasped him
-to her, and began shouting for Moraelyn  instead. There was
-no answer, then, somehow the elf was there, unharmed, his blade sheathed again. But he was breathing hard.
+ Edward fled, yelling for his mother, who was running toward the bushes and calling him. She clasped him to her, and began shouting for Moraelyn instead. There was no answer, then, somehow the elf was there, unharmed, his blade sheathed again. But he was breathing hard.
 
  "Did you kill it? Are you hurt?"
 
- "No and no. I was shielded. Barely. You disturbed a sow in
-her den with her litter. Fortunately, she thought she'd had eno
-ugh after the first
-impact. I daresay she's unaccustomed to finding her enemies
-still standing afterwards."
+ "No and no. I was shielded. Barely. You disturbed a sow in her den with her litter. Fortunately, she thought she'd had enough after the first impact. I daresay she's unaccustomed to finding her enemies still standing afterwards."
 
- "Why didn't you kill her?" Edward demanded, feeling
-bloodthirsty after his fright.
-
- "A katana, even the Ebony Blade, is not the weapon I'd choose against a mother sow. A spear, maybe. The
-longer the better. Besides, if we leave her be, there'll be six
-pigs here next year, with luck."
+ "Why didn't you kill her?" Edward demanded, feeling bloodthirsty after his fright. "A katana, even the Ebony Blade, is not the weapon I'd choose against a mother sow. A spear, maybe. The longer the better. Besides, if we leave her be, there'll be six pigs here next year, with luck."
 
  "You made a magic shield," Edward said, wide-eyed.
 
- "Aye, barring the shield, she'd have left a few marks even on
-a tough old dark elf."
+ "Aye, barring the shield, she'd have left a few marks even on a tough old dark elf."
 
  "Edward, it would be gracious to thank your rescuer." His mother prompted.
 
- "Thank you," Edward said automatically, his mind busy with
-more questions. How had the elf known of his danger? How did he get there
-gh after the first
-impact. I daresay she's unaccustomed to finding her enemies
-still standing afterwards."
+ "Thank you," Edward said automatically, his mind busy with more questions. How had the elf known of his danger? How did he get there so quickly?
 
- "Why didn't you kill her?" Edward demanded, feeling
-bloodthirsty after his fright.
+ "There is scarcely need to thank me for saving my son's life. Thank Shade," Moraelyn said. "The cat told me there was trouble."
 
- "A katana, even the Ebony Blade, is not the weapon I'd choose against a mother sow. A spear, maybe. The
-longer the better. Besides, if we leave her be, there'll be six
-pigs here next year, with luck."
+ Edward knelt and hugged the smug purring cat. "Good old Shade. I can always count on him."
 
- "You made a magic shield," Edward said, wide-eyed.
+ "My son". "Our son". The words rang proudly out at the least excuse. Edward puzzled over this for awhile; it wanted an explanation. The one he favored was that Moraelyn simply didn't know him very well yet, and was prone to give the benefit of the doubt to strangers. Eventually ... but in the meantime he might as well enjoy it. It was ... nice. Having a father that was proud of you, that liked being with you, took you to places, talked to you, listened to you. And most remarkably of all, let you alone when you needed to be. Moraelyn only really liked being alone when he was composing a ballad.
 
- "Aye, barring the shield, she'd have left a few marks even on
-a tough old dark elf."
+ Edward told Beech and Willow about the mother pig. "I ran when he told me to. Would you? Because he said to. I couldn't think of any way to help, but ... " Willow and Beech listened carefully, exchanged glances, and said they'd think about the problem.
 
- "Edward, it would be gracious to thank your rescuer." His mother prompted.
+ After supper around the evening fire, Willow took up her small harp and began to sing about the joys of an autumn afternoon and berries ... .except that Moraelyn sent the boy off to pick berries. They'd got that part wrong. Moraelyn sat up sharply and looked around, but the others had slipped away into the darkness and Willow wasn't looking at him.
 
- "Thank you," Edward said automatically, his mind busy with
-more questions. How had the elf known of his danger? How did he get there
-so quickly?
+ Mith strolled into the firelight, taking mincing steps, picking pantomime berries and eating them noisily. Moraelyn put his head down and groaned. Mith pantomimed finding something then skipped along in delight. Mats' head and shoulders lurched into the firelight. Mith reached a hand to pat him, then leapt back with a squeal as Mats tried to rip him with a tusk. Huge tusks and a pig nose adorned his face. Mith crouched, hands to his face in exaggerated horror. An [sic] Silk, clad in black, leaped between Mith and Mats with a shower of sparks, jerkin backwards, hose about its knees, shoeless. It reached for its sword, but Mats charged and knocked it flying; it spun out of sight. Mats, scrambling on all fours, missed Mith, but tore his hose. Mith scampered around the fire with Mats after him. Silk, sword in one hand, the other tugging at the hose chased after Mats, beating him with the sword.
 
- "There is scarcely need to thank me for saving my son's life.
-Thank Shade," Moraelyn said. "The cat told me there was
-trouble."
+ Another figure appeared, clad in Aliera's blue gown with Beech's head sticking out above wearing a long dark wig. Mith cowered behind her skirts. She glared at Mats and he froze. Silk tripped and sprawled behind him. Beech tossed his hair back, patted Mith reassuringly on the head, wet one finger and smoothed an eyebrow, then leisurely picked up his bow, aimed and twanged.
 
- Edward knelt and hugged the smug purring cat. "Good old
-Shade. I can always count on him."
-
- "My son". "Our son". The words rang proudly out at the
-least excuse. Edward puzzled over this for awhile; it wanted an explanation. The one he
-favored was that Moraelyn simply didn't know him very well
-yet, and was prone to give the benefit of the doubt to
-strangers. Eventually ... but in the meantime he might as
-well enjoy it. It was ... nice. Having a father that was
-proud of you, that liked being with you, took you places,
-talked to you, listened to you. And most remarkably of all, let you alone when you needed to be. Moraelyn only really liked being alone when he was
-composing a ballad.
-
- Edward told Beech and Willow about the mother pig. "I ran
-when he told me to. Would you? Because he said to. I couldn't think of any way to help, but ... "
-Willow and Beech listened carefully, exchanged glances, and
-said they'd think about the problem.
-
- After supper around the evening fire, Willow took up her
-small harp and began to sing about the joys of an autumn
-afternoon and berries ... .except that Moraelyn sent the
-boy off to pick berries. They'd got that part wrong.
-Moraelyn sat up sharply and looked around, but the others had slipped away into the
-darkness and Willow wasn't looking at him.
-
- Mith strolled into the firelight, taking mincing steps,
-picking pantomime berries and eating them noisily. Moraelyn
-put his head down and groaned. Mith pantomimed finding something then skipped along in delight. Mats' head and shoulders
-lurched into the firelight. Mith reached a hand to pat him,
-then leapt back with a squeal as Mats tried to rip him with a
-tusk. Huge tusks and a pig nose adorned his face. Mith
-crouched, hands to his face in exaggerated horror. And Silk, 
-clad in black, leaped between Mith  and Mats with a shower of sparks, jerkin backwards,
-hose about its knees, shoeless. It reached for its sword, but
-Mats charged and knocked it flying; it spun out of sight.
-Mats, scrambling on all fours, missed Mith, but tore his
-hose. Mith scampered around the fire with Mats after him.
-Silk, sword in one hand, the other tugging at the hose chased
-after Mats,  beating him with the sword.
-
- Another figure appeared, clad in Aliera's blue gown with
-Beech's head sticking out above wearing a long dark wig. Mith
-cowered behind her skirts. She glared at Mats and he froze.
-Silk tripped and sprawled behind him. Beech tossed his hair
-back, patted Mith  reassuringly on the head, wet one finger and smoothed an eyebrow, then leisurely picked up his
-bow, aimed and twanged.
-
- Mats leaped backwards, collapsing on top of Silk with a
-very realistic death rattle. Beech and Mith embraced,
-ignoring Silk, still flat beneath Mats.
-
- Moraelyn had begun laughing when Silk first leaped out.
-Aliera had waited for Beech's appearance. Now tears were
-running down her cheeks. Moraelyn was doubled over, pounding his fist against
-a tree. Ripples and giggles of  silvery laughter sounded all around and showers of gold coins
-fell into the circle. The Companions gathered themselves
-together and bowed, as humans did.
+ Mats leaped backwards, collapsing on top of Silk with a very realistic death rattle. Beech and Mith embraced, ignoring Silk, still flat beneath Mats. Moraelyn had begun laughing when Silk first leaped out. Aliera had waited for Beech's appearance. Now tears were running down her cheeks. Moraelyn was doubled over, pounding his fist against a tree. Ripples and giggles of silvery laughter sounded all around and showers of gold coins fell into the circle. The Companions gathered themselves together and bowed, as humans did.
 
  "Again, do it again!"
 
- "Noo-ooo!" Moraelyn gasped, still laughing. "Ah, you came
-nearer killing me than the sow did! I beg mercy!"
+ "Noo-ooo!" Moraelyn gasped, still laughing. "Ah, you came nearer killing me than the sow did! I beg mercy!"
 
- "Another night, gentle persons ... our king has had a very
-long day. We thank you all."
+ "Another night, gentle persons ... our king has had a very long day. We thank you all."
 
- Gods, had the entire town seen? Edward stared behind him, but
-they were all melting away into the dark. "That's not what
-happened." he yelled. "You were a hero. They made fun of
-you."
+ Gods, had the entire town seen? Edward stared behind him, but they were all melting away into the dark. "That's not what happened." he yelled. "You were a hero. They made fun of you."
 
- "Yes, yes and yes. Especially the last. By Jephre himself,
-that was funny!"
+ "Yes, yes and yes. Especially the last. By Jephre himself, that was funny!"
 
- "They all saw that! And you're going to let them do it
-again?" Edward was scandalized. They had all looked
-ridiculous.
+ "They all saw that! And you're going to let them do it again?" Edward was scandalized. They had all looked ridiculous.
 
- "Let them? It'll be done all over Tamriel for centuries to
-come, I doubt not. But never again so well."
+ "Let them? It'll be done all over Tamriel for centuries to come, I doubt not. But never again so well."
 
  "But it didn't happen like that at all."
 
- "It would have if Mats--I mean the sow had charged again. Ariana's bow would have been far more effective than my
-poor blade. And she'd have seen Moraelyn leap like a khajiit!" His finger smoothed an eyebrow in a gesture typical of Aliera and he went off again
-into a long laugh. "Aye, she'd have slain the beast with a
-look, if she couldn't find an arrow. Mats, you were more like
-the sow than she like herself. Bigger, too, I swear! Mith, you
-old rogue, only you could look so innocent."
+ "It would have if Mats--I mean the sow had charged again. Ariana's bow would have been far more effective than my poor blade. And she'd have seen Moraelyn leap like a khajiit!" His finger smoothed an eyebrow in a gesture typical of Aliera and he went off again into a long laugh. "Aye, she'd have slain the beast with a look, if she couldn't find an arrow. Mats, you were more like the sow than she like herself. Bigger, too, I swear! Mith, you old rogue, only you could look so innocent."
 
  "Bu-uut--it's not true!" Edward protested.
 
- "Boy, you think there's only one truth? Was what you saw
-today truth? Did you see all the truth? Even of what did happe
-n? What you saw here tonight will light up truths unseen,
-if you allow it ... you could spend a lifetime reflecting
-on it and yet not see it whole, for it goes ever further and
-deeper, spreading like ripples in a pool, beyond us all and out into the deep stillness of forever.
-What happens is only a tiny part of truth ... maybe the least
-part. And what you see is smaller yet."
+ "Boy, you think there's only one truth? Was what you saw today truth? Did you see all the truth? Even of what did happen? What you saw here tonight will light up truths unseen, if you allow it ... you could spend a lifetime reflecting on it and yet not see it whole, for it goes ever further and deeper, spreading like ripples in a pool, beyond us all and out into the deep stillness of forever. What happens is only a tiny part of truth ... maybe the least part. And what you see is smaller yet."
 
- Edward still thought that a king really ought to have more
-dignity. But he didn't say so. ? What you saw here tonight will light up truths unseen,
-if you allow it ... you could spend a lifetime reflecting
-on it and yet not see it whole, for it goes ever further and
-deeper, spreading like ripples in a pool, beyond us all and out into the deep stillness of forever.
-What happens is only a tiny part of truth ... maybe the least
-part. And what you see is smaller yet."
-
- Edward still thought that a king really ought to have more
-dignity. But he didn't say so. 
+ Edward still thought that a king really ought to have more dignity. But he didn't say so.

--- a/Assets/StreamingAssets/Text/Books/BOK00103-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00103-LOC.txt
@@ -3,169 +3,52 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]King Edward, Part IV
 
-
-
 [/font=4]
 
 [/center]
 
-[/center]Chap 4: Stories
+[/center]Stories
 
-[/center] Edward faced his mother defiantly. "I'm not sick and I'm not 
-a
-baby. I can  stay here by myself. I don't need Mith." There
-was a dangerous glint in  Moraelyn's eyes. Aliera's lips thinned.
-"You will mind him, Edward."
+ Edward faced his mother defiantly. "I'm not sick and I'm not a baby. I can stay here by myself. I don't need Mith." There was a dangerous glint in Moraelyn's eyes. Aliera's lips thinned. "You will mind him, Edward."
 
  "Yes, madam," Edward said sulkily.
 
- "Come on, wife. Mith knows how to deal with princes who don't
-want his  company." The three adults laughed a bit in their
-irritating way at a joke  he didn't understand.
+ "Come on, wife. Mith knows how to deal with princes who don't want his company." The three adults laughed a bit in their irritating way at a joke he didn't understand.
 
- The weather was drizzly and Edward had the sniffles. His
-mother had  decided that he shouldn't go out, even though they
-were only going  visiting. Moraelyn had taken his side, but threw out his hands and raised  his brows at
-Edward in a helpless gesture when Aliera insisted that he 
-stay behind. Mith, whom Edward liked the least of the
-Companions, had  volunteered to stay with him. Even Ssa'ass
-would have been better. Mith  was -- scruffy looking. Like a
-stableboy. And cheeky, even for a  Companion. Edward sulked
-silently for awhile longer. Mith had fetched a  broom and
-was sweeping the house out, brushing dirt from the room
-
-baby. I can  stay here by myself. I don't need Mith." There
-was a dangerous glint in  Moraelyn's eyes. Aliera's lips thinned.
-"You will mind him, Edward."
-
- "Yes, madam," Edward said sulkily.
-
- "Come on, wife. Mith knows how to deal with princes who don't
-want his  company." The three adults laughed a bit in their
-irritating way at a joke  he didn't understand.
-
- The weather was drizzly and Edward had the sniffles. His
-mother had  decided that he shouldn't go out, even though they
-were only going  visiting. Moraelyn had taken his side, but threw out his hands and raised  his brows at
-Edward in a helpless gesture when Aliera insisted that he 
-stay behind. Mith, whom Edward liked the least of the
-Companions, had  volunteered to stay with him. Even Ssa'ass
-would have been better. Mith  was -- scruffy looking. Like a
-stableboy. And cheeky, even for a  Companion. Edward sulked
-silently for awhile longer. Mith had fetched a  broom and
-was sweeping the house out, brushing dirt from the room
-above  into the room Edward was in. What on earth was the use of staying in when  there
-wasn't really any 'in' to stay in? Edward got tired of
-sulking,  fetched a broom and went up to help sweep.
+ The weather was drizzly and Edward had the sniffles. His mother had decided that he shouldn't go out, even though they were only going visiting. Moraelyn had taken his side, but threw out his hands and raised his brows at Edward in a helpless gesture when Aliera insisted that he stay behind. Mith, whom Edward liked the least of the Companions, had volunteered to stay with him. Even Ssa'ass would have been better. Mith was -- scruffy looking. Like a stableboy. And cheeky, even for a Companion. Edward sulked silently for awhile longer. Mith had fetched a broom and was sweeping the house out, brushing dirt from the room above into the room Edward was in. What on earth was the use of staying in when there wasn't really any 'in' to stay in? Edward got tired of sulking, fetched a broom and went up to help sweep.
 
  "Mith", Edward said. "have you ever been to the Crystal Tower?"
 
- "I have. It's an unchancy place at first, but you'll grow
-used to it."  Mith was applying his broom with energy and
-whistling. Sweeping was kind  of fun here. There weren't any
-sides to the platforms so all you had to do  was brush the
-dirt and leaves over the side. You started at the top and 
-worked your way down.
+ "I have. It's an unchancy place at first, but you'll grow used to it." Mith was applying his broom with energy and whistling. Sweeping was kind of fun here. There weren't any sides to the platforms so all you had to do was brush the dirt and leaves over the side. You started at the top and worked your way down.
 
- "You're quick with the broom, Mith. I haven't half finished
-my side yet.  Will there be others there like me?"
+ "You're quick with the broom, Mith. I haven't half finished my side yet. Will there be others there like me?"
 
- "Oh, some children, I'd think. Most'll be somewhat older. I
-should be  quick with a broom. My father had me sweeping out
-the king's stables when  I was your age. I used to dream and
-talk too much like you; he beat me for  it. So I learned to be
-quick."
+ "Oh, some children, I'd think. Most'll be somewhat older. I should be quick with a broom. My father had me sweeping out the king's stables when I was your age. I used to dream and talk too much like you; he beat me for it. So I learned to be quick." Edward swept faster, stirring up dust. "Not like that, boy. Watch me. Anyway, there's no hurry; it's just habit with me. Moraelyn'd serve me my head on a platter if I touched you. My father, heh, he was always....well, he was a hard man to please. He was a Nord."
 
- Edward swept faster, stirring up dust. "Not like that,
-boy. Watch me.  Anyway, there's no hurry; it's just habit with
-me. Moraelyn'd serve me my  head on a platter if I touched
-you. My father, heh, he was always....well,  he was a hard
-man to please. He was a Nord."
+ "Your father?" Edward stared at Mith, but Mith looked much like the other Dark Elves he'd seen. Not many. Dark elves didn't come to Daggerfall; Gerald had banned them. But he'd seen some on his rare trips to other courts. And there were some in Firsthold besides Moraelyn and Mith. "Did he have red hair?" Mith's hair was a dark red. Gerald had red hair. "He tended the stables for Moraelyn?" No wonder Mith looked like a stableboy. But Edward kept his tone polite. Mith had a sharp tongue....and Edward knew that neither of his parents would be sympathetic if he complained that Mith had been impertinent.
 
- "Your father?" Edward stared at Mith, but Mith looked much
-like the other  Dark Elves he'd seen. Not many. Dark elves didn't come to Daggerfall;  Gerald had banned them. But
-he'd seen some on his rare trips to other  courts. And there
-were some in Firsthold besides Moraelyn and Mith. "Did  he have red hair?" Mith's hair was a dark red.
-Gerald had red hair. "He  tended the stables for Moraelyn?" No wonder Mith looked like a
-stableboy.  But Edward kept his tone polite. Mith had a sharp
-tongue....and Edward  knew that neither of his parents would
-be sympathetic if he complained  that Mith had been
-impertinent.
+ "He did have red hair. Maybe I got mine from him...but mostly mixed elf and human children come out dark elf. No, Moraelyn wasn't a king then or expecting to be....'sides this was in Blacklight, where I was born. Moraelyn's brother was king in Ebonheart in those days. He came up to visit our King and brought Moraelyn along. To keep him out of trouble, he said." Mith grinned. "I grinned when I heard him say that, and I saw the boy looking at me out of the tail of his eye, but he wouldn't take notice. Like I was the dirt or something worse. His brother tossed him a pouch and told him to go into town and get his knife mended. Jerked his thumb at me and told me to show him the way.
 
- "He did have red hair. Maybe I got mine from him...but
-mostly mixed elf  and human children come out dark elf. No,
-Moraelyn wasn't a king then or  expecting to be....'sides this was in
-Blacklight, where I was born.  Moraelyn's brother was king in
-Ebonheart in those days. He came up to  visit our King and
-brought Moraelyn along. To keep him out of trouble, he 
-said." Mith grinned. "I grinned when I heard him say that,
-and I saw the  boy looking at me out of the tail of his eye,
-but he wouldn't take notice.  Like I was the dirt or something
-worse. His brother tossed him a pouch and  told him to go into
-town and get his knife mended. Jerked his thumb at me  and told
-me to show him the way.
+ "Moraelyn said he didn't need an escort to find a store and stalked off like princes do." Mith grinned knowingly at Edward. But the grin wasn't unfriendly. Edward smiled back a bit, and Mith went on. "Our king eyeballed me, so I took off after him. Moraelyn didn't spare me so much as a glance. Went four blocks out of his way, down by the wharfs, and when I tried to tell him where the store was he shoved me right off the pier. I could Levitate, of course, but he caught me by surprise and I went in with a big splash....and everyone laughing like jackasses. I got myself out and went straight to the store and waited for him...but not so he could see me....and when he finally showed up, I lifted the pouch right off him. He didn't even know it was gone. So in he goes and tosses the knife on the counter and tells the smith to fix it right off. Which he does. Only then Moraelyn can't pay him....tells the smith he's the King of Ebonheart's brother...the smith just laughs and says, "And I'm the Archmagister"....then the smith calls the guard and three of them show up. Well, Moraelyn wasn't what he is now--three guards wouldn't even warm him up nowadays--but he was even faster then. He was out of there so fast he nearly knocked me over at the door. He lost the guards pretty quick; all that armor slows 'em down. I found him crouching in one of those hedge mazes in the park. He was doubled over out of breath but still I stood a good ways off while I asked him real nasty if he needed an escort back to the Palace. Not that I was planning to go back! I was gonna take the money and run and never look back, I tell you! But I had to have the last word. I wasn't born high but I was born proud.
 
- "Moraelyn said he didn't need an escort to find a store and
-stalked off  like princes do." Mith grinned knowingly at
-Edward. But the grin wasn't  unfriendly. Edward smiled back
-a bit, and Mith went on. "Our king  eyeballed me, so I took
-off after him. Moraelyn didn't spare me so much as  a
-glance. Went four blocks out of his way, down by the wharfs,
-and when I  tried to tell him where the store was he shoved me
-right off the pier. I  could Levitate, of course, but he
-caught me by surprise and I went in with  a big
-splash....and everyone laughing like jackasses. I got myself
-out and  went straight to the store and waited for him...but
-not so he could see  me....and when he finally showed up, I
-lifted the pouch right off him. He  didn't even know it was
-gone. So in he goes and tosses the knife on the  counter and
-tells the smith to fix it right off. Which he does. Only then 
-Moraelyn can't pay him....tells the smith he's the King of
-Ebonheart's  brother...the smith just laughs and says, "And I'm the Archmagister"....then  the
-smith calls the guard and three of them show up. Well,
-Moraelyn wasn't  what he is now--three guards wouldn't even
-warm him up nowadays--but he  was even faster then. He was out
-of there so fast he nearly knocked me  over at the door. He
-lost the guards pretty quick; all that armor slows  'em down.
-I found him crouching in one of those hedge mazes in the park.  He was doubled over out of breath but still I stood a good ways off while  I asked him real nasty if he needed an escort
-back to the Palace. Not that  I was planning to go back! I
-was gonna take the money and run and never  look back, I tell you! But I had to have the last word. I
-wasn't born high  but I was born proud.
+ "He glared at me for a minute or so, catching his breath, then he just rolled over and started to laugh that laugh of his. Prince or not, I started to like him then. When we'd finished laughing, more or less, we started talking. I told him I didn't want to go back. Nor dared to. "Princes don't get blamed, Prince," I said, "Stableboys do." He said that wasn't entirely the case, but he saw my point. Then he said that as I was his escort then he must obey his brother and come with me. And that his name was Moraelyn, not Prince. We've been together ever since....more or less."
 
- "He glared at me for a minute or so, catching his breath, then he just 
-rolled over and started to laugh that laugh of his. Prince
-or no, I  started to like him then. When we'd finished
-laughing, more or less, we  started talking. I told him I didn't want to go back. Nor dared to.  "Princes don't get blamed, Prince," I said, "Stableboys do." He said that  wasn't entirely the case,
-but he saw my point. Then he said that as I was  his escort then
-he must obey his brother and come with me. And that his  name
-was Moraelyn, not Prince. We've been together ever
-since....more or less."
+ Edward smiled politely. He could see why Mith had run away, but not why Moraelyn had gone with him. Unless he was afraid to face his brother about the stolen money. Edward tried to imagine Moraelyn being afraid to face anyone and failed. "I wish I was brave. Like you and Moraelyn."
 
- Edward smiled politely. He could see why Mith had run away,
-but not why  Moraelyn had gone with him. Unless he was afraid to face his brother about  the stolen money. Edward
-tried to imagine Moraelyn being afraid to face  anyone and
-failed. "I wish I was brave. Like you and Moraelyn."
-
- "Why, you are brave. And your courage will grow with the
-rest of you."
+ "Why, you are brave. And your courage will grow with the rest of you."
 
  "Are there only High Elf boys at the Tower?"
 
- "There'll be other sorts, too, most likely. A few Dark
-Elves, for sure.  D'ye miss your own kind?"
+ "There'll be other sorts, too, most likely. A few Dark Elves, for sure. D'ye miss your own kind?"
 
- Edward shook his head. "Human boys don't like me much anyway.
-Nor High Elf  boys..." His eyes filled suddenly and he turned
-his head away. But Mith's  voice was unexpectedly gentle. "I
-thought you wanted to go to the Tower."
+ Edward shook his head. "Human boys don't like me much anyway. Nor High Elf boys..." His eyes filled suddenly and he turned his head away. But Mith's voice was unexpectedly gentle. "I thought you wanted to go to the Tower."
 
  "I do. But--"
 
@@ -177,84 +60,25 @@ thought you wanted to go to the Tower."
 
  "Did you go there alone, Mith?"
 
- "No. Moraelyn did, but he was older than you, by a good
-bit. A grown man,  in fact. They didn't take any but High Elf
-students in those days, you  know. But Moraelyn heard of them
-and said he wanted to go there. We were  together already, the
-seven of us, save for Aliera, and a handy bunch in a  fight.
-Moraelyn had already gotten that Dragon's Blade he wears,
-and the  Dragon's Tooth to go with it....remind me to tell
-you about that  sometime....and he was a famous fighter
-already. And the rest of us aren't  slackers. But he thought
-we could be better at the spellcasting and the  Tower was
-the place to learn that. Well, no one goes near the Tower 
-without an invitation. No one! No one would even tell you
-where it was.  But they'd tell you where NOT to go. So he went there. Alone. One morning  he
-was gone and there a note saying for us to wait for him. So
-we did,  here in Firsthold. He was gone two weeks, then he came
-back one night,  rowing across with the tide. He just said they'd accepted him, but he  couldn't say anything more
-about it. But he asked me to come back with him.
+ "No. Moraelyn did, but he was older than you, by a good bit. A grown man, in fact. They didn't take any but High Elf students in those days, you know. But Moraelyn heard of them and said he wanted to go there. We were together already, the seven of us, save for Aliera, and a handy bunch in a fight. Moraelyn had already gotten that Dragon's Blade he wears, and the Dragon's Tooth to go with it....remind me to tell you about that sometime....and he was a famous fighter already. And the rest of us aren't slackers. But he thought we could be better at the spellcasting and the Tower was the place to learn that. Well, no one goes near the Tower without an invitation. No one! No one would even tell you where it was. But they'd tell you where NOT to go. So he went there. Alone. One morning he was gone and there a note saying for us to wait for him. So we did, here in Firsthold. He was gone two weeks, then he came back one night, rowing across with the tide. He just said they'd accepted him, but he couldn't say anything more about it. But he asked me to come back with him.
 
- "'They want me?' 'Well, they've accepted one Dark Elf,' he said. 'One
-more  shouldn't bother them too much.' So we go there, and
-bless me if the  Archmagister himself didn't meet us at the
-door and demand to know the  meaning of this. I wanted to
-turn myself into a rock! I was wishing hard  that I _was_
-stable dung! And figured I was like to get my wish soon. But 
-Moraelyn speaks up real polite that this is the friend he'd
-mentioned and  the Archmagister had expressed an interest in
-his abilities, and naturally  he'd want to see for himself....
+ "'They want me?' 'Well, they've accepted one Dark Elf,' he said. 'One more shouldn't bother them too much.' So we go there, and bless me if the Archmagister himself didn't meet us at the door and demand to know the meaning of this. I wanted to turn myself into a rock! I was wishing hard that I was stable dung! And figured I was like to get my wish soon. But Moraelyn speaks up real polite that this is the friend he'd mentioned and the Archmagister had expressed an interest in his abilities, and naturally he'd want to see for himself....
 
- "But the Archmagister was real interested. See, they don't wear armor or  carry anything but a staff and a dagger. They think it interferes with 
-their spellcasting, all that metal. But Moraelyn could
-cast pretty well  even with chain and with any one-hand weapon at all. And I could cast
- wearing leather and as much as a saber, though it's an
-unwieldy weapon; I  like my short sword better. Truth, they
-didn't think that much of me, but  Moraelyn....he'd camped
-outside their door. And when they tried to move  him he just sat there! They threw
-all the spells they had at him, the  troll guards...everything.
-Nothing. He laid the trolls out flat and left  'em to
-regenerate. If they tried to beat him with their staffs he'd
-ward  them off with his blade...and the spells didn't turn
-him a hair."
+ "But the Archmagister was real interested. See, they don't wear armor or carry anything but a staff and a dagger. They think it interferes with their spellcasting, all that metal. But Moraelyn could cast pretty well even with chain and with any one-hand weapon at all. And I could cast wearing leather and as much as a saber, though it's an unwieldy weapon; I like my short sword better. Truth, they didn't think that much of me, but Moraelyn....he'd camped outside their door. And when they tried to move him he just sat there! They threw all the spells they had at him, the troll guards...everything. Nothing. He laid the trolls out flat and left 'em to regenerate. If they tried to beat him with their staffs he'd ward them off with his blade...and the spells didn't turn him a hair."
 
  Edward's mouth gaped open. "How'd he do that!?! He said--"
 
- "Well, it was a trick, in a way. He'd picked up something
-that came  natural to Willow. See, Willow is different."
+ "Well, it was a trick, in a way. He'd picked up something that came natural to Willow. See, Willow is different."
 
  "I didn't know Willow could cast!"
 
- "Well, she doesn't have any mana, ordinarily....but she
-can absorb it if  you cast a spell AT her, see. O'course it
-wasn't much use to her, since  she'd never been able to learn
-what t'do with it once she got it. Couldn't  get it back once
-it was gone, so she couldn't practice. Until Morelyn got 
-hold of her and trained her. Well, Moraelyn had figured out
-pretty much  how Willow did what she did....though it cost
-Moraelyn mana to do what  came natural to Willow. So
-Moraelyn sat there absorbing everything they  threw at him
-and burning it off into a big shield. Drove 'em wild."
+ "Well, she doesn't have any mana, ordinarily....but she can absorb it if you cast a spell AT her, see. O'course it wasn't much use to her, since she'd never been able to learn what t'do with it once she got it. Couldn't get it back once it was gone, so she couldn't practice. Until Morelyn got hold of her and trained her. Well, Moraelyn had figured out pretty much how Willow did what she did....though it cost Moraelyn mana to do what came natural to Willow. So Moraelyn sat there absorbing everything they threw at him and burning it off into a big shield. Drove 'em wild."
 
- "He said the Archmagister could best him, though." Edward
-suspected that Mith  was making up the whole story.
+ "He said the Archmagister could best him, though." Edward suspected that Mith was making up the whole story.
 
- "Well, so he did, when he finally came. But all the rest of
-'em together  couldn't do it. And all Moraelyn wanted was
-to study with them. We were a  sight, the two of us dark elves
-in our battle gear among all that white  and gold. I felt
-li
-ke a fish out of water, but Moraelyn was interested in  what they had to say....and
-you can bet they hung on every word he said.  Not too many
-words at first. After a fortnight or so, he told me one
-night  to tell the Archmagister that he'd be back in a couple
-of days. And he shows  up with Silk! 'Course he'd been telling
-'em about the Khajiits...and  they'd been asking questions.
+ "Well, so he did, when he finally came. But all the rest of 'em together couldn't do it. And all Moraelyn wanted was to study with them. We were a sight, the two of us dark elves in our battle gear among all that white and gold. I felt like a fish out of water, but Moraelyn was interested in what they had to say....and you can bet they hung on every word he said. Not too many words at first. After a fortnight or so, he told me one night to tell the Archmagister that he'd be back in a couple of days. And he shows up with Silk! 'Course he'd been telling 'em about the Khajiits...and they'd been asking questions.
 
- "The Archmagister's no fool. He just stared at Silk, and she purred real loud  and
-rubbed up against him and asked "How ya doin', Archmagister,
-baby?" The  Archmagister kinda pushes Silk away and says in a
-whisper, "How--many--more?"
+ "The Archmagister's no fool. He just stared at Silk, and she purred real loud and rubbed up against him and asked "How ya doin', Archmagister, baby?" The Archmagister kinda pushes Silk away and says in a whisper, "How--many--more?"
 
  "Just two, sir."
 
@@ -262,39 +86,13 @@ whisper, "How--many--more?"
 
  "Wood elves, sir."
 
- "Just wood elves. Plain ordinary wood elves. No horns,
-hooves or tails."
+ "Just wood elves. Plain ordinary wood elves. No horns, hooves or tails."
 
-e a fish out of water, but Moraelyn was interested in  what they had to say....and
-you can bet they hung on every word he said.  Not too many
-words at first. After a fortnight or so, he told me one
-night  to tell the Archmagister that he'd be back in a couple
-of days. And he shows  up with Silk! 'Course he'd been telling
-'em about the Khajiits...and  they'd been asking questions.
+ "Yes sir. Ah, one of them has an extraordinary Absorb ability with some very unusual features. The other's just a Bard."
 
- "The Archmagister's no fool. He just stared at Silk, and she purred real loud  and
-rubbed up against him and asked "How ya doin', Archmagister,
-baby?" The  Archmagister kinda pushes Silk away and says in a
-whisper, "How--many--more?"
+ "Very well. You may bring the one with the Absorb. We don't want a Bard! They are not true mages."
 
- "Just two, sir."
-
- "What are they?"
-
- "Wood elves, sir."
-
- "Just wood elves. Plain ordinary wood elves. No horns,
-hooves or tails."
-
- "Yes sir. Ah, one of them has an extraordinary Absorb
-ability with some  very unusual features. The other's just a
-Bard."
-
- "Very well. You may bring the one with the Absorb. We don't
-want a Bard!  They are not true mages."
-
- "Well, that's most generous of you, sir, but the Bard's her
-brother, sir  and I swore to their parents that I wouldn't separate them. So it'll just  be the three of us."
+ "Well, that's most generous of you, sir, but the Bard's her brother, sir and I swore to their parents that I wouldn't separate them. So it'll just be the three of us."
 
  "Her brother."
 
@@ -302,96 +100,48 @@ brother, sir  and I swore to their parents that I wouldn't separate them. So it'
 
  "You may bring them both."
 
- So three days later he's back with the twins AND Ssa'ass AND
-Slave. The  Archmagister looks at them and sort of bobs up
-and down, but he speaks real  quiet. "Dark Elf, by pair of
-twins, did you mean TWO SETS of twins? Are  you going to
-tell me that these--these are twins???" Well, I could see 
-that Moraelyn was kinda sorry he hadn't thought of trying
-that, but he  said, "No sir, the twins are Beech and Willow.
-The Argonian and the Nord  are not prospective initiates.
-They are specimens. For your collection.  You don't have
-any like them so I thought--"
+ So three days later he's back with the twins AND Ssa'ass AND Slave. The Archmagister looks at them and sort of bobs up and down, but he speaks real quiet. "Dark Elf, by pair of twins, did you mean TWO SETS of twins? Are you going to tell me that these--these are twins???" Well, I could see that Moraelyn was kinda sorry he hadn't thought of trying that, but he said, "No sir, the twins are Beech and Willow. The Argonian and the Nord are not prospective initiates. They are specimens. For your collection. You don't have any like them so I thought--"
 
- "You thought. I do not have a dragon either! Are you going
-to think to  bring me that next?"
+ "You thought. I do not have a dragon either! Are you going to think to bring me that next?"
 
  "Oh, aye, I could. Would you like one?"
 
  "Tell me you are not serious."
 
- "Well, I couldn't promise. And it would take quite a long
-time, a year  maybe, but--"
+ "Well, I couldn't promise. And it would take quite a long time, a year maybe, but--"
 
- The Archmagister's eyes rolled up toward heaven. "Thank
-you, All-Mother, I  have at least a year to prepare." he
-whispered. 
+ The Archmagister's eyes rolled up toward heaven. "Thank you, All-Mother, I have at least a year to prepare." he whispered.
 
- "I don't think Mats and Ssa'ass should have been made
-specimens. They're  people. Even if they aren't elves."
+ "I don't think Mats and Ssa'ass should have been made specimens. They're people. Even if they aren't elves."
 
- "Oh, they made Ssa'ass an initiate when they found out that
-he had some  interesting Heal spells."
+ "Oh, they made Ssa'ass an initiate when they found out that he had some interesting Heal spells."
 
  "But Mats?"
 
- "Mats never minds anything. He hasn't a bit of magic; he
-couldn't be an  initiate. Anyway he'd have hated it. He spent his time gaming with the  guards.
-When he wasn't being studied. Seems he has some interesting
-magic  resistances. Anyway, since then, the initiates aren't
-just High Elves. And  they don't all follow the Mage way."
+ "Mats never minds anything. He hasn't a bit of magic; he couldn't be an initiate. Anyway he'd have hated it. He spent his time gaming with the guards. When he wasn't being studied. Seems he has some interesting magic resistances. Anyway, since then, the initiates aren't just High Elves. And they don't all follow the Mage way."
 
  "I shall. I shall be just like the Archmagister."
 
- "Oh, aye, exactly," Moraelyn's voice sounded lightly
-behind him. "I'll cut  the ears off a donkey for thee and dye
-thy skin with saffron. Bleach thy  hair white and stretch thee a
-foot--" Moraelyn swung him high. "Art well,  son? I told
-thee so, Aliera. He's not ill at all. Good, because the 
-Archmagister's returned. We go to the Tower tomorrow."
+ "Oh, aye, exactly," Moraelyn's voice sounded lightly behind him. "I'll cut the ears off a donkey for thee and dye thy skin with saffron. Bleach thy hair white and stretch thee a foot--" Moraelyn swung him high. "Art well, son? I told thee so, Aliera. He's not ill at all. Good, because the Archmagister's returned. We go to the Tower tomorrow."
 
- 'We' was just Moraelyn and Edward. Aliera had caught
-Edward's cold and  they took some pleasure in insisting she
-remain in bed. Moraelyn rowed  them across the river in a
-small boat and they walked for most of the day,  resting a
-little at midday. It was evening when they reached the tower
-and  the setting sun was glinting off it. Even the sea far
-below looked red.  There was a hush over the countryside.
+ 'We' was just Moraelyn and Edward. Aliera had caught Edward's cold and they took some pleasure in insisting she remain in bed. Moraelyn rowed them across the river in a small boat and they walked for most of the day, resting a little at midday. It was evening when they reached the tower and the setting sun was glinting off it. Even the sea far below looked red. There was a hush over the countryside.
 
  "It's tall, isn't it?" Edward paused to look.
 
  "Towers generally are."
 
- "Did you really--" Edward broke off. Questions starting in
-that fashion  did not draw satisfactory answers from the
-elf.
+ "Did you really--" Edward broke off. Questions starting in that fashion did not draw satisfactory answers from the elf.
 
- "Has Mith been telling thee tales? He's had ten years to
-polish that one.  I doubt not it glistens like the Tower."
+ "Has Mith been telling thee tales? He's had ten years to polish that one. I doubt not it glistens like the Tower."
 
  "He told me how you met, too."
 
  "I thought he would."
 
- "I didn't understand why you went off with him? He was a
-thief and a  stableboy and you were a prince."
+ "I didn't understand why you went off with him? He was a thief and a stableboy and you were a prince."
 
  "You have just named three excellent reasons, Prince."
 
  "You never give me serious answers."
 
- "A serious charge. Very well, then. I saw myself through
-Mith's eyes and  misliked what I saw: a callous bully and a
-coward, fit to be neither boy  nor man nor prince. Why did
-you run off, Prince?"
-
- Edward hung his head mutely. "Nay, _I_ do not require
-answers. Come, it  grows late." Moraelyn reached his hand
-for Edward's, but Edward shook him  off. If Moraelyn was a
-coward what did that make Edward? He looked at the  Tower door
-where Moraelyn had demanded and won entrance, though all
-would  shut him out. Edward could never do anything like
-that, but at least he  could walk in on his own as an invited
-guest.
-
- 
+ "A serious charge. Very well, then. I saw myself through Mith's eyes and misliked what I saw: a callous bully and a coward, fit to be neither boy nor man nor prince. Why did you run off, Prince?" Edward hung his head mutely. "Nay, I do not require answers. Come, it grows late." Moraelyn reached his hand for Edward's, but Edward shook him off. If Moraelyn was a coward what did that make Edward? He looked at the Tower door where Moraelyn had demanded and won entrance, though all would shut him out. Edward could never do anything like that, but at least he could walk in on his own as an invited guest.

--- a/Assets/StreamingAssets/Text/Books/BOK00104-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00104-LOC.txt
@@ -3,56 +3,32 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]King Edward, Part V
 
-
-
 [/font=4]
 
- Chap 5: In the Crystal Tower
+[/center]
 
+[/center]In the Crystal Tower
 
+ Inside the Tower, Edward's first impression was of whiteness. Floors, walls, ceiling, all were white and radiated light. Their footsteps made soft crunching noises on the rough floor surface. Except for that, it was very still ... with occasional soft, unrecognizable far-off sounds. Moraelyn moved confidently through winding halls and long rooms. He seemed very black in all that white. They passed long pools of water with fountains that sparkled in the light.
 
-
-
- Inside the Tower, Edward's first impression was of whiteness.
-Floors, walls, ceiling, all were white and radiated light.
-Their footsteps made soft crunching noises on the rough
-floor surface. Except for that, it was very still ... with
-occasional soft, unrecognizable far-off sounds. Moraelyn 
-moved confidently through winding halls and long rooms. He
-seemed very black in all that white. They passed long pools
-of water with fountains  that sparkled in the light.
-
- "Where is everyone?" Edward whispered. 
+ "Where is everyone?" Edward whispered.
 
  "At table, I hope. I'm hungry. Aren't you?"
 
- "No." Abruptly a big, broad ugly shape appeared in front
-of them and roared a challenge. Edward grabbed for
-Moraelyn's arm with both hands. Moraelyn shook him off
-irritably. "Gods, boy, don't grab my sword arm if ever you
-do spot a monster. Stay clear!" But Moraelyn didn't reach
-for his blade. He stood still while the monster wrapped its
-long arms around him  and pounded on his back, still
-roaring. Moraelyn roared back and pounded on the monster's
-chest. Then he introduced Edward to the Captain of the
-Archmagister's guard.
+ "No." Abruptly a big, broad ugly shape appeared in front of them and roared a challenge. Edward grabbed for Moraelyn's arm with both hands. Moraelyn shook him off irritably. "Gods, boy, don't grab my sword arm if ever you do spot a monster. Stay clear!" But Moraelyn didn't reach for his blade. He stood still while the monster wrapped its long arms around him and pounded on his back, still roaring. Moraelyn roared back and pounded on the monster's chest. Then he introduced Edward to the Captain of the Archmagister's guard.
 
- "Don't hug him," Moraelyn warned the troll, who grinned at
-Edward showing pointy teeth. "He'll break."
+ "Don't hug him," Moraelyn warned the troll, who grinned at Edward showing pointy teeth. "He'll break."
 
- "I thought trolls were dangerous!" Edward gasped as they
-ascended a long winding stairway.
+ "I thought trolls were dangerous!" Edward gasped as they ascended a long winding stairway.
 
- "They are. I'll have bruises for a fortnight. I'd have
-shielded, but I didn't like to hurt his feelings."
+ "They are. I'll have bruises for a fortnight. I'd have shielded, but I didn't like to hurt his feelings."
 
  "He likes you?!"
 
@@ -62,61 +38,27 @@ shielded, but I didn't like to hurt his feelings."
 
  "They keep the rats down."
 
- More trolls, but these paid them little heed. Another long
-stairway. More corridors. A sort of guardroom where three
-trolls appeared to be gaming  with bones. One of them
-shambled to his feet and led them down a shadowy passage. A
-row of cages with huge rats, then some with small odd
-creatures that looked rather like elves seen in a badly
-distorted mirror (though Edward kept this observation to
-himself). They gobbled and squeaked as the elf and boy paced
-quickly by.
+ More trolls, but these paid them little heed. Another long stairway. More corridors. A sort of guardroom where three trolls appeared to be gaming with bones. One of them shambled to his feet and led them down a shadowy passage. A row of cages with huge rats, then some with small odd creatures that looked rather like elves seen in a badly distorted mirror (though Edward kept this observation to himself). They gobbled and squeaked as the elf and boy paced quickly by.
 
- "Goblins," Moraelyn said with distaste. They turned a corner
-and went past two cages that held only large stone statues.
-There seemed to be more cages off down other hallways. The
-troll unlocked a huge black metal door. It clanged shut
-behind them. A very large green and yellow hooved creature
-sat man-like in one corner. Its unwinking eyes didn't flicker
-as they passed quickly and climbed still another stair. More
-white halls. These were patrolled by huge black dogs that
-sniffed at them as they passed. Edward stretched a hand to pet
-one, but it snarled at him.
+ "Goblins," Moraelyn said with distaste. They turned a corner and went past two cages that held only large stone statues. There seemed to be more cages off down other hallways. The troll unlocked a huge black metal door. It clanged shut behind them. A very large green and yellow hooved creature sat man-like in one corner. Its unwinking eyes didn't flicker as they passed quickly and climbed still another stair. More white halls. These were patrolled by huge black dogs that sniffed at them as they passed. Edward stretched a hand to pet one, but it snarled at him.
 
  "I wouldn't." Moraelyn said.
 
  "Yes Sir."
 
- They came to another massive black metal door. A voice
-sounded. "What is black and white, has one body, two heads,
-four arms, four legs, two red eyes and two brown?"
+ They came to another massive black metal door. A voice sounded. "What is black and white, has one body, two heads, four arms, four legs, two red eyes and two brown?"
 
- "That's disgusting!" Moraelyn yelled at the door, hands on
-hips. 
+ "That's disgusting!" Moraelyn yelled at the door, hands on hips.
 
- "You are correct, mortal. You may pass." The door swung
-slowly open, creaking. There was no one behind it, just a
-narrow stairway that wound sharply. It seemed dark above.
-Moraelyn raced up the stairs, leaving Edward clinging to
-the bottom rail, shaking. There was not a thing to do  but
-follow.
+ "You are correct, mortal. You may pass." The door swung slowly open, creaking. There was no one behind it, just a narrow stairway that wound sharply. It seemed dark above. Moraelyn raced up the stairs, leaving Edward clinging to the bottom rail, shaking. There was not a thing to do but follow.
 
- "Welcome, Edward." The Archmagister stood white and gold
-in the center of a large dim room. Huge windows looked out on
-the purple twilit sea below. "Come here, child. Give me your
-hands."
+ "Welcome, Edward." The Archmagister stood white and gold in the center of a large dim room. Huge windows looked out on the purple twilit sea below. "Come here, child. Give me your hands."
 
- Edward put his hands in the Archmagister's who smiled down at
-him. Edward's fatigue and fear vanished instantly. He smiled
-back at the Archmagister, who  said softly. "It is well. You
-may go," to the furious dark elf who stood glowering to one
-side. Edward was barely aware of him, his whole attention
-occupied by the Archmagister.
+ Edward put his hands in the Archmagister's who smiled down at him. Edward's fatigue and fear vanished instantly. He smiled back at the Archmagister, who said softly. "It is well. You may go," to the furious dark elf who stood glowering to one side. Edward was barely aware of him, his whole attention occupied by the Archmagister.
 
  "Goodbye, Edward."
 
- "'Bye." Edward didn't take his eyes off the Archmagister.
-From far away he heard the dark elf go down the stairs.
+ "'Bye." Edward didn't take his eyes off the Archmagister. From far away he heard the dark elf go down the stairs.
 
  "He calls you son," the Archmagister said.
 
@@ -126,154 +68,74 @@ From far away he heard the dark elf go down the stairs.
 
  Edward sighed. "No sir."
 
- "That may be as well. You will return to Daggerfall one
-day. And then you must be Corcyr's son. So let the claim be
-on Moraelyn's side." The Archmagister moved companionably
-to the windows with him. The dusk was fast gathering as Edward
-stared out over the hill through which they'd journeyed. A
-dark figure appeared below and strode swiftly off into the
-night.
+ "That may be as well. You will return to Daggerfall one day. And then you must be Corcyr's son. So let the claim be on Moraelyn's side." The Archmagister moved companionably to the windows with him. The dusk was fast gathering as Edward stared out over the hill through which they'd journeyed. A dark figure appeared below and strode swiftly off into the night.
 
- "That's Moraelyn! I thought he was going to stay the night.
-It's dangerous out there alone in the dark. There are evil
-things out there. Can't you--"
+ "That's Moraelyn! I thought he was going to stay the night. It's dangerous out there alone in the dark. There are evil things out there. Can't you--"
 
- "Dangerous for any evil that meets Moraelyn in his present
-mood. He will go safely, I promise you."
+ "Dangerous for any evil that meets Moraelyn in his present mood. He will go safely, I promise you."
 
- "Oh. But I haven't thanked him. He's been very kind, really.
-Why was he so angry about the door? It was just a silly
-question. The answer was him and my mother, when they're
-asleep and I'm not there. How do you make a door talk? Is it
-an illusion?"
+ "Oh. But I haven't thanked him. He's been very kind, really. Why was he so angry about the door? It was just a silly question. The answer was him and my mother, when they're asleep and I'm not there. How do you make a door talk? Is it an illusion?"
 
- "That's three questions. Which of them do you want answered?
-Aren't you hungry? Would you like a bowl of stew?"
+ "That's three questions. Which of them do you want answered? Aren't you hungry? Would you like a bowl of stew?"
 
  "Yes, please. I'd like to hear about the door, please."
 
- "Ah. You think the talking door may prove more
-comprehensible than a surly dark elf? More interesting? Or
-safer?" The Archmagister's large golden eyes regarded the
-boy thoughtfully.
+ "Ah. You think the talking door may prove more comprehensible than a surly dark elf? More interesting? Or safer?" The Archmagister's large golden eyes regarded the boy thoughtfully.
 
- "I don't know if I, uh, like him. Sometimes I think I ...  and
-then other times I ... do you understand about liking? He said
-he didn't."
+ "I don't know if I, uh, like him. Sometimes I think I ... and then other times I ... do you understand about liking? He said he didn't."
 
- "You would be more comfortable if you felt the same way
-about him at all times, yet you do not."
+ "You would be more comfortable if you felt the same way about him at all times, yet you do not."
 
  "Yes, that's it, exactly. You do understand."
 
  "Moraelyn is not a comfortable man."
 
- "Well, I don't mean that exactly. Sometimes he is. Like when
-we rode the dragon."
+ "Well, I don't mean that exactly. Sometimes he is. Like when we rode the dragon."
 
- The Archmagister laughed aloud. His laughter reminded Edward
-of chimes. "Yes, yes. I find comfort myself in having
-Moraelyn near at hand when dragons are about."
+ The Archmagister laughed aloud. His laughter reminded Edward of chimes. "Yes, yes. I find comfort myself in having Moraelyn near at hand when dragons are about."
 
- A young high elf brought in a bowl of stew and set it down on
-the table. Edward felt a bit disappointed that the stew had
-come in such an ordinary way. Until he remembered that the
-Archmagister hadn't sent for the stew.
+ A young high elf brought in a bowl of stew and set it down on the table. Edward felt a bit disappointed that the stew had come in such an ordinary way. Until he remembered that the Archmagister hadn't sent for the stew.
 
- "The priest at home in Daggerfall said it was a mark of evil
-things, that they cannot bear the light," Edward said between
-mouthfuls. "Moraelyn doesn't like sunlight. And he's
-black."
+ "The priest at home in Daggerfall said it was a mark of evil things, that they cannot bear the light," Edward said between mouthfuls. "Moraelyn doesn't like sunlight. And he's black."
 
  "I see. Do you know what evil is?"
 
  "Um, well, if you do bad things, then you're evil?"
 
- "I see. If the cook had burnt the stew, would he then be
-evil?"
+ "I see. If the cook had burnt the stew, would he then be evil?"
 
- Edward grinned. "No, just a bad cook. But if he did it on
-purpose, then I guess he'd have done an evil thing ... but
-maybe he wouldn't be altogether evil. Maybe he was just
-angry about something."
+ Edward grinned. "No, just a bad cook. But if he did it on purpose, then I guess he'd have done an evil thing ... but maybe he wouldn't be altogether evil. Maybe he was just angry about something."
 
- "Or perhaps the sort of person who is pleased by spoiling
-others' pleasure?"
+ "Or perhaps the sort of person who is pleased by spoiling others' pleasure?"
 
- "I guess that'd make my little brothers evil. They sure like
-to spoil my fun."
+ "I guess that'd make my little brothers evil. They sure like to spoil my fun."
 
  "And you?"
 
- Edward felt his face redden. "I don't take any notice of
-them," he said quickly. The Archmagister's large golden eyes
-regarded him steadily. To his own dismay, Edward began to
-cry. He bawled like a baby. "I don't know what's wrong with
-me," he gasped. "I never cry, really, I don't -- hardly ever
---"
+ Edward felt his face redden. "I don't take any notice of them," he said quickly. The Archmagister's large golden eyes regarded him steadily. To his own dismay, Edward began to cry. He bawled like a baby. "I don't know what's wrong with me," he gasped. "I never cry, really, I don't -- hardly ever --"
 
- "Why ever not?" Edward looked up. His tears had blurred his
-sight, but there seemed to be tears on the Archmagister's
-face. His hand reached up to feel the wetness. "You have been
-very alone, have you not?" the Archmagister said.
+ "Why ever not?" Edward looked up. His tears had blurred his sight, but there seemed to be tears on the Archmagister's face. His hand reached up to feel the wetness. "You have been very alone, have you not?" the Archmagister said.
 
- "Yes. Until you brought the unicorn for me, I was all
-alone. They endure no evil," Edward sighed with
-satisfaction, feeling relaxed and comfortable. The
-Archmagister was wonderful. 
+ "Yes. Until you brought the unicorn for me, I was all alone. They endure no evil," Edward sighed with satisfaction, feeling relaxed and comfortable. The Archmagister was wonderful.
 
- "We summoned the unicorn, Moraelyn and the dragon and I and
-others. It's a great magic and one no single man or woman
-may command. But don't trouble yourself overmuch with
-judging good and evil. That's a human notion. Life  is
-complex; I know of nothing that is wholly good or wholly
-evil. Not even the unicorn."
+ "We summoned the unicorn, Moraelyn and the dragon and I and others. It's a great magic and one no single man or woman may command. But don't trouble yourself overmuch with judging good and evil. That's a human notion. Life is complex; I know of nothing that is wholly good or wholly evil. Not even the unicorn."
 
- Edward's time in the Tower passed quickly. There were few
-other novices and the youngest of these was several years
-older than Edward. The boy spent several hours each day with
-the Archmagister. He learned to cast a few  spells and to
-open his mind so that he could renew his magicka quickly while
-he slept. But often they just talked. Sometimes Edward was
-given a book to read. Other times he was allowed to choose one
-from the thousands in the library. He usually tired of them
-quickly. He didn't read Elvish script easily; his tutor had
-taught him the letters, but their few books were in Bretic.
+ Edward's time in the Tower passed quickly. There were few other novices and the youngest of these was several years older than Edward. The boy spent several hours each day with the Archmagister. He learned to cast a few spells and to open his mind so that he could renew his magicka quickly while he slept. But often they just talked. Sometimes Edward was given a book to read. Other times he was allowed to choose one from the thousands in the library. He usually tired of them quickly. He didn't read Elvish script easily; his tutor had taught him the letters, but their few books were in Bretic.
 
- Spellcasting was more fun. Fire spells came easily to him
-and he learned to shield himself readily, but to his chagrin,
-he couldn't Heal at all. He invariably made things worse for
-the unlucky rats he was allowed to practice on. 
+ Spellcasting was more fun. Fire spells came easily to him and he learned to shield himself readily, but to his chagrin, he couldn't Heal at all. He invariably made things worse for the unlucky rats he was allowed to practice on.
 
- "I don't know what I'm doing wrong!" Edward cried out in
-frustration. He sent a dart of fire at the writhing rat and it
-turned into a charred corpse. 
+ "I don't know what I'm doing wrong!" Edward cried out in frustration. He sent a dart of fire at the writhing rat and it turned into a charred corpse.
 
- "Edward, it will be well if you let the Heal spells wait
-awhile yet."
+ "Edward, it will be well if you let the Heal spells wait awhile yet."
 
- "Moraelyn said Light Heal is the first spell anybody
-learns," Edward said sulkily.
+ "Moraelyn said Light Heal is the first spell anybody learns," Edward said sulkily.
 
- "Did he? Well, he is a practitioner of magic, not a
-theorist. Even I would hesitate to say what a Breton might or
-might not learn, and when he might learn it. You are the
-first of your people with whom I have worked. Certainly
-Moraelyn has had no experience with your race, except for
-your mother, of course."
+ "Did he? Well, he is a practitioner of magic, not a theorist. Even I would hesitate to say what a Breton might or might not learn, and when he might learn it. You are the first of your people with whom I have worked. Certainly Moraelyn has had no experience with your race, except for your mother, of course."
 
  "My mother can't do magic."
 
- "No, but we think the ability lies within her. She has not been
-able to learn to master it, possibly because she was too old
-when she first tried. If you want my opinion it is your
-thoughts and not your hands which are causing your
-difficulty. Weeping might help."
+ "No, but we think the ability lies within her. She has not been able to learn to master it, possibly because she was too old when she first tried. If you want my opinion it is your thoughts and not your hands which are causing your difficulty. Weeping might help."
 
- "I don't feel like crying," Edward said rather sullenly. He
-felt more like kicking something, although incinerating the
-rat had helped relieve some of that.
+ "I don't feel like crying," Edward said rather sullenly. He felt more like kicking something, although incinerating the rat had helped relieve some of that.
 
  "Meditation might help, then."
-
- 

--- a/Assets/StreamingAssets/Text/Books/BOK00105-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00105-LOC.txt
@@ -3,278 +3,116 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]King Edward, Part VI
 
-
-
 [/font=4]
-
-[/center] Chap 6: Training
 
 [/center]
 
-[/center] The day Edward was to leave the Archmagister summoned him,
-presented him with  a mithril staff and bade him farewell.
+[/center]Training
 
- Back in his small cell Edward removed his novitiate robe
-and donned the  grey shirt, black pants and red sash he'd worn
-to the Tower. He fingered  the sash lovingly. His mother had
-purchased the shirt and pants, saying  they looked sturdy and
-maybe wouldn't show the dirt from the journey.  Moraelyn had
-given him the silk sash with its embroidery of twined leaves 
-and flowers, birds and butterflies in mithril, dwarven
-and elven metallic  threads. But he'd waited until they were across the
-channel. Aliera had  said it cost too dear; she'd suggested
-cutting down one of Moraelyn's old  ones to fit, but the elf had adamantly refused to let
-her have any of  them. Edward smiled, remembering, and
-wrapped the sash twice round his  waist then knotted the ends
-carefully. He took the staff and ran down to  meet his
-parents.
+ The day Edward was to leave the Archmagister summoned him, presented him with a mithril staff and bade him farewell.
 
- He'd meant to fling himself at them, but Moraelyn was alone and Edward  stopped still.
-"Where's my mother? Is she--?"
+ Back in his small cell Edward removed his novitiate robe and donned the grey shirt, black pants and red sash he'd worn to the Tower. He fingered the sash lovingly. His mother had purchased the shirt and pants, saying they looked sturdy and maybe wouldn't show the dirt from the journey. Moraelyn had given him the silk sash with its embroidery of twined leaves and flowers, birds and butterflies in mithril, dwarven and elven metallic threads. But he'd waited until they were across the channel. Aliera had said it cost too dear; she'd suggested cutting down one of Moraelyn's old ones to fit, but the elf had adamantly refused to let her have any of them. Edward smiled, remembering, and wrapped the sash twice round his waist then knotted the ends carefully. He took the staff and ran down to meet his parents.
 
- "She wanted to stay and choose a horse for you. Didn't trust
-it to Beech."
+ He'd meant to fling himself at them, but Moraelyn was alone and Edward stopped still. "Where's my mother? Is she--?"
+
+ "She wanted to stay and choose a horse for you. Didn't trust it to Beech."
 
  "A horse? For me! Really?"
 
- "Of course. You can't walk all the way to Morrowwind."
+ "Of course. You can't walk all the way to Morrowind."
 
- "I thought I'd have to ride behind--someone. Look, the
-Archmagister gave me  my staff! Isn't it beautiful?"
+ "I thought I'd have to ride behind--someone. Look, the Archmagister gave me my staff! Isn't it beautiful?"
 
- The elf took it and hefted it, trying a few swings and
-feints. "Good  balance and weight for thee, I think. Light for
-me. Show me how you use  it. Suppose I attack you." He used
-his bare hands and Edward fell into a  defensive position,
-blocked him, then thrust the staff toward Moraelyn's  ribs. He
-danced easily aside, but praised the boy.
+ The elf took it and hefted it, trying a few swings and feints. "Good balance and weight for thee, I think. Light for me. Show me how you use it. Suppose I attack you." He used his bare hands and Edward fell into a defensive position, blocked him, then thrust the staff toward Moraelyn's ribs. He danced easily aside, but praised the boy.
 
- "A mage should have a dagger, too. I thought you might like
-to have Tooth  here." Edward's eye popped. Tooth had an
-ebony blade and a hilt made from  a real dragon's tooth. The elf slid it from its sheath and handed it to  Edward who took it carefully.
-The blade had a wicked point and the edge  was sharp enough to
-shave with. Mats borrowed it sometimes. He'd carved  the hilt,
-too.
+ "A mage should have a dagger, too. I thought you might like to have Tooth here." Edward's eye popped. Tooth had an ebony blade and a hilt made from a real dragon's tooth. The elf slid it from its sheath and handed it to Edward who took it carefully. The blade had a wicked point and the edge was sharp enough to shave with. Mats borrowed it sometimes. He'd carved the hilt, too.
 
  "Are you sure Mats doesn't mind?"
 
- "Quite sure." Moraelyn unbuckled his belt and slid the sheath off it.  There was a new belt for
-Edward of snakeskin, soft and pliable and a  buckle with the black rose of Morrowwind on it, just like
-Moraelyn's.  "It's from the Companions." He knelt to fit the
-belt and dagger and the  sash over it properly, and Edward threw his arms about his neck.
-"It's  wonderful. I do thank thee and them, too! And oh, I've
-missed all of thee  so much."
+ "Quite sure." Moraelyn unbuckled his belt and slid the sheath off it. There was a new belt for Edward of snakeskin, soft and pliable and a buckle with the black rose of Morrowwind [sic] on it, just like Moraelyn's. "It's from the Companions." He knelt to fit the belt and dagger and the sash over it properly, and Edward threw his arms about his neck. "It's wonderful. I do thank thee and them, too! And oh, I've missed all of thee so much."
 
  "We missed you, too, son. Let's go or we'll miss our tide."
 
- "I wouldn't want to worry mother," he said, trying to
-sound casual about  having a mother that would worry about
-him.
+ "I wouldn't want to worry mother," he said, trying to sound casual about having a mother that would worry about him.
 
- "No fear; I told her not to look for us until tomorrow
-night....just in  case. But we'll surprise her."
+ "No fear; I told her not to look for us until tomorrow night....just in case. But we'll surprise her."
 
  "Good thinking."
 
- They made good speed and reached the inlet before the tide
-was full.
+ They made good speed and reached the inlet before the tide was full.
 
- "Shall I show you how to use Tooth, or would you rather
-rest?"
+ "Shall I show you how to use Tooth, or would you rather rest?"
 
  "Tooth! I can rest in the boat while you work."
 
- Moraelyn shielded himself and Edward too, saying that
-Tooth's bite was no  joke. "I could have shielded myself,"
-Edward said proudly. "I'm good at  that. But my Heals go
-all wrong."
+ Moraelyn shielded himself and Edward too, saying that Tooth's bite was no joke. "I could have shielded myself," Edward said proudly. "I'm good at that. But my Heals go all wrong."
 
  "It'll come. Give it time."
 
- Evidently Tooth wanted time too. Try as he might, he
-couldn't get near the  elf with the blade, even though
-Moraelyn kept his feet planted and simply  swerved his body,
-ducking and weaving...and laughing. Frustrated, Edward 
-sheathed Tooth and picked up the staff and whacked at him,
-swinging it  with both hands. It wasn't doing any harm, but
-it made satisfying sounds  as it thwacked against the spell
-shield. Moraelyn let him hit, but stopped  the staff easily
-when the spell had been used up. Edward threw it on the 
-ground and turned away; the elf reached for him in
-consolation. Edward  snatched Tooth from the sheath and
-thrust it straight at the elf's heart.  The blade was knocked
-spinning from his hand. Edward had braced to stop  the thrust
-and hold it and he felt the shock even through his shield. Then  Moraelyn was
-kneeling before him, nursing his left hand across his right 
-knee, his face grey with shock and disbelief. Blood was
-gushing from his  wrist like a fountain. "Give me thy sash!"
+ Evidently Tooth wanted time too. Try as he might, he couldn't get near the elf with the blade, even though Moraelyn kept his feet planted and simply swerved his body, ducking and weaving... and laughing. Frustrated, Edward sheathed Tooth and picked up the staff and whacked at him, swinging it with both hands. It wasn't doing any harm, but it made satisfying sounds as it thwacked against the spell shield. Moraelyn let him hit, but stopped the staff easily when the spell had been used up. Edward threw it on the ground and turned away; the elf reached for him in consolation. Edward snatched Tooth from the sheath and thrust it straight at the elf's heart. The blade was knocked spinning from his hand. Edward had braced to stop the thrust and hold it and he felt the shock even through his shield. Then Moraelyn was kneeling before him, nursing his left hand across his right knee, his face grey with shock and disbelief. Blood was gushing from his wrist like a fountain. "Give me thy sash!"
 
- "I--I didn't--" Edward's teeth were rattling in his head. He
-felt sick and  dizzy. Bile washed up in his mouth. "D-d-didn't--m-m-mean." So much blood.
+ "I--I didn't--" Edward's teeth were rattling in his head. He felt sick and dizzy. Bile washed up in his mouth. "D-d-didn't--m-m-mean." So much blood.
 
- "Boy, don't faint now. I need thy aid. The sash. Now, Edward! Pack it into  the wound. Gods, what a mess!" The hand was
-half severed at the wrist.  Edward sat down abruptly,
-shaking all over, but his hands packed the sash  into the open 
-wound, then he wrapped the
-rest round the hand and wrist.
-
- "Take my sash and make a sling." Moraelyn eased the injured
-limb into the  sling and then released his other hand. He took
-the water bottle from his  belt and drank it down. "I need
-more water. Where's thy staff? There's a  well two miles
-back. Where's Tooth? Go find it and don't cut yourself on
-it."
+ "Boy, don't faint now. I need thy aid. The sash. Now, Edward! Pack it into the wound. Gods, what a mess!" The hand was half severed at the wrist. Edward sat down abruptly, shaking all over, but his hands packed the sash into the open wound, then he wrapped the rest round the hand and wrist. "Take my sash and make a sling." Moraelyn eased the injured limb into the sling and then released his other hand. He took the water bottle from his belt and drank it down. "I need more water. Where's thy staff? There's a well two miles back. Where's Tooth? Go find it and don't cut yourself on it."
 
  "I don't want it."
 
- "Not many blades have bathed in Moraelyn's blood. 'Twill
-bring you luck.  Do as I say."
+ "Not many blades have bathed in Moraelyn's blood. 'Twill bring you luck. Do as I say."
 
  "The tide's in."
 
- "Aye and Firsthold could be on Jone for all the good it does
-us. I can't  row one handed."
+ "Aye and Firsthold could be on Jone for all the good it does us. I can't row one handed."
 
  "I could--"
 
-ound, then he wrapped the
-rest round the hand and wrist.
-
- "Take my sash and make a sling." Moraelyn eased the injured
-limb into the  sling and then released his other hand. He took
-the water bottle from his  belt and drank it down. "I need
-more water. Where's thy staff? There's a  well two miles
-back. Where's Tooth? Go find it and don't cut yourself on
-it."
-
- "I don't want it."
-
- "Not many blades have bathed in Moraelyn's blood. 'Twill
-bring you luck.  Do as I say."
-
- "The tide's in."
-
- "Aye and Firsthold could be on Jone for all the good it does
-us. I can't  row one handed."
-
- "I could--"
-
- "No, you cannot. You haven't the strength. The current's
-swift here. I  prefer to die on land. Edward, we cannot stay
-here. The blood smell will  draw beasts. If I faint, get well away and climb a tree. And pray." He  climbed
-to his feet and leaned on the staff, breathing hard. "Stay
-close,  but don't grab at me, no matter what happens." He took
-a small step, then another.
+ "No, you cannot. You haven't the strength. The current's swift here. I prefer to die on land. Edward, we cannot stay here. The blood smell will draw beasts. If I faint, get well away and climb a tree. And pray." He climbed to his feet and leaned on the staff, breathing hard. "Stay close, but don't grab at me, no matter what happens." He took a small step, then another.
 
  "I'm sorry."
 
- "Doubtless. You picked a poor time and place to turn
-assassin. A good  assassin always has an escape planned."
+ "Doubtless. You picked a poor time and place to turn assassin. A good assassin always has an escape planned."
 
- "Yessir." Edward sniffed back his tears. "Sir, I cannot
-Heal you, but I  can restore some vigor."
+ "Yessir." Edward sniffed back his tears. "Sir, I cannot Heal you, but I can restore some vigor."
 
- "Can you? 'T'would be of great help." The spell Edward
-cast shook the elf;  he gasped, but stood straighter and firmer
-after the shock wore off. "I  can do it again," Edward offere
-d eagerly.
+ "Can you? 'T'would be of great help." The spell Edward cast shook the elf; he gasped, but stood straighter and firmer after the shock wore off. "I can do it again," Edward offered eagerly.
 
  "Nay. You have plenty of power but want finesse. But 'tis much better, now."
 
- Moraelyn was walking better; he sounded better too. Edward
-tried to blot  the picture of the injury out of his mind. They
-moved slowly, Moraelyn  leaning against a tree from time to time to rest. Nothing
-molested them.  After an interminable time of silent
-travelling they reached the old well.  Moraelyn drained the
-first bottle and Edward refilled it, drank himself,  then
-filled it yet again.
+ Moraelyn was walking better; he sounded better too. Edward tried to blot the picture of the injury out of his mind. They moved slowly, Moraelyn leaning against a tree from time to time to rest. Nothing molested them. After an interminable time of silent travelling they reached the old well. Moraelyn drained the first bottle and Edward refilled it, drank himself, then filled it yet again.
 
- "We'll spend the night in there." 'There' was a large
-ramshackle building,  apparently deserted. The elf kicked
-the locked door open. Inside it was  pitch dark. "Light?"
-Edward offered.
+ "We'll spend the night in there." 'There' was a large ramshackle building, apparently deserted. The elf kicked the locked door open. Inside it was pitch dark. "Light?" Edward offered.
 
- "Nay. I can see. Save your power and stay by me." There
-was a skittering  noise. Rats! Edward shielded them both
-without thinking, pulled Tooth out,  and placed his back to
- eagerly.
+ "Nay. I can see. Save your power and stay by me." There was a skittering noise. Rats! Edward shielded them both without thinking, pulled Tooth out, and placed his back to the elf's. A rat leaped and drove itself onto the blade. Moraelyn swung the staff and laid out two more. Others scurried off.
 
- "Nay. You have plenty of power but want finesse. But 'tis much better, now."
+ "Well done, lad!" They found a small windowless room and shut the door behind them. There seemed to be some wood about; probably it had been some sort of storage room off the kitchen. Moraelyn sat down against the wall.
 
- Moraelyn was walking better; he sounded better too. Edward
-tried to blot  the picture of the injury out of his mind. They
-moved slowly, Moraelyn  leaning against a tree from time to time to rest. Nothing
-molested them.  After an interminable time of silent
-travelling they reached the old well.  Moraelyn drained the
-first bottle and Edward refilled it, drank himself,  then
-filled it yet again.
+ "So. You can use a knife. Was all that pretense? To put me off my guard?"
 
- "We'll spend the night in there." 'There' was a large
-ramshackle building,  apparently deserted. The elf kicked
-the locked door open. Inside it was  pitch dark. "Light?"
-Edward offered.
+ Edward was appalled. He burst into tears, protesting that he'd never harm Moraelyn willingly. "I meant it for jest; I thought it'd make you laugh...I was angry, at first, but at myself, my clumsiness, not you...it was a sudden thought....I love you dear!"
 
- "Nay. I can see. Save your power and stay by me." There
-was a skittering  noise. Rats! Edward shielded them both
-without thinking, pulled Tooth out,  and placed his back to
-the elf's. A rat leaped and drove itself onto the  blade.
-Moraelyn swung the staff and laid out two more. Others
-scurried off.
+ The elf reached out with his good arm and pulled Edward down to him. "That's worth a hand, then, any day."
 
- "Well done, lad!" They found a small windowless room and shut the door  behind them. There
-seemed to be some wood about; probably it had been some 
-sort of storage room off the kitchen. Moraelyn sat down
-against the wall.
-
- "So. You can use a knife. Was all that pretense? To put me
-off my guard?"
-
- Edward was appalled. He burst into tears, protesting that
-he'd never harm  Moraelyn willingly. "I meant it for jest;
-I thought it'd make you  laugh...I was angry, at first, but
-at myself, my clumsiness, not you...it  was a sudden thought....I love you dear!"
-
- The elf reached out with his good arm and pulled Edward
-down to him.  "That's worth a hand, then, any day."
-
- Edward sobbed against his shoulder while Moraelyn soothed him with
-pats.  "You are my real father."
+ Edward sobbed against his shoulder while Moraelyn soothed him with pats. "You are my real father."
 
  "Edward, I am not..."
 
- "Nay, thou art. Thee puts my well-being ahead of thine and
-loves me when I  least deserve it. Thee's been kind and
-generous and never asked anything  of me save to my own
-profit. Thee'd give thy very life for mine. That's  what real
-fathers do. And I've given thee naught but pain. He who sired
-me  despises me and my mother because we are unlike him. We are
-not like you  either, and yet you love us well. I will do
-better by you, dear Father."
+ "Nay, thou art. Thee puts my well-being ahead of thine and loves me when I least deserve it. Thee's been kind and generous and never asked anything of me save to my own profit. Thee'd give thy very life for mine. That's what real fathers do. And I've given thee naught but pain. He who sired me despises me and my mother because we are unlike him. We are not like you either, and yet you love us well. I will do better by you, dear Father."
 
- "I gave thee cause enough for offense. I took thy mother from
-thee."
+ "I gave thee cause enough for offense. I took thy mother from thee."
 
- "You risked losing her because you would not part me from
-my father. You  did not know me and my father was your bitter
-enemy. And yet you took  thought for us. You could not know how unnatural he is. It
- isn't in you."
+ "You risked losing her because you would not part me from my father. You did not know me and my father was your bitter enemy. And yet you took thought for us. You could not know how unnatural he is. It isn't in you."
 
- "Granted. And yet the offense and your anger at it
-remain."
+ "Granted. And yet the offense and your anger at it remain."
 
- "I love you!" Edward protested. But he heard an angry edge
-in his voice.
+ "I love you!" Edward protested. But he heard an angry edge in his voice.
 
- "And hate me." Moraelyn's voice was so calm and quiet that
-they might have  been discussing the weather.
+ "And hate me." Moraelyn's voice was so calm and quiet that they might have been discussing the weather.
 
  "I can't do both....can I?"
 
@@ -284,217 +122,80 @@ they might have  been discussing the weather.
 
  "I believe you."
 
- "Am I -- am I, evil? I _was_ sorry; I'd give anything if it
-hadn't  happened, but--I--".
+ "Am I -- am I, evil? I was sorry; I'd give anything if it hadn't happened, but--I--".
 
  "Took some measure of satisfaction in it."
 
-isn't in you."
-
- "Granted. And yet the offense and your anger at it
-remain."
-
- "I love you!" Edward protested. But he heard an angry edge
-in his voice.
-
- "And hate me." Moraelyn's voice was so calm and quiet that
-they might have  been discussing the weather.
-
- "I can't do both....can I?"
-
- "Can you?"
-
- "I didn't mean to hurt you."
-
- "I believe you."
-
- "Am I -- am I, evil? I _was_ sorry; I'd give anything if it
-hadn't  happened, but--I--".
-
- "Took some measure of satisfaction in it."
-
- Edward's throat was choked with sobs; he couldn't speak, but
-nodded into  Moraelyn's shoulder. The elf's hand stroked him
-gently.
+ Edward's throat was choked with sobs; he couldn't speak, but nodded into Moraelyn's shoulder. The elf's hand stroked him gently.
 
  "Did I'ric tell you of the Daedra?"
 
- "The demons? No. Is it a demon makes me do such things? I am
-evil, then."
+ "The demons? No. Is it a demon makes me do such things? I am evil, then."
 
- "No, you are not. But the daedra feed on actions such as
-that.  They--encourage them. And your anger draws them. But
-they can't make you  do anything. And they or it's not inside
-you. But it is connected to you."
+ "No, you are not. But the daedra feed on actions such as that. They--encourage them. And your anger draws them. But they can't make you do anything. And they or it's not inside you. But it is connected to you."
 
- "I don't want it. I want it to go away. How can I make it go
-away?"
+ "I don't want it. I want it to go away. How can I make it go away?"
 
- "Why don't you want it? You draw power from it. That's what let you shield 
-us both with the rats attacked."
+ "Why don't you want it? You draw power from it. That's what let you shield us both wit the rats attacked."
 
  "Mana? That doesn't come from demons."
 
- "No, but the ability to use it can. Look, some of your deeds
-feed the  daedra. But you draw power from it at the same
-time. Then the power's  yours, to use as you choose."
+ "No, but the ability to use it can. Look, some of your deeds feed the daedra. But you draw power from it at the same time. Then the power's yours, to use as you choose."
 
  "Do you have a daedra?"
 
- "I do and it's a big one, too, but I think everyone has one
-or more. Some  are stronger than others, that's all. But
-don't go around asking after  them. It's not polite."
+ "I do and it's a big one, too, but I think everyone has one or more. Some are stronger than others, that's all. But don't go around asking after them. It's not polite."
 
  "I want mine to go away!" Edward wailed.
 
- "So you say. But pretending it isn't there will not accomplish that.  Having a daedra
-is a bit like riding a horse. You must keep control. The 
-daedra do not care for you. It would as lief feed off your
-pain or injury  or death as any other, and find a new host. They
-do not think or plan as  we can and I do not think they
-experience time as we do. So acts that feed  the daedra take
-place in the moment and while you are caught up in them,  past
-and future cease to exist for you too. It is an intensely
-pleasurable  experience, but it can also be very dangerous.
-And very addictive, so that  you begin to think only of
-feeding your daedra. You cease to think of the  gods and those
-you love and even yourself. When you have walked too far 
-along that path, you lose the will to choose another."
+ "So you say. But pretending it isn't there will not accomplish that. Having a daedra is a bit like riding a horse. You must keep control. The daedra do not care for you. It would as lief feed off your pain or injury or death as any other, and find a new host. They do not think or plan as we can and I do not think they experience time as we do. So acts that feed the daedra take place in the moment and while you are caught up in them, past and future cease to exist for you too. It is an intensely pleasurable experience, but it can also be very dangerous. And very addictive, so that you begin to think only of feeding your daedra. You cease to think of the gods and those you love and even yourself. When you have walked too far along that path, you lose the will to choose another."
 
  "How terrible! What must I do then?"
 
- "It is terrible, the worst that can befall a person.
-Remember this night.  How you felt. Learn to recognize the
-daedra's hunger for what it is, and  think about what you do. You are young and this is
-heavy for you, but you  are at risk. Ah!" The elf's body
-stiffened and he caught his breath.  Edward guessed that the wound was paining him. 
+ "It is terrible, the worst that can befall a person. Remember this night. How you felt. Learn to recognize the daedra's hunger for what it is, and think about what you do. You are young and this is heavy for you, but you are at risk. Ah!" The elf's body stiffened and he caught his breath. Edward guessed that the wound was paining him.
 
- Moraelyn said that he must sleep a bit, and could Edward
-keep watch and  wake him in an hour's time. Then he could set a
-lock on the door and they  could both rest.
+ Moraelyn said that he must sleep a bit, and could Edward keep watch and wake him in an hour's time. Then he could set a lock on the door and they could both rest.
 
- "Aye, sir...and I might do somewhat more. I cannot set a
-lock, but..." The  door would not latch, nor would it stay
-open, but would swing nearly shut.  Edward felt about near
-the wall behind it and found a wedge. He shut the  door and
-drove the wedge home with a chunk of wood. "I thought so. 'Tis
- awkward to pass such a door with both arms full of wood. We
-have such at  ho--in Gerald's palace. Now anything trying to
-come in will rouse you; you  can use your power to cast heal
-instead of lock."
+ "Aye, sir...and I might do somewhat more. I cannot set a lock, but..." The door would not latch, nor would it stay open, but would swing nearly shut. Edward felt about near the wall behind it and found a wedge. He shut the door and drove the wedge home with a chunk of wood."I thought so. 'Tis awkward to pass such a door with both arms full of wood. We have such at ho--in Gerald's palace. Now anything trying to come in will rouse you; you can use your power to cast heal instead of lock."
 
- "Why, well thought of, indeed." He freed his blade and laid it on the  floor beside him. "We may as
-well both sleep then."
+ "Why, well thought of, indeed." He freed his blade and laid it on the floor beside him. "We may as well both sleep then."
 
- They slept fitfully. There were often scrabblings at the
-door and in the  walls, but nothing entered their small
-closet. Moraelyn cast Heal several  time during the night.
-By morning he pronounced himself as fit "as a  one-handed man
-can be." He unwrapped the sash-bandage and inspected the 
-wound. The bleeding was stopped; the hand was still warm to
-the touch; it  no longer hurt him nor was it swollen or
-discolored. But the wound was  still open and the hand
-useless. Nerves and muscles had been severed and  some of the
-small bones broken. Such repair was beyond his skill.
-Edward,  feeling the daedra feed on the sight, turned quickly
-away.
+ They slept fitfully. There were often scrabblings at the door and in the walls, but nothing entered their small closet. Moraelyn cast Heal several time during the night. By morning he pronounced himself as fit "as a one-handed man can be." He unwrapped the sash-bandage and inspected the wound. The bleeding was stopped; the hand was still warm to the touch; it no longer hurt him nor was it swollen or discolored. But the wound was still open and the hand useless. Nerves and muscles had been severed and some of the small bones broken. Such repair was beyond his skill. Edward, feeling the daedra feed on the sight, turned quickly away.
 
- Moraelyn grinned. "You may as well let it feed; it's a
-harmless sort of  feeding. The damage is done."
+ Moraelyn grinned. "You may as well let it feed; it's a harmless sort of feeding. The damage is done."
 
  "I mean to starve it," Edward said firmly.
 
- "You can try to do that or you can learn to control it
-instead, and still  walk with the gods. I think we'd best go
-back to the Tower."
+ "You can try to do that or you can learn to control it instead, and still walk with the gods. I think we'd best go back to the Tower."
 
  "Aye, they'll be able to heal you there, will they not?"
 
- "I know not. At the least they'll be able to attach it more firmly than it  is at present. Ah, do not look so downcast. The skill to mend it is  somewhere, if not in the Tower.
-Ssa'ass is good with battle injuries and  there are Temples which know more
-of the healing arts than the Tower  mages. Besides, it's only
-my left hand." He held up the wadded sash, stiff  with his dried blood. "The color's more practical t
-han thy mother
-thought.  Let's see if we can wash it out a bit. Never have I
-come so ill-equipped  on a journey. I might have been
-strolling down the main street in  Ebonheart. Thy mother will
-kill me."
+ "I know not. At the least they'll be able to attach it more firmly than it is at present. Ah, do not look so downcast. The skill to mend it is somewhere, if not in the Tower. Ssa'ass is good with battle injuries and there are Temples which know more of the healing arts than the Tower mages. Besides, it's only my left hand." He held up the wadded sash, stiff with his dried blood. "The color's more practical than thy mother thought. Let's see if we can wash it out a bit. Never have I come so ill-equipped on a journey. I might have been strolling down the main street in Ebonheart. Thy mother will kill me."
 
- "Right after she kills me," Edward sighed. "At least
-returning to the  Tower will delay that." They came out into the bright courtyard. The  morning sun was
-already high in the western sky.
+ "Right after she kills me," Edward sighed. "At least returning to the Tower will delay that." They came out into the bright courtyard. The morning sun was already high in the western sky.
 
- "Not so. Edward, the Companions are coming now! I hear
-them. Mara, let me  think of a real good lie!" 
+ "Not so. Edward, the Companions are coming now! I hear them. Mara, let me think of a real good lie!"
 
- Mith trotted into the courtyard. "Here they are!" he called
-back to the  others. By Torgo, you ARE injured. Let me see
-that. We thought to row  across to meet you; we saw the blood on the shore and tracked you here. 
-What attacked you?"
+ Mith trotted into the courtyard. "Here they are!" he called back to the others. By Torgo, you ARE injured. Let me see that. We thought to row across to meet you; we saw the blood on the shore and tracked you here. What attacked you?"
 
  "A demon."
 
- "A demon! What!? In the open like that in daylight? Gods,
-an thy mother
-thought.  Let's see if we can wash it out a bit. Never have I
-come so ill-equipped  on a journey. I might have been
-strolling down the main street in  Ebonheart. Thy mother will
-kill me."
+ "A demon! What!? In the open like that in daylight? Gods, what was it carrying, an ebony dai-katana?" Mith whistled as he inspected the injury. Aliera and the others ran up. She hugged Edward, "Are you all right, darling? I was worried." then paled as she saw her husband's hand.
 
- "Right after she kills me," Edward sighed. "At least
-returning to the  Tower will delay that." They came out into the bright courtyard. The  morning sun was
-already high in the western sky.
+ "You must be slowing down. How'd you let a demon do that to you?" Mith demanded.
 
- "Not so. Edward, the Companions are coming now! I hear
-them. Mara, let me  think of a real good lie!" 
+ "It was the boy...he grabbed at my arm in fright and my shield spell failed. It wasn't his fault; it was an accident. Ali, don't look at it. Edward, why don't you take thy mother to see the rat you killed?"
 
- Mith trotted into the courtyard. "Here they are!" he called
-back to the  others. By Torgo, you ARE injured. Let me see
-that. We thought to row  across to meet you; we saw the blood on the shore and tracked you here. 
-What attacked you?"
+ "I want to watch Ssa'ass," Edward objected, then remembered that it would feed his daedra. But he might learn something about healing if he watched, which would be a good thing. This was going to be more complicated than he'd thought.
 
- "A demon."
+ "Oh, Edward," Aliera said. "You must keep clear in a fight."
 
- "A demon! What!? In the open like that in daylight? Gods,
-what was it  carrying, an ebony dai-katana?" Mith whistled
-as he inspected the injury.  Aliera and the others ran up.
-She hugged Edward, "Are you all right,  darling? I was worried." then paled as she
-saw her husband's hand.
+ "He killed a rat in the old inn there, after. Did right well. Kept his head, put his back to mine, shielded us both. Anyone's apt to panic in his first fight. Especially if he isn't expecting it."
 
- "You must be slowing down. How'd you let a demon do that to you?" Mith 
-demanded. 
-
- "It was the boy...he grabbed at my arm in fright and my
-shield spell  failed. It wasn't his fault; it was an
-accident. Ali, don't look at it.  Edward, why don't you take
-thy mother to see the rat you killed?"
-
- "I want to watch Ssa'ass," Edward objected, then
-remembered that it would  feed his daedra. But he might
-learn something about healing if he watched,  which would be a
-good thing. This was going to be more complicated than  he'd
-thought.
-
- "Oh, Edward," Aliera said. "You must keep clear in a
-fight."
-
- "He killed a rat in the old inn there, after. Did right well.
-Kept his  head, put his back to mine, shielded us both.
-Anyone's apt to panic in his  first fight. Especially if he isn't expecting it."
-
- Ssa'ass came up last, as usual, elbowed the others aside and inspected the  injury, hissing. "I cann
-fixxxx thissss. It'ss cleann." He looked it over  carefully,
-bending the hand back to open the wound. Then he brought the 
-hand forward, so that the edges of the tissue met. He was
-very particular  about getting it aligned just so. Then he
-had Mats hold it in place while  he cast spells over it. All
-outer traces of the injury vanished, leaving  not even a
-scar. Moraelyn swung it with satisfaction, twitching his 
-fingers. "Thanks, Ssa'ass. It's stiff, but..."
+ Ssa'ass came up last, as usual, elbowed the others aside and inspected the injury, hissing. "I cann fixxxx thissss. It'ss cleann." He looked it over carefully, bending the hand back to open the wound. Then he brought the hand forward, so that the edges of the tissue met. He was very particular about getting it aligned just so. Then he had Mats hold it in place while he cast spells over it. All outer traces of the injury vanished, leaving not even a scar. Moraelyn swung it with satisfaction, twitching his fingers. "Thanks, Ssa'ass. It's stiff, but..."
 
  "Tomorrow, I ffinissshhh."
 
- "My poor baby," Aliera fussed over Edward. "You must have
-been so  frightened. And you spent the whole night in that awful house?"
+ "My poor baby," Aliera fussed over Edward. "You must have been so frightened. And you spent the whole night in that awful house?"
 
- "I'm not a baby. I wasn't afraid; my father was there." 
+ "I'm not a baby. I wasn't afraid; my father was there."

--- a/Assets/StreamingAssets/Text/Books/BOK00106-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00106-LOC.txt
@@ -3,380 +3,111 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]King Edward, Part VII
 
-
-
 [/font=4]
 
 [/center]
 
-[/center] Chap 7: Dragon
+[/center]Dragon
 
+ "So you saw a demon? And killed a rat with Tooth? That's a fine ebony dagger, Tooth is. They're rare so you want to take real good care of it," Mith said. "I can't tell you about the blade except it came from Moraelyn's father. It's the one his brother sent him to repair just before we ran away. Would you like to hear about how they got the dragon's tooth that Mats carved the hilt from?"
 
+ Edward nodded, caressing the curved hilt with its lightly carved intertwined roses, thorns and leaves. It was well after supper and everyone but him and Mith had left the fire for one reason or another. Aliera and Moraelyn had gone for a walk hand in hand, Aliera holding Moraelyn's newly healed left hand in both of hers. They'd laughed and shaken their heads when he'd offered to come along, "Not tonight," Aliera had said. "Go to sleep soon. We'll be leaving before dawn." Willow had gone to visit a High Elf friend. Beech, Ssa'ass, Mats and the Khajiit woman, Silk, had also gone off together, laughing. They'd invited Mith to come along, but Mith had declined.
 
- "So you saw a demon? And killed a rat with Tooth? That's a
-fine ebony dagger, Tooth is. They're rare so you want to take
-real good care of it," Mith said. "I can't tell you about
-the blade except it came from Moraelyn's father. It's the
-one his brother sent him to repair just before we ran away.
-Would you like to hear about how they got the dragon's tooth
-that Mats carved the hilt from?"
+ "Khajiits! They're all turning into a bunch of shameless Khajiits," Mith said. The short Dark Elf sat close to the glowing embers, knees to chest. His hair and eyes glowed in the dim light. "If you're going to pair, you should pair, not turn it into an tourney. They'll be selling tickets next. But each to his own. Khajiits think we're weird because we like eating as a group. Silk says it put her right off her food at first, listening to everybody chew. Well, having a bunch of watchers puts me off--I s'pose you're too young for this kind of talk."
 
- Edward nodded, caressing the curved hilt with its lightly
-carved intertwined roses, thorns and leaves. It was well
-after supper and everyone but him and Mith had left the fire
-for one reason or another. Aliera and Moraelyn had gone for
-a walk hand in hand, Aliera holding Moraelyn's newly healed
-left hand in both of hers. They'd laughed and shaken their heads
-when he'd offered to come along, "Not tonight," Aliera had
-said. "Go to sleep soon. We'll be leaving before dawn."
-Willow had gone to visit a High Elf friend. Beech, Ssa'ass,
-Mats and the Khajiit woman, Silk, had also gone off
-together, laughing. They'd invited Mith to come along, but
-Mith had declined.
+ Edward shrugged. It was a beautiful night, crisply cool, no moon, but the stars were very large and bright.
 
- "Khajiits! They're all turning into a bunch of shameless
-Khajiits," Mith said. The short Dark Elf sat close to the
-glowing embers, knees to chest.  His hair and eyes glowed in the
-dim light. "If you're going to pair, you should pair, not
-turn it into an tourney. They'll be selling tickets next. 
-But each to his own. Khajiits think we're weird because we like
-eating as a group. Silk says it put her right off her food at
-first, listening to  everybody chew. Well, having a bunch
-of watchers puts me off--I s'pose you're too young for this
-kind of talk."
+ "Anyway, it was just a few months after Mats had joined up with us. We were up in Skyrim, travelling from town to town. Just three kids seeing the country a bit, picking up odd jobs where we could. Moraelyn entered tournaments if we heard about them, but he wasn't winning that much ... just about enough to cover healing him up afterwards. You can get beat up pretty bad fighting Skyrim style -- that's without shielding spells, or any other spells for that matter, no magic allowed -- even if it isn't to the death. And he drew a few types that didn't mind seeing a little dark elf blood spilled in the sand. Or a lot. And the crowds were against him at first. It can get pretty lonely in the arena, especially if you're beating the home town favorite. And it's even worse if he's beating you.
 
- Edward shrugged. It was a beautiful night, crisply cool,
-no moon, but the stars were very large and bright.
+ "Mats and me 'ud be the only ones for him, and sometimes we didn't dare cheer too loud. They'd look real funny at a Nord boy cheering a Dark Elf back then. 'Course Mats was so big, not many wanted to start anything with him. That was a long time ago. Moraelyn's the favorite now if things get tough. 'Course the crowds will cheer for a good match, but hardly anyone really wants to see him lose now. They like seeing the best, even if it comes wrapped in a dark elf hide. And when he walks into an arena you know you're seeing the best. Not but what they'd like seeing a Nord that's better. And Mats may get there soon. He doesn't fight his best against Moraelyn, though. Maybe he doesn't want to, or maybe Moraelyn just knows him too well. Oh, well, you want to hear about the dragon ...
 
- "Anyway, it was just a few months after Mats had joined up
-with us. We were up in Skyrim, travelling from town to town.
-Just three kids seeing  the country a bit, picking up odd jobs
-where we could. Moraelyn entered tournaments if we heard
-about them, but he wasn't winning that much ... just about
-enough to cover healing him up afterwards. You can get beat up pretty bad fighting Skyrim style -- that's
-without shielding spells, or any other spells for that
-matter, no magic allowed -- even if it isn't to the death.
-And he drew a few types that didn't mind seeing a little dark
-elf blood spilled in the sand. Or a lot. And the crowds were
-against him at first. It can get pretty lonely in the arena,
-especially if you're beating the home town favorite. And
-it's even worse if he's beating you.   "Mats and me 'ud be the
-only ones for him, and sometimes we didn't dare cheer too
-loud. They'd look real funny at a Nord boy cheering a Dark
-Elf back then. 'Course Mats was so big, not many wanted to
-start anything with him. That was a long time ago.
-Moraelyn's the favorite now if things get tough. 'Course the
-crowds will cheer for a good match, but hardly anyone really wants to see him lose now. They like seeing
-the best, even if it comes wrapped in a dark elf hide. And
-when he walks into an arena you know you're seeing the best.
-Not but what they'd like seeing a Nord that's better. And
-Mats may get there soon. He doesn't fight his best against 
-Moraelyn, though. Maybe he doesn't want to, or maybe
-Moraelyn just knows him too well. Oh, well, you want to hear
-about the dragon ... 
+ "So Moraelyn was gambling with this Nord in a tavern one night, trying to pick up a little easy gold. The pot's pretty big, and the man can't match his bet, so he says he'll put this map on the pile and tap Moraelyn. Says it's a map to the hiding place of the best blade ever made. Says there's a spell on it so that if you hit your opponent, you get as much heal as he gets hurt. That some Mage hid it just before he died so's only someone worthy of it can get to it.
 
- "So Moraelyn was gambling with this Nord in a tavern one
-night, trying to pick up a little easy gold. The pot's
-pretty big, and the man can't match his bet, so he says he'll pu
-t this map on
-the pile and tap Moraelyn. Says it's a map to the hiding place of the best blade ever made. Says
-there's a spell on it so that if you hit your opponent, you
-get as much heal as he gets hurt. That some Mage hid it just
-before he died so's only someone worthy of it can get to it.
+ "'And you think I look worthy?' Moraelyn says, grinning. We were young and dumb, but not all that dumb.
 
- "'And you think I look worthy?' Moraelyn says, grinning. We
-were young and dumb, but not all that dumb.
+ "The Nord grins back and says 'I saw you fight in Falcreath, kid. You look like you'd take a chance.'
 
- "The Nord grins back and says 'I saw you fight in Falcreath,
-kid. You look like you'd take a chance.' 
+ "'Why not? The story alone is worth the gold. You ought to be a Bard.' So anyway Moraelyn wins the pot and tosses the man enough back to keep his throat wet all evening. Just for laughs we look at the map. It showed the Dragon's Teeth Mountains down in Hammerfell. Real wild country. And there's an 'X' and some writing saying 'Fang Lair'. Mats gets excited and says he's heard of the place, but he'd never known just where it was.
 
- "'Why not? The story alone is worth the gold. You ought to
-be a Bard.' So anyway Moraelyn wins the pot and tosses the
-man enough back to keep his throat wet all evening. Just for
-laughs we look at the map. It showed the Dragon's Teeth
-Mountains down in Hammerfell. Real wild country. And there's an 'X' and some writing saying
-'Fang Lair'. Mats gets excited and says he's heard of the
-place, but he'd never known just where it was.
+ "'And you still don't,' I say. 'Any fool can draw a map, just as any fool can look at one. I could do as much myself.'
 
- this map on
-the pile and tap Moraelyn. Says it's a map to the hiding place of the best blade ever made. Says
-there's a spell on it so that if you hit your opponent, you
-get as much heal as he gets hurt. That some Mage hid it just
-before he died so's only someone worthy of it can get to it.
-
- "'And you think I look worthy?' Moraelyn says, grinning. We
-were young and dumb, but not all that dumb.
-
- "The Nord grins back and says 'I saw you fight in Falcreath,
-kid. You look like you'd take a chance.' 
-
- "'Why not? The story alone is worth the gold. You ought to
-be a Bard.' So anyway Moraelyn wins the pot and tosses the
-man enough back to keep his throat wet all evening. Just for
-laughs we look at the map. It showed the Dragon's Teeth
-Mountains down in Hammerfell. Real wild country. And there's an 'X' and some writing saying
-'Fang Lair'. Mats gets excited and says he's heard of the
-place, but he'd never known just where it was.
-
- "'And you still don't,' I say. 'Any fool can draw a map,
-just as any fool can look at one. I could do as much
-myself.'
-
- "Mats says Fang Lair is an old dwarf mine, but  there's
-supposed to be a dragon there now, and the dwarves are gone.
-Moraelyn looks real interested at the mention of a mine, and
-asks what they mined there. Mats says mithril and gold.
+ "Mats says Fang Lair is an old dwarf mine, but there's supposed to be a dragon there now, and the dwarves are gone. Moraelyn looks real interested at the mention of a mine, and asks what they mined there. Mats says mithril and gold.
 
  "Moraelyn says, 'Hmmmmm.'
 
- "The mithril had him interested. We couldn't afford really
-good weapons. And mithril's scarce, but it's light to carry
-for its worth, and easy to mine and work if you know how; and
-he did. He didn't believe in the magic blade or the dragon,
-but he thought the mine might be real. Mining's in his blood,
-as it is in all the R'Aathim, the royal Kin of Ebonheart.
+ "The mithril had him interested. We couldn't afford really good weapons. And mithril's scarce, but it's light to carry for its worth, and easy to mine and work if you know how; and he did. He didn't believe in the magic blade or the dragon, but he thought the mine might be real. Mining's in his blood, as it is in all the R'Aathim, the royal Kin of Ebonheart.
 
- "It took us a couple of months to get there. We couldn't afford horses. We never would have found it without the
-map. It's tricky country, full of  canyons and hidden
-valleys. We sure never expected what we saw when we did get
-there. You could see the towers from the canyon mouth, way
-back in there. Dark elves live right in caverns if they mine,
-but the dwarves had built a hall over the top of their mines.
-It's a pretty thing on the outside. Narrow towers, and arched
-bridges between them. Delicate looking; you wouldn't expect
-work like that from Dwarves. Merged right into the rocks too. And there was a big stone
-dragon mounted above the gate. 
+ "It took us a couple of months to get there. We couldn't afford horses. We never would have found it without the map. It's tricky country, full of canyons and hidden valleys. We sure never expected what we saw when we did get there. You could see the towers from the canyon mouth, way back in there. Dark elves live right in caverns if they mine, but the dwarves had built a hall over the top of their mines. It's a pretty thing on the outside. Narrow towers, and arched bridges between them. Delicate looking; you wouldn't expect work like that from Dwarves. Merged right into the rocks too. And there was a big stone dragon mounted above the gate.
 
- "'There's your dragon, Mats,' I said. The inside wasn't much to look at, just rock wall. The doorway was
-enormous, but the doors were gone. There was a balcony
-running right around a big open pit ...  probably the start
-of the mine, turned into a hall. And right in the middle was
-more treasure than you can imagine ... piled up almost like
-a haystack that'd been flattened out. And what had flattened
-it was a golden dragon curled right over it; we didn't even
-see him at first, 'cause he blended with the rest of the gold. Well, we just froze in place. We
-hadn't seen a sign of live dragon outside. The place
-smelled of brimstone, but most mines do. And there that
-dragon was, just lying there. And it's gotta be two miles to
-any kind of shelter. 
+ "'There's your dragon, Mats,' I said. The inside wasn't much to look at, just rock wall. The doorway was enormous, but the doors were gone. There was a balcony running right around a big open pit ... probably the start of the mine, turned into a hall. And right in the middle was more treasure than you can imagine ... piled up almost like a haystack that'd been flattened out. And what had flattened it was a golden dragon curled right over it; we didn't even see him at first, 'cause he blended with the rest of the gold. Well, we just froze in place. We hadn't seen a sign of live dragon outside. The place smelled of brimstone, but most mines do. And there that dragon was, just lying there. And it's gotta be two miles to any kind of shelter.
 
  "'I told you there was a dragon,' Mats whispers.
 
  "'Shhhhh,' Moraelyn says. 'Look what's in front of his nose.'
 
- "I'd been busy looking AT his nose, believe you me. But there
-was a sword lying right there naked, sure enough ... .and the
-blade was dark metal that  looked just like his dagger.
+ "I'd been busy looking AT his nose, believe you me. But there was a sword lying right there naked, sure enough ... .and the blade was dark metal that looked just like his dagger."'You two start back,' Moraelyn says, 'I'm going to try for that blade, anyway. If that's not ebony, I'm a wood elf. Maybe the dragon's dead, or asleep for the winter ... or maybe it's not alive at all. Just something the dwarves made to guard their treasure. Like the scarecrows the Nord farmers put in their grain fields. At worst, I'll distract him long enough for you to get clear.'
 
- "'You two start back,' Moraelyn says, 'I'm going to try for
-that blade, anyway. If that's not ebony, I'm a wood elf.
-Maybe the dragon's dead, or asleep for the winter ... or
-maybe it's not alive at all. Just something the dwarves made to guard their treasure. Like the scarecrows the Nord farmers put in their
-grain fields. At worst, I'll distract him long enough for
-you to get clear.'
+ "I'd a mind to take him up on it, but Mats just shook his head, and I was kinda ashamed to go back alone.
 
- "I'd a mind to take him up on it, but Mats just shook his head,
-and I was kinda ashamed to go back alone.
+ "'Let's all just clear out,' I said. That thing looked real enough to scare ME away. But Moraelyn casts Invisibility and heads on down the stair, not making a sound that even I could hear. I could see Mats hated letting him go down alone, but Mats couldn't sneak past a blind, deaf beggar in a fish market. So we strung our bows and figured we could try to get off a couple of shots and maybe get lucky and take out the eyes if the dragon woke up and went for Moraelyn. Mats and I move around to where we can get onto a tower stair fast if we have to, figuring the dragon can't get in there. Then we scrunch down and peer between the railings. Not that there was anything to see except the dragon lying there. Which really is a lot to see, at that.
 
- "'Let's all just clear out,' I said. That thing looked real
-enough to scare ME away. But Moraelyn casts Invisibility
-and heads on down the stair, not making a sound that even I
-could hear. I could see Mats hated letting him go down alone, but Mats couldn't sneak past a blind,
-deaf beggar in a fish market. So we strung our bows and
-figured we could try to get off a couple of shots and maybe
-get lucky and take out the eyes if the dragon woke up and went for Moraelyn. Mats and
-I move around to where we can get onto a tower stair fast if
-we have to, figuring the dragon can't get in there. Then we
-scrunch down and peer between the railings. Not that there
-was anything to see except the dragon lying there. Which really is a lot to see, at that.
+ "Then those dragon eyes popped open and my heart gave one big jump and then seemed to quit entirely.
 
- "Then those dragon eyes popped open and my heart gave one
-big jump and then seemed to quit entirely.
+ "'Ahhhhh! Dinner comes to me today,' the dragon says. 'Take a good look at my hoard, dark elf. You will not steal it nor even view it long, but your bones will keep it company ... .forever.'
 
- "'Ahhhhh! Dinner comes to me today,' the dragon says. 'Take a
-good look at my hoard, dark elf. You will not steal it nor
-even view it long, but your bones will keep it company ...
-.forever.'
+ "'I don't want your hoard, dragon, just the sword you guard. I'll trade you mine for it; mine's bigger.' I couldn't see Moraelyn, but his voice was coming from right near where the sword was. Which was practically in the dragon's mouth!
 
- "'I don't want your hoard, dragon, just the sword you
-guard. I'll trade you mine for it; mine's bigger.' I
-couldn't see Moraelyn, but his voice was coming from right near where the sword was. Which was practically in
-the dragon's mouth!
-
- "'I get a meal and both swords. Why should I settle for just
-your poor sword?'
+ "'I get a meal and both swords. Why should I settle for just your poor sword?'
 
  "'Let me pass and I'll get you more gold from below.'
 
- "'I have gold enough.' The dragon yawned and I thought he was
-going to swallow Moraelyn right then, but he turned his head
-away -- away from us, too. Mats was looking to get a shot,
-but it was really dark in there for Nord eyes and he was
-scared of hitting Moraelyn, since he couldn't locate him that well by
-sound. 'Course Moraelyn's too smart to get between us and the dragon, but Mats wasn't smart
-enough then to think that far along. Slavery dulls the wits
-in some ways, Mats says, and he hadn't been free very long. I
-could see well enough, and I could tell by sound exactly
-where Moraelyn was, but the shot was clean out of my range.
+ "'I have gold enough.' The dragon yawned and I thought he was going to swallow Moraelyn right then, but he turned his head away -- away from us, too. Mats was looking to get a shot, but it was really dark in there for Nord eyes and he was scared of hitting Moraelyn, since he couldn't locate him that well by sound. 'Course Moraelyn's too smart to get between us and the dragon, but Mats wasn't smart enough then to think that far along. Slavery dulls the wits in some ways, Mats says, and he hadn't been free very long. I could see well enough, and I could tell by sound exactly where Moraelyn was, but the shot was clean out of my range.
 
- "The dragon goes on, 'But there is something you can do for
-me, elf, and prolong your life a few more minutes.'
+ "The dragon goes on, 'But there is something you can do for me, elf, and prolong your life a few more minutes.'
 
- "'A few more minutes sound pretty good just now, dragon.
-What would you ask of me?' Moraelyn's voice sounded as calm
-and easy as if he was asking if  there would be rain tomorrow.
-He can keep his head in a tight spot, I'll give him that.
+ "'A few more minutes sound pretty good just now, dragon. What would you ask of me?' Moraelyn's voice sounded as calm and easy as if he was asking if there would be rain tomorrow. He can keep his head in a tight spot, I'll give him that.
 
- "'I have a toothache. It's too far back for me to reach it with my claws. Canst see it, elf?' The
-dragon gapes his jaws to bare his teeth.
+ "'I have a toothache. It's too far back for me to reach it with my claws. Canst see it, elf?' The dragon gapes his jaws to bare his teeth. "Moraelyn's invisiblity spell wore off about then, and I could see him standing there staring up into that cavern of a mouth. 'Lower your head a bit so I can get a good look.' He puts out his hand and pulls the upper lip aside, cool as you please, and examines the inner gum carefully. Damndest thing I ever saw.
 
- "Moraelyn's invisiblity spell wore off about then, and I
-could see him standing there staring up into that cavern of
-a mouth. 'Lower your head a bit so I can get a good look.' He
-puts out his hand and pulls the upper lip aside, cool as you
-please, and examines the inner gum carefully. Damndest
-thing I ever saw.
+ "'It's abcessed [sic]. Thy gum wants lancing, and the tooth should come out. I can lance it if you trust me in there with a sword.'
 
- "'It's abcessed. Thy gum wants lancing, and the  tooth
-should come out. I can lance it if you trust me in there with
-a sword.'
+ "'And why should I trust you, dark elf? I hear no good of your kind.'
 
- "'And why should I trust you, dark elf? I hear no good of
-your kind.'
+ "'You must be spending too much time with Nords, then. I wouldn't be able to kill you before you killed me. Why should I even try? Listen, I have some friends up above. Suppose they hunt you up a nice fat deer. I'll lance your gum and you can let me go and eat the deer. Else you can just eat me now, toothache and all.'
 
- "'You must be spending too much time with Nords, then. I
-wouldn't be able to kill you before you killed me. Why
-should I even try? Listen, I have  some friends up above.
-Suppose they hunt you up a nice fat deer. I'll lance your
-gum and you can let me go and eat the deer. Else you can just
- eat me now, toothache and all.' 
+ "'Hssssssss. What makes you think your friends will return once they're away?'
 
- "'Hssssssss. What makes you think your friends will return
-once they're away?'
+ "'They're not very smart. I think for them. They'd be lost without me. Good hunting, guys! Uh, if they can't find a deer, is there anything else you'd like? Pig, maybe? A few rabbits? Nuts? Berries? Hurry up, will you?' But we had hand signals and his hands said to get out of there and stay out!
 
- "'They're not very smart. I think for them. They'd be lost
-without me. Good hunting, guys! Uh, if they can't find a
-deer, is there anything else you'd  like? Pig, maybe? A few rabbits? Nuts? Berries?
-Hurry up, will you?' But we had hand signals and his hands
-said to get out of there and stay out!   "I'd a been glad to;
-I mean I'm fond of Moraelyn but I didn't see my dying
-alongside would bring him any comfort. I'd a been glad to
-see him clear if it was me that was on the menu, and I figured
-he felt the same way. But that thick-skulled Nord wouldn't listen to me! Said if dying beside him  was all we
-could do, then that's what we'd do. Nord nonsense. Sounds good in a song, though.
+ "I'd a been glad to; I mean I'm fond of Moraelyn but I didn't see my dying alongside would bring him any comfort. I'd a been glad to see him clear if it was me that was on the menu, and I figured he felt the same way. But that thick-skulled Nord wouldn't listen to me! Said if dying beside him was all we could do, then that's what we'd do. Nord nonsense. Sounds good in a song, though.
 
- "So we took a couple hours getting a deer and headed back
-with it. I figured Moraelyn was filling the dragon's belly by now, and the
-dragon would be happy to add a deer, another Dark Elf and a
-Nord to round out his day's rations. But Moraelyn was still sitting there,  chatting with
-the dragon. He didn't look that pleased to see us, either.
-Told us to leave the deer and go and he'd lance the abcess
-once we're away. But Mats says he's been thinking. Oh, brother,
-I thought. Mats doesn't think too often, and that's a good
-thing, really. He's decided he can get a chain round that bad
-tooth, fasten down the end to the floor, and then the dragon
-can give it a good yank himself.
+ "So we took a couple hours getting a deer and headed back with it. I figured Moraelyn was filling the dragon's belly by now, and the dragon would be happy to add a deer, another Dark Elf and a Nord to round out his day's rations. But Moraelyn was still sitting there, chatting with the dragon. He didn't look that pleased to see us, either. Told us to leave the deer and go and he'd lance the abcess once we're away. But Mats says he's been thinking. Oh, brother, I thought. Mats doesn't think too often, and that's a good thing, really. He's decided he can get a chain round that bad tooth, fasten down the end to the floor, and then the dragon can give it a good yank himself.
 
- "The dragon likes the idea, so Moraelyn lances that abcess to
-take the swelling down to where the dragon can gulp the deer
-with some comfort. And then they rig up a chain and get that
-tooth out. Made a hell of a mess, that. Blood and pus
-everywhere. And Moraelyn's got us casting Heal spells on this dragon to stop the bleed
-ing and close up the wound.
+ "The dragon likes the idea, so Moraelyn lances that abcess to take the swelling down to where the dragon can gulp the deer with some comfort. And then they rig up a chain and get that tooth out. Made a hell of a mess, that. Blood and pus everywhere. And Moraelyn's got us casting Heal spells on this dragon to stop the bleeding and close up the wound.
 
- "'Ah, hum, good, very good. All right, Moraelyn, you've
-proven yourself. Take the sword and go.'
+ "'Ah, hum, good, very good. All right, Moraelyn, you've proven yourself. Take the sword and go.'
 
- "Moraelyn looks at him. 'You mean this was some kind of
-test?' he says. 'How long have you had that toothache?'
+ "Moraelyn looks at him. 'You mean this was some kind of test?' he says. 'How long have you had that toothache?'
 
- "'Long indeed, as you measure time, mortal, yet not very
-long at all for dragonkind. Hear my story then: a scraggly young mage came along,
-hoping to steal my gold. I caught him at it; we had
-increasingly harsh words, and he attempted a spell aimed at
-me. His pitiful spell affected me little, and I killed him.
-But ummmm...' The dragon looked away briefly, then resumed
-his tale. 'The little runt had apparently cast a home-made
-Curse spell upon himself, and when I crunched him...' The
-dragon scowled fiercely, remembering, then continued,
-'Anyway, the ache only came on bad when someone came along
-to try for the sword. The sharpest pain went away if I ate the intruder
-... but I usually didn't, though I've singed a few in
-ng and close up the wound.
+ "'Long indeed, as you measure time, mortal, yet not very long at all for dragonkind. Hear my story then: a scraggly young mage came along, hoping to steal my gold. I caught him at it; we had increasingly harsh words, and he attempted a spell aimed at me. His pitiful spell affected me little, and I killed him. But ummmm...' The dragon looked away briefly, then resumed his tale. 'The little runt had apparently cast a home-made Curse spell upon himself, and when I crunched him...' The dragon scowled fiercely, remembering, then continued, 'Anyway, the ache only came on bad when someone came along to try for the sword. The sharpest pain went away if I ate the intruder ... but I usually didn't, though I've singed a few in self-defense; heh, waft a bit of fire and most of them fled. Deer are plentiful; there is something er, ah, unpleasant about eating someone you've talked to. That greasy mage gave me indigestion for days. Cramps and runny bowels and too much gas, even for a dragon. So that toothache never did completely go away. And the people who've come along haven't been very pleasant either ... all in all one of the most unpleasant stretches in my life. I couldn't stay away from the vicinity of the sword for very long of course. Part of the curse.'
 
- "'Ah, hum, good, very good. All right, Moraelyn, you've
-proven yourself. Take the sword and go.'
+ "'We could stay on for awhile, if you like. We're good company. I'm Moraelyn; my red-headed friend is Mith, and the big guy is Mats. I'd still like to look for mithril below and I've never had a dragon friend before.'
 
- "Moraelyn looks at him. 'You mean this was some kind of
-test?' he says. 'How long have you had that toothache?'
+ "'I might like that. You have good friends, and even though you have said that you must do the thinking for them. I think that they can do some thinking on their own, and it would appear that they have decided that you are a worthwhile fellow,' The dragon hesitated for a second and actually managed to look shy! 'You can call me Akatosh.'
 
- "'Long indeed, as you measure time, mortal, yet not very
-long at all for dragonkind. Hear my story then: a scraggly young mage came along,
-hoping to steal my gold. I caught him at it; we had
-increasingly harsh words, and he attempted a spell aimed at
-me. His pitiful spell affected me little, and I killed him.
-But ummmm...' The dragon looked away briefly, then resumed
-his tale. 'The little runt had apparently cast a home-made
-Curse spell upon himself, and when I crunched him...' The
-dragon scowled fiercely, remembering, then continued,
-'Anyway, the ache only came on bad when someone came along
-to try for the sword. The sharpest pain went away if I ate the intruder
-... but I usually didn't, though I've singed a few in
-self-defense; heh, waft a bit of fire and most of them fled.
-Deer are plentiful; there is something er, ah, unpleasant
-about eating someone you've talked to. That greasy mage
-gave me indigestion for days. Cramps and runny bowels and
-too much gas, even for a dragon. So that toothache never did
-completely go away. And the people who've come along
-haven't been very pleasant either ... all in all one of the
-most unpleasant stretches in my life. I couldn't stay away from the vicinity of the sword for very long of course. Part
-of the curse.'
+ "So we stayed for a couple of weeks. Hunted with the dragon -- now that's an experience! Searched the mines ... didn't find much down there. But the dragon gave us the jewels from his hoard. Said he only needed the metal; they absorb it into their scales while they lie on it. So we did pretty well out of it after all. Moraelyn tried to give Mats the sword. Claimed that he'd have sure tried to kill that dragon if we hadn't come back, and would have been toasted. But Mats wouldn't take it. Said the dragon gave it to Moraelyn so that was clearly who was supposed to get it. Mats took the tooth, but he made the hilt you've got now and gave Moraelyn that, too. Told me he'd never had anything worth giving before, and it made him feel good. He's real pleased Moraelyn chose to give it to you."
 
- "'We could stay on for awhile, if you like. We're good
-company. I'm Moraelyn; my red-headed friend is Mith, and the
-big guy is Mats. I'd still like to look for mithril below and I've never had a dragon friend before.'
-
- "'I might like that. You have good friends, and even though
-you have said that you must do the thinking for them. I think that they can do some  thinking on
-their own, and it would appear that they have decided that
-you are a worthwhile fellow,' The dragon hesitated for a
-second and  actually managed to look shy! 'You can call me
-Akatosh.'
-
- "So we stayed for a couple of weeks. Hunted with the dragon --
-now that's an experience! Searched  the mines ... didn't find much down
-there. But the dragon gave us the jewels from his hoard. Said he only needed the metal; they absorb it into
-their scales while they lie on it. So we did pretty well out
-of it after all. Moraelyn tried to give Mats the sword.
-Claimed that he'd have sure tried to kill that dragon if we
-hadn't come back, and would have been toasted. But Mats
-wouldn't take it. Said the dragon gave it to Moraelyn so that was clearly who was
-supposed to get it. Mats took the tooth, but he made the hilt
-you've got now and gave Moraelyn that, too. Told me he'd
-never had anything worth giving before, and it made him feel
-good. He's real pleased Moraelyn chose to give it to you."
-
- "I think Mats should have got the sword," Edward said. "He
-didn't try to steal anything. It was really brave of him to
-come back, even when he didn't think it'd do any good.
-Moraelyn tried to steal, got caught and then just tried to talk his way out of it. You could
-all have been killed  because of him."
+ "I think Mats should have got the sword," Edward said. "He didn't try to steal anything. It was really brave of him to come back, even when he didn't think it'd do any good. Moraelyn tried to steal, got caught and then just tried to talk his way out of it. You could all have been killed because of him."
 
  "That's just what Moraelyn said. Ah, well, Mats likes that big axe of his better than a blade anyway."
 
- Edward sighed. "I wish I was brave like Mats. I guess I'm more
-like you."
+ Edward sighed. "I wish I was brave like Mats. I guess I'm more like you."
 
- "Aye," Moraelyn's voice sounded behind him, startling the
-boy. "Tart tongued, like Mith. No matter. I'll be well
-pleased if you're as brave as Mith. And if once I'm gone they
-say no more of me than 'he did what he had to do', my spirit
-will be at peace." 
+ "Aye," Moraelyn's voice sounded behind him, startling the boy. "Tart tongued, like Mith. No matter. I'll be well pleased if you're as brave as Mith. And if once I'm gone they say no more of me than 'he did what he had to do', my spirit will be at peace."

--- a/Assets/StreamingAssets/Text/Books/BOK00107-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00107-LOC.txt
@@ -3,290 +3,116 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]King Edward, Part VIII
 
-
-
 [/font=4]
 
 [/center]
 
-[/center]Chap 8: Wilderland
+[/center]Wilderland
 
-[/center]
+ The journey through Valenwood was pleasant. The weather held fair for the most part, with sunny days and cool nights. Bright leaves of scarlet, crimson, gold and green drifted down to form a carpet beneath their horses' feet. Valenwood was very different from the somber, steep forests of High Rock. When they reached the northern border, Edward, looking back, saw that the trees were mostly bare, shorn of their glory. Before them lay a wide green land of rolling hills with only a few stands of trees. It seemed to spread on forever.
 
+ "This is Wilderland, Edward," Moraelyn said. "Be on your guard. It seems a pleasant land, but no king's writ runs here. Each man's hand is against every other's -- and there are worse than men. All the races of Tamriel meet here, and clash, save thine, perhaps."
 
+ They journeyed for some days more with small incident ... save one for a band of Khajiit raiders that crept up on their camp by night. These were easily repelled. Silk slew one and the rest ran off yowling. The gentle wood elf girl, Willow, lobbed fireballs after them. There were no roads, just small paths that criss-crossed one another and seemingly led nowhere.
 
- The journey through Valenwood was pleasant. The weather
-held fair for the most part, with sunny days and cool
-nights. Bright leaves of scarlet,  crimson, gold and green
-drifted down to form a carpet beneath their horses' feet.
-Valenwood was very different from the somber, steep forests
-of High Rock. When they reached the northern border, Edward,
-looking back, saw that the trees were mostly bare, shorn of
-their glory. Before them lay a wide green land of rolling hills with only a few stands of
-trees. It seemed to spread on forever.
-
- "This is Wilderland, Edward," Moraelyn said. "Be on your
-guard. It seems a pleasant land, but no king's writ runs here. Each man's hand is against every
-other's -- and there are worse than men. All the races of
-Tamriel meet here, and clash, save thine, perhaps." 
-
- They journeyed for some days more with small incident ...
-save one for a band of Khajiit raiders that crept up on
-their camp by night. These were easily repelled. Silk slew
-one and the rest ran off yowling. The gentle wood elf girl,
-Willow, lobbed fireballs after them. There were no roads, just small paths that criss-crossed one another
-and seemingly led nowhere.
-
- After two weeks of steady riding they came to a bowl shaped
-place in the hills where the land was tilled. The fields looked fair and
-were stacked  with harvest, but the folk were dispirited,
-ragged, and unfriendly. Questions about inns got only shrugs and
-puzzled looks. Armed bands challenged them at times and
-demanded to know their business. When Moraelyn said they were
-bound for Morrowind, they were told to pass through quickly
-and mind they stole nothing.
+ After two weeks of steady riding they came to a bowl shaped place in the hills where the land was tilled. The fields looked fair and were stacked with harvest, but the folk were dispirited, ragged, and unfriendly. Questions about inns got only shrugs and puzzled looks. Armed bands challenged them at times and demanded to know their business. When Moraelyn said they were bound for Morrowind, they were told to pass through quickly and mind they stole nothing.
 
  "Passage is all we wish," Moraelyn said quietly.
 
- "Someone should teach these folk manners," the usually
-placid Mats growled.
+ "Someone should teach these folk manners," the usually placid Mats growled.
 
- "Thou mayst stay and open a school of etiquette, if it
-pleases thee," Moraelyn said, "I fear my life's too short to
-teach the lessons these villains require. Still, I like not
-the look of the sky; it looks e'en more evil than the folk. I think we'll try our luck in the town."
+ "Thou mayst stay and open a school of etiquette, if it pleases thee," Moraelyn said, "I fear my life's too short to teach the lessons these villains require. Still, I like not the look of the sky; it looks e'en more evil than the folk. I think we'll try our luck in the town."
 
- The town was surrounded by a palisade of wood and had a
-stout gate. Guards looked them over and refused them
-entrance. "None but humans enter here,  elf. Take thy rabble and begone."
+ The town was surrounded by a palisade of wood and had a stout gate. Guards looked them over and refused them entrance. "None but humans enter here, elf. Take thy rabble and begone."
 
- "I see. Ali, Mats, Edward, thou seemst to qualify for the
-hospitality here. The rest of us will shelter elsewhere."
+ "I see. Ali, Mats, Edward, thou seemst to qualify for the hospitality here. The rest of us will shelter elsewhere."
 
- Aliera announced that she would see them all blown back to Firsthold by the storm before she'd step within
-these gates. So they circled the town, passing a moat with stone walls within and a keep of some
-sort within that. A track north took them past a small house
-with a large barn nearby. Both looked in poor repair, but
-Moraelyn sent Aliera and Edward to knock at the door and ask
-if they might sleep in the barn. The rest waited in the road.
+ Aliera announced that she would see them all blown back to Firsthold by the storm before she'd step within these gates. So they circled the town, passing a moat with stone walls within and a keep of some sort within that. A track north took them past a small house with a large barn nearby. Both looked in poor repair, but Moraelyn sent Aliera and Edward to knock at the door and ask if they might sleep in the barn. The rest waited in the road.
 
- An elderly woman answered their knock; she looked pleased to
-see them. "Stay? Aye, I'd be glad of the company. No need
-to sleep in the barn, though, lady. I've a room to spare. My 
-name's Ora Engelsdottir." Aliera gestured
-toward the waiting Companions. The woman squinted toward
-them.  "Thy man's there and some friends? Aye, we'll all
-squeeze together then. T'will be warmer so. I've a pot of
-soup on the fire; made it to last me a  week but you're
-welcome to it. I can make more."
+ An elderly woman answered their knock; she looked pleased to see them. "Stay? Aye, I'd be glad of the company. No need to sleep in the barn, though, lady. I've a room to spare. My name's Ora Engelsdottir." Aliera gestured toward the waiting Companions. The woman squinted toward them. "Thy man's there and some friends? Aye, we'll all squeeze together then. T'will be warmer so. I've a pot of soup on the fire; made it to last me a week but you're welcome to it. I can make more."
 
  "My husband's an elf."
 
- "Is he so? He looks to take good care of thee and thy son.
-Thou's fat as pigs. Bring them in. I wish my grand-daughter
-had such a one to care for her."
+ "Is he so? He looks to take good care of thee and thy son. Thou's fat as pigs. Bring them in. I wish my grand-daughter had such a one to care for her."
 
- Ora refused payment, saying she was not yet at such a pass
-that her guests must pay for her hospitality. She said tales
-and song and an evening's merriment would be payment enough. Pots and dishes were set out to catch the
-worst of the leaks; she knew them all well. They gathered
-around the hearth and made very merry while the storm raged,
-banging the shutters and doors and threatening to blow the
-roof away altogether.
+ Ora refused payment, saying she was not yet at such a pass that her guests must pay for her hospitality. She said tales and song and an evening's merriment would be payment enough. Pots and dishes were set out to catch the worst of the leaks; she knew them all well. They gathered around the hearth and made very merry while the storm raged, banging the shutters and doors and threatening to blow the roof away altogether.
 
- "Tell me, my lady," Ora whispered apart to Aliera, "He's
-ame's Ora Engelsdottir." Aliera gestured
-toward the waiting Companions. The woman squinted toward
-them.  "Thy man's there and some friends? Aye, we'll all
-squeeze together then. T'will be warmer so. I've a pot of
-soup on the fire; made it to last me a  week but you're
-welcome to it. I can make more."
+ "Tell me, my lady," Ora whispered apart to Aliera, "He's truly good to thee? He's so big and so black."
 
- "My husband's an elf."
+ "Truly good," Aliera said keeping her mouth serious while her eyes laughed.
 
- "Is he so? He looks to take good care of thee and thy son.
-Thou's fat as pigs. Bring them in. I wish my grand-daughter
-had such a one to care for her."
-
- Ora refused payment, saying she was not yet at such a pass
-that her guests must pay for her hospitality. She said tales
-and song and an evening's merriment would be payment enough. Pots and dishes were set out to catch the
-worst of the leaks; she knew them all well. They gathered
-around the hearth and made very merry while the storm raged,
-banging the shutters and doors and threatening to blow the
-roof away altogether.
-
- "Tell me, my lady," Ora whispered apart to Aliera, "He's
-truly good to thee? He's so big and so black."
-
- "Truly good," Aliera said keeping her mouth serious while
-her eyes laughed.
-
- "Aye, 'tis well, then. He put me a bit in mind of our baron, who's big and dark --
-oh, not so dark as thy elf. He took my grand-daughter, Caron
--- and,  he does not treat her well. He -- he hurts her, my
-lady. And she dare not run away. Where would she go?" Tears
-gathered in Ora's eyes and followed  worn familiar tracks down her cheeks.
+ "Aye, 'tis well, then. He put me a bit in mind of our baron, who's big and dark -- oh, not so dark as thy elf. He took my grand-daughter, Caron -- and, he does not treat her well. He -- he hurts her, my lady. And she dare not run away. Where would she go?" Tears gathered in Ora's eyes and followed worn familiar tracks down her cheeks.
 
  When their hostess had gone to sleep in her own room, Aliera repeated what she had been told.
 
- "Let's rescue the girl," Beech said, "we grow stale with
-inaction."
+ "Let's rescue the girl," Beech said, "we grow stale with inaction."
 
  "Aye!" said Silk and Willow at once.
 
- Mats growled an agreement. Mith and Ssa'ass looked
-interested.
+ Mats growled an agreement. Mith and Ssa'ass looked interested.
 
- Moraelyn looked doubtful. "We cannot right every wrong in
-Tamriel. This baron offers his folk shelter of a kind. They
-could leave if they liked it better outside."
+ Moraelyn looked doubtful. "We cannot right every wrong in Tamriel. This baron offers his folk shelter of a kind. They could leave if they liked it better outside."
 
- "Aye," Mith said, "he keeps the bandits off so he may rob the
-folk at leisure."
+ "Aye," Mith said, "he keeps the bandits off so he may rob the folk at leisure."
 
- "An we pull him down? There'll be another to take his place. Or else the outside will come in and there'll be nothing
-left at all."
+ "An we pull him down? There'll be another to take his place. Or else the outside will come in and there'll be nothing left at all."
 
- "Nothing would be better than this filthy something," Mats
-said.
+ "Nothing would be better than this filthy something," Mats said.
 
- "There's that." The storm seemed to have moved away. Aliera
-went to the door and stared up into the sky where clouds
-raced past the eastern moon. A single large brilliant blue
-star hung near the moon. "Zenithar hangs near Tamriel
-tonight. Moraelyn?"
+ "There's that." The storm seemed to have moved away. Aliera went to the door and stared up into the sky where clouds raced past the eastern moon. A single large brilliant blue star hung near the moon. "Zenithar hangs near Tamriel tonight. Moraelyn?"
 
- "I'd thought to mend her roofs tomorrow if it's fair," he said as she returned to the fireside. "We'll
-do so much at least. As for the rest -- Aliera?"
+ "I'd thought to mend her roofs tomorrow if it's fair," he said as she returned to the fireside. "We'll do so much at least. As for the rest -- Aliera?"
 
- "She asked for my help, in a way ... and I -- I think I hear
-Zenithar's voice in the wind and feel his hand in the rain on
-this night."
+ "She asked for my help, in a way ... and I -- I think I hear Zenithar's voice in the wind and feel his hand in the rain on this night."
 
  "Thy quest, then, wife."
 
- Aliera nodded, unsmiling. She curled up with Moraelyn in
-the chimney corner and they whispered and laughed together
-for awhile. Edward fell  asleep. In the morning he was sent up on
-the roof to help Beech and Willow place new shingles.
-Moraelyn wrote a letter which he gave to Mats, telling  him
-to take it to the baron, to arrive at the castle around
-dinnertime and to go afoot.
+ Aliera nodded, unsmiling. She curled up with Moraelyn in the chimney corner and they whispered and laughed together for awhile. Edward fell asleep. In the morning he was sent up on the roof to help Beech and Willow place new shingles. Moraelyn wrote a letter which he gave to Mats, telling him to take it to the baron, to arrive at the castle around dinnertime and to go afoot.
 
- "You're going to challenge him for the girl!" Edward
-grinned. "But will he fight? And wouldn't he take her back
-again once we're gone?"
+ "You're going to challenge him for the girl!" Edward grinned. "But will he fight? And wouldn't he take her back again once we're gone?"
 
- "Mmm. Since he wouldn't let me in his town, thy mother
-thought to invite him to our house instead." Moraelyn
-stamped the letter with his sealing ring and handed it to
-Mats.
+ "Mmm. Since he wouldn't let me in his town, thy mother thought to invite him to our house instead." Moraelyn stamped the letter with his sealing ring and handed it to Mats.
 
- "Oh. It's a long way to your house still, isn't it?" Edward
-felt a bit of disappointment that no rescue seemed imminent,
-but he supposed it really was not reasonable to expect
-eight people to take a keep, even if they were Moraelyn's
-Companions. Probably the songs exaggerated their deeds.
+ "Oh. It's a long way to your house still, isn't it?" Edward felt a bit of disappointment that no rescue seemed imminent, but he supposed it really was not reasonable to expect eight people to take a keep, even if they were Moraelyn's Companions. Probably the songs exaggerated their deeds.
 
- Moraelyn grinned, ruffled Edward's hair and told him to
-cease his questions, get up on the roof, and mind his mother.
-Moraelyn and Mith set off together on foot. Aliera said they
-were going hunting. They did not return even at suppertime. Aliera told Edward not to worry; they'd meet later.
+ Moraelyn grinned, ruffled Edward's hair and told him to cease his questions, get up on the roof, and mind his mother. Moraelyn and Mith set off together on foot. Aliera said they were going hunting. They did not return even at suppertime. Aliera told Edward not to worry; they'd meet later.
 
- It was well after sundown when she bid their hostess
-farewell. They took all the horses with them and left them in a
-grove near the north wall of the keep. Aliera asked Edward if
-he wanted to wait for them with the horses. Edward asked where
-they were going.
+ It was well after sundown when she bid their hostess farewell. They took all the horses with them and left them in a grove near the north wall of the keep. Aliera asked Edward if he wanted to wait for them with the horses. Edward asked where they were going.
 
- "We have to enter the keep to get Ora's grandchild out. No
-questions, Edward. If you're coming, then stay with me and do exactly as I say. Levitate across the moat: I
-must swim. Once across we'll scale the wall. Once inside,
-just follow me and be as silent as you can."
+ "We have to enter the keep to get Ora's grandchild out. No questions, Edward. If you're coming, then stay with me and do exactly as I say. Levitate across the moat: I must swim. Once across we'll scale the wall. Once inside, just follow me and be as silent as you can."
 
- Edward gaped at his mother and the other Companions. How
-could the six of them possibly storm a keep? Three women, two
-men and a boy? There would be guards up on the wall and a
-lot more inside. Mats would be inside too,  though, he
-guessed. But where were Moraelyn and Mith?
+ Edward gaped at his mother and the other Companions. How could the six of them possibly storm a keep? Three women, two men and a boy? There would be guards up on the wall and a lot more inside. Mats would be inside too, though, he guessed. But where were Moraelyn and Mith?
 
- There were fearsome things in the moat. Edward began a
-protest, then thought better of it. Ssa'ass slid into the moat first. There was some splashing and hissing, then the
-water went quiet. Aliera entered the water. The others levitated. 
+ There were fearsome things in the moat. Edward began a protest, then thought better of it. Ssa'ass slid into the moat first. There was some splashing and hissing, then the water went quiet. Aliera entered the water. The others levitated.
 
- "Here's the ropes," Beech said, feeling along the wall. There
-were three ropes. Edward, Beech and Ssa'ass went up first;
-Aliera, Willow and Silk followed. Moraelyn and Mith were
-waiting above. Two guards were snoring softly in a heap.
+ "Here's the ropes," Beech said, feeling along the wall. There were three ropes. Edward, Beech and Ssa'ass went up first; Aliera, Willow and Silk followed. Moraelyn and Mith were waiting above. Two guards were snoring softly in a heap.
 
- "How--" Edward began, and found his mother's hand clapped
-over his mouth. A guard from another wall section called
-out and Edward's heart stopped beating. Mith called 
-something back to him and tramping footsteps moved away. 
+ "How--" Edward began, and found his mother's hand clapped over his mouth. A guard from another wall section called out and Edward's heart stopped beating. Mith called something back to him and tramping footsteps moved away.
 
- The Companions went silently down the stairs and slipped
-across the yard like shadows. There was no guard on the door
-to the keep itself. Inside the passages were eerily quiet. They
-stopped at an imposing door and flattened themselves
-against the wall beside it. They could hear voices within. A
-thin chilling wail sounded and died away. Moraelyn whistled
-a snatch of song into the silence that followed. The door
-swung open and they raced inside, falling on the startled
-guards like furies.
+ The Companions went silently down the stairs and slipped across the yard like shadows. There was no guard on the door to the keep itself. Inside the passages were eerily quiet. They stopped at an imposing door and flattened themselves against the wall beside it. They could hear voices within. A thin chilling wail sounded and died away. Moraelyn whistled a snatch of song into the silence that followed. The door swung open and they raced inside, falling on the startled guards like furies.
 
- Edward was last inside, Tooth in his hand; he stabbed the
-nearest guard in the side, and Beech finished him with a blow
-to the head. Mats had been inside; it was he who had opened the
-door. His axe clove the head of one guard, then swung against the inner door. Aliera and Willow had
-barred the strong outer door. Moraelyn's opponent was a
-very young man. He'd taken one look at the big dark elf,
-dropped his sword and fallen to his knees, praying  for
-mercy.
+ Edward was last inside, Tooth in his hand; he stabbed the nearest guard in the side, and Beech finished him with a blow to the head. Mats had been inside; it was he who had opened the door. His axe clove the head of one guard, then swung against the inner door. Aliera and Willow had barred the strong outer door. Moraelyn's opponent was a very young man. He'd taken one look at the big dark elf, dropped his sword and fallen to his knees, praying for mercy.
 
- Moraelyn eyed him with disgust and said, "Greet Zenithar for me; tell him Moraelyn
-of Ebonheart commends you to his mercy. I have none for such
-as you." He slashed the young guard's throat. Blood sprayed
-over Moraelyn's leathers. His victim fell over, gurgling
-horribly. A burning acid rose in Edward's throat; he swallowed hard and looked away.
+ Moraelyn eyed him with disgust and said, "Greet Zenithar for me; tell him Moraelyn of Ebonheart commends you to his mercy. I have none for such as you." He slashed the young guard's throat. Blood sprayed over Moraelyn's leathers. His victim fell over, gurgling horribly. A burning acid rose in Edward's throat; he swallowed hard and looked away.
 
- The guards inside the anteroom had been dispatched, but outside the door shouts and
-footfalls thundered and there was pounding on the door.
-Edward followed his mother into the inner chamber, which was empty save
-for a naked girl tied spreadeagle on the enormous bed, her
-eyes starting from her head.
+ The guards inside the anteroom had been dispatched, but outside the door shouts and footfalls thundered and there was pounding on the door. Edward followed his mother into the inner chamber, which was empty save for a naked girl tied spreadeagle on the enormous bed, her eyes starting from her head.
 
- The Companions cut her free while Aliera caught her
-shoulders. "Thy grandmother sent us, child. Where's the
-baron?"
+ The Companions cut her free while Aliera caught her shoulders. "Thy grandmother sent us, child. Where's the baron?"
 
- The girl pointed at a bookcase, then clung to Aliera. She was no bigger than Edward and seemed not
-much older. Her breasts were just beginning. She was covered
-with welts and blood and purple-yellow bruises. Aliera
-flung her own cloak over the girl. Beech picked her up. Mith's
-fingers were feeling over the bookcase; there was a click and
-a section slid aside. He went through  cautiously. The others
-followed and the secret door closed after them. 
+ The girl pointed at a bookcase, then clung to Aliera. She was no bigger than Edward and seemed not much older. Her breasts were just beginning. She was covered with welts and blood and purple-yellow bruises. Aliera flung her own cloak over the girl. Beech picked her up. Mith's fingers were feeling over the bookcase; there was a click and a section slid aside. He went through cautiously. The others followed and the secret door closed after them.
 
- "I think it's just a bolt hole," Mith said, "but there'll be
-traps, no doubt."
+ "I think it's just a bolt hole," Mith said, "but there'll be traps, no doubt."
 
- "Go warily, then, friend," Aliera said. "There's no hurry.
-I think the baron plans to show his departing guests the door,
-as a good host should." 
+ "Go warily, then, friend," Aliera said. "There's no hurry. I think the baron plans to show his departing guests the door, as a good host should."
 
- A narrow passage opened to the left. Mith sent a bolt of
-light down it. The floor was littered with bones. Human
-bones. Small skulls stared eyelessly. "I'm going to enjoy
-killing him," Moraelyn said.
+ A narrow passage opened to the left. Mith sent a bolt of light down it. The floor was littered with bones. Human bones. Small skulls stared eyelessly. "I'm going to enjoy killing him," Moraelyn said.
 
  "No!" Aliera protested. "My quest, my kill!"
 
@@ -294,278 +120,89 @@ killing him," Moraelyn said.
 
  "I want it sung that he died by Aliera's hand! I claim my right to face him, king."
 
- "Leave him to me and we'll sing it your way! He's twice your
-size. D'you want to fight ME for the right?" The elf leaned
-over her, a full head taller.
+ "Leave him to me and we'll sing it your way! He's twice your size. D'you want to fight ME for the right?" The elf leaned over her, a full head taller.
 
- "If I must." Aliera brushed past him, slinging her shield on
-her arm, and drawing her short sword as she ran. Moraelyn
-grabbed at her, missed, and ran after her. His size hampered
-him in the low, narrow passage. Sparks flew from his spell shield as he caroomed recklessly off the walls.
+ "If I must." Aliera brushed past him, slinging her shield on her arm, and drawing her short sword as she ran.
 
- "Come on, you two," Mith yelled from ahead. "I'm not
-promising to save him for you."
+ Moraelyn grabbed at her, missed, and ran after her. His size hampered him in the low, narrow passage. Sparks flew from his spell shield as he caroomed recklessly off the walls.
 
- "Moraelyn," Edward gasped, running after him. "You're not
-going to let her!"
+ "Come on, you two," Mith yelled from ahead. "I'm not promising to save him for you."
 
- "Let her! How d'ye propose I stop her? I'm open to
-suggestions, short of actually fighting her myself." He
-seemed half-angry, half-amused.
+ "Moraelyn," Edward gasped, running after him. "You're not going to let her!"
+
+ "Let her! How d'ye propose I stop her? I'm open to suggestions, short of actually fighting her myself." He seemed half-angry, half-amused.
 
  "M-maybe he's gone by now."
 
- "Nay, he's locked in here with us; we found the exit earlier
-from the other side and Mith set a lock the baron will not
-undo."
+ "Nay, he's locked in here with us; we found the exit earlier from the other side and Mith set a lock the baron will not undo."
 
  "Well, paralyze her. You can carry her."
 
- "She's activated her shield; it reflects spells, among other
-things. I'd only paralyze myself and I'd be inconvenient to
-carry. She'll be all right. It's an excellent shield. It
-casts a very powerful protective  spell. I'ric himself
-devised it."
+ "She's activated her shield; it reflects spells, among other things. I'd only paralyze myself and I'd be inconvenient to carry. She'll be all right. It's an excellent shield. It casts a very powerful protective spell. I'ric himself devised it."
 
- "Having a spot of trouble with your locks tonight, baron?"
-Mith's voice came clearly from ahead. They emerged into a
-larger space where the baron had been clawing vainly at
-switches beside a massive door. "Shoddy work. You should get
-another smith."
+ "Having a spot of trouble with your locks tonight, baron?" Mith's voice came clearly from ahead. They emerged into a larger space where the baron had been clawing vainly at switches beside a massive door. "Shoddy work. You should get another smith."
 
- "He won't be needing one," Aliera snarled. The Companions
-spread around her in a semi-circle. The baron set his back to
-the door and set himself in a fighting stance. He was a big
-man, as big as Mats, and he was holding an axe as big as the
-one Mats wielded, and wearing a breastplate and helm. He
-addressed Moraelyn.
+ "He won't be needing one," Aliera snarled. The Companions spread around her in a semi-circle. The baron set his back to the door and set himself in a fighting stance. He was a big man, as big as Mats, and he was holding an axe as big as the one Mats wielded, and wearing a breastplate and helm. He addressed Moraelyn.
 
- "Nine against one. I'd expect odds like that from you black
-devils," Moraelyn was at the back of the group, yet the baron
- had
-singled him out as the leader. People did, somehow.
+ "Nine against one. I'd expect odds like that from you black devils," Moraelyn was at the back of the group, yet the baron had singled him out as the leader. People did, somehow.
 
- "You prefer the advantage of weight, do you not? But my
-wife wants you to herself. She cannot resist your charms it
-seems. Nor can I; I could not wait for you to respond to my
-invitation, so I came to you instead."
+ "You prefer the advantage of weight, do you not? But my wife wants you to herself. She cannot resist your charms it seems. Nor can I; I could not wait for you to respond to my invitation, so I came to you instead."
 
- "I beat her and the rest of you kill me? Hah! It might be worth
-it at that," he added, staring at Aliera with cold dark eyes.
+ "I beat her and the rest of you kill me? Hah! It might be worth it at that," he added, staring at Aliera with cold dark eyes.
 
- Aliera smiled a terrible smile. Her dark hair swung free
-about her shoulders and she seemed to glow. "You will not beat this woman, baron, but if you do, then you go free.
-You are mine alone tonight. Swear it all,  by Zenithar! If
-he haps to kill me, my ghost will hound him to his grave and
-beyond." She sounded rather pleased at the prospect. Edward began to shiver.
+ Aliera smiled a terrible smile. Her dark hair swung free about her shoulders and she seemed to glow. "You will not beat this woman, baron, but if you do, then you go free. You are mine alone tonight. Swear it all, by Zenithar! If he haps to kill me, my ghost will hound him to his grave and beyond." She sounded rather pleased at the prospect. Edward began to shiver.
 
  "By Zenithar!"
 
- The baron laughed, "I don't believe you, but one last
-female for my collection then. Are you so wearied of her, elf
-?"
+ The baron laughed, "I don't believe you, but one last female for my collection then. Are you so wearied of her, elf?"
 
- "Are you so afraid of her that you'd rather face me
-instead?" Somewhere deep in his mind Edward realized that the
-elf was right. Despite the baron's bravado, he was afraid of
-Aliera. Edward hadn't sworn with the  others. He clutched his staff tightly but his feet seemed rooted
-to the floor.
+ "Are you so afraid of her that you'd rather face me instead?" Somewhere deep in his mind Edward realized that the elf was right. Despite the baron's bravado, he was afraid of Aliera. Edward hadn't sworn with the others. He clutched his staff tightly but his feet seemed rooted to the floor.
 
- The baron laughed again and swung a mighty blow at Aliera
-in answer, but it deflected harmlessly off her shield. His
-eyes widened as he realized she was spell shielded. Aliera
-danced aside and cut his arm. She was nimble, but he managed to land many blows. If her shield went ... Edward did not
-finish the thought.
+ The baron laughed again and swung a mighty blow at Aliera in answer, but it deflected harmlessly off her shield. His eyes widened as he realized she was spell shielded. Aliera danced aside and cut his arm. She was nimble, but he managed to land many blows. If her shield went ... Edward did not finish the thought.
 
- But he was leaving himself somewhat open in the hope of wearing her shield down and she was scoring hits against
-his limbs. She kept her blows low, trying to cost him the use
-of his legs and drain him of blood. All the while she taunted
-him about his manhood,  saying she would geld him ere he died.
-A great blow knocked her back; her shield flashed and was gone.
+ But he was leaving himself somewhat open in the hope of wearing her shield down and she was scoring hits against his limbs. She kept her blows low, trying to cost him the use of his legs and drain him of blood. All the while she taunted him about his manhood, saying she would geld him where he died. A great blow knocked her back; her shield flashed and was gone.
 
-had
-singled him out as the leader. People did, somehow.
-
- "You prefer the advantage of weight, do you not? But my
-wife wants you to herself. She cannot resist your charms it
-seems. Nor can I; I could not wait for you to respond to my
-invitation, so I came to you instead."
-
- "I beat her and the rest of you kill me? Hah! It might be worth
-it at that," he added, staring at Aliera with cold dark eyes.
-
- Aliera smiled a terrible smile. Her dark hair swung free
-about her shoulders and she seemed to glow. "You will not beat this woman, baron, but if you do, then you go free.
-You are mine alone tonight. Swear it all,  by Zenithar! If
-he haps to kill me, my ghost will hound him to his grave and
-beyond." She sounded rather pleased at the prospect. Edward began to shiver.
-
- "By Zenithar!"
-
- The baron laughed, "I don't believe you, but one last
-female for my collection then. Are you so wearied of her, elf
-?"
-
- "Are you so afraid of her that you'd rather face me
-instead?" Somewhere deep in his mind Edward realized that the
-elf was right. Despite the baron's bravado, he was afraid of
-Aliera. Edward hadn't sworn with the  others. He clutched his staff tightly but his feet seemed rooted
-to the floor.
-
- The baron laughed again and swung a mighty blow at Aliera
-in answer, but it deflected harmlessly off her shield. His
-eyes widened as he realized she was spell shielded. Aliera
-danced aside and cut his arm. She was nimble, but he managed to land many blows. If her shield went ... Edward did not
-finish the thought.
-
- But he was leaving himself somewhat open in the hope of wearing her shield down and she was scoring hits against
-his limbs. She kept her blows low, trying to cost him the use
-of his legs and drain him of blood. All the while she taunted
-him about his manhood,  saying she would geld him ere he died.
-A great blow knocked her back; her shield flashed and was gone.
-
-"
-
- "Are you so afraid of her that you'd rather face me
-instead?" Somewhere deep in his mind Edward realized that the
-elf was right. Despite the baron's bravado, he was afraid of
-Aliera. Edward hadn't sworn with the  others. He clutched his staff tightly but his feet seemed rooted
-to the floor.
-
- The baron laughed again and swung a mighty blow at Aliera
-in answer, but it deflected harmlessly off her shield. His
-eyes widened as he realized she was spell shielded. Aliera
-danced aside and cut his arm. She was nimble, but he managed to land many blows. If her shield went ... Edward did not
-finish the thought.
-
- But he was leaving himself somewhat open in the hope of wearing her shield down and she was scoring hits against
-his limbs. She kept her blows low, trying to cost him the use
-of his legs and drain him of blood. All the while she taunted
-him about his manhood,  saying she would geld him ere he died.
-A great blow knocked her back; her shield flashed and was gone.
-
- The baron raised his axe high to cleave her skull with a single
-blow. Her arm drew back and she threw her slender short sword
-straight into her enemy's eye. He dropped the axe and fell
-screaming to his knees, hands clawing at his face. Aliera
-stepped forward and thrust the sword home, piercing deep
-within the brain. The body fell over, twitching and jerking.
+ The baron raised his axe high to cleave her skull with a single blow. Her arm drew back and she threw her slender short sword straight into her enemy's eye. He dropped the axe and fell screaming to his knees, hands clawing at his face. Aliera stepped forward and thrust the sword home, piercing deep within the brain. The body fell over, twitching and jerking.
 
  "Well fought, wife!"
 
- "I had a master trainer, and a better armorer!" Aliera
-laughed, then she threw back her head and shouted wordlessly in
-triumph, raising her arms, fists clenched.
+ "I had a master trainer, and a better armorer!" Aliera laughed, then she threw back her head and shouted wordlessly in triumph, raising her arms, fists clenched.
 
- "That you did!" Moraelyn grabbed Silk in a rough hug and kissed her noisily. "It's a neat trick
-you taught her, Silk."
+ "That you did!" Moraelyn grabbed Silk in a rough hug and kissed her noisily. "It's a neat trick you taught her, Silk."
 
- "I'll thank you to cease flirting with my trainer,
-husband!" Aliera said, wiping her slender adamantium blade
-carefully. 
+ "I'll thank you to cease flirting with my trainer, husband!" Aliera said, wiping her slender adamantium blade carefully.
 
- "Me flirt? Not while thy blood's up ... and thy shield's
-still charged. I'm just thanking her. I'll kiss I'ric too when
-next I see him."
+ "Me flirt? Not while thy blood's up ... and thy shield's still charged. I'm just thanking her. I'll kiss I'ric too when next I see him."
 
- "Is he truly dead?" Caron had clung to Beech throughout the
-fight with her eyes closed. Now she regarded Aliera with --
-Awe, Edward thought was the  right word. Edward felt
-something of the same, although it was akin to horror.
+ "Is he truly dead?" Caron had clung to Beech throughout the fight with her eyes closed. Now she regarded Aliera with -- Awe, Edward thought was the right word. Edward felt something of the same, although it was akin to horror.
 
- "Dead enough," Aliera said, regarding the still faintly
-twitching form, with satisfaction. The girl drew closer,
-then knelt beside him. She picked up a stone and smashed it
-into the face again and again, sobbing. When she had done,
-Ssa'ass cast some healing spells on her. Mith unlocked the
-door. They'd come out quite near to where they had left the
-horses. 
+ "Dead enough," Aliera said, regarding the still faintly twitching form, with satisfaction. The girl drew closer, then knelt beside him. She picked up a stone and smashed it into the face again and again, sobbing. When she had done, Ssa'ass cast some healing spells on her. Mith unlocked the door. They'd come out quite near to where they had left the horses.
 
- They took the girl back to her mother's house and left her there, instructing her to tell
-anyone that ventured to molest her, that Zenithar's servants
-would return if she were harmed. The bewildered old woman
-clasped her granddaughter to her. As she bade them farewell,
-she  whispered to Aliera to look after that man of hers. 
+ They took the girl back to her mother's house and left her there, instructing her to tell anyone that ventured to molest her, that Zenithar's servants would return if she were harmed. The bewildered old woman clasped her granddaughter to her. As she bade them farewell, she whispered to Aliera to look after that man of hers.
 
  "Oh, I do," Aliera said. "I do."
 
+[/center]* * *
 
+ When they stopped for rest Aliera came over to Edward to talk to him, but he protested that he was very tired and just wanted to sleep. Moraelyn tugged her away, saying that if her son did not need her then she could see to her man, who did. They moved out of the circle of firelight. Edward lay wakeful, listening to their small, stifled sounds. That was not unusual. It had troubled him at first. "I can't sleep; you're too noisy," he'd protested one night. "What are you doing, anyway?" That had drawn giggles from the Companions. "Can't you at least pretend you're sleeping?" Moraelyn had asked plaintively. "Now I know why dark elves seldom have more than one child. What I do not understand is how humans manage to get so many." Moraelyn and Aliera had come back to lie by him that night, but after that he had pretended to sleep, like the others.
 
- *    *     *       *       *       *         *         *
+ And the noises were too familiar now to keep images of the night's adventures from flashing through his mind, as vivid as if they were happening again in truth. He could feel his daedra feeding and could not stop it. It just wasn't fair, he thought, but now he was beginning to see what Moraelyn meant by feeding his daedra and yet walking with the gods. With Zenithar.
 
+ Moraelyn came back, carrying Aliera. He set her gently down, then stretched himself out between Edward and her.
 
-
- When they stopped for rest Aliera came over to Edward to
-talk to him, but he protested that he was very tired and just
-wanted to sleep. Moraelyn tugged her away, saying that if
-her son did not need her then she could see to her man, who
-did. They moved out of the circle of firelight. Edward lay
-wakeful, listening to their small, stifled sounds. That was
-not unusual. It had troubled him at first. "I can't sleep;
-you're too noisy," he'd protested one night. "What are you
-doing, anyway?" That had drawn giggles from the Companions. "Can't
-you at least pretend you're sleeping?" Moraelyn had asked
-plaintively. "Now  I know why dark elves seldom have more
-than one child. What I do not understand is how humans
-manage to get so many." Moraelyn and Aliera had come back to lie by him that night, but after that he had pretended to s
-leep, like the others.
-
- And the noises were too familiar now to keep images of the
-night's adventures from flashing through his mind, as vivid
-as if they were happening again in truth. He  could feel his
-daedra feeding and could not stop it. It just wasn't fair,
-he thought, but now he was beginning to see what Moraelyn
-meant by feeding his daedra and yet walking with the gods. With Zenithar.
-
- Moraelyn came back, carrying Aliera. He set her gently down,
-then stretched himself out between Edward and her.
-
- "It must be difficult, being a woman," he said softly. "It
-was hard, watching her. Just watching."
+ "It must be difficult, being a woman," he said softly. "It was hard, watching her. Just watching."
 
  Edward nodded.
 
- "I've asked it often enough, of her," Moraelyn continued. 
-"She told me how hard it is, but I never knew until tonight. I knew she'd win. Zenithar was with her, and all the baron had
-was his daedra. And still it was very hard to watch. She makes
-that cast nine tries out of ten, and there were more uses on
-eep, like the others.
-
- And the noises were too familiar now to keep images of the
-night's adventures from flashing through his mind, as vivid
-as if they were happening again in truth. He  could feel his
-daedra feeding and could not stop it. It just wasn't fair,
-he thought, but now he was beginning to see what Moraelyn
-meant by feeding his daedra and yet walking with the gods. With Zenithar.
-
- Moraelyn came back, carrying Aliera. He set her gently down,
-then stretched himself out between Edward and her.
-
- "It must be difficult, being a woman," he said softly. "It
-was hard, watching her. Just watching."
-
- Edward nodded.
-
- "I've asked it often enough, of her," Moraelyn continued. 
-"She told me how hard it is, but I never knew until tonight. I knew she'd win. Zenithar was with her, and all the baron had
-was his daedra. And still it was very hard to watch. She makes
-that cast nine tries out of ten, and there were more uses on
-the shield if she missed ... he'd have dropped of exhaustion before he wore it out entirely."
+ "I've asked it often enough, of her," Moraelyn continued. "She told me how hard it is, but I never knew until tonight. I knew she'd win. Zenithar was with her, and all the baron had was his daedra. And still it was very hard to watch. She makes that cast nine tries out of ten, and there were more uses on the shield if she missed ... he'd have dropped of exhaustion before he wore it out entirely."
 
  "I keep thinking about it, too ... and the guard you ... he asked for mercy?"
 
- "I know. And yet, he listened to that ... night after night.
-And still he remained the baron's man."
+ "I know. And yet, he listened to that ... night after night. And still he remained the baron's man."
 
- "Most men are not as strong as you are. Maybe he couldn't help himself?"
-Why was he pleading for a man already dead? His mind kept
-replaying the night's events as if they might yet come out
-differently, for better or for worse.
+ "Most men are not as strong as you are. Maybe he couldn't help himself?" Why was he pleading for a man already dead? His mind kept replaying the night's events as if they might yet come out differently, for better or for worse.
 
- "Even to witness evil such as that corrupts the soul. To
-watch and do nothing ... Mats would have stayed my hand had
-there been anything there worth keeping. And it's worse for the
-young; I am sorry you had to pass through this night."
+ "Even to witness evil such as that corrupts the soul. To watch and do nothing ... Mats would have stayed my hand had there been anything there worth keeping. And it's worse for the young; I am sorry you had to pass through this night."
 
  "Is my soul corrupted now?"
 
@@ -573,24 +210,15 @@ young; I am sorry you had to pass through this night."
 
  "Can you Heal me now?"
 
- "Aye." Moraelyn gathered the boy in his arms, then rolled
-over so that Edward lay between his parents. Aliera put her
-arms around him without really waking. Her strong woman smell mingled with Moraelyn's musky dark spice odor in Edward's nostrils.
+ "Aye." Moraelyn gathered the boy in his arms, then rolled over so that Edward lay between his parents. Aliera put her arms around him without really waking. Her strong woman smell mingled with Moraelyn's musky dark spice odor in Edward's nostrils.
 
- "She was so angry," Edward whispered. He'd wondered if he
-would ever really feel the same toward her again ... and yet
-her arms were still as comforting as before. Maybe Moraelyn
-too had needed that reassurance and had been wise enough to
-ask for it.
+ "She was so angry," Edward whispered. He'd wondered if he would ever really feel the same toward her again ... and yet her arms were still as comforting as before. Maybe Moraelyn too had needed that reassurance and had been wise enough to ask for it.
 
  "She's a woman. That sort of injury to another touches her near," he said.
 
  How near? The boy looked the question he dared not put.
 
- "Thy father's not a monster. But she was wed to a man who did
-not care for her, and she could not leave him. It's common
-enough among thy race, which makes it none the easier to bear,
-I think."
+ "Thy father's not a monster. But she was wed to a man who did not care for her, and she could not leave him. It's common enough among thy race, which makes it none the easier to bear, I think."
 
  "She has a daedra, too, then?" Edward asked sadly.
 
@@ -598,19 +226,12 @@ I think."
 
  "It wasn't really a fair fight, her shielded and not him."
 
- "Fair fighting's for the arena, boy. Would you fight a wolf
-or hell hound without weapons, spells and armor, though
-they have none? I would not."
+ "Fair fighting's for the arena, boy. Would you fight a wolf or hell hound without weapons, spells and armor, though they have none? I would not."
 
- "What will become of Caron and Ora? And the other folk, now
-that the baron's dead?"
+ "What will become of Caron and Ora? And the other folk, now that the baron's dead?"
 
- "Do I look like the prophet Marukh? How should I know? We can
-stop here in the spring and see what's been planted in the
-field we burned tonight. I've no mind to stay and plow it. I've my own fields to tend -- listen to
-me, I sound like a Nord farmer. Mines to dig is more like it."
-He yawned.
+ "Do I look like the prophet Marukh? How should I know? We can stop here in the spring and see what's been planted in the field we burned tonight. I've no mind to stay and plow it. I've my own fields to tend -- listen to me, I sound like a Nord farmer. Mines to dig is more like it." He yawned.
 
  "The others didn't think about afterwards. You did."
 
- "I'm a king; it's what we do." 
+ "I'm a king; it's what we do."

--- a/Assets/StreamingAssets/Text/Books/BOK00108-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00108-LOC.txt
@@ -3,479 +3,147 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
-[/center]King Edward, Chapter IX
-
-
+[/center]King Edward, Part IX
 
 [/font=4]
 
+[/center]
 
+[/center]Luck
 
-[/center]King Edward, Chapter IX:
+ Edward knelt behind Moraelyn, leaning over his shoulder so that he could see the cards the elf held. He was sitting away from the fire, so it was dark for human eyes, but Moraelyn was the only one of the group who would allow Edward to see his hand. The other players, Beech, Mith and Mats said Edward brought them bad luck. Moraelyn said that it was not really a question of luck, but that their hands were reflected in Edward's face for those that had the eyes to see such images. It was too dark for Beech and Mats to see Edward now, and Moraelyn blocked him from Mith's view. And yet, the pile of coins in front of Moraelyn had grown smaller since Edward had taken a place behind him. But this time he had been dealt a good hand. Edward could see that. It was Mats' turn. He was cogitating.
 
-[/center]Luck 
+ "You're shivering, son," Moraelyn said, "Have you no warmer clothing? We must find something for you. Here, come share my cloak, then. You can hold the cards if you like." The wind was chill; there was a bite to it now that they were farther north and the year had grown older. Edward accepted the shelter of Moraelyn's arm and warm fur cloak and sat close against his side.
 
-
-
-[/center] Edward knelt behind Moraelyn, leaning over his shoulder so that he could see the cards
-the elf held. He was sitting away from the fire, so it was dark
-for human eyes, but Moraelyn was the only one of the group
-who would allow Edward to see his hand. The other players,
-Beech, Mith and Mats said Edward brought them bad luck.
-Moraelyn said that it was not really a question of luck, but that their hands were reflected in Edward's face for
-those that had the eyes to see such images. It was too dark for
-Beech and Mats to see Edward now, and Moraelyn blocked him
-from Mith's view. And yet, the pile of coins in front of
-Moraelyn had grown smaller since Edward had taken a place
-behind him. But this time he had been dealt a good hand.
-Edward could see that. It was Mats' turn. He was cogitating.
-
- "You're shivering, son," Moraelyn said, "Have you no
-warmer clothing? We must find something for you. Here, come
-share my cloak, then. You can hold the cards if you like."
-The wind was chill; there was a bite to it now that they were
-farther north and the year had grown older. Edward accepted
-the shelter of Moraelyn's arm and warm fur cloak and sat
-close against his side.
-
- "I think I'll just play the cards I hold," Mats said at last,
-and pushed a pile of coins into the pot, then with sudden
-resolve, added a few more. "There."
+ "I think I'll just play the cards I hold," Mats said at last, and pushed a pile of coins into the pot, then with sudden resolve, added a few more. "There."
 
  "Throw the hand down, Edward, we're through."
 
- "But there aren't many better hands than what we've got!"
-Edward protested.
+ "But there aren't many better hands than what we've got!" Edward protested.
 
- "Edward!" Moraelyn growled. 
+ "Edward!" Moraelyn growled.
 
- "Well, how'm I s'posed to learn?" Mats didn't have to show
-his cards unless they matched his bet.
+ "Well, how'm I s'posed to learn?" Mats didn't have to show his cards unless they matched his bet.
 
- "By watching. Silently. Oh, very well. No one ever told
-me that fatherhood came cheaply." He shoved most of his coins
-into the pot to match Mats' bet and Edward laid the hand
-down. 
+ "By watching. Silently. Oh, very well. No one ever told me that fatherhood came cheaply." He shoved most of his coins into the pot to match Mats' bet and Edward laid the hand down.
 
- "Ah," Mats said, "you needn't do that, my friend. I'll show 
-the boy my cards for
-free."
+ "Ah," Mats said, "you needn't do that, my friend. I'll show the boy my cards for free."
 
- "You filthy Nord," Moraelyn said in disgust, "put down
-your cards and take my gold, if you can beat my hand. Let's
-see if I'm the one who needs educating on how to play this
-game."
+ "You filthy Nord," Moraelyn said in disgust, "put down your cards and take my gold, if you can beat my hand. Let's see if I'm the one who needs educating on how to play this game."
 
- "You don't," Mats grinned. "Except that you could have
-accepted my generous offer instead of throwing an insult at
-me." Mats laid down the perfect hand called The Ladies.
+ "You don't," Mats grinned. "Except that you could have accepted my generous offer instead of throwing an insult at me." Mats laid down the perfect hand called The Ladies.
 
- "A taunt like that rates an insult. Mats, that hand is
-almost worth the viewing price. Five beautiful Ladies! You
-don't see them together every day; they're not that fond of one another's
-company."
+ "A taunt like that rates an insult. Mats, that hand is almost worth the viewing price. Five beautiful Ladies! You don't see them together every day; they're not that fond of one another's company."
 
  "How'd you know?" Edward demanded.
 
- "Ah, that'd be telling," Moraelyn grinned. "Some things you're supposed to learn for
-yourself. That's part of the game. But remember that a good
-he boy my cards for
-free."
-
- "You filthy Nord," Moraelyn said in disgust, "put down
-your cards and take my gold, if you can beat my hand. Let's
-see if I'm the one who needs educating on how to play this
-game."
-
- "You don't," Mats grinned. "Except that you could have
-accepted my generous offer instead of throwing an insult at
-me." Mats laid down the perfect hand called The Ladies.
-
- "A taunt like that rates an insult. Mats, that hand is
-almost worth the viewing price. Five beautiful Ladies! You
-don't see them together every day; they're not that fond of one another's
-company."
-
- "How'd you know?" Edward demanded.
-
- "Ah, that'd be telling," Moraelyn grinned. "Some things you're supposed to learn for
-yourself. That's part of the game. But remember that a good
-hand's worthless if someone else holds a better."
+ "Ah, that'd be telling," Moraelyn grinned. "Some things you're supposed to learn for yourself. That's part of the game. But remember that a good hand's worthless if someone else holds a better."
 
  "I'm sorry." Edward looked ruefully at the few remaining coins.
 
- "No matter. It's foolish to play with Mats on those nights
-when the God of Luck himself stands at his shoulder and all I
-have at mine is a runaway Breton prince who should be in his
-bed. He'd have had that money off me i' the end. This way we'll
-get a bit of sleep."
+ "No matter. It's foolish to play with Mats on those nights when the God of Luck himself stands at his shoulder and all I have at mine is a runaway Breton prince who should be in his bed. He'd have had that money off me in the end. This way we'll get a bit of sleep."
 
- "Spoilsport," Mats grumped. "It's not every night Sai
-visits me and I do enjoy his presence."
+ "Spoilsport," Mats grumped. "It's not every night Sai visits me and I do enjoy his presence."
 
- "He can leave as quickly as he comes. Sai's not someone you
-want to get overfond of, Mats."
+ "He can leave as quickly as he comes. Sai's not someone you want to get overfond of, Mats."
 
- "Who should know that better than I? Nay, do not apologize.
-I appreciate your concern for me, my friend. It's not
-altogether unwarranted, but I am mindful of the temptation.
-I know how undependable Sai's favor is, and how capricious.
-I play only among my friends, whom I do trust."
+ "Who should know that better than I? Nay, do not apologize. I appreciate your concern for me, my friend. It's not altogether unwarranted, but I am mindful of the temptation. I know how undependable Sai's favor is, and how capricious. I play only among my friends, whom I do trust."
 
- "Goodnight, then." Moraelyn and Mith went off to join those who were already
-asleep, leaving Mats and Beech and Edward by the fire. The
-dark elves' natural sleep pattern was a period of five or six hours during the day, and a short nap of two
-or three hours after midnight. Now that they were travelling, they were sleeping only at night,
-which was a difficult adjustment for Mith and Moraelyn,
-who had to use spells to cope with it. Edward had slept a
-bit as soon as they had stopped for the night, while the others
-prepared supper. In consequence he was now wide awake. Beech was yawning. Mats seemed to require less sleep than the rest.
+ "Goodnight, then." Moraelyn and Mith went off to join those who were already asleep, leaving Mats and Beech and Edward by the fire. The dark elves' natural sleep pattern was a period of five or six hours during the day, and a short nap of two or three hours after midnight. Now that they were travelling, they were sleeping only at night, which was a difficult adjustment for Mith and Moraelyn, who had to use spells to cope with it. Edward had slept a bit as soon as they had stopped for the night, while the others prepared supper. In consequence he was now wide awake. Beech was yawning. Mats seemed to require less sleep than the rest.
 
- "Tell me about Sai, Mats. I've never heard of him before. I
-didn't know there was a god of luck. I thought luck just
-happened."
+ "Tell me about Sai, Mats. I've never heard of him before. I didn't know there was a god of luck. I thought luck just happened."
 
- "Being as you're Breton, I can understand that. Bretons like things explained, clear and
-reasonable, in sequence, so one thing follows from another,
-and you know where you are. Most gods are like that. They lay down rules and
-if you obey them and pay homage to the god, why then he or she grants you favor. And the better you
-keep the rules and the more you worship the god, the higher you
-rise in his favor. Those rules aren't always easy to keep,
-and one god's rules may require you to violate another's
-but you know where you are. Well, Sai's not like that. He's
-not a daedra, but he's got a daedric side to him, for sure. One thing, if you worship him
-too much, he'll abandon you altogether. They call it 'Sai's
-Affliction'. It's an overwhelming desire for the god's
-constant presence. My father suffered from it, poor man.
-The disease is more than just a desire for the god's presence.
-The sufferers require continual proof of the god's favor. So they
-gamble incessantly. Not to win, for all they do with
-winnings is keep on gambling until they lose. Then they do
-what they must to raise a stake so they can gamble again.
+ "Being as you're Breton, I can understand that. Bretons like things explained, clear and reasonable, in sequence, so one thing follows from another, and you know where you are. Most gods are like that. They lay down rules and if you obey them and pay homage to the god, why then he or she grants you favor. And the better you keep the rules and the more you worship the god, the higher you rise in his favor. Those rules aren't always easy to keep, and one god's rules may require you to violate another's but you know where you are. Well, Sai's not like that. He's not a daedra, but he's got a daedric side to him, for sure. One thing, if you worship him too much, he'll abandon you altogether. They call it 'Sai's Affliction'. It's an overwhelming desire for the god's constant presence. My father suffered from it, poor man. The disease is more than just a desire for the god's presence. The sufferers require continual proof of the god's favor. So they gamble incessantly. Not to win, for all they do with winnings is keep on gambling until they lose. Then they do what they must to raise a stake so they can gamble again.
 
- "Oh, it's a terrible thing. Terrible. My father sold me as a slave because
-of it. Later he sold my oldest sister. Then, when he was in
-debt yet again, he killed himself in one of his rare lucid mome
-nts when he could see what was happening
-to him. What he was doing to his family, himself. 'Course I
-was just a kid when I was sold. I didn't understand. I
-thought it was because of some fault of mine that I'd been
-sent away, laziness or stupidity or disobedience, and that if I'd only been a better son it wouldn't a happened. That's Auriel's way. It's intended
-that children should respect their parents and learn from
-them, but some parents aren't deserving of respect. Well,
-it was a sickness in him, so my mother says. I don't know that he
-should be blamed for it, any more than if he had red plague or leprosy. I believe her, yet sometimes I still
-feel it was my fault. Well, that was bad luck you might
-say. But Sai sent me Moraelyn and that was a lucky day
-indeed.
+ "Oh, it's a terrible thing. Terrible. My father sold me as a slave because of it. Later he sold my oldest sister. Then, when he was in debt yet again, he killed himself in one of his rare lucid moments when he could see what was happening to him. What he was doing to his family, himself. 'Course I was just a kid when I was sold. I didn't understand. I thought it was because of some fault of mine that I'd been sent away, laziness or stupidity or disobedience, and that if I'd only been a better son it wouldn't a happened. That's Auriel's way. It's intended that children should respect their parents and learn from them, but some parents aren't deserving of respect. Well, it was a sickness in him, so my mother says. I don't know that he should be blamed for it, any more than if he had red plague or leprosy. I believe her, yet sometimes I still feel it was my fault. Well, that was bad luck you might say. But Sai sent me Moraelyn and that was a lucky day indeed.
 
- "What other god would put it into his head to stop one human
-from beating on another? Any other elf in Tamriel would
-have turned away in disgust or stopped to watch and laugh
-at the stupid humans. Two dark elf kids against four grown
-Nords, and for all they knew I deserved what I was getting. I
-could have been a thief or murderer. I suppose I was a thief. I'd stolen myself, so
-ts when he could see what was happening
-to him. What he was doing to his family, himself. 'Course I
-was just a kid when I was sold. I didn't understand. I
-thought it was because of some fault of mine that I'd been
-sent away, laziness or stupidity or disobedience, and that if I'd only been a better son it wouldn't a happened. That's Auriel's way. It's intended
-that children should respect their parents and learn from
-them, but some parents aren't deserving of respect. Well,
-it was a sickness in him, so my mother says. I don't know that he
-should be blamed for it, any more than if he had red plague or leprosy. I believe her, yet sometimes I still
-feel it was my fault. Well, that was bad luck you might
-say. But Sai sent me Moraelyn and that was a lucky day
-indeed.
+ "What other god would put it into his head to stop one human from beating on another? Any other elf in Tamriel would have turned away in disgust or stopped to watch and laugh at the stupid humans. Two dark elf kids against four grown Nords, and for all they knew I deserved what I was getting. I could have been a thief or murderer. I suppose I was a thief. I'd stolen myself, so to speak."
 
- "What other god would put it into his head to stop one human
-from beating on another? Any other elf in Tamriel would
-have turned away in disgust or stopped to watch and laugh
-at the stupid humans. Two dark elf kids against four grown
-Nords, and for all they knew I deserved what I was getting. I
-could have been a thief or murderer. I suppose I was a thief. I'd stolen myself, so
-to speak."
+ "Moraelyn can't say himself why he did it. He says he was spoiling for a fight that day and seeing slavecatchers on Morrowind soil did nothing to ease his temper. That's why I say: it was Sai. But it was Moraelyn that listened to the god.
 
- "Moraelyn can't say himself why he did it. He says he was
-spoiling for a fight that day and seeing slavecatchers on
-Morrowind soil did nothing to ease his temper. That's why I
-say: it was Sai. But it was Moraelyn that listened to the
-god.
+ "There's no doubt it's a grand thing to feel Sai's hand on your shoulder. It's like riding the finest horse, like love itself. You're one with the world, and everything goes your way, everything's on your side, instead of being the constant struggle that life really is. You don't have to be smart or handsome or kind or witty. Things just go your way. If you do something dumb it doesn't matter. It'll turn out to be the right thing to have done. Lucky. Some folks do seem to be born lucky, others unlucky. I don't know why. Most everyone feels Sai's presence sometimes, I guess. You have, haven't you?"
 
- "There's no doubt it's a grand thing to feel Sai's hand on your
-shoulder. It's like riding the finest horse, like love itself.
-You're one with the world, and everything goes your way,
-everything's on your side, instead of being the constant struggle that life really is. You don't have to be
-smart or handsome or kind or witty. Things just go your
-way. If you do something dumb it doesn't matter. It'll turn
-out to be the right thing to have done. Lucky. Some folks do seem to be born lucky, others unlucky. I don't know
-why. Most everyone feels Sai's presence sometimes, I guess.
-You have, haven't you?"
+ Edward shook his head. He'd no idea what Mats was talking about.
 
- Edward shook his head. He'd no idea what Mats was talking
-about.
+ "Well, it's a kind of greed, I guess, this Sai's Affliction. You see, there's only so much luck to spread around, and if a few folks got it all, there'd be none left for the rest. Like tonight, I won that last pot, but the others had to lose it. Everyone can't win with Sai. That's not true with other gods, not necessarily. You still don't understand, do you? Would you like to hear a story about Sai?"
 
- "Well, it's a kind of greed, I guess, this Sai's Affliction.
-You see, there's only so much luck to spread around, and if a
-few folks got it all, there'd be none left for the rest. Like
-tonight, I won that last pot, but the others had to lose it.
-Everyone can't win with Sai. That's not true with other gods,
-not necessarily. You still don't understand, do you?
-Would you like to hear a story about Sai?"
+ Edward nodded. Mats was a good-natured fellow, but usually quite silent. Edward had thought him rather stupid. Mats' luck at cards seemed to have loosened his tongue, and now Edward saw that he thought a lot more than he talked.
 
- Edward nodded. Mats was a good-natured fellow, but
-usually quite silent. Edward had thought him rather stupid.
-Mats' luck at cards seemed to have loosened his tongue, and now Edward saw that he thought a
-lot more than he talked.
+[/center]* * *
 
- *                              *                             *
+ Long, long ago, when people were fewer and wolves more numerous than now a young widow named Josea lived smack in the middle of what is now the province of Skyrim. She was an ordinary sort of woman, neither plain nor pretty. She had smooth brown hair, warm brown eyes, a short nose, a full round face, and body to match. She'd been born the only child of peasant farmers. Her parents had been carried off by typhoid when she was seventeen. Shortly afterwards she had married Tom, a strong young woodcutter with a cheerful disposition and a roving eye. He'd gotten her pregnant quickly, then turned his attentions elsewhere. Shortly before the babe was due he'd been killed by the local goldsmith who'd come home unexpectedly, found the handsome woodcutter in bed with his wife, and stuck a knife in his back.
 
- Long, long ago, when people were fewer and wolves more
-numerous than now a young widow named Josea lived smack in
-the middle of what is now the province of Skyrim. She was an ordinary sort of woman, neither plain nor
-pretty. She had smooth brown hair, warm brown eyes, a short
-nose, a full round face, and body to match. She'd been
-born the only child of peasant farmers. Her parents had been
-carried off by typhoid when she was seventeen. Shortly afterwards she had
-married Tom, a strong young woodcutter with a cheerful
-disposition and a roving eye. He'd gotten her pregnant
-quickly, then turned his attentions elsewhere. Shortly
-before the babe was due he'd been killed by the local
-goldsmith who'd come home unexpectedly, found the handsome
-woodcutter in bed with his wife, and stuck a knife in his back.
+ Tom's death had occurred on Heart's Day. The babe, a boy, was born four months later during Mid Year. Two neighbor women came to help her birth him and one stayed a few days. After that she was left to cope with caring for child and smallholding as best she could.
 
- Tom's death had occurred on Heart's Day. The babe, a boy,
-was born four months later during Mid Year. Two neighbor
-women came to help her birth him and one stayed a few days. After that she was left to cope with caring for child and
-smallholding as best she could.
+ One evening in the next Morningstar, Josea went out to the small barn to do the evening chores, leaving the babe asleep in his crib. The wind was howling. She had to clutch her cloak tightly around her. She milked and fed the cow, fed the pigs and chickens. When she left the barn she walked out into a fierce blizzard. The wind had risen so that the barn door was wrenched from her hand and slammed back against the side of the barn. She couldn't even see the house, which was near the road, and some little distance from the barn, but she set off toward it with confidence.
 
- One evening in the next Morningstar, Josea went out to the
-small barn to do the evening chores, leaving the babe
-asleep in his crib. The wind was howling. She had to clutch
-her cloak tightly around her. She milked and fed the cow, fed
-the pigs and chickens. When she left the barn she walked out
-into a fierce blizzard. The wind had risen so that the barn
-door was wrenched from her hand and slammed back against the
-side of the barn. She couldn't even see the house, which was
-near the road, and some little distance from the barn, but
-she set off toward it with confidence.
+ She'd lived here all her life and knew every inch of ground, although she'd never seen a storm quite this fierce and sudden. Already there were two inches of snow beneath her feet. She struggled against the wind for some time, until at last she realized that she must somehow have gone past the house. She turned back and tried to follow her own footprints, reasoning that at least she'd warm herself in the barn before setting out again. But the snow was falling so thickly that her footprints vanished before her eyes, and she was quite lost, and cold.
 
- She'd lived here all her life and knew every inch of ground,
-although she'd never seen a storm quite this fierce and
-sudden. Already there were two inches of snow beneath her
-feet. She struggled against the wind for some time, until at
-last she realized that she must somehow have gone past the house. She turned back and tried to follow her own footprints,
-reasoning that at least she'd warm herself in the barn before
-setting out again. But the snow was falling so thickly that
-her footprints vanished before her eyes, and she was quite lost, and cold.
+ Josea struggled on, hoping to come across something recognizable, a boulder or a tree or the road if not house or barn. Her hands and feet were wet and numb. She hadn't dressed heavily and was now chilled to the bone, with ice forming on her eyebrows and lashes.
 
- Josea struggled on, hoping to come across something
-recognizable, a boulder or a tree or the road if not house
-or barn. Her hands and feet were wet and numb. She hadn't dressed heavily and was now chilled to the bone, with ice
-forming on her eyebrows and lashes.
+ "Timmy! Tiimmmeee!" She cried her child's name, hoping against hope that the babe would wake and cry and that she might follow the sound to him. She stood and listened, gasping the cold air into her lungs, but there was only the howling of the wind. The wind, or something more? A grey shape took form in front of her, staring at her with slitted yellow eyes. A great grey wolf.
 
- "Timmy! Tiimmmeee!" She cried her child's name, hoping
-against hope that the babe would wake and cry and that she
-might follow the sound to him. She stood and listened, gasping the cold air into her lungs, but there was only the
-howling of the wind. The wind, or something more? A grey
-shape took form in front of her, staring at her with slitted
-yellow eyes. A great grey wolf.
+ Her heart seemed to stop. Her eyes filled with tears as she thought of her child lying helpless in the house alone, and his mother dead outside. How unlucky, to die so close to shelter! Unlucky. But she had always been unlucky, the unluckiest woman she knew. It might be days before any thought to visit her. She sank down to her knees, exhausted. The wolf sat before her, threw back its head and voiced its dreadful howl.
 
- Her heart seemed to stop. Her eyes filled with tears as she
-thought of her child lying helpless in the house alone, and
-his mother dead outside. How unlucky, to die so close to
-shelter! Unlucky. But she had always been unlucky, the
-unluckiest woman she knew. It might be days before any thought
-to visit her. She sank down to her knees, exhausted. The wolf sat before her, threw back
-its head and voiced its dreadful howl.
+ Her frozen hands scrabbled in the snow, looking for stone or stick, anything with which to defend herself against the pack. Another dark shadow appeared from the whirling white snow. She scrambled backwards in a panic. This one was also gray, but tall and two-legged, gray cloaked and hooded. Its gloved hand reached for the wolf's head and patted it. Her scream died in her throat.
 
- Her frozen hands scrabbled in the snow, looking for stone or
-stick, anything with which to defend herself against the pack.
-Another dark shadow appeared from the whirling white snow. She scrambled backwards
-in a panic. This one was also gray, but tall and
-two-legged, gray cloaked and hooded. Its gloved hand reached for the wolf's head and
-patted it. Her scream died in her throat.
+ "No need to fear, lass. We'll not bring you harm, nay quite otherwise. Be you the mother of yon child?"
 
- "No need to fear, lass. We'll not bring you harm, nay
-quite otherwise. Be you the mother of yon child?"
+ She nodded dumbly. His voice was deep and kind, clear in the high whistling of the wind, but her eyes went to his dread companion.
 
- She nodded dumbly. His voice was deep and kind, clear in the high whistling of the wind,
-but her eyes went to his dread companion.
+ "No need to fear," he repeated. "My friend Grellan here will lead us back to safety. Unless you indeed do wish to spend the night here." His hands reached for hers and pulled her up, and she leaned on his arm and hobbled alongside him.
 
- "No need to fear," he repeated. "My friend Grellan here will lead us back to safety. Unless
-you indeed do wish to spend the night here." His hands reached
-for hers and pulled her up, and she leaned on his arm and
-hobbled alongside him.
+ When at last they reached her door, he said, "I stopped here hoping for shelter from the storm. I hope you don't mind?"
 
- When at last they reached her door, he said, "I stopped here
-hoping for shelter from the storm. I hope you don't mind?"
+ How could she refuse? Men too could be wolves, but if he were it wasn't likely he'd take no for an answer anyway. "P-p-please come in. I l-left the k-kettle on the boil but I expect it's empty by now," she said inanely.
 
- How could she refuse? Men too could be wolves, but if he
-were it wasn't likely he'd take no for an answer anyway. "P-p-please come
-in. I l-left the k-kettle on the boil but I expect it's empty
-by now," she said inanely.
+ "I did go in, when there was no response to my knock, and found the babe asleep and alone, and the kettle boiling away. I took the kettle from the fire, but left the babe be. I knew his mother would not be far, and sent Grellan to find you. Lucky for you, but then I have always brought luck to those around me."
 
- "I did go in, when there was no response to my knock, and
-found the babe asleep and alone, and the kettle boiling
-away. I took the kettle from the fire, but left the babe be. I
-knew his mother would not be far, and sent Grellan to find you. Lucky for you, but then I have
-always brought luck to those around me."
+ He threw back his hood and she saw that he was tall and pale, with silver hair and eyes, but a young face. His countenance was grim, but the silver eyes were kind and his mouth gentle. "My horse too will want shelter on this night. Have you a shed to offer him?"
 
- He threw back his hood and she saw that he was tall and pale,
-with silver hair and eyes, but a young face. His countenance
-was grim, but the silver eyes were kind and his mouth gentle.
-"My horse too will want shelter on this night. Have you a shed
-to offer him?"
+ While he stabled his horse she changed out of her wet clothing and fixed a bit of supper for them: soup and bread and cheese, and elmroot tea. As she dished it up she apologized meekly for the meager fare.
 
- While he stabled his horse she changed out of her wet clothing
-and fixed a bit of supper for them: soup and bread and
-cheese, and elmroot tea. As she dished it up she apologized meekly for the meager fare.
+ "Why, 'tis a feast compared to my efforts!" He smiled, and fell to, hungrily. Grellan lay by the fire, his eyes fixed on his master, who occasionally flung him a morsel. "He ate well yesterday, luckily for your chickens, else I'd have to buy one from you."
 
- "Why, 'tis a feast compared to my efforts!" He smiled, and fell to,
-hungrily. Grellan lay by the fire, his eyes fixed on his
-master, who occasionally flung him a morsel. "He ate well
-yesterday, luckily for your chickens, else I'd have to buy
-one from you."
-
- "Nay, nay," she protested. "I'm deep in your debt and
-glad to share anything I have with you." The babe stirred and cried then, and she picked him up, changed his wet diaper,
-and put him to her breast.
+ "Nay, nay," she protested. "I'm deep in your debt and glad to share anything I have with you." The babe stirred and cried then, and she picked him up, changed his wet diaper, and put him to her breast.
 
  "Where's your husband, lady?"
 
- She hesitated a moment--the thought flashed that she should not tell this stranger how alone and unprotected she
-was--then told him the truth.
+ She hesitated a moment--the thought flashed that she should not tell this stranger how alone and unprotected she was--then told him the truth.
 
- "A sad tale, truly," he said, "but he's left you a handsome
-child, and you seem quite comfortable here." His eyes went
-round the humble one room cottage, crib and feather bed at
-one end, covered with a quilt of her mother's making, and
-stone hearth at the other, table and chairs made by her father
-in the middle. A ladder led to the loft where she'd slept as a child. Suddenly the simple room seemed a palace to her. They were warm and dry
-and well fed, and indeed what could be better?
+ "A sad tale, truly," he said, "but he's left you a handsome child, and you seem quite comfortable here." His eyes went round the humble one room cottage, crib and feather bed at one end, covered with a quilt of her mother's making, and stone hearth at the other, table and chairs made by her father in the middle. A ladder led to the loft where she'd slept as a child. Suddenly the simple room seemed a palace to her. They were warm and dry and well fed, and indeed what could be better?
 
- "Why, you're right, stranger. I am lucky after all. Now,
-will you tell me something of yourself?"
+ "Why, you're right, stranger. I am lucky after all. Now, will you tell me something of yourself?"
 
- "I am less fortunate than you in some ways. I am a
-wanderer, and born to wanderers, a tinker by trade, though I
-can turn my hand to most things. I have never been married
-and have no children, nor have I ever had a home other than
-the wagon my horse pulls. I've never stayed long in one place. My parents named me Sai,
-but most folks call me Lucky."
+ "I am less fortunate than you in some ways. I am a wanderer, and born to wanderers, a tinker by trade, though I can turn my hand to most things. I have never been married and have no children, nor have I ever had a home other than the wagon my horse pulls. I've never stayed long in one place. My parents named me Sai, but most folks call me Lucky."
 
- "Lucky is what I will call you then, for you have indeed
-been lucky for me."
+ "Lucky is what I will call you then, for you have indeed been lucky for me."
 
- He stood and stretched, and began clearing the remnants of
-their meal from the table. He poured water from the copper
-kettle into the basin and washed and dried the dishes, something she had never seen a man do before.
-After the babe was fed they played with him on the hearthrug
-while he told her of some of the odd and wonderful places
-and peoples he had met with on his journeys, and once again
-her life seemed very narrow and dull. After an hour or two
-the babe grew tired and cranky, and she took him on her lap and
-sang to him until he fell asleep. She laid him in his crib and wrapped him warmly in a rabbit
-fur bunting.
+ He stood and stretched, and began clearing the remnants of their meal from the table. He poured water from the copper kettle into the basin and washed and dried the dishes, something she had never seen a man do before. After the babe was fed they played with him on the hearthrug while he told her of some of the odd and wonderful places and peoples he had met with on his journeys, and once again her life seemed very narrow and dull. After an hour or two the babe grew tired and cranky, and she took him on her lap and sang to him until he fell asleep. She laid him in his crib and wrapped him warmly in a rabbit fur bunting.
 
- When she went back to the fire, Lucky reached for her hand and
-held it for a moment, without a word, then they were in one
-another's arms and kissing hungrily. They shed their clothing and lay together shamelessly, enjoying each others bodies
-in the flickering rosy firelight. He loved the roundness of
-her breasts and thighs, belly and buttocks, and said she was
-as juicy as an apple. His bleached lean muscular body and
-silken hair fascinated her as much. She had loved Tom and known pleasant
-moments with him, but nothing like she felt with this
-stranger. 
+ When she went back to the fire, Lucky reached for her hand and held it for a moment, without a word, then they were in one another's arms and kissing hungrily. They shed their clothing and lay together shamelessly, enjoying each others bodies in the flickering rosy firelight. He loved the roundness of her breasts and thighs, belly and buttocks, and said she was as juicy as an apple. His bleached lean muscular body and silken hair fascinated her as much. She had loved Tom and known pleasant moments with him, but nothing like she felt with this stranger.
 
- She woke in bed in the morning, to the baby's crying as
-usual. Lucky wasn't there and she thought he must have been a
-vivid dream. Then the door opened and shut, and he was striding toward her, fully dressed, and motioning her to stay
-where she was. He kissed her lips, then brought the babe to her and stood watching as he suckled. "What a pity that we
-remember not the pleasure we once knew."
+ She woke in bed in the morning, to the baby's crying as usual. Lucky wasn't there and she thought he must have been a vivid dream. Then the door opened and shut, and he was striding toward her, fully dressed, and motioning her to stay where she was. He kissed her lips, then brought the babe to her and stood watching as he suckled. "What a pity that we remember not the pleasure we once knew."
 
- "Yet we have pleasures still that we will remember," she said, and felt her cheeks redden at her boldness. What a wanton he must think her!
+ "Yet we have pleasures still that we will remember," she said, and felt her cheeks redden at her boldness. What a wanton he must think her!" he said, and laid his cold hand against her hot cheek.
 
- "Indeed," he said, and laid his cold hand against her hot
-cheek. 
+ The storm had stopped during the night, but the snow was deep on the road, and it was clear that it would be days before the horse could pull Lucky's small wagon along the road. That wagon was brightly painted with leaves and vines and flowers in red and blue and green and yellow. The wheels were red with yellow spokes. It had a canvas top, also painted, blue with white fleecy clouds. Josea loved the wagon but it sorted oddly with Lucky's quiet greyness.
 
- The storm had stopped during the night, but the snow was
-deep on the road, and it was clear that it would be days
-before the horse could pull Lucky's small wagon along the
-road. That wagon was brightly painted with leaves and vines
-and flowers in red and blue and green and yellow. The
-wheels were red with yellow spokes. It had a canvas top,
-also painted, blue with white fleecy clouds. Josea loved the
-wagon but it sorted oddly with Lucky's quiet greyness.
+ Lucky did small jobs for her, mending tools, hinges, and utensils. He cut more wood for her, saying that if she did not need it this year, there would be another. He stayed a week and a thaw came and then a freeze, and the road was rutted but fit for travel. They looked at one another in the morning light, and he said that it couldn't hurt to stay another day, or maybe two...if she was not yet tired of him. She wasn't.
 
- Lucky did small jobs for her, mending tools, hinges, and
-utensils. He cut more wood for her, saying that if she did not need it
-this year, there would be another. He stayed a week and a thaw
-came and then a freeze, and the road was rutted but fit for
-travel. They looked at one another in the morning light, and
-he said that it couldn't hurt to stay another day, or maybe
-two ... if she was not yet tired of him. She wasn't.
+ After another week, Lucky asked her if she would come with him. Her heart leaped at the question, but she looked around the little house where she'd spent all her life, thought of her land and village and her babe, and said, "I can't go. I've no desire to travel, and I don't want to bring my babe up as a homeless waif."
 
- After another week, Lucky asked her if she would come with him. Her heart leaped at the question, but she looked around the
-little house where she'd spent all her life, thought of her
-land and village and her babe, and said, "I can't go. I've
-no desire to travel, and I don't want to bring my babe up
-as a homeless waif."
+ Pain flashed across Lucky's pale face, but he only nodded, harnessed up his horse, and kissed her goodbye. Tears clouded her eyes and blurred the gay wagon colors.
 
- Pain flashed across Lucky's pale face, but he only nodded,
-harnessed up his horse, and kissed her goodbye. Tears clouded her eyes and blurred the gay wagon colors.
+ Sun's Dawn passed very slowly, with rain and sleet and snow, but nothing like the storm that had brought Lucky to her. Occasionally there was a knock at her door, which started her heart pounding, but always it was just a villager, come to buy the dried herbs she sold. Then, on the first night of First Seed, she heard the creak of a wagon and knew. She flew to the door, her face alight and flung herself into his arms.
 
- Sun's Dawn passed very slowly, with rain and sleet and
-snow, but nothing like the storm that had brought Lucky to
-her. Occasionally there was a knock at her door, which started
-her heart pounding, but always it was just a villager,
-come to buy the dried herbs she sold. Then, on the first night
-of First Seed, she heard the creak of a wagon and knew. She
-flew to the door, her face alight and flung herself into his
-arms.
+ "I can't stay," he said. "I'm just passing through--" and that was all the talking they did for quite awhile.
 
- "I can't stay," he said. "I'm just passing through--" and
-that was all the talking they did for quite awhile. 
+ Spring came and crocuses poked their noses up through the snow. Lucky spaded up her garden. Curious neighbors came to call, but found out no more about him than she knew. She sold them eggs -- her chickens were laying very well -- and dried herbs and an elixir she made from her grandmother's recipe, which was sovereign for headache and rheumatism. They hired Lucky for odd jobs, despite their suspicion of him.
 
- Spring came and crocuses poked their noses up through the
-snow. Lucky spaded up her garden. Curious neighbors came to
-call, but found out no more about him than she knew. She sold
-them eggs -- her chickens were laying very well -- and dried
-herbs and an elixir she made from her grandmother's recipe,
-which was sovereign for headache and rheumatism. They hired
-Lucky for odd jobs, despite their suspicion of him. 
-
- Lucky continued to come and go, never saying where or when
-he'd be back, but he seldom stayed away more than a few days.
-He spoke no words of love, but loved her fiercely all the
-same. Josea's round belly grew rounder, and she weaned
-Timmy to cow's milk. Lucky's trips became shorter and less
-frequent. All around the land prospered. Even the oldest
-could not recall a better harvest. In Hearthfire Josea
-birthed a beautiful baby girl with silver hair, but eyes of
-cornflower blue. Lucky held his child and joy radiated from
-him, so that he seemed to burn with a white fire.
-
-  
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-   
+ Lucky continued to come and go, never saying where or when he'd be back, but he seldom stayed away more than a few days. He spoke no words of love, but loved her fiercely all the same. Josea's round belly grew rounder, and she weaned Timmy to cow's milk. Lucky's trips became shorter and less frequent. All around the land prospered. Even the oldest could not recall a better harvest. In Hearthfire Josea birthed a beautiful baby girl with silver hair, but eyes of cornflower blue. Lucky held his child and joy radiated from him, so that he seemed to burn with a white fire.

--- a/Assets/StreamingAssets/Text/Books/BOK00109-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00109-LOC.txt
@@ -3,299 +3,89 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
-[/center]King Edward, Chapter X
-
-
+[/center]King Edward, Part X
 
 [/font=4]
 
+[/center]
 
-
-[/center]Chapter X: Josea and Lucky, Part II
-
-
-
-
+[/center]Josea and Lucky, Part II
 
  Mats continued his story of Lucky and Josea.
 
+ The years passed, twenty of them. More children came. Timmy took a bride. The land continued to prosper. Few died, so there were many people now, and much of the forest was cleared for farms. Others became soldiers or sailors. Their voyages and battles all prospered, and they returned home laden with booty. The gods were with them, people said, for they were virtuous and deserving folk. Skyrim was united now under King Vrage the Gifted, second and noblest son of the legendary Harald of Ysgramoor, thus Josea's king was high king of all Skyrim. The Nords under Vrage's leadership spread into Morrowind and High Rock, conquering some of the sly and thievish dark elves and the weak and superstitious Bretons.
 
+ Josea and Lucky had opened a store and built a fine big house for their family. One night Josea awoke alone, and heard voices in the hall. She left her bed and crept to see. The voices sounded angry!
 
- *
-*
-*
+ Lucky was standing there in his nightshirt; the passing years had changed him little. He looked no older, but he had grown leaner and paler, and somehow less substantial. Standing with him were a tall matronly woman, dark haired, and clad in a fine blue robe, a knight in black armor, carrying a black sword and a handsome blond man, greenclad, with a bow. Two elves were there as well, one fair and one with golden skin; one had a harp, the other a lute. Elves had not been seen in Skyrim in years! How did quiet simple Lucky come to know such grand people?
 
+ "Is this how you keep your pact with us? Did we not make the rules clear to you?"
 
+ The woman was shouting at Lucky, who only muttered, "Lady Mara, I didn't realize it had been so long. It was only for a few days ... and then a few days more. And then there were the children and Josea needed me. I thought no harm. Things seemed to go well for everyone. It hasn't been so long. Tamriel did well enough without me before." Lucky spoke softly, yet his face was set and Josea knew how stubborn he could be.
 
- The years passed, twenty of them. More children came. Timmy
-took a bride. The land continued to prosper. Few died, so
-there were many people now, and much of the forest was
-cleared for farms. Others became soldiers or sailors. Their
-voyages and battles all prospered, and they returned home laden with booty. The gods were with them, people said, for they were virtuous and deserving folk. Skyrim was united now under King Vrage the  Gifted, second and noblest son of the legendary Harald of Ysgramoor, thus Josea's king was high king of all Skyrim. The Nords under Vrage's leadership spread into Morrowind and High Rock, conquering some of the sly and thievish dark elves and the weak and superstitious Bretons. 
+ "Everyone! What of the Bretons? What of the dark elves? And the wood elves. Of the ice elves I say nothing. They are gone, gone altogether and forever."
 
- Josea and Lucky had opened a store and built a fine big house
-for their family. One night Josea awoke alone, and heard
-voices in the hall. She left her bed and crept to see. The
-voices sounded angry!
+ "Such shy folk ... I tried," Lucky faltered. "I did try. The ice elves were very hard to find, and not that friendly when I did find them."
 
- Lucky was standing there in his nightshirt; the passing years ha
-d changed him little. He looked no older, but he had grown leaner and paler, and somehow less substantial. Standing with him were a tall matronly woman, dark haired, and clad in a fine blue robe, a knight in black armor, carrying a black sword and a handsome blond man, greenclad, with a bow. Two elves were there as well, one fair and one with golden skin; one had a harp, the other a lute. Elves had not been seen in Skyrim in years! How did quiet simple Lucky come to know such grand people?
+ "Are all the elves to follow them, and the Bretons, and then the other races?"
 
- "Is this how you keep your pact with us? Did we not make the
-rules clear to you?"
+ "I'll go; I will go. But High Rock and Morrowind are so far from here. And how can I leave my children? Surely, I am entitled to children? And my woman ..."
 
- The woman was shouting at Lucky, who only muttered, "Lady
-Mara, I didn't realize it had been so long. It was only for
-a few days ... and then a few days more. And then there were
-the children and Josea needed me. I thought no harm. Things
-seemed to go well for everyone. It hasn't been so long.
-Tamriel did well enough without me before." Lucky spoke
-softly, yet his face was set and Josea knew how stubborn he
-could be.
+ "You could have arranged matters as I did," said the green clad ranger. "Now it's too late for that. Matters have gone too far. We trusted you. It was a simple assignment. Yet we should have watched him." This last sentence was addressed to the black knight.
 
- "Everyone! What of the Bretons? What of the dark elves? And
-the wood elves. Of the ice elves I say nothing. They are gone,
-gone altogether and forever."
+ "I did watch him," the knight snapped, waving his sword, which Josea now saw was actually a part of his arm. "Yet alone I could do nothing! I'd few devotees in either High Rock or Morrowind. Once I realized I knew I had to find the rest of you; alone I could do little. What I could, I did. They're halted for now, yet the damage must be repaired, and he who caused it must do the fixing, Tinker! It won't be easy. You'll have to avoid the Skyrim folk altogether for a couple of hundred years, I think."
 
- "Such shy folk ... I tried," Lucky faltered. "I did try.
-The ice elves were very hard to find, and not that friendly
- changed him little. He looked no older, but he had grown leaner and paler, and somehow less substantial. Standing with him were a tall matronly woman, dark haired, and clad in a fine blue robe, a knight in black armor, carrying a black sword and a handsome blond man, greenclad, with a bow. Two elves were there as well, one fair and one with golden skin; one had a harp, the other a lute. Elves had not been seen in Skyrim in years! How did quiet simple Lucky come to know such grand people?
+ "No! My Lord Ebonarm, no!" The cry was wrenched from Lucky's heart. "I cannot. I implore you. Do not ask it of me ... leave me something of my own! Why must I always give it all to others? I'm tired of it! You promised me a life, and what you gave me, that endless wandering, was not a life!" The black knight Ebonarm scowled back at Lucky.
 
- "Is this how you keep your pact with us? Did we not make the
-rules clear to you?"
+ "We are a gentle folk," the wood elf bard said in his musical voice, "yet Zenithar can no longer be restrained. And if he wars against you, the other elven gods stand with him! If the gods war, Tamriel itself may be destroyed. You may find daedra to stand with you; they love chaos. But I think you will find that not even Springseed, Ebonarm and Mara will fight for you if you defy them further."
 
- The woman was shouting at Lucky, who only muttered, "Lady
-Mara, I didn't realize it had been so long. It was only for
-a few days ... and then a few days more. And then there were
-the children and Josea needed me. I thought no harm. Things
-seemed to go well for everyone. It hasn't been so long.
-Tamriel did well enough without me before." Lucky spoke
-softly, yet his face was set and Josea knew how stubborn he
-could be.
+ "Jephre speaks truth, as ever. Let us not speak of war among ourselves, my friend. We wished your folk no ill. We deeply regret what has happened and will labor to repair our fault. I regret our long absence, yet it was necessary. Raen and I were needed -- elsewhere." Mara said. "And not even a god, or a goddess, can be everywhere at once.
 
- "Everyone! What of the Bretons? What of the dark elves? And
-the wood elves. Of the ice elves I say nothing. They are gone,
-gone altogether and forever."
+ "As for you, Sai," she said, turning to Lucky, "One night a year with your woman and your children I will grant you. But not in the flesh. The temptations are too strong for you, I see. It was a mistake to let you hold the flesh so long. I apologize to the rest of you. Now, go and make your farewells. You are dismissed."
 
- "Such shy folk ... I tried," Lucky faltered. "I did try.
-The ice elves were very hard to find, and not that friendly
-when I did find them."
+ The knight and ranger vanished, but the elves remained. The golden skinned one spoke to Mara, "Watch these new folk of yours more carefully, Lady Mara. We are a patient people, and kindly disposed to other sentient races, yet there are limits to our patience. Take warning." Then the elves too were gone.
 
- "Are all the elves to follow them, and the Bretons, and
-then the other races?"
+ Lucky fell to his knees, clutching at Mara's robe, his face a mask of anguish, "Lady, wait! I implore you. Am I never to feel again? Never? It is more than I can bear. The rest of you can assume mortal form on occasion. Better I should have died naturally, and gone to rest," he added bitterly.
 
- "I'll go; I will go. But High Rock and Morrowind are so far
-from here. And how can I leave my children? Surely, I am
-entitled to children? And my woman ..."
+ Mara considered, frowning. "Others have paid dearly for the life you have stolen. Their spirits are not at rest; they too will exact payment. And yet ...very well. If you will labor to repair the damage you have done, then you may on occasion assume bodily form, but not as human. Wolf shape shall be yours, in return for the kindness you showed Grellan."
 
- "You could have arranged matters as I did," said the green
-clad ranger. "Now it's too late for that. Matters have gone
-too far. We trusted you. It was a simple assignment. Yet we
-should have watched him." This last sentence was addressed to
-the black knight.
+ And she was gone, leaving Lucky standing alone, barefoot. Josea ran to him and clasped him ... oh, how thin and cold he was!
 
- "I did watch him," the knight snapped, waving his sword, which
-Josea now saw was actually a part of his arm. "Yet alone I
-could do nothing! I'd few devotees in either High Rock or
-Morrowind. Once I realized I knew I had to find the rest of
-you; alone I could do little. What I could, I did. They're
-halted for now, yet the damage must be repaired, and he who
-caused it must do the fixing, Tinker! It won't be easy.
-You'll have to avoid the Skyrim folk altogether for a couple
-of hundred years, I think."
+ "What is it, dearest? Who were they? What does it mean? Oh, don't leave us!"
 
- "No! My Lord Ebonarm, no!" The cry was wrenched from
-Lucky's heart. "I cannot. I implore you. Do not ask it of me
-... leave me something of my own! Why must I always give it
-all to others? I'm tired of it! You promised me a life, and
-what you gave me, that endless wandering, was not a life!"
-The black knight Ebonarm scowled back at Lucky.
+ "I must," he said, shivering. "I have stayed far too long. My dearest, I am Luck itself. I was born with the talent, though mortal as yourself. My lord took me for a soldier. I was killed in my first battle, even as the battle was won. I e'er brought luck to others, ne'er to myself, never. Ebonarm appeared to me, said I had an interesting talent and offered me immortality if I would agree to spread my luck about.
 
- "We are a gentle folk," the wood elf bard said in his
-musical voice, "yet Zenithar can no longer be restrained.
-And if he wars against you, the other elven gods stand with
-him! If the gods war, Tamriel itself may be destroyed. You
-may find daedra to stand with you; they love chaos. But I
-think you will find that not even Springseed, Ebonarm and
-Mara will fight for you if you defy them further."
+ "He said the gods were overworked, seeing to events, and constantly quarreling over what should happen. He thought that I could balance things out naturally with my inborn talent. I was young. I'd barely lived. I didn't want to die, so I agreed, and Ebonarm said that I could keep my body for a time. I wouldn't age or die, but I would fade slowly, as you have seen. I am nearly eighty now. I did as he bade for many years. Then I met you, and found myself trapped by your need, I think. I was your Luck, you see, what you needed. And truth is, I needed you, too, my dear love.
 
- "Jephre speaks truth, as ever. Let us not speak of war among
-ourselves, my friend. We wished your folk no ill. We
-deeply regret what has happened and will labor to repair
-our fault. I regret our long absence, yet it was necessary.
-Raen and I were needed -- elsewhere." Mara said. "And not
-even a god, or a goddess, can be everywhere at once.
+ "Yet while I've stayed here, my luck has spread like ripples, strongest in the center, weak along the edges until there's none at all in Morrowind and High Rock and the Wilderness to the south, and the folk are dead or chained in slavery. Also I've brought luck only to the Nords among whom I've lived, so that the wood elves have fled and the ice elves have died. Now I must go, and bring Luck back to them and redress the balance, as it should have been."
 
- "As for you, Sai," she said, turning to Lucky, "One night a
-year with your woman and your children I will grant you.
-But not in the flesh. The temptations are too strong for
-you, I see. It was a mistake to let you hold the flesh so
-long. I apologize to the rest of you. Now, go and make your
-farewells. You are dismissed."
+ He went to the children's rooms and kissed them as they slept, while his tears fell on them. Then he said, "I'll be with you one night each year, though you will not see me. Yet you will feel my presence, dearest. Oh, and I could never speak of love or marriage ... but know I love you, as no man or god loved woman." Then he kissed her one last time, and was gone.
 
- The knight and ranger vanished, but the elves remained. The
-golden skinned one spoke to Mara, "Watch these new folk of
-yours more carefully, Lady Mara. We are a patient
-people, and kindly disposed to other sentient races, yet there
-are limits to our patience. Take warning." Then the elves
-too were gone. 
-
- Lucky fell to his knees, clutching at Mara's robe, his face a
-mask of anguish, "Lady, wait! I implore you. Am I never to
-feel again? Never? It is more than I can bear. The rest of
-you can assume mortal form on occasion. Better I should
-have died naturally, and gone to rest," he added bitterly.
-
- Mara considered, frowning. "Others have paid dearly for
-the life you have stolen. Their spirits are not at rest; they
-too will exact payment. And yet ...very well. If you will
-labor to repair the damage you have done, then you may on
-occasion assume bodily form, but not as human. Wolf shape
-shall be yours, in return for the kindness you showed
-Grellan."
-
- And she was gone, leaving Lucky standing alone, barefoot.
-Josea ran to him and clasped him ... oh, how thin and cold he
-was!
-
- "What is it, dearest? Who were they? What does it mean? Oh,
-don't leave us!"
-
- "I must," he said, shivering. "I have stayed far too long.
-My dearest, I am Luck itself. I was born with the talent,
-though mortal as yourself. My lord took me for a soldier. I
-was killed in my first battle, even as the battle was won. I
-e'er brought luck to others, ne'er to myself, never. Ebonarm
-appeared to me, said I had an interesting talent and
-offered me immortality if I would agree to spread my luck
-about.
-
- "He said the gods were overworked, seeing to events, and
-constantly quarreling over what should happen. He thought
-that I could balance things out naturally with my inborn
-talent. I was young. I'd barely lived. I didn't want to die,
-so I agreed, and Ebonarm said that I could keep my body for a
-time. I wouldn't age or die, but I would fade slowly, as
-you have seen. I am nearly eighty now. I did as he bade for
-many years. Then I met you, and found myself trapped by
-your need, I think. I was your Luck, you see, what you needed.
-And truth is, I needed you, too, my dear love.
-
- "Yet while I've stayed here, my luck has spread like
-ripples, strongest in the center, weak along the edges until
-there's none at all in Morrowind and High Rock and the
-Wilderness to the south, and the folk are dead or chained in
-slavery. Also I've brought luck only to the Nords among
-whom I've lived, so that the wood elves have fled and the ice
-elves have died. Now I must go, and bring Luck back to them
-and redress the balance, as it should have been."
-
- He went to the children's rooms and kissed them as they slept,
-while his tears fell on them. Then he said, "I'll be with you
-one night each year, though you will not see me. Yet you will
-feel my presence, dearest. Oh, and I could never speak of
-love or marriage ... but know I love you, as no man or god
-loved woman." Then he kissed her one last time, and was gone.
-
- *
-*
-*
-
- Mats stopped talking at last. The fire had burned down to
-ashes. Edward drew a long breath.
+ Mats stopped talking at last. The fire had burned down to ashes. Edward drew a long breath.
 
  "That's some story," Edward said. "Is it true?"
 
- "Are you calling my grandmother a liar? I know she used to
-leave a bit of food and a bowl of milk out on winter nights.
-'For the Wolf,' she said. And we Nords hold it very unlucky
-to attack a wolf unless it attacks you. It just might be Sai!
+ "Are you calling my grandmother a liar? I know she used to leave a bit of food and a bowl of milk out on winter nights. 'For the Wolf,' she said. And we Nords hold it very unlucky to attack a wolf unless it attacks you. It just might be Sai!
 
- "My grandmother said she got the tale from her
-great-grandmother, and her great was Josea herself. So she
-said. Or maybe it was her great-great-grandmother. I get
-lost there. Anyway it happened during the reign of King Vrage
-the Gifted, like I said, when the Nords invaded Morrowind and
-High Rock. It took Sai a hundred and fifty years to get things
-set right again, and he needed a lot of help. From
-Moraelyn's brothers and father, among others. The dark elves
-and Bretons have been lucky to get their lands back, you see,
-and it's been hard times for Skyrim folk, although once your
-luck builds up the way theirs did, it takes a long time to
-really run out altogether. And Sai didn't make the same
-mistake again. He's been spreading luck around ever since.
-Otherwise folk get arrogant and start thinking they're
-entitled to more than others. Yet he's kept his promise. You
-see, I'm his descendant and once a year I feel his presence.
-That was tonight."
+ "My grandmother said she got the tale from her great-grandmother, and her great was Josea herself. So she said. Or maybe it was her great-great-grandmother. I get lost there. Anyway it happened during the reign of King Vrage the Gifted, like I said, when the Nords invaded Morrowind and High Rock. It took Sai a hundred and fifty years to get things set right again, and he needed a lot of help. From Moraelyn's brothers and father, among others. The dark elves and Bretons have been lucky to get their lands back, you see, and it's been hard times for Skyrim folk, although once your luck builds up the way theirs did, it takes a long time to really run out altogether. And Sai didn't make the same mistake again. He's been spreading luck around ever since. Otherwise folk get arrogant and start thinking they're entitled to more than others. Yet he's kept his promise. You see, I'm his descendant and once a year I feel his presence. That was tonight."
 
- "I thought being a god means you can do just as you
-please," Edward said. 
+ "I thought being a god means you can do just as you please," Edward said.
 
- "Well, they can, you see. Sai did, for awhile, but he and
-his fellow gods weren't pleased with the results. There's
-rules to being a god, it seems, just as there are rules to being
-a man or a boy."
+ "Well, they can, you see. Sai did, for awhile, but he and his fellow gods weren't pleased with the results. There's rules to being a god, it seems, just as there are rules to being a man or a boy."
 
  "Who makes the rules then?" Edward demanded.
 
- Mats laughed. "Best save that question up for the
-Archmagister. It's much too deep for me! Well, I don't know
-about you, but I'm going to have a drink -- I'm parched after
-so much talking -- and then rouse Mith, so I can sleep
-myself."
+ Mats laughed. "Best save that question up for the Archmagister. It's much too deep for me! Well, I don't know about you, but I'm going to have a drink -- I'm parched after so much talking -- and then rouse Mith, so I can sleep myself."
 
- "Mats, I was taught that Moraelyn's father and brothers
-were just raiders and that the Nords were the real owners of
-the lands they took. That the dark elves come up out of the
-ground and raid for meanness and profit."
+ "Mats, I was taught that Moraelyn's father and brothers were just raiders and that the Nords were the real owners of the lands they took. That the dark elves come up out of the ground and raid for meanness and profit."
 
- "Moraelyn's father, Kronin, and his brothers, Cruethys and
-Ephen, took to raiding after the Nords drove them out of
-Ebonheart. Guerilla warfare isn't pretty, but neither is
-losing your homeland. Human memories of that time are faded
-hand-me-downs, but there's a fair number of dark elves who
-lived through it still around. Moraelyn's aunt Yoriss for
-one, she who rules in Kragenmoor. Oh, there's some dark elves
-still, along the borderland in Blacklight, who are just
-thieves and kidnappers, no question. They have holds up in
-the mountain caverns and raid farms and villages in east
-Skyrim. But Moraelyn's folk have naught to do with them,
-leastways not since they regained their own lands in
-Morrowind. Moraelyn hates the raiding. He'd stop it if he
-could." Mats sighed.
+ "Moraelyn's father, Kronin, and his brothers, Cruethys and Ephen, took to raiding after the Nords drove them out of Ebonheart. Guerilla warfare isn't pretty, but neither is losing your homeland. Human memories of that time are faded hand-me-downs, but there's a fair number of dark elves who lived through it still around. Moraelyn's aunt Yoriss for one, she who rules in Kragenmoor. Oh, there's some dark elves still, along the borderland in Blacklight, who are just thieves and kidnappers, no question. They have holds up in the mountain caverns and raid farms and villages in east Skyrim. But Moraelyn's folk have naught to do with them, leastways not since they regained their own lands in Morrowind. Moraelyn hates the raiding. He'd stop it if he could." Mats sighed.
 
  "Why can't he?"
 
- Mats yawned widely. "That's a matter of politics and
-power, boy. You ask him about it, and you'll likely get more
-answer than you want, for once. Me, I'm off to bed. Good
-night."
-
-
-
-  
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-   
+ Mats yawned widely. "That's a matter of politics and power, boy. You ask him about it, and you'll likely get more answer than you want, for once. Me, I'm off to bed. Good night."

--- a/Assets/StreamingAssets/Text/Books/BOK00110-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00110-LOC.txt
@@ -3,448 +3,135 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]King Edward, Part XI
 
-
-
 [/font=4]
 
 [/center]
 
-[/center] The Companions stayed the night at a crude but comfortable
-inn at a tiny village that called itself Raven Spring,
-located in the foothills of the Wrothgarian Mountains. The
-next morning they resumed their journey eastward, moving
-through rolling hills towards the Skyrim and Hammerfell
-borders, and camping the next two nights under clear early
-summer skies. When they resumed traveling the third morning,
-Moraelyn told everyone to watch the slopes north of the
-road for a notch opening to a high meadow that faced to the
-southwest. Shortly afterward everyone spotted it almost
-simultaneously when the group completed a bend around a
-rocky outcrop.
+ The Companions stayed the night at a crude but comfortable inn at a tiny village that called itself Raven Spring, located in the foothills of the Wrothgarian Mountains. The next morning they resumed their journey eastward, moving through rolling hills towards the Skyrim and Hammerfell borders, and camping the next two nights under clear early summer skies. When they resumed traveling the third morning, Moraelyn told everyone to watch the slopes north of the road for a notch opening to a high meadow that faced to the southwest. Shortly afterward everyone spotted it almost simultaneously when the group completed a bend around a rocky outcrop.
 
- Silk and Beech went ahead to scout a good route, and to look
-for a campsite for the evening ahead. By dusk they had covered
-most of the distance to the meadow, but still faced some
-stiff climbing the next morning. They agreed that it was time to camp
-once again, but happily a lunchtime picnic seemed very
-likely the next day.
+ Silk and Beech went ahead to scout a good route, and to look for a campsite for the evening ahead. By dusk they had covered most of the distance to the meadow, but still faced some stiff climbing the next morning. They agreed that it was time to camp once again, but happily a lunchtime picnic seemed very likely the next day.
 
- By mid-day the next day, which was Loredas the 5th of Mid
-Year, the Companions were sprawled across a grassy slope
-within the Dragon Village, having been joined by Akatosh and
-one other dragon. This second dragon was smaller than
-Akatosh, and seemed to be a female, although
-characteristically Akatosh had just introduced the dragon
-as Debudjen, with no further explanations being
-forthcoming. The two dragons politely chatted with the
-humanoids as they enjoyed their repast, though Debudjen flew
-off afterwards, to arc gracefully above, and then swoop
-down upon a steer in a grassy field some distance away.
+ By mid-day the next day, which was Loredas the 5th of Mid Year, the Companions were sprawled across a grassy slope within the Dragon Village, having been joined by Akatosh and one other dragon. This second dragon was smaller than Akatosh, and seemed to be a female, although characteristically Akatosh had just introduced the dragon as Debudjen, with no further explanations being forthcoming. The two dragons politely chatted with the humanoids as they enjoyed their repast, though Debudjen flew off afterwards, to arc gracefully above, and then swoop down upon a steer in a grassy field some distance away.
 
- Akatosh had been watching Edward's reaction to this, and
-asked: "Why did you flinch, Edward? Debudjen had not eaten
-recently, and really behaved no differently than you just have."
+ Akatosh had been watching Edward's reaction to this, and asked: "Why did you flinch, Edward? Debudjen had not eaten recently, and really behaved no differently than you just have."
 
- Edward replied with a small smile, "I don't think that our
-meal was quite that violent in nature."
+ Edward replied with a small smile, "I don't think that our meal was quite that violent in nature."
 
- Akatosh returned the smile, but then responded. "A good
-reminder then, that we are only similar, rather than the same."
+ Akatosh returned the smile, but then responded. "A good reminder then, that we are only similar, rather than the same."
 
- Edward paused, squinting into the mid-afternoon sun, and
-then turned to the golden dragon: "Akatosh - why did you
-choose this spot for your village?"
+ Edward paused, squinting into the mid-afternoon sun, and then turned to the golden dragon: "Akatosh - why did you choose this spot for your village?"
 
- "Well, it was high enough up into the mountains to suit us,
-but flat enough for raising the cattle ... with trees for the deer ...  and it is very defensible for all of us. There is
-plenty of room for the humans to build their ranches and
-farms, and the elves are quite comfortable in the dense trees
-along the cliff edges. The adits in the surrounding cliff
-faces provide us the access to our lairs, which we have
-located within the mining tunnel system. All in all, an
-ideal site for such an experiment involving this many races
-of beings. It even opens to the southwest, providing
-reasonable warmth for the smaller beings, with some
-protection from the elements during the colder months."
+ "Well, it was high enough up into the mountains to suit us, but flat enough for raising the cattle ... with trees for the deer ... and it is very defensible for all of us. There is plenty of room for the humans to build their ranches and farms, and the elves are quite comfortable in the dense trees along the cliff edges. The adits in the surrounding cliff faces provide us the access to our lairs, which we have located within the mining tunnel system. All in all, an ideal site for such an experiment involving this many races of beings. It even opens to the southwest, providing reasonable warmth for the smaller beings, with some protection from the elements during the colder months."
 
- Edward responded, "It is difficult for me to get used to the
-notion of a village without some central concentration of
-buildings - but perhaps these will be developed in the
-future; at least, a few buildings for meetings and
-socializing. And, I suppose that there are also some
-beautiful sunsets to be seen."
+ Edward responded, "It is difficult for me to get used to the notion of a village without some central concentration of buildings - but perhaps these will be developed in the future; at least, a few buildings for meetings and socializing. And, I suppose that there are also some beautiful sunsets to be seen."
 
- The dragon smiled again, but replied "Quite so, but I am the
-only one of the dragonkind to show any interest, and that was
-not a legitimate consideration when we chose this site." Then
-wistfully: "I wish that I could assemble the words to
-describe some of them. I have attempted this many, many
-times, but the results just are not ...very admirable."
-More briskly: "And by the way, we do intend to erect a
-meeting hall for the humanoids, and also some stores for
-barter and other exchanges of goods."
+ The dragon smiled again, but replied "Quite so, but I am the only one of the dragonkind to show any interest, and that was not a legitimate consideration when we chose this site." Then wistfully: "I wish that I could assemble the words to describe some of them. I have attempted this many, many times, but the results just are not ...very admirable." More briskly: "And by the way, we do intend to erect a meeting hall for the humanoids, and also some stores for barter and other exchanges of goods."
 
- Moraelyn had wandered over and seated himself, and he asked,
-with a notable absence of the usual humanoid respect for
-dragons, "Whatever possessed you to attempt such a crazy
-experiment, Akatosh?"
+ Moraelyn had wandered over and seated himself, and he asked, with a notable absence of the usual humanoid respect for dragons, "Whatever possessed you to attempt such a crazy experiment, Akatosh?"
 
- The dragon paused thoughtfully, and then replied "As is my
-wont I had been analyzing, in this case one might say the history of dragon behavior. Clearly our lengthy contest of
-resistance to these new Aurielian gods was futile, but it
-took many of our generations for us to realize and accept
-this. Then, our next pattern was to isolate ourselves, even
-from each other, and to resist intrusion from any and all
-beings. The exception of course was to mate among ourselves
-and procreate our race. However, aside from that one
-activity, we fought any and all for our precious privacy,
-and really for no good reason except that we can be an
-especially stubborn race."
+ The dragon paused thoughtfully, and then replied "As is my wont I had been analyzing, in this case one might say the history of dragon behavior. Clearly our lengthy contest of resistance to these new Aurielian gods was futile, but it took many of our generations for us to realize and accept this. Then, our next pattern was to isolate ourselves, even from each other, and to resist intrusion from any and all beings. The exception of course was to mate among ourselves and procreate our race. However, aside from that one activity, we fought any and all for our precious privacy, and really for no good reason except that we can be an especially stubborn race."
 
- Edward said, "Then you maintained a pattern of behavior
-long after the reason for it was gone?"
+ Edward said, "Then you maintained a pattern of behavior long after the reason for it was gone?"
 
- Akatosh looked a bit embarrassed. He said stiffly, "I believe
-that is what I I just said. We are not the only sentient race
-to fall prey to that."
+ Akatosh looked a bit embarrassed. He said stiffly, "I believe that is what I just said. We are not the only sentient race to fall prey to that."
 
- Edward said, "The Archmagister has told me that much
-behavior is inborn." 
+ Edward said, "The Archmagister has told me that much behavior is inborn."
 
- Moraelyn smiled at him, "And inborn behavior patterns are a
-particular problem for long-lived species who change
-slowly as conditions change. We elves suffer from it even
-more than you short-lived humans, which is why we like to keep
-things as they are, though life is change and to resist it
-utterly is death. Dragons live far, far longer than even
-elves, and, in consequence, breed even more slowly. Still,
-who can say what alterations being born into a social
-setting may produce, for good or ill, in dragon behavior."
+ Moraelyn smiled at him, "And inborn behavior patterns are a particular problem for long-lived species who change slowly as conditions change. We elves suffer from it even more than you short-lived humans, which is why we like to keep things as they are, though life is change and to resist it utterly is death. Dragons live far, far longer than even elves, and, in consequence, breed even more slowly. Still, who can say what alterations being born into a social setting may produce, for good or ill, in dragon behavior."
 
- Aliera had by this time joined the conversation, and
-observed: "The Daedra must have been long pleased with
-dragon behavior."
+ Aliera had by this time joined the conversation, and observed: "The Daedra must have been long pleased with dragon behavior."
 
- Akatosh responded, "Perhaps so, but I approached our ...
-queen with this suggestion moreso because it seemed clear to
-me that as a race we had fallen into a stasis, and we needed
-to break this shell in order to invigorate ourselves. She
-didn't quite agree with me, but, perhaps because of my
-reputation, she told me to go ahead and make this attempt."
+ Akatosh responded, "Perhaps so, but I approached our ... queen with this suggestion moreso because it seemed clear to me that as a race we had fallen into a stasis, and we needed to break this shell in order to invigorate ourselves. She didn't quite agree with me, but, perhaps because of my reputation, she told me to go ahead and make this attempt."
 
- By this point, all of the Companions were sitting within
-hearing range, and Mats asked: "Did you have to get your
-queen's permission? And have there been many difficulties
-among the various races?"
+ By this point, all of the Companions were sitting within hearing range, and Mats asked: "Did you have to get your queen's permission? And have there been many difficulties among the various races?"
 
- "Permission is not quite accurate in this case, Mats; being
-the beings that we are, it was moreso that I was obliged to
-tell her of this so that she would have the information. For
-example, other dragons regularly come to me with
-potential military intelligence, following this same
-philosophy of preparedness."
+ "Permission is not quite accurate in this case, Mats; being the beings that we are, it was moreso that I was obliged to tell her of this so that she would have the information. For example, other dragons regularly come to me with potential military intelligence, following this same philosophy of preparedness."
 
- Mats grinned and said, "You mean 'just in case', right? But
-what about these elves and humans?"
+ Mats grinned and said, "You mean 'just in case', right? But what about these elves and humans?"
 
- "Ah, our humanoid Lord and Lady do set a most remarkable
-example of tolerance and respect for differing shapes and
-customs. I owe a debt of gratitude to Moraelyn for the loan
-of his smiths and miners, who have been most generous in
-sharing their knowledge and skills with the Bretons that my young friend Edward and I have, ah, persuaded to attempt settlement here. It is my experience that
-Bretons, well, many Bretons, will do virtually anything
-so long as it is profitable and they gain skill and
-knowledge from it. The Nordic lust for individual honor and glory makes the mithril armor and weapons produced here extremely
-profitable -- t'was sheer genius that inspired Aliera to
-insist that we sell only to the nobility -- while the delving
-opens new tunnels and provides access to -- that which we dragons require." Akatosh smiled a
-little slyly. He was very reticent on the subject of exactly what dragons required. "Beech
-and Willow have made it known among their people that wood
-elves are welcome here, so those who have long missed their
-ancient High Rock homes have returned to these hills."
+ "Ah, our humanoid Lord and Lady do set a most remarkable example of tolerance and respect for differing shapes and customs. I owe a debt of gratitude to Moraelyn for the loan of his smiths and miners, who have been most generous in sharing their knowledge and skills with the Bretons that my young friend Edward and I have, ah, persuaded to attempt settlement here. It is my experience that Bretons, well, many Bretons, will do virtually anything so long as it is profitable and they gain skill and knowledge from it. The Nordic lust for individual honor and glory makes the mithril armor and weapons produced here extremely profitable -- t'was sheer genius that inspired Aliera to insist that we sell only to the nobility -- while the delving opens new tunnels and provides access to -- that which we dragons require." Akatosh smiled a little slyly. He was very reticent on the subject of exactly what dragons required. "Beech and Willow have made it known among their people that wood elves are welcome here, so those who have long missed their ancient High Rock homes have returned to these hills."
 
- "Fortunate for me that I'm now a Duke, and thus qualified to wear and carry
-mithril. If only I could afford more than a piece or two!
-But for the cost I might retire --" Mats said.
+ "Fortunate for me that I'm now a Duke, and thus qualified to wear and carry mithril. If only I could afford more than a piece or two! But for the cost I might retire --" Mats said.
 
- "If you retired you would not require the mithril,"
-Moraelyn pointed out.
+ "If you retired you would not require the mithril," Moraelyn pointed out.
 
- "And what of my son and daughter? Thinkst thou I will beg
-from thee for them?" Mats said indignantly. "My knees and
-wind may not be what once they were, I grant you. I'fact I'm
-somewhat tempted to remain up here, now I am here, yet I can
-still swing my axe with any!"
+ "And what of my son and daughter? Thinkst thou I will beg from thee for them?" Mats said indignantly. "My knees and wind may not be what once they were, I grant you. I'fact I'm somewhat tempted to remain up here, now I am here, yet I can still swing my axe with any!"
 
- Mith grinned delightedly, "Nords can't count. It's why they
-seek honor and glory, not profit. Honor and glory are not
-amenable to enumeration much past what one can tally on the
-fingers. Mats, if thou art but thirty-nine, thou wert the largest ten year old humanoid I e
-ver met or hope to meet!"
+ Mith grinned delightedly, "Nords can't count. It's why they seek honor and glory, not profit. Honor and glory are not amenable to enumeration much past what one can tally on the fingers. Mats, if thou art but thirty-nine, thou wert the largest ten year old humanoid I ever met or hope to meet!"
 
- "But what then are these benefits to those who neither delve
-nor smith?" Mats persisted, ignoring his old friend. "I
-would think that many would be terrified to live so close to
-such ... formidable beings" Mats spoke the last of this with
-a sly grin.
+ "But what then are these benefits to those who neither delve nor smith?" Mats persisted, ignoring his old friend. "I would think that many would be terrified to live so close to such ... formidable beings" Mats spoke the last of this with a sly grin.
 
- "Well, on the other hand, the presence of the 'formidable
-beings' means that they are certainly well-protected. And
-this area is surprisingly fertile, so the crops seem to be
-growing well ... and although they provide the meat for us,
-we allocate one fifth of each herd to them for their own
-consumption. We've also been finding out what I have long suspected - the three sets of races, when
-combined, fight much more effectively than the sum of each
-when considered in isolation - that is, each race covers or
-cancels weaknesses of the others. At least it is certainly
-true that the local goblin population has been drastically reduced in a very short
-period of time."
+ "Well, on the other hand, the presence of the 'formidable beings' means that they are certainly well-protected. And this area is surprisingly fertile, so the crops seem to be growing well ... and although they provide the meat for us, we allocate one fifth of each herd to them for their own consumption. We've also been finding out what I have long suspected - the three sets of races, when combined, fight much more effectively than the sum of each when considered in isolation - that is, each race covers or cancels weaknesses of the others. At least it is certainly true that the local goblin population has been drastically reduced in a very short period of time."
 
- "Aye," Edward responded, "so Moraelyn proved in
-er met or hope to meet!"
+ "Aye," Edward responded, "so Moraelyn proved in Morrowind."
 
- "But what then are these benefits to those who neither delve
-nor smith?" Mats persisted, ignoring his old friend. "I
-would think that many would be terrified to live so close to
-such ... formidable beings" Mats spoke the last of this with
-a sly grin.
+ "With a bit of help from his friends," Moraelyn acknowledged. "I reap the praise, but i'truth I'm little more than the standard they wave -- and at times I feel more like the target they set up!"
 
- "Well, on the other hand, the presence of the 'formidable
-beings' means that they are certainly well-protected. And
-this area is surprisingly fertile, so the crops seem to be
-growing well ... and although they provide the meat for us,
-we allocate one fifth of each herd to them for their own
-consumption. We've also been finding out what I have long suspected - the three sets of races, when
-combined, fight much more effectively than the sum of each
-when considered in isolation - that is, each race covers or
-cancels weaknesses of the others. At least it is certainly
-true that the local goblin population has been drastically reduced in a very short
-period of time."
-
- "Aye," Edward responded, "so Moraelyn proved in
-Morrowind."
-
- "With a bit of help from his friends," Moraelyn
-acknowledged. "I reap the praise, but i'truth I'm little
-more than the standard they wave -- and at times I feel more
-like the target they set up!"
-
- A wave of laughter greeted this remark. Edward persisted, "With
-you and the others up here, Akatosh, I feel my borders are
-well guarded, should Skyrim ever feel the urge to move its borders
-west again."
+ A wave of laughter greeted this remark. Edward persisted, "With you and the others up here, Akatosh, I feel my borders are well guarded, should Skyrim ever feel the urge to move its borders west again."
 
  Aliera asked: "Was it easy to convince the other dragons to move to here?"
 
- "Actually, the most difficult part of that was moving our
-hoards to our new lairs" Akatosh responded with a lazy
-smile, "although once it was known that we had no use for the
-metals, gems and jewelry that we accumulate, everything went much more smoothly." But then more seriously:
-"Essentially I had to approach each dragon personally,
-and ... convince them that this idea had merit. Again, once I
-had persuaded a couple of our especially independent
-specimens, things went much more smoothly. However, there are
-only nine of us living in this area ... and there is really
-only room for two or three more of us. We shall have to see what develops hereafter."
+ "Actually, the most difficult part of that was moving our hoards to our new lairs" Akatosh responded with a lazy smile, "although once it was known that we had no use for the metals, gems and jewelry that we accumulate, everything went much more smoothly." But then more seriously: "Essentially I had to approach each dragon personally, and ... convince them that this idea had merit. Again, once I had persuaded a couple of our especially independent specimens, things went much more smoothly. However, there are only nine of us living in this area ... and there is really only room for two or three more of us. We shall have to see what develops hereafter."
 
- Aliera now observed: "I think that now the gods and goddesses might look very favorably indeed on dragon
-behavior."
+ Aliera now observed: "I think that now the gods and goddesses might look very favorably indeed on dragon behavior."
 
- "That may be so, Aliera, but again that was not really why
-this was done. Besides, they still may remember and resent
-our long opposition to them."
+ "That may be so, Aliera, but again that was not really why this was done. Besides, they still may remember and resent our long opposition to them."
 
  Beech asked deferentially "But what is the name of this village?"
 
- Akatosh sighed, and then responded "I fear that we shall
-never reach a decision, since each race has decided opinions
-in that regard. Perhaps once the initial building phase is
-completed, we will able to be more contemplative about
-such matters."
+ Akatosh sighed, and then responded "I fear that we shall never reach a decision, since each race has decided opinions in that regard. Perhaps once the initial building phase is completed, we will able to be more contemplative about such matters."
 
- Beech replied "That just doesn't seem right - everywhere
-should have a name, shouldn't it?"
+ Beech replied "That just doesn't seem right - everywhere should have a name, shouldn't it?"
 
- Willow chuckled and then said "Perhaps to us this is so, but who knows how dragons
-think; and I'm sure that the humans and elves will squabble over the style of the name, besides the
-specifics of it."
+ Willow chuckled and then said "Perhaps to us this is so, but who knows how dragons think; and I'm sure that the humans and elves will squabble over the style of the name, besides the specifics of it."
 
- Moraelyn interrupted with great drama, "Surely you don't mean to imply that an elf can be overly
-stubborn!?" and the discussion dissolved into a period of
-laughter and teasing amongst the group.
+ Moraelyn interrupted with great drama, "Surely you don't mean to imply that an elf can be overly stubborn!?" and the discussion dissolved into a period of laughter and teasing amongst the group.
 
  Presently, Akatosh said, "I favor the name 'Section 22.'"
 
- Beech stared at him, "Akatosh, I see what thou dost mean about
-thy difficulties with the poetic. If you will allow my frank
-opinion? That is the single worst village name I have ever
-heard."
+ Beech stared at him, "Akatosh, I see what thou dost mean about thy difficulties with the poetic. If you will allow my frank opinion? That is the single worst village name I have ever heard."
 
- Akatosh sighed gustily, then pardoned himself hastily to
-Beech -- humanoids found dragon sighs quite unpleasant and sometimes actually
-hazardous. "Then thou seest what I mean by differences. To
-me, it is very meaningful, and most appropriate. Is
-'Section 16' any better as a name? Not? Then is it the word
-'Section' that offends you? In what way is it inferior to
-'Keep' or 'Reich' or 'Glen' or 'Hold'?"
+ Akatosh sighed gustily, then pardoned himself hastily to Beech -- humanoids found dragon sighs quite unpleasant and sometimes actually hazardous. "Then thou seest what I mean by differences. To me, it is very meaningful, and most appropriate. Is 'Section 16' any better as a name? Not? Then is it the word 'Section' that offends you? In what way is it inferior to 'Keep' or 'Reich' or 'Glen' or 'Hold'?"
 
- Edward said, "But Akatosh, a name should make some sense. At
-least humans think so. You should have 21 other sections
-first, if you're going to name this place '22'."
+ Edward said, "But Akatosh, a name should make some sense. At least humans think so. You should have 21 other sections first, if you're going to name this place '22'."
 
- "Really?" Akatosh said, "Why is that? Are not all numbers
-equally valid? They serve well to distinguish one place
-from another. There could be many 'Greenvales' for
-instance. I myself know of four such villages. The number
-'Twenty-two' does appeal to me....aesthetically, as well
-as possessing some 'sense' -- at least to me," he smiled
-secretively.
+ "Really?" Akatosh said, "Why is that? Are not all numbers equally valid? They serve well to distinguish one place from another. There could be many 'Greenvales' for instance. I myself know of four such villages. The number 'Twenty-two' does appeal to me....aesthetically, as well as possessing some 'sense' -- at least to me," he smiled secretively.
 
- Moraelyn said, "I think Lord Akatosh is enjoying what some
-call an 'in-joke'. Were I so rash as to instruct a dragon in manners--"
+ Moraelyn said, "I think Lord Akatosh is enjoying what some call an 'in-joke'. Were I so rash as to instruct a dragon in manners--"
 
- "Who," Silk said, "would e'er accuse Moraelyn of being
-rash?"
+ "Who," Silk said, "would ever accuse Moraelyn of being rash?"
 
- A bit later, Edward asked Akatosh: "Do you think that we could
-play a game or two of Battle? I brought the board and
-playing pieces with me."
+ A bit later, Edward asked Akatosh: "Do you think that we could play a game or two of Battle? I brought the board and playing pieces with me."
 
- Moraelyn interrupted "I'm afraid that Akatosh and I must discuss some matters this evening - and you'd only lose
-again anyway" he added with a fond smile.
+ Moraelyn interrupted "I'm afraid that Akatosh and I must discuss some matters this evening - and you'd only lose again anyway" he added with a fond smile.
 
- Edward replied "But I can beat everyone else ... Akatosh,
-will I ever win a game with you?"
+ Edward replied "But I can beat everyone else ... Akatosh, will I ever win a game with you?"
 
- "No, Edward, you won't", and Akatosh was slightly bemused
-by Edward's startled expression, and then the hearty laugh that quickly followed it.
+ "No, Edward, you won't", and Akatosh was slightly bemused by Edward's startled expression, and then the hearty laugh that quickly followed it.
 
- "That wasn't very diplomatic of you, Akatosh. But why won't
-I ever win?"
+ "That wasn't very diplomatic of you, Akatosh. But why won't I ever win?"
 
- "Because I have been playing for much longer than you have Edward, and so long as I continue to play, you will not
-be able to catch up to me. Besides, this game is what I am
-starting to think of as a 'bounded problem', and that sort is
-most easily dealt with."
+ "Because I have been playing for much longer than you have Edward, and so long as I continue to play, you will not be able to catch up to me. Besides, this game is what I am starting to think of as a 'bounded problem', and that sort is most easily dealt with."
 
- "What do you mean by 'a bounded problem', Akatosh?" asked
-Mats.
+ "What do you mean by 'a bounded problem', Akatosh?" asked Mats.
 
- "That is a problem that has a countable number of possible
-actions and results, Mats. There are only 81 squares on the
-board, and each side has exactly 27 playing pieces, each
-piece moves in a specific way, and so on."
+ "That is a problem that has a countable number of possible actions and results, Mats. There are only 81 squares on the board, and each side has exactly 27 playing pieces, each piece moves in a specific way, and so on."
 
- "But the game is like a real battle, isn't it?" asked
-Ssa'ass.
+ "But the game is like a real battle, isn't it?" asked Ssa'ass.
 
- "No, it is very good practice for learning, and for
-thinking about how to execute a battle - but my Elven Archers
-never become tired or demoralized, and my Master Mage always does what I want.
-Such things seldom happen in a real battle."
+ "No, it is very good practice for learning, and for thinking about how to execute a battle - but my Elven Archers never become tired or demoralized, and my Master Mage always does what I want. Such things seldom happen in a real battle."
 
- Moraelyn nodded in agreement, and asked with mock slyness
-"Then what is an example of an unbounded problem?"
+ Moraelyn nodded in agreement, and asked with mock slyness "Then what is an example of an unbounded problem?"
 
- "Certainly a real battle ... but also, to me a poem is an
-unbounded problem"
+ "Certainly a real battle ... but also, to me a poem is an unbounded problem"
 
- "But any poem can be analyzed, Akatosh" Aliera said
-chidingly.
+ "But any poem can be analyzed, Akatosh" Aliera said chidingly.
 
- "Of course - but only after it is written. I am unable to
-define, or bound, the act of writing it, though ...  that is,
-the act of creating it. If I start to write a poem ... there
-are so many possibilities" and then wryly "I never get
-beyond the first line, because I start imagining all the
-things that I could put into the beginning and...." 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- 
+ "Of course - but only after it is written. I am unable to define, or bound, the act of writing it, though ... that is, the act of creating it. If I start to write a poem ... there are so many possibilities" and then wryly "I never get beyond the first line, because I start imagining all the things that I could put into the beginning and...."

--- a/Assets/StreamingAssets/Text/Books/BOK00111-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00111-LOC.txt
@@ -3,462 +3,135 @@ Author: Anonymous
 IsNaughty: False
 Price: 300
 IsUnique: False
-WhenVarSet: 
+WhenVarSet:
 Content:
-
 
 [/font=2]
 
 [/center]King Edward, Part XII
 
-
-
 [/font=4]
 
 [/center]
 
-[/center] The dragon had paused, so Edward interjected, "Mother and I have been
-discussing the nature of the gods recently, Akatosh, and she
-thinks that poetry would be a godly activity. What do you
-think about that notion?"
+ The dragon had paused, so Edward interjected, "Mother and I have been discussing the nature of the gods recently, Akatosh, and she thinks that poetry would be a godly activity. What do you think about that notion?"
 
- "I am not so certain that one can attribute anything to the
-gods, Edward. They are another example of an unbounded
-problem, of course, but also, their characteristics are just
-not very well known to us."
+ "I am not so certain that one can attribute anything to the gods, Edward. They are another example of an unbounded problem, of course, but also, their characteristics are just not very well known to us."
 
- "But surely one can determine things about any being that is
-a god?"
+ "But surely one can determine things about any being that is a god?"
 
- Akatosh replied, "I do not think that we can, at present; they
-are not like the Daedra, who have a nature that is with them at
-their birth. That is, the Daedra capabilities are inherent in them, and not are the result of any
-changes that have occurred to them."
+ Akatosh replied, "I do not think that we can, at present; they are not like the Daedra, who have a nature that is with them at their birth. That is, the Daedra capabilities are inherent in them, and not are the result of any changes that have occurred to them."
 
  Willow interrupted: "Akatosh, we can determine that the gods have a few basic characteristics, can't we?"
 
- Edward added "Of course, Akatosh - they are powerful beings
-who can perform acts that are incomprehensible to us. That
-in itself must signify their difference."
+ Edward added "Of course, Akatosh - they are powerful beings who can perform acts that are incomprehensible to us. That in itself must signify their difference."
 
- Akatosh nodded and replied "I understand your point of
-view, but to a farming community on Tamriel in our southern
-lands, that could also describe how they would perceive me.
-Perhaps this is attributable to the fact that they seldom see
-a dragon nowadays, but it also does not mean that I am a
-god ... neither does it mean that I am not a god."
+ Akatosh nodded and replied "I understand your point of view, but to a farming community on Tamriel in our southern lands, that could also describe how they would perceive me. Perhaps this is attributable to the fact that they seldom see a dragon nowadays, but it also does not mean that I am a god ... neither does it mean that I am not a god."
 
- Willow giggled, and said "Of course you're not a god,
-Akatosh" and Edward, smiling, nodded agreement.
+ Willow giggled, and said "Of course you're not a god, Akatosh" and Edward, smiling, nodded agreement.
 
- Akatosh replied "How do you know, Willow? I can understand
-that you would guess that I am not a god, particularly
-since I am a dragon." He grinned, and then continued "But
-how can you  know that I am not a god?"
+ Akatosh replied "How do you know, Willow? I can understand that you would guess that I am not a god, particularly since I am a dragon." He grinned, and then continued "But how can you know that I am not a god?"
 
- Edward scoffingly replied "Well, I know that I'm not a god anyway. And I've certainly never seen you
-perform any godly acts, Akatosh - you also don't seem to
-have any worshippers about either."
+ Edward scoffingly replied "Well, I know that I'm not a god anyway. And I've certainly never seen you perform any godly acts, Akatosh - you also don't seem to have any worshippers about either."
 
- The Companions were smiling and generally agreeing with
-this, but Akatosh responded "But that does not mean that I
-have no worshippers, nor does it mean that I cannot perform
-any godly acts - it just means that you have not seen either
-of these. I am not yet certain that gods and goddesses require
-worshippers to maintain their existence. And as I said, I
-can perform magic that would look like 'godly acts' to many
-Tamrielians."
+ The Companions were smiling and generally agreeing with this, but Akatosh responded "But that does not mean that I have no worshippers, nor does it mean that I cannot perform any godly acts - it just means that you have not seen either of these. I am not yet certain that gods and goddesses require worshippers to maintain their existence. And as I said, I can perform magic that would look like 'godly acts' to many Tamrielians."
 
- "But the gods must have worshippers, Akatosh" said Aliera,
-"That's how they get their ... sustenance, or whatever it is
-that allows them to continue ... to be godly. Husband, you
-must know more about this subject. After all, you made a
-god of your brother S'ephen."
+ "But the gods must have worshippers, Akatosh" said Aliera, "That's how they get their ... sustenance, or whatever it is that allows them to continue ... to be godly. Husband, you must know more about this subject. After all, you made a god of your brother S'ephen."
 
- "I did no such thing!" Moraelyn responded, with a touch of indignation. "His godhood is between him and his
-worshippers, among whom I am numbered. I did establish a
-temple cult in his memory. Anyone with the worldly means
-could do as much for anyone, living or dead. That alone is
-not enough. Maybe it helps -- facilitate matters, but I think it's not really necessary. I know no more of it, but if
-you want my opinion--" he paused politely for confirmation that it was indeed still solicited, as
-elven etiquette demanded if one were giving opinion at
-length.
+ "I did no such thing!" Moraelyn responded, with a touch of indignation. "His godhood is between him and his worshippers, among whom I am numbered. I did establish a temple cult in his memory. Anyone with the worldly means could do as much for anyone, living or dead. That alone is not enough. Maybe it helps -- facilitate matters, but I think it's not really necessary. I know no more of it, but if you want my opinion--" he paused politely for confirmation that it was indeed still solicited, as elven etiquette demanded if one were giving opinion at length.
 
- He continued. "There must be something, well, godly, in the
-person's soul or essence or whatever part it is that does not
-die with the body. I know not whether that capacity is innate
-in the person, from birth or conception, or quickening ...
-whene'er it is that soul and body are wedded for a life
-span, or whether great deeds and great generosity might breed
-it, enlarging the soul and transmuting it, so to speak. We all change and grow
-with each passing day, with every breath, some more than
-others. What else is life about?"
+ He continued. "There must be something, well, godly, in the person's soul or essence or whatever part it is that does not die with the body. I know not whether that capacity is innate in the person, from birth or conception, or quickening ... whenever it is that soul and body are wedded for a life span, or whether great deeds and great generosity might breed it, enlarging the soul and transmuting it, so to speak. We all change and grow with each passing day, with every breath, some more than others. What else is life about?"
 
- He went on without pausing for an answer to his rhetorical
-question, probably for fear that he might get one. "In
-other cases, gods seem to arise from a locality, a
-mountain, or a spring, or wood, or a collection of localities, such as Tamriel itself. Places, like persons have
-souls, some greater than others. This place might produce a
-god or a daedra -- or maybe it already has one or more. As it
-changes, so do its gods and daedra, I think. Maybe they can
-choose to resist the change or aid it, if propitiated."
+ He went on without pausing for an answer to his rhetorical question, probably for fear that he might get one. "In other cases, gods seem to arise from a locality, a mountain, or a spring, or wood, or a collection of localities, such as Tamriel itself. Places, like persons have souls, some greater than others. This place might produce a god or a daedra -- or maybe it already has one or more. As it changes, so do its gods and daedra, I think. Maybe they can choose to resist the change or aid it, if propitiated."
 
- He looked at Akatosh inquiringly. The dragon had stopped
-fighting the new gods, he said, but would he go so far as to
-worship them? "That speaks to the question of whence gods
-arise, but source is not nature: of that I know as little as
-the rest of you, maybe less, since the question does not truly
-interest me. The gods are; my worship of them benefits me and
-mine. It is sufficient."
+ He looked at Akatosh inquiringly. The dragon had stopped fighting the new gods, he said, but would he go so far as to worship them? "That speaks to the question of whence gods arise, but source is not nature: of that I know as little as the rest of you, maybe less, since the question does not truly interest me. The gods are; my worship of them benefits me and mine. It is sufficient."
 
- Akatosh did not respond immediately and Aliera refused to be distracted, "But suppose such a cult were established and worshippers provided
-for one of small and mean spirit. Would that spirit not
-become a god?"
+ Akatosh did not respond immediately and Aliera refused to be distracted, "But suppose such a cult were established and worshippers provided for one of small and mean spirit. Would that spirit not become a god?"
 
- "I suppose it might be done, if one were determined enough
-and had a sufficiency of means to pay worshippers to
-perform rituals without -- spirit -- behind them. Maybe that's
-where small, mean gods come from, wife. Or maybe daedra?
-Maybe I'll raise a cult to thee and see what happens."
+ "I suppose it might be done, if one were determined enough and had a sufficiency of means to pay worshippers to perform rituals without -- spirit -- behind them. Maybe that's where small, mean gods come from, wife. Or maybe daedra? Maybe I'll raise a cult to thee and see what happens."
 
- "Are you calling my spirit small and mean?" Ali glared at
-him.
+ "Are you calling my spirit small and mean?" Ali glared at him.
 
- "Only by comparison -- you don't fancy yourself a goddess, do you? You might make a daedra,
-though. The experiment might be a bit too chancy. Could I just mourn you
-for a century or two instead?"
+ "Only by comparison -- you don't fancy yourself a goddess, do you? You might make a daedra, though. The experiment might be a bit too chancy. Could I just mourn you for a century or two instead?"
 
- "Mm. I'll think on it. What about you? You've deeds enough
-already to qualify for godhood, surely ... although if you
-plan on many more such you may not outlive me."
+ "Mm. I'll think on it. What about you? You've deeds enough already to qualify for godhood, surely ... although if you plan on many more such you may not outlive me."
 
- "I'm doomed to be R'Aathim, living and dead. It's godhood of a sort, but what a sort! Don't begrudge
-me my long life span. Think of me doomed to eternity in the
-gloomy Ebonheart council chamber listening to the eternal
-wrangles ... small wonder the dead R'Aathim pulled the
-place down on the live ones twenty years ago, thus causing my
-brother and my mother to join their number. The dead R'Aathim
-must have welcomed the century and a half of respite while
-the Nords held Ebonheart."
+ "I'm doomed to be R'Aathim, living and dead. It's godhood of a sort, but what a sort! Don't begrudge me my long life span. Think of me doomed to eternity in the gloomy Ebonheart council chamber listening to the eternal wrangles ... small wonder the dead R'Aathim pulled the place down on the live ones twenty years ago, thus causing my brother and my mother to join their number. The dead R'Aathim must have welcomed the century and a half of respite while the Nords held Ebonheart."
 
- "But your brother S'ephen was killed too, as well as your
-brother King Cruethys, and S'ephen wasn't R'Aathim, being
-your mother's son and not your father's, if I have the story
-straight -- that's why he got his own temple," Edward said.
-"So why did they kill him, too? The story sounds very daedric
-to me."
+ "But your brother S'ephen was killed too, as well as your brother King Cruethys, and S'ephen wasn't R'Aathim, being your mother's son and not your father's, if I have the story straight -- that's why he got his own temple," Edward said. "So why did they kill him, too? The story sounds very daedric to me."
 
- "You'd have me justify the ways of the gods to you, would
-you? I think they act for ends we cannot see, and slay the
-just and the unjust together -- not that I'd label any of my
-Kin as either -- not altogether. We see only the means -- how
-can we judge? Gods too face choices; I do not think their
-power supreme. They can overrule nature on occasion, as can
-any Mage, yet they, like Mages, are in the end bound by it --
-and their overrule must answer other rules still -- and in
-those rules, whate'er they be, I think lies the answer to your
-questions. I think it's not something men and women may know
-while living."
+ "You'd have me justify the ways of the gods to you, would you? I think they act for ends we cannot see, and slay the just and the unjust together -- not that I'd label any of my Kin as either -- not altogether. We see only the means -- how can we judge? Gods too face choices; I do not think their power supreme. They can overrule nature on occasion, as can any Mage, yet they, like Mages, are in the end bound by it -- and their overrule must answer other rules still -- and in those rules, whatever they be, I think lies the answer to your questions. I think it's not something men and women may know while living."
 
- Akatosh smiled and replied "It is not so easy to describe the
-gods, is it? This is true even though, myself included, each
-of us thinks that we have a mental picture of what godliness
-means. On the other hand, the gods and goddesses certainly do exist - and I also believe that there is a
-connection of some sort between them and the Daedra, and
-another connection between these entities and the power associated with
-performing magic."
+ Akatosh smiled and replied "It is not so easy to describe the gods, is it? This is true even though, myself included, each of us thinks that we have a mental picture of what godliness means. On the other hand, the gods and goddesses certainly do exist - and I also believe that there is a connection of some sort between them and the Daedra, and another connection between these entities and the power associated with performing magic."
 
- "The priests of Julianos have been calling this power
-'Magicka'" said a stranger who had joined the group.
+ "The priests of Julianos have been calling this power 'Magicka'" said a stranger who had joined the group.
 
- Akatosh replied "Greetings bard. Please allow me to
-introduce ... Geoffrey, a ... wandering poet who has been
-visiting our village for these last few days." The
-Companions greeted the wood elf newcomer, some rising to their feet to do so according
-to their individual customs, and then all resumed sitting
-(actually sprawling about) and conversing.
+ Akatosh replied "Greetings bard. Please allow me to introduce ... Geoffrey, a ... wandering poet who has been visiting our village for these last few days." The Companions greeted the wood elf newcomer, some rising to their feet to do so according to their individual customs, and then all resumed sitting (actually sprawling about) and conversing.
 
- "A number of priests are theorizing that the gods and
-goddesses live on another plane, as do the Daedra - there is some debate
-amongst these priests as to whether they share the same plane
-of existence, or whether each has their own. And some of the
-Alessian priests are claiming that we can visit these
-alternate planes in our nightly dreams" added Beech.
+ "A number of priests are theorizing that the gods and goddesses live on another plane, as do the Daedra - there is some debate amongst these priests as to whether they share the same plane of existence, or whether each has their own. And some of the Alessian priests are claiming that we can visit these alternate planes in our nightly dreams" added Beech.
 
- Edward asked "Why doesn't someone just ask a goddess or a
-Daedra about this?"
+ Edward asked "Why doesn't someone just ask a goddess or a Daedra about this?"
 
- Geoffrey chuckled and replied "Most of us are not able to be
-so thoughtful when confronted by one of these beings, Edward. Also,
-there is a common belief that the gods and Daedra are as
-reluctant to discuss their own natures as dragons are to
-reveal anyone's True Name."
+ Geoffrey chuckled and replied "Most of us are not able to be so thoughtful when confronted by one of these beings, Edward. Also, there is a common belief that the gods and Daedra are as reluctant to discuss their own natures as dragons are to reveal anyone's True Name."
 
- Edward looked quizzically at Akatosh, but Beech stated to
-Geoffrey "Well said, Bard" ... and that pair shared the slightest of smiles.
+ Edward looked quizzically at Akatosh, but Beech stated to Geoffrey "Well said, Bard" ... and that pair shared the slightest of smiles.
 
- Beech then said, "Do you know what the Resolutions of Zenithar
-has been saying about the gods and magic? This magic power,
-or Magicka, is just the power generated by the existence of,
-well, existance itself.  When it becomes focused by living
-beings through natural processes, then it becomes accessible to the gods and
-goddesses as worship power, which is the next level of
-Magicka. After receiving some from their worshippers, the
-gods can then concentrate it up to god-level power - the
-true Magicka. The gods themselves can't generate the mid-level
-Magicka, since they are dependent on it for their own existence, but they can 'convert it' to Magicka, which can
-then be used by mortals to cast spells.  This Magicka is
-usually dispersed widely across the planes but there are
-areas of greater and lesser concentration due to
-interferences with the dispersion process."
+ Beech then said, "Do you know what the Resolutions of Zenithar has been saying about the gods and magic? This magic power, or Magicka, is just the power generated by the existence of, well, existance [sic] itself. When it becomes focused by living beings through natural processes, then it becomes accessible to the gods and goddesses as worship power, which is the next level of Magicka. After receiving some from their worshippers, the gods can then concentrate it up to god-level power - the true Magicka. The gods themselves can't generate the mid-level Magicka, since they are dependent on it for their own existence, but they can 'convert it' to Magicka, which can then be used by mortals to cast spells. This Magicka is usually dispersed widely across the planes but there are areas of greater and lesser concentration due to interferences with the dispersion process."
 
- "When a goddess loses worshippers, her inflow of mid-level
-Magicka is decreased, so she in turn produces less god-level
-Magicka. With less Magicka under her control (for providing
-to worshippers, or dispersion), her influence is decreased
-in the mortal planes - of course the converse is also true. 
-In the extreme, she receives nothing, and is relegated to a
-state of Stasis, barely existing from the ordinary Magicka
-generated by her few remaining Consecrated lands, zones of
-influence, and so on."
+ "When a goddess loses worshippers, her inflow of mid-level Magicka is decreased, so she in turn produces less god-level Magicka. With less Magicka under her control (for providing to worshippers, or dispersion), her influence is decreased in the mortal planes - of course the converse is also true. In the extreme, she receives nothing, and is relegated to a state of Stasis, barely existing from the ordinary Magicka generated by her few remaining Consecrated lands, zones of influence, and so on."
 
- Beech continued, "On the other hand, Daedra receive very
-specific, or 'modified' mid-level Magicka from a few
-mortals with specific areas of interest, and these Daedra are
-normally tied to very specific circumstances. Because of the
-ir nature, they gain much more power from their
-small worship base, but the gods, with their much broader
-base, generally have greater overall power, even though
-the amount of concentrated worship that they receive from
-any one source is much less than a Daedra's. Most of the Magicka that the gods
-'process' is dispersed into and throughout the universe, no
-longer under their control, thereby making it available for
-everyone.  It's not really something they do consciously,
-but as a natural process that happens automatically - in other words ... just because they are divine."
+ Beech continued, "On the other hand, Daedra receive very specific, or 'modified' mid-level Magicka from a few mortals with specific areas of interest, and these Daedra are normally tied to very specific circumstances. Because of their nature, they gain much more power from their small worship base, but the gods, with their much broader base, generally have greater overall power, even though the amount of concentrated worship that they receive from any one source is much less than a Daedra's. Most of the Magicka that the gods 'process' is dispersed into and throughout the universe, no longer under their control, thereby making it available for everyone. It's not really something they do consciously, but as a natural process that happens automatically - in other words ... just because they are divine."
 
- Aliera said, "I would think that Magicka is simply
-available to sentient beings, although the gods and Daedra
-could facilitate its usage. I would think that the gods and
-Daedra have other influences on us as well, because not
-everyone has spellcasting ability! Maybe in those
-'alternate planes' it's actually existance, and not
-sentient entities, that radiates Magicka, just as the stars
-give off light in our dimension. I just assume that Magicka is
-'out there' in the ether, or maybe sentient consciousnesses
-automatically tap into an alternate plane as they sleep.
-I think that everyone has some supply of Magicka, but most
-r nature, they gain much more power from their
-small worship base, but the gods, with their much broader
-base, generally have greater overall power, even though
-the amount of concentrated worship that they receive from
-any one source is much less than a Daedra's. Most of the Magicka that the gods
-'process' is dispersed into and throughout the universe, no
-longer under their control, thereby making it available for
-everyone.  It's not really something they do consciously,
-but as a natural process that happens automatically - in other words ... just because they are divine."
+ Aliera said, "I would think that Magicka is simply available to sentient beings, although the gods and Daedra could facilitate its usage. I would think that the gods and Daedra have other influences on us as well, because not everyone has spellcasting ability! Maybe in those 'alternate planes' it's actually existance [sic], and not sentient entities, that radiates Magicka, just as the stars give off light in our dimension. I just assume that Magicka is 'out there' in the ether, or maybe sentient consciousnesses automatically tap into an alternate plane as they sleep. I think that everyone has some supply of Magicka, but most don't know how to use it very well, or else they adopt a way of life that inhibits or forbids its use. Maybe certain gods and Daedra serve as facilitators for the entire process; that is, both obtaining and using Magicka? But how do priests heal and cure and bless? Is Magicka involved at all or do they invoke their goddesses directly?"
 
- Aliera said, "I would think that Magicka is simply
-available to sentient beings, although the gods and Daedra
-could facilitate its usage. I would think that the gods and
-Daedra have other influences on us as well, because not
-everyone has spellcasting ability! Maybe in those
-'alternate planes' it's actually existance, and not
-sentient entities, that radiates Magicka, just as the stars
-give off light in our dimension. I just assume that Magicka is
-'out there' in the ether, or maybe sentient consciousnesses
-automatically tap into an alternate plane as they sleep.
-I think that everyone has some supply of Magicka, but most
-don't know how to use it very well, or else they adopt a way of life that inhibits or forbids
-its use. Maybe certain gods and Daedra serve as facilitators
-for the entire process; that is, both obtaining and using
-Magicka? But how do priests heal and cure and bless? Is
-Magicka involved at all or do they invoke their goddesses
-directly?"
+ Ssa'ass said, "I am not ssssure that Magicka isss usssed; perhapsss there isss yet another capability involved here. Thisss capability would be unknown at thisss time, and maybe even unsssensssed... but I feel fairly certain that sssomehow it is a godly 'force' that they are employing."
 
- Ssa'ass said, "I am not ssssure that Magicka isss usssed;
-perhapss there isss yet another capability involved here.
-Thisss capability would be unknown at thisss time, and maybe
-even unsssenssssed... but I feel fairly certain that
-sssomehow it is a godly 'force' that they are employing."
+ Then Geoffrey responded: "Ssa'ass, I believe that Magicka fills the universe of planes. All things are infused with Magicka to one extent or another. In this regard Magicka is attracted to some people and things over others, and some people with talent or training can control and even release Magicka in new forms. There may be other sources of Magicka available by tapping into alternate and otherworldly planes. There is also the possibility of alternate planes that are entirely void of Magicka. Regardless, certain beings of great power, such as the gods and Daedra, can not only control Magicka, but can see, absorb, and transfuse Magicka to and from objects and people. By employing this ability, worshippers of these beings are sometimes capable of greater acts of Magic than they could accomplish otherwise. Also in this way, some items sacred to powerful beings can be said to be holy, with additional amounts of directed Magicka provided by gods or goddesses."
 
- Then Geoffrey responded: "Ssa'ass, I believe that Magicka
-fills the universe of planes.  All things are infused with
-Magicka to one extent or another.  In this regard Magicka is
-attracted to some people and things over others, and some
-people with talent or training can control and even
-release Magicka in new forms. There may be other sources of
-Magicka available by tapping into alternate and
-otherworldly planes.  There is also the possibility of
-alternate planes that are entirely void of Magicka.
-Regardless, certain beings of great power, such as the gods
-and Daedra, can not only control Magicka, but can see,
-absorb, and transfuse Magicka to and from objects and
-people. By employing this ability, worshippers of these
-beings are sometimes capable of greater acts of Magic than
-they could accomplish otherwise. Also in this way, some items
-sacred to powerful beings can be said to be holy, with
-additional amounts of directed Magicka provided by gods or
-goddesses."
+ "Magic items fall into two main categories by definition. Items that draw on the surrounding Magicka to create spell-like effects, and items that hold Magicka in reserve for their own internal effects. Normally magic items which absorb Magicka, giving increased abilities to their wielders, only affect themselves and are considered to use internal Magicka. In some areas where great amounts of Magicka have been used, the surroundings may be completely devoid of it. This of course negates the ability of beings to produce magic effects in these areas, although gods and Daedra carry their own supplies of Magicka, as do magic items that do not depend on the use of surrounding Magicka."
 
- "Magic items fall into two main categories by definition.
-Items that draw on the surrounding Magicka to create
-spell-like effects, and items that hold Magicka in reserve for
-their own internal effects.  Normally magic items which
-absorb Magicka, giving increased abilities to their
-wielders, only affect themselves and are considered to use
-internal Magicka. In some areas where great amounts of
-Magicka have been used, the surroundings may be completely
-devoid of it.  This of course negates the ability of beings
-to produce magic effects in these areas, although gods and
-Daedra carry their own supplies of Magicka, as do magic
-items that do not depend on the use of surrounding Magicka."
+ Aliera said, "We've been investigating some rumors and stories concerning something that might be called anti-Magicka. I think the presence of a powerful Daedra with whom you weren't in 'tune' could cause interference with spellcasting - maybe even cancel out existing spells. Perhaps particular Daedra simply favor thief or warrior types. Or some goddesses, and their priests, might frown on 'competing' magic in certain areas, for example in locations dedicated to them. So then unauthorized spells could interfere with their rituals."
 
- Aliera said, "We've been investigating some rumors and
-stories concerning something that might be called
-anti-Magicka. I think the presence of a powerful Daedra with
-whom you weren't in 'tune' could cause interference with
-spellcasting - maybe even cancel out existing spells.
-Perhaps particular Daedra simply favor thief or warrior
-types. Or some goddesses, and their priests, might frown on
-'competing' magic in certain areas, for example in
-locations dedicated to them. So then unauthorized spells
-could interfere with their rituals."
+ Willow asked, "Can Daedra supply Magicka? And how about both a god and a Daedra being nearby? - wouldn't they sort of nullify each other's powers? This might be the cause of the anti-Magicka effect."
 
- Willow asked, "Can Daedra supply Magicka? And how about
-both a god and a Daedra being nearby? - wouldn't they sort of
-nullify each other's powers? This might be the cause of the
-anti-Magicka effect."
+ "I've experienced an anti-Magicka zone myself" inserted Mith. "It felt a lot like the effect of casting a spell like Dispel Magicka. At the time, I thought that a truly powerful spellcaster could still effectively cast spells, but their resulting power would have been much reduced. I didn't get a chance to test this out though" added Mith with a smile.
 
- "I've experienced an anti-Magicka zone myself" inserted
-Mith. "It felt a lot like the effect of casting a spell like
-Dispel Magicka. At the time, I thought that a truly powerful
-spellcaster could still effectively cast spells, but their resulting power would have
-been much reduced. I didn't get a chance to test this out though" added Mith with a smile.
+ "We can also assume that certain powerful spells, creatures and even magic items might actually drain the surrounding area of Magicka," replied Geoffrey. "This could be extended to places where great amounts of magic energy were once gathered and expended, for example in ancient temples where great spells were cast, or battlefields where powerful mages contested. Perhaps certain metals or stones could act as absorbers of Magicka, allowing for whole structures of anti-Magicka zones. If so, you might be able to wear a amulet made out of anti-Magicka material and gain a good advantage against spellcasters. Perhaps the purity of the material used would allow for better and better magic resistance".
 
- "We can also assume that certain powerful spells,
-creatures and even magic items might actually drain the
-surrounding area of Magicka," replied Geoffrey. "This could
-be extended to places where great amounts of magic energy
-were once gathered and expended, for example in ancient
-temples where great spells were cast, or battlefields where
-powerful mages contested. Perhaps certain metals or stones
-could act as absorbers of Magicka, allowing for whole structures of anti-Magicka zones. If so, you might
-be able to wear a amulet made out of anti-Magicka material
-and gain a good advantage against spellcasters.  Perhaps the purity of the material used would allow for
-better and better magic resistance".
+ Akatosh spoke: "Dragons have long been interested in the anti-Magicka effect, naturally enough. We have found some amulets that appear to act as Magicka absorbers. They might contain something like Negative Magicka, in which case they would attract any 'stray' Magicka floating free in the local area. They are made of a stone, or mineral, resembling marble - it is very rare, but could be extracted, and shaped by skilled craftsmen. For example, I'm sure that the dwarves could have worked with this material. They might have made these amulets - or even that statue that I once saw ... it was taller than any of you humanoids. Regardless, in these mountains we have found deposits scattered throughout the halls and tunnels at random, sometimes deep within the walls. Consequently, one appears to go in and out of these anti-Magicka zones of varying intensities, with little or no warning. I have been imagining that this material works almost automatically; it seems to 'reflexively' absorb Magicka if given a chance to. However, we cannot rule out the possibility that they have been magically charged somehow - perhaps this happened long ago, but the charge has somehow remained."
 
- Akatosh spoke: "Dragons have long been interested in the
-anti-Magicka effect, naturally enough. We have found some
-amulets that appear to act as Magicka absorbers. They might
-contain something like Negative Magicka, in which case they
-would attract any 'stray' Magicka floating free in the
-local area. They are made of a stone, or mineral, resembling
-marble - it is very rare, but could be extracted, and
-shaped by skilled craftsmen. For example, I'm sure that the
-dwarves could have worked with this material. They might have m
-ade
-these amulets - or even that statue that I once saw ... it was
-taller than any of you humanoids. Regardless, in these
-mountains we have found deposits scattered throughout the
-halls and tunnels at random, sometimes deep within the
-walls. Consequently, one appears to go in and out of these
-anti-Magicka zones of varying intensities, with little or no
-warning. I have been imagining that this material works
-almost automatically; it seems to 'reflexively' absorb
-Magicka if given a chance to. However, we cannot rule out the
-possibility that they have been magically charged somehow -
-perhaps this happened long ago, but the charge has somehow
-remained."
+ Moraelyn asked, "Would the amulet affect its wearer, or would he be immune?"
 
- Moraelyn asked, "Would the amulet affect its wearer, or
-would he be immune?"
+ "Maybe a blocking spell could be developed, and then cast, to shield the wearer from the effects of the substance."
 
- "Maybe a blocking spell could be developed, and then cast,
-to shield the wearer from the effects of the substance."
+ Moraelyn then asked, "But Akatosh, getting back to our earlier discussions - what do you think of the speculations concerning the connections between the gods and goddesses, Daedra and Magicka?"
 
- Moraelyn then asked, "But Akatosh, getting back to our
-earlier discussions - what do you think of the speculations
-de
-these amulets - or even that statue that I once saw ... it was
-taller than any of you humanoids. Regardless, in these
-mountains we have found deposits scattered throughout the
-halls and tunnels at random, sometimes deep within the
-walls. Consequently, one appears to go in and out of these
-anti-Magicka zones of varying intensities, with little or no
-warning. I have been imagining that this material works
-almost automatically; it seems to 'reflexively' absorb
-Magicka if given a chance to. However, we cannot rule out the
-possibility that they have been magically charged somehow -
-perhaps this happened long ago, but the charge has somehow
-remained."
+ Akatosh replied, "I think that there are many truths that we do not know, and perhaps there are some truths that we are not meant to know."
 
- Moraelyn asked, "Would the amulet affect its wearer, or
-would he be immune?"
+ Moraelyn asked with a smile, "All right then, I've always wanted to know this - considering the shape of your mouth and teeth, how do dragons manage to speak the humanoid languages so clearly?"
 
- "Maybe a blocking spell could be developed, and then cast,
-to shield the wearer from the effects of the substance."
+ Akatosh paused, and then carefully responded, "Why, in much the same way that we can fly, even though our wings are not naturally strong enough to support such heavy torsos."
 
- Moraelyn then asked, "But Akatosh, getting back to our
-earlier discussions - what do you think of the speculations
-concerning the connections between the gods and goddesses,
-Daedra and Magicka?"
+ "Speaking of dragon flight and sunsets..." Mith said, rising to his feet and squinting into the red-gold eastern sky, "We have a vistor [sic], Dragon Lord. That's not a bird."
 
- Akatosh replied, "I think that there are many truths that we do not know, and perhaps
-there are some truths that we are not meant to know."
+ Akatosh's head came up and he too scanned the sky. Tension grew in him, and one by one the Companions rose, watching as the distant dot grew nearer and resolved itself into the largest dragon they'd seen yet.
 
- Moraelyn asked with a smile, "All right then, I've always
-wanted to know this - considering the shape of your mouth and teeth, how do dragons manage to speak the humanoid
-languages so clearly?"
+ "Ma-Tylda!" Akatosh exclaimed, "She deigns to bestow her presence on us!" His wings lifted and unfurled, and the Companions broke and ran for cover as he took flight. The two dragons wheeled through the sky, spouting great gouts of flame against the purpling sky.
 
- Akatosh paused, and then carefully responded,  "Why, in
-much the same way that we can fly, even though our wings are not
-naturally strong enough to support such heavy torsos."
+ "They're fighting," Edward cried, "what does it mean. Who is Ma-Tylda?"
 
- "Speaking of dragon flight and sunsets..." Mith said,
-rising to his feet and squinting into the red-gold eastern sky,
-"We have a vistor, Dragon Lord. That's not a bird."
-
- Akatosh's head came up and he too scanned the sky. Tension grew in him, and one by one the Companions rose, watching as
-the distant dot grew nearer and resolved itself into the
-largest dragon they'd seen yet.
-
- "Ma-Tylda!" Akatosh exclaimed, "She deigns to bestow her
-presence on us!" His wings lifted and unfurled, and the
-Companions broke and ran for cover as he took flight. The
-two dragons wheeled through the sky, spouting great gouts of
-flame against the purpling sky.
-
- "They're fighting," Edward cried, "what does it mean. Who is
-Ma-Tylda?"
-
- "I don't know who she is, son," Moraelyn replied, "but they
-do not fight. You behold a dragon greeting ceremony." The
-pair alit beyond a rock outcropping out of sight. 
+ "I don't know who she is, son," Moraelyn replied, "but they do not fight. You behold a dragon greeting ceremony." The pair alit beyond a rock outcropping out of sight.
 
  "Should we go greet the stranger, too?" Edward asked.
 
- "Nay," Mith said. "They'll let us know if our  presence is
-wanted -- look, even the other dragons stay away." It was true. Dragon heads had poked from the caverns to witness the event, but none of them had taken
-wing, and now they were retreating to their hoards within.
+ "Nay," Mith said. "They'll let us know if our presence is wanted -- look, even the other dragons stay away." It was true. Dragon heads had poked from the caverns to witness the event, but none of them had taken wing, and now they were retreating to their hoards within.
 
- The Companions ambled back into the meadow together and
-built a fire as a chill wind had sprung up. The elves sang an
-evening hymn to the stars, deftly weaving the dark elf
-version with the wood elf form. Aliera added her voice to theirs, but Mats
-and Edward and Silk and Ssa'ass sat listening silently.
-They couldn't manage elven music of this kind. Geoffrey had
-a particularly clear sweet voice, Edward thought.
+ The Companions ambled back into the meadow together and built a fire as a chill wind had sprung up. The elves sang an evening hymn to the stars, deftly weaving the dark elf version with the wood elf form. Aliera added her voice to theirs, but Mats and Edward and Silk and Ssa'ass sat listening silently. They couldn't manage elven music of this kind. Geoffrey had a particularly clear sweet voice, Edward thought.
 
- Akatosh returned presently, smiling in satisfaction. "Ma-Tylda's going to join us
-here, at least for awhile," he said. He was actually glowing
-in the dusk, each scale giving off a golden radiance.
+ Akatosh returned presently, smiling in satisfaction. "Ma-Tylda's going to join us here, at least for awhile," he said. He was actually glowing in the dusk, each scale giving off a golden radiance.
 
- "Is she your queen?" Edward asked, feeling very small and
-human.
+ "Is she your queen?" Edward asked, feeling very small and human.
 
- "She -- just is. Maybe she'll want to meet you all some day. I hope so. Until then, well, I don't talk about other
-dragons, you know."
+ "She -- just is. Maybe she'll want to meet you all some day. I hope so. Until then, well, I don't talk about other dragons, you know."
 
- To which Edward blinked in surprise and then surmise, and the
-discussion dissolved into jokes and songs for the remainder
-of that clear and beautiful evening. 
+ To which Edward blinked in surprise and then surmise, and the discussion dissolved into jokes and songs for the remainder of that clear and beautiful evening.

--- a/Assets/StreamingAssets/Text/Books/BOK00112-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00112-LOC.txt
@@ -6,16 +6,13 @@ IsUnique: False
 WhenVarSet: LiftedCurse
 Content:
 
-
 [/font=2]
 
 [/center]Bourn in Wood, Part I
 
+[/center]by Lord Woodborne
 
-[/center]
-[/font=4]by Lord Woodborne
-
-[/center]
+[/font=4]
 
 [/center]
 

--- a/Assets/StreamingAssets/Text/Books/BOK00113-LOC.txt
+++ b/Assets/StreamingAssets/Text/Books/BOK00113-LOC.txt
@@ -6,16 +6,13 @@ IsUnique: False
 WhenVarSet: LiftedCurse
 Content:
 
-
 [/font=2]
 
 [/center]Bourn in Wood, Part II
 
+[/center]by Lord Woodborne
 
-[/center]
-[/font=4]by Lord Woodborne
-
-[/center]
+[/font=4]
 
 [/center]
 


### PR DESCRIPTION
Working with English version of the DFU I noticed poorly formatted books. Well, most of them have some artifacts. 

Since SDF and non-SDF books in game respect book boundaries and hence could be auto formatted, I want to clean texts.

Nothing fancy, just
* One paragraph is one line
* No multi-spaces
* No extra empty lines.

Before (Broken Diamonds):

![Screenshot 2024-03-16 204922](https://github.com/Interkarma/daggerfall-unity/assets/1652113/088bc54f-05b2-468b-8f28-435c7acbea5a)

After (Broken Diamonds):

![Screenshot 2024-03-16 212352](https://github.com/Interkarma/daggerfall-unity/assets/1652113/86ad250f-ed55-43db-a4fe-39e83370545c)
