### PR TITLE
Fix loss of mage light dlight while spell is active

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/MageLight.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Illusion/MageLight.cs
@@ -159,6 +159,11 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
             {
                 myLight.transform.position = GameManager.Instance.PlayerObject.transform.position;
             }
+            else
+            {
+                // We lost the light somehow, recreate it
+                StartLight();
+            }
         }
 
         // IsLikeKind checks if another incumbent effect is equal to this effect


### PR DESCRIPTION
While mage light is active, going through a terrain change (exterior <---> interior or using the teleport spell/mage guild service) would cause loss of the dynamic light. The only way to get it back is to wait until the spell expires (or dispel it manually) and recast — a recast while the spell is active won't do it. This simply checks if the spell lost the light somehow and recreates it.