### PR TITLE
Allow faction ruler type to be set by mods

### DIFF
--- a/Assets/Scripts/Game/Player/PersistentFactionData.cs
+++ b/Assets/Scripts/Game/Player/PersistentFactionData.cs
@@ -513,6 +513,27 @@ namespace DaggerfallWorkshop.Game.Player
 
         #endregion
 
+        #region Ruler type
+
+        /// <summary>
+        /// Set ruler value. Allows changes of rulers to have appropriate title.
+        /// See MacroHelper.GetRulerTitle() for value mapping.
+        /// </summary>
+        public bool SetRulerType(int factionID, int ruler)
+        {
+            if (factionDict.ContainsKey(factionID))
+            {
+                FactionFile.FactionData factionData = factionDict[factionID];
+                factionData.ruler = ruler;
+                factionDict[factionID] = factionData;
+                return true;
+            }
+
+            return false;
+        }
+
+        #endregion
+
         #region Allies and Enemies
 
         /// <summary>


### PR DESCRIPTION
This allows changes of rulers to have appropriate title when %rt macro is used. Without this new rulers must be a Lord which is the default. No one is clamouring for this, but I realised that Cliff's change to add a ruler luckily is okay because it's a Lord but in future this could be useful.

Tested this with a bare bones quest script that prints the %rt macro. Happy to supply this if any reviewers want it.