### PR TITLE
Push inventory window directly instead of through message queue

### DIFF
--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -14,6 +14,7 @@ using System;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Items;
+using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Banking;
 using UnityEngine;
@@ -216,7 +217,8 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         private void ReceiveArmorPopup_OnClose()
         {
-            DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
+            UserInterfaceManager uiManager = DaggerfallUI.Instance.UserInterfaceManager;
+            uiManager.PushWindow(DaggerfallUI.Instance.InventoryWindow);
         }
 
         public void ReceiveHouse()

--- a/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
+++ b/Assets/Scripts/Game/Guilds/KnightlyOrder.cs
@@ -14,7 +14,6 @@ using System;
 using DaggerfallWorkshop.Game.Serialization;
 using DaggerfallWorkshop.Utility;
 using DaggerfallWorkshop.Game.Items;
-using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using DaggerfallWorkshop.Game.Banking;
 using UnityEngine;
@@ -217,8 +216,7 @@ namespace DaggerfallWorkshop.Game.Guilds
 
         private void ReceiveArmorPopup_OnClose()
         {
-            UserInterfaceManager uiManager = DaggerfallUI.Instance.UserInterfaceManager;
-            uiManager.PushWindow(DaggerfallUI.Instance.InventoryWindow);
+            DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
         }
 
         public void ReceiveHouse()

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -957,7 +957,7 @@ namespace DaggerfallWorkshop.Game
             }
             // Open inventory window with activated loot container as remote target (if we fall through to here)
             DaggerfallUI.Instance.InventoryWindow.LootTarget = loot;
-            DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
+            uiManager.PushWindow(DaggerfallUI.Instance.InventoryWindow);
         }
 
         void DisableEmptyCorpseContainer(GameObject go)
@@ -1087,7 +1087,8 @@ namespace DaggerfallWorkshop.Game
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.Yes)
             {
                 // Open inventory window with activated private container as remote target (pre-set)
-                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
+                UserInterfaceManager uiManager = DaggerfallUI.Instance.UserInterfaceManager;
+                uiManager.PushWindow(DaggerfallUI.Instance.InventoryWindow);
             }
             else
                 DaggerfallUI.Instance.InventoryWindow.LootTarget = null;
@@ -1136,8 +1137,9 @@ namespace DaggerfallWorkshop.Game
             }
             else
             {
+                UserInterfaceManager uiManager = DaggerfallUI.Instance.UserInterfaceManager;
                 DaggerfallUI.Instance.InventoryWindow.AllowDungeonWagonAccess();
-                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
+                uiManager.PushWindow(DaggerfallUI.Instance.InventoryWindow);
             }
             sender.CloseWindow();
         }

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -1131,6 +1131,7 @@ namespace DaggerfallWorkshop.Game
         // Access wagon or dungeon exit
         private void DungeonWagonAccess_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
         {
+            sender.CloseWindow();
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.No)
             {
                 playerEnterExit.TransitionDungeonExterior(true);
@@ -1141,7 +1142,6 @@ namespace DaggerfallWorkshop.Game
                 DaggerfallUI.Instance.InventoryWindow.AllowDungeonWagonAccess();
                 uiManager.PushWindow(DaggerfallUI.Instance.InventoryWindow);
             }
-            sender.CloseWindow();
         }
 
         // Look for building array on object, then on direct parent

--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -1131,17 +1131,16 @@ namespace DaggerfallWorkshop.Game
         // Access wagon or dungeon exit
         private void DungeonWagonAccess_OnButtonClick(DaggerfallMessageBox sender, DaggerfallMessageBox.MessageBoxButtons messageBoxButton)
         {
-            sender.CloseWindow();
             if (messageBoxButton == DaggerfallMessageBox.MessageBoxButtons.No)
             {
                 playerEnterExit.TransitionDungeonExterior(true);
             }
             else
             {
-                UserInterfaceManager uiManager = DaggerfallUI.Instance.UserInterfaceManager;
                 DaggerfallUI.Instance.InventoryWindow.AllowDungeonWagonAccess();
-                uiManager.PushWindow(DaggerfallUI.Instance.InventoryWindow);
+                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
             }
+            sender.CloseWindow();
         }
 
         // Look for building array on object, then on direct parent

--- a/Assets/Scripts/Game/Questing/Actions/GivePc.cs
+++ b/Assets/Scripts/Game/Questing/Actions/GivePc.cs
@@ -13,6 +13,7 @@ using System;
 using UnityEngine;
 using System.Text.RegularExpressions;
 using DaggerfallWorkshop.Utility;
+using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
 using FullSerializer;
 
@@ -190,8 +191,9 @@ namespace DaggerfallWorkshop.Game.Questing.Actions
             // Open loot reward container once QuestComplete dismissed
             if (rewardLoot != null)
             {
+                UserInterfaceManager uiManager = DaggerfallUI.Instance.UserInterfaceManager;
                 DaggerfallUI.Instance.InventoryWindow.LootTarget = rewardLoot;
-                DaggerfallUI.PostMessage(DaggerfallUIMessages.dfuiOpenInventoryWindow);
+                uiManager.PushWindow(DaggerfallUI.Instance.InventoryWindow);
             }
         }
 


### PR DESCRIPTION
Occasionally activating a loot container (e.g. a loot pile, a corpse, a store shelf, a quest reward, etc) would open the inventory and the `lootTarget` would somehow be null — the inventory would open but the loot column on the right would just be the ground instead of the loot container. It seems to always happen upon the very first activation of a loot container after a load of a save game.

The cause may be a possible race condition between the `lootTarget` being set and the UI message queue being processed. Pushing the UI window directly instead of going through the UI message queue seems to solve this.

Dungeon wagon access prompts and knightly order armor reward prompts have been changed as well, just in case this bug affects them too.