### PR TITLE
Fix custom item type being lost upon splitting item stack

### DIFF
--- a/Assets/Scripts/Game/Items/ItemCollection.cs
+++ b/Assets/Scripts/Game/Items/ItemCollection.cs
@@ -264,7 +264,7 @@ namespace DaggerfallWorkshop.Game.Items
                 return null;
             if (numberToPick == stack.stackCount)
                 return stack;
-            DaggerfallUnityItem pickedItems = new DaggerfallUnityItem(stack);
+            DaggerfallUnityItem pickedItems = ItemBuilder.CreateItem(stack.ItemGroup, stack.TemplateIndex);
             pickedItems.stackCount = numberToPick;
             AddItem(pickedItems, noStack: true);
             stack.stackCount -= numberToPick;


### PR DESCRIPTION
Upon splitting a stack `new DaggerfallUnityItem()` is called instead of `ItemBuilder.CreateItem()`, so any custom items lose their custom class type as `(DaggerfallUnityItem)Activator.CreateInstance(itemClassType)` is not called. This fixes that so custom items properly retain their type upon split.

Fixes #2758