### PR TITLE
Add OnTransportModeChanged event to TransportManager

### DIFF
--- a/Assets/Scripts/Game/TransportManager.cs
+++ b/Assets/Scripts/Game/TransportManager.cs
@@ -330,6 +330,7 @@ namespace DaggerfallWorkshop.Game
         private void UpdateMode(TransportModes transportMode)
         {
             // Update the transport mode and stop any riding sounds playing.
+            TransportModes previousMode = mode;
             mode = transportMode;
             if (ridingAudioSource.isPlaying)
                 ridingAudioSource.Stop();
@@ -399,7 +400,22 @@ namespace DaggerfallWorkshop.Game
                 DaggerfallUI.Instance.FadeBehaviour.FadeHUDFromBlack();
                 mode = TransportModes.Foot;
             }
-        } 
+            // Raise mode changed event
+            RaiseOnTransportModeChangedEvent(transportMode, previousMode);
+        }
+        #endregion
+
+        #region Events
+
+        // OnTransportModeChanged
+        public delegate void OnTransportModeChangedEventHandler(TransportModes newMode, TransportModes previousMode);
+        public static event OnTransportModeChangedEventHandler OnTransportModeChanged;
+        protected virtual void RaiseOnTransportModeChangedEvent(TransportModes newMode, TransportModes previousMode)
+        {
+            if (OnTransportModeChanged != null)
+                OnTransportModeChanged(newMode, previousMode);
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
This is an simpler alternative way to add a OnTransportModeChanged event to the TransportManager which provides the new and old transport mode after all the changes have been made, providing mods with all of the info required to post-manipulate the mode as desired.

The only oddity is with ship as this isn't really a transport mode, just a toggle teleport that was added to the others. When moving to ship it will be to Foot and when returning it'll be to Ship.

This is intended as an alternative to both PR's #2692 and #2694 and I would appreciate if @ArshvirGoraya could check whether this meets their needs and report back if additional info is needed for some use case?
