### PR TITLE
Refactor FormulaHelper to read racial resistances

### DIFF
--- a/Assets/Scripts/Game/Entities/RaceTemplate.cs
+++ b/Assets/Scripts/Game/Entities/RaceTemplate.cs
@@ -187,6 +187,8 @@ namespace DaggerfallWorkshop.Game.Entity
 
             PaperDollHeadsMale = "FACE00I0.CIF";
             PaperDollHeadsFemale = "FACE10I0.CIF";
+
+            ResistanceFlags = DFCareer.EffectFlags.Magic;
         }
     }
 

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1514,7 +1514,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             var raceTemplate = playerEntity.GetLiveRaceTemplate();
             if ((elementType == DFCareer.Elements.Fire && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Fire) != 0) ||
                 (elementType == DFCareer.Elements.Frost && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Frost) != 0) ||
-                (elementType == DFCareer.Elements.DiseaseOrPoison && (raceTemplate.ResistanceFlags & (DFCareer.EffectFlags.Disease | DFCareer.EffectFlags.Poison)) != 0) ||
+                (elementType == DFCareer.Elements.DiseaseOrPoison && (raceTemplate.ResistanceFlags & effectFlags & (DFCareer.EffectFlags.Disease | DFCareer.EffectFlags.Poison)) != 0) ||
                 (elementType == DFCareer.Elements.Shock && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Shock) != 0) ||
                 (elementType == DFCareer.Elements.Magic && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Magic) != 0))
                 savingThrow += 30;

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1509,9 +1509,14 @@ namespace DaggerfallWorkshop.Game.Formulas
                 savingThrow += 25;
 
             savingThrow += biographyMod + modifier;
-            if (elementType == DFCareer.Elements.Frost && target == playerEntity && playerEntity.Race == Races.Nord)
-                savingThrow += 30;
-            else if (elementType == DFCareer.Elements.Magic && target == playerEntity && playerEntity.Race == Races.Breton)
+
+            // Apply racial resistances
+            var raceTemplate = playerEntity.GetLiveRaceTemplate();
+            if ((elementType == DFCareer.Elements.Fire && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Fire) != 0) ||
+                (elementType == DFCareer.Elements.Frost && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Frost) != 0) ||
+                (elementType == DFCareer.Elements.DiseaseOrPoison && (raceTemplate.ResistanceFlags & (DFCareer.EffectFlags.Disease | DFCareer.EffectFlags.Poison)) != 0) ||
+                (elementType == DFCareer.Elements.Shock && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Shock) != 0) ||
+                (elementType == DFCareer.Elements.Magic && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Magic) != 0))
                 savingThrow += 30;
 
             // Handle perfect immunity of 100% or greater

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1510,14 +1510,17 @@ namespace DaggerfallWorkshop.Game.Formulas
 
             savingThrow += biographyMod + modifier;
 
