### PR TITLE
Replace PC Gold Weight Literal With Loaded Value

### DIFF
--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -77,7 +77,7 @@ namespace DaggerfallWorkshop.Game.Banking
 
     public static class DaggerfallBankManager
     {
-        public const float goldUnitWeightInKg = 0.0025f;
+        public static float goldUnitWeightInKg = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Currency,0).baseWeight;
         private const float deedSellMult = 0.85f;
         private const float housePriceMult = 1280f;
         private const uint loanRepayMinutes = DaggerfallDateTime.DaysPerYear * DaggerfallDateTime.MinutesPerDay;

--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -77,7 +77,17 @@ namespace DaggerfallWorkshop.Game.Banking
 
     public static class DaggerfallBankManager
     {
-        public static float goldUnitWeightInKg = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Currency,0).baseWeight;
+        private static float cachedGoldUnitWeightInKg = -1.0f;
+        public static float goldUnitWeightInKg
+        {
+            get
+            {
+                if (cachedGoldUnitWeightInKg == -1.0f)
+                    cachedGoldUnitWeightInKg = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Currency, 0).baseWeight;
+                return cachedGoldUnitWeightInKg;
+            }
+        }
+        
         private const float deedSellMult = 0.85f;
         private const float housePriceMult = 1280f;
         private const uint loanRepayMinutes = DaggerfallDateTime.DaysPerYear * DaggerfallDateTime.MinutesPerDay;


### PR DESCRIPTION
The weight of Gold Pieces in the player's inventory is stored in DaggerfallBankManager.cs as a literal value. This change instead indirectly loads it in from the itemTemplates array set in ItemHelper.cs

The intended result is that it thus exposes to mods the weight of gold pieces in the player's inventory, which it does according to my tests. It also appropriately affects certain transfers of gold pieces.