### PR TITLE
Improve custom door support for custom models

### DIFF
--- a/Assets/Editor/X-DoorBoxCollider.preset
+++ b/Assets/Editor/X-DoorBoxCollider.preset
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!181963792 &2655988077585873504
+Preset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: X-DoorBoxCollider
+  m_TargetType:
+    m_NativeTypeID: 65
+    m_ManagedTypePPtr: {fileID: 0}
+    m_ManagedTypeFallback: 
+  m_Properties:
+  - target: {fileID: 0}
+    propertyPath: m_Material
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_IsTrigger
+    value: 1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Enabled
+    value: 1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Size.x
+    value: 0.5
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Size.y
+    value: 2.25
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Size.z
+    value: 1.25
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Center.x
+    value: -4.85
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Center.y
+    value: 1.1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Center.z
+    value: 11.2
+    objectReference: {fileID: 0}

--- a/Assets/Editor/X-DoorBoxCollider.preset.meta
+++ b/Assets/Editor/X-DoorBoxCollider.preset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0df13854f0e58584ea0db0de04afbd94
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2655988077585873504
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Z-DoorBoxCollider.preset
+++ b/Assets/Editor/Z-DoorBoxCollider.preset
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!181963792 &2655988077585873504
+Preset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Z-DoorBoxCollider
+  m_TargetType:
+    m_NativeTypeID: 65
+    m_ManagedTypePPtr: {fileID: 0}
+    m_ManagedTypeFallback: 
+  m_Properties:
+  - target: {fileID: 0}
+    propertyPath: m_Material
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_IsTrigger
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Enabled
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Size.x
+    value: 1.25
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Size.y
+    value: 2.25
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Size.z
+    value: 0.5
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Center.x
+    value: -4.85
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Center.y
+    value: 1.1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Center.z
+    value: 11.2
+    objectReference: {fileID: 0}

--- a/Assets/Editor/Z-DoorBoxCollider.preset.meta
+++ b/Assets/Editor/Z-DoorBoxCollider.preset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64185a38d37de1a46990a174bee7282a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2655988077585873504
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -482,7 +482,7 @@ namespace DaggerfallWorkshop
 
                 // Add any DF model static doors unless suppressed
                 if (modelData.Doors != null && !disableClassicDoors)
-                    doors.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, entryDoor.blockIndex, entryDoor.recordIndex, modelMatrix));
+                    doors.AddRange(staticDoors);
 
 
                 if ((modelGO != null) && (isAutomapRun))

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -444,9 +444,11 @@ namespace DaggerfallWorkshop
                 Vector3 modelScale = RMBLayout.GetModelScaleVector(obj);
                 Matrix4x4 modelMatrix = Matrix4x4.TRS(modelPosition, Quaternion.Euler(modelRotation), modelScale);
 
-                // Does this model have doors?
+                // Does this Daggerfall model have any static doors?
+                bool disableClassicDoors = false;
+                StaticDoor[] staticDoors = null;
                 if (modelData.Doors != null)
-                    doors.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, entryDoor.blockIndex, entryDoor.recordIndex, modelMatrix));
+                    staticDoors = GameObjectHelper.GetStaticDoors(ref modelData, entryDoor.blockIndex, entryDoor.recordIndex, modelMatrix);
 
                 // Inject custom GameObject if available
                 GameObject modelGO = MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, node.transform, modelMatrix);
@@ -471,6 +473,17 @@ namespace DaggerfallWorkshop
                         dfMesh.SetClimate(climateBase, climateSeason, WindowStyle.Disabled);
                     }
                 }
+                else
+                {
+                    // For a custom model initialise any custom doors
+                    List<StaticDoor> customStaticDoors = CustomDoor.InitDoorsInterior(modelGO, staticDoors, entryDoor.blockIndex, entryDoor.recordIndex, modelMatrix, out disableClassicDoors);
+                    doors.AddRange(customStaticDoors);
+                }
+
+                // Add any DF model static doors unless suppressed
+                if (modelData.Doors != null && !disableClassicDoors)
+                    doors.AddRange(GameObjectHelper.GetStaticDoors(ref modelData, entryDoor.blockIndex, entryDoor.recordIndex, modelMatrix));
+
 
                 if ((modelGO != null) && (isAutomapRun))
                     modelGO.AddComponent<AutomapModel>();

