### PR TITLE
Receice quests from MG and Knights based on either rank or level

### DIFF
--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -630,7 +630,7 @@ namespace DaggerfallConnect.Arena2
         {
             RulerImmune = 0x10,
             Summoned = 0x40,
-            questByRankOrLevel = 0x100, // Not in classic
+            QuestByRankOrLevel = 0x100, // Not in classic
         }
 
         #endregion

--- a/Assets/Scripts/API/FactionFile.cs
+++ b/Assets/Scripts/API/FactionFile.cs
@@ -630,6 +630,7 @@ namespace DaggerfallConnect.Arena2
         {
             RulerImmune = 0x10,
             Summoned = 0x40,
+            questByRankOrLevel = 0x100, // Not in classic
         }
 
         #endregion

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/VampirismEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/VampirismEffect.cs
@@ -239,7 +239,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                     // Get the regional vampire clan faction id for affecting reputation on success/failure, and current rep
                     int factionId = (int)vampireClan;
                     int reputation = GameManager.Instance.PlayerEntity.FactionData.GetReputation(factionId);
-                    int rank = 0;
+                    int rank = GameManager.Instance.PlayerEntity.Level; // questByRankOrLevel flag should make that redundant, but only if FactionData.txt is up-to-date
                     int level = GameManager.Instance.PlayerEntity.Level;
 
                     // Select a quest at random from appropriate pool

--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/VampirismEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/VampirismEffect.cs
@@ -239,6 +239,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                     // Get the regional vampire clan faction id for affecting reputation on success/failure, and current rep
                     int factionId = (int)vampireClan;
                     int reputation = GameManager.Instance.PlayerEntity.FactionData.GetReputation(factionId);
+                    int rank = 0;
+                    int level = GameManager.Instance.PlayerEntity.Level;
 
                     // Select a quest at random from appropriate pool
                     Quest offeredQuest = GameManager.Instance.QuestListsManager.GetGuildQuest(
@@ -246,7 +248,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                         MembershipStatus.Member,
                         factionId,
                         reputation,
-                        GameManager.Instance.PlayerEntity.Level);
+                        rank,
+                        level);
                     if (offeredQuest != null)
                         QuestMachine.Instance.StartQuest(offeredQuest);
                 }

--- a/Assets/Scripts/Game/Questing/QuestListsManager.cs
+++ b/Assets/Scripts/Game/Questing/QuestListsManager.cs
@@ -350,7 +350,7 @@ namespace DaggerfallWorkshop.Game.Questing
                 // Modifications for Temple dual membership status
                 MembershipStatus tplMemb = (guildGroup == FactionFile.GuildGroups.HolyOrder && status != MembershipStatus.Nonmember) ? MembershipStatus.Member : status;
 
-                int rankOrLevel = GameManager.Instance.PlayerEntity.FactionData.GetFlag(factionId, FactionFile.Flags.questByRankOrLevel) ? Math.Max(rank, level) : rank;
+                int rankOrLevel = GameManager.Instance.PlayerEntity.FactionData.GetFlag(factionId, FactionFile.Flags.QuestByRankOrLevel) ? Math.Max(rank, level) : rank;
 
                 List<QuestData> pool = new List<QuestData>();
                 foreach (QuestData quest in guildQuests)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -563,7 +563,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Set up a pool of available quests.
             QuestListsManager questListsManager = GameManager.Instance.QuestListsManager;
-            questPool = questListsManager.GetGuildQuestPool(guildGroup, status, factionId, guild.GetReputation(playerEntity), guild.Rank);
+            questPool = questListsManager.GetGuildQuestPool(guildGroup, status, factionId, guild.GetReputation(playerEntity), guild.Rank, GameManager.Instance.PlayerEntity.Level);
 
             // Show the quest selection list if that feature has been enabled.
             if (DaggerfallUnity.Settings.GuildQuestListBox)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
@@ -131,10 +131,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Get the faction id for affecting reputation on success/failure, and current rep
             int factionId = witchNPC.Data.factionID;
             int reputation = GameManager.Instance.PlayerEntity.FactionData.GetReputation(factionId);
+            int rank = 0;
             int level = GameManager.Instance.PlayerEntity.Level;     // Not a proper guild so rank = player level
 
             // Select a quest at random from appropriate pool
