### PR TITLE
mods list search

### DIFF
--- a/Assets/StreamingAssets/Text/ModSystem.txt
+++ b/Assets/StreamingAssets/Text/ModSystem.txt
@@ -49,6 +49,8 @@ cleanConfigurationDir,      Found configuration files for unknown or uninstalled
 backToOptions,              Options
 backToOptionsInfo,          Back to options without saving changes
 modsFound,                  Mods Found
+modsSearch,                 Search
+modsNoMatching,             No matching mod found
 settings,                   Settings
 settingsInfo,               Change mod settings
 presets,                    Presets


### PR DESCRIPTION
Mod list search (#2705) implementation

At first I tried to implement view filtering (only display mods that matched), but that made the semantic of "increase mod order" and "decrease mod order" buttons... complicated. Also, the mod manager relies heavily on several arrays using the same indices, so it was almost intractable.

So I implemented a simpler search; Within the UI components limitations, I added a text field, and "up" and "down" arrow to find the previous and next match. It's serviceable.