### PR TITLE
Reverse order of merchants selling quotes

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -1116,7 +1116,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                         msgOffset = 1;
                 }
                 if (WindowMode == WindowModes.Sell || WindowMode == WindowModes.SellMagic)
-                    msgOffset += 3;
+                    msgOffset = 5 - msgOffset;
 
                 DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
                 TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(TradeMessageBaseId + msgOffset);


### PR DESCRIPTION
Buying and selling dialogs are in reverse order of "success" in the resources, fix how offset is computed.

Light testing with a character with low mercantile and personality skills, messages when selling stuff went from "I'm losing my shirt" to "take it or leave it", which felt more in line. More testing welcome. 

Forums: https://forums.dfworkshop.net/viewtopic.php?t=6723