--- a/Assets/Scripts/Internal/DaggerfallStaticBuildings.cs
+++ b/Assets/Scripts/Internal/DaggerfallStaticBuildings.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Unity
+// Project:         Daggerfall Unity
 // Copyright:       Copyright (C) 2009-2023 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -74,7 +74,7 @@ namespace DaggerfallWorkshop
                 go.transform.position = Buildings[i].modelMatrix.GetColumn(3);
                 go.transform.position += transform.position;
                 go.transform.rotation = Quaternion.LookRotation(Buildings[i].modelMatrix.GetColumn(2), Buildings[i].modelMatrix.GetColumn(1));
-                c.center = new Vector3(0, Buildings[i].size.y / 2, 0);
+                c.center = Buildings[i].centre;
                 c.size = Buildings[i].size * 1.01f;
 
                 // Check if hit was inside trigger

--- a/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
@@ -4,11 +4,12 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: TheLacus
-// Contributors:    
+// Contributors:    Hazelnut
 // 
 // Notes:           This is to be considered EXPERIMENTAL and can be changed or removed at any time.
 //
 
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace DaggerfallWorkshop.Utility.AssetInjection
@@ -16,26 +17,22 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     /// <summary>
     /// Defines a custom door for a building imported by Asset-Injection framework.
     /// </summary>
-    /// <remarks>
-    /// TODO:
-    /// - Interior to exterior transition should be based on position of new doors.
-    /// </remarks>
     [ExecuteInEditMode]
-    [RequireComponent(typeof(BoxCollider))]
+    //[RequireComponent(typeof(BoxCollider))]
     public class CustomDoor : MonoBehaviour
     {
         private StaticDoor? staticDoor;
-        
-        [Tooltip("Disables all classic doors on this building (not only on the gameobject where this component is added).")]
+
+        [Tooltip("Sets the door type for this custom door. (ignored if a DF model static door is copied)")]
+        public DoorTypes DoorType = DoorTypes.Building;
+
+        [Tooltip("Used to specify a door index to copy from this model's StaticDoor array if available for this custom door, defaults to -1 to not copy.")]
+        public int StaticDoorCopied = -1;
+
+        [Tooltip("Disables all classic doors on this model. (Exit a building doesn't work well if this is true and all custom doors are copied)")]
         public bool DisableClassicDoors = false;
         
-        [Tooltip("Choose which of the doors in this model's Static Door array will be copied for this custom door.")]
-        public int StaticDoorCopied = 0;
-
-        /// <summary>
-        /// The trigger for this door.
-        /// </summary>
-        [Tooltip("The trigger for this door. If unset, uses the first box collider found on gameobject.")]
+        [Tooltip("The box collider defining this door. If unset, uses the first box collider found on model gameobject.")]
         public BoxCollider DoorTrigger;
 
         private void Awake()
@@ -43,50 +40,89 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             if (!DoorTrigger)
                 DoorTrigger = GetComponent<BoxCollider>();
             DoorTrigger.isTrigger = true;
+            DoorTrigger.enabled = (StaticDoorCopied == -1) ? false : true;
         }
 
         /// <summary>
         /// Set static door data to all doors in the given building gameobject.
         /// </summary>
         /// <param name="building">The imported gameobject which provides building and doors.</param>
-        /// <param name="staticDoors">The list of static doors for the vanilla building.</param>
+        /// <param name="staticDoors">A list of static doors for the vanilla building for copying, if available.</param>
         /// <param name="buildingKey">The key of the building that owns the doors.</param>
