### PR TITLE
Fix expiring equipped items not adjusting armorvalues

### DIFF
--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -135,7 +135,10 @@ namespace DaggerfallWorkshop.Game.Items
                     foreach (EquipSlots slotToCheck in Enum.GetValues(typeof(EquipSlots)))
                     {
                         if (player.ItemEquipTable.GetItem(slotToCheck) == item)
+                        {
                             player.ItemEquipTable.UnequipItem(slotToCheck);
+                            player.UpdateEquippedArmorValues(item, false);
+                        }
                     }
                     itemsToRemove.Add(item);
                 }


### PR DESCRIPTION
Fixes issue #2640.

I think this should go into 1.1 since it's a clear fix of broken functionality and the blast radius is miniscule.