### PR TITLE
Use magic items at range while silenced

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -312,7 +312,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public bool SetReadySpell(EntityEffectBundle spell, bool noSpellPointCost = false)
         {
             // Do nothing if silenced or cast already in progress
-            if ((SilenceCheck() && !noSpellPointCost) || castInProgress)
+            if ((!noSpellPointCost && SilenceCheck()) || castInProgress)
                 return false;
 
             // Spell must appear valid
@@ -401,7 +401,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public void CastReadySpell()
         {
             // Do nothing if silenced
-            if (SilenceCheck() && !readySpellDoesNotCostSpellPoints)
+            if (!readySpellDoesNotCostSpellPoints && SilenceCheck())
                 return;
 
             // Must have a ready spell and a previous cast must not be in progress

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -401,7 +401,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
         public void CastReadySpell()
         {
             // Do nothing if silenced
-            if (SilenceCheck())
+            if (SilenceCheck() && !readySpellDoesNotCostSpellPoints)
                 return;
 
             // Must have a ready spell and a previous cast must not be in progress


### PR DESCRIPTION
In classic you can use all magic items while silenced, but in Daggerfall Unity you couldn't use magic items at range, because while silence lets you ready magic items, it does not let you release their spells.
Most likely an overlook.
    
Also, SilenceCheck() can do side effets (display "You are silenced" and reset readied spell), so when used with short-circuited logic operators, order matters and it should be placed late/last.
    
Forums: https://forums.dfworkshop.net/viewtopic.php?t=6725