### PR TITLE
Fix enemies sometimes hearing thru walls

### DIFF
--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -923,24 +923,30 @@ namespace DaggerfallWorkshop.Game
             return seen;
         }
 
+        readonly int defaultLayerOnlyMask = 1 << LayerMask.NameToLayer("Default");
+
         bool CanHearTarget()
         {
             float hearingScale = 1f;
 
-            // If something is between enemy and target then return false (was reduce hearingScale by half), to minimize
-            // enemies walking against walls.
-            // Hearing is not impeded by doors or other non-static objects
-            RaycastHit hit;
-            Ray ray = new Ray(transform.position, directionToTarget);
-            if (Physics.Raycast(ray, out hit))
+            // TODO: Modify this by how much noise the target is making
+            if (distanceToTarget < (HearingRadius * hearingScale) + mobile.Enemy.HearingModifier)
             {
-                //DaggerfallEntityBehaviour entity = hit.transform.gameObject.GetComponent<DaggerfallEntityBehaviour>();
-                if (GameObjectHelper.IsStaticGeometry(hit.transform.gameObject))
-                    return false;
+                // If something is between enemy and target then return false (was reduce hearingScale by half), to minimize
+                // enemies walking against walls.
+                // Hearing is not impeded by doors or other non-static objects
+                Ray ray = new Ray(transform.position, directionToTarget);
+                RaycastHit[] hits = Physics.RaycastAll(ray, distanceToTarget); // , defaultLayerOnlyMask 
+                foreach (RaycastHit hit in hits)
+                {
+                    //DaggerfallEntityBehaviour entity = hit.transform.gameObject.GetComponent<DaggerfallEntityBehaviour>();
+                    if (GameObjectHelper.IsStaticGeometry(hit.transform.gameObject))
+                        return false;
+                }
+                return true;
             }
 
-            // TODO: Modify this by how much noise the target is making
-            return distanceToTarget < (HearingRadius * hearingScale) + mobile.Enemy.HearingModifier;
+            return false;
         }
 
         #endregion

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -923,11 +923,14 @@ namespace DaggerfallWorkshop.Game
             return seen;
         }
 
-        readonly int defaultLayerOnlyMask = 1 << LayerMask.NameToLayer("Default");
+        int defaultLayerOnlyMask = 0;
 
         bool CanHearTarget()
         {
             float hearingScale = 1f;
+
+            if (defaultLayerOnlyMask == 0)
+                defaultLayerOnlyMask = 1 << LayerMask.NameToLayer("Default");
 
             // TODO: Modify this by how much noise the target is making
             if (distanceToTarget < (HearingRadius * hearingScale) + mobile.Enemy.HearingModifier)
@@ -936,7 +939,7 @@ namespace DaggerfallWorkshop.Game
                 // enemies walking against walls.
                 // Hearing is not impeded by doors or other non-static objects
                 Ray ray = new Ray(transform.position, directionToTarget);
-                RaycastHit[] hits = Physics.RaycastAll(ray, distanceToTarget); // , defaultLayerOnlyMask 
+                RaycastHit[] hits = Physics.RaycastAll(ray, distanceToTarget, defaultLayerOnlyMask);
                 foreach (RaycastHit hit in hits)
                 {
                     //DaggerfallEntityBehaviour entity = hit.transform.gameObject.GetComponent<DaggerfallEntityBehaviour>();

--- a/Assets/Scripts/Game/EnemySenses.cs
+++ b/Assets/Scripts/Game/EnemySenses.cs
@@ -946,7 +946,7 @@ namespace DaggerfallWorkshop.Game
                     if (nhits < hitsBuffer.Length)
                         break;
                     // hitsBuffer may have overflowed, retry with a larger buffer
-                    hitsBuffer = new RaycastHit[nhits + 1];
+                    hitsBuffer = new RaycastHit[hitsBuffer.Length * 2];
                 };
                 for (int i = 0; i < nhits; i++)
                 {


### PR DESCRIPTION

Previous code checked that the first obstacle between an enemy and its target was an object tagged "static" to determine if the enemy could hear the target (followed by a distance check).
In some cases that allowed enemies to hear targets when they shouldn't (other static tagged objects along the "line of hearing" not checked), leading to enemies facing walls or still chasing enemies thru walls when you encounter them.

This PR first checks for distance to target (like CanSeeTarget() does), then checks if they're no object tagged static inbetween the enemy and its target.
As an optimization, only objects on layer "Default" are considered, and Physics.RaycastNonAlloc() API is used to lower memory allocations.

Forums: https://forums.dfworkshop.net/viewtopic.php?t=6759