### PR TITLE
Control-U during character class creation resets bonus pool

### DIFF
--- a/Assets/Scripts/Game/UserInterface/DaggerfallShortcut.cs
+++ b/Assets/Scripts/Game/UserInterface/DaggerfallShortcut.cs
@@ -47,6 +47,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
             MainMenuStart,
             MainMenuExit,
 
+            // Class Creation Menu
+            ResetBonusPool,
+
             // Options menu
             OptionsExit,
             OptionsContinue,

--- a/Assets/Scripts/Game/UserInterfaceWindows/CreateCharCustomClass.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/CreateCharCustomClass.cs
@@ -100,6 +100,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Rect specialAdvantageButtonRect = new Rect(249, 98, 66, 22);
         Rect specialDisadvantageButtonRect = new Rect(249, 122, 66, 22);
         Rect reputationButtonRect = new Rect(249, 146, 66, 22);
+        Rect resetButtonRect = new Rect(0, 0, 0,0);
         Rect exitButtonRect = new Rect(263, 172, 38, 21);
 
         #endregion
@@ -113,6 +114,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Button specialAdvantageButton;
         Button specialDisadvantageButton;
         Button reputationButton;
+        Button resetButton;
         Button exitButton;
 
         #endregion
@@ -250,6 +252,11 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             reputationButton = DaggerfallUI.AddButton(reputationButtonRect, NativePanel);
             reputationButton.OnMouseClick += ReputationButton_OnMouseClick;
             reputationButton.ClickSound = DaggerfallUI.Instance.GetAudioClip(SoundClips.ButtonClick);
+
+            // (Hidden) Reset bonus pool
+            resetButton = DaggerfallUI.AddButton(resetButtonRect, NativePanel);
+            resetButton.Hotkey = DaggerfallShortcut.GetBinding(DaggerfallShortcut.Buttons.ResetBonusPool);
+            resetButton.OnKeyboardEvent += ResetButton_OnKeyboardEvent;
 
             // Exit button
             exitButton = DaggerfallUI.AddButton(exitButtonRect, NativePanel);
@@ -392,6 +399,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         {
             createCharReputationWindow = new CreateCharReputationWindow(uiManager, this);
             uiManager.PushWindow(createCharReputationWindow);
+        }
+
+        protected virtual void ResetButton_OnKeyboardEvent(BaseScreenComponent sender, Event keyboardEvent)
+        {
+            if (keyboardEvent.type == EventType.KeyDown)
+            {
+                DaggerfallUI.Instance.PlayOneShot(SoundClips.ButtonClick);
+                statsRollout.BonusPool = 0;
+            }
         }
 
         void ExitButton_OnMouseClick(BaseScreenComponent sender, Vector2 position)

--- a/Assets/StreamingAssets/Text/DialogShortcuts.txt
+++ b/Assets/StreamingAssets/Text/DialogShortcuts.txt
@@ -38,6 +38,9 @@ MainMenuLoad,         L
 MainMenuStart,        S
 MainMenuExit,         E
 
+-- Character class creation menu
+ResetBonusPool,       Ctrl-U
+
 -- Options menu
 OptionsExit,          E
 OptionsContinue,      C

--- a/Assets/StreamingAssets/Text/DialogShortcuts.txt
+++ b/Assets/StreamingAssets/Text/DialogShortcuts.txt
@@ -38,7 +38,7 @@ MainMenuLoad,         L
 MainMenuStart,        S
 MainMenuExit,         E
 
--- Character class creation menu
+-- Character class creation screen
 ResetBonusPool,       Ctrl-U
 
 -- Options menu


### PR DESCRIPTION
Classic Daggerfall uses plain U key, but since in Daggerfall Unity the class name input field always has focus, that key would add an U character to the class name instead.

Remark: Under Linux, keyboard handling behaves a bit differently in the Unity Editor and in the Standalone Player: standalone player filters out control characters, while the editor does not, adding a "?" in the class name when Control-U is pressed. They could be filtered explicitly:

```diff
diff --git a/Assets/Scripts/Game/UserInterface/TextBox.cs b/Assets/Scripts/Game/UserInterface/TextBox.cs
index 9da458cef..6d660339f 100644
--- a/Assets/Scripts/Game/UserInterface/TextBox.cs +++ b/Assets/Scripts/Game/UserInterface/TextBox.cs @@ -453,6 +453,14 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         }
                     }
                 }
+                else // !numeric
+                {
+                    // Filter control characters
+                    if ((int)character < 0x20)
+                    {
+                        return;
+                    }
+                }

                 // For upper only, force everything to caps
                 if (upperOnly)
```
but it seems less risky to just be aware of this small problem happening in the Editor only.
(just tested that the problem doesn't occur under Windows).