### PR TITLE
Move the hardcoding of items that don't encumber into templates

### DIFF
--- a/Assets/Resources/ItemTemplates.txt
+++ b/Assets/Resources/ItemTemplates.txt
@@ -1877,7 +1877,8 @@
         "worldTextureArchive": 0,
         "worldTextureRecord": 0,
         "playerTextureArchive": 213,
-        "playerTextureRecord": 1
+        "playerTextureRecord": 1,
+        "hasNoEncumbrance": true
     },
     {
         "index": 94,
@@ -1897,7 +1898,8 @@
         "worldTextureArchive": 0,
         "worldTextureRecord": 0,
         "playerTextureArchive": 201,
-        "playerTextureRecord": 0
+        "playerTextureRecord": 0,
+        "hasNoEncumbrance": true
     },
     {
         "index": 95,
@@ -1917,7 +1919,8 @@
         "worldTextureArchive": 0,
         "worldTextureRecord": 0,
         "playerTextureArchive": 213,
-        "playerTextureRecord": 1
+        "playerTextureRecord": 1,
+        "hasNoEncumbrance": true
     },
     {
         "index": 96,
@@ -1937,7 +1940,8 @@
         "worldTextureArchive": 0,
         "worldTextureRecord": 0,
         "playerTextureArchive": 213,
-        "playerTextureRecord": 1
+        "playerTextureRecord": 1,
+        "hasNoEncumbrance": true
     },
     {
         "index": 97,
@@ -1957,7 +1961,8 @@
         "worldTextureArchive": 0,
         "worldTextureRecord": 0,
         "playerTextureArchive": 213,
-        "playerTextureRecord": 1
+        "playerTextureRecord": 1,
+        "hasNoEncumbrance": true
     },
     {
         "index": 98,
@@ -1977,7 +1982,8 @@
         "worldTextureArchive": 0,
         "worldTextureRecord": 0,
         "playerTextureArchive": 213,
-        "playerTextureRecord": 1
+        "playerTextureRecord": 1,
+        "hasNoEncumbrance": true
     },
     {
         "index": 99,
@@ -2638,7 +2644,8 @@
         "worldTextureRecord": 16,
         "playerTextureArchive": 0,
         "playerTextureRecord": 0,
-        "isNotRepairable": true
+        "isNotRepairable": true,
+        "hasNoEncumbrance": true
     },
     {
         "index": 132,
@@ -5762,6 +5769,7 @@
         "worldTextureArchive": 209,
         "worldTextureRecord": 8,
         "playerTextureArchive": 0,
-        "playerTextureRecord": 0
+        "playerTextureRecord": 0,
+        "hasNoEncumbrance": true
     }
 ]

--- a/Assets/Scripts/API/ItemsFile.cs
+++ b/Assets/Scripts/API/ItemsFile.cs
@@ -66,6 +66,7 @@ namespace DaggerfallConnect.FallExe
 
         // DFU extension fields
         public bool isNotRepairable;                // Defaults to false if not specified
+        public bool hasNoEncumbrance;               // Indicates an items weight doesn't count for encumbrance, defaults to false
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -662,13 +662,14 @@ namespace DaggerfallWorkshop.Game.Items
             return (TemplateIndex == templateIndex);
         }
 
-        // Horses, carts, arrows and maps are not counted against encumbrance.
+        // By default horses, carts, arrows and maps are not counted against encumbrance.
+        // Denoted by "hasNoEncumbrance": true in template.
         public float EffectiveUnitWeightInKg()
         {
-            if (ItemGroup == ItemGroups.Transportation || TemplateIndex == (int)Weapons.Arrow ||
-                IsOfTemplate(ItemGroups.MiscItems, (int)MiscItems.Map))
+            if (ItemTemplate.hasNoEncumbrance)
                 return 0f;
-            return weightInKg;
+            else
+                return weightInKg;
         }
 
         /// <summary>


### PR DESCRIPTION
This allows mods to change arrows so that their weight counts towards encumbrance. A mod to do this would consist of a single file ItemTemplates.json with the following entry:

```
{
    {
        "index": 131,
        "hasNoEncumbrance": false
    }
}
```