-            // Apply racial resistances
-            var raceTemplate = playerEntity.GetLiveRaceTemplate();
-            if ((elementType == DFCareer.Elements.Fire && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Fire) != 0) ||
-                (elementType == DFCareer.Elements.Frost && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Frost) != 0) ||
-                (elementType == DFCareer.Elements.DiseaseOrPoison && (raceTemplate.ResistanceFlags & effectFlags & (DFCareer.EffectFlags.Disease | DFCareer.EffectFlags.Poison)) != 0) ||
-                (elementType == DFCareer.Elements.Shock && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Shock) != 0) ||
-                (elementType == DFCareer.Elements.Magic && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Magic) != 0))
-                savingThrow += 30;
+            // Apply player racial resistances
+            if (target == playerEntity)
+            {
+                var raceTemplate = playerEntity.GetLiveRaceTemplate();
+                if ((elementType == DFCareer.Elements.Fire && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Fire) != 0) ||
+                    (elementType == DFCareer.Elements.Frost && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Frost) != 0) ||
+                    (elementType == DFCareer.Elements.DiseaseOrPoison && (raceTemplate.ResistanceFlags & effectFlags & (DFCareer.EffectFlags.Disease | DFCareer.EffectFlags.Poison)) != 0) ||
+                    (elementType == DFCareer.Elements.Shock && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Shock) != 0) ||
+                    (elementType == DFCareer.Elements.Magic && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Magic) != 0))
+                    savingThrow += 30;
+            }
 
             // Handle perfect immunity of 100% or greater
             // Otherwise clamping to 5-95 allows a perfectly immune character to sometimes receive incoming payload

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1460,14 +1460,24 @@ namespace DaggerfallWorkshop.Game.Formulas
             int biographyMod = 0;
 
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+
+            // Apply player racial flags
+            if (target == playerEntity)
+            {
+                var raceTemplate = playerEntity.GetLiveRaceTemplate();
+                if (SpellHasFlags(elementType, raceTemplate.ResistanceFlags, effectFlags))
+                    savingThrow += 30;
+                if (SpellHasFlags(elementType, raceTemplate.ImmunityFlags, effectFlags))
+                    savingThrow = 100;
+                if (SpellHasFlags(elementType, raceTemplate.LowToleranceFlags, effectFlags))
+                    savingThrow -= 25;
+                if (SpellHasFlags(elementType, raceTemplate.CriticalWeaknessFlags, effectFlags))
+                    savingThrow -= 50;
+            }
+
             if ((effectFlags & DFCareer.EffectFlags.Paralysis) != 0)
             {
                 toleranceFlags |= GetToleranceFlag(target.Career.Paralysis);
-                // Innate immunity if high elf. Start with 100 saving throw, but can be modified by
-                // tolerance flags. Note this differs from classic, where high elves have 100% immunity
-                // regardless of tolerance flags.
-                if (target == playerEntity && playerEntity.Race == Races.HighElf)
-                    savingThrow = 100;
             }
             if ((effectFlags & DFCareer.EffectFlags.Magic) != 0)
             {
@@ -1510,18 +1520,6 @@ namespace DaggerfallWorkshop.Game.Formulas
 
             savingThrow += biographyMod + modifier;
 
-            // Apply player racial resistances
-            if (target == playerEntity)
-            {
-                var raceTemplate = playerEntity.GetLiveRaceTemplate();
-                if ((elementType == DFCareer.Elements.Fire && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Fire) != 0) ||
-                    (elementType == DFCareer.Elements.Frost && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Frost) != 0) ||
-                    (elementType == DFCareer.Elements.DiseaseOrPoison && (raceTemplate.ResistanceFlags & effectFlags & (DFCareer.EffectFlags.Disease | DFCareer.EffectFlags.Poison)) != 0) ||
-                    (elementType == DFCareer.Elements.Shock && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Shock) != 0) ||
-                    (elementType == DFCareer.Elements.Magic && (raceTemplate.ResistanceFlags & DFCareer.EffectFlags.Magic) != 0))
-                    savingThrow += 30;
-            }
-
             // Handle perfect immunity of 100% or greater
             // Otherwise clamping to 5-95 allows a perfectly immune character to sometimes receive incoming payload
             // This doesn't seem to match immunity intent or player expectations from classic
@@ -1546,6 +1544,16 @@ namespace DaggerfallWorkshop.Game.Formulas
             }
 
             return Mathf.Clamp(percentDamageOrDuration, 0, 100);
+        }
+
+        private static bool SpellHasFlags(DFCareer.Elements elementType, DFCareer.EffectFlags checkFlags, DFCareer.EffectFlags spellEffectFlags)
+        {
+            return (elementType == DFCareer.Elements.Fire && (checkFlags & DFCareer.EffectFlags.Fire) != 0) ||
+            (elementType == DFCareer.Elements.Frost && (checkFlags & DFCareer.EffectFlags.Frost) != 0) ||
+            (elementType == DFCareer.Elements.DiseaseOrPoison && (checkFlags & spellEffectFlags & (DFCareer.EffectFlags.Disease | DFCareer.EffectFlags.Poison)) != 0) ||
+            (elementType == DFCareer.Elements.Shock && (checkFlags & DFCareer.EffectFlags.Shock) != 0) ||
+            (elementType == DFCareer.Elements.Magic && (checkFlags & DFCareer.EffectFlags.Magic) != 0) ||
+            (spellEffectFlags & DFCareer.EffectFlags.Paralysis) != 0 && (checkFlags & DFCareer.EffectFlags.Paralysis) != 0;
         }
 
         public static int SavingThrow(IEntityEffect sourceEffect, DaggerfallEntity target)


### PR DESCRIPTION
FormulaHelper previously applied racial resistances by reading the player's race directly. With this change, the saving throw calculation will be modified by the contents of the player's RaceTemplate.

Addresses the following issue:
https://github.com/Interkarma/daggerfall-unity/issues/2660