-        /// <param name="dontCreateStaticDoors">If true, custom door components request to suppress classic doors.</param>
-        public static void InitDoors(GameObject building, StaticDoor[] staticDoors, int buildingKey, out bool dontCreateStaticDoors)
+        /// <param name="blockIndex">Block index for RMB doors.</param>
+        /// <param name="recordIndex">Record index of interior.</param>
+        /// <param name="buildingMatrix">Individual building matrix.</param>
+        /// <param name="disableClassicDoors">If true, at least one custom door component has disabled classic doors for all models for this building.</param>
+        /// <returns>List of StaticDoor data for any custom doors that don't copy a DF model StaticDoor.</returns>
+        public static List<StaticDoor> InitDoors(GameObject building, StaticDoor[] staticDoors, int buildingKey, int blockIndex, int recordIndex, Matrix4x4 buildingMatrix, out bool disableClassicDoors)
         {
-            dontCreateStaticDoors = false;
-            // Set data to all doors in the building
+            // Iterate through all custom door components for this building
+            disableClassicDoors = false;
             CustomDoor[] allCustomDoors = building.GetComponentsInChildren<CustomDoor>();
+            List<StaticDoor> customStaticDoors = new List<StaticDoor>(allCustomDoors.Length);
             for (int i = 0; i < allCustomDoors.Length; i++)
             {
                 if (allCustomDoors[i].DisableClassicDoors == true)
-                    dontCreateStaticDoors = true;
+                    disableClassicDoors = true;
 
-                if ((allCustomDoors[i].StaticDoorCopied < 0) || (allCustomDoors[i].StaticDoorCopied > staticDoors.Length))
+                // If no static doors available (i.e. not replacing a DF model with door data) or not configured to copy one
+                if (allCustomDoors[i].StaticDoorCopied == -1 || staticDoors == null || staticDoors.Length == 0)
+                {
+                    // Calculate the door normal (note only works for X & Z, so no trapdoors)
+                    Vector3 doorCenter = allCustomDoors[i].DoorTrigger.center;
+                    Vector3 doorSize = allCustomDoors[i].DoorTrigger.size;
+                    Vector3 doorNormal = new Vector3();
+                    if (doorSize.x < doorSize.z && doorSize.x < doorSize.y)
+                        doorNormal.x = Mathf.Sign(doorCenter.x);
+                    else if (doorSize.z < doorSize.x && doorSize.z < doorSize.y)
+                        doorNormal.z = Mathf.Sign(doorCenter.z);
+                    else if (doorSize.y < doorSize.x && doorSize.y < doorSize.z)
+                        doorNormal.y = Mathf.Sign(doorCenter.y);
+
+                    // Construct new StaticDoor data for this custom door and add it to list
+                    StaticDoor staticDoor = new StaticDoor
+                    {
+                        doorType = allCustomDoors[i].DoorType,
+                        buildingKey = buildingKey,
+                        blockIndex = blockIndex,
+                        recordIndex = recordIndex,
+                        buildingMatrix = buildingMatrix,
+                        doorIndex = i,
+                        centre = doorCenter,
+                        size = doorSize,
+                        normal = doorNormal
+                    };
+                    customStaticDoors.Add(staticDoor);
+                }
+                else if (allCustomDoors[i].StaticDoorCopied < staticDoors.Length)
+                {
+                    // Copy data from the specified existing static door
+                    StaticDoor staticDoor = staticDoors[allCustomDoors[i].StaticDoorCopied];
+                    staticDoor.buildingKey = buildingKey;
+                    allCustomDoors[i].staticDoor = staticDoor;
+                }
+                else
                 {
                     string objectName;
                     if (allCustomDoors[i].name == "default")
                         objectName = allCustomDoors[i].transform.parent.name + "\\default";
                     else
                         objectName = allCustomDoors[i].name;
-                    Debug.LogErrorFormat("StaticDoorCopied for model {0} is outside the valid range for it's Static Door array. Defaulting to 0", objectName);
-                    allCustomDoors[i].StaticDoorCopied = 0;
+                    Debug.LogErrorFormat("StaticDoorCopied for CustomDoor {1} on model {0} is outside the valid range for its Static Door array and has been ignored.", objectName, i);
                 }
-                // Make data for the static door; only the common data for the building is needed.
-                StaticDoor staticDoor = staticDoors[allCustomDoors[i].StaticDoorCopied];
-                staticDoor.buildingKey = buildingKey;
-
-                allCustomDoors[i].staticDoor = staticDoor;
             }
+
+            return customStaticDoors;
         }
 
         /// <summary>
-        /// Checks for a door hit.
+        /// Checks for a door hit in custom doors copied (linked) from DF model static doors.
         /// </summary>
         /// <param name="raycastHit">The raycast result.</param>
         /// <param name="door">The door found at hit position.</param>
         /// <returns>True if a door has been hit.</returns>
         /// <remarks>
