### PR TITLE
Fixed book mapping contributes not being detected on Windows

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModManager.cs
+++ b/Assets/Game/Addons/ModSupport/ModManager.cs
@@ -963,15 +963,29 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
                 var directory = Path.GetDirectoryName(file);
 
                 if (!string.IsNullOrEmpty(directory) && directory.EndsWith("SpellIcons"))
+                {
                     AddNameToList(ref spellIcons, file);
-                else if (!string.IsNullOrEmpty(directory) && directory.EndsWith("Books/Mapping"))
-                    AddNameToList(ref booksMapping, file);
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(directory) && directory.EndsWith("Mapping"))
+                {
+                    var parentDirectory = Path.GetDirectoryName(directory);
+                    if (!string.IsNullOrEmpty(parentDirectory) && parentDirectory.EndsWith("Books"))
+                    {
+                        AddNameToList(ref booksMapping, file);
+                        continue;
+                    }
+                }
 
                 if (automaticallyRegisterQuestLists)
                 {
                     var name = Path.GetFileNameWithoutExtension(file);
                     if (!string.IsNullOrEmpty(name) && name.StartsWith("QuestList-"))
+                    {
                         AddNameToList(ref questLists, name.Substring(10));
+                        continue;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fix for #2636.

Before #2580, we used to leave contributes untouched if no contributes were detected. Instead now, we always update contributes, removing files that are not detected by the function.

Detection of book mappings has always been broken on Windows. The path returned by `Path.GetDirectoryName` uses `\` to separate paths, but the check for Books/Mapping checked with a forward slash.

I instead changed this function to properly detect the path Books/Mapping on any platform. As a result, the books should now properly be detected on Windows, and updating the mapping should always give the correct result.