### PR TITLE
Fixed binary incompatibility introduced by #2632

### DIFF
--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -77,17 +77,19 @@ namespace DaggerfallWorkshop.Game.Banking
 
     public static class DaggerfallBankManager
     {
-        private static float cachedGoldUnitWeightInKg = -1.0f;
-        public static float goldUnitWeightInKg
+        private static float cachedGoldItemWeightInKg = -1.0f;
+        // Returns the weight of a single gold coin based on the item template
+        public static float goldItemWeightInKg
         {
             get
             {
-                if (cachedGoldUnitWeightInKg == -1.0f)
-                    cachedGoldUnitWeightInKg = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Currency, 0).baseWeight;
-                return cachedGoldUnitWeightInKg;
+                if (cachedGoldItemWeightInKg == -1.0f)
+                    cachedGoldItemWeightInKg = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Currency, 0).baseWeight;
+                return cachedGoldItemWeightInKg;
             }
         }
-        
+
+        [Obsolete("Replace with 'goldItemWeightInKg'")] public const float goldUnitWeightInKg = 0.0025f;
         private const float deedSellMult = 0.85f;
         private const float housePriceMult = 1280f;
         private const uint loanRepayMinutes = DaggerfallDateTime.DaysPerYear * DaggerfallDateTime.MinutesPerDay;

--- a/Assets/Scripts/Game/DaggerfallBankManager.cs
+++ b/Assets/Scripts/Game/DaggerfallBankManager.cs
@@ -77,19 +77,19 @@ namespace DaggerfallWorkshop.Game.Banking
 
     public static class DaggerfallBankManager
     {
-        private static float cachedGoldItemWeightInKg = -1.0f;
-        // Returns the weight of a single gold coin based on the item template
-        public static float goldItemWeightInKg
+        private static float cachedGoldPieceWeightInKg = -1.0f;
+        // Returns the weight of a single gold piece based on the item template
+        public static float goldPieceWeightInKg
         {
             get
             {
-                if (cachedGoldItemWeightInKg == -1.0f)
-                    cachedGoldItemWeightInKg = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Currency, 0).baseWeight;
-                return cachedGoldItemWeightInKg;
+                if (cachedGoldPieceWeightInKg == -1.0f)
+                    cachedGoldPieceWeightInKg = DaggerfallUnity.Instance.ItemHelper.GetItemTemplate(ItemGroups.Currency, 0).baseWeight;
+                return cachedGoldPieceWeightInKg;
             }
         }
 
-        [Obsolete("Replace with 'goldItemWeightInKg'")] public const float goldUnitWeightInKg = 0.0025f;
+        [Obsolete("Replace with 'goldPieceWeightInKg'")] public const float goldUnitWeightInKg = 0.0025f;
         private const float deedSellMult = 0.85f;
         private const float housePriceMult = 1280f;
         private const uint loanRepayMinutes = DaggerfallDateTime.DaysPerYear * DaggerfallDateTime.MinutesPerDay;
@@ -367,7 +367,7 @@ namespace DaggerfallWorkshop.Game.Banking
 
             // Check weight limit
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
-            if (playerEntity.CarriedWeight + (amount * goldUnitWeightInKg) > playerEntity.MaxEncumbrance)
+            if (playerEntity.CarriedWeight + (amount * goldPieceWeightInKg) > playerEntity.MaxEncumbrance)
                 return TransactionResult.TOO_HEAVY;
 
             BankAccounts[regionIndex].accountGold -= amount;

--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -181,7 +181,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public int DarkBrotherhoodRequirementTally { get { return darkBrotherhoodRequirementTally; } set { darkBrotherhoodRequirementTally = value; } }
         public uint TimeToBecomeVampireOrWerebeast { get { return timeToBecomeVampireOrWerebeast; } set { timeToBecomeVampireOrWerebeast = value; } }
         public uint LastTimePlayerAteOrDrankAtTavern { get { return lastTimePlayerAteOrDrankAtTavern; } set { lastTimePlayerAteOrDrankAtTavern = value; } }
