### PR TITLE
Allow to close console with Escape key

### DIFF
--- a/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
+++ b/Assets/Game/Addons/UnityConsole/Console/Scripts/ConsoleController.cs
@@ -55,8 +55,8 @@ namespace Wenzil.Console
         {
             if (DaggerfallWorkshop.Game.InputManager.Instance.GetKeyDown(toggleKey))
                 ui.ToggleConsole();
-            else if (DaggerfallWorkshop.Game.InputManager.Instance.GetBackButtonDown() && closeOnEscape)
-                ui.CloseConsole();
+            else if (closeOnEscape && ui.isConsoleOpen && DaggerfallWorkshop.Game.InputManager.Instance.GetBackButtonUp())
+                ui.ToggleConsole();
             else if (Input.GetKeyDown(KeyCode.UpArrow))
                 NavigateInputHistory(true);
             else if (Input.GetKeyDown(KeyCode.DownArrow))

--- a/Assets/Scenes/DaggerfallUnityGame.unity
+++ b/Assets/Scenes/DaggerfallUnityGame.unity
@@ -2625,6 +2625,10 @@ PrefabInstance:
       propertyPath: m_Value
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 11400012, guid: 312abd0527754e047a6bfbc424f09ace, type: 3}
+      propertyPath: closeOnEscape
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 11400024, guid: 312abd0527754e047a6bfbc424f09ace, type: 3}
       propertyPath: m_FontData.m_Font
       value: 


### PR DESCRIPTION
Saw a streamer struggle twice because he opened the console unintentionally and had no idea how to close it, so closed and restarted the game instead.

Unless there's any inconvenience, I think it would be best to enable by default an already existing feature of the console: allow to close it with the Escape key in addition to the console toggle key.

(some additional fixes required because of bit rot)