+        /// Only used for custom doors that were linked to a DF model static door, e.g. staticDoor reference is set.
         /// Modders should ensure that the CustomDoor component is added to the right gameobject.
         /// This allows to avoid unnecessary seeks on parent/children, which are potentially performance heavy.
         /// </remarks>
@@ -95,15 +131,13 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             var doors = raycastHit.transform.GetComponents<CustomDoor>();
             for (int i = 0; i < doors.Length; i++)
             {
+                if (!doors[i].staticDoor.HasValue)
+                    continue;
+
                 if (doors[i].DoorTrigger.bounds.Contains(raycastHit.point))
                 {
-                    if (doors[i].staticDoor.HasValue)
-                    {
-                        door = doors[i].staticDoor.Value;
-                        return true;
-                    }
-
-                    Debug.LogErrorFormat("Static door for {0} is not set.", raycastHit.transform.name);
+                    door = doors[i].staticDoor.Value;
+                    return true;
                 }
             }
 

--- a/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
@@ -18,7 +18,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     /// Defines a custom door for a building imported by Asset-Injection framework.
     /// </summary>
     [ExecuteInEditMode]
-    //[RequireComponent(typeof(BoxCollider))]
+    [RequireComponent(typeof(BoxCollider))]
     public class CustomDoor : MonoBehaviour
     {
         private StaticDoor? staticDoor;

--- a/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
+++ b/Assets/Scripts/Utility/AssetInjection/Components/CustomDoor.cs
@@ -84,16 +84,20 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 // If no static doors available (i.e. not replacing a DF model with door data) or not configured to copy one
                 if (allCustomDoors[i].StaticDoorCopied == -1 || staticDoors == null || staticDoors.Length == 0)
                 {
-                    // Calculate the door normal
+                    // Calculate the door normal using smallest dimension as direction
                     Vector3 doorCenter = allCustomDoors[i].DoorTrigger.center;
                     Vector3 doorSize = allCustomDoors[i].DoorTrigger.size;
                     Vector3 doorNormal = new Vector3();
-                    if (doorSize.x < doorSize.z && doorSize.x < doorSize.y)
+                    if (doorSize.x < doorSize.z && doorSize.x < doorSize.y) {
                         doorNormal.x = Mathf.Sign(doorCenter.x);
-                    else if (doorSize.z < doorSize.x && doorSize.z < doorSize.y)
+                        doorSize.x = doorSize.z;    // Set x=z so static door hit detection works
+                    } else if (doorSize.z < doorSize.x && doorSize.z < doorSize.y) {
                         doorNormal.z = Mathf.Sign(doorCenter.z);
-                    else if (doorSize.y < doorSize.x && doorSize.y < doorSize.z)
+                        doorSize.z = doorSize.x;    // Set z=x so static door hit detection works
+                    }
+                    else if (doorSize.y < doorSize.x && doorSize.y < doorSize.z) {
                         doorNormal.y = Mathf.Sign(doorCenter.y);
+                    }
 
                     // Invert normal for interior doors (building key = -1)
                     if (buildingKey < 0) {

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -842,7 +842,7 @@ namespace DaggerfallWorkshop.Utility
                     ModelData modelData;
                     dfUnity.MeshReader.GetModelData(obj.ModelIdNum, out modelData);
 
-                    // Does this model have doors?
+                    // Does this Daggerfall model have any static doors?
                     StaticDoor[] staticDoors = null;
                     if (modelData.Doors != null)
                         staticDoors = GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, recordCount, modelMatrix);

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -870,12 +870,12 @@ namespace DaggerfallWorkshop.Utility
                         staticBuilding.modelMatrix = modelMatrix;
                         staticBuilding.recordIndex = recordCount;
                         if (go == null || modelData.Indices != null) {
-                            staticBuilding.centre = new Vector3(modelData.DFMesh.Centre.X, modelData.DFMesh.Centre.Y, modelData.DFMesh.Centre.Z) * MeshReader.GlobalScale;
                             staticBuilding.size = new Vector3(modelData.DFMesh.Size.X, modelData.DFMesh.Size.Y, modelData.DFMesh.Size.Z) * MeshReader.GlobalScale;
+                            staticBuilding.centre = new Vector3(0, modelData.DFMesh.Size.Y / 2, 0) * MeshReader.GlobalScale; // All DF meshes are already centred on X & Z, moved this assumption to here from DaggerfallStaticBuildings.hasHit()
                         } else {
                             Renderer goRenderer = go.GetComponent<Renderer>();
+                            staticBuilding.centre = new Vector3(goRenderer.bounds.center.x, goRenderer.bounds.center.y, goRenderer.bounds.center.z) - go.transform.position;
                             staticBuilding.size = new Vector3(goRenderer.bounds.size.x, goRenderer.bounds.size.y, goRenderer.bounds.size.z);
-                            staticBuilding.centre = staticBuilding.size / 2;    // Seems to replicate DFMesh.Centre whereas goRenderer.bounds.center.z gives position.z for some reason.
                         }
                         buildingsOut.Add(staticBuilding);
                         firstModel = false;

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -840,7 +840,7 @@ namespace DaggerfallWorkshop.Utility
 
                     // Get model data
                     ModelData modelData;
-                    dfUnity.MeshReader.GetModelData(obj.ModelIdNum, out modelData);
+                    bool hasModelData = dfUnity.MeshReader.GetModelData(obj.ModelIdNum, out modelData);
 
                     // Does this Daggerfall model have any static doors?
                     StaticDoor[] staticDoors = null;
@@ -851,10 +851,14 @@ namespace DaggerfallWorkshop.Utility
                     GameObject go;
                     if (!(go = MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, parent, modelMatrix)))
                     {
-                        if (combiner == null || IsCityGate(obj.ModelIdNum) || IsBulletinBoard(obj.ModelIdNum) || PlayerActivate.HasCustomActivation(obj.ModelIdNum))
+                        if (!hasModelData) {
+                            Debug.LogError($"Could not load model '{obj.ModelIdNum}' in block '{blockData.Name}'");
+                            continue;
+                        } else if (combiner == null || IsCityGate(obj.ModelIdNum) || IsBulletinBoard(obj.ModelIdNum) || PlayerActivate.HasCustomActivation(obj.ModelIdNum)) {
                             AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent);
-                        else
+                        } else {
                             combiner.Add(ref modelData, modelMatrix);
+                        }
                     }
 
                     // Store building information for first model of record

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -874,7 +874,6 @@ namespace DaggerfallWorkshop.Utility
                             staticBuilding.size = new Vector3(modelData.DFMesh.Size.X, modelData.DFMesh.Size.Y, modelData.DFMesh.Size.Z) * MeshReader.GlobalScale;
                         } else {
                             Renderer goRenderer = go.GetComponent<Renderer>();
-                            //staticBuilding.centre = new Vector3(goRenderer.bounds.center.x, goRenderer.bounds.center.y, goRenderer.bounds.center.z);
                             staticBuilding.size = new Vector3(goRenderer.bounds.size.x, goRenderer.bounds.size.y, goRenderer.bounds.size.z);
                             staticBuilding.centre = staticBuilding.size / 2;    // Seems to replicate DFMesh.Centre whereas goRenderer.bounds.center.z gives position.z for some reason.
                         }

