### PR TITLE
Add More Substantial Override Paths For Physical Combat, 9/11/2024

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -246,6 +246,12 @@ namespace DaggerfallWorkshop.Game
         {
             const int doYouSurrenderToGuardsTextID = 15;
 
+            if (GameManager.Instance.WeaponManager.moddedPhysicalAttackBehaviorEnabled)
+            {
+                if (FormulaHelper.AlterMonsterVsPlayerPhysicalAttackAction(weapon, entityBehaviour))
+                    return 0;
+            }
+
             EnemyEntity entity = entityBehaviour.Entity as EnemyEntity;
             PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
 
@@ -302,6 +308,12 @@ namespace DaggerfallWorkshop.Game
 
         private int ApplyDamageToNonPlayer(Items.DaggerfallUnityItem weapon, Vector3 direction, bool bowAttack = false)
         {
+            if (GameManager.Instance.WeaponManager.moddedPhysicalAttackBehaviorEnabled)
+            {
+                if (FormulaHelper.AlterMonsterVsMonsterPhysicalAttackAction(weapon, entityBehaviour, senses, direction, bowAttack))
+                    return 0;
+            }
+
             if (senses.Target == null)
                 return 0;
             // TODO: Merge with hit code in WeaponManager to eliminate duplicate code

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -1074,6 +1074,33 @@ namespace DaggerfallWorkshop.Game.Formulas
             return damage;
         }
 
+        public static bool AlterPlayerVsMonsterPhysicalAttackAction(DaggerfallUnityItem weapon, bool arrowHit, bool arrowSummoned, Transform hitTransform, Vector3 impactPosition, Vector3 direction)
+        {
+            Func<DaggerfallUnityItem, bool, bool, Transform, Vector3, Vector3, bool> del;
+            if (TryGetOverride("AlterPlayerVsMonsterPhysicalAttackAction", out del))
+                return del(weapon, arrowHit, arrowSummoned, hitTransform, impactPosition, direction);
+
+            return false;
+        }
+
+        public static bool AlterMonsterVsPlayerPhysicalAttackAction(DaggerfallUnityItem weapon, DaggerfallEntityBehaviour entityBehaviour)
+        {
+            Func<DaggerfallUnityItem, DaggerfallEntityBehaviour, bool> del;
+            if (TryGetOverride("AlterMonsterVsPlayerPhysicalAttackAction", out del))
+                return del(weapon, entityBehaviour);
+
+            return false;
+        }
+
+        public static bool AlterMonsterVsMonsterPhysicalAttackAction(DaggerfallUnityItem weapon, DaggerfallEntityBehaviour entityBehaviour, EnemySenses senses, Vector3 direction, bool bowAttack)
+        {
+            Func<DaggerfallUnityItem, DaggerfallEntityBehaviour, EnemySenses, Vector3, bool, bool> del;
+            if (TryGetOverride("AlterMonsterVsMonsterPhysicalAttackAction", out del))
+                return del(weapon, entityBehaviour, senses, direction, bowAttack);
+
+            return false;
+        }
+
         /// <summary>
         /// Allocate any equipment damage from a strike, and reduce item condition.
         /// </summary>

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -55,6 +55,9 @@ namespace DaggerfallWorkshop.Game
         public float ChanceToBeParried = 0.1f;      // Example: Chance for player hit to be parried
         public DaggerfallMissile ArrowMissilePrefab;
 
+        // Allows a mod to specify whether to skip over certain vanilla behavior related to physical attack logic, so it can do its own behavior
+        public bool moddedPhysicalAttackBehaviorEnabled = false;
+
         //float weaponSensitivity = 1.0f;             // Sensitivity of weapon swings to mouse movements
         private Gesture _gesture;
         private int _longestDim;                    // Longest screen dimension, used to compare gestures for attack
@@ -486,6 +489,12 @@ namespace DaggerfallWorkshop.Game
         // Returns true if hit an enemy entity
         public bool WeaponDamage(DaggerfallUnityItem strikingWeapon, bool arrowHit, bool arrowSummoned, Transform hitTransform, Vector3 impactPosition, Vector3 direction)
         {
+            if (moddedPhysicalAttackBehaviorEnabled)
+            {
+                if (FormulaHelper.AlterPlayerVsMonsterPhysicalAttackAction(strikingWeapon, arrowHit, arrowSummoned, hitTransform, impactPosition, direction))
+                    return false;
+            }
+
             DaggerfallEntityBehaviour entityBehaviour = hitTransform.GetComponent<DaggerfallEntityBehaviour>();
             var entityMobileUnit = hitTransform.GetComponentInChildren<MobileUnit>();
             EnemyMotor enemyMotor = hitTransform.GetComponent<EnemyMotor>();


### PR DESCRIPTION
The idea behind these changes is to allow for much more of the vanilla behavior for the physical combat systems to be circumvented if a modder chooses to, the override methods in FormulaHelper being there so they can also do whatever actions they want to instead. In this instance hopefully with as little impact on other parts of the code and execution as possible, 9/11/2024.

My current desire for these is that just overriding the CalculateDamage method does not all suppression of vanilla stuff that happens regardless of what is changed in that damage calculation method, things such as sounds being played being the most notable one, and others as well.

Note: I don't know why in Github Desktop said CRLF was used instead of LF, my IDE said everything was in LF when I was doing these changes. Hopefully that is not an issue and can be corrected if necessary.