### PR TITLE
Null check ImageData for BlitCloakInterior

### DIFF
--- a/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
+++ b/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
@@ -382,7 +382,8 @@ namespace DaggerfallWorkshop.Game.Utility
             if (cloak2 != null)
             {
                 ImageData interior2 = DaggerfallUnity.Instance.ItemHelper.GetCloakInteriorImage(cloak2);
-                DrawTexture(interior2, cloak2);
+                if (interior2.texture != null)
+                    DrawTexture(interior2, cloak2);
                 return;
             }
 
@@ -391,7 +392,8 @@ namespace DaggerfallWorkshop.Game.Utility
             if (cloak1 != null)
             {
                 ImageData interior1 = DaggerfallUnity.Instance.ItemHelper.GetCloakInteriorImage(cloak1);
-                DrawTexture(interior1, cloak1);
+                if (interior1.texture != null)
+                    DrawTexture(interior1, cloak1);
             }
         }
 

--- a/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
+++ b/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
@@ -246,6 +246,9 @@ namespace DaggerfallWorkshop.Game.Utility
 
         void DrawTexture(ImageData srcImage, Rect srcRect, Rect targetRect, DaggerfallUnityItem item = null)
         {
+            if (srcImage.texture == null)
+                return;
+
             // Calculate image position relative to origin
             int posX = (int)targetRect.xMin - paperDollOrigin.X;
             int posY = (int)targetRect.yMin - paperDollOrigin.Y;
@@ -265,7 +268,7 @@ namespace DaggerfallWorkshop.Game.Utility
             TextureReplacement.OverridePaperdollItemRect(item, srcImage, scale, ref screenRect);
 
             // Draw with custom shader for paper doll item masking
-            if (item != null)
+            if (item != null && srcImage.maskTexture != null)
             {
                 paperDollMaterial.SetTexture("_MaskTex", srcImage.maskTexture);
                 Graphics.DrawTexture(screenRect, srcImage.texture, srcRect, 0, 0, 0, 0, paperDollMaterial);
@@ -382,8 +385,7 @@ namespace DaggerfallWorkshop.Game.Utility
             if (cloak2 != null)
             {
                 ImageData interior2 = DaggerfallUnity.Instance.ItemHelper.GetCloakInteriorImage(cloak2);
-                if (interior2.texture != null)
-                    DrawTexture(interior2, cloak2);
+                DrawTexture(interior2, cloak2);
                 return;
             }
 
@@ -392,8 +394,7 @@ namespace DaggerfallWorkshop.Game.Utility
             if (cloak1 != null)
             {
                 ImageData interior1 = DaggerfallUnity.Instance.ItemHelper.GetCloakInteriorImage(cloak1);
-                if (interior1.texture != null)
-                    DrawTexture(interior1, cloak1);
+                DrawTexture(interior1, cloak1);
             }
         }
 


### PR DESCRIPTION
Fixes the paperdoll throwing a null exception trying to blit a cloak interior for a custom item that goes into the cloak slot and doesn't count as one of the hard coded cloaks (`Formal_cloak` or `Casual_cloak`).

Addresses part of #2740.