--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -847,40 +847,48 @@ namespace DaggerfallWorkshop.Utility
                     if (modelData.Doors != null)
                         staticDoors = GameObjectHelper.GetStaticDoors(ref modelData, blockData.Index, recordCount, modelMatrix);
 
+                    // Import custom GameObject, or else use the Daggerfall model
+                    GameObject go;
+                    if (!(go = MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, parent, modelMatrix)))
+                    {
+                        if (combiner == null || IsCityGate(obj.ModelIdNum) || IsBulletinBoard(obj.ModelIdNum) || PlayerActivate.HasCustomActivation(obj.ModelIdNum))
+                            AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent);
+                        else
+                            combiner.Add(ref modelData, modelMatrix);
+                    }
+
                     // Store building information for first model of record
                     // First model is main record structure, others are attachments like posts
                     // Only main structure is needed to resolve building after hit-test
-                    int buildingKey = 0;
                     if (firstModel)
                     {
-                        // Create building key for this record - considered experimental for now
-                        buildingKey = BuildingDirectory.MakeBuildingKey((byte)layoutX, (byte)layoutY, (byte)recordCount);
-
                         StaticBuilding staticBuilding = new StaticBuilding();
                         staticBuilding.modelMatrix = modelMatrix;
                         staticBuilding.recordIndex = recordCount;
-                        staticBuilding.centre = new Vector3(modelData.DFMesh.Centre.X, modelData.DFMesh.Centre.Y, modelData.DFMesh.Centre.Z) * MeshReader.GlobalScale;
-                        staticBuilding.size = new Vector3(modelData.DFMesh.Size.X, modelData.DFMesh.Size.Y, modelData.DFMesh.Size.Z) * MeshReader.GlobalScale;
+                        if (go == null || modelData.Indices != null) {
+                            staticBuilding.centre = new Vector3(modelData.DFMesh.Centre.X, modelData.DFMesh.Centre.Y, modelData.DFMesh.Centre.Z) * MeshReader.GlobalScale;
+                            staticBuilding.size = new Vector3(modelData.DFMesh.Size.X, modelData.DFMesh.Size.Y, modelData.DFMesh.Size.Z) * MeshReader.GlobalScale;
+                        } else {
+                            Renderer goRenderer = go.GetComponent<Renderer>();
+                            //staticBuilding.centre = new Vector3(goRenderer.bounds.center.x, goRenderer.bounds.center.y, goRenderer.bounds.center.z);
+                            staticBuilding.size = new Vector3(goRenderer.bounds.size.x, goRenderer.bounds.size.y, goRenderer.bounds.size.z);
+                            staticBuilding.centre = staticBuilding.size / 2;    // Seems to replicate DFMesh.Centre whereas goRenderer.bounds.center.z gives position.z for some reason.
+                        }
                         buildingsOut.Add(staticBuilding);
                         firstModel = false;
                     }
 
