### PR TITLE
FPS Weapon Movement variable

### DIFF
--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -106,6 +106,7 @@ namespace DaggerfallWorkshop.Game
         public WeaponStates WeaponState { get { return weaponState; } }
 
         public Color Tint { get; set; } = Color.white;
+        public Vector2 Offset { get; set; } = Vector2.zero;
 
         #endregion
 
@@ -175,8 +176,23 @@ namespace DaggerfallWorkshop.Game
             {
                 // Draw weapon texture behind other HUD elements
                 Texture2D tex = curCustomTexture ? curCustomTexture : weaponAtlas.AtlasTexture;
-                DaggerfallUI.DrawTextureWithTexCoords(weaponPosition, tex, curAnimRect, true, Tint);
+                DaggerfallUI.DrawTextureWithTexCoords(GetWeaponPosition(), tex, curAnimRect, true, Tint);
             }
+        }
+
+        public Rect GetWeaponPosition()
+        {
+            if (Offset != Vector2.zero)
+            {
+                Rect weaponPositionOffset = weaponPosition;
+
+                weaponPositionOffset.x += Offset.x;
+                weaponPositionOffset.y += Offset.y;
+
+                return weaponPositionOffset;
+
+            } else
+                return weaponPosition;
         }
 
         public void OnAttackDirection(WeaponManager.MouseDirections direction)

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -108,7 +108,7 @@ namespace DaggerfallWorkshop.Game
         public Color Tint { get; set; } = Color.white;
 
         public Vector2 Position { get; set; } = Vector2.zero;   //Moves the sprite in screen distance
-        public Vector2 Scale { get; set; } = Vector2.zero;
+        public Vector2 Scale { get; set; } = Vector2.one;
         public Vector2 Offset { get; set; } = Vector2.zero;     //Moves the sprite relative to its own dimensions ("Offset.x = 0.5f" will move "sprite.width * 0.5f"). Applied after Scale.
 
         #endregion
@@ -187,8 +187,8 @@ namespace DaggerfallWorkshop.Game
         {
             if (Position != Vector2.zero)
                 Position = Vector2.zero;
-            if (Scale != Vector2.zero)
-                Scale = Vector2.zero;
+            if (Scale != Vector2.one)
+                Scale = Vector2.one;
             if (Offset != Vector2.zero)
                 Offset = Vector2.zero;
         }
@@ -196,7 +196,7 @@ namespace DaggerfallWorkshop.Game
         //Combines the base WeaponPosition Rect with Position, Scale and Offset
         public Rect GetWeaponRect()
         {
-            if (Position != Vector2.zero || Scale != Vector2.zero || Offset != Vector2.zero)
+            if (Position != Vector2.zero || Scale != Vector2.one || Offset != Vector2.zero)
             {
                 Rect weaponPositionOffset = weaponPosition;
 
@@ -204,8 +204,8 @@ namespace DaggerfallWorkshop.Game
                 weaponPositionOffset.x += Position.x;      
                 weaponPositionOffset.y += Position.y;
 
-                weaponPositionOffset.width += weaponPositionOffset.width * Scale.x;
-                weaponPositionOffset.height += weaponPositionOffset.height * Scale.y;
+                weaponPositionOffset.width *= Scale.x;
+                weaponPositionOffset.height *= Scale.y;
 
                 //Adds the Offset to the Rect's position
                 weaponPositionOffset.x += weaponPositionOffset.width * Offset.x;

--- a/Assets/Scripts/Game/FPSWeapon.cs
+++ b/Assets/Scripts/Game/FPSWeapon.cs
@@ -106,7 +106,10 @@ namespace DaggerfallWorkshop.Game
         public WeaponStates WeaponState { get { return weaponState; } }
 
         public Color Tint { get; set; } = Color.white;
-        public Vector2 Offset { get; set; } = Vector2.zero;
+
+        public Vector2 Position { get; set; } = Vector2.zero;   //Moves the sprite in screen distance
+        public Vector2 Scale { get; set; } = Vector2.zero;
+        public Vector2 Offset { get; set; } = Vector2.zero;     //Moves the sprite relative to its own dimensions ("Offset.x = 0.5f" will move "sprite.width * 0.5f"). Applied after Scale.
 
         #endregion
 
@@ -176,18 +179,37 @@ namespace DaggerfallWorkshop.Game
             {
                 // Draw weapon texture behind other HUD elements
                 Texture2D tex = curCustomTexture ? curCustomTexture : weaponAtlas.AtlasTexture;
-                DaggerfallUI.DrawTextureWithTexCoords(GetWeaponPosition(), tex, curAnimRect, true, Tint);
+                DaggerfallUI.DrawTextureWithTexCoords(GetWeaponRect(), tex, curAnimRect, true, Tint);
             }
         }
 
-        public Rect GetWeaponPosition()
+        private void LateUpdate()
         {
+            if (Position != Vector2.zero)
+                Position = Vector2.zero;
+            if (Scale != Vector2.zero)
+                Scale = Vector2.zero;
             if (Offset != Vector2.zero)
+                Offset = Vector2.zero;
+        }
+
+        //Combines the base WeaponPosition Rect with Position, Scale and Offset
+        public Rect GetWeaponRect()
+        {
+            if (Position != Vector2.zero || Scale != Vector2.zero || Offset != Vector2.zero)
             {
                 Rect weaponPositionOffset = weaponPosition;
 
-                weaponPositionOffset.x += Offset.x;
-                weaponPositionOffset.y += Offset.y;
+                //Adds the Position to the Rect's position
+                weaponPositionOffset.x += Position.x;      
+                weaponPositionOffset.y += Position.y;
+
+                weaponPositionOffset.width += weaponPositionOffset.width * Scale.x;
+                weaponPositionOffset.height += weaponPositionOffset.height * Scale.y;
+
+                //Adds the Offset to the Rect's position
+                weaponPositionOffset.x += weaponPositionOffset.width * Offset.x;
+                weaponPositionOffset.y += weaponPositionOffset.height * Offset.y;
 
                 return weaponPositionOffset;
 


### PR DESCRIPTION
Adds an Offset variable that lets other scripts move the FPS Weapon sprite while preserving the original weaponPosition variable, mostly made to support mods that add weapon sway/bob.

 [SAMPLE](https://streamable.com/p2o26c) of Offset working with mod (not included)

If nothing tries to change the FPSWeapon Offset, it should behave entirely like usual. I hope. Suggestions for better implementation are always welcome.