### PR TITLE
Transport Manager Events

### DIFF
--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -325,6 +325,47 @@ namespace DaggerfallWorkshop.Game
 
         #endregion
 
+        #region Event Arguments
+
+        /// <summary>
+        /// Types of ship transition encountered by TransportManager.
+        /// </summary>
+        public enum TransportShipType
+        {
+            ToShip,
+            FropShip,
+        }
+        #endregion
+
+        #region Events
+
+        // OnTransportModeChanged
+        public delegate void OnTransportModeChangedEventHandler(TransportModes TransportMode);
+        /// <summary>
+        /// An event that is raised when the transport mode is changed.
+        /// </summary>
+        public static event OnTransportModeChangedEventHandler OnTransportModeChanged;
+        protected virtual void RaiseOnTransportModeChangedEvent(TransportModes TransportMode)
+        {
+            if (OnTransportModeChanged != null){
+                OnTransportModeChanged(TransportMode);
+            }
+        }
+
+        // OnTransportModeShipChanged
+        public delegate void OnTransportModeShipChangedEventHandler(TransportShipType transportShipType);
+        /// <summary>
+        /// An event that is raised when the transport mode is changed to or from ship.
+        /// </summary>
+        public static event OnTransportModeShipChangedEventHandler OnTransportModeShipChanged;
+        protected virtual void RaiseOnTransportModeShipChangedEvent(TransportShipType transportShipType)
+        {
+            if (OnTransportModeShipChanged != null){
+                OnTransportModeShipChanged(transportShipType);
+            }
+        }
+        #endregion
+
         #region Private Methods
 
         private void UpdateMode(TransportModes transportMode)
@@ -366,6 +407,10 @@ namespace DaggerfallWorkshop.Game
                 StreamingWorld world = GameManager.Instance.StreamingWorld;
                 DFPosition shipCoords = DaggerfallBankManager.GetShipCoords();
 
+                // Raise change event for ship before setting to foot.
+                RaiseOnTransportModeChangedEvent(mode);
+                mode = TransportModes.Foot;
+
                 // Is there recorded position before boarding and is player on the ship?
                 if (IsOnShip())
                 {
@@ -386,6 +431,8 @@ namespace DaggerfallWorkshop.Game
                     boardShipPosition = null;
                     // Restore cached scene (ship is special case, cache will not be cleared)
                     SaveLoadManager.RestoreCachedScene(world.SceneName);
+                    // Raise ship event
+                    RaiseOnTransportModeShipChangedEvent(TransportShipType.FropShip);
                 }
                 else
                 {
@@ -395,10 +442,12 @@ namespace DaggerfallWorkshop.Game
                     // Teleport to the players ship, restoring cached scene.
                     world.TeleportToCoordinates(shipCoords.X, shipCoords.Y, StreamingWorld.RepositionMethods.RandomStartMarker);
                     SaveLoadManager.RestoreCachedScene(world.SceneName);
+                    // Raise ship event
+                    RaiseOnTransportModeShipChangedEvent(TransportShipType.ToShip);
                 }
                 DaggerfallUI.Instance.FadeBehaviour.FadeHUDFromBlack();
-                mode = TransportModes.Foot;
             }
+            RaiseOnTransportModeChangedEvent(mode);
         } 
         #endregion
     }


### PR DESCRIPTION
# Add Events for Transport Mode Changes

Adds events inside of "TransportManager.cs" and triggers them inside the UpdateMode method.

- OnTransportModeChanged 
  - Usage: `TransportManager.OnTransportModeChanged += TransportManager_OnTransportModeChanged;`
  - A simple event that is raised when the TransportMode changes. Has the new TransportMode value as a parameter.
- OnTransportModeShipChanged 
  - Usage: `TransportManager.OnTransportModeShipChanged += TransportManager_OnTransportModeShipChanged;`
  - An event that is raised when the transport mode is changed to or from ship. Has a ToShip or FromShip parameter to indicate if we are warping to the ship or out of it.

Why have a separate event for the ship?

- The code doesn't handle the ship mode like the others. It sets it to foot immediately after the ship is warped into or out of. This can be problematic if a developer makes some [mod](https://github.com/ArshvirGoraya/Remember-Transport-Mode) that sets the `TransportMode` to something right after warping to the ship. Whatever they set it to will be overwritten by the automatic "foot" transport mode set by the code. So an event specifically for the ship is better for those cases as those will only be raised when the ship has been warped to/from and after the foot transport mode has been automatically set. It ends up being much cleaner for any code that needs to run right after the TransportMode is set to the ship.

It may also be useful to have an event like "ChangingFromTransportMode," to let developers know when the TransportMode is changing away from something. I haven't added this however, since a nice alternative is just creating an accessible variable called PreviousTransportMode, which they can check whenever the above `OnTransportModeChanged` is fired. This isn't needed for my mod specifically, but I thought it was worth mentioning as it may be useful for others. 