### PR TITLE
Use a snow emitter around the camera

### DIFF
--- a/Assets/Scenes/DaggerfallUnityGame.unity
+++ b/Assets/Scenes/DaggerfallUnityGame.unity
@@ -820,6 +820,15 @@ PrefabInstance:
       propertyPath: m_BeforeStackBundles.Array.data[0].assemblyQualifiedName
       value: ColorBoost, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
       objectReference: {fileID: 0}
+    - target: {fileID: 4609117991535154, guid: 53a45b46ca97a974f8e677f68c2a85e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 198237622866876544, guid: 53a45b46ca97a974f8e677f68c2a85e6,
+        type: 3}
+      propertyPath: ShapeModule.m_Scale.y
+      value: 40
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 53a45b46ca97a974f8e677f68c2a85e6, type: 3}
 --- !u!1 &348738038


### PR DESCRIPTION
Specially when going down hills, it's obvious that the snow emitter is above the player and snow particles can't keep up with player's movement.

Simplest fix is to use an emitter around the camera instead of above; It's not perfect but greatly improves the visual effect worse cases.

Test:

    set_weather 6
    location 3

(maybe use location 3 multiple times until you spawn on the sea side of Sentinel)
Then descend in the direction of the sea, preferably on horse

Source:
https://gamedev.stackexchange.com/questions/198424/in-a-top-down-3d-game-how-can-i-simulate-snow-without-actually-covering-entire