### PR TITLE
Removed the "protected internal" keywords from the DaggerfallTravelPopUp.EndPos setter.

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTravelPopUp.cs
@@ -94,7 +94,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
         #region Properties
 
-        public DFPosition EndPos { get { return endPos; } protected internal set { endPos = value;} }
+        public DFPosition EndPos { get { return endPos; } set { endPos = value;} }
         public DaggerfallTravelMapWindow TravelWindow { get { return travelWindow; } protected internal set { travelWindow = value; } }
         public bool SpeedCautious { get { return speedCautious;} set {speedCautious = value; } }
         public bool TravelShip { get { return travelShip;} set { travelShip = value;} }


### PR DESCRIPTION
Allows mods to change the endPos of DaggerfallTravelPopUp.

[Video](https://streamable.com/o0a2f8) of proof-of-concept fast travel encounter mod I was working on. If it decides to roll an encounter, it will change the destination of the travel in the DaggerfallTravelPopUp.OnPreFastTravel event. Nothing fancy. This threw me for a loop because it pretty much worked flawlessly as a virtual mod and only caused an error when building the DFMOD.