### PR TITLE
Allow other transportation items to be added by mods

### DIFF
--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -13,6 +13,7 @@ using DaggerfallConnect.Arena2;
 using DaggerfallConnect.Utility;
 using DaggerfallWorkshop.Game.Banking;
 using DaggerfallWorkshop.Game.Items;
+using System.Collections.Generic;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -67,6 +68,9 @@ namespace DaggerfallWorkshop.Game
 
         public Color Tint { get; set; } = Color.white;
 
+        public void AddHorseItemIndex(int index) { horseItemIndexes.Add(index); }
+        List<int> horseItemIndexes = new List<int>() { (int)Transportation.Horse };
+
         #endregion
 
         #region Public Methods
@@ -82,7 +86,6 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// True when player owns a cart
         /// </summary>
-        /// <returns></returns>
         public bool HasCart()
         {
             ItemCollection inventory = GameManager.Instance.PlayerEntity.Items;
@@ -93,12 +96,15 @@ namespace DaggerfallWorkshop.Game
         /// <summary>
         /// True when player owns a horse
         /// </summary>
-        /// <returns></returns>
         public bool HasHorse()
         {
             ItemCollection inventory = GameManager.Instance.PlayerEntity.Items;
 
-            return inventory.Contains(ItemGroups.Transportation, (int)Transportation.Horse);
+            foreach (int horseItemIndex in horseItemIndexes)
+                if (inventory.Contains(ItemGroups.Transportation, horseItemIndex))
+                    return true;
+
+            return false;
         }
 
         /// <summary>

--- a/Assets/Scripts/Internal/DaggerfallLoot.cs
+++ b/Assets/Scripts/Internal/DaggerfallLoot.cs
@@ -253,6 +253,10 @@ namespace DaggerfallWorkshop
                         }
                         // Add any modded items registered in applicable groups
                         int[] customItemTemplates = itemHelper.GetCustomItemsForGroup(itemGroup);
+                        // Ensure there's a (21-rarity)% chance for a custom transportation item to be generated
+                        if (chanceMod == 0 && itemGroup == ItemGroups.Transportation)
+                            chanceMod = 20;
+
                         for (int j = 0; j < customItemTemplates.Length; j++)
                         {
                             ItemTemplate itemTemplate = itemHelper.GetItemTemplate(itemGroup, customItemTemplates[j]);

--- a/Assets/Scripts/Utility/ImageReader.cs
+++ b/Assets/Scripts/Utility/ImageReader.cs
@@ -292,7 +292,7 @@ namespace DaggerfallWorkshop.Utility
                     int archive = AssetInjection.TextureReplacement.FileNameToArchive(filename);
                     if (createTexture && AssetInjection.TextureReplacement.TryImportTexture(archive, record, frame, out imageData.texture))
                         createTexture = false;
-                    if (createAllFrameTextures && frameCount > 1 && AssetInjection.TextureReplacement.TryImportTexture(archive, record, out imageData.animatedTextures))
+                    if (createAllFrameTextures && AssetInjection.TextureReplacement.TryImportTexture(archive, record, out imageData.animatedTextures))
                         createAllFrameTextures = false;
 
                     break;


### PR DESCRIPTION
- Allows custom transportation items to be contributed by mods and actually have a chance to appear in shops.
- Allow new horses to enable the horse transportation option. (this could be done for carts as well if desired, but I don't think people really use this much so won't want to add any new ones)
- Allow custom items to have animated icons in inventory. (bugfix)