-                    bool dontCreateStaticDoors = false;
-
-                    // Import custom GameObject or use Daggerfall Model
-                    GameObject go;
-                    if (go = MeshReplacement.ImportCustomGameobject(obj.ModelIdNum, parent, modelMatrix))
+                    // For a custom model, create building key for this record and initialise any custom doors
+                    bool disableClassicDoors = false;
+                    if (go != null)
                     {
-                        // Find doors
-                        if (staticDoors != null && staticDoors.Length > 0)
-                            CustomDoor.InitDoors(go, staticDoors, buildingKey, out dontCreateStaticDoors);
+                        int buildingKey = BuildingDirectory.MakeBuildingKey((byte)layoutX, (byte)layoutY, (byte)recordCount);
+                        List<StaticDoor> customStaticDoors = CustomDoor.InitDoors(go, staticDoors, buildingKey, blockData.Index, recordCount, modelMatrix, out disableClassicDoors);
+                        doorsOut.AddRange(customStaticDoors);
                     }
-                    else if (combiner == null || IsCityGate(obj.ModelIdNum) || IsBulletinBoard(obj.ModelIdNum) || PlayerActivate.HasCustomActivation(obj.ModelIdNum))
-                        AddStandaloneModel(dfUnity, ref modelData, modelMatrix, parent);
-                    else
-                        combiner.Add(ref modelData, modelMatrix);
 
-                    if (modelData.Doors != null && !dontCreateStaticDoors)
+                    // Add any DF model static doors unless suppressed
+                    if (modelData.Doors != null && !disableClassicDoors)
                         doorsOut.AddRange(staticDoors);
                 }
 


### PR DESCRIPTION
Improve custom door support for custom models, enabled for building exterior / interior and dungeon exterior doors. CustomDoor now creates its own StaticDoor data same as any DF model StaticDoor, allowing completely new custom models using non-classic model id's to be supported. 

Retained the existing copy mechanism that uses the boxcollider to test for a hit and the copied door data. This copy mechanism has been retained for backwards compatibility, code could be simplified if it were removed. I don't think it's that useful anymore. If any published mods use CustomDoor then they should continue to work identically as long as the copy index was set.

Player placement for both entering and exiting is now correct. The exception is when replacing a classic model with all building doors disabled in favour of custom doors all copying these classic doors.

Included 2 boxcollider presets for custom doors facing X or Z with standard DF door size 1.25, 2, 0.5. They're in Assets/Editor/ because Unity insisted they went in Assets folder and that seemed the most appropriate place. Will remove from PR if requested.

Ninelan will be testing this out to check my testing didn't miss anything. Instructions added to the wiki here: https://github.com/Interkarma/daggerfall-unity/wiki/Custom-Doors

Resolves #2643 