### PR TITLE
Handle being silenced during casting animation

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -2097,6 +2097,8 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
 
         private void PlayerSpellCasting_OnReleaseFrame()
         {
+            castInProgress = false;
+
             // Must have a ready spell
             if (readySpell == null)
                 return;
@@ -2134,7 +2136,6 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             readySpell = null;
             readySpellCastingCost = 0;
             instantCast = false;
-            castInProgress = false;
             readySpellDoesNotCostSpellPoints = false;
         }
 


### PR DESCRIPTION
If player is silenced, only readySpell is reset by SilenceCheck(): https://github.com/Interkarma/daggerfall-unity/blob/master/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs#L1941

If this happens during spellcasting animation, castInProgress is true, and stays at true after the animation is finished because the first thing PlayerSpellCasting_OnReleaseFrame() checks is whether readySpell is not null:
https://github.com/Interkarma/daggerfall-unity/blob/master/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs#L2101

Consequently, player cannot cast spells until (s)he reload a game.

This PR resets castInProgress unconditionally at the beginning of PlayerSpellCasting_OnReleaseFrame(), which is consistent with the animation being over.

Forums: https://forums.dfworkshop.net/viewtopic.php?t=6763