### PR TITLE
Mergable building override automap data

### DIFF
--- a/Assets/Scripts/API/BlocksFile.cs
+++ b/Assets/Scripts/API/BlocksFile.cs
@@ -846,7 +846,7 @@ namespace DaggerfallConnect.Arena2
             BuildingReplacementData buildingReplacementData;
             for (int i = 0; i < recordCount; i++)
             {
-                // Check for replacement building data and use it if found
+                // Check for replacement building data and use it, if found
                 if (WorldDataReplacement.GetBuildingReplacementData(blocks[block].Name, block, i, out buildingReplacementData))
                 {
                     blocks[block].DFBlock.RmbBlock.SubRecords[i] = buildingReplacementData.RmbSubRecord;
@@ -857,8 +857,8 @@ namespace DaggerfallConnect.Arena2
                         blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].Quality = buildingReplacementData.Quality;
                     if (buildingReplacementData.NameSeed > 0)
                         blocks[block].DFBlock.RmbBlock.FldHeader.BuildingDataList[i].NameSeed = buildingReplacementData.NameSeed;
-                    if (buildingReplacementData.AutoMapData != null && buildingReplacementData.AutoMapData.Length == 64 * 64)
-                        blocks[block].DFBlock.RmbBlock.FldHeader.AutoMapData = buildingReplacementData.AutoMapData;
+
+                    WorldDataReplacement.ApplyBuildingReplacementAutoMapData(buildingReplacementData, ref blocks[block].DFBlock.RmbBlock.FldHeader.AutoMapData);
                 }
                 else
                 {

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -376,6 +376,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 }
                 dfBlock.Index = block;
 
+                // For RMB blocks, check for individual building overrides and replace those records.
                 if (blockName.EndsWith(".RMB"))
                     ReplaceRmbBlockBuildingData(blockName, block, ref dfBlock);
 
@@ -390,7 +391,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         }
 
         /// <summary>
-        /// Replace overridden RMB block data with any record specific building data.
+        /// Replaces overridden RMB block data records with specific building data, if found.
         /// </summary>
         /// <param name="blockName">Block name</param>
         /// <param name="blockIndex">Block index</param>

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -405,7 +405,11 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 // Check for replacement building data and use it if found
                 if (GetBuildingReplacementData(blockName, blockIndex, i, out buildingReplacementData))
                 {
-                    dfBlock.RmbBlock.SubRecords[i] = buildingReplacementData.RmbSubRecord;
+                    // Only replace the Exterior and Interior parts of the subrecord, leaving building coordinates and rotation as specified by the override RMB
+                    dfBlock.RmbBlock.SubRecords[i].Exterior = buildingReplacementData.RmbSubRecord.Exterior;
+                    dfBlock.RmbBlock.SubRecords[i].Interior = buildingReplacementData.RmbSubRecord.Interior;
+
+                    // Update the corresponding entry in the building data list where appropriate
                     if (buildingReplacementData.FactionId > 0)
                         dfBlock.RmbBlock.FldHeader.BuildingDataList[i].FactionId = buildingReplacementData.FactionId;
                     dfBlock.RmbBlock.FldHeader.BuildingDataList[i].BuildingType = (DFLocation.BuildingTypes)buildingReplacementData.BuildingType;

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -42,6 +42,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
     {
         #region Fields & Constants
 
+        public const int AutoMapDataSize = 64 * 64;
         const int noReplacementIndicator = -1;
         const string worldData = "WorldData";
         static readonly string worldDataPath = Path.Combine(Application.streamingAssetsPath, worldData);
@@ -417,8 +418,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                         dfBlock.RmbBlock.FldHeader.BuildingDataList[i].Quality = buildingReplacementData.Quality;
                     if (buildingReplacementData.NameSeed > 0)
                         dfBlock.RmbBlock.FldHeader.BuildingDataList[i].NameSeed = buildingReplacementData.NameSeed;
-                    if (buildingReplacementData.AutoMapData != null && buildingReplacementData.AutoMapData.Length == 64 * 64)
-                        dfBlock.RmbBlock.FldHeader.AutoMapData = buildingReplacementData.AutoMapData;
+
+                    ApplyBuildingReplacementAutoMapData(buildingReplacementData, ref dfBlock.RmbBlock.FldHeader.AutoMapData);
                 }
             }
         }
@@ -483,6 +484,23 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         public static int MakeLocationKey(int regionIndex, int locationIndex)
         {
             return (locationIndex * 100) + regionIndex;
+        }
+
+        /// <summary>
+        /// Applies automap data from that defined in building replacement data. Values of '30' will be ignored allowing only the relevant parts to be modified.
+        /// </summary>
+        /// <param name="buildingData">BuildingReplacementData input</param>
+        /// <param name="blockAutoMapData">A reference to the block automap data byte array to merge into</param>
+        public static void ApplyBuildingReplacementAutoMapData(BuildingReplacementData buildingData, ref byte[] blockAutoMapData)
+        {
+            if (buildingData.AutoMapData != null && buildingData.AutoMapData.Length == AutoMapDataSize)
+            {
+                for (int i = 0; i < AutoMapDataSize; i++)
+                {
+                    if (buildingData.AutoMapData[i] != 30)
+                        blockAutoMapData[i] = buildingData.AutoMapData[i];
+                }
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/WorldDataReplacement.cs
@@ -398,7 +398,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <param name="dfBlock">DFBlock data to modify</param>
         private static void ReplaceRmbBlockBuildingData(string blockName, int blockIndex, ref DFBlock dfBlock)
         {
-            int recordCount = dfBlock.RmbBlock.FldHeader.NumBlockDataRecords;
+            int recordCount = dfBlock.RmbBlock.SubRecords.Length;
             BuildingReplacementData buildingReplacementData;
             for (int i = 0; i < recordCount; i++)
             {


### PR DESCRIPTION
This allows building overrides to only replace the automap data for the relevant area of the RMB for the specific building. This effectively enables merging of overridden map data. The picture below shows the town map, first is with the building override data being used (current functionality), second is without the building override (the modified RMB map data taken from Beautiful Cities), and the third is with functionality added by this PR where the building override only overwrites the part it needs to.

![autodataMerge](https://github.com/user-attachments/assets/483c7ed0-7726-480e-8332-2f60adb44ff0)

You can see it overwrites some of the nearby buildings, but after adjusting the amount of area it looks very good. (note Beautiful Cities map data doesn't include the random objects and flats that can be displayed using the red grid icon)

![autodataMerge2](https://github.com/user-attachments/assets/ff3ee8d6-70c0-4ad1-96bc-f32acc644176)

The unused value of '30' is used to signify no change for that pixel in a building override automap data byte array. See the attached modified building file for an example where the automap data has been changed to only affect the building area. It can be compared to the original from my [Archaeologists mod](https://github.com/ajrb/dfunity-mods/blob/master/Archaeologists/WorldData/PAWNAL03.RMB-857-building3.json).

[PAWNAL03.RMB-857-building3.json](https://github.com/user-attachments/files/18240766/PAWNAL03.RMB-857-building3.json)
