### PR TITLE
Fix: ItemData_v1.GetSaveData() also saves className now.

### DIFF
--- a/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
+++ b/Assets/Scripts/Game/Items/DaggerfallUnityItem.cs
@@ -813,6 +813,7 @@ namespace DaggerfallWorkshop.Game.Items
             data.timeForItemToDisappear = timeForItemToDisappear;
             data.timeHealthLeechLastUsed = timeHealthLeechLastUsed;
             data.artifactIndexBitfield = artifactIndexBitfield;
+            data.className = GetType().ToString();
 
             return data;
         }


### PR DESCRIPTION
I added a custom DaggerfallUnityItem to the game. Works fine until I load a savegame with the item in my inventory (or in store shelves)

It's because the className is not saved and upon deserialization it will become a regular DaggerfallUnityItem with the default `UseItem`-Method and no custom icon (it will have no icon at all)

A workaround would be this (on my custom item class)
```csharp
public override ItemData_v1 GetSaveData()
{
    ItemData_v1 saveData = base.GetSaveData();
    saveData.className = GetType().ToString();
    
    return saveData;
}
```
But maybe it doesn't hurt to let DFU take care of this, because while deserializing it's already checking for `className`.