### PR TITLE
Add Contextual Macros for Capitalized Gender-Specific Pronouns

### DIFF
--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -34,6 +34,7 @@ namespace DaggerfallWorkshop.Utility
 
         public static System.Random random = new System.Random();
 
+        
         #region macro definitions and handler mappings
 
         static Dictionary<string, MacroHandler> macroHandlers = new Dictionary<string, MacroHandler>()
@@ -101,12 +102,6 @@ namespace DaggerfallWorkshop.Utility
             { "%g2self", Pronoun2self },// Himself/Herself etc...
             { "%g3", Pronoun3 },  // His/Her
             { "%g4", Pronoun4 },  // His/Hers
-            { "%G", PronounCap }, // He/She, first letter capitalized
-            { "%G1", PronounCap }, // He/She, first letter capitalized
-            { "%G2", Pronoun2Cap }, // Him/Her, first letter capitalized
-            { "%G2self", Pronoun2selfCap }, // Himself/Herself, first letter capitalized
-            { "%G3", Pronoun3Cap }, // His/Her, first letter capitalized
-            { "%G4", Pronoun4Cap }, // His/Hers, first letter capitalized
             { "%gii", GoldCarried }, // Amount of gold in hand
             { "%gdd", GodDesc }, // God description i.e. God of Logic
             { "%god", God }, // God of current region or current temple
@@ -241,6 +236,12 @@ namespace DaggerfallWorkshop.Utility
             { "%pg2", PlayerPronoun2 }, // Him/Her (player)
             { "%pg2self", PlayerPronoun2self },// Himself/Herself (player)
             { "%pg3", PlayerPronoun3 },  // His/Her (player)
+            { "%G", PronounCap }, // He/She, first letter capitalized
+            { "%G1", PronounCap }, // He/She, first letter capitalized
+            { "%G2", Pronoun2Cap }, // Him/Her, first letter capitalized
+            { "%G2self", Pronoun2selfCap }, // Himself/Herself, first letter capitalized
+            { "%G3", Pronoun3Cap }, // His/Her, first letter capitalized
+            { "%G4", Pronoun4Cap }, // His/Hers, first letter capitalized
             { "%hrn", HomeRegion },  // Home region (of person)
             { "%pcl", PlayerLastname }, // Character's last name
             { "%day", DayNum }, // Current day of the month (ex: 1, 2, ..., 30)
@@ -394,6 +395,12 @@ namespace DaggerfallWorkshop.Utility
                 default:
                     return TextManager.Instance.GetLocalizedText("Lord");
             }
+        }
+
+        private static string CapFirst(string tempString)
+        {
+            // Capitalizes first letter of a string, e.g. for capitalized pronoun macros
+            return tempString.Substring(0, 1).ToUpper() + tempString.Substring(1);
         }
 
         #endregion
@@ -1323,32 +1330,27 @@ namespace DaggerfallWorkshop.Utility
         public static string PronounCap(IMacroContextProvider mcp)
         {   // %G & %G1
             if (mcp == null) return null;
-            string tmpPronoun = mcp.GetMacroDataSource().Pronoun();
-            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+            return CapFirst(mcp.GetMacroDataSource().Pronoun());
         }
         public static string Pronoun2Cap(IMacroContextProvider mcp)
         {   // %G2
             if (mcp == null) return null;
-            string tmpPronoun = mcp.GetMacroDataSource().Pronoun2();
-            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+            return CapFirst(mcp.GetMacroDataSource().Pronoun2());
         }
         public static string Pronoun2selfCap(IMacroContextProvider mcp)
         {   // %G2self
             if (mcp == null) return null;
-            string tmpPronoun = mcp.GetMacroDataSource().Pronoun2self();
-            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+            return CapFirst(mcp.GetMacroDataSource().Pronoun2self());
         }
         public static string Pronoun3Cap(IMacroContextProvider mcp)
         {   // %G3
             if (mcp == null) return null;
-            string tmpPronoun = mcp.GetMacroDataSource().Pronoun3();
-            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+            return CapFirst(mcp.GetMacroDataSource().Pronoun3());
         }
         public static string Pronoun4Cap(IMacroContextProvider mcp)
         {   // %G4
             if (mcp == null) return null;
-            string tmpPronoun = mcp.GetMacroDataSource().Pronoun4();
-            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+            return CapFirst(mcp.GetMacroDataSource().Pronoun4());
         }
         
         public static string QuestDate(IMacroContextProvider mcp)

