### PR TITLE
Restore vampire player barks

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/VampirismEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/VampirismEffect.cs
@@ -12,6 +12,7 @@
 using UnityEngine;
 using FullSerializer;
 using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Utility;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Questing;
 using DaggerfallWorkshop.Game.Items;
@@ -169,14 +170,16 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
 
         public override bool GetCustomRaceGenderAttackSoundData(PlayerEntity entity, out SoundClips soundClipOut)
         {
+            const int chanceOfBarkSound = 20;
+
             switch (entity.Gender)
             {
                 default:
                 case Genders.Male:
-                    soundClipOut = SoundClips.EnemyVampireAttack;
+                    soundClipOut = Dice100.SuccessRoll(chanceOfBarkSound) ? SoundClips.EnemyVampireBark : SoundClips.EnemyVampireAttack;
                     break;
                 case Genders.Female:
-                    soundClipOut = SoundClips.EnemyFemaleVampireAttack;
+                    soundClipOut = Dice100.SuccessRoll(chanceOfBarkSound) ? SoundClips.EnemyFemaleVampireBark : SoundClips.EnemyFemaleVampireAttack;
                     break;
             }
 


### PR DESCRIPTION
Restores missing vampire player bark sounds when attacking. I have no idea what the chance for them to play is in original Daggerfall, so I chose a value that seems somewhat reasonable.

Fixes #2716