### PR TITLE
Fix static NPCs in houses not being hidden at night

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -5,7 +5,7 @@
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
 // Contributors:    Allofich, Numidium, TheLacus
-// 
+//
 // Notes:
 //
 
@@ -87,8 +87,8 @@ namespace DaggerfallWorkshop.Game
         public const float MobileNPCActivationDistance = 256 * MeshReader.GlobalScale;
 
         // Opening and closing hours by building type
-        public static byte[] openHours  = {  7,  8,  9,  8,  0,  9, 10, 10,  9,  6,  9, 11,  9,  9,  0,  0, 10, 0 };
-        public static byte[] closeHours = { 22, 16, 19, 15, 25, 21, 19, 20, 18, 23, 23, 23, 20, 20, 25, 25, 16, 0 };
+        public static byte[] openHours  = {  7,  8,  9,  8,  0,  9, 10, 10,  9,  6,  9, 11,  9,  9,  0,  0, 10, 0, 6, 6, 6, 6, 6, 6, 0 };
+        public static byte[] closeHours = { 22, 16, 19, 15, 25, 21, 19, 20, 18, 23, 23, 23, 20, 20, 25, 25, 16, 0, 18, 18 ,18, 18, 18, 18, 25 };
 
         const int PrivatePropertyId = 37;
 
@@ -1039,7 +1039,7 @@ namespace DaggerfallWorkshop.Game
             if (openEffect == null)
                 return false;
 
-            return openEffect.TriggerExteriorOpenEffect(buildingLockValue); 
+            return openEffect.TriggerExteriorOpenEffect(buildingLockValue);
         }
 
         /// <summary>
@@ -1284,10 +1284,9 @@ namespace DaggerfallWorkshop.Game
             // Handle House1 through House4
             // TODO: Figure out the rest of house door calculations.
             // TODO: Need to lock doors if quest target for stealing, and unlock for other quests.
-            else if (type >= DFLocation.BuildingTypes.House1 && type <= DFLocation.BuildingTypes.House4
-                && DaggerfallUnity.Instance.WorldTime.Now.IsDay)
+            else if (type >= DFLocation.BuildingTypes.House1 && type <= DFLocation.BuildingTypes.House4)
             {
-                unlocked = true;
+                unlocked = IsBuildingOpen(type);
             }
             // Handle stores
             else if (RMBLayout.IsShop(type))

--- a/Assets/Scripts/Internal/DaggerfallInterior.cs
+++ b/Assets/Scripts/Internal/DaggerfallInterior.cs
@@ -5,7 +5,7 @@
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
 // Contributors:    Nystul, Hazelnut, Numidium, Ferital
-// 
+//
 // Notes:
 //
 
@@ -346,7 +346,7 @@ namespace DaggerfallWorkshop
             PlayerEnterExit playerEnterExit = GameManager.Instance.PlayerEnterExit;
             DFLocation.BuildingTypes buildingType = playerEnterExit.BuildingType;
             if ((RMBLayout.IsShop(buildingType) && !playerEnterExit.IsPlayerInsideOpenShop) ||
-                (!RMBLayout.IsShop(buildingType) && buildingType <= DFLocation.BuildingTypes.Palace && buildingType != DFLocation.BuildingTypes.HouseForSale))
+                (!RMBLayout.IsShop(buildingType) && buildingType <= DFLocation.BuildingTypes.House4 && buildingType != DFLocation.BuildingTypes.HouseForSale))
             {
                 Transform npcTransforms = transform.Find(peopleFlats);
                 if (PlayerActivate.IsBuildingOpen(buildingType))
@@ -1202,21 +1202,20 @@ namespace DaggerfallWorkshop
                 StaticNPC npc = go.AddComponent<StaticNPC>();
                 npc.SetLayoutData(obj, entryDoor.buildingKey);
 
-                // Disable people if shop or building is closed
                 DFLocation.BuildingTypes buildingType = buildingData.buildingType;
-                if ((RMBLayout.IsShop(buildingType) && !GameManager.Instance.PlayerEnterExit.IsPlayerInsideOpenShop) ||
-                    (buildingType <= DFLocation.BuildingTypes.Palace && !RMBLayout.IsShop(buildingType) 
-                     && !(PlayerActivate.IsBuildingOpen(buildingType) || buildingType == DFLocation.BuildingTypes.GuildHall && guild.HallAccessAnytime())))
-                {
-                    go.SetActive(false);
-                }
+                bool isTGDBHouseMember = buildingData.buildingType == DFLocation.BuildingTypes.House2 && buildingData.factionID != 0 && isMemberOfBuildingGuild;
+
                 // Disable people if player owns this house
-                else if (DaggerfallBankManager.IsHouseOwned(buildingData.buildingKey))
+                if (DaggerfallBankManager.IsHouseOwned(buildingData.buildingKey))
                 {
                     go.SetActive(false);
                 }
-                // Disable people if this is TG/DB house and player is not a member
-                else if (buildingData.buildingType == DFLocation.BuildingTypes.House2 && buildingData.factionID != 0 && !isMemberOfBuildingGuild)
+                // Disable people if shop or building is closed (or this is TG/DB house and player is not a member)
+                else if ((RMBLayout.IsShop(buildingType) && !GameManager.Instance.PlayerEnterExit.IsPlayerInsideOpenShop) ||
+                         (!RMBLayout.IsShop(buildingType) && buildingType <= DFLocation.BuildingTypes.House4
+                            && !PlayerActivate.IsBuildingOpen(buildingType)
+                            && !(buildingType == DFLocation.BuildingTypes.GuildHall && guild.HallAccessAnytime())
+                            && !isTGDBHouseMember))
                 {
                     go.SetActive(false);
                 }
@@ -1264,7 +1263,7 @@ namespace DaggerfallWorkshop
                     {
                         boxCollider.center = meshRenderer.bounds.center;
                         boxCollider.size = meshRenderer.bounds.size;
-                    }  
+                    }
 
                     // Update climate
                     DaggerfallMesh dfMesh = go.GetComponent<DaggerfallMesh>();


### PR DESCRIPTION
Houses were being omitted from the conditional to disable NPCs at night. This adds building types `House1` to `House4` to the NPC disable/enable functions. Also includes new entries to the open/closed hours arrays for `House2` to `Ship`.

Fixes #2662