### PR TITLE
camera clamping fix

### DIFF
--- a/Assets/Scripts/Game/PlayerMouseLook.cs
+++ b/Assets/Scripts/Game/PlayerMouseLook.cs
@@ -66,7 +66,6 @@ namespace DaggerfallWorkshop.Game
             get { return cameraPitch * Mathf.Rad2Deg; }
             set
             {
-                value = Mathf.Clamp(value, pitchMin, pitchMax);
                 cameraPitch = value * Mathf.Deg2Rad;
                 if (cameraPitch > piover2 * .99f)
                     cameraPitch = piover2 * .99f;

--- a/Assets/Scripts/Game/PlayerMouseLook.cs
+++ b/Assets/Scripts/Game/PlayerMouseLook.cs
@@ -66,6 +66,7 @@ namespace DaggerfallWorkshop.Game
             get { return cameraPitch * Mathf.Rad2Deg; }
             set
             {
+                value = Mathf.Clamp(value, -pitchMax, -pitchMin);
                 cameraPitch = value * Mathf.Deg2Rad;
                 if (cameraPitch > piover2 * .99f)
                     cameraPitch = piover2 * .99f;
@@ -126,7 +127,7 @@ namespace DaggerfallWorkshop.Game
                 sensitivityY = sensitivity.y * sensitivityScale;
             }
 
-            Vector2 rawMouseDelta = new Vector2(InputManager.Instance.LookX, InputManager.Instance.LookY);
+            Vector2 rawMouseDelta = new Vector2(InputManager.Instance.LookX, -InputManager.Instance.LookY);
 
             lookTarget += Vector2.Scale(rawMouseDelta, new Vector2(sensitivityX, sensitivityY * (invertMouseY ? -1 : 1)));
 
@@ -140,12 +141,11 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Clamp target look pitch to range of straight down to straight up
-            lookTarget.y = Mathf.Clamp(lookTarget.y, pitchMin, pitchMax);
-
+            lookTarget.y = Mathf.Clamp(lookTarget.y, -pitchMax, -pitchMin);
             ApplySmoothing();
 
             Yaw = lookCurrent.x;
-            Pitch = -lookCurrent.y;
+            Pitch = lookCurrent.y;
         }
 
         // Updates lookCurrent by moving it a fraction towards lookTarget


### PR DESCRIPTION
# Fix Camera pitchMin and pitchMax Clamping
## Problem:
Expected behaviour of `pitchMin`: limits how far you can look down.
Expected behaviour of `pitchMax`: limits how far you can look up.

Current Behaviour: Whichever value is closer to 0, sets both the minimum and maximum of how far the camera can look up/down.

Example:
- `pitchMax = 10` and `pitchMin = -90`: look up to 10, but can only look down to -10 (even with pitchMin set to -90).
- `pitchMax = 90` and `pitchMin = -10`: look down to -10, but can only look up to 10 (even with pitchMax set to 90).
## Why its Happening:
This happens because the code clamps the pitch value **twice**. Inside the `update()` and in `Pitch`'s setter function.
This wouldn't be a problem if we weren't also switching the value's sign before the setter function, which results in the value being clamped in its sign-flipped state as well as its normal state.
### Examples
**Positive Value:**
```CS
lookTarget.y = 90
pitchMax = 90
pitchMin = -20
... // Update:
lookTarget.y = Mathf.Clamp(lookTarget.y, pitchMin, pitchMax) // lookTarget.y = 90
Pitch = -lookTarget.y // In actual code we use -lookCurrent.y, which is just lookTarget.y, after smoothing is applied
... // Setter:
public float Pitch
{ set {
    // value = -90: sent here after its sign is flipped
    value = Mathf.Clamp(value, pitchMin, pitchMax) // value = -20. Should be 90.
  }
}
```
**Negative Value:**
```CS
lookTarget.y = -90
pitchMax = 90
pitchMin = -20
... // Update:
lookTarget.y = Mathf.Clamp(lookTarget.y, pitchMin, pitchMax) // -20.
... // Setter:
// value = +20
value = Mathf.Clamp(value, pitchMin, pitchMax) // value = 20. Should be -20.
```
## Solution:
Remove the `Mathf.Clamp()` call inside the setter function. The update function clamps this value anyway, so the clamping is still working, but just on Update().

A problem with this solution is a mod may rely on the clamping in the setter function, not the Update(). So, an alternative solution may be better. Otherwise, those mods would have to update (e.g., clamp the value themselves before assigning to `Pitch`).