### PR TITLE
Fix spell absorption capping

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -2131,6 +2131,10 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
                 lastSpell = readySpell;
                 lastReadySpellCastingCost = readySpellCastingCost;
             }
+            else
+            {
+                lastReadySpellCastingCost = 0;
+            }
             readySpell = null;
             readySpellCastingCost = 0;
             instantCast = false;

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -2126,14 +2126,14 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
             // Clear ready spell and reset casting - do not update last spell if casting from item
             RaiseOnCastReadySpell(readySpell);
-            if (!readySpellDoesNotCostSpellPoints)
+            if (readySpellDoesNotCostSpellPoints)
             {
-                lastSpell = readySpell;
-                lastReadySpellCastingCost = readySpellCastingCost;
+                lastReadySpellCastingCost = 0;
             }
             else
             {
-                lastReadySpellCastingCost = 0;
+                lastSpell = readySpell;
+                lastReadySpellCastingCost = readySpellCastingCost;
             }
             readySpell = null;
             readySpellCastingCost = 0;


### PR DESCRIPTION
When absorbing magicka from own spells, DFU explicitly ensures that magicka recovered is not larger than the magicka that was used. For this, it needs to track how much magicka was spent for the last spell: lastReadySpellCastingCost

A special case was not correctly handled though: when the last spell came from a magic item, lastReadySpellCastingCost should be set 0 so that next absorption of own spells is not capped.
That worked by luck when the game was just started because lastReadySpellCastingCost was still 0, but broke after first spell casting.

Forums: https://forums.dfworkshop.net/viewtopic.php?t=6755