### PR TITLE
Fix for QuestListsManager.GetQuest

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModTypes.cs
+++ b/Assets/Game/Addons/ModSupport/ModTypes.cs
@@ -93,6 +93,11 @@ namespace DaggerfallWorkshop.Game.Utility.ModSupport
         public string[] QuestLists { get; internal set; }
 
         /// <summary>
+        /// Names of all quests added with quest lists
+        /// </summary>
+        public string[] LooseQuestsList { get; internal set; }
+
+        /// <summary>
         /// Names of spell icon packs; each name corresponds to a <see cref="Texture2D"/>
         /// asset and a <see cref="TextAsset"/> with `.json` extension.
         /// </summary>

--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -278,19 +278,19 @@ namespace DaggerfallWorkshop.Game.Questing
         /// </summary>
         public Quest GetQuest(string questName, int factionId = 0)
         {
-            // First check QuestSourceFolder containing classic quests.
-            string questFileName = questName + QExt;
-            string questFile = Path.Combine(QuestMachine.QuestSourceFolder, questFileName);
-            if (File.Exists(questFile))
-                return LoadQuest(questName, QuestMachine.QuestSourceFolder, factionId);
+            // First check QuestSourceFolder containing classic quests and mods.
+            Quest quest = LoadQuest(questName, QuestMachine.QuestSourceFolder, factionId);
+            if (quest != null)
+                return quest;
 
+            string questFileName = questName + QExt;
             // Check each registered init quest & containing folder.
             foreach (QuestData questData in init)
             {
                 if (questData.name == questName)
                     return LoadQuest(questData, factionId);
 
-                questFile = Path.Combine(questData.path, questFileName);
+                string questFile = Path.Combine(questData.path, questFileName);
                 if (File.Exists(questFile))
                     return LoadQuest(questName, questData.path, factionId);
             }

--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -278,19 +278,25 @@ namespace DaggerfallWorkshop.Game.Questing
         /// </summary>
         public Quest GetQuest(string questName, int factionId = 0)
         {
-            // First check QuestSourceFolder containing classic quests and mods.
-            Quest quest = LoadQuest(questName, QuestMachine.QuestSourceFolder, factionId);
-            if (quest != null)
-                return quest;
-
+            // First check QuestSourceFolder containing classic quests.
             string questFileName = questName + QExt;
+            string questFile = Path.Combine(QuestMachine.QuestSourceFolder, questFileName);
+            if (File.Exists(questFile))
+                return LoadQuest(questName, QuestMachine.QuestSourceFolder, factionId);
+            
+            // Then check if we can override or load this quest from any mod.
+            if (ModManager.Instance.AnyModContainsQuest(questName))
+            {
+                return LoadQuest(questName, "", factionId);
+            }
+
             // Check each registered init quest & containing folder.
             foreach (QuestData questData in init)
             {
                 if (questData.name == questName)
                     return LoadQuest(questData, factionId);
 
-                string questFile = Path.Combine(questData.path, questFileName);
+                questFile = Path.Combine(questData.path, questFileName);
                 if (File.Exists(questFile))
                     return LoadQuest(questName, questData.path, factionId);
             }


### PR DESCRIPTION
QuestListsManager.GetQuest() will check mods for quests as well.
I removed `if (File.Exists(questFile))` check, because `LoadQuest()` function also checks for that, and more importantly, checking mods for quest files included.
Then, if we didn't find any, we proceed as usual.