### PR TITLE
Fixed error during GetCourtOfCurrentRegion query in Mournoth

### DIFF
--- a/Assets/Scripts/Internal/PlayerGPS.cs
+++ b/Assets/Scripts/Internal/PlayerGPS.cs
@@ -471,7 +471,7 @@ namespace DaggerfallWorkshop
             // Find court in current region
             FactionFile.FactionData[] factions = GameManager.Instance.PlayerEntity.FactionData.FindFactions(
                 (int)FactionFile.FactionTypes.Courts,
-                (int)FactionFile.SocialGroups.Nobility,
+                -1,
                 (int)FactionFile.GuildGroups.Region,
                 CurrentRegionIndex);
 

--- a/Assets/StreamingAssets/Factions/FACTION.TXT
+++ b/Assets/StreamingAssets/Factions/FACTION.TXT
@@ -4830,7 +4830,7 @@ vam: 154
 	race: 2
 	flat: 183 3
 	flat: 183 9
-	sgroup: 2
+	sgroup: 3
 	ggroup: 15
 	flags: 0
 	minf: 20


### PR DESCRIPTION
In FACTION.TXT, you can find 44 factions of the "Court" guild type. Out of these, 43 have the social group Nobility - we have only one exception, the Court of Mournoth.

```
    #567
    type: 14
    name: Court of Mournoth
    rep: 0
    summon: -1
    region: 53
    power: 51
    face: -1
    race: 2
    flat: 183 3
    flat: 183 9
>>> sgroup: 2
    ggroup: 15
    flags: 0
    minf: 20
    maxf: 80
```

As documented at the top of FACTION.TXT, 
```
; The field sgroup should be set to one of the following values:
; COMMONER	0
; MERCHANT	1
; SCHOLAR	2
; NOBILITY	3
; UNDERWORLD	4
```
sgroup of 2 is Scholar.

In DFU's search for the current region's Court, it specified that the faction it's looking *has* to be Nobility. This is an unnecessary restriction, and causes the Scholarly Court of Mournoth to fail to return here, causing an exception to be thrown. 

This PR simply allows all social groups to be considered a court, as long as it's of the regional guild group and the court faction type