### PR TITLE
Add city wall automap display name

### DIFF
--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -5,7 +5,7 @@
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
 // Contributors:    Allofich, Hazelnut, ifkopifko, Numidium, TheLacus
-// 
+//
 // Notes:
 //
 
@@ -277,7 +277,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             chance += shopQuality + weightAndNumItems;
             return Mathf.Clamp(chance, 5, 95);
         }
-        
+
         // Calculate chance of stealth skill hiding the user.
         public static int CalculateStealthChance(float distanceToTarget, DaggerfallEntityBehaviour target)
         {
@@ -2264,7 +2264,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             if(TryGetOverride("CalculateEffectCosts", out del))
                 return del(effect, settings, casterEntity);
 
-            bool activeComponents = false;            
+            bool activeComponents = false;
 
             // Get related skill
             int skillValue = 0;
@@ -2547,7 +2547,7 @@ namespace DaggerfallWorkshop.Game.Formulas
 
             int cost = 0;
             int skill = 50; // 50 is used for item enchantments
-            
+
             for (int i = 0; i < 3; ++i)
             {
                 if (i < spell.effects.Length && spell.effects[i].type != -1)
@@ -2684,7 +2684,7 @@ namespace DaggerfallWorkshop.Game.Formulas
             // The below yields correct enchantment power for staves matching classic
             switch(weaponMaterial)
             {
-                default:       
+                default:
                 case WeaponMaterialTypes.Steel:         // Steel uses base enchantment power
                     return 0f;
                 case WeaponMaterialTypes.Iron:          // Iron is -25% from base
@@ -3068,6 +3068,12 @@ namespace DaggerfallWorkshop.Game.Formulas
                     {
                         a = TextManager.Instance.GetLocalizedText("palace");
                     }
+                    singleton = true;
+                    break;
+
+                case DFLocation.BuildingTypes.Town23:
+                    // City wall
+                    a = TextManager.Instance.GetLocalizedText("cityWall");
                     singleton = true;
                     break;
 

--- a/Assets/StreamingAssets/Text/Master Localization CSV Files/Internal_Strings.csv
+++ b/Assets/StreamingAssets/Text/Master Localization CSV Files/Internal_Strings.csv
@@ -1578,3 +1578,4 @@ random,Random
 nordSurnameImmutableSuffix,sen
 confirmDefaultControls,Are you sure you want to set default controls?
 saveLoadPromptFormat,{0} for '{1}'
+cityWall,City Wall


### PR DESCRIPTION
Adds `Town23` to the building type switch within `GenerateBuildingName()`. After using info on or entering the building it will be marked as "City Wall".

This was a bit of a headache to PR, as the `Internal_Strings.csv` file is a horrible mix of `CRLF` and `LF` line endings. Had to fight git and my editor so the commit diff wasn't 500+ line changes.

Fixes #2649