-            offeredQuest = GameManager.Instance.QuestListsManager.GetGuildQuest(FactionFile.GuildGroups.Witches, MembershipStatus.Nonmember, factionId, reputation, level);
+            offeredQuest = GameManager.Instance.QuestListsManager.GetGuildQuest(FactionFile.GuildGroups.Witches, MembershipStatus.Nonmember, factionId, reputation, rank, level);
             if (offeredQuest != null)
             {
                 // Log offered quest

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallWitchesCovenPopupWindow.cs
@@ -131,8 +131,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Get the faction id for affecting reputation on success/failure, and current rep
             int factionId = witchNPC.Data.factionID;
             int reputation = GameManager.Instance.PlayerEntity.FactionData.GetReputation(factionId);
-            int rank = 0;
-            int level = GameManager.Instance.PlayerEntity.Level;     // Not a proper guild so rank = player level
+            int rank = GameManager.Instance.PlayerEntity.Level;     // Not a proper guild so rank = player level
+                                                                    // questByRankOrLevel flag makes that redundant, but only if FactionData.txt is up-to-date
+            int level = GameManager.Instance.PlayerEntity.Level;
 
             // Select a quest at random from appropriate pool
             offeredQuest = GameManager.Instance.QuestListsManager.GetGuildQuest(FactionFile.GuildGroups.Witches, MembershipStatus.Nonmember, factionId, reputation, rank, level);

--- a/Assets/StreamingAssets/Factions/FACTION.TXT
+++ b/Assets/StreamingAssets/Factions/FACTION.TXT
@@ -2055,7 +2055,7 @@ rep: 0
 summon: -1
 region: 63
 power: 50
-flags: 1
+flags: 257
 ally: 152
 enemy: 62
 face: -1
@@ -2074,7 +2074,7 @@ rep: 0
 summon: -1
 region: 64
 power: 50
-flags: 1
+flags: 257
 enemy: 154
 face: -1
 race: 18
@@ -2092,7 +2092,7 @@ rep: 0
 summon: -1
 region: 65
 power: 50
-flags: 1
+flags: 257
 ally: 150
 enemy: 157
 face: -1
@@ -2111,7 +2111,7 @@ rep: 0
 summon: -1
 region: 66
 power: 50
-flags: 1
+flags: 257
 enemy: 156
 face: -1
 race: 18
@@ -2129,7 +2129,7 @@ rep: 0
 summon: -1
 region: 67
 power: 50
-flags: 1
+flags: 257
 enemy: 158
 face: -1
 race: 18
@@ -2147,7 +2147,7 @@ rep: 0
 summon: -1
 region: 68
 power: 50
-flags: 1
+flags: 257
 enemy: 157
 face: -1
 race: 18
@@ -2165,7 +2165,7 @@ rep: 0
 summon: -1
 region: 69
 power: 50
-flags: 1
+flags: 257
 enemy: 158
 enemy: 153
 face: -1
@@ -2184,7 +2184,7 @@ rep: 0
 summon: -1
 region: 70
 power: 50
-flags: 1
+flags: 257
 enemy: 152
 face: -1
 race: 18
@@ -2202,7 +2202,7 @@ rep: 0
 summon: -1
 region: 71
 power: 50
-flags: 1
+flags: 257
 enemy: 154
 enemy: 150
 face: -1

--- a/Assets/StreamingAssets/Factions/FACTION.TXT
+++ b/Assets/StreamingAssets/Factions/FACTION.TXT
@@ -5724,7 +5724,7 @@ rep: 0
 summon: 4
 region: 19
 power: 25
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 184 8
@@ -5740,7 +5740,7 @@ rep: 0
 summon: 17
 region: 56
 power: 25
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 179 2
@@ -5756,7 +5756,7 @@ rep: 0
 summon: 17
 region: 2
 power: 25
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 179 4
@@ -5772,7 +5772,7 @@ rep: 0
 summon: 17
 region: 34
 power: 25
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 184 8
@@ -5788,7 +5788,7 @@ rep: 0
 summon: 17
 region: 18
 power: 15
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 179 2
@@ -5804,7 +5804,7 @@ rep: 0
 summon: 17
 region: 17
 power: 25
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 179 4
@@ -5820,7 +5820,7 @@ rep: 0
 summon: 17
 region: 41
 power: 30
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 184 8
@@ -5836,7 +5836,7 @@ rep: 0
 summon: 17
 region: 49
 power: 20
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 179 2
@@ -5852,7 +5852,7 @@ rep: 0
 summon: 17
 region: 2
 power: 25
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 179 4
@@ -5868,7 +5868,7 @@ rep: 0
 summon: 17
 region: 18
 power: 20
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 184 8
@@ -5884,7 +5884,7 @@ rep: 0
 summon: 17
 region: 33
 power: 25
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 179 2
@@ -5900,7 +5900,7 @@ rep: 0
 summon: 17
 region: 12
 power: 20
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 179 4
@@ -5916,7 +5916,7 @@ rep: 0
 summon: 17
 region: 52
 power: 15
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 184 8
@@ -5932,7 +5932,7 @@ rep: 0
 summon: 17
 region: 35
 power: 10
-flags: 1
+flags: 257
 face: -1
 race: -1
 flat: 179 2

--- a/Assets/StreamingAssets/Factions/FACTION.TXT
+++ b/Assets/StreamingAssets/Factions/FACTION.TXT
@@ -649,7 +649,7 @@ maxf: 90
 		summon: -1
 		region: -1
 		power: 25
-		flags: 0
+		flags: 256
 		face: -1
 		race: -1
 		flat: 183 3
@@ -786,7 +786,7 @@ maxf: 90
 		summon: -1
 		region: -1
 		power: 20
-		flags: 0
+		flags: 256
 		face: -1
 		race: -1
 		flat: 183 2
@@ -1677,7 +1677,7 @@ rep: 0
 summon: -1
 region: -1
 power: 60
-flags: 0
+flags: 256
 face: -1
 race: -1
 flat: 177 0
@@ -2608,6 +2608,7 @@ vam: 152
 	summon: -1
 	region: 6
 	power: 25
+	flags: 256
 	face: -1
 	race: 3
 	flat: 183 3
@@ -2848,7 +2849,7 @@ vam: 150
 		summon: -1
 		region: 18
 		power: 20
-		flags: 0
+		flags: 256
 		ally: 371
 		face: -1
 		race: 3
@@ -3038,7 +3039,7 @@ vam: 150
 	summon: -1
 	region: 19
 	power: 15
-	flags: 0
+	flags: 256
 	face: -1
 	race: 3
 	flat: 183 3
@@ -3277,7 +3278,7 @@ vam: 151
 		summon: -1
 		region: 22
 		power: 20
-		flags: 0
+		flags: 256
 		ally: 400
 		face: -1
 		race: 3
@@ -3415,7 +3416,7 @@ vam: 154
 		summon: -1
 		region: 23
 		power: 25
-		flags: 0
+		flags: 256
 		face: -1
 		race: 2
 		flat: 183 2
@@ -3642,7 +3643,7 @@ vam: 154
 		summon: -1
 		region: 24
 		power: 20
-		flags: 0
+		flags: 256
 		ally: 390
 		enemy: 357
 		face: -1
@@ -4348,7 +4349,7 @@ vam: 158
 	summon: -1
 	region: 44
 	power: 20
-	flags: 0
+	flags: 256
 	face: -1
 	race: 2
 	flat: 183 3
@@ -4790,7 +4791,7 @@ vam: 155
 	summon: -1
 	region: 52
 	power: 17
-	flags: 0
+	flags: 256
 	face: -1
 	race: 2
 	flat: 183 3
@@ -5019,7 +5020,7 @@ vam: 157
 	summon: -1
 	region: 56
 	power: 25
-	flags: 0
+	flags: 256
 	face: -1
 	race: 2
 	flat: 183 2


### PR DESCRIPTION
In classic Daggerfall, Mages guild and knightly orders can provide quests not only if the player's rank is sufficient, but also if his/her level is sufficient. This PR implements this behavior.

This uses a bit in FactionData's flags, so I think it could be set by mods too.

I provided stubs for mods backward compatibility, even if I don't know if any mod overrides QuestListManager.GetGuildQuest() or QuestListManager.GetGuildQuestPool()

Remark: FACTION.TXT is parsed then cached in FactionData.txt in saves, so you may have to edit or remove FactionData.txt to get updated faction data?

Forums:
https://forums.dfworkshop.net/viewtopic.php?p=68013#p68013
https://forums.dfworkshop.net/viewtopic.php?p=43591#p43591