### PR TITLE
Fix UI/popups background color to use the one set in settings.ini

### DIFF
--- a/Assets/Scripts/Game/EnemyAttack.cs
+++ b/Assets/Scripts/Game/EnemyAttack.cs
@@ -278,7 +278,7 @@ namespace DaggerfallWorkshop.Game
 
                         DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.UIManager);
                         messageBox.SetTextTokens(DaggerfallUnity.Instance.TextProvider.GetRSCTokens(doYouSurrenderToGuardsTextID));
-                        messageBox.ParentPanel.BackgroundColor = Color.clear;
+                        messageBox.ParentPanel.BackgroundColor = new Color(0, 0, 0, DaggerfallUnity.Settings.DimAlphaStrength);
                         messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.Yes);
                         messageBox.AddButton(DaggerfallMessageBox.MessageBoxButtons.No);
                         messageBox.OnButtonClick += SurrenderToGuardsDialogue_OnButtonClick;

--- a/Assets/Scripts/Game/Questing/QuestMachine.cs
+++ b/Assets/Scripts/Game/Questing/QuestMachine.cs
@@ -904,7 +904,7 @@ namespace DaggerfallWorkshop.Game.Questing
             DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.UIManager, DaggerfallMessageBox.CommonMessageBoxButtons.YesNo, tokens);
             messageBox.ClickAnywhereToClose = false;
             messageBox.AllowCancel = false;
-            messageBox.ParentPanel.BackgroundColor = Color.clear;
+            messageBox.ParentPanel.BackgroundColor = new Color(0, 0, 0, DaggerfallUnity.Settings.DimAlphaStrength);
 
             return messageBox;
         }

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallGuildServicePopupWindow.cs
@@ -96,7 +96,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             guild = guildManager.GetGuild(guildGroup, buildingFactionId);
 
             // Clear background
-            ParentPanel.BackgroundColor = Color.clear;
+            ParentPanel.BackgroundColor = new Color(0, 0, 0, DaggerfallUnity.Settings.DimAlphaStrength);
         }
 
         #endregion

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallPopupWindow.cs
@@ -55,7 +55,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             : base(uiManager, screenWidth, screenHeight)
         {
             this.previousWindow = previousWindow;
-            this.screenDimColor.a = 0; //DaggerfallUnity.Settings.DimAlphaStrength;
+            this.screenDimColor = new Color(0, 0, 0, DaggerfallUnity.Settings.DimAlphaStrength);
         }
 
         protected override void Setup()

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallQuestPopupWindow.cs
@@ -116,7 +116,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             messageBox.SetTextTokens(tokens, this.offeredQuest.ExternalMCP);
             messageBox.ClickAnywhereToClose = true;
             messageBox.AllowCancel = true;
-            messageBox.ParentPanel.BackgroundColor = Color.clear;
+            messageBox.ParentPanel.BackgroundColor = new Color(0, 0, 0, DaggerfallUnity.Settings.DimAlphaStrength);
 
             // Exit menu on close if requested
             if (exitOnClose)

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallRestWindow.cs
@@ -133,7 +133,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             LoadTextures();
 
             // Hide world while resting
-            ParentPanel.BackgroundColor = Color.black;
+            ParentPanel.BackgroundColor = new Color(0, 0, 0, DaggerfallUnity.Settings.DimAlphaStrength);
 
             // Create interface panel
             mainPanel.HorizontalAlignment = HorizontalAlignment.Center;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallTransportWindow.cs
@@ -66,7 +66,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             : base(uiManager)
         {
             // Clear background
-            ParentPanel.BackgroundColor = Color.clear;
+            ParentPanel.BackgroundColor = new Color(0, 0, 0, DaggerfallUnity.Settings.DimAlphaStrength);
             // Prevent duplicate close calls with base class's exitKey (Escape)
             AllowCancel = false;
         }


### PR DESCRIPTION
Fix most of the UI/popups backdrop/dim that was supposed to be based on the `DimAlphaStrength` property from the `settings.ini` file, also fix the inconsistency with the "Rest" screen that has black background. Here some examples of **before and after based on the default 50% dim**:

![image1912](https://github.com/user-attachments/assets/216a344b-730f-4d1a-998b-81bef2abcd21)

This PR would also allow mods to expose this setting so players can choose between 0% and 100% dim via mod settings. 

This is specially useful when there are lots of text and buttons on UI stacked at same time like in the map travel scenario (2nd example).