### PR TITLE
Fixed the Mod Loader Interface Window's Extract Text in Portable Inst

### DIFF
--- a/Assets/Game/Addons/ModSupport/ModLoaderInterfaceWindow.cs
+++ b/Assets/Game/Addons/ModSupport/ModLoaderInterfaceWindow.cs
@@ -612,7 +612,7 @@ public class ModLoaderInterfaceWindow : DaggerfallPopupWindow
         if (assets == null)
             return;
 
-        string path = Path.Combine(Application.persistentDataPath, "Mods", "ExtractedFiles", mod.FileName);
+        string path = Path.Combine(DaggerfallUnityApplication.PersistentDataPath, "Mods", "ExtractedFiles", mod.FileName);
         Directory.CreateDirectory(path);
 
         for (int i = 0; i < assets.Length; i++)


### PR DESCRIPTION
See issue at #2661.

I did a search for `Application.persistentDataPath`, it should be the last one