### PR TITLE
Hack for runtime loading of WAV files

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
@@ -46,7 +46,8 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
         /// <returns>True if sound is found.</returns>
         public static bool TryImportSound(SoundClips sound, out AudioClip audioClip)
         {
-            return TryImportAudioClip(sound.ToString(), ".wav", false, out audioClip);
+            // For some inane reason loading .wav files unstreamed is completely broken.
+            return TryImportAudioClip(sound.ToString(), ".wav", true, out audioClip);
         }
 
         /// <summary>


### PR DESCRIPTION
Loading loose WAV audio clip files is completely broken. On current Unity version (`2019.4`) it just falls back to the default DF audio files (presumably because the returned AudioClip is null), but on Unity `2022.3` it fails to fall back (presumably because the returned AudioClip is not null, just empty) so there is no sound at all. Loading of loose OGG music files works just fine though.

I don't know why, but setting WAV files to load streamed fixes this issue. :shrug: 