### PR TITLE
Fix inconsistency in NPC answers about a person and their location

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -580,6 +580,28 @@ namespace DaggerfallWorkshop.Game
                 return NPCKnowledgeAboutItem.KnowsAboutItem;
             }
 
+            // Fixed from classic: an NPC who is no aware of the location of a quest building
+            // where a quest person is located obviously can't know the person location
+            if (listItem.questionType == QuestionType.Person && currentKeySubjectBuildingKey != -1)
+            {
+                foreach (ListItem buildingGroupListItem in listTopicLocation)
+                {
+                    ListItem buildingListItem = buildingGroupListItem.listChildItems.Find(x => x.buildingKey == currentKeySubjectBuildingKey);
+                    if (buildingListItem != null)
+                    {
+                        // Set the NPC knowledge about the building if it has not been set yet
+                        if (buildingListItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.NotSet)
+                            buildingListItem.npcKnowledgeAboutItem = GetNPCKnowledgeAboutItem(buildingListItem);
+
+                        if (buildingListItem.npcKnowledgeAboutItem == NPCKnowledgeAboutItem.DoesNotKnowAboutItem)
+                            return NPCKnowledgeAboutItem.DoesNotKnowAboutItem;
+
+                        // Found the building, no need to continue
+                        break;
+                    }
+                }
+            }
+
             // Make roll result be the same every time for a given NPC
             if (currentNPCType == NPCType.Mobile)
                 DFRandom.Seed = (uint)lastTargetMobileNPC.GetHashCode();


### PR DESCRIPTION
This fixes an old and annoying issue present in bot classic DF and DFU, where an NPC wouldn't know the location of a building, but would still give information about that building when asked about an NPC located there, as in the example below.

![ask-building-bug-1](https://github.com/user-attachments/assets/8536a638-c81a-4134-9b20-6ace39cf9a93)
![ask-building-bug-2](https://github.com/user-attachments/assets/b8207afb-65eb-4a7b-9e5f-1001462f3ae4)


