### PR TITLE
Fix The Akatosh Chantry bug

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -3025,9 +3025,23 @@ namespace DaggerfallWorkshop.Game.Formulas
                     break;
 
                 case DFLocation.BuildingTypes.Temple:
-                    // Temples get name from faction data - always seem to be first child of factionID
+                    // Temples get name from faction data - always seem to be first child of the top-level factionID
                     if (GameManager.Instance.PlayerEntity.FactionData.GetFactionData(factionID, out factionData))
                     {
+                        // Traverse up to find the top-level faction
+                        while (factionData.parent != 0)
+                        {
+                            if (GameManager.Instance.PlayerEntity.FactionData.GetFactionData(factionData.parent, out FactionFile.FactionData parentFaction))
+                            {
+                                factionData = parentFaction;
+                            }
+                            else
+                            {
+                                break; // If we can't find the parent, stop the loop
+                            }
+                        }
+
+                        // Now that we have the top-level faction, get its first child
                         if (factionData.children.Count > 0)
                         {
                             FactionFile.FactionData firstChild;


### PR DESCRIPTION
This fixes a bug in which temples of Akatosh are incorrectly named The Order of the Hour instead of The Akatosh Chantry, even though all NPCs inside refer to it as The Akatosh Chantry.

The bug was [noticed six years ago here](https://forums.dfworkshop.net/viewtopic.php?t=877) and likely replicates DOS Daggerfall behavior. The cause is a mistake in vanilla location data for Akatosh temples. Most location data sets the Temple FactionID as the relevant god (ie 33 for Stendarr) and then this method grabs the first child (106 for Temple of Stendarr). However, the location data for Akatosh temples refer directly to The Akatosh Chantry (FactionID 92) instead of the god (FactionID 26). The first child of The Akatosh Chantry is The Order of the Hour.

This PR makes the method first traverse to the top-level factionID and then takes its first child for temple names.