### PR TITLE
Fix PlaceNpc action not serializing marker

### DIFF
--- a/Assets/Scripts/Game/Questing/Actions/PlaceFoe.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlaceFoe.cs
@@ -4,8 +4,8 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
-// 
+// Contributors:
+//
 // Notes:
 //
 
@@ -79,7 +79,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             }
 
             // Assign Foe to Place
-            place.AssignQuestResource(foeSymbol, marker);
+            place.AssignQuestResource(foe.Symbol, marker);
 
             SetComplete();
         }

--- a/Assets/Scripts/Game/Questing/Actions/PlaceNpc.cs
+++ b/Assets/Scripts/Game/Questing/Actions/PlaceNpc.cs
@@ -4,8 +4,8 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    
-// 
+// Contributors:
+//
 // Notes:
 //
 
@@ -123,6 +123,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
         {
             public Symbol npcSymbol;
             public Symbol placeSymbol;
+            public int marker;
         }
 
         public override object GetSaveData()
@@ -130,6 +131,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             SaveData_v1 data = new SaveData_v1();
             data.npcSymbol = npcSymbol;
             data.placeSymbol = placeSymbol;
+            data.marker = marker;
 
             return data;
         }
@@ -142,6 +144,7 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             SaveData_v1 data = (SaveData_v1)dataIn;
             npcSymbol = data.npcSymbol;
             placeSymbol = data.placeSymbol;
+            marker = data.marker;
         }
 
         #endregion


### PR DESCRIPTION
Marker indexes for the `PlaceNpc` quest action are not properly serialized, causing quest npcs to be placed at a random marker when the action is loaded. This is quite obvious in the quest `Lord K'avar Part III`, where the Lord K'avar flat could be located at a incorrect marker, and the foe at the correct one, causing K'avar to seemingly teleport across the dungeon.

Also edited `PlaceFoe`'s `AssignQuestResource` pattern to match that of `PlaceNpc`'s `AssignQuestResource` for consistency.

Fixes #2700