### PR TITLE
Fix drums in custom soundfonts

### DIFF
--- a/Assets/Scripts/AudioSynthesis/Synthesis/Synthesizer.MidiControl.cs
+++ b/Assets/Scripts/AudioSynthesis/Synthesis/Synthesizer.MidiControl.cs
@@ -26,6 +26,8 @@ namespace DaggerfallWorkshop.AudioSynthesis.Synthesis
             // Get the correct instrument depending if it is a drum or not
             SynthParameters sChan = synthChannels[channel];
             Patch inst = bank.GetPatch(sChan.bankSelect, sChan.program);
+            if (inst == null && channel == 9)
+                inst = bank.GetPatch(sChan.bankSelect, 0); // Attempt falling back to patch 0 for drums
             if (inst == null)
                 return;
             // A NoteOn can trigger multiple voices via layers

--- a/Assets/Scripts/AudioSynthesis/Synthesis/Synthesizer.MidiControl.cs
+++ b/Assets/Scripts/AudioSynthesis/Synthesis/Synthesizer.MidiControl.cs
@@ -26,7 +26,7 @@ namespace DaggerfallWorkshop.AudioSynthesis.Synthesis
             // Get the correct instrument depending if it is a drum or not
             SynthParameters sChan = synthChannels[channel];
             Patch inst = bank.GetPatch(sChan.bankSelect, sChan.program);
-            if (inst == null && channel == 9)
+            if (inst == null && channel == MidiHelper.DrumChannel)
                 inst = bank.GetPatch(sChan.bankSelect, 0); // Attempt falling back to patch 0 for drums
             if (inst == null)
                 return;


### PR DESCRIPTION
Many soundfonts will only provide percussion on patch 0 of bank 128. This fix allows attempting to fall back to the default percussion patch location when a drum patch is unavailable.

See this comment for an example of the common soundfont bank and patch setup for drums: https://github.com/LMMS/lmms/issues/323#issuecomment-40160617

To verify the problem, try loading this OPL3.SF2 soundfont [OPL3.zip](https://github.com/Interkarma/daggerfall-unity/files/14804912/OPL3.zip) with the current release version and notice the percussion during 5strong.mid is missing in the startup screen. When this fix is applied the percussion will work.