-        public float CarriedWeight { get { return Items.GetWeight() + (goldPieces * DaggerfallBankManager.goldUnitWeightInKg); } }
+        public float CarriedWeight { get { return Items.GetWeight() + (goldPieces * DaggerfallBankManager.goldPieceWeightInKg); } }
         public float WagonWeight { get { return WagonItems.GetWeight(); } }
         public RegionDataRecord[] RegionData { get { return regionData; } set { regionData = value; } }
         public uint LastGameMinutes { get { return lastGameMinutes; } set { lastGameMinutes = value; } }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -1296,7 +1296,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             if (usingWagon)
             {
                 // Check wagon weight limit
-                int wagonCanHold = ComputeCanHoldAmount(playerGold, DaggerfallBankManager.goldUnitWeightInKg, ItemHelper.WagonKgLimit, remoteItems.GetWeight());
+                int wagonCanHold = ComputeCanHoldAmount(playerGold, DaggerfallBankManager.goldPieceWeightInKg, ItemHelper.WagonKgLimit, remoteItems.GetWeight());
                 if (goldToDrop > wagonCanHold)
                 {
                     goldToDrop = wagonCanHold;
@@ -2249,7 +2249,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         private void UpdateItemInfoPanelGold()
         {
             int gold = GameManager.Instance.PlayerEntity.GoldPieces;
-            float weight = gold * DaggerfallBankManager.goldUnitWeightInKg;
+            float weight = gold * DaggerfallBankManager.goldPieceWeightInKg;
             TextFile.Token[] tokens = {
                 TextFile.CreateTextToken(string.Format(goldAmount, gold)),
                 TextFile.NewLineToken,

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTradeWindow.cs
@@ -1035,7 +1035,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
                 {
                     case WindowModes.Sell:
                     case WindowModes.SellMagic:
-                        float goldWeight = tradePrice * DaggerfallBankManager.goldUnitWeightInKg;
+                        float goldWeight = tradePrice * DaggerfallBankManager.goldPieceWeightInKg;
                         if (PlayerEntity.CarriedWeight + goldWeight <= PlayerEntity.MaxEncumbrance)
                         {
                             PlayerEntity.GoldPieces += tradePrice;


### PR DESCRIPTION
While the changes introduced by #2632 do not require users to change their source to work (API compatible), it does prevent mods compiled on another DFU version from working (ABI incompatible).

For example, Jagget tested current master on v1.1.1, and got the following error:
```
System.MissingMethodException: single DaggerfallWorkshop.Game.Banking.DaggerfallBankManager.get_goldUnitWeightInKg()
  at Game.Mods.UncannyUI.Scripts.UncannyInventoryWindow.UpdateLocalTargetIcon () [0x0001e] in <73871b0f6c3841c4ab7a9171904397a8>:0 
  at Game.Mods.UncannyUI.Scripts.UncannyInventoryWindow.Setup () [0x00614] in <73871b0f6c3841c4ab7a9171904397a8>:0 
  at DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallBaseWindow.Update () [0x00069] in <10d69f57d88e45598ab36ac2d243732c>:0 
  at DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallPopupWindow.Update () [0x00000] in <10d69f57d88e45598ab36ac2d243732c>:0 
  at DaggerfallWorkshop.Game.UserInterfaceWindows.DaggerfallInventoryWindow.Update () [0x00000] in <10d69f57d88e45598ab36ac2d243732c>:0 
  at Game.Mods.UncannyUI.Scripts.UncannyInventoryWindow.Update () [0x00000] in <73871b0f6c3841c4ab7a9171904397a8>:0 
  at DaggerfallWorkshop.Game.DaggerfallUI.Update () [0x000d8] in <10d69f57d88e45598ab36ac2d243732c>:0 
```
Without changing his code, the code now relied on the `get` from `goldUnitWeightInKg`, which did not exist in v1.1.1. This is not an issue, since mods don't have to support older versions. But it does show that the opposite problem would occur if a mod expected a `const` and found only a `get`.

See 44b829bb659f66374b7c301503 for reference. 

I reintroduced goldUnitWeightInKg as an obsolete constant (warns if users recompile their mods without changing to the new variable), and changed the new variable to 'goldItemWeightInKg'