### PR TITLE
Always display negociated prices

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -1102,25 +1102,26 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             int msgOffset = 0;
             int tradePrice = GetTradePrice();
 
+            if (cost >> 1 <= tradePrice)
+            {
+                if (cost - (cost >> 2) <= tradePrice)
+                    msgOffset = 2;
+                else
+                    msgOffset = 1;
+            }
+            if (WindowMode == WindowModes.Sell || WindowMode == WindowModes.SellMagic)
+                msgOffset += 3;
+
+            DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
+            TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(TradeMessageBaseId + msgOffset);
+            messageBox.SetTextTokens(tokens, this);
             if (WindowMode != WindowModes.Sell && WindowMode != WindowModes.SellMagic && PlayerEntity.GetGoldAmount() < tradePrice)
             {
-                DaggerfallUI.MessageBox(NotEnoughGoldId);
+                messageBox.ClickAnywhereToClose = true;
+                messageBox.Show();
             }
             else
             {
-                if (cost >> 1 <= tradePrice)
-                {
-                    if (cost - (cost >> 2) <= tradePrice)
-                        msgOffset = 2;
-                    else
-                        msgOffset = 1;
-                }
-                if (WindowMode == WindowModes.Sell || WindowMode == WindowModes.SellMagic)
-                    msgOffset += 3;
-
-                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
-                TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(TradeMessageBaseId + msgOffset);
-                messageBox.SetTextTokens(tokens, this);
                 messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
                 messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No);
                 messageBox.OnButtonClick += ConfirmTrade_OnButtonClick;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -1112,7 +1112,6 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (WindowMode == WindowModes.Sell || WindowMode == WindowModes.SellMagic)
                 msgOffset += 3;
 
-            DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
             TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(TradeMessageBaseId + msgOffset);
             if (WindowMode != WindowModes.Sell && WindowMode != WindowModes.SellMagic && PlayerEntity.GetGoldAmount() < tradePrice)
             {
@@ -1121,14 +1120,13 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 combineTokens.AddRange(tokens);
                 combineTokens.Add(new TextFile.Token(TextFile.Formatting.NewLineOffset, null));
                 combineTokens.AddRange(notEnoughGoldTokens);
-                messageBox.SetTextTokens(combineTokens.ToArray(), this);
-                messageBox.ClickAnywhereToClose = true;
-                messageBox.Show();
+                DaggerfallUI.MessageBox(combineTokens.ToArray(), this);
             }
             else
             {
+                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
                 messageBox.SetTextTokens(tokens, this);
-                messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
+                messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes, true);
                 messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No);
                 messageBox.OnButtonClick += ConfirmTrade_OnButtonClick;
                 uiManager.PushWindow(messageBox);

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -1120,6 +1120,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 combineTokens.AddRange(tokens);
                 combineTokens.Add(new TextFile.Token(TextFile.Formatting.NewLineOffset, null));
                 combineTokens.AddRange(notEnoughGoldTokens);
+                combineTokens.Add(TextFile.CreateFormatToken(TextFile.Formatting.JustifyCenter));
                 DaggerfallUI.MessageBox(combineTokens.ToArray(), this);
             }
             else

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -1114,14 +1114,20 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             DaggerfallMessageBox messageBox = new DaggerfallMessageBox(uiManager, this);
             TextFile.Token[] tokens = DaggerfallUnity.Instance.TextProvider.GetRandomTokens(TradeMessageBaseId + msgOffset);
-            messageBox.SetTextTokens(tokens, this);
             if (WindowMode != WindowModes.Sell && WindowMode != WindowModes.SellMagic && PlayerEntity.GetGoldAmount() < tradePrice)
             {
+                TextFile.Token[] notEnoughGoldTokens = DaggerfallUnity.Instance.TextProvider.GetRSCTokens(NotEnoughGoldId);
+                var combineTokens = new List<TextFile.Token>();
+                combineTokens.AddRange(tokens);
+                combineTokens.Add(new TextFile.Token(TextFile.Formatting.NewLineOffset, null));
+                combineTokens.AddRange(notEnoughGoldTokens);
+                messageBox.SetTextTokens(combineTokens.ToArray(), this);
                 messageBox.ClickAnywhereToClose = true;
                 messageBox.Show();
             }
             else
             {
+                messageBox.SetTextTokens(tokens, this);
                 messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
                 messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No);
                 messageBox.OnButtonClick += ConfirmTrade_OnButtonClick;


### PR DESCRIPTION
When trying to buy from a shop and not having enough gold to pay the negociated price,

In classic Daggerfall:
- displays the same dialog box as usual, with merchant negociated price message, and Yes/No buttons;
- if you click on No, dialog box just closes;
- if you click on Yes, a message box "You don't have enough gold" is displayed

In Daggerfall Unity:
- you get the message box "You don't have enough gold"

So you never learn the negociated price, and how far you are from being able to afford buying what you are interested in.

This PR replaces the "You don't have enough gold" message with the merchant negociated price message.