--- a/Assets/Scripts/Utility/MacroHelper.cs
+++ b/Assets/Scripts/Utility/MacroHelper.cs
@@ -101,6 +101,12 @@ namespace DaggerfallWorkshop.Utility
             { "%g2self", Pronoun2self },// Himself/Herself etc...
             { "%g3", Pronoun3 },  // His/Her
             { "%g4", Pronoun4 },  // His/Hers
+            { "%G", PronounCap }, // He/She, first letter capitalized
+            { "%G1", PronounCap }, // He/She, first letter capitalized
+            { "%G2", Pronoun2Cap }, // Him/Her, first letter capitalized
+            { "%G2self", Pronoun2selfCap }, // Himself/Herself, first letter capitalized
+            { "%G3", Pronoun3Cap }, // His/Her, first letter capitalized
+            { "%G4", Pronoun4Cap }, // His/Hers, first letter capitalized
             { "%gii", GoldCarried }, // Amount of gold in hand
             { "%gdd", GodDesc }, // God description i.e. God of Logic
             { "%god", God }, // God of current region or current temple
@@ -1309,13 +1315,42 @@ namespace DaggerfallWorkshop.Utility
             if (mcp == null) return null;
             return mcp.GetMacroDataSource().Pronoun3();
         }
-
         public static string Pronoun4(IMacroContextProvider mcp)
         {   // %g4
             if (mcp == null) return null;
             return mcp.GetMacroDataSource().Pronoun4();
         }
-
+        public static string PronounCap(IMacroContextProvider mcp)
+        {   // %G & %G1
+            if (mcp == null) return null;
+            string tmpPronoun = mcp.GetMacroDataSource().Pronoun();
+            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+        }
+        public static string Pronoun2Cap(IMacroContextProvider mcp)
+        {   // %G2
+            if (mcp == null) return null;
+            string tmpPronoun = mcp.GetMacroDataSource().Pronoun2();
+            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+        }
+        public static string Pronoun2selfCap(IMacroContextProvider mcp)
+        {   // %G2self
+            if (mcp == null) return null;
+            string tmpPronoun = mcp.GetMacroDataSource().Pronoun2self();
+            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+        }
+        public static string Pronoun3Cap(IMacroContextProvider mcp)
+        {   // %G3
+            if (mcp == null) return null;
+            string tmpPronoun = mcp.GetMacroDataSource().Pronoun3();
+            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+        }
+        public static string Pronoun4Cap(IMacroContextProvider mcp)
+        {   // %G4
+            if (mcp == null) return null;
+            string tmpPronoun = mcp.GetMacroDataSource().Pronoun4();
+            return tmpPronoun.Substring(0, 1).ToUpper() + tmpPronoun.Substring(1);
+        }
+        
         public static string QuestDate(IMacroContextProvider mcp)
         {   // %qdt
             if (mcp == null) return null;


### PR DESCRIPTION
Some quest dialog and strings include GSP (gender-specific pronoun) macros (e.g. %g1). However, the macro handler always makes these lower-case, which is improper at the beginning of a sentence, in English at least.

Instead of making GSP macros always capitalized, and unnecessarily deifying characters, it makes more sense to capitalize only the ones at the beginning of a sentence. I found an earlier proposal which suggested code changes to detect when one is used at the beginning of a sentence. However, this detection becomes problematic when accounting for whitespace, unusual punctuation, and other languages whose sentences may end with different symbols.

Therefore, I added new macros which capitalize the first letter of the GSP, which can be placed in quest/string files as needed to replace GSPs found at the beginning of sentences. I plan on modifying - if this is merged - my upcoming quest dialog improvements, in order to utilize these new macros.
I tested all these new macros and they do work; macro names are case-sensitive.