### PR TITLE
Auto-Dismount After OnPreTransition

### DIFF
--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -199,7 +199,8 @@ namespace DaggerfallWorkshop.Game
             neighClip = dfAudioSource.GetAudioClip((int)horseSound);
 
             // Init event listener for transitions.
-            PlayerEnterExit.OnPreTransition += new PlayerEnterExit.OnPreTransitionEventHandler(HandleTransition);
+            PlayerEnterExit.OnTransitionInterior += HandleTransition;
+            PlayerEnterExit.OnTransitionDungeonInterior += HandleTransition;
         }
 
         // Handle interior/exterior transition events by setting transport mode to Foot.

--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -50,6 +50,10 @@ namespace DaggerfallWorkshop.Game
             get { return mode; }
             set { UpdateMode(value); }
         }
+        public TransportModes PreviousTransportMode
+        {
+            get { return previousTransportMode; }
+        }
 
         /// <summary>True when player is on foot.</summary>
         public bool IsOnFoot
@@ -142,6 +146,9 @@ namespace DaggerfallWorkshop.Game
         #region Private Fields
 
         private TransportModes mode = TransportModes.Foot;
+
+        private TransportModes previousTransportMode = TransportModes.Foot;
+
         private PlayerPositionData_v1 boardShipPosition;    // Holds the player position from before boarding a ship.
 
 
@@ -199,8 +206,7 @@ namespace DaggerfallWorkshop.Game
             neighClip = dfAudioSource.GetAudioClip((int)horseSound);
 
             // Init event listener for transitions.
-            PlayerEnterExit.OnTransitionInterior += HandleTransition;
-            PlayerEnterExit.OnTransitionDungeonInterior += HandleTransition;
+            PlayerEnterExit.OnPreTransition += new PlayerEnterExit.OnPreTransitionEventHandler(HandleTransition);
         }
 
         // Handle interior/exterior transition events by setting transport mode to Foot.
@@ -331,6 +337,7 @@ namespace DaggerfallWorkshop.Game
         private void UpdateMode(TransportModes transportMode)
         {
             // Update the transport mode and stop any riding sounds playing.
+            previousTransportMode = mode;
             mode = transportMode;
             if (ridingAudioSource.isPlaying)
                 ridingAudioSource.Stop();


### PR DESCRIPTION
# Auto Dismount AFTER OnPreTransition

For a mod, I wanted to use the `OnPreTransition` event listener defined in "PlayerEnterExit.cs" to know what the `TransportMode` was prior to transitioning into an interior. However, "TransportManager.cs" automatically sets the `TransportMode` to foot on this event. So, what the `TransportMode` was prior to the transition isn't able to be known by any `OnPreTransition` event listeners after that one has been triggered, and the workaround for this isn't as performant as just checking what the `TransportMode` is on this event.

In my opinion, it makes more sense semantically for the `OnPreTransition` event to be able to access what the `TransportMode` was pre the transition. 

Therefore, this PR simply sets the `TransportMode` to foot in the "OnTransitionInterior" events instead. 
 - The "OnTransitionExterior" events aren't added as we can't change the `TransportMode` inside, so when we exit, we will already be on foot and don't need to auto dismount.

The changes in this PR shouldn't change anything for the player and there doesn't seem to be any problems in my play testing. There is nothing in the code that relies on the `TransportMode` being set to foot on the `OnPreTransition` event, so nothing should break. 

Ultimately, it would be nice to allow developers and modders to know what the `TranportMode` is prior to transitioning into an interior using the `OnPreTransition` event, and not require a less performant workaround. 