### PR TITLE
Fixed "PersistentDataPath" usage in Editor context

### DIFF
--- a/Assets/Scripts/DaggerfallUnityApplication.cs
+++ b/Assets/Scripts/DaggerfallUnityApplication.cs
@@ -18,10 +18,21 @@ using UnityEngine;
 public static class DaggerfallUnityApplication
 {
     static string persistentDataPath;
-    public static string PersistentDataPath { get { return persistentDataPath; } }
 
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-    static void SubsystemInit()
+    public static string PersistentDataPath
+    {
+        get
+        {
+            if (persistentDataPath == null)
+            {
+                InitializePersistentPath();
+            }
+
+            return persistentDataPath;
+        }
+    }
+
+    private static void InitializePersistentPath()
     {
 #if UNITY_EDITOR && SEPARATE_DEV_PERSISTENT_PATH
         persistentDataPath = String.Concat(Application.persistentDataPath, ".devenv");
@@ -29,7 +40,15 @@ public static class DaggerfallUnityApplication
 #else
         persistentDataPath = Application.persistentDataPath;
 #endif
+    }
 
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void SubsystemInit()
+    {
+        if (persistentDataPath == null)
+        {
+            InitializePersistentPath();
+        }
         InitLog();
     }
 
@@ -40,14 +59,14 @@ public static class DaggerfallUnityApplication
 
         public LogHandler()
         {
-            string filePath = Path.Combine(PersistentDataPath, "Player.log");
+            string filePath = Path.Combine(persistentDataPath, "Player.log");
 
             string errorMessage = null;
             try
             {
                 if(File.Exists(filePath))
                 {
-                    string prevPath = Path.Combine(PersistentDataPath, "Player-prev.log");
+                    string prevPath = Path.Combine(persistentDataPath, "Player-prev.log");
                     File.Delete(prevPath);
                     File.Move(filePath, prevPath);
                 }


### PR DESCRIPTION
Fixed issue caused by #2607.

Before #2607, PersistentDataPath was lazily initialized whenever it was requested. In #2607, I made it get defined on application start. I failed to consider that PersistentDataPath was used in Editor code. Currently, if you open the editor on the latest code, it should throw a null reference exception.

This change turns it back into lazy initialization, so editor code still initializes it.