### PR TITLE
Relink children if any new custom factions with parents were added

### DIFF
--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -138,13 +138,21 @@ namespace DaggerfallWorkshop.Game.Player
         /// </summary>
         public void AddCustomFactions()
         {
+            bool relink = false;
             foreach (int id in FactionFile.CustomFactions.Keys)
             {
                 if (!factionDict.ContainsKey(id))
                 {
-                    factionDict.Add(id, FactionFile.CustomFactions[id]);
-                    factionNameToIDDict.Add(FactionFile.CustomFactions[id].name, id);
+                    FactionFile.FactionData factionData = FactionFile.CustomFactions[id];
+                    factionDict.Add(id, factionData);
+                    factionNameToIDDict.Add(factionData.name, id);
+                    if (factionData.parent > 0)
+                        relink = true;
                 }
+            }
+            // Relink faction children if any new custom factions with parents were added
+            if (relink) {
+                FactionFile.RelinkChildren(factionDict);
             }
         }
 


### PR DESCRIPTION
Missed this back in 2018. If new custom factions are added by mods and they specify parent factions, this needs to be processed by the child linking code FactionFile.RelinkChildren() otherwise it does nothing.

Found this when Cliffworms added a named NPC to Betony - this should be used at the provinces ruler but it wasn't. Will confirm once this has been completely tested. 

Still doesn't help being able to modify existing faction data to, for example, set the ruler value for Betony. Tried some things for that but breakpoints stopped working and I just can't continue today.