### PR TITLE
Allow mods to add new RMB blocks

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -504,7 +504,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return false;
         }
 
-        private static void AssignNextIndex(string blockName)
+        public static void AssignNextIndex(string blockName)
         {
             newBlockNames[nextBlockIndex] = blockName;
             newBlockIndices[blockName] = nextBlockIndex;


### PR DESCRIPTION
Mods currently cannot access custom RMB blocks. New RMB blocks are only added to WorldDataReplacement's new block index when a player visits a regular Daggerfall location. This is a problem for mods like LocationLoader (in World of Daggerfall), which aims to add custom RMB blocks throughout the world, not just at regular locations. This PR simply sets WorldDataReplacement.AssignNextIndex to public, allowing LocationLoader to call it and add a new RMB block to the index.