### PR TITLE
Allow guild quests to be dispensed by player level as well as rank

### DIFF
--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -48,6 +48,11 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public abstract List<DFCareer.Skills> TrainingSkills { get; }
 
+        public virtual bool IsAllowLevelQuests()
+        {
+            return false;
+        }
+
         #endregion
 
         #region Guild Ranks

--- a/Assets/Scripts/Game/Guilds/Guild.cs
+++ b/Assets/Scripts/Game/Guilds/Guild.cs
@@ -48,7 +48,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public abstract List<DFCareer.Skills> TrainingSkills { get; }
 
-        public virtual bool IsAllowLevelQuests()
+        public virtual bool IsSatisfyQuestReqByLevel()
         {
             return false;
         }

--- a/Assets/Scripts/Game/Guilds/IGuild.cs
+++ b/Assets/Scripts/Game/Guilds/IGuild.cs
@@ -30,6 +30,8 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         List<DFCareer.Skills> TrainingSkills { get; }
 
+        bool IsAllowLevelQuests();
+
         #endregion
 
         #region Guild Ranks

--- a/Assets/Scripts/Game/Guilds/IGuild.cs
+++ b/Assets/Scripts/Game/Guilds/IGuild.cs
@@ -30,7 +30,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         List<DFCareer.Skills> TrainingSkills { get; }
 
-        bool IsAllowLevelQuests();
+        bool IsSatisfyQuestReqByLevel();
 
         #endregion
 

--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -80,6 +80,11 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public override List<DFCareer.Skills> TrainingSkills { get { return null; } }
 
+        public override bool IsAllowLevelQuests()
+        {
+            return true;
+        }
+
         #endregion
 
         #region Knightly Order

--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -80,7 +80,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public override List<DFCareer.Skills> TrainingSkills { get { return null; } }
 
-        public override bool IsAllowLevelQuests()
+        public override bool IsSatisfyQuestReqByLevel()
         {
             return true;
         }

--- a/Assets/Scripts/Game/Guilds/MagesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/MagesGuild.cs
@@ -64,6 +64,11 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public override List<DFCareer.Skills> TrainingSkills { get { return trainingSkills; } }
 
+        public override bool IsAllowLevelQuests()
+        {
+            return true;
+        }
+
         #endregion
 
         #region Guild Membership and Faction

--- a/Assets/Scripts/Game/Guilds/MagesGuild.cs
+++ b/Assets/Scripts/Game/Guilds/MagesGuild.cs
@@ -64,7 +64,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         public override List<DFCareer.Skills> TrainingSkills { get { return trainingSkills; } }
 
-        public override bool IsAllowLevelQuests()
+        public override bool IsSatisfyQuestReqByLevel()
         {
             return true;
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -563,7 +563,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             // Set the effective guild rank, player level can override for some guilds. (e.g. Mages/Knights)
             int rank = guild.Rank;
-            if (guild.IsAllowLevelQuests() && playerEntity.Level > rank)
+            if (guild.IsSatisfyQuestReqByLevel() && playerEntity.Level > rank)
                 rank = playerEntity.Level;
 
             // Set up a pool of available quests.

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -561,9 +561,14 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             // Get the faction id for affecting reputation on success/failure
             int factionId = GetFactionIdForGuild();
 
+            // Set the effective guild rank, player level can override for some guilds. (e.g. Mages/Knights)
+            int rank = guild.Rank;
+            if (guild.IsAllowLevelQuests() && playerEntity.Level > rank)
+                rank = playerEntity.Level;
+
             // Set up a pool of available quests.
             QuestListsManager questListsManager = GameManager.Instance.QuestListsManager;
-            questPool = questListsManager.GetGuildQuestPool(guildGroup, status, factionId, guild.GetReputation(playerEntity), guild.Rank);
+            questPool = questListsManager.GetGuildQuestPool(guildGroup, status, factionId, guild.GetReputation(playerEntity), rank);
 
             // Show the quest selection list if that feature has been enabled.
             if (DaggerfallUnity.Settings.GuildQuestListBox)

--- a/Assets/StreamingAssets/Tables/QuestList-Classic.txt
+++ b/Assets/StreamingAssets/Tables/QuestList-Classic.txt
@@ -151,9 +151,9 @@ Q0C00Y06, Witches, N, 0, 0, Passed
 Q0C00Y07, Witches, N, 0, 0, Passed
 Q0C00Y08, Witches, N, 0, 0, Passed
 Q0C0XY02, Witches, N, 0, X, Passed
-Q0C10Y00, Witches, N, 10, 0, Passed
-Q0C20Y02, Witches, N, 20, 0, Passed
-Q0C4XY04, Witches, N, 40, X, Passed
+Q0C10Y00, Witches, N, 1, 0, Passed
+Q0C20Y02, Witches, N, 2, 0, Passed
+Q0C4XY04, Witches, N, 4, X, Passed
 
 -- Commoners
 A0C00Y00, Commoners, N, 0, 0, Passed


### PR DESCRIPTION
Guild quests can be dispensed by player level as well as rank if minReq is <10 depending on the guild implementation. Proposed alternative to #2678 .

Enabled for Mages Guild and Knightly Orders.

Will add for Witch Coverns if evidence from classic Daggerfall is provided that contradicts https://en.uesp.net/wiki/Daggerfall:Witch_Covens

Only other thought is whether this change should have a way to disable this for players who prefer how DFU 1.0 currently works. Happy to add a setting or ini file property if you think worthwhile, @KABoissonneault & @petchema ?