### PR TITLE
Restore letter signoff macro expansion for names

### DIFF
--- a/Assets/Scripts/Game/Items/ItemHelper.cs
+++ b/Assets/Scripts/Game/Items/ItemHelper.cs
@@ -343,19 +343,8 @@ namespace DaggerfallWorkshop.Game.Items
                     {
                         Message msg = quest.GetMessage(questItem.UsedMessageID);
                         TextFile.Token[] tokens = msg.GetTextTokens(expandMacros:false);
-                        string signoff = "";
-                        int lines = 0;
-                        for (int i = tokens.Length-1; i >= 0; i--)
-                        {
-                            TextFile.Token token = tokens[i];
-                            if (!string.IsNullOrEmpty(token.text))
-                            {
-                                signoff = token.text.Trim() + " " + signoff;
-                                lines++;
-                            }
-                            if (lines >= 1)
-                                return TextManager.Instance.GetLocalizedText("letterPrefix") + signoff;
-                        }
+                        QuestMacroHelper macroHelper = new QuestMacroHelper();
+                        return macroHelper.ExpandLetterSignoff(quest, tokens);
                     }
                 }
             }


### PR DESCRIPTION
Restores macro expansions (except location name macros) in letter signoff inside the hover tooltip.

Interkarma [disabled](https://github.com/Interkarma/daggerfall-unity/commit/319e5c0ef0f286e243d7fef11e14e7541f335c69) macro expansion for letter signoffs because location data lookup could potentially cause serious performance degradation from world reloads ([dfworkshop thread source](https://forums.dfworkshop.net/viewtopic.php?p=66826#p66826)).

This restores letter signoff macro expansion for all macros _except_ location based ones, so it shouldn't impact performance.