### PR TITLE
Make building replacements compatible with RMB replacements

### DIFF
--- a/Assets/Scripts/Utility/RMBLayout.cs
+++ b/Assets/Scripts/Utility/RMBLayout.cs
@@ -642,6 +642,28 @@ namespace DaggerfallWorkshop.Utility
                     for (int i = 0; i < block.RmbBlock.SubRecords.Length; i++)
                     {
                         ref DFLocation.BuildingData building = ref block.RmbBlock.FldHeader.BuildingDataList[i];
+
+                        // Check for replacement building data and use it if found
+                        if (WorldDataReplacement.GetBuildingReplacementData(blockName, block.Index, i, out buildingReplacementData))
+                        {
+                            // Replace the entire SubRecord (contains both exterior and interior data)
+                            block.RmbBlock.SubRecords[i] = buildingReplacementData.RmbSubRecord;
+
+                            // Use replacement metadata (FactionId, NameSeed, Quality, etc.)
+                            if (buildingReplacementData.FactionId > 0)
+                                building.FactionId = buildingReplacementData.FactionId;
+                            if (buildingReplacementData.Quality > 0)
+                                building.Quality = buildingReplacementData.Quality;
+                            building.NameSeed = buildingReplacementData.NameSeed;
+                            building.BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.BuildingType;
+
+                            // Check for and replace AutoMap data
+                            if (buildingReplacementData.AutoMapData != null && buildingReplacementData.AutoMapData.Length == 64 * 64)
+                            {
+                                block.RmbBlock.FldHeader.AutoMapData = buildingReplacementData.AutoMapData;
+                            }
+                        }
+
                         if (IsNamedBuilding(building.BuildingType))
                         {
                             // Try to find next building and merge data


### PR DESCRIPTION
Currently modded building replacements and modded RMB replacements are incompatible. Whenever a mod tries to change a building in a modded RMB, the building's metadata is changed but the exterior and interior remains unchanged. This is an especially big problem for unmaintained building replacement mods like Tavern's Redone and Soldier's Luxury, which are incompatible with newer RMB replacement mods like Cities Overhauled and Beautiful Cities.

This PR fixes these incompatibilities by applying building replacements in RMBLayout, after applying RMB replacements. It modifies the method GetLocationBuildingData, in which building replacements change metadata, so that it also changes RMBSubRecords.

Everything appears to be working as intended upon testing. Buildings are replaced in modded RMBs exactly as they would be were the building replacement affecting a vanilla block. Both interior and exterior data (as with Lively Cities) works correctly. Factions (like Archaeologists Guild) work correctly and appear in blue on the automap. Named buildings like taverns still get their metadata from the location data after the building replacements are applied, so their nameseeds and quality etc are correct. This PR also appears to be robust to modded RMBs with many buildings deleted (ie Beautiful Villages); no NullReferences or Index out of range occurred.