### PR TITLE
Enable variant custom guilds

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -593,6 +593,12 @@ namespace DaggerfallConnect.Arena2
             Witches = 22,
             Vampires = 23,
             Orsinium = 24,
+            GGroup25 = 25,
+            GGroup26 = 26,
+            GGroup27 = 27,
+            GGroup28 = 28,
+            GGroup29 = 29,
+            GGroup30 = 30,
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -178,7 +178,11 @@ namespace DaggerfallWorkshop.Game.Guilds
                         return (IGuild)Activator.CreateInstance(guildType, new object[] { KnightlyOrder.GetOrder(variant) });
 
                     default:
-                        return (IGuild)Activator.CreateInstance(guildType);
+                        try {
+                            return (IGuild)Activator.CreateInstance(guildType, new object[] { variant });
+                        } catch (MissingMethodException) {
+                            return (IGuild)Activator.CreateInstance(guildType);
+                        }
                 }
             }
             else

--- a/Assets/Scripts/Game/Guilds/GuildManager.cs
+++ b/Assets/Scripts/Game/Guilds/GuildManager.cs
@@ -178,11 +178,10 @@ namespace DaggerfallWorkshop.Game.Guilds
                         return (IGuild)Activator.CreateInstance(guildType, new object[] { KnightlyOrder.GetOrder(variant) });
 
                     default:
-                        try {
+                        if (guildType.GetConstructor(new Type[] { typeof(int) }) != null)
                             return (IGuild)Activator.CreateInstance(guildType, new object[] { variant });
-                        } catch (MissingMethodException) {
+                        else
                             return (IGuild)Activator.CreateInstance(guildType);
-                        }
                 }
             }
             else


### PR DESCRIPTION
Try creating guild using variant so that custom guilds can have sub-groups like Temples and Knight Orders do.

Also entended the guild groups enum so we have plenty of guild entries available. Pretty sure this has no detremental effect.