### PR TITLE
No spinning coins on wagon while stealing from shelves

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -791,7 +791,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected virtual void SetRemoteItemsAnimation()
         {
             // Add animation handler for shop shelf stealing
-            if (shopShelfStealing)
+            if (shopShelfStealing && !usingWagon)
             {
                 remoteItemListScroller.BackgroundAnimationHandler = StealItemBackgroundAnimationHandler;
                 remoteItemListScroller.BackgroundAnimationDelay = coinsAnimationDelay;
@@ -1074,6 +1074,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             }
 
             usingWagon = show;
+            SetRemoteItemsAnimation();
             remoteItemListScroller.ResetScroll();
             Refresh(false);
         }


### PR DESCRIPTION
If, while stealing from a shelf (during a break in) you look at your wagon, the wagon items should not have the spinning coins animation.
[SAVE9.zip](https://github.com/Interkarma/daggerfall-unity/files/14790931/SAVE9.zip)
