### PR TITLE
Fix for possible zombie items from MakePermanent action

### DIFF
--- a/Assets/Scripts/Game/Questing/Item.cs
+++ b/Assets/Scripts/Game/Questing/Item.cs
@@ -5,7 +5,7 @@
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Lypyl (lypyldf@gmail.com), Gavin Clayton (interkarma@dfworkshop.net)
 // Contributors:    Hazelnut
-// 
+//
 // Notes:
 //
 
@@ -19,7 +19,7 @@ using FullSerializer;
 using DaggerfallWorkshop.Game.Guilds;
 
 /*Example patterns:
- * 
+ *
  * Item _gold_ gold
  * Item _gold1_ gold range 5 to 25
  * Item talisman talisman
@@ -281,8 +281,19 @@ namespace DaggerfallWorkshop.Game.Questing
             madePermanent = true;
 
             // Set current DaggerfallUnityItem instance as permanent
-            if (DaggerfallUnityItem != null)
-                DaggerfallUnityItem.MakePermanent();
+            if (item != null)
+                item.MakePermanent();
+
+            // Make sure permanency is synced for items in player item collections
+            Entity.PlayerEntity playerEntity = GameManager.Instance.PlayerEntity;
+            DaggerfallUnityItem[] items = playerEntity.Items.ExportQuestItems(ParentQuest.UID, Symbol);
+            if (items == null || items.Length == 0)
+                return;
+
+            foreach (DaggerfallUnityItem dfitem in items)
+            {
+                dfitem.MakePermanent();
+            }
         }
 
         #endregion


### PR DESCRIPTION
This was somewhat [addressed](https://github.com/Interkarma/daggerfall-unity/issues/2262#issuecomment-1261602732) in the past, but it only resyncs permanency between the virtual quest item and the inventory item with item transfer (e.g. foe has quest items; those quest items are made permanent; foe is killed and player loots those quest items). It doesn't cover items already in the player inventory when a `MakePermanent` action happens, potentially leading to a desynced state — the dreaded "zombie" item.

~~This workaround should fix the issue in a low impact way by resyncing permanency when the inventory window is setup and when it refreshes.~~

Changed to be much cleaner, though it won't fix bugged items already made permanent in saves retroactively.

Fixes #2720