### PR TITLE
Daggerfall Proofreading Project, Part 2: Quest Files

### DIFF
--- a/Assets/StreamingAssets/Quests/$CUREVAM.txt
+++ b/Assets/StreamingAssets/Quests/$CUREVAM.txt
@@ -34,15 +34,15 @@ RumorsPostfailure:  [1006]
 <ce>_hunter_ and %g3 men killed a lot of vampires in %reg, but I doubt they
 <ce>                             got them all.
                                      <--->
-<ce> _hunter_ should have left well enough alone.  %g3 crusades just send
-<ce> the vampires into hiding, and when %g leaves, they come back stronger than  ever.
+<ce> _hunter_ should have left well enough alone.  %G3 crusades just send
+<ce> the vampires into hiding, and when %g leaves, they come back stronger than ever.
 
 RumorsPostsuccess:  [1007]
 <ce>_hunter_ and %g3 men killed a lot of vampires in %reg, but I doubt they
 <ce>                             got them all.
                                      <--->
-<ce> _hunter_ should have left well enough alone.  %g3 crusades just send
-<ce> the vampires into hiding, and when %g leaves, they come back stronger than  ever.
+<ce> _hunter_ should have left well enough alone.  %G3 crusades just send
+<ce> the vampires into hiding, and when %g leaves, they come back stronger than ever.
 
 QuestorPostsuccess:  [1008]
 Error -- 1008 called
@@ -110,7 +110,7 @@ Message:  1022
 <ce>             we can save the lives of many of our kinfolk.
 <ce>              Do not underestimate the danger you are in,
 <ce>               %pcf.  _hunter_ is ruthless and competent,
-<ce>              and %g3 spies are everywhere.  %g would make
+<ce>              and %g3 spies are everywhere.  %G would make
 <ce>              an excellent addition to %vam -- perhaps %g
 <ce>              will yet.  Be that as it may, %g knows your
 <ce>              name, and do not doubt that %g will attempt
@@ -131,7 +131,7 @@ Message:  1023
 <ce>                 advise against intruding on an elder's
 <ce>             seclusion lightly, however.  It would be best
 <ce>                 if you looked up _vamp2_ of ___vamp2_.
-<ce>              %g is the Keeper of the Bloodline, and will
+<ce>              %G is the Keeper of the Bloodline, and will
 <ce>              be able to tell you with certainty which of
 <ce>              %vam elders is your bloodfather.  Take this
 <ce>              bracelet to %g2 so %g will know I sent you.

--- a/Assets/StreamingAssets/Quests/$CUREWER.txt
+++ b/Assets/StreamingAssets/Quests/$CUREWER.txt
@@ -30,21 +30,21 @@ QuestComplete:  [1004]
 <ce>                        right before your eyes.
 
 RumorsDuringQuest:  [1005]
-<ce>   _hunter_ is coming to %reg to clean out the werebeast infection.
+<ce>   _hunter_ is coming to %reg to clean out the werebeast infestation.
 <ce> Maybe then we'll be able to walk the streets at night again without fear.
 
 RumorsPostfailure:  [1006]
-<ce>_hunter_ and %g3 men killed a lot of loops in %reg, but I'll be hanged
+<ce>_hunter_ and %g3 men killed a lot of loups in %reg, but I'll be hanged
 <ce>                          if they got 'em all.
                                      <--->
-<ce> _hunter_ should have left well enough alone.  %g3 crusades just send
+<ce> _hunter_ should have left well enough alone.  %G3 crusades just send
 <ce>                  the werecreatures into greater fury.
 
 RumorsPostsuccess:  [1007]
-<ce>_hunter_ and %g3 men killed a lot of loops in %reg, but I'll be hanged
+<ce>_hunter_ and %g3 men killed a lot of loups in %reg, but I'll be hanged
 <ce>                          if they got 'em all.
                                      <--->
-<ce> _hunter_ should have left well enough alone.  %g3 crusades just send
+<ce> _hunter_ should have left well enough alone.  %G3 crusades just send
 <ce>                  the lycanthropes into greater fury.
 
 QuestorPostsuccess:  [1008]
@@ -104,7 +104,7 @@ Message:  1020
  compassion. I offer you one last chance to save
  yourself.  Go to _priest_ of
  __priest_ in ___priest_ if you wish
- to live. %g is wise in the ways of lycanthropy, and if
+ to live. %G is wise in the ways of lycanthropy, and if
  anyone can help you, %g can.
     I will wait =huntstart_ days before sending my hunters
  after you.  Use the time wisely.
@@ -120,7 +120,7 @@ Message:  1021
 <ce>           can be lifted, although I hesitate to speak of it,
 <ce>          as the cure may be worse than the disease.  We must
 <ce>              lower our voices.  You may not be aware that
-<ce>           lycanthropy is an hereditary condition, passed on
+<ce>           lycanthropy is a hereditary condition, passed on
 <ce>            in certain families, although it can lie dormant
 <ce>            for generations before reappearing.  This is why
 <ce>          the great crusades against lycanthropes led by those
@@ -146,7 +146,7 @@ Message:  1022
 <ce>             As far as I know, he still lives in ___local_,
 <ce>            the family home for generations.  But first, you
 <ce>             will need to see _alchemist_ in ___alchemist_.
-<ce>            %g has assisted me in such matters before.  The
+<ce>            %G has assisted me in such matters before.  The
 <ce>          surest way to pass on the disease is for the victim
 <ce>          to drink the blood of the lycanthrope.  _alchemist_
 <ce>            will ask no questions and tell no tales at your
@@ -196,7 +196,7 @@ Message:  1026
 <ce>                and didn't want _child_ to find out the
 <ce>               truth about it.  I never figured out what
 <ce>                it was all about.  Yes, _child_ was his
-<ce>                only child.  %g was taken in by a family
+<ce>                only child.  %G was taken in by a family
 <ce>                 from __childhouse_ after %g3 father's
 <ce>                 death.  I'm afraid that's all I know.
 
@@ -227,7 +227,7 @@ Message:  1050
  The lycanthrope hunter _hunter_
  has sent me a letter vowing to
  hunt me down unless I cure myself
- of lycanthropy.  %g directed me to
+ of lycanthropy.  %G directed me to
  a _priest_ of __priest_,
  ___priest_. I have =huntstart_ days
  before the hunt begins.
@@ -247,7 +247,7 @@ Message:  1052
 %qdt:
  I declined _priest_'s offer to cure
  my lycanthropy by inflicting it on
- another.  %g3 only additional advice
+ another.  %G3 only additional advice
  was to seek out a book which might
  lead me to a Coven purported to have
  the cure.  The book's last known location

--- a/Assets/StreamingAssets/Quests/30C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/30C00Y00.txt
@@ -69,7 +69,7 @@ The vampire in ___mondung_ apparently decided that it was time to move on.
 I guess that vampire did still need blood after all. It left for some reason.
 
 RumorsPostsuccess:  [1007]
-I don't care if that vampire did conquer its bloodlust: I'm glad it's dead.
+I don't care if that vampire did conquer its bloodlust; I'm glad it's dead.
 <--->
 The stars of Namira burned bright last night. Always hungry, never satisfied.
 

--- a/Assets/StreamingAssets/Quests/40C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/40C00Y00.txt
@@ -62,7 +62,7 @@ I can't trust anyone at the Mages Guild, knowing =monster_ is a member.
 <--->
 Mages say =monster_ is hiding from Oblivion's wrath at ___fakedung_.
 <--->
-Mage's are gathering to scour ___fakedung_ for that scoundrel =monster_.
+Mages are gathering to scour ___fakedung_ for that scoundrel =monster_.
 <--->
 I saw a bunch of mages heading out to ___fakedung_.
 <--->
@@ -99,7 +99,7 @@ The _artifact_ can open any lock.
 Message:  1015
 Mages say =monster_ is hiding from Oblivion's wrath at ___fakedung_.
 <--->
-Mage's are gathering to scour ___fakedung_ for that scoundrel =monster_.
+Mages are gathering to scour ___fakedung_ for that scoundrel =monster_.
 <--->
 I saw a bunch of mages heading out to ___fakedung_.
 <--->
@@ -108,7 +108,7 @@ I heard that traitor =monster_ is now hiding out in ___fakedung_.
 Message:  1016
 <ce>                           %oth!  =monster_,
 <ce>                     Oblivion's agent is upon us!
-<ce>               I've moved the most valuable reagents to
+<ce>                 I've moved the most valuable reagents
 <ce>                          to ___fakedung_ and
 <ce>                  plan to meet you there after you've
 <ce>                      dealt with that pesky %ra.
@@ -150,7 +150,7 @@ Message:  1021
 %qdt:
  =monster_ offered me _bow_
  in exchange for %g3 life, and I
- could not resist.  %g said that
+ could not resist.  %G said that
  it is somewhere in ___bowdung_.
  Since I have already betrayed
  Nocturnal, I may as well try to
@@ -160,7 +160,7 @@ Message:  1022
 %qdt:
  =monster_ offered me the _ring_
  in exchange for %g3 life, and I
- could not resist.  %g said that
+ could not resist.  %G said that
  it is somewhere in ___ringdung_.
  Since I have already betrayed
  Nocturnal, I may as well try to
@@ -170,7 +170,7 @@ Message:  1023
 %qdt:
  =monster_ offered me the _staff_
  in exchange for %g3 life, and I
- could not resist.  %g said that
+ could not resist.  %G said that
  it is somewhere in ___staffdung_.
  Since I have already betrayed
  Nocturnal, I may as well try

--- a/Assets/StreamingAssets/Quests/50C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/50C00Y00.txt
@@ -81,12 +81,12 @@ Old =monster_ moved up north. So I guess we know where plague will follow.
 I hear the Daedra themselves fear =monster_ and its power.
 
 RumorsPostsuccess:  [1007]
-=monster_ they say fancied itself more powerful than the daedra themselves.
+=monster_ they say fancied itself more powerful than the Daedra themselves.
 <--->
 =monster_ got its reward for boasting about its power over life and death.
 
 Message:  1011
-They say _qgfriend_ is a very pleasant and charming =qgfriend_, who is also a daedra-worshipper.
+They say _qgfriend_ is a very pleasant and charming =qgfriend_, who is also a Daedra-worshipper.
 <--->
 _qgfriend_ is rumored to be Peryite's slave in %reg.
 

--- a/Assets/StreamingAssets/Quests/60C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/60C00Y00.txt
@@ -97,7 +97,7 @@ Sheogorath is the Mad One, the Daedra who revels in chaos and lunacy.
 Message:  1013
 _artifact_ is an ancient artifact with wildly random magical effects.
 <--->
-_artifact_ can transform its targets into other other creatures.
+_artifact_ can transform its targets into other creatures.
 
 Message:  1014
 _qgfriend_ is one of the Daedra Prince Sheogorath's most loyal servants.

--- a/Assets/StreamingAssets/Quests/70C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/70C00Y00.txt
@@ -69,7 +69,7 @@ RumorsPostfailure:  [1006]
 Everyone's afraid to do anything at all fun with people like =monster_ around.
 
 RumorsPostsuccess:  [1007]
-Lots of people are happy about =monster_'s death. Just desserts for %g3 ilk.
+Lots of people are happy about =monster_'s death. Just deserts for %g3 ilk.
 <--->
 The orgies have started up again now that =monster_'s out of the picture.
 

--- a/Assets/StreamingAssets/Quests/80C0XY00.txt
+++ b/Assets/StreamingAssets/Quests/80C0XY00.txt
@@ -41,7 +41,7 @@ AcceptQuest:  [1002]
 <ce>             meet you at the palace there for convenience.
 <ce>               I don't think the whole affair should take
 <ce>                 more than =1stparton_ days if done as
-<ce>               efficiently as it should. Go then into the
+<ce>               efficiently as it should be. Go then into the
 <ce>                     world and do my bidding, %pcn.
 
 QuestFail:  [1003]
@@ -54,7 +54,7 @@ QuestComplete:  [1004]
 <ce>                     old =monster_. She just didn't
 <ce>               know how to keep her mouth shut, you know?
 <ce>                  Anyhow, here's the _artifact_. Not a
-<ce>             halfbad smasher. And who knows? You might have
+<ce>             half-bad smasher. And who knows? You might have
 <ce>                 to use it on Malacath himself one day.
 <ce>                             I'm joking ...
 <ce>                               of course.
@@ -108,8 +108,8 @@ Message:  1030
 =monster_,
  
       Malacath wishes _murder_ dead.
- %g3 agents have uncovered one too many of
- our plots.  %g must be stopped before all
+ %G3 agents have uncovered one too many of
+ our plots.  %G must be stopped before all
  our plans for %reg are ruined.  You will
  find %g2 in the Palace of ___ruler_.  Make
  sure %g3 death cannot be traced back to us.
@@ -123,7 +123,7 @@ Message:  1030
 Message:  1040
 <ce>                     %oth!  _qgfriend_ was behind
 <ce>                    _murder_'s death?  And involved
-<ce>                   in a daedra plot as well?  We may
+<ce>                   in a daedric plot as well?  We may
 <ce>                 never have solved this murder without
 <ce>                   your help, %pcn.  Your loyalty to
 <ce>                     the %rt will not be forgotten.

--- a/Assets/StreamingAssets/Quests/90C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/90C00Y00.txt
@@ -25,7 +25,7 @@ RefuseQuest:  [1001]
 <ce>                        contemptible, sniveling,
 <ce>                        virtuous, sterling piece
 <ce>                        of goblin snot! I'm not
-<ce>                        going waste my precious
+<ce>                       going to waste my precious
 <ce>                          time with anyone so
 <ce>                           poisonously moral.
 
@@ -96,7 +96,7 @@ Vaernima is the Daedra Lady of Corruption and Decay. Not nice to look at.
 Vaernima is a Regent of Oblivion, and her sphere is Corruption and Decay.
 
 Message:  1014
-The Skull of Corruptions creates dark and oppositional duplicates of a target.
+The Skull of Corruption creates dark and oppositional duplicates of a target.
 <--->
 The Skull brings forth a target's dark half from Vaernima's plane of Oblivion.
 

--- a/Assets/StreamingAssets/Quests/A0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y00.txt
@@ -81,9 +81,9 @@ QuestLogEntry:  [1010]
 Message:  1011
 _npc1_,
     You are a most spiteful man. How could I ever
- have thought that I loved you. Since you caught me
+ have thought that I loved you? Since you caught me
  on the balcony in the arms of _npc2_,
- I can now reveal that we are indeed lovers. %g is
+ I can now reveal that we are indeed lovers. %G is
  able to give me everything that you cannot. You made
  me feel unclean with your disgusting gifts of gold.
  Do not ever darken my doorway again.
@@ -96,7 +96,7 @@ My dearest _npc1_,
  anything to regain your love. What you saw on the
  balcony was not of my desire. I had too much to drink
  that night and _npc2_ took advantage of
- the moment to steal a kiss. %g has been flogged and
+ the moment to steal a kiss. %G has been flogged and
  is no longer in my service. Please forgive me.
  I love only you.
  
@@ -143,7 +143,7 @@ Message:  1019
 Baron _npc1_,
     Count _npc2_ will be
  waiting for you in the pass.
- %g3 truce agreement is an
+ %G3 truce agreement is an
  honorable and fair one.
                   _npc3_
 
@@ -160,7 +160,7 @@ Message:  1021
 Honorable _npc1_,
     I have decided to cast my
  vote for _npc3_ at the
- next guild meeting. %g has
+ next guild meeting. %G has
  shown %g3 faithfulness to
  the guild many times.
                   _npc2_

--- a/Assets/StreamingAssets/Quests/A0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y06.txt
@@ -49,7 +49,7 @@ Message:  1011
 
 Message:  1012
 <ce>                       Know me for who I really
-<ce>                      am. I am your mortal enemy,
+<ce>                      am: I am your mortal enemy,
 <ce>                          _traitor_! I have a
 <ce>                       special fate in store for
 <ce>                                 you.
@@ -58,7 +58,7 @@ Message:  1013
 <ce>                        I didn't know _traitor_
 <ce>                      would betray you like that.
 <ce>                       I ain't got no beef with
-<ce>                          you, %pcn. %g moved
+<ce>                          you, %pcn. %G moved
 <ce>                    to _hidingplace_ here in town.
 <ce>                          Look for %g2 there.
 

--- a/Assets/StreamingAssets/Quests/A0C00Y07.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y07.txt
@@ -34,9 +34,9 @@ RumorsDuringQuest:  [1005]
 <ce>                   I think it's hilarious! _qgiver_'s
 <ce>                  _house_ is overrun with giant bugs!
                                      <--->
-<ce>                    I feel sorry for _qgiver_. %g3
+<ce>                    I feel sorry for _qgiver_. %G3
 <ce>                    _house_ has been virtually taken
-<ce>                over by 12 foot long rats with poisonous
+<ce>                over by 12-foot-long rats with poisonous
 <ce>                stingers. I hear they can turn a man to
 <ce>                      stone with a single glance!
 
@@ -62,7 +62,7 @@ QuestorPostsuccess:  [1008]
                                      <--->
 <ce>                Everyone, listen up. I want you to meet
 <ce>             my friend, %pcn, exterminator extraordinaire.
-<ce>               %g rid my _house_ of three dozen monsters!
+<ce>               %G rid my _house_ of three dozen monsters!
 
 QuestorPostfailure:  [1009]
 <ce>                  You! You ruined me! I lost _house_
@@ -77,8 +77,8 @@ QuestorPostfailure:  [1009]
 QuestLogEntry:  [1010]
 %qdt:
  In ___qgiver_, I met _qgiver_.
- %g asked me to rid _house_ in
- __house_ of monsters. %g needs
+ %G asked me to rid _house_ in
+ __house_ of monsters. %G needs
  them gone within a day.
 
 Message:  1011

--- a/Assets/StreamingAssets/Quests/A0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y10.txt
@@ -30,7 +30,7 @@ RefuseQuest:  [1001]
                                      <--->
 <ce>            I didn't think so. Go on with whatever you do.
                                      <--->
-<ce>                Didn't think you would say yes anyway.
+<ce>                Didn't think you would say yes, anyway.
 <ce>                       Now begone with yourself.
 
 AcceptQuest:  [1002]
@@ -88,7 +88,7 @@ QuestorPostsuccess:  [1008]
 QuestorPostfailure:  [1009]
 <ce>                  Hah! You didn't even bother to show
 <ce>                  up for the duel. Thought I wouldn't
-<ce>                    remember eh? Shove off, coward!
+<ce>                    remember, eh? Shove off, coward!
 
 Message:  1016
 <ce>                     Oh, smelly one. 'Tis not your
@@ -124,7 +124,7 @@ Message:  1018
 
 Message:  1019
 <ce>                    Then the %ra is not a coward as
-<ce>                     _giver_ said you were. %g paid
+<ce>                     _giver_ said you were. %G paid
 <ce>                  me well to come here and cut you to
 <ce>                pieces. And I shall. Prepare for battle!
                                      <--->

--- a/Assets/StreamingAssets/Quests/A0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y11.txt
@@ -54,7 +54,7 @@ RumorsPostfailure:  [1006]
 <ce>                       might break out there now.
                                      <--->
 <ce>                      _giver_ is overwrought with
-<ce>                    grief. %g3 cousin in ___cousin_
+<ce>                    grief. %G3 cousin in ___cousin_
 <ce>                             died recently.
 
 RumorsPostsuccess:  [1007]
@@ -71,7 +71,7 @@ RumorsPostsuccess:  [1007]
 QuestorPostsuccess:  [1008]
 <ce>                  Bless you, %pcf. I will never forget
 <ce>                    what you did for _cousin_ and I.
-<ce>                    %g has fully recovered from the
+<ce>                    %G has fully recovered from the
 <ce>                              Wizard Bane.
 
 QuestorPostfailure:  [1009]
@@ -84,13 +84,13 @@ QuestLogEntry:  [1010]
  _giver_ of ___giver_ has
  paid me to heal %g3 cousin,
  _cousin_ of ___cousin_.
- %g will most likely die in =questtime_ days.
+ %G will most likely die in =questtime_ days.
  I will receive another _gold2_ gold when I
  have saved %g2.
 
 Message:  1011
 %qdt:
- I have seen _cousin_. %g3 condition
+ I have seen _cousin_. %G3 condition
  is even worse than _giver_ said.
  _cousin_ says that _healer_ in
  ___healer_ might have a cure.
@@ -136,7 +136,7 @@ Message:  1015
 Message:  1017
 %qdt:
  I have bought a Talisman from _healer_ of
- ___healer_ that cures Wizard Fever, the
+ ___healer_ that cures Wizard Bane, the
  disease that is afflicting _cousin_.
 
 Message:  1019
@@ -162,7 +162,7 @@ Message:  1041
 <ce>                     You'll find %g2 in ___healer_.
                                      <--->
 <ce>                 I've heard of _healer_ of ___healer_.
-<ce>    %g has quite a reputation for healing the most difficult cases.
+<ce>    %G has quite a reputation for healing the most difficult cases.
 
 
 -- Symbols used in the QRC file:

--- a/Assets/StreamingAssets/Quests/A0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y12.txt
@@ -44,7 +44,7 @@ RumorsPostfailure:  [1006]
 
 RumorsPostsuccess:  [1007]
 <ce>                    You must be the %ra that found
-<ce>                 _giver_'s book for %g2. %g is telling
+<ce>                 _giver_'s book for %g2. %G is telling
 <ce>                 everyone about it. You'd think it was
 <ce>                     the king that had been saved.
 
@@ -66,7 +66,7 @@ QuestLogEntry:  [1010]
 
 Message:  1014
 <ce>                  You may want to try _informant_ in
-<ce>              _informant1_. %g seems to know everything
+<ce>              _informant1_. %G seems to know everything
 <ce>                 that goes on around __informant1_.
                                      <--->
 <ce>                   You should ask at the local inns.
@@ -93,7 +93,7 @@ Message:  1025
 <ce>                          through these ears.
 <ce>              Enough about me. I did hear something about
 <ce>                _giver_'s misfortunes. You want to find
-<ce>                     _thief_. %g has been looking
+<ce>                     _thief_. %G has been looking
 <ce>                    for a first printing of _book_
 <ce>                for some time. And %g is also the type
 <ce>                   who takes things without asking,
@@ -103,7 +103,7 @@ Message:  1035
 %qdt:
  _informant_ has given me valuable
  information about the missing
- _book_. %g seems to think that
+ _book_. %G seems to think that
  _thief_ might be mixed up in it
  somehow. Now if I could just find %g2...
 
@@ -114,7 +114,7 @@ _thief_ lives in __house_.
 <--->
 _thief_ spends %g3 nights at _house_.
 <--->
-You should try to find _thief_ at %g3 home. %g lives in __house_.
+You should try to find _thief_ at %g3 home. %G lives in __house_.
 <--->
 _thief_ does a lot of trading at _store_.
 <--->

--- a/Assets/StreamingAssets/Quests/A0C00Y14.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y14.txt
@@ -22,7 +22,7 @@ QuestorOffer:  [1000]
                                      <--->
 <ce>                         Hi, I'm _questgiver_.
 <ce>                     I need someone to drop off an
-<ce>                    item for me. It's a just a short
+<ce>                     item for me. It's just a short
 <ce>                     trip across town, but I'm too
 <ce>                  busy right now. There's _gold_ gold
 <ce>                             in it for ya.
@@ -39,20 +39,20 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>                   Great! Here is the package. Take
 <ce>                      it to _pickuplocal_ here in
-<ce>                    town. %g will pay you. It needs
+<ce>                    town. %G will pay you. It needs
 <ce>                   to be there by this time tomorrow.
                                      <--->
 <ce>                   At last, someone willing to work
 <ce>                    for a living. Just take this to
 <ce>                      _pickuplocal_ here in town.
-<ce>                    %g'll give you the _gold_ gold.
+<ce>                    %G'll give you the _gold_ gold.
 <ce>                       Get it to %g2 by this time
 <ce>                               tomorrow.
 
 QuestComplete:  [1004]
 <ce>                       I was hoping _questgiver_
 <ce>                would be able to get this to me in time.
-<ce>                      %g has been so busy lately.
+<ce>                      %G has been so busy lately.
 <ce>                  Here is the _gold_ %g promised you.
 
 RumorsDuringQuest:  [1005]

--- a/Assets/StreamingAssets/Quests/A0C00Y15.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y15.txt
@@ -42,13 +42,13 @@ AcceptQuest:  [1002]
 <ce>                       Great! Take this package
 <ce>                        to ___pickupregion_ and
 <ce>                        ask for _pickupregion_.
-<ce>                       %g will pay you. It needs
+<ce>                       %G will pay you. It needs
 <ce>                   to be there in =traveltime_ days.
 <ce>                          Here is the package.
                                      <--->
 <ce>                What luck! My friend is _pickupregion_
 <ce>                     in ___pickupregion_. Just ask
-<ce>                  around, everyone knows %g2. %g will
+<ce>                  around, everyone knows %g2. %G will
 <ce>                    pay you right away. If you take
 <ce>                   longer than =traveltime_ days, you
 <ce>                      might as well throw it away.
@@ -57,7 +57,7 @@ AcceptQuest:  [1002]
 QuestComplete:  [1004]
 <ce>                       I was hoping _questgiver_
 <ce>                would be able to get this to me in time.
-<ce>                      %g has been so busy lately.
+<ce>                      %G has been so busy lately.
 <ce>                 Here is the _gold_ you were promised.
 
 RumorsDuringQuest:  [1005]

--- a/Assets/StreamingAssets/Quests/A0C00Y16.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y16.txt
@@ -32,7 +32,7 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>            My prayers have been answered. _missingperson_
 <ce>             has not been seen for four days, and I am very
-<ce>             worried about %g2. %g has been seen consorting
+<ce>             worried about %g2. %G has been seen consorting
 <ce>                   with _friend1_ and _friend2_. You
 <ce>              might want to start with them. If you can't
 <ce>                 find _missingperson_ within two days,
@@ -47,7 +47,7 @@ RumorsDuringQuest:  [1005]
 
 RumorsPostfailure:  [1006]
 <ce>                    No one has seen _missingperson_
-<ce>                 for days now. %g has been given up for
+<ce>                 for days now. %G has been given up for
 <ce>                  dead. I hear _questgiver_ is grief-
 <ce>                           stricken over it.
 
@@ -67,7 +67,7 @@ QuestorPostfailure:  [1009]
 QuestLogEntry:  [1010]
 On %qdt,
  I agreed to help _questgiver_ find
- _missingperson_. %g has been missing
+ _missingperson_. %G has been missing
  for four days. My only clues are that
  %g has been seen with _friend2_
  and _friend1_ recently. If
@@ -100,7 +100,7 @@ Message:  1023
 Message:  1024
 <ce>                       _missingperson_? Yeah, I
 <ce>                       know what happened to %g2.
-<ce>                      %g got killed, that's what.
+<ce>                      %G got killed, that's what.
 <ce>                       My friend Smiley asked %g2
 <ce>                      real nice for %g3 gold, and
 <ce>                        %g wouldn't hand it over.
@@ -111,7 +111,7 @@ Message:  1024
 Message:  1031
 <ce>                     _missingperson_? Naw. Haven't
 <ce>                     seen %g2 for a couple of days.
-<ce>                     Try asking _friend3_. %g might
+<ce>                     Try asking _friend3_. %G might
 <ce>                                 know.
 
 Message:  1032
@@ -137,7 +137,7 @@ Message:  1034
 Message:  1040
 <ce>                      What are you doing here? I
 <ce>                         don't ever want to see
-<ce>                      _questgiver_ again. Hey! let
+<ce>                      _questgiver_ again. Hey! Let
 <ce>                     me go! You can't just drag me
 <ce>                      through the streets to %g2.
 
@@ -162,7 +162,7 @@ Message:  1052
 
 Message:  1053
 <ce>                        So _missingperson_ has
-<ce>                    left town? %g didn't need to do
+<ce>                    left town? %G didn't need to do
 <ce>                    that. I would have forgiven %g2.
 
 Message:  1054

--- a/Assets/StreamingAssets/Quests/A0C00Y17.txt
+++ b/Assets/StreamingAssets/Quests/A0C00Y17.txt
@@ -48,19 +48,19 @@ QuestComplete:  [1004]
 
 RumorsDuringQuest:  [1005]
 <ce>                   I hear the guards are looking for
-<ce>                 _questgiver_. %g had to flee the town.
+<ce>                 _questgiver_. %G had to flee town.
                                      <--->
 <ce>                 Don't you know? The Thieves Guild is
 <ce>                   after _questgiver_. Or was it the
 <ce>                      Dark Brotherhood? I forget.
                                      <--->
 <ce>                     I heard _questgiver_ has been
-<ce>                   forced to marry. %g has to get to
+<ce>                   forced to marry. %G has to get to
 <ce>                       __destination_ before the
 <ce>                       pregnancy begins to show.
 
 RumorsPostfailure:  [1006]
-<ce>                     They caught _questgiver_. %g
+<ce>                     They caught _questgiver_. %G
 <ce>                      will stand trial next week.
 
 RumorsPostsuccess:  [1007]
@@ -77,12 +77,12 @@ QuestorPostsuccess:  [1008]
 QuestorPostfailure:  [1009]
 <ce>                    You! Because you wouldn't help
 <ce>                    me get out of town, the Thieves
-<ce>                      Guild took my shop! Go away.
+<ce>                     Guild took my shop! Go away.
 
 QuestLogEntry:  [1010]
 %qdt:
  I met _questgiver_
- in ___questgiver_. %g
+ in ___questgiver_. %G
  will pay me to escort %g2 to
  _destination_ in __destination_.
  In particular, %g needs to get to _destination_

--- a/Assets/StreamingAssets/Quests/A0C01Y01.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y01.txt
@@ -38,7 +38,7 @@ RumorsDuringQuest:  [1005]
 <ce>                             rough %g2 up.
 
 RumorsPostfailure:  [1006]
-<ce>                    I saw _qgiver_ recently. %g was
+<ce>                    I saw _qgiver_ recently. %G was
 <ce>                        beaten up by some thugs.
 
 RumorsPostsuccess:  [1007]

--- a/Assets/StreamingAssets/Quests/A0C01Y03.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y03.txt
@@ -30,7 +30,7 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>                The only person who might help you find
 <ce>                         _hermit_ is _spouse_.
-<ce>                     %g can be found in ___spouse_.
+<ce>                     %G can be found in ___spouse_.
 <ce>              Take these flowers. They are %g3 favorites.
 <ce>                 They may gain you some favor with %g2.
 <ce>                    Here is a letter with _hermit_'s
@@ -49,7 +49,7 @@ QuestComplete:  [1004]
 
 RumorsDuringQuest:  [1005]
 <ce>                    _qgiver_ is smitten with love.
-<ce>                   %g has been trying to get _spouse_
+<ce>                   %G has been trying to get _spouse_
 <ce>                to accept a marriage proposal for ages.
 
 RumorsPostfailure:  [1006]
@@ -113,7 +113,7 @@ Speak not of love or hate, but tell
 
 Message:  1015
 On %qdt, I spoke with
- _spouse_. %g told me that
+ _spouse_. %G told me that
  _hermit_ left to
  study under _teacher_
  in __school_.
@@ -122,14 +122,14 @@ Message:  1016
 On %qdt, I met with
  _hermit_'s teacher,
  _teacher_ of
- __school_. %g said that
+ __school_. %G said that
  _hermit_ had secluded %g2self in
  ___dungeon_.
 
 Message:  1017
 Speak not of love or hate, but tell
  me this: what gift can you give to
- to me that I can never buy for myself?
+ me that I can never buy for myself?
  
  'It's KINDNESS, stupid!'
 

--- a/Assets/StreamingAssets/Quests/A0C01Y06.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y06.txt
@@ -70,7 +70,7 @@ QuestLogEntry:  [1010]
  who told me %g3 master,
  _master_, would pay _gold_ gold
  pieces for an unknown but certainly
- dangerous task. %g1 is staying in
+ dangerous task. %G1 is staying in
  _meetingplace_ in __meetingplace_.
 
 Message:  1011
@@ -88,7 +88,7 @@ Message:  1012
 Message:  1013
 <ce>                    Don't hurt me, %pcn! I didn't
 <ce>               know what _master_ was planning. I ain't
-<ce>               got no beef with you, honest. %g didn't
+<ce>               got no beef with you, honest. %G didn't
 <ce>                   tell me nothin', I swear, %g just
 <ce>                 paid me to send you to %g2. It's %g2
 <ce>                   you want, not me, right? I hear

--- a/Assets/StreamingAssets/Quests/A0C01Y09.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y09.txt
@@ -33,13 +33,13 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>                    Excellent! You are a smart one.
 <ce>                    This is easy gold. Go to _store_
-<ce>                and find _merchant_. %g has the specific
+<ce>                and find _merchant_. %G has the specific
 <ce>                   _item_ I need. Remember, there is
 <ce>                   only a month 'til the celebration.
                                      <--->
 <ce>          Very good. This is easy gold. You'll have to go to
 <ce>                 _store_ to find the exact kind I need.
-<ce>                 Talk to _merchant_. %g runs the place.
+<ce>                 Talk to _merchant_. %G runs the place.
 
 
 QuestComplete:  [1004]

--- a/Assets/StreamingAssets/Quests/A0C01Y13.txt
+++ b/Assets/StreamingAssets/Quests/A0C01Y13.txt
@@ -42,7 +42,7 @@ QuestFail:  [1003]
 %qdt:
  Someone has been spreading rumors around
  ___giver_ about _giver_.
- %g has hired me to put a stop
+ %G has hired me to put a stop
  to them for _gold_ gold. I have 1 month to
  return with proof of my success.
 
@@ -113,7 +113,7 @@ Message:  1018
  outlining the plan to kidnap _lover_,
  and _giver_ has now divulged that
  %g hired some bandits to lock him away in
- ___dungeon_. %g begged for his life
+ ___dungeon_. %G begged for his life
  and asked that I rescue _lover_.
 
 Message:  1020

--- a/Assets/StreamingAssets/Quests/A0C0XY04.txt
+++ b/Assets/StreamingAssets/Quests/A0C0XY04.txt
@@ -13,7 +13,7 @@ QRC:
 
 QuestorOffer:  [1000]
 <ce>                         My name is _agent_. I
-<ce>                    represent a someone that needs
+<ce>                     represent someone that needs
 <ce>                   to... acquire something. Whoever
 <ce>                     delivers it will be rewarded
 <ce>                          with _artifact_. I
@@ -63,7 +63,7 @@ QuestorPostfailure:  [1009]
 QuestLogEntry:  [1010]
 On %qdt,
  I met with _agent_ of ___agent_.
- %g told me that a mysterious client of
+ %G told me that a mysterious client of
  %g3 was looking for daedric _ingredient_.
  If I can find it, I will get the _artifact_.
  The daedric _ingredient_ is somewhere
@@ -87,7 +87,7 @@ Message:  1012
 <ce>                   know that _qgiver_ is not what %g
 <ce>                 seems. The _artifact_ is a long lost
 <ce>                 item of great power that %g has never
-<ce>                  owned. %g means to kill you once %g
+<ce>                  owned. %G means to kill you once %g
 <ce>                     has possession of the daedric
 <ce>                    _ingredient_. Cease this futile
 <ce>                 attack and I will give you a magical
@@ -125,7 +125,7 @@ Message:  1015
 <ce>                       as %g is known to %g3 own
 <ce>                       people, has earned you a
 <ce>                        reward. Members of the
-<ce>                      Mage's Guild now trust you
+<ce>                      Mages Guild now trust you
 <ce>                        far more than before."
 
 Message:  1020

--- a/Assets/StreamingAssets/Quests/A0C10Y02.txt
+++ b/Assets/StreamingAssets/Quests/A0C10Y02.txt
@@ -35,7 +35,7 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>                You are my savior! My name is _qgiver_.
 <ce>             Quickly now, for you only have =timeforq_ days
-<ce>                 before they kill _child_. %g is being
+<ce>                 before they kill _child_. %G is being
 <ce>                    held in _dbguild_ in __dbguild_.
 
 QuestFail:  [1003]
@@ -57,7 +57,7 @@ RumorsDuringQuest:  [1005]
 
 RumorsPostfailure:  [1006]
 <ce>                   I don't think that _qgiver_ will
-<ce>                   survive the season. %g'll probably
+<ce>                   survive the season. %G'll probably
 <ce>                 commit suicide. You did hear that the
 <ce>         Dark Brotherhood kidnapped and slew %g3 child, _child_?
 
@@ -92,7 +92,7 @@ On %qdt, _qgiver_
  %g3 child _child_ by the Dark
  Brotherhood. I immediately agreed to
  rescue %g2 from _dbguild_ in
- __dbguild_. %g3 family will wait
+ __dbguild_. %G3 family will wait
  =timeforq_ days for my return to
  __qgiver_ in ___qgiver_.
 

--- a/Assets/StreamingAssets/Quests/A0C10Y05.txt
+++ b/Assets/StreamingAssets/Quests/A0C10Y05.txt
@@ -68,7 +68,7 @@ QuestorPostsuccess:  [1008]
 
 QuestorPostfailure:  [1009]
 <ce>                  I have lost my _betrothed_ forever!
-<ce>                   %g has been forced to wed _ruler_.
+<ce>                   %G has been forced to wed _ruler_.
 <ce>                 And you want me to help you? Get out!
 
 QuestLogEntry:  [1010]

--- a/Assets/StreamingAssets/Quests/A0C41Y18.txt
+++ b/Assets/StreamingAssets/Quests/A0C41Y18.txt
@@ -24,7 +24,7 @@ AcceptQuest:  [1002]
 <ce>                 Thank %god! You don't know how much
 <ce>                  this means to me. Here's your gold.
 <ce>                Now, take this to _dummy_ in ___dummy_.
-<ce>                 %g'll pay you the rest. I really must
+<ce>                 %G'll pay you the rest. I really must
 <ce>                   be going now. Thank you so much!
 
 QuestComplete:   [1004]

--- a/Assets/StreamingAssets/Quests/B0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/B0B00Y00.txt
@@ -73,7 +73,7 @@ _qgiver_ promised Princess _lady_'s father that she would be protected.
 RumorsPostfailure:  [1006]
 The Princess managed to escape ___mondung_ by herself. Some knightly valor.
 <--->
-The Princess just wandered in ___qgiver_ by herself, pale from bloodloss.
+The Princess just wandered in ___qgiver_ by herself, pale from blood loss.
 
 RumorsPostsuccess:  [1007]
 The knights are celebrating the heroism of the great %ra who rescued _lady_.
@@ -117,7 +117,7 @@ Dear %pcf,
  of %reg would not want you to foil the
  rather lascivious plans of one of its order, do not
  fear. =monster_ is about
- as precious to our cold hearts as a puddle of month
+ as precious to our cold hearts as a puddle of month-
  old spew.
       Enjoy yourself. And, if you are so inclined,
  enjoy _lady_.

--- a/Assets/StreamingAssets/Quests/B0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/B0B00Y01.txt
@@ -12,7 +12,7 @@ QRC:
 
 QuestorOffer:  [1000]
 <ce>                    We have a traitor in __qgiver_,
-<ce>                 a villianous _monster_ who has turned
+<ce>                 a villainous _monster_ who has turned
 <ce>                 against %g3 brethren. Our honor is at
 <ce>                         stake, %pct. Join our
 <ce>                            righteous fury.
@@ -20,7 +20,7 @@ QuestorOffer:  [1000]
 <ce>                      __qgiver_ has been betrayed
 <ce>                       by a perfidious _monster_.
 <ce>                  Will you help us track the cowardly
-<ce>                     villian down and destroy %g2?
+<ce>                     villain down and destroy %g2?
 
 RefuseQuest:  [1001]
 <ce>                 An ignoble reply. I expected better.

--- a/Assets/StreamingAssets/Quests/B0B20Y07.txt
+++ b/Assets/StreamingAssets/Quests/B0B20Y07.txt
@@ -72,7 +72,7 @@ QuestLogEntry:  [1010]
  ==qgiver_ in ___qgiver_
  gave me the task of wiping
  out an orc band that makes
- it's home in __dungeon_.
+ its home in __dungeon_.
  In particular I must get the
  leader, a certain _monster_.
  I need to get back to %g2

--- a/Assets/StreamingAssets/Quests/B0B50Y11.txt
+++ b/Assets/StreamingAssets/Quests/B0B50Y11.txt
@@ -30,12 +30,12 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>                       _nobleman_ wants to begin
 <ce>                    rebuilding within =2dung_ days.
-<ce>                    %g has the deed to ___dungeon_,
+<ce>                    %G has the deed to ___dungeon_,
 <ce>                     where you'll find the spirit.
 
 QuestComplete:  [1004]
 <ce>                       _nobleman_ will be quite
-<ce>                      pleased. %g has even offered
+<ce>                      pleased. %G has even offered
 <ce>                       to dedicate a fountain in
 <ce>                               your name.
 
@@ -62,7 +62,7 @@ QuestLogEntry:  [1010]
  pled with me to rid ___dungeon_
  of a ghost that is haunting
  it. I have =2dung_ days before
- they they need to begin
+ they need to begin
  the reconstruction.
 
 Message:  1011

--- a/Assets/StreamingAssets/Quests/B0B60Y12.txt
+++ b/Assets/StreamingAssets/Quests/B0B60Y12.txt
@@ -16,7 +16,7 @@ QuestorOffer:  [1000]
 <ce>                        It seems _nobleman_ just
 <ce>                      read about an ancient family
 <ce>                      curse. Now %g is scared out
-<ce>                     of %g3 mind. %g wants someone
+<ce>                     of %g3 mind. %G wants someone
 <ce>                    to go destroy %g3 great, great,
 <ce>                       great grandmother, whom %g
 <ce>                      fears walks the earth as an
@@ -63,7 +63,7 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 _nobleman_ is a superstitious fool, but %g3 great grandmother was an odd one.
 <--->
-_nobleman_ comes a strange family. Maybe %g3 great grandmother is a zombie.
+_nobleman_ comes from a strange family. Maybe %g3 great grandmother is a zombie.
 
 RumorsPostfailure:  [1006]
 %kno looked into _nobleman_'s story and, I guess, decided it was a hoax.

--- a/Assets/StreamingAssets/Quests/B0B70Y14.txt
+++ b/Assets/StreamingAssets/Quests/B0B70Y14.txt
@@ -20,7 +20,7 @@ QuestorOffer:  [1000]
 <ce>               it's bad. All sorts of Daedric beings are
 <ce>                entering into our world. The Mages Guild
 <ce>               says it can seal the breach, but it falls
-<ce>                  to us to slay the Daedras that have
+<ce>                  to us to slay the Daedra that have
 <ce>                  already crossed over. Will you take
 <ce>                      up this quest, not for gold,
 <ce>                             but for glory?
@@ -91,7 +91,7 @@ QuestLogEntry:  [1010]
 %qdt:
  _qgiver_ of
  ==qgiver_ in ___qgiver_
- says that Daedras are pouring
+ says that Daedra are pouring
  through a dimensional rift.
  I must go to ___dungeon_
  and kill them all. They will
@@ -106,7 +106,7 @@ Message:  1011
 <ce>                                    
 <ce>                       "The last Daedra is dead.
 <ce>                        With it dead, Tamriel is
-<ce>                        safe again. Hey what are
+<ce>                        safe again. Hey, what are
 <ce>                        you doing! Let go of my
 <ce>                        arms! I am a guild mage!
 <ce>                        Don't blow out that..."

--- a/Assets/StreamingAssets/Quests/B0B70Y16.txt
+++ b/Assets/StreamingAssets/Quests/B0B70Y16.txt
@@ -15,7 +15,7 @@ QuestorOffer:  [1000]
 <ce>                   Shhh! Don't let anyone else hear
 <ce>                         this, %pct. I just got
 <ce>               word that a dragon has been spotted! Well,
-<ce>                 not a full grown dragon, just a little
+<ce>                 not a full-grown dragon, just a little
 <ce>               dragonling. There is no quest more heroic
 <ce>                 for a member of ==qgiver_ than to slay
 <ce>               a dragon. I know where it is, you go kill
@@ -76,7 +76,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostfailure:  [1006]
 %kno went stomping about in ___dungeon_ for no reason.

--- a/Assets/StreamingAssets/Quests/B0B71Y03.txt
+++ b/Assets/StreamingAssets/Quests/B0B71Y03.txt
@@ -126,7 +126,7 @@ I heard a great joke. %jok
 The legal system in %reg has its good points and bad ones.
 
 QuestorPostsuccess:  [1008]
-So, you won that which you quested for. What would have now?
+So, you won that which you quested for. What would you have now?
 
 QuestorPostfailure:  [1009]
 I haven't anything to say to you, %pcf.
@@ -135,7 +135,7 @@ I wasted my breath talking to you before.
 
 QuestLogEntry:  [1010]
 %qdt:
- I embarked upon a quest to find a legendary,
+ I embarked upon a quest to find a legendary
  artifact of power. The only clue
  _questgiver_ of __questgiver_
  was able to provide is that a witch hermited
@@ -230,7 +230,7 @@ Message:  1022
 <ce>                             in __palace_.
 
 Message:  1025
-<ce>                      What are you doing! I don't
+<ce>                      What are you doing!? I don't
 <ce>                       want to go with you. Help!
 <ce>                          Mommy, daddy, help!
 
@@ -243,7 +243,7 @@ Message:  1027
 
 Message:  1032
 <ce>                     Ah yes, my heir. What did you
-<ce>                      say it's name was? _child_?
+<ce>                      say its name was? _child_?
 <ce>                         Yes, %g will do fine.
 <ce>                         %pcn, you have earned
 <ce>                  the right to pursue _aurielshield_.
@@ -254,7 +254,7 @@ Message:  1032
 
 Message:  1031
 <ce>                     Ah yes, my heir. What did you
-<ce>                      say it's name was? _child_?
+<ce>                      say its name was? _child_?
 <ce>                         Yes, %g will do fine.
 <ce>                         %pcn, you have earned
 <ce>                   the right to pursue _aurielsbow_.
@@ -265,7 +265,7 @@ Message:  1031
 
 Message:  1033
 <ce>                     Ah yes, my heir. What did you
-<ce>                      say it's name was? _child_?
+<ce>                      say its name was? _child_?
 <ce>                         Yes, %g will do fine.
 <ce>                         %pcn, you have earned
 <ce>                    the right to pursue _lordsmail_.

--- a/Assets/StreamingAssets/Quests/B0B80Y17.txt
+++ b/Assets/StreamingAssets/Quests/B0B80Y17.txt
@@ -38,7 +38,7 @@ AcceptQuest:  [1002]
 
 QuestComplete:  [1004]
 <ce>                        Hail to the hero, %pcn!
-<ce>                      Well done! You name will be
+<ce>                      Well done! Your name will be
 <ce>                     recorded in all the histories.
 
 RumorsDuringQuest:  [1005]

--- a/Assets/StreamingAssets/Quests/B0B81Y02.txt
+++ b/Assets/StreamingAssets/Quests/B0B81Y02.txt
@@ -39,7 +39,7 @@ AcceptQuest:  [1002]
 
 QuestComplete:  [1004]
 <ce>                        Hail to the hero, %pcn!
-<ce>                       Well done! You name shall
+<ce>                       Well done! Your name shall
 <ce>                     be recorded in the histories.
 
 RumorsDuringQuest:  [1005]
@@ -87,7 +87,7 @@ Message:  1020
  it points toward. It is too
  late for me. I will die down
  here in ___dungeon2_,
- lost among it's dark passageways.
+ lost among its dark passageways.
  First, I will hide my clue.
  If I cannot...
 
@@ -110,7 +110,7 @@ Message:  1031
 <ce>                   to tell you mine. What's the use
 <ce>                    in bein' a wizard if you can't
 <ce>                    know things normal folks don't.
-<ce>                    I also know why your here. You
+<ce>                   I also know why you're here. You
 <ce>                      want Chrysamere, except you
 <ce>                   didn't know it by name, did you?
 <ce>                     The only way you're gonna get
@@ -122,7 +122,7 @@ Message:  1032
 <ce>                  I know your name. What's the use in
 <ce>                   bein' a wizard if you can't know
 <ce>                     things normal folks don't. I
-<ce>                     also know why your here. You
+<ce>                    also know why you're here. You
 <ce>                    want The Necromancer's Amulet,
 <ce>                     except you didn't know it by
 <ce>                      name, did you? The only way
@@ -135,7 +135,7 @@ Message:  1033
 <ce>                  I know your name. What's the use in
 <ce>                   bein' a wizard if you can't know
 <ce>                     things normal folks don't. I
-<ce>                     also know why your here. You
+<ce>                    also know why you're here. You
 <ce>                   want The Staff of Magnus, except
 <ce>                    you didn't know it by name, did
 <ce>                  you? The only way you're gonna get
@@ -147,7 +147,7 @@ Message:  1034
 <ce>                  I know your name. What's the use in
 <ce>                   bein' a wizard if you can't know
 <ce>                     things normal folks don't. I
-<ce>                     also know why your here. You
+<ce>                     also know why you're here. You
 <ce>                    want The Warlock's Ring, except
 <ce>                    you didn't know it by name, did
 <ce>                  you? The only way you're gonna get

--- a/Assets/StreamingAssets/Quests/B0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y06.txt
@@ -72,7 +72,7 @@ QuestLogEntry:  [1010]
  I only have =2dung_ days.
 
 Message:  1011
-<ce>                        On it's back is a large
+<ce>                        On its back is a large
 <ce>                      scorched area. This must be
 <ce>                       the one _qgiver_ spoke of.
 

--- a/Assets/StreamingAssets/Quests/B0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/B0C00Y10.txt
@@ -65,10 +65,10 @@ QuestLogEntry:  [1010]
  the knightly order in ___qgiver_
  gave me the task of wiping
  out an orc band that makes
- it's home in ___dungeon_.
- In particular I must get the
- leader, a certain =monster_
- I need to get back to %g2
+ its home in ___dungeon_.
+ In particular, I must get the
+ leader, a certain =monster_.
+ I need to get back to %g2 in
  =2dung_ days or %g will
  assume I'm dead.
 

--- a/Assets/StreamingAssets/Quests/C0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y01.txt
@@ -38,12 +38,12 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>                 Good. We have already sent one of the
 <ce>                        Temple, _priest_ to the
-<ce>                    desacrilized ___mondung_, where
+<ce>                    desacralized ___mondung_, where
 <ce>                    _prophet_ asserts that %g first
 <ce>                        witnessed the miracle.
 <ce>                     If _priest_ needs assistance,
 <ce>                I will send for you. In the meanwhile,
-<ce>                 I want you to find some more secular
+<ce>                 I want you to find some more-secular
 <ce>                       information on _prophet_,
 <ce>                   by asking around in %g3 hometown,
 <ce>                          __tavern_. A loyal
@@ -236,7 +236,7 @@ _lover_, My Love,
       First, forgive the silence of your
  love. It was not another attack of brain
  fever. For some months now, I have been
- in spiritual turmoil, unfit to for any
+ in spiritual turmoil, unfit for any
  company, even for the comfort of your
  dulcet fellowship. My days of pain are
  over, but for this -- I can never see you
@@ -303,7 +303,7 @@ Message:  1026
 Message:  1027
 Truly nauseating.
 <--->
-A hacked off finger.
+A hacked-off finger.
 <--->
 A chunk of somebody's hand.
 <--->
@@ -313,9 +313,9 @@ Not bad with a little salt and honey.
 <--->
 It looks like an old __qgiver_ ceremony. They used to do that to corpses.
 <--->
-When in __qgiver_, _prophet_ used to disect cadavers just that precisely.
+When in __qgiver_, _prophet_ used to dissect cadavers just that precisely.
 <--->
-__qgiver_ abandoned that kind of funereal disection, but _prophet_ espouses it.
+__qgiver_ abandoned that kind of funereal dissection, but _prophet_ espouses it.
 
 Message:  1028
 <ce>                        It was nice of _priest_

--- a/Assets/StreamingAssets/Quests/C0B00Y14.txt
+++ b/Assets/StreamingAssets/Quests/C0B00Y14.txt
@@ -71,7 +71,7 @@ Message:  1020
  _questgiver_ of __questgiver_
  in ___questgiver_ has sent me
  to slay an undead creature haunting
- ___mondung_.  %g gave me a vial
+ ___mondung_.  %G gave me a vial
  of specially prepared holy water
  which I must sprinkle on the monster's
  body in order to prevent its spirit
@@ -99,13 +99,13 @@ Message:  1050
 <ce>                Ah, wait, I am so forgetful these days!
 <ce>                 You first need to take the holy water
 <ce>                      to _priest_, of __priest_ in
-<ce>                  ___priest_.  %g will place the final
+<ce>                  ___priest_.  %G will place the final
 <ce>                            blessing on it.
 
 Message:  1051
 <ce>                   _priest_ takes the vial from you
-<ce>                  without a word.  %g gravely blesses
-<ce>                    it, then you.  %g hands it back
+<ce>                  without a word.  %G gravely blesses
+<ce>                    it, then you.  %G hands it back
 <ce>                    and returns to %g3 meditations.
 
 Message:  1060

--- a/Assets/StreamingAssets/Quests/C0B10Y05.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y05.txt
@@ -33,7 +33,7 @@ AcceptQuest:  [1002]
 <ce>                            In ___dungeon_,
 <ce>                       you will find _custodian_,
 <ce>                   a servant of this temple for many
-<ce>                   years. %g will safeguard the item
+<ce>                   years. %G will safeguard the item
 <ce>                  and keep it out of the hands of the
 <ce>                  orcs. We have bound it in spells to
 <ce>                   protect you from its evil effects.
@@ -83,7 +83,7 @@ Message:  1011
 <ce>                              _evilitem_.
 
 Message:  1012
-<ce>            The evil _evilitem_, sparks and disintegrates.
+<ce>            The evil _evilitem_ sparks and disintegrates.
 <ce>                      You suddenly feel very sick.
 
 

--- a/Assets/StreamingAssets/Quests/C0B10Y06.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y06.txt
@@ -11,8 +11,8 @@ DisplayName: The Expiatory Sacrifice
 QRC:
 
 QuestorOffer:  [1000]
-<ce>                 They tell me that you quite loyal to
-<ce>                 the temple. I need you perform a vital
+<ce>                They tell me that you are quite loyal to
+<ce>                the temple. I need you to perform a vital
 <ce>                   task for us. %god has become angry
 <ce>                 with us. You need not concern yourself
 <ce>                  with why. Our only hope is to hold a
@@ -66,7 +66,7 @@ QuestLogEntry:  [1010]
 %qdt:
  _qgiver_ of __qgiver_,
  in ___qgiver_, told me that %g3 god was
- angered. %g needs untainted
+ angered. %G needs untainted
  _ingredient_ from ___dungeon_
  for a rite of atonement. It
  must be in _qgiver_'s

--- a/Assets/StreamingAssets/Quests/C0B10Y07.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y07.txt
@@ -69,7 +69,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostfailure:  [1006]
 __qgiver_ has been cursing the name %pcn.

--- a/Assets/StreamingAssets/Quests/C0B10Y15.txt
+++ b/Assets/StreamingAssets/Quests/C0B10Y15.txt
@@ -24,7 +24,7 @@ RefuseQuest:  [1001]
 <ce>                  I understand.  A lich is a fearsome
 <ce>                   opponent for one of your youth and
 <ce>                     inexperience.  Perhaps as you
-<ce>                      mature you will take up this
+<ce>                      mature you will take this up
 <ce>                       again.  %god go with you.
 
 AcceptQuest:  [1002]

--- a/Assets/StreamingAssets/Quests/C0B20Y08.txt
+++ b/Assets/StreamingAssets/Quests/C0B20Y08.txt
@@ -11,8 +11,8 @@ DisplayName: The Rite of Atonement
 QRC:
 
 QuestorOffer:  [1000]
-<ce>                 They tell me that you quite loyal to
-<ce>                 the temple. I need you perform a vital
+<ce>                They tell me that you are quite loyal to
+<ce>                 the temple. I need you to perform a vital
 <ce>                   task for us. %god has become angry
 <ce>                 with us. You need not concern yourself
 <ce>                  with why. Our only hope is to hold a
@@ -66,7 +66,7 @@ QuestLogEntry:  [1010]
 %qdt:
  _qgiver_ of __qgiver_,
  in ___qgiver_, told me that %g3 god was
- angered. %g needs untainted
+ angered. %G needs untainted
  _ingredient_ from ___dungeon_
  for a rite of atonement. It
  must be in _qgiver_'s

--- a/Assets/StreamingAssets/Quests/C0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y10.txt
@@ -31,7 +31,7 @@ RefuseQuest:  [1001]
 <ce>                            temple leaders.
 
 AcceptQuest:  [1002]
-<ce>                        _cousin_ in ___cousin_
+<ce>                       _cousin_ in ___cousin_ is
 <ce>                  suffering from an unusual disease.
 <ce>                   I was about to dispatch a cleric
 <ce>                   to treat %g2. I will delay them a

--- a/Assets/StreamingAssets/Quests/C0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/C0C00Y12.txt
@@ -14,7 +14,7 @@ QuestorOffer:  [1000]
 <ce>                       Normally I would not give
 <ce>                         work to someone not a
 <ce>                          member of __qgiver_.
-<ce>                      However, we are short handed
+<ce>                      However, we are short-handed
 <ce>                       right now. A brazen thief
 <ce>                          stole a _religitem_
 <ce>                       from the temple. A priest

--- a/Assets/StreamingAssets/Quests/CUSTOM01.txt
+++ b/Assets/StreamingAssets/Quests/CUSTOM01.txt
@@ -9,7 +9,7 @@ QuestorOffer:  [1000]
 <ce>I hope you're not afraid of the dark, %pcn...
 <ce>Some necromancer is raising hordes of zombies
 <ce>and skeletons at ___graveyard_.
-<ce>We have a contract to end this villian's life
+<ce>We have a contract to end this villain's life
 <ce>and put a stop to their evil deeds.
 <ce>There's _reward_ gold in it for you.
 

--- a/Assets/StreamingAssets/Quests/D0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/D0B00Y00.txt
@@ -42,7 +42,7 @@ AcceptQuest:  [1002]
 QuestFail:  [1003]
 <ce>                    You had best move along, %pcf.
 <ce>                 You do not have very much more time to
-<ce>                        kill that Dragonslayer.
+<ce>                        kill that dragonslayer.
 
 QuestComplete:  [1004]
 <ce>                   I am glad to see you back, %pcf.

--- a/Assets/StreamingAssets/Quests/F0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/F0B00Y00.txt
@@ -97,7 +97,7 @@ QuestLogEntry:  [1010]
 <ce>                 By Dibella, I've been a nervous wreck
 <ce>                 waitin' for you to show up. Here's the
 <ce>                icon -- I'm glad to be rid of it. I can
-<ce>                  feel every cutthroat's eyes on on it.
+<ce>                   feel every cutthroat's eyes on it.
 <ce>                You better get back to the House before
 <ce>                    they think you ran off with it.
 

--- a/Assets/StreamingAssets/Quests/G0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/G0B00Y00.txt
@@ -51,7 +51,7 @@ The traitor is apparently tougher than _qgiver_ thought. What an escape.
 The renegade has moved north I hear, but the memory still plagues the order.
 
 RumorsPostsuccess:  [1007]
-The traitor's story just proves it. You don't play around with the Kynaran Order.
+The traitor's story just proves it: you don't play around with the Kynaran Order.
 <--->
 I always thought the Order would be more merciful to that dolt.
 

--- a/Assets/StreamingAssets/Quests/H0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/H0B00Y00.txt
@@ -51,7 +51,7 @@ QuestComplete:  [1004]
 <ce>                           -- you deserve it.
 
 RumorsDuringQuest:  [1005]
-That ___mondung_ has always been creepy. Now it supposed to be haunted.
+That ___mondung_ has always been creepy. Now it's supposed to be haunted.
 <--->
 As far as I'm concerned, leave the haunt alone. No one goes near it anyway.
 
@@ -79,7 +79,7 @@ QuestLogEntry:  [1010]
  place for the Benevolence of Mara,
  of a haunting spirit of some sort.
  I have =1stparton_ days to cleanse
- ___mondung_ of it's haunt.
+ ___mondung_ of its haunt.
 
 Message:  1020
 <ce>                  "My spirit will now rest at peace."

--- a/Assets/StreamingAssets/Quests/J0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/J0B00Y00.txt
@@ -27,7 +27,7 @@ AcceptQuest:  [1002]
 <ce>                   affairs, but in this case, we feel
 <ce>                 justified. This thief, you see, stole
 <ce>                 directly from one of our caravans and
-<ce>                is ransoming us for use of the highway.
+<ce>                is extorting us for use of the highway.
 <ce>               Such nerve. You will find the little thug
 <ce>                    in a hideout called ___mondung_.
 <ce>                      Be back in =1stparton_ days.
@@ -46,8 +46,7 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 That footpad is single-handedly ruining the economy.
 <--->
-<ce>         They think that highwayman is a thief, but the crook
-<ce>                    is highly trained with a blade.
+They think that highwayman is a thief, but the crook is highly trained with a blade.
 
 RumorsPostfailure:  [1006]
 That robber moved to a different hideout, but the roads still aren't safe.

--- a/Assets/StreamingAssets/Quests/K0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y00.txt
@@ -28,7 +28,7 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>                  Great. _competitor_ has a store in
 <ce>                 __storehouse_ called _storehouse_ and
-<ce>                   in it is a _mitem_ that I want you
+<ce>                  in it is a _mitem_ that I want you to
 <ce>            liberate. And, on your way out, please drop this
 <ce>            note off anywhere in the store. I can't resist.
 <ce>                 _competitor_ is going to pass that
@@ -64,7 +64,7 @@ Turns out that _competitor_ is a tougher merchant than _qgiver_ could dream of.
 RumorsPostsuccess:  [1007]
 _competitor_ has lost that contract %g worked so hard to get from _qgiver_.
 <--->
-_qgiver_ has %g3 old contract back and is happy as a well fed harpy.
+_qgiver_ has %g3 old contract back and is happy as a well-fed harpy.
 
 QuestorPostsuccess:  [1008]
 Well, you got me the _mitem_, so what can I do for you?
@@ -86,7 +86,7 @@ Message:  1011
  _competitor_,
  
  
- Fine security for your security.
+ Find security for your security.
  
  
  

--- a/Assets/StreamingAssets/Quests/K0C00Y02.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y02.txt
@@ -61,7 +61,7 @@ The maid at _mansion_ said she saw some undesirables watching the place.
 RumorsPostfailure:  [1006]
 %t %rn seems to think that the head of the smuggling operation is _qgiver_.
 <--->
-_qgiver_ has apparently been smuggling foscarium, pretending its gold.
+_qgiver_ has apparently been smuggling foscarium, pretending it's gold.
 <--->
 _palace_ has cut off relations with _qgiver_ completely, from what I hear.
 <--->

--- a/Assets/StreamingAssets/Quests/K0C00Y04.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y04.txt
@@ -36,7 +36,7 @@ QuestorOffer:  [1000]
 RefuseQuest:  [1001]
 <ce>                      No? That is too bad. Well,
 <ce>                     I probably should get someone
-<ce>                        who looks more like me
+<ce>                        who looks more like me,
 <ce>                                anyhow.
 
 AcceptQuest:  [1002]
@@ -62,7 +62,7 @@ _lover_, they say, has caused more deaths than any plague.
 <--->
 _lover_'s last lover died in %g3 arms, trying to satisfy %g3 ... appetite.
 <--->
-If _lover_ finds out they're finding a duel over %g2 ... %oth, that'll be it.
+If _lover_ finds out they're fighting a duel over %g2 ... %oth, that'll be it.
 
 RumorsPostfailure:  [1006]
 _lover_ has left _competitor_ and _qgiver_ too.

--- a/Assets/StreamingAssets/Quests/K0C00Y05.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y05.txt
@@ -32,7 +32,7 @@ QuestorOffer:  [1000]
 RefuseQuest:  [1001]
 <ce>                    A heart of stone, just like The
 <ce>                      Fighters Guild. What is an
-<ce>                  innocent child's life worth anyhow?
+<ce>                  innocent child's life worth, anyhow?
 
 AcceptQuest:  [1002]
 <ce>                   Thank you, thank you. I can give
@@ -170,7 +170,7 @@ Message:  1018
 Message:  1019
 %qdt:
  I have met with _knight_ of
- The Fighters Guild. %g told me that
+ The Fighters Guild. %G told me that
  _child_ is being kept in safety at
  _childlocale_ in __childlocale_.
 

--- a/Assets/StreamingAssets/Quests/K0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y06.txt
@@ -126,7 +126,7 @@ _priest_ has risen above the scandals that plagued %g3 early days in ==priest_.
 <--->
 _priest_ usually can be found in meditation at _priesthome_, __priesthome_ right about now.
 <--->
-Most everyone in __priesthome_, except _noble_, greatly respect _priest_.
+Most everyone in __priesthome_, except _noble_, greatly respects _priest_.
 <--->
 The only person _priest_ obviously dislikes is that =merchant_, _merchant_.
 
@@ -504,7 +504,7 @@ Message:  1040
 <ce>                      beyond suspicion -- _noble_
 <ce>               of the royal house of %reg. You're going
 <ce>             to need some evidence to prove it and I'm not
-<ce>             going to stick my neck out anymore. The only
+<ce>             going to stick my neck out any more. The only
 <ce>            other thing I can tell you is that, during the
 <ce>                       weekends, _noble_ spends
 <ce>                      %g3 time at ___mondung_ and
@@ -515,7 +515,7 @@ Message:  1040
 Message:  1041
 <ce>                   Hi, %pcf. I couldn't talk to you
 <ce>             at the tavern -- it was too public. I really
-<ce>              was a witness at the burglary at __qgiver_.
+<ce>              was a witness of the burglary at __qgiver_.
 <ce>           In fact, I did it. But the one who paid me to do
 <ce>           it and the one who said I should blame a stranger
 <ce>                        for it was _priest_, a
@@ -574,7 +574,7 @@ QuestTimeLapse:  [1045]
 %qdt:
  _witness_
  confessed that %g knew who committed the
- burglary and it isn't me. On the other
+ burglary and that it wasn't me. On the other
  hand, _priest_, the true
  engineer behind it, will be difficult to
  convict. The two places where I might find
@@ -590,7 +590,7 @@ Message:  1046
  which I've been framed, at least, according
  to _witness_. Further,
  %g says, _thief_ is now
- so well respected, I'll need hard evidence
+ so well-respected, I'll need hard evidence
  to convict %g2. I might be able to find
  this evidence in _thiefhouse_
  or ___mondung_, or both places.
@@ -656,7 +656,7 @@ _priest_
  
  Dear _priest_,
  
-      Ignore my last letter when I applauded you
+      Ignore my last letter where I applauded you
  for your enormous contribution to ==priest_.
  That _gem_ that you said was a donation
  was stolen from _qgiver_. If
@@ -743,7 +743,7 @@ Message:  1056
 <ce>                      cell in _thiefhouse_? %oth,
 <ce>                  it's priceless! Quickly, now, %pcf,
 <ce>                      get that _gem_ to _qgiver_
-<ce>               and I'll make spread the word around that
+<ce>                 and I'll spread the word around that
 <ce>                      the true thief of __qgiver_
 <ce>                       is a priest of ==priest_!
 
@@ -766,8 +766,8 @@ Message:  1058
 <ce>                        a scapegoat? _guard4_!
                                      <--->
 <ce>                       Why couldn't you just get
-<ce>                    out of %reg and left everything
-<ce>                           along, %ra? %oth,
+<ce>                 out of %reg and have left everything
+<ce>                           alone, %ra? %oth,
 <ce>                         you'll wish you had!
 
 Message:  1059
@@ -794,7 +794,7 @@ Message:  1091
 %qdt:
  I met with _witness_ who
  told me that the one behind the stolen _gem_
- is indeed _merchant_. %g spends
+ is indeed _merchant_. %G spends
  %g3 nights at home, in _thiefhouse_
  of ___thiefhouse_,
  and has a stash at ___mondung_.
@@ -804,7 +804,7 @@ Message:  1092
 %qdt:
  I met with _witness_ who
  told me that the one behind the stolen _gem_
- is indeed _noble_. %g spends
+ is indeed _noble_. %G spends
  %g3 nights at home, in _thiefhouse_
  of ___thiefhouse_,
  and has a stash at ___mondung_.
@@ -814,7 +814,7 @@ Message:  1093
 %qdt:
  I met with _witness_ who
  told me that the one behind the stolen _gem_
- is indeed _priest_. %g spends
+ is indeed _priest_. %G spends
  %g3 nights at home, in _thiefhouse_
  of ___thiefhouse_,
  and has a stash at ___mondung_.
@@ -824,7 +824,7 @@ Message:  1094
 %qdt:
  I met with _witness_ who
  told me that the one behind the stolen _gem_
- is indeed _thief_. %g spends
+ is indeed _thief_. %G spends
  %g3 nights at home, in _thiefhouse_
  of ___thiefhouse_,
  and has a stash at ___mondung_.

--- a/Assets/StreamingAssets/Quests/K0C00Y07.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y07.txt
@@ -65,7 +65,7 @@ AcceptQuest:  [1002]
 <ce>                    in ___kidnapper_, a =kidnapper_
 <ce>                   named _kidnapper_. Once =2ransom_
 <ce>           days have passed, %g will send word to %g3 friends
-<ce>                   whereever they're keeping _victim_
+<ce>                   where-ever they're keeping _victim_
 <ce>              and they'll kill %g2. Please don't let that
 <ce>                       happen. Good luck, friend.
 
@@ -141,7 +141,7 @@ Message:  1013
 Message:  1014
 <ce>                          _qgiver_ sent you?
 <ce>                        %oth, thank %god! Quick,
-<ce>                          let's get out here!
+<ce>                         let's get out of here!
 
 Message:  1015
 =thug_,

--- a/Assets/StreamingAssets/Quests/K0C00Y08.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y08.txt
@@ -73,7 +73,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostfailure:  [1006]
 I got a boil the other day ... but it healed.
@@ -102,7 +102,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostsuccess:  [1007]
 _qgiver_ is happy as a harpy about %g3 new acquisition.

--- a/Assets/StreamingAssets/Quests/K0C00Y09.txt
+++ b/Assets/StreamingAssets/Quests/K0C00Y09.txt
@@ -129,7 +129,7 @@ Message:  1012
 <ce>                               surrender!
                                      <--->
 <ce>                              I give up!
-<ce>                               I give up!
+<ce>                              I give up!
                                      <--->
 <ce>                            Don't kill me!
 <ce>                              I surrender!

--- a/Assets/StreamingAssets/Quests/K0C01Y00.txt
+++ b/Assets/StreamingAssets/Quests/K0C01Y00.txt
@@ -83,7 +83,7 @@ QuestLogEntry:  [1010]
  _qgiver_ of
  __qgiver_, ___qgiver_ has
  sent me to prevent %g3 unloved lover's
- ransom. I can either find and slay this
+ ransom. I can find and slay this
  _victim_, but I have
  no clue of where %g is. Or I can go to
  ___mondung2_, %g3

--- a/Assets/StreamingAssets/Quests/K0C01Y10.txt
+++ b/Assets/StreamingAssets/Quests/K0C01Y10.txt
@@ -26,7 +26,7 @@ AcceptQuest:  [1002]
 <ce>              particular rare scroll for me. This is not
 <ce>             the type of job I could give to the Fighters
 <ce>              Guild, for the scroll is protected by some
-<ce>               powerful daedra spirits and has the power
+<ce>               powerful daedric spirits and has the power
 <ce>                 to summon creatures from the plane of
 <ce>                     Oblivion. Go to ___mondung_,
 <ce>               find the scroll, and bring it back to me
@@ -35,7 +35,7 @@ AcceptQuest:  [1002]
 <ce>                  tempest that nearly destroyed you.
 
 QuestComplete:  [1004]
-<ce>                 Ah, the Bothdorji Scroll. Very good.
+<ce>                 Ah, the Bothdorjii Scroll. Very good.
 <ce>                 Now, let me tell you about the storm.
 <ce>                 You sailed an unmarked ship from the
 <ce>                Imperial City, but your identity, your
@@ -75,7 +75,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostfailure:  [1006]
 I got a boil the other day ... but it healed.
@@ -104,20 +104,20 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostsuccess:  [1007]
-The daedric stars burn bright and cold last evening.
+The daedric stars burned bright and cold last evening.
 <--->
 Dire portents of daedra in Mundus have I seen.
 
 QuestorPostsuccess:  [1008]
-You brought me the Bothdorji Scroll, %pcf. How could I forget you for that?
+You brought me the Bothdorjii Scroll, %pcf. How could I forget you for that?
 
 QuestorPostfailure:  [1009]
 <ce>                   I don't see why I should talk to
 <ce>                         you at all, %pcf. You
-<ce>                 didn't bring me the Bothdorji Scroll.
+<ce>                 didn't bring me the Bothdorjii Scroll.
 
 QuestLogEntry:  [1010]
 %qdt:

--- a/Assets/StreamingAssets/Quests/K0C0XY01.txt
+++ b/Assets/StreamingAssets/Quests/K0C0XY01.txt
@@ -12,7 +12,7 @@ DisplayName: The Harpies' Nest
 QRC:
 
 QuestorOffer:  [1000]
-<ce>          I have a not uncommon situation on my hands. A nest
+<ce>          I have a not-uncommon situation on my hands. A nest
 <ce>           of harpies has moved into an old property of mine,
 <ce>          and while I personally couldn't care less, our wise
 <ce>            and benevolent %rt has decreed that the owner of
@@ -36,11 +36,11 @@ AcceptQuest:  [1002]
 <ce>              days. Obviously that does not leave a lot of
 <ce>                   time. I had hoped that _contact_,
 <ce>          the mercenary I had hired earlier from the Fighters
-<ce>            Guild would have been more capable. And, listen,
+<ce>            Guild, would have been more capable. And, listen,
 <ce>                   %pcf, you don't have to clear out
 <ce>                all ___mondung_. Just kill four or five
 <ce>             of the critters and get back here. I know! The
-<ce>               clan leaders wear specially dyed gryphon's
+<ce>               clan leaders wear specially-dyed gryphon's
 <ce>                   feathers. Bring back one of those
 <ce>               and I'll have the proof I need. Just make
 <ce>             certain you don't fail to return in =2mondung_
@@ -106,7 +106,7 @@ __qgiver_, ___qgiver_
  interview, let me tell you that I promised the
  Guildmaster I'd ask you to look for _contact_
  while you're in ___mondung_. _contact_
- looks is a =contact_, so %g should
+ is a =contact_, so %g should
  stick out at ___mondung_.
       Well, I've fulfilled my promise to the Guildmaster.
  Personally, I don't care if you throw this letter away
@@ -143,7 +143,7 @@ Message:  1020
  =2mondung_ days for a reward of _reward_ gold pieces.
 
 Message:  1050
-1 harpie dead
+1 harpy dead
 
 Message:  1051
 2 harpies dead

--- a/Assets/StreamingAssets/Quests/K0C30Y03.txt
+++ b/Assets/StreamingAssets/Quests/K0C30Y03.txt
@@ -20,7 +20,7 @@ QuestorOffer:  [1000]
 <ce>             the deed to a valuable piece of property. Now
 <ce>                    _patsy_ and the deed have both
 <ce>           vanished. Rumor has it that %g fell on some hard
-<ce>             time financially, but the sum I loaned is not
+<ce>             times financially, but the sum I loaned is not
 <ce>             easily swallowed by my enterprises. Tangling
 <ce>                    with the likes of _patsy_ will
 <ce>              likely be dangerous, but I need a champion.
@@ -99,7 +99,7 @@ Message:  1012
 <ce>            Thank you, sweets. I've heard you're the decent
 <ce>            sort, and I thought I'd give you a break. I was
 <ce>                   hired by _patsy_ a few weeks ago --
-<ce>          not for the reason you're thinkin. All I had to
+<ce>          not for the reason you're thinkin'. All I had to
 <ce>           do was flirt with some old gaffer and get him to
 <ce>          ask me out to dinner on a specific day. I guess to
 <ce>          get him out of his house, because I found out later
@@ -153,7 +153,7 @@ Message:  1016
 <ce>                in the robbery down to the last penny.
 <ce>                    We just want to answer certain
 <ce>                  questions about the robbery itself.
-<ce>                      Things it would be best not
+<ce>                     Things that would be best not
 <ce>                      discussed with a stranger,
 <ce>                            you understand.
 
@@ -354,17 +354,17 @@ Message:  1038
 
 Message:  1039
 %qdt:
- I have met with _guard_. %g has discovered
+ I have met with _guard_. %G has discovered
  _patsy_'s location in ___mondung2_.
  To distract %g3 soldiers, I
- must drop a letter in %g3 allies
+ must drop a letter in %g3 allies'
  stronghold, ___mondung_, and then meet
  _guard_ at ___mondung2_ to get
  _patsy_.
 
 Message:  1040
 %qdt:
- I have met with _guard_. %g told
+ I have met with _guard_. %G told
  me that _patsy_ had a relationship
  with _hooker_, a prostitute in __house1_.
  I'll find her at _house1_ there.

--- a/Assets/StreamingAssets/Quests/L0A01L00.txt
+++ b/Assets/StreamingAssets/Quests/L0A01L00.txt
@@ -25,7 +25,7 @@ QuestComplete:  [1004]
 <ce>                             Here is yours.
 
 RumorsDuringQuest:  [1005]
-_npc_ ought to watch %g3 step. %g has a number of enemies.
+_npc_ ought to watch %g3 step. %G has a number of enemies.
 
 RumorsPostfailure:  [1006]
 It is unwise to disregard the Dark Brotherhood. Unwise and fatal.

--- a/Assets/StreamingAssets/Quests/L0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y00.txt
@@ -42,7 +42,7 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 That assassin ran off to ___mondun_ like the hounds of hell were behind him.
 <--->
-_qgiver_ can't just let that traitor go after what %g did to the Brotherhood.
+_qgiver_ can't just let that traitor go, after what %g did to the Brotherhood.
 
 RumorsPostfailure:  [1006]
 That traitor is apparently tougher than _qgiver_ thought. What an escape.
@@ -51,7 +51,7 @@ That traitor is apparently tougher than _qgiver_ thought. What an escape.
  the memory still plagues the Brotherhood.
 
 RumorsPostsuccess:  [1007]
-The traitor's story just proves it. You don't play around with the Brotherhood.
+The traitor's story just proves it: you don't play around with the Brotherhood.
 <--->
 I never thought the Brotherhood would be merciful to a dolt like that traitor assassin.
 
@@ -61,7 +61,7 @@ What do you need, o slayer of the traitor?
 QuestorPostfailure:  [1009]
 <ce>                  I am ill at ease speaking with you.
 <ce>                  After all, I trusted you to account
-<ce>                        that traitor, didn't I?
+<ce>                       that traitor, didn't I?
 
 QuestLogEntry:  [1010]
 %qdt:

--- a/Assets/StreamingAssets/Quests/L0B00Y02.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y02.txt
@@ -103,7 +103,7 @@ After slaying %n,
 Message:  1012
 %qdt:
  I found a note on =assassin_'s body.
- %g3 employer is =boss_, and %g3
+ %G3 employer is =boss_, and %g3
  stronghold is ___stronghold_.
 
 Message:  1013

--- a/Assets/StreamingAssets/Quests/L0B00Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B00Y03.txt
@@ -60,7 +60,7 @@ RumorsPostsuccess:  [1007]
 Who can say what would've happened if that _mage_ had been suffered to live.
 
 QuestorPostsuccess:  [1008]
-Greeting and salutations. How may =qgiver_ assist thee, slayer of mages?
+Greetings and salutations. How may =qgiver_ assist thee, slayer of mages?
 
 QuestorPostfailure:  [1009]
 <ce>               You have failed your contract with us, so

--- a/Assets/StreamingAssets/Quests/L0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B10Y03.txt
@@ -67,7 +67,7 @@ RumorsPostfailure:  [1006]
 Some say that =target_ is dead. But others have seen %g2 ... at night only.
 
 RumorsPostsuccess:  [1007]
-Funny, the Brotherhood offing that bloodsucker. You think they'd get along.
+Funny, the Brotherhood offing that bloodsucker. You'd think they'd get along.
 <--->
 Apparently, =target_'s last target was more than %g expected him to be.
 

--- a/Assets/StreamingAssets/Quests/L0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/L0B20Y02.txt
@@ -74,7 +74,7 @@ QuestorPostfailure:  [1009]
 <ce>                   What makes you think that I'd be
 <ce>                    interested in talking with a %ra
 <ce>                     who can't even slay one lousy
-<ce>                    knight. Leave my sight at once.
+<ce>                    knight? Leave my sight at once.
 
 Message:  1020
 %qdt:

--- a/Assets/StreamingAssets/Quests/L0B30Y03.txt
+++ b/Assets/StreamingAssets/Quests/L0B30Y03.txt
@@ -18,7 +18,7 @@ QuestorOffer:  [1000]
 <ce>                 you need to exercise your humility and
 <ce>                  take on an assignment with dangerous
 <ce>                   political connotations. We have a
-<ce>                  contract on a high ranking member of
+<ce>                  contract on a high-ranking member of
 <ce>                  the Mages Guild. Are you up for it?
 
 RefuseQuest:  [1001]

--- a/Assets/StreamingAssets/Quests/L0B30Y09.txt
+++ b/Assets/StreamingAssets/Quests/L0B30Y09.txt
@@ -15,8 +15,8 @@ QuestorOffer:  [1000]
 <ce>                 We have an anonymous job for you. It
 <ce>                happens every now and then that someone
 <ce>                 pays us to remove someone, but never
-<ce>                 reveals why, or may even work though
-<ce>                  a go between to keep their identity
+<ce>                 reveals why, or may even work through
+<ce>                  a go-between to keep their identity
 <ce>                 secret. At any rate, the job is yours
 <ce>                            if you want it.
 

--- a/Assets/StreamingAssets/Quests/L0B50Y11.txt
+++ b/Assets/StreamingAssets/Quests/L0B50Y11.txt
@@ -13,7 +13,7 @@ QRC:
 
 QuestorOffer:  [1000]
 <ce>                 We have an interesting job available
-<ce>                       to a high ranking member
+<ce>                       to a high-ranking member
 <ce>                  of the Thieves Guild. This will be
 <ce>                     a tough one. Do you want it?
 
@@ -26,7 +26,7 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>                   You are a sharp one. The target's
 <ce>                      name is _marknpc_, here in
-<ce>                       ___questgiver_. %g moves
+<ce>                       ___questgiver_. %G moves
 <ce>                      around a lot and is usually
 <ce>                 protected by bodyguards. Be careful.
 <ce>                 You have seven days. When it is done,
@@ -80,8 +80,8 @@ Message:  1015
 
 Message:  1020
 <ce>                    _marknpc_ enjoys an occasional
-<ce>                rendezvous with me. %g never stays long.
-<ce>                   %g just uses me for %g3 pleasure.
+<ce>                rendezvous with me. %G never stays long.
+<ce>                   %G just uses me for %g3 pleasure.
 <ce>                 For 50 gold I'll gladly sell %g2 out.
 
 Message:  1021
@@ -95,8 +95,8 @@ Message:  1022
 
 Message:  1023
 <ce>                     _marknpc_ comes here every day
-<ce>                   at around 6 o'clock. %g sends %g3
-<ce>                   bodyguards away. %g is only here
+<ce>                   at around 6 o'clock. %G sends %g3
+<ce>                   bodyguards away. %G is only here
 <ce>                          for an hour or so.
 
 Message:  1030

--- a/Assets/StreamingAssets/Quests/L0B60Y10.txt
+++ b/Assets/StreamingAssets/Quests/L0B60Y10.txt
@@ -55,10 +55,10 @@ RumorsPostsuccess:  [1007]
 Did you hear about that war hero? Killed in a duel. What a shame.
 
 QuestorPostsuccess:  [1008]
-You battle with that war hero is still being told %pcn.
+Your battle with that war hero is still being told %pcn.
 
 QuestorPostfailure:  [1009]
-You failed in your contract to kill the war hero. The brotherhood never forgets failure.
+You failed in your contract to kill the war hero. The Brotherhood never forgets failure.
 
 Message:  1020
 %qdt:

--- a/Assets/StreamingAssets/Quests/M0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y00.txt
@@ -13,7 +13,7 @@ QRC:
 QuestorOffer:  [1000]
 <ce>          We've got a little job you might be interested in.
 <ce>            Seems there's a loup -- whatcha call your basic
-<ce>             werewolf, wereboar, or some kind 'o werebeasty
+<ce>             werewolf, wereboar, or some kind o' werebeasty
 <ce>                 that's been bothering a lot of farmers
 <ce>              in the area, and we need someone to kill it.
 <ce>          It'll mean _reward_ gold in your pocket. That sound
@@ -46,7 +46,7 @@ Didja hear that howling last night? Wolf howling?
 RumorsPostfailure:  [1006]
 Werewolves are real nomads, I guess. I hear our loup moved down south.
 <--->
-My cousin tells me that our wereboar was spotted down south aways.
+My cousin tells me that our wereboar was spotted down south a ways.
 
 RumorsPostsuccess:  [1007]
 I hear they found out that werething was a priest during the day!
@@ -60,7 +60,7 @@ QuestorPostsuccess:  [1008]
 
 QuestorPostfailure:  [1009]
 <ce>                  Get outta here. You're so pathetic.
-<ce>                   You couldn't even handle a werewolf.
+<ce>                  You couldn't even handle a werewolf.
 
 Message:  1020
 <ce>                   The lycanthrope threat is ended.

--- a/Assets/StreamingAssets/Quests/M0B00Y06.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y06.txt
@@ -27,7 +27,7 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>                    "OK, %pcf. Get over to _house_
 <ce>                 here in town. Get it done in one day.
-<ce>               Nobody wants a animal left roaming around
+<ce>               Nobody wants an animal left roaming around
 <ce>                in their place. Come back here when the
 <ce>                 beast is dead and I'll have your pay
 <ce>                           waiting for you."
@@ -46,7 +46,7 @@ RumorsPostfailure:  [1006]
 That creature mauled some woman before being chased out of town. What a pity.
 
 RumorsPostsuccess:  [1007]
-The Fighter's Guild killed that bear that got into _house_. It's a good thing we have them around.
+The Fighters Guild killed that bear that got into _house_. It's a good thing we have them around.
 
 QuestorPostsuccess:  [1008]
 Good job killin' that beast. What can I do for you?
@@ -58,7 +58,7 @@ QuestLogEntry:  [1010]
 %qdt:
  The Fighters Guild of ___qgiver_
  has asked me to slay a wild beast which
- has gotten into _house_. It's got
+ has gotten into _house_. It's got to
  be done in one day.
 
 Message:  1011
@@ -75,19 +75,19 @@ Message:  1014
 
 Message:  1021
 <ce>                   You hear a voice call out from an
-<ce>                      upper floor, "Its a bear."
+<ce>                      upper floor, "It's a bear."
 
 Message:  1022
 <ce>                   You hear a voice call out from an
-<ce>                      upper floor, "Its a harpy."
+<ce>                      upper floor, "It's a harpy."
 
 Message:  1023
 <ce>                   You hear a voice call out from an
-<ce>                     upper floor, "Its a spider."
+<ce>                     upper floor, "It's a spider."
 
 Message:  1024
 <ce>                   You hear a voice call out from an
-<ce>                      upper floor, "Its a tiger."
+<ce>                      upper floor, "It's a tiger."
 
 Message:  1080
 <ce>                 By the way, since you seemed to have

--- a/Assets/StreamingAssets/Quests/M0B00Y15.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y15.txt
@@ -17,7 +17,7 @@ QuestorOffer:  [1000]
 <ce>                are willing to take it. Actually, some
 <ce>                members prefer these jobs because they
 <ce>                pay just as well as the more difficult
-<ce>                ones. A house here in town has infested
+<ce>                ones. A house here in town is infested
 <ce>                by giant rodents. The wife claims they
 <ce>                 are rats, the husband claims they are
 <ce>                bats. Either way, they want them gone.
@@ -25,7 +25,7 @@ QuestorOffer:  [1000]
 
 RefuseQuest:  [1001]
 <ce>                  Obviously you have no love for the
-<ce>                 Fighter's Guild. I will make sure to
+<ce>                 Fighters Guild. I will make sure to
 <ce>                   tell them what you really think.
 
 AcceptQuest:  [1002]
@@ -40,7 +40,7 @@ QuestComplete:  [1004]
 <ce>                          pays the same, eh?
 
 RumorsDuringQuest:  [1005]
-<ce>                   Some idiot didn't repair his roof
+<ce>                   Some idiot didn't repair her roof
 <ce>                   for a couple of months. Now she's
 <ce>                     got giant bats in her house.
 
@@ -55,7 +55,7 @@ RumorsPostsuccess:  [1007]
 <ce>                 I heard the Fighters Guild sent some
 <ce>                   %ra over to kill the bats in that
 <ce>                 woman's home. Cost her a bundle, but
-<ce>                 I suppose its better than abandoning
+<ce>                 I suppose it's better than abandoning
 <ce>                               her home.
 
 QuestorPostsuccess:  [1008]

--- a/Assets/StreamingAssets/Quests/M0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y16.txt
@@ -48,7 +48,7 @@ RumorsDuringQuest:  [1005]
 
 RumorsPostfailure:  [1006]
 <ce> I'm glad that giant finally moved out of ___mondung_.  I guess it got
-<ce>       bored with it's bland diet of villager night after night.
+<ce>       bored with its bland diet of villager night after night.
 
 RumorsPostsuccess:  [1007]
 <ce>      Thank %god _dummy_ finally sent someone to kill that giant
@@ -59,12 +59,12 @@ QuestorPostsuccess:  [1008]
 
 QuestorPostfailure:  [1009]
 <ce>                In my day, you could get kicked out of
-<ce>               the Fighter's Guild if you couldn't kill
+<ce>               the Fighters Guild if you couldn't kill
 <ce>                a simple giant.  Times change, I guess.
 
 Message:  1020
 %qdt:
- _questgiver_ of the Fighter's Guild
+ _questgiver_ of the Fighters Guild
  of ___questgiver_ has hired me to
  kill a giant in ___mondung_.
  I am to report back within =qtime_ days

--- a/Assets/StreamingAssets/Quests/M0B00Y17.txt
+++ b/Assets/StreamingAssets/Quests/M0B00Y17.txt
@@ -25,7 +25,7 @@ AcceptQuest:  [1002]
 <ce>                  Here's the situation. Seems _dummy_
 <ce>                has this pet sabertooth tiger -- don't
 <ce>                 ask -- and it ran off a few days ago.
-<ce>                   %g had it tracked to ___mondung_,
+<ce>                   %G had it tracked to ___mondung_,
 <ce>                but now we need someone to go in there
 <ce>                  and bring it out. Alive. The trick
 <ce>                 is that it's been trained to respond
@@ -54,7 +54,7 @@ QuestComplete:  [1004]
 <ce>                    at heart, wouldn't hurt a fly.
 <ce>                  Here's your _gold_ gold, just like
 <ce>                   I promised that nice _questgiver_
-<ce>                        at the Fighter's Guild.
+<ce>                        at the Fighters Guild.
 
 RumorsDuringQuest:  [1005]
 <ce>     Did you hear that _dummy_'s tiger escaped again?  Killed and
@@ -64,7 +64,7 @@ RumorsPostfailure:  [1006]
 <ce>    _dummy_'s tiger seems to have disappeared for good. Thank %god!
 
 RumorsPostsuccess:  [1007]
-<ce>     _dummy_ actually hired someone from the Fighter's Guild to go
+<ce>     _dummy_ actually hired someone from the Fighters Guild to go
 <ce>fetch %g3 pet tiger for %g2. What sap would take a silly job like that?
 
 QuestorPostsuccess:  [1008]
@@ -85,7 +85,7 @@ Message:  1020
  very well. I am to bring the tiger back
  to its owner, _dummy_, at __dummy_
  of ___dummy_ within =qtime_ days.
- %g'll pay me _gold_ gold.
+ %G'll pay me _gold_ gold.
 
 Message:  1021
 %qdt:
@@ -160,7 +160,7 @@ Message:  1061
 <ce>                   Yes, what do you want?  Oh...good
 <ce>                   gracious, a letter from _victim_!
 <ce>                     Why is it stained with blood?
-<ce>                    %g's dead?  Dear me. %g always
+<ce>                    %G's dead?  Dear me. %G always
 <ce>                    was so sweet to me, I'm afraid
 <ce>                   %g had the delusion that we were
 <ce>                   in love. Poor soul, what a tragic

--- a/Assets/StreamingAssets/Quests/M0B11Y18.txt
+++ b/Assets/StreamingAssets/Quests/M0B11Y18.txt
@@ -26,7 +26,7 @@ AcceptQuest:  [1002]
 <ce>                blade and can keep a secret. Naturally,
 <ce>                    I thought of you. _target_ will
 <ce>              meet you at 10:00 tonight at _targethouse_.
-<ce>                %g will tell you more when you arrive.
+<ce>                %G will tell you more when you arrive.
 <ce>              I would come with you, but since I am known
 <ce>                as %g3 friend, I might lead %g3 enemies
 <ce>                 to %g2. Watch your back on this one.

--- a/Assets/StreamingAssets/Quests/M0B1XY01.txt
+++ b/Assets/StreamingAssets/Quests/M0B1XY01.txt
@@ -20,7 +20,7 @@ QuestorOffer:  [1000]
 <ce>                      little hackin' 'n slashin'?
 
 RefuseQuest:  [1001]
-<ce>                      Too bad. Seemed pretty like
+<ce>                         Too bad. Seemed like
 <ce>                   a pretty damn generous deal to me.
 
 AcceptQuest:  [1002]
@@ -36,7 +36,7 @@ AcceptQuest:  [1002]
 <ce>                            get outta here.
 
 QuestFail:  [1003]
-<ce>                  Listen kid, I'm know I'm a charmer,
+<ce>                   Listen kid, I know I'm a charmer,
 <ce>                     but them harpies are waiting,
 <ce>                     and make sure to get all five
 <ce>                            of 'em, get it?

--- a/Assets/StreamingAssets/Quests/M0B21Y19.txt
+++ b/Assets/StreamingAssets/Quests/M0B21Y19.txt
@@ -17,16 +17,16 @@ QuestorOffer:  [1000]
 <ce>                 Standard protection job.  Interested?
 
 RefuseQuest:  [1001]
-<ce>               Sure, you're lookin' for more high class
+<ce>               Sure, you're lookin' for more high-class
 <ce>                        work these days, right?
 
 AcceptQuest:  [1002]
 <ce>                   All right.  The client's name is
 <ce>                    _victim_, over at _victimhouse_
-<ce>                just up the street from here.  %g wants
+<ce>                just up the street from here.  %G wants
 <ce>                   you over there right away.  Seemed
 <ce>                   very agitated, you know the type.
-<ce>                     %g'll give you all the details
+<ce>                     %G'll give you all the details
 <ce>                          when you get there.
 
 QuestFail:  [1003]
@@ -50,7 +50,7 @@ QuestorPostfailure:  [1009]
 <ce>                        more seriously, I guess.
 
 Message:  1015
-<ce>   _darkb_ lives in ___darkb_, I think.  %g's always hanging around
+<ce>   _darkb_ lives in ___darkb_, I think.  %G's always hanging around
 <ce>    with sinister types, though, so don't go looking for %g2 unless
 <ce>                      you're looking for trouble.
                                      <--->
@@ -58,7 +58,7 @@ Message:  1015
 
 Message:  1016
 <ce>     _darkb_ is one of the leaders of the local Dark Brotherhood.
-<ce>             %g3 headquarters is in __darkb_ in ___darkb_.
+<ce>             %G3 headquarters is in __darkb_ in ___darkb_.
 
 Message:  1020
 %qdt:
@@ -143,7 +143,7 @@ Message:  1041
                                      <--->
 <ce>         The Dark Brotherhood has vowed to track down whoever
 <ce>              broke into their headquarters in ___darkb_.
-<ce>                 I'm sure glad it's not me their after.
+<ce>                 I'm sure glad it's not me they're after.
 
 Message:  1050
 <ce>               Yes...?  Wait, you're that Fighters Guild

--- a/Assets/StreamingAssets/Quests/M0B30Y03.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y03.txt
@@ -67,7 +67,7 @@ QuestorPostsuccess:  [1008]
 
 QuestorPostfailure:  [1009]
 <ce>                  Failure is not taken lightly in the
-<ce>                Fighter's Guild. If you couldn't handle
+<ce>                Fighters Guild. If you couldn't handle
 <ce>                 a Daedroth, you shouldn't have taken
 <ce>                 the job. I've got better things to do
 <ce>                  than waste my time talking to you.

--- a/Assets/StreamingAssets/Quests/M0B30Y04.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y04.txt
@@ -69,7 +69,7 @@ I lost money betting against that %ra that went to kill that lich.
 
 QuestorPostsuccess:  [1008]
 <ce>                  The lich slayer has returned! What
-<ce>                   will it be now? Dragons? Daedras?
+<ce>                   will it be now? Dragons? Daedra?
 
 QuestorPostfailure:  [1009]
 <ce>                 I wouldn't have taken a job to face a
@@ -90,7 +90,7 @@ Message:  1030
  The Fighters Guild
  of ___questgiver_ has hired me to
  slay a lich in =1stparton_ days or less.
- The liches' lair is a place called
+ The lich's lair is a place called
  ___mondung_.
 
 Message:  1080

--- a/Assets/StreamingAssets/Quests/M0B30Y08.txt
+++ b/Assets/StreamingAssets/Quests/M0B30Y08.txt
@@ -32,7 +32,7 @@ AcceptQuest:  [1002]
 <ce>                  and it's worth _gold_ gold to you.
 
 QuestComplete:  [1004]
-<ce>               Was the old boy as foul smelling as they
+<ce>               Was the old boy as foul-smelling as they
 <ce>                say? Like a drawer of knickers left in
 <ce>                  the rain for a month. Well, here is
 <ce>                            your pay, %pcn.
@@ -44,11 +44,11 @@ RumorsDuringQuest:  [1005]
 
 RumorsPostfailure:  [1006]
 <ce>                 They found a woman dead in her home.
-<ce>                  The rotted corpse of her long dead
+<ce>                  The rotted corpse of her long-dead
 <ce>                    husband was found next to her.
 
 RumorsPostsuccess:  [1007]
-<ce>                 I hear the Fighter's Guild sent some
+<ce>                 I hear the Fighters Guild sent some
 <ce>                tough over to take care of that zombie.
 <ce>                    They're a good lot, the guild.
 

--- a/Assets/StreamingAssets/Quests/M0B40Y05.txt
+++ b/Assets/StreamingAssets/Quests/M0B40Y05.txt
@@ -34,11 +34,13 @@ AcceptQuest:  [1002]
 <ce>                           waiting for you.
 
 QuestFail:  [1003]
+<ce>                       
+
+QuestComplete:  [1004]
 <ce>                       The spriggan is kindling?
 <ce>                      You are proving yourself to
 <ce>                       be quite reliable, %pct.
 
-QuestComplete:  [1004]
 <ce>                       Here is your _gold_ gold
 <ce>                             as promised.
 
@@ -62,7 +64,7 @@ QuestorPostsuccess:  [1008]
 
 QuestorPostfailure:  [1009]
 <ce>                    Spriggans aren't so tough. What
-<ce>                   happened? You get scared and hid?
+<ce>                   happened? You got scared and hid?
 
 QuestLogEntry:  [1010]
 On %qdt,

--- a/Assets/StreamingAssets/Quests/M0B40Y05.txt
+++ b/Assets/StreamingAssets/Quests/M0B40Y05.txt
@@ -34,13 +34,11 @@ AcceptQuest:  [1002]
 <ce>                           waiting for you.
 
 QuestFail:  [1003]
-<ce>                       
-
-QuestComplete:  [1004]
 <ce>                       The spriggan is kindling?
 <ce>                      You are proving yourself to
 <ce>                       be quite reliable, %pct.
 
+QuestComplete:  [1004]
 <ce>                       Here is your _gold_ gold
 <ce>                             as promised.
 
@@ -136,7 +134,7 @@ Message:  1080
 <ce>               By the way, since I'm feelin' charitable,
 <ce>              here's a map to a hole called ___newdung_.
 <ce>              Full of monsters needin' killing, treasure
-<ce>                    to loot, the works.  Have fun.
+<ce>                    to loot, the works. Have fun.
 
 
 -- Symbols used in the QRC file:

--- a/Assets/StreamingAssets/Quests/M0B50Y09.txt
+++ b/Assets/StreamingAssets/Quests/M0B50Y09.txt
@@ -40,7 +40,7 @@ QuestComplete:  [1004]
 
 RumorsDuringQuest:  [1005]
 <ce>                  The Mages Guild has refused to kill
-<ce>                that rampaging gargoyle. They claim its
+<ce>                that rampaging gargoyle. They claim it's
 <ce>                    not their fault. Lazy bastards.
 
 RumorsPostfailure:  [1006]

--- a/Assets/StreamingAssets/Quests/M0B60Y10.txt
+++ b/Assets/StreamingAssets/Quests/M0B60Y10.txt
@@ -17,7 +17,7 @@ QuestorOffer:  [1000]
 <ce>                          Are you interested?
 
 RefuseQuest:  [1001]
-<ce>                     You must prefer the low risk
+<ce>                     You must prefer the low-risk
 <ce>                       jobs, like hunting rats.
 
 AcceptQuest:  [1002]

--- a/Assets/StreamingAssets/Quests/M0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y11.txt
@@ -32,7 +32,7 @@ AcceptQuest:  [1002]
 <ce>                        I'll speak well of you.
 
 QuestComplete:  [1004]
-<ce>              I guess you aren't the weak kneed jellyfish
+<ce>              I guess you aren't the weak-kneed jellyfish
 <ce>               everyone says you are. I'll make sure the
 <ce>                     right people hear about this.
 
@@ -44,11 +44,11 @@ RumorsDuringQuest:  [1005]
 RumorsPostfailure:  [1006]
 <ce>               Some drunken fool stumbled into his house
 <ce>               and got killed by a giant scorpion. Seems
-<ce>               he thought the Fighter's Guild had taken
+<ce>               he thought the Fighters Guild had taken
 <ce>                          care of the beast.
 
 RumorsPostsuccess:  [1007]
-<ce>                 The Fighter's Guild is a good bunch.
+<ce>                 The Fighters Guild is a good bunch.
 <ce>                They killed a giant scorpion that found
 <ce>                     its way into someone's house.
 
@@ -64,7 +64,7 @@ QuestorPostfailure:  [1009]
 QuestLogEntry:  [1010]
 %qdt:
  The Fighters Guild of ___qgiver_
- has offered to let me to slay a
+ has offered to let me slay a
  giant scorpion which has gotten into
  _house_. It's got be done today.
 

--- a/Assets/StreamingAssets/Quests/M0C00Y12.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y12.txt
@@ -24,7 +24,7 @@ QuestorOffer:  [1000]
 <ce>                          Are you interested?
 
 RefuseQuest:  [1001]
-<ce>                     I should have known you were
+<ce>                    I should have known you were not
 <ce>                          serious about work.
 
 AcceptQuest:  [1002]
@@ -36,13 +36,13 @@ AcceptQuest:  [1002]
 QuestComplete:  [1004]
 <ce>                          You got spunk %pcf.
 <ce>                       Keep up the good work and
-<ce>                       you'll be Fighter's Guild
+<ce>                       you'll be Fighters Guild
 <ce>                             material yet.
 
 RumorsDuringQuest:  [1005]
 <ce>               Did you hear about the idiot that brought
-<ce>                home a giant spider's egg. Now he's got
-<ce>                an eight legged pet thats trying to eat
+<ce>                home a giant spider's egg? Now he's got
+<ce>                an eight-legged pet that's trying to eat
 <ce>                            him for dinner!
 
 RumorsPostfailure:  [1006]
@@ -51,7 +51,7 @@ RumorsPostfailure:  [1006]
 
 RumorsPostsuccess:  [1007]
 <ce>             You're that guy that killed the giant spider.
-<ce>           You should join the Fighter's Guild or something.
+<ce>           You should join the Fighters Guild or something.
 
 QuestorPostsuccess:  [1008]
 <ce>                  Nicely done with that giant spider.
@@ -65,7 +65,7 @@ QuestLogEntry:  [1010]
 %qdt:
  The Fighters Guild of
  ___qgiver_ has
- offered to let me to kill
+ offered to let me kill
  a giant spider which hatched
  in _house_.
  It's got be done today.

--- a/Assets/StreamingAssets/Quests/M0C00Y13.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y13.txt
@@ -13,7 +13,7 @@ QRC:
 
 QuestorOffer:  [1000]
 <ce>                            I am _qgiver_.
-<ce>                 The Fighter's Guild doesn't hand out
+<ce>                 The Fighters Guild doesn't hand out
 <ce>                  charity work. If I weren't short on
 <ce>                 fighters right now, I'd have to send
 <ce>                 you away %pcn. I do need a fighter to
@@ -23,7 +23,7 @@ QuestorOffer:  [1000]
 <ce>                     a stand up %ra. Is it a deal?
 
 RefuseQuest:  [1001]
-<ce>                    You've just make a big mistake
+<ce>                    You've just made a big mistake
 <ce>                     %pcn. Don't come looking for
 <ce>                        work here for a while.
 
@@ -37,14 +37,14 @@ QuestComplete:  [1004]
 <ce>                        Did you get cut up bad?
 <ce>                     A couple more jobs like this
 <ce>                      and you can write your own
-<ce>                   ticket into the Fighter's Guild.
+<ce>                   ticket into the Fighters Guild.
 
 RumorsDuringQuest:  [1005]
 <ce>                Barbarians are raiding the farms again.
 
 RumorsPostfailure:  [1006]
 <ce>                 The barbarians looted four farmsteads
-<ce>                before the Fighter's Guild stepped in.
+<ce>                before the Fighters Guild stepped in.
 
 RumorsPostsuccess:  [1007]
 <ce>                  Aren't you the %ra that chased off
@@ -63,7 +63,7 @@ QuestLogEntry:  [1010]
 %qdt:
  The Fighters Guild of
  ___qgiver_ has
- offered to let me to take
+ offered to let me take
  care of some barbarian
  marauding _house_.
  I have one full day.

--- a/Assets/StreamingAssets/Quests/M0C00Y14.txt
+++ b/Assets/StreamingAssets/Quests/M0C00Y14.txt
@@ -22,7 +22,7 @@ QuestorOffer:  [1000]
 
 RefuseQuest:  [1001]
 <ce>                  Obviously you have no love for the
-<ce>                 Fighter's Guild. I will make sure to
+<ce>                 Fighters Guild. I will make sure to
 <ce>                   tell them what you really think.
 
 AcceptQuest:  [1002]
@@ -36,7 +36,7 @@ QuestComplete:  [1004]
 <ce>                    Killing rats, even giant ones,
 <ce>                      doesn't take much skill. It
 <ce>                      does put you in favor with
-<ce>                         us though. Good work.
+<ce>                        us, though. Good work.
 
 RumorsDuringQuest:  [1005]
 <ce>                   Some idiot bought four barrels of

--- a/Assets/StreamingAssets/Quests/N0B00Y04.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y04.txt
@@ -76,10 +76,10 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostfailure:  [1006]
-_qgiver_ has been complaining about the quality of Mages Guildmembers.
+_qgiver_ has been complaining about the quality of Mages Guild members.
 
 RumorsPostsuccess:  [1007]
 I got a boil the other day ... but it healed.
@@ -137,7 +137,7 @@ QuestTimeLapse:  [1045]
 <ce>                      You suddenly remember that
 <ce>                       _qgiver_ had asked you to
 <ce>                      bring him a _ingredient_ by
-<ce>                      today.  %g will no doubt be
+<ce>                      today.  %G will no doubt be
 <ce>                             disappointed.
 
 

--- a/Assets/StreamingAssets/Quests/N0B00Y06.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y06.txt
@@ -25,10 +25,10 @@ QuestorOffer:  [1000]
                                      <--->
 <ce>                  Recipes are a daft business, %pct.
 <ce>               I'm working on a formula that calls for a
-<ce>                  "goodly piece of =mummy_. What is a
+<ce>                  "goodly piece of =mummy_." What is a
 <ce>                   =mummy_? An herb? A mineral? Well,
 <ce>              I've researched the matter and found =mummy_
-<ce>            is a mummy. Imagine that. And this particularly
+<ce>             is a mummy. Imagine that. And this particular
 <ce>                  mummy is right here in %reg. Could I
 <ce>              talk you into going to its tomb and grabbing
 <ce>            a piece of =mummy_ for, say, _gold_ gold pieces?
@@ -94,7 +94,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostsuccess:  [1007]
 =mummy_'s reign in %reg began before the First Era and ended with you.
@@ -102,7 +102,7 @@ RumorsPostsuccess:  [1007]
 _qgiver_ finally can finish %g3 potion thanks to =mummy_'s contribution.
 
 QuestorPostsuccess:  [1008]
-How are you, %pcf? I hope you aren't coming down with mummy rot or anything.
+How are you, %pcf? I hope you aren't coming down with Mummy Rot or anything.
 
 QuestorPostfailure:  [1009]
 <ce>                     I needed that wrapping, %pcf.

--- a/Assets/StreamingAssets/Quests/N0B00Y08.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y08.txt
@@ -59,7 +59,7 @@ QuestComplete:  [1004]
 <ce>                             gold pieces.
 
 RumorsDuringQuest:  [1005]
-Poor _warrior_ has been awake for days. I think %g2 sanity is going.
+Poor _warrior_ has been awake for days. I think %g3 sanity is going.
 <--->
 The witch who cursed _warrior_ with sleeplessness really did a job on %g2.
 
@@ -69,7 +69,7 @@ _warrior_ and the Mages Guild are at odds. They couldn't help %g2.
 _warrior_ made peace with the witches, but hasn't forgiven the Mages Guild.
 
 RumorsPostsuccess:  [1007]
-_warrior_ is still sleeping I hear. Now they're afraid %g'll never wake up.
+_warrior_ is still sleeping, I hear. Now they're afraid %g'll never wake up.
 <--->
 The witch who cursed _warrior_ has vowed vengeance on the man who cured %g2.
 

--- a/Assets/StreamingAssets/Quests/N0B00Y09.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y09.txt
@@ -23,7 +23,7 @@ QuestorOffer:  [1000]
 <ce>                     The Mages Guild of ___qgiver_
 <ce>            has an exciting opportunity to benefit from the
 <ce>              work of the renowned researcher and scholar,
-<ce>                   _scholar_. %g has agreed to donate
+<ce>                   _scholar_. %G has agreed to donate
 <ce>              some of %g3 research to the Guild if we send
 <ce>                 someone to ___scholar_ to pick it up.
 <ce>                 Not surprisingly, %g fears Necromancer
@@ -54,7 +54,7 @@ QuestComplete:  [1004]
 <ce>                               job, %pct.
 
 RumorsDuringQuest:  [1005]
-Maybe that _scholar_ is a celebrity to scholar types, but %g's just a =scholar_
+Maybe that _scholar_ is a celebrity to scholar types, but %g's just a =scholar_.
 <--->
 It's an honor for ___scholar_ to host the renowned _scholar_'s visit to %reg.
 
@@ -184,19 +184,19 @@ When white light is passed through a gas
  evidence, essense, morality, and extraction.
 
 Message:  1017
-_scholar_ is only one of the most respected scholars in Tamriel
+_scholar_ is only one of the most-respected scholars in Tamriel.
 <--->
-_scholar_ is a =scholar_, a very well-respected scholar
+_scholar_ is a =scholar_, a very well-respected scholar.
 <--->
-_scholar_ is only going to be visiting %reg for a short time
+_scholar_ is only going to be visiting %reg for a short time.
 <--->
-One of the finest minds of the third era, so they say
+One of the finest minds of the third era, so they say.
 <--->
-_scholar_ would definitely agree that %g's a genius
+_scholar_ would definitely agree that %g's a genius.
 <--->
-_scholar_ is a typical intellectual. No idea of what's going on
+_scholar_ is a typical intellectual: no idea of what's going on.
 <--->
-_scholar_'s very clever, but %g3 brains sometimes go to %g3 head
+_scholar_'s very clever, but %g3 brains sometimes go to %g3 head.
 <--->
 Talk to _db_ over in ___db_ -- %g's been asking about _scholar_ too.
 <--->
@@ -217,7 +217,7 @@ Message:  1019
 <ce>                little something I whipped together that
 <ce>                should keep you from getting in trouble
 <ce>                      with _qgiver_ and the other
-<ce>                 Mages Guildmembers. All research notes
+<ce>                 Mages Guild members. All research notes
 <ce>                look alike anyhow. When they don't yield
 <ce>                results, the Guild will just throw more
 <ce>                assistants at it or give up the project

--- a/Assets/StreamingAssets/Quests/N0B00Y16.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y16.txt
@@ -7,7 +7,7 @@
 -- Edited for Daggerfall Unity by Jay_H
 Messages: 52
 Quest: N0B00Y16
-DisplayName: Open a chest
+DisplayName: Open a Chest
 -- Message panels
 QRC:
 
@@ -34,7 +34,7 @@ AcceptQuest:  [1002]
 <ce>                  matters, but the Guild could use %g3
 <ce>                patronage, so I agreed to send someone.
 <ce>                From what I am told, it sounds like one
-<ce>                   of _mage_'s trick boxes.  %g made
+<ce>                   of _mage_'s trick boxes.  %G made
 <ce>                 hundreds of them in %g3 day, mainly as
 <ce>                 gifts for %g3 friends, and they still
 <ce>               turn up from time to time, as the workman-
@@ -42,7 +42,7 @@ AcceptQuest:  [1002]
 <ce>                Oh yes, well, the secret to these boxes
 <ce>               is that they are almost impossible to open
 <ce>              in any way except by the use of the simple,
-<ce>               standard Open spell.  %g specifically made
+<ce>               standard Open spell.  %G specifically made
 <ce>             them resistant to the fancy alternative spells
 <ce>              %g3 friends liked to use.  Yes, %g tended to
 <ce>              waste %g3 considerable talents on jokes like
@@ -61,7 +61,7 @@ QuestComplete:  [1004]
 <ce>                     and all that rot.  Jolly good.
 
 RumorsDuringQuest:  [1005]
-<ce>        Did you hear about _merchant_?  %g bought an old chest
+<ce>        Did you hear about _merchant_?  %G bought an old chest
 <ce>                and now %g can't open it.  What a hoot!
 
 RumorsPostfailure:  [1006]
@@ -95,7 +95,7 @@ Message:  1030
 <ce>                   I knew my old friend _questgiver_
 <ce>                   wouldn't let me down.  Here is the
 <ce>                   box.  I hope you have some idea of
-<ce>                  how to open it.  I'm at my wits end.
+<ce>                  how to open it.  I'm at my wit's end.
 
 Message:  1040
 <ce>                  As you cast Open on the chest, the
@@ -134,7 +134,7 @@ Message:  1043
 
 Message:  1050
 <ce>                    Tell _questgiver_ I appreciate
-<ce>                   %g2 sending you to help...I guess.
+<ce>                   %g2 sending you to help... I guess.
 <ce>                     Of course, if I had known what
 <ce>                      was inside, I might not have
 <ce>                       been so eager to open it!

--- a/Assets/StreamingAssets/Quests/N0B00Y17.txt
+++ b/Assets/StreamingAssets/Quests/N0B00Y17.txt
@@ -42,7 +42,7 @@ AcceptQuest:  [1002]
 <ce>              a catalogue once held by the library at ...
 <ce>              oh yes, nowadays it's known as ___hintdung_.
 <ce>                You might also try a colleague of mine,
-<ce>                _scholar_.  %g is an expert on _maker_.
+<ce>                _scholar_.  %G is an expert on _maker_.
 <ce>              Wrote the definitive biography, although in
 <ce>              my opinion ... ah, well, no time to get into
 <ce>                that old debate.  You'll find _scholar_
@@ -63,13 +63,13 @@ QuestComplete:  [1004]
 <ce>                here it is.  Well, as it happens, while
 <ce>               you were gone, I had quite a breakthrough
 <ce>                in my research.  You see, it wasn't the
-<ce>                 azimuth vectors at all, the key to the
+<ce>                azimuthal vectors at all, the key to the
 <ce>                whole problem is actually ... well, the
 <ce>                 point is, I no longer need the _item_.
 <ce>                It is a beautiful piece of work, though,
 <ce>                isn't it?  Why don't you keep it, since
 <ce>                  you went to all the trouble to find
-<ce>                  it for me.  Now if you'll excuse me,
+<ce>                  it for me?  Now if you'll excuse me,
 <ce>                        I must get back to work.
 
 RumorsDuringQuest:  [1005]
@@ -135,7 +135,7 @@ Message:  1024
 Message:  1025
 %qdt:
  I spoke with _scholar_ in ___scholardung_.
- %g was unable to help me in my search for
+ %G was unable to help me in my search for
  the _item_, but I agreed to get
  some alchemical ingredients for %g2 from
  _contact_ of __contact_ in
@@ -226,7 +226,7 @@ Message:  1042
 <ce>                Excellent.  Here, let me jot down what
 <ce>                  I need.  Take this list to _contact_
 <ce>                     of __contact_ in ___contact_.
-<ce>                   %g's the only one I trust to give
+<ce>                   %G's the only one I trust to give
 <ce>                    me the exact ingredients I need.
 <ce>                    I'll expect you back here within
 <ce>                    =time2_ days.  Please be prompt.
@@ -243,7 +243,7 @@ Message:  1044
 <ce>               "Charge to my account", ha!  That's rich.
 <ce>                 Listen, I'll give you the _ingredient_
 <ce>                %g asked for, but the rest will have to
-<ce>               be special ordered, and I'm not doing that
+<ce>               be special-ordered, and I'm not doing that
 <ce>                  until %g pays me for everything else
 <ce>                I've sent to %g2.  I'm sorry, but that's
 <ce>                           the best I can do.

--- a/Assets/StreamingAssets/Quests/N0B10Y01.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y01.txt
@@ -79,7 +79,7 @@ I hear they found out that atronach was made with the soul of %t's brother!
 <--->
 A lot of people feel safer knowing that atronach is dead.
 <--->
-Everybody's talking about that atronach that %ra hunted down?
+Everybody's talking about that atronach that %ra hunted down.
 
 QuestorPostsuccess:  [1008]
 I haven't forgotten about the atronach crisis, if that's what's concerning you.

--- a/Assets/StreamingAssets/Quests/N0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/N0B10Y03.txt
@@ -53,7 +53,7 @@ The thieves have been threatening to steal the Mages Guild's _treasure_.
 RumorsPostfailure:  [1006]
 The thieves finally got that _treasure_ after all.
 <--->
-The Mages Guild should've got real guards. That's why they lost the _treasure_
+The Mages Guild should've got real guards. That's why they lost the _treasure_.
 
 RumorsPostsuccess:  [1007]
 Those thieves aren't going to try to get that _treasure_ again, I bet.
@@ -88,12 +88,12 @@ Message:  1011
  be after me for sure.
 
 Message:  1012
-<ce>                      Lookee here boys. A guard.
+<ce>                      Lookee here, boys. A guard.
 <ce>                        Gee, I'm all scared and
-<ce>                        shaking. Lets leave the
+<ce>                        shaking. Let's leave the
 <ce>                        tongue on the door as a
 <ce>                        warning not to mess with
-<ce>                      the thieves guild. Get him!
+<ce>                      the Thieves Guild. Get him!
 
 Message:  1013
 <ce>                      I claim bounty on the thief

--- a/Assets/StreamingAssets/Quests/N0B11Y18.txt
+++ b/Assets/StreamingAssets/Quests/N0B11Y18.txt
@@ -29,7 +29,7 @@ AcceptQuest:  [1002]
 <ce>               continued survival.  We have learned that
 <ce>            %g is currently doing some kind of unsanctioned
 <ce>               research over in ___rebelhouse_, apparently
-<ce>            oblivious to %g3 danger.  You have =qtime_ days
+<ce>            oblivious to the danger.  You have =qtime_ days
 <ce>            to dispose of this menace and report back to me.
 
 QuestFail:  [1003]
@@ -61,7 +61,7 @@ Message:  1021
 Message:  1030
 <ce>                   So, _questgiver_ has sent another
 <ce>                  of %g3 lackeys to bring me to heel.
-<ce>                 The old women who run the Mages Guild
+<ce>                 The old men who run the Mages Guild
 <ce>               have no sense of adventure, take no risks,
 <ce>                dare nothing, and learn nothing.  I have
 <ce>               never lifted a finger against them, except
@@ -106,7 +106,7 @@ Dear _questgiver_,
 <ce>                                _rebel_
 
 Message:  1041
-<ce>                     Why...that impertinent!  I am
+<ce>                     Why... that impertinent!  I am
 <ce>                      speechless!  You can now see
 <ce>                      why _rebel_ must be stopped
 <ce>                   at all costs, before he undermines
@@ -127,7 +127,7 @@ Message:  1050
 
 Message:  1051
 <ce>                    Surely you are ready to concede
-<ce>              my point.  We could have such fun together!
+<ce>              my point?  We could have such fun together!
 
 Message:  1052
 <ce>               _questgiver_ has taught you persistence,

--- a/Assets/StreamingAssets/Quests/N0B20Y02.txt
+++ b/Assets/StreamingAssets/Quests/N0B20Y02.txt
@@ -21,7 +21,7 @@ QuestorOffer:  [1000]
 <ce>                        that a rival of %g3 may
 <ce>                       send assassins to slay %g2
 <ce>                         while %g is helpless.
-<ce>                    %g will give you an ensorcelled
+<ce>                    %G will give you an ensorcelled
 <ce>                              _magicitem_
 <ce>                          if the assassins are
 <ce>                 stopped. Will you take up this quest?
@@ -46,7 +46,7 @@ RefuseQuest:  [1001]
 
 AcceptQuest:  [1002]
 <ce>                    As I expected.  _sleepingmage_
-<ce>                is just beginning his three hour trance,
+<ce>                is just beginning his three-hour trance,
 <ce>                 so you must guard _magesguild_ during
 <ce>                 that time and protect him while he is
 <ce>                 vulnerable. At the end of his trance,
@@ -102,7 +102,7 @@ Message:  1011
 <ce>                    Stand aside, apprentice whelp!
 <ce>                   We mean to cut down _sleepingmage_
 <ce>                     before he can awaken. Move or
-<ce>                        we'll cut you down too.
+<ce>                        we'll cut you down, too.
 
 Message:  1012
 <ce>                     Fool! You should know better

--- a/Assets/StreamingAssets/Quests/N0B20Y05.txt
+++ b/Assets/StreamingAssets/Quests/N0B20Y05.txt
@@ -25,8 +25,8 @@ QuestorOffer:  [1000]
 <ce>                        The people of %reg have
 <ce>                been demanding that the Mages Guild take
 <ce>                 a stand against the mad wizard who has
-<ce>                been terrorizing the land for some time
-<ce>                 now. Now, by order of the Archmagister
+<ce>                been terrorizing the land for some time.
+<ce>                   Now, by order of the Archmagister
 <ce>                himself, we are doing just that. I know
 <ce>                 it's hardly the assignment a scholarly
 <ce>                 institution should give, but would you

--- a/Assets/StreamingAssets/Quests/N0B21Y14.txt
+++ b/Assets/StreamingAssets/Quests/N0B21Y14.txt
@@ -23,7 +23,7 @@ AcceptQuest:  [1002]
 <ce>                           brought you here.
 
 QuestComplete:  [1004]
-<ce>                  You are a credit to the guild %pcf.
+<ce>                  You are a credit to the guild, %pcf.
 
 RumorsDuringQuest:  [1005]
 _noble_ is certainly one of the greatest nobles in %reg.
@@ -64,7 +64,7 @@ Message:  1011
                      The Acolyte
 
 Message:  1012
-The Acolyte was said to be nobleman before he became the Oracle's disciple.
+The Acolyte was said to be a nobleman before he became the Oracle's disciple.
 <--->
 The Acolyte does all of the Oracle's footwork. Understandable at her age.
 <--->
@@ -120,8 +120,8 @@ Message:  1016
 %qdt:
  The Acolyte told me that
  he is attempting to convince
- _noble_, to leave _noblehouse_
- lest %g die and by dying, bring
+ _noble_ to leave _noblehouse_
+ lest %g die, and by dying, bring
  calamity to all %reg. I have been
  asked either to speak with _noble_
  myself or go to __oracletemple_
@@ -168,7 +168,7 @@ Message:  1020
 <ce>               interested in hiding my head because some
 <ce>                mad old crone had a bad dream about me.
 <ce>               As it happens, I am waiting for some word
-<ce>                         about my love, _love_
+<ce>                         about my love _love_,
 <ce>                who was kidnapped. I will listen to %g3
 <ce>               advice on this matter, but I will not go
 <ce>                into hiding while %g remains in danger.

--- a/Assets/StreamingAssets/Quests/N0B30Y15.txt
+++ b/Assets/StreamingAssets/Quests/N0B30Y15.txt
@@ -29,7 +29,7 @@ AcceptQuest:  [1002]
 <ce>                       Fine attitude %pcn. There
 <ce>                    is one thing I did not tell you.
 <ce>                   This imp was a familiar to a very
-<ce>                    high ranking mage. It seems the
+<ce>                    high-ranking mage. It seems the
 <ce>                  imp fell into an experimental spell
 <ce>                  and has been imbued with all manner
 <ce>                   of spell-like powers. You can find

--- a/Assets/StreamingAssets/Quests/N0B40Y07.txt
+++ b/Assets/StreamingAssets/Quests/N0B40Y07.txt
@@ -68,7 +68,7 @@ QuestComplete:  [1004]
 <ce>                               enjoyed.
 
 RumorsDuringQuest:  [1005]
-Daedras seem to be attracted to ___mondung_. Must be some spiritual about it.
+Daedra seem to be attracted to ___mondung_. Must be something spiritual about it.
 <--->
 <ce>      Old _qgiver_ is forever summoning things up and
 <ce>                           getting %g2-self in trouble.
@@ -77,7 +77,7 @@ RumorsPostfailure:  [1006]
 The daedric stars last night shone particularly bright.
 
 RumorsPostsuccess:  [1007]
-_qgiver_'s daedra is gone for now. But daedras have a habit of returning.
+_qgiver_'s daedra is gone for now. But daedra have a habit of returning.
 <--->
 ___mondung_ is relatively purged of daedric influence, at least for now.
 

--- a/Assets/StreamingAssets/Quests/N0C00Y10.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y10.txt
@@ -75,7 +75,7 @@ QuestorPostfailure:  [1009]
 QuestLogEntry:  [1010]
 <ce>                          You may want to try
 <ce>                     _informant_ in _informant1_.
-<ce>                           %g seems to know
+<ce>                           %G seems to know
 <ce>                        everything that goes on
 <ce>                         around __informant1_.
                                      <--->

--- a/Assets/StreamingAssets/Quests/N0C00Y11.txt
+++ b/Assets/StreamingAssets/Quests/N0C00Y11.txt
@@ -82,7 +82,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostsuccess:  [1007]
 I got a boil the other day ... but it healed.
@@ -111,7 +111,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 QuestorPostsuccess:  [1008]
 I haven't forgotten you, %pcf. You're the %ra who got the _ingredient_.

--- a/Assets/StreamingAssets/Quests/O0A0AL00.txt
+++ b/Assets/StreamingAssets/Quests/O0A0AL00.txt
@@ -86,7 +86,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 RumorsPostsuccess:  [1007]
 I got a boil the other day ... but it healed.
@@ -127,7 +127,7 @@ QuestLogEntry:  [1010]
 Message:  1020
 <ce>                      A one-eyed beggar hands you
 <ce>                       a letter. "A woman in gray
-<ce>                     paid me to give this to you."
+<ce>                     paid me to give this to you,"
 <ce>                                he says.
 
 Message:  1018

--- a/Assets/StreamingAssets/Quests/O0B00Y00.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y00.txt
@@ -36,7 +36,7 @@ AcceptQuest:  [1002]
 <ce>                      in. Get over to __contact_
 <ce>                          and give _contact_
 <ce>                 this hunk of _metal_ in exchange for
-<ce>                  the _gems_, and then you bring the
+<ce>                    the _gems_, and then you bring
 <ce>                     it back here. You understand?
 <ce>                  Good. Now, hurry, there ain't time.
 
@@ -60,10 +60,10 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 Well, everyone knows that _contact_ stole that jewel. Why don't they get %g2?
 <--->
-There's a lot of poshes at __contact_. Guards aren't wanted in there.
+There's a lot of posses at __contact_. Guards aren't wanted in there.
 
 RumorsPostfailure:  [1006]
-The guards finally got _contact_. Guess %g couldn't hold 'em out forever.
+The guards finally got _contact_. Guess %g couldn't hold 'em off forever.
 <--->
 Yeah, they found the %t's _gems_ and arrested that =contact_ alright.
 

--- a/Assets/StreamingAssets/Quests/O0B00Y01.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y01.txt
@@ -82,7 +82,7 @@ QuestLogEntry:  [1010]
 <ce>                      Well done, %pcf. I couldn't
 <ce>                  have made it here as easily carrying
 <ce>                   that _weapons_. Here's a sample of
-<ce>                  what I've stolen so far...a _gems_.
+<ce>                  what I've stolen so far... a _gems_.
 <ce>                   Bring it back to _questgiver_ and
 <ce>                     let %g2 know I'm fine. Thanks
 <ce>                      again, %pcf. See you later.

--- a/Assets/StreamingAssets/Quests/O0B00Y12.txt
+++ b/Assets/StreamingAssets/Quests/O0B00Y12.txt
@@ -73,7 +73,7 @@ Message:  1021
 %qdt:
  I just got a note from _contact1_
  saying %g was unable to meet me in
- ___contact1_.  %g told me to
+ ___contact1_.  %G told me to
  go to ___contact2_ instead,
  and deliver the shipment to a
  =contact2_ in __contact2_.

--- a/Assets/StreamingAssets/Quests/O0B10Y00.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y00.txt
@@ -36,7 +36,7 @@ AcceptQuest:  [1002]
 <ce>                      in. Get over to __contact_
 <ce>                          and give _contact_
 <ce>                 this hunk of _metal_ in exchange for
-<ce>                  the _gems_, and then you bring the
+<ce>                  the _gems_, and then you bring
 <ce>                     it back here. You understand?
 <ce>                  Good. Now, hurry, there ain't time.
 
@@ -60,10 +60,10 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 Well, everyone knows that _contact_ stole that jewel. Why don't they get %g2?
 <--->
-There's a lot of poshes at __contact_. Guards aren't wanted in there.
+There's a lot of posses at __contact_. Guards aren't wanted in there.
 
 RumorsPostfailure:  [1006]
-The guards finally got _contact_. Guess %g couldn't hold 'em out forever.
+The guards finally got _contact_. Guess %g couldn't hold 'em off forever.
 <--->
 Yeah, they found the %t's _gems_ and arrested that =contact_ alright.
 

--- a/Assets/StreamingAssets/Quests/O0B10Y03.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y03.txt
@@ -37,11 +37,11 @@ AcceptQuest:  [1002]
 QuestComplete:  [1004]
 <ce>                      Boy, some guys are hard ta
 <ce>                      figure out. Can you believe
-<ce>                      he paid to have this lifted
+<ce>                      he paid to have this lifted?
 <ce>                      Wasn't as if there was some
 <ce>                      "hideous guardian" stoppin'
 <ce>                      from doin' it himself. Huh?
-<ce>                       There was! Maybe he wasn't
+<ce>                      There was?! Maybe he wasn't
 <ce>                       so screwy. Here's yer fee
 <ce>                           %pcf. Good workin'
 <ce>                                with ya.

--- a/Assets/StreamingAssets/Quests/O0B10Y05.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y05.txt
@@ -14,7 +14,7 @@ QRC:
 QuestorOffer:  [1000]
 <ce>                            Ho there %pcf!
 <ce>                       You remember me, _qgiver_?
-<ce>                         Are up for a guild job
+<ce>                       Are you up for a guild job
 <ce>                       today? I got one here that
 <ce>                       seems right up your alley.
 

--- a/Assets/StreamingAssets/Quests/O0B10Y07.txt
+++ b/Assets/StreamingAssets/Quests/O0B10Y07.txt
@@ -14,7 +14,7 @@ QRC:
 QuestorOffer:  [1000]
 <ce>                      We have had our eye on you
 <ce>                          %pcf. Never mind who
-<ce>                       "we" are. You're an up and
+<ce>                      "we" are. You're an up-and-
 <ce>                      coming member of this guild.
 <ce>                      If you were to do a special
 <ce>                       job for us, for no pay, we
@@ -23,7 +23,7 @@ QuestorOffer:  [1000]
 <ce>                            What do you say?
 
 RefuseQuest:  [1001]
-<ce>                       Watch your back you dirty
+<ce>                       Watch your back, you dirty
 <ce>                            little turncoat!
 
 AcceptQuest:  [1002]

--- a/Assets/StreamingAssets/Quests/O0B2XY09.txt
+++ b/Assets/StreamingAssets/Quests/O0B2XY09.txt
@@ -14,7 +14,7 @@ QuestorOffer:  [1000]
 <ce>                       You can call me _qgiver_.
 <ce>                     I have wind of some _coastal_
 <ce>                      that some pig of a merchant
-<ce>                       just bought. I want to you
+<ce>                       just bought. I want you to
 <ce>                       pinch it an bring it here.
 <ce>                       I'll pay you _gold_ gold.
 <ce>                          Are you interested?

--- a/Assets/StreamingAssets/Quests/P0B00L03.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L03.txt
@@ -97,7 +97,7 @@ Dear %pcn,
 <ce>                               _vampire_
 
 Message:  1011
-%g's a very nice and intelligent =vampire_ at __vampire_.
+%G's a very nice and intelligent =vampire_ at __vampire_.
 <--->
 _vampire_ is that nice =vampire_ you'll find at __vampire_, %di of here.
 

--- a/Assets/StreamingAssets/Quests/P0B00L04.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L04.txt
@@ -22,7 +22,7 @@ Error: Questtext 1002 called.
 QuestComplete:  [1004]
 <ce>                Is that a hint of sorrow on your brow,
 <ce>                       %pcf? I quite understand.
-<ce>                 I have on more than on occasion had to
+<ce>                I have on more than one occasion had to
 <ce>                slay an offspring of mine. You must try
 <ce>                to rise above this mawkish mortal regard
 <ce>                 for propagation. What you have had to
@@ -92,7 +92,7 @@ I heard a great joke. %jok
 <--->
 %jok Can you explain that to me?
 <--->
-The legal system in %reg has it good points and bad ones.
+The legal system in %reg has its good points and bad ones.
 
 QuestorPostsuccess:  [1008]
 Error: Questtext 1008 Called

--- a/Assets/StreamingAssets/Quests/P0B00L06.txt
+++ b/Assets/StreamingAssets/Quests/P0B00L06.txt
@@ -60,7 +60,7 @@ QuestLogEntry:  [1010]
  
       Those doddering, unenlightened
  barbarians who call themselves the Mages
- Guild are involved in yet another rather
+ Guild are involved in yet another rather-
  pointless endeavor. This time, they may,
  though accidentally, be on a path toward
  breaking the shade and exposing %vam.
@@ -97,7 +97,7 @@ Message:  1012
 <ce>                        anywhere in %reg. _mage_
 <ce>                    is in ___mondung_, a laboratory
 <ce>               of sorts. I want you to get the notes for
-<ce>                 this research and bring it back to me.
+<ce>                this research and bring them back to me.
 <ce>                      _mage_, I understand, keeps
 <ce>              the notes on %g3 person under the laughable
 <ce>                misconception that they are safe there.

--- a/Assets/StreamingAssets/Quests/P0B01L02.txt
+++ b/Assets/StreamingAssets/Quests/P0B01L02.txt
@@ -27,7 +27,7 @@ My dear %pcf,
     I am looking forward to making your acquaintance
  less formally, %pcf. Do not fail to come.
  
-<ce>                               In death,
+<ce>                               In Death,
 <ce>                           _vampire_ of %vam
 
 RefuseQuest:  [1001]

--- a/Assets/StreamingAssets/Quests/P0B10L08.txt
+++ b/Assets/StreamingAssets/Quests/P0B10L08.txt
@@ -98,7 +98,7 @@ Message:  1013
 Blood Sponge,
  
       My coven tells me that your monsters,
- your weird little pack of blood snorting
+ your weird little pack of blood-snorting
  bugaboos, have a monopoly on the terror
  business in %reg, and that my
  own children are afraid to expand their
@@ -126,7 +126,7 @@ Message:  1015
 <ce>                        Welcome to ___mondung_,
 <ce>                      %pcn. I take it you are here
 <ce>                           on behalf of %vam
-<ce>                    to acknowledge that the Coven of
+<ce>                    to acknowledge that The Coven of
 <ce>                     ==daedra_, Prince of Oblivion
 <ce>                     is henceforth supreme in %reg?
 

--- a/Assets/StreamingAssets/Quests/P0B20L09.txt
+++ b/Assets/StreamingAssets/Quests/P0B20L09.txt
@@ -55,7 +55,7 @@ QuestLogEntry:  [1010]
  Come immediately.
  
  
-                  Yours in death,
+                  Yours in Death,
  
                   _vamp_
 

--- a/Assets/StreamingAssets/Quests/Q0C00Y01.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y01.txt
@@ -18,7 +18,7 @@ QuestorOffer:  [1000]
 <ce>                 our coven. I know wherein this packet
 <ce>                  of printed lies has been placed, but
 <ce>                   we need someone like thee to fight
-<ce>                   its guardian and bring it us. Wilt
+<ce>                 its guardian and bring it to us. Wilt
 <ce>                      thou assist ==qgiver_ thus?
 
 RefuseQuest:  [1001]

--- a/Assets/StreamingAssets/Quests/Q0C00Y06.txt
+++ b/Assets/StreamingAssets/Quests/Q0C00Y06.txt
@@ -12,7 +12,7 @@ DisplayName: Problems with Vampires
 QRC:
 
 QuestorOffer:  [1000]
-<ce>                  We have a potential problem I fear.
+<ce>                 We have a potential problem, I fear.
 <ce>                 A vampire ancient hateful of witches
 <ce>                  hath moved into an abandoned castle
 <ce>                  in our territory. Obviously this is

--- a/Assets/StreamingAssets/Quests/Q0C0XY02.txt
+++ b/Assets/StreamingAssets/Quests/Q0C0XY02.txt
@@ -33,7 +33,7 @@ AcceptQuest:  [1002]
 <ce>                 Wilt thou truly? If thou wilt, a fine
 <ce>                        _mitem_ will be crafted
 <ce>                for thee. Now, journey thou to farthest
-<ce>                     __tavern_ and seek the one who has
+<ce>                     __tavern_ and seek he who has
 <ce>                    betrayed us, a villainous =man_
 <ce>                       who calls %g2-self _man_.
 <ce>                Give to %g2 this _jewelry_, tell %g2 it
@@ -57,7 +57,7 @@ QuestComplete:  [1004]
 <ce>                      before %g is put to death.
 
 RumorsDuringQuest:  [1005]
-_man_ is a true example of self-made =man_. A marvel to behold.
+_man_ is a true example of a self-made =man_. A marvel to behold.
 <--->
 ==qgiver_ can be extremely vengeful.
 
@@ -82,8 +82,8 @@ QuestorPostfailure:  [1009]
 
 Message:  1011
 <ce>                         _man_ thanks you for
-<ce>                   the _jewelry_. %g tries it on as
-<ce>                 you are telling %g2 who sent it. %g3
+<ce>                   the _jewelry_. %G tries it on as
+<ce>                 you are telling %g2 who sent it. %G3
 <ce>                   eyes light up in fear at the name
 <ce>                      of ==qgiver_, and then the
 <ce>                          fear turns to pain.

--- a/Assets/StreamingAssets/Quests/Q0C10Y00.txt
+++ b/Assets/StreamingAssets/Quests/Q0C10Y00.txt
@@ -42,11 +42,11 @@ QuestFail:  [1003]
 <ce>                     We have not time for chatter.
 
 QuestComplete:  [1004]
-<ce>                  Quick sister, take this %ra's load.
+<ce>                  Quick, sister, take this %ra's load.
 <ce>                           Mince the _item1_,
 <ce>                         peel the _item2_, and
 <ce>                          grind the _item3_ to
-<ce>                  bits. Here we have three glittering
+<ce>                  bits. Here, we have three glittering
 <ce>                 baubles we have no use for. Take them,
 <ce>                   %pcn, as our way of thanking thee.
 
@@ -56,7 +56,7 @@ The weather has been predictable lately. The Witches must be sleeping.
 One of those witches tried to come to town on business, but we chased her out.
 
 RumorsPostfailure:  [1006]
-Remember when the witches cursed our %t. Guess they're losing their spark.
+Remember when the witches cursed our %t? Guess they're losing their spark.
 <--->
 It's said that the ==qgiver_ are losing their skills.
 

--- a/Assets/StreamingAssets/Quests/Q0C20Y02.txt
+++ b/Assets/StreamingAssets/Quests/Q0C20Y02.txt
@@ -42,7 +42,7 @@ QuestFail:  [1003]
 
 QuestComplete:  [1004]
 <ce>                    Ah, there is the _magicitem_ we
-<ce>                  need for our spell. Quickly, sisters
+<ce>                 need for our spell. Quickly, sisters,
 <ce>                   rend it and rip it and boil it in
 <ce>                     a covered tub. Here have we a
 <ce>                       lump of _reward_ for thee,

--- a/Assets/StreamingAssets/Quests/Q0C4XY04.txt
+++ b/Assets/StreamingAssets/Quests/Q0C4XY04.txt
@@ -36,7 +36,7 @@ AcceptQuest:  [1002]
 QuestFail:  [1003]
 <ce>                           The heart, %pcn,
 <ce>                           is in ___mondung_
-<ce>                       in the breast of a daedra
+<ce>                       in the breast of a daedra.
 <ce>                         Look not for it here.
 
 QuestComplete:  [1004]

--- a/Assets/StreamingAssets/Quests/R0C10Y00.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y00.txt
@@ -23,7 +23,7 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>            Very good. I'm giving you an emerald for you to
 <ce>                       give my contact, _npc1_ of
-<ce>                    ___npc1_.  %g will be waiting in
+<ce>                    ___npc1_.  %G will be waiting in
 <ce>                      __npc1_.  The item needs to
 <ce>               be there in =1stparton_ days. That's very
 <ce>                important. Once you've made it that far,

--- a/Assets/StreamingAssets/Quests/R0C10Y02.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y02.txt
@@ -14,7 +14,7 @@ QuestorOffer:  [1000]
 <ce>                 I need someone to bring an item to a
 <ce>                    contact of mine in ___contact_.
 <ce>               You will receive an item in return. If you
-<ce>              bring that item back to me, I will happy to
+<ce>             bring that item back to me, I will be happy to
 <ce>                 reward you with _reward_ gold pieces.
 <ce>                             Do you agree?
 

--- a/Assets/StreamingAssets/Quests/R0C10Y05.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y05.txt
@@ -21,7 +21,7 @@ QuestorOffer:  [1000]
 <ce>                      monster. This foul parasite
 <ce>                        lives in a decrepit old
 <ce>                       place called ___mondung_.
-<ce>                          %g has agreed to pay
+<ce>                          %G has agreed to pay
 <ce>                    the creature's assassin _reward_
 <ce>                        gold in return. Not too
 <ce>                      bad, I'm sure you'll agree.

--- a/Assets/StreamingAssets/Quests/R0C10Y06.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y06.txt
@@ -20,7 +20,7 @@ QuestorOffer:  [1000]
 <ce>                 outrage. On the other hand, I will pay
 <ce>              the full amount of the ransom, _reward_ gold
 <ce>                 pieces to you if you would go to their
-<ce>                   holdout and steal the _item_ back.
+<ce>                   hideout and steal the _item_ back.
 <ce>                               Will you?
 
 RefuseQuest:  [1001]
@@ -64,7 +64,7 @@ RumorsPostsuccess:  [1007]
 <ce>                 A bunch of orcs are complaining that
 <ce>                 _questgiver_ stole a relic of theirs.
                                      <--->
-<ce>              ___itemdung_ is apparently as not as secure
+<ce>               ___itemdung_ is apparently not as secure
 <ce>                   a hiding spot as one might think.
 
 QuestorPostsuccess:  [1008]

--- a/Assets/StreamingAssets/Quests/R0C10Y08.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y08.txt
@@ -32,7 +32,7 @@ AcceptQuest:  [1002]
 <ce>                    _item_ to a temple, _itemplace_
 <ce>                     in __itemplace_. It apparently
 <ce>               has some sort of religious significance to
-<ce>              them. In order to avoid embarassment, I need
+<ce>              them. In order to avoid embarrassment, I need
 <ce>                   you to steal the _item_ out of the
 <ce>                  temple and get it to _transporter_.
 <ce>                  You'll find %g2 at _inn_ in __inn_.
@@ -111,7 +111,7 @@ _questgiver_
  _questgiver_'s home in ___questgiver_.
 
 Message:  1020
-<ce>           Stop thief!  Vile desecrator of our holy _item_!
+<ce>           Stop, thief!  Vile desecrator of our holy _item_!
 
 
 -- Symbols used in the QRC file:

--- a/Assets/StreamingAssets/Quests/R0C10Y09.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y09.txt
@@ -25,7 +25,7 @@ RefuseQuest:  [1001]
 
 AcceptQuest:  [1002]
 <ce>               Good. I have a ... procurer in my employ.
-<ce>                       Distinctive looking, =spy_
+<ce>                      A distinctive-looking =spy_
 <ce>                      going by the name of _spy_.
 <ce>                     Well, _spy_'s found a special
 <ce>                       _item_ of interest to me,
@@ -41,7 +41,7 @@ AcceptQuest:  [1002]
 
 QuestFail:  [1003]
 <ce>                      %pcf, you're back, which is
-<ce>                    pleasant, but without my _item_
+<ce>                    pleasant, but without my _item_,
 <ce>                    which is not so pleasant. Is the
 <ce>                    assignment too difficult for you
 <ce>                        to understand? Go get my

--- a/Assets/StreamingAssets/Quests/R0C10Y10.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y10.txt
@@ -17,7 +17,7 @@ QuestorOffer:  [1000]
 <ce>                      agent of mine, speak up now.
                                      <--->
 <ce>                I could use the services of someone of
-<ce>               moderate talent, above average discretion,
+<ce>               moderate talent, above-average discretion,
 <ce>                 and willingness to assume the position
 <ce>                  of a lowly courier for _reward_ gold
 <ce>                      pieces. Are you that person?
@@ -41,7 +41,7 @@ QuestFail:  [1003]
 
 QuestComplete:  [1004]
 <ce>                   Ah, good to see you %pcf. And the
-<ce>                  _weapon_ too. Excellent. Here's the
+<ce>                  _weapon_, too. Excellent. Here's the
 <ce>                _reward_ gold pieces I believe you were
 <ce>                       promised by _questgiver_.
 

--- a/Assets/StreamingAssets/Quests/R0C10Y11.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y11.txt
@@ -61,7 +61,7 @@ RumorsPostsuccess:  [1007]
 Some =qgfriend_ was just here, waving around some _item_.
 <--->
 <ce>             I guess _questgiver_ didn't steal that _item_
-<ce>                      after all or else %g ate it.
+<ce>                      after all, or else %g ate it.
 
 QuestorPostsuccess:  [1008]
 I recognize those sturdy young legs. How are you, my old courier?
@@ -75,7 +75,7 @@ QuestorPostfailure:  [1009]
 <ce>                         have no time for you.
 
 Message:  1011
-%g's a thoroughly respectable ruler, with kleptomanic tendencies.
+%G's a thoroughly-respectable ruler, with kleptomaniac tendencies.
 <--->
 A big-time jewelry smuggler, from what I hear.
 

--- a/Assets/StreamingAssets/Quests/R0C10Y12.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y12.txt
@@ -56,7 +56,7 @@ QuestComplete:  [1004]
 RumorsDuringQuest:  [1005]
 Those guards are even searching _questgiver_'s house for that _item_ shipment.
 <--->
-It's a complete mystery where that _item_ disappeared. Everyone's curious.
+It's a complete mystery where that _item_ disappeared to. Everyone's curious.
 
 RumorsPostfailure:  [1006]
 What an embarrassment for _questgiver_. The stolen _item_ was traced to %g2.
@@ -81,7 +81,7 @@ QuestorPostfailure:  [1009]
 Message:  1011
 _questgiver_ is a rather small-time ruler, but a big-time _item_ smuggler.
 <--->
-_questgiver_'s in over %g3 head in this _item_ smuggling business.
+_questgiver_'s in over %g3 head in this _item_-smuggling business.
 
 Message:  1012
 Supposedly _contact_ is a fence for stolen merchandise.

--- a/Assets/StreamingAssets/Quests/R0C10Y13.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y13.txt
@@ -29,7 +29,7 @@ AcceptQuest:  [1002]
 <ce>                           Very good, %pcf.
 <ce>                Now, listen carefully: take this _item_
 <ce>            to the palace in __palace_ and find a =contact_.
-<ce>                   That will be _contact_. %g will be
+<ce>                   That will be _contact_. %G will be
 <ce>                 expecting you, and will likely reward
 <ce>                  you for your trouble.  You'd best be
 <ce>                  on your way.  Do not fail me, %pcf.
@@ -69,7 +69,7 @@ Ah, it's my agent of peace. How goes it with you, my friend?
 
 QuestorPostfailure:  [1009]
 <ce>                   By failing to bring _contact_ the
-<ce>                      _item_ you promised to get,
+<ce>                      _item_ you promised to deliver,
 <ce>                 you've made my peace plans rather more
 <ce>                            difficult, %pcf.
 <ce>                            Out of my sight.
@@ -77,7 +77,7 @@ QuestorPostfailure:  [1009]
 QuestLogEntry:  [1010]
 %qdt:
 _questgiver_ has
- given me _reward_ gold to go
+ implied a reward if I go
  to __palace_ palace
  to bring a peace offering, a _item_
  to _contact_.  I must be there in

--- a/Assets/StreamingAssets/Quests/R0C10Y14.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y14.txt
@@ -25,7 +25,7 @@ AcceptQuest:  [1002]
 <ce>                     mine who left on an assignment
 <ce>                          without %g3 _item_.
 <ce>                    I need it rushed to ___contact_
-<ce>                    straight-away. There's a little
+<ce>                    straight away. There's a little
 <ce>                     place there called __contact_
 <ce>                     where you can find a =contact_
 <ce>                            named _contact_.
@@ -61,7 +61,7 @@ That =contact_ has been moping around __contact_ for days now.
 RumorsPostfailure:  [1006]
 Poor _contact_ -- %g3 delivery never came and %g had to leave without it.
 <--->
-I wonder what _contact_ was waiting for anyhow. Some kind of miracle?
+I wonder what _contact_ was waiting for, anyhow. Some kind of miracle?
 
 RumorsPostsuccess:  [1007]
 _contact_ left __contact_ happy as a harpy. Guess %g got what %g needed.

--- a/Assets/StreamingAssets/Quests/R0C10Y15.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y15.txt
@@ -80,7 +80,7 @@ QuestorPostfailure:  [1009]
 
 QuestLogEntry:  [1010]
 <ce>                   Thank %god you've arrived, %pcf.
-<ce>               Give me the diamond quick. Now take this
+<ce>               Give me the diamond, quick. Now take this
 <ce>                        _item2_ and bring it to
 <ce>                       _npc2_ over in __npc2_ --
 <ce>                       that's in ___npc2_. Once

--- a/Assets/StreamingAssets/Quests/R0C10Y18.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y18.txt
@@ -108,7 +108,7 @@ Message:  1020
 <ce>                      Thieves Guild is allowed to
 <ce>                     smuggle. I guess _questgiver_
 <ce>                    thought %g was above the rules.
-<ce>                     %g was wrong. You're going to
+<ce>                     %G was wrong. You're going to
 <ce>                       give me that _item2_, and
 <ce>                     _questgiver_ is going to learn
 <ce>                        not to cross the Thieves

--- a/Assets/StreamingAssets/Quests/R0C10Y21.txt
+++ b/Assets/StreamingAssets/Quests/R0C10Y21.txt
@@ -37,7 +37,7 @@ AcceptQuest:  [1002]
 <ce>              in =1stparton_ days that would make our job
 <ce>               much easier. When the deed is done, report
 <ce>                 to my cousin's palace in ___qgfriend_.
-<ce>                  %g's the one who's going to pay you
+<ce>                  %G's the one who's going to pay you
 <ce>                             for all this.
 
 QuestFail:  [1003]
@@ -92,7 +92,7 @@ Message:  1015
 %qdt:
  I have =1stparton_ days to slay an orc shaman
  in ___mondung_, and then get to _qgfriend_'s
- palace in ___qgfriend_.  %g
+ palace in ___qgfriend_.  %G
  will pay me my _reward_ gold pieces
  for the shaman's death.
 

--- a/Assets/StreamingAssets/Quests/R0C11Y03.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y03.txt
@@ -33,7 +33,7 @@ AcceptQuest:  [1002]
 <ce>                 _chemist_'s hands in =1stparton_ days,
 <ce>                it will be too old to be used. After you
 <ce>               have delivered it, return for your reward.
-<ce>                        Good luck and godspeed to ___chemist_.
+<ce>                 Good luck and godspeed to ___chemist_.
 
 --in 1002, added the name of the city you need to go to at the end.
 
@@ -81,7 +81,7 @@ QuestorPostfailure:  [1009]
 <ce>                      decision to return to court.
 
 QuestLogEntry:  [1010]
-<ce>             Oh marvelous. An outstanding aortas daedrae,
+<ce>             Oh, marvelous. An outstanding aortas daedrae,
 <ce>               with minimal decomposition. Hurry back to
 <ce>                        _questgiver_ now, %pcf.
 <ce>                There's a lot on %g3 mind, and if you're
@@ -105,7 +105,7 @@ _questgiver_ has a lot of faith in alchemistry, like a lot of nobles do.
 Message:  1013
 A daedra's heart. It never spoils, but some recipes call for it to be fresh.
 <--->
-The heart of a daedra. Not the sort of thing daedras like in mortals' hands.
+The heart of a daedra. Not the sort of thing daedra like in mortals' hands.
 
 Message:  1015
 %qdt:

--- a/Assets/StreamingAssets/Quests/R0C11Y16.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y16.txt
@@ -19,7 +19,7 @@ QuestorOffer:  [1000]
 RefuseQuest:  [1001]
 <ce>                     No? I wasn't expecting you to
 <ce>                   turn down _reward_ gold for a few
-<ce>                   days work. How many peasants would
+<ce>                  days' work. How many peasants would
 <ce>                   murder for that kind of money? Ah,
 <ce>                      well. Your life, I suppose.
 
@@ -27,7 +27,7 @@ AcceptQuest:  [1002]
 <ce>                     Excellent, %pcf. Now, I have
 <ce>                       a spy, _npc1_ in ___npc1_
 <ce>                 who needs a telescope to continue %g3
-<ce>                  survelliance activities. I am given
+<ce>                  surveillance activities. I am given
 <ce>                  to understand %g has found something
 <ce>                   of interest to a mutual friend of
 <ce>                  ours, which needs to be delivered as
@@ -47,17 +47,17 @@ QuestComplete:  [1004]
 <ce>                     _npc1_ told me to expect you.
 <ce>                          I am _npc2_. Let me
 <ce>                    have a look at that relic. Very
-<ce>                    interesting indeed. Well, here's
+<ce>                    interesting, indeed. Well, here's
 <ce>                  your _reward_ gold pieces. You never
 <ce>                            saw me, got it?
 
 RumorsDuringQuest:  [1005]
-If _questgiver_ really has a spy network, it must be pretty well hidden.
+If _questgiver_ really has a spy network, it must be pretty well-hidden.
 <--->
 It's said that _npc1_ is a spy, but %g never leaves __npc1_.
 
 RumorsPostfailure:  [1006]
-Turns out they caught _npc1_ and confiscated %g3 illgotten loot.
+Turns out they caught _npc1_ and confiscated %g3 ill-gotten loot.
 <--->
 They say _npc1_ was a spy in the service of _questgiver_.
 
@@ -88,8 +88,8 @@ QuestLogEntry:  [1010]
 <ce>                         a =npc2_ in ___npc2_.
 <ce>                         The name's _npc2_ and
 <ce>                      you'll find %g2 at __npc2_.
-<ce>                Your gold will be waiting for you there
-<ce>                 as well. Be better be on your way; %g
+<ce>                Your gold will be waiting for you there,
+<ce>                  as well. Better be on your way; %g
 <ce>                 expects you there in =2ndparton_ days.
 
 Message:  1015

--- a/Assets/StreamingAssets/Quests/R0C11Y19.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y19.txt
@@ -23,20 +23,20 @@ RefuseQuest:  [1001]
 <ce>                        Nothing personal, %pcf.
 
 AcceptQuest:  [1002]
-<ce>                Well, that's good anyway. Not long ago,
+<ce>                Well, that's good, anyway. Not long ago,
 <ce>                during a time of financial stagnancy, I
 <ce>                pawned a ring given to me by the Emperor
 <ce>                  himself. I figured that Uriel Septim
 <ce>                 never makes it down to this corner of
 <ce>               the Empire, but now I hear his agents are
-<ce>               in the area, and I must have to have that
+<ce>                   in the area, and I must have that
 <ce>                  ring back. _contact_, of __contact_
 <ce>           in ___contact_, will only hold it for =1stparton_
 <ce>            more days.  Here's the gold to pay for the ring.
 <ce>                 Good luck and %god speed your journey.
 
 QuestFail:  [1003]
-<ce>                        My ring, %pcf? The %god
+<ce>                        My ring, %pcf? The %god-
 <ce>                    forsaken ring I sent you to get?
 <ce>                    Where is it? If you've lost it,
 <ce>                    I'll have your rotten %ra hide!
@@ -64,9 +64,9 @@ _questgiver_ entertained the Imperial statesmen in great style, I understand.
 The Imperial statesmen were apparently very satisfied with their visit.
 
 QuestorPostsuccess:  [1008]
-Ah, hello, ring bearer. What can I do for you?
+Ah, hello, ring-bearer. What can I do for you?
 <--->
-You helped keep me in good standing with the Empire. Now, what I can do for you?
+You helped keep me in good standing with the Empire. Now, what can I do for you?
 
 QuestorPostfailure:  [1009]
 <ce>                    The Imperial emissaries didn't
@@ -82,7 +82,7 @@ QuestLogEntry:  [1010]
 <ce>                         _questgiver_ wants the
 <ce>                   ring before the Imperial statesmen
 <ce>                   arrive, you better be on your way.
-<ce>                   You only have a very little time.
+<ce>                      You only have a little time.
 
 Message:  1015
 %qdt:

--- a/Assets/StreamingAssets/Quests/R0C11Y26.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y26.txt
@@ -24,7 +24,7 @@ QuestorOffer:  [1000]
 RefuseQuest:  [1001]
 <ce>                 Not an uncommon response. Then I have
 <ce>                 little choice, but to call on some of
-<ce>                 my less savoury contacts for help --
+<ce>                 my less-savoury contacts for help --
 <ce>                   an option I was hoping to avoid.
 
 AcceptQuest:  [1002]
@@ -157,7 +157,7 @@ Message:  1015
 <ce>                 %g2, mostly I was afraid of %g2 so I
 <ce>              guess I let %g2 think I liked %g2. 'Course
 <ce>              now I'm getting letters like this. I think
-<ce>                   %g's very much could be the ____qgiver_
+<ce>                   %g very much could be the ____qgiver_
 <ce>                 Ripper. He lives at _ripperhouse_ if
 <ce>                 you want to go see %g2 for real life.
 
@@ -176,7 +176,7 @@ Message:  1020
  I have arrived in ___qgiver_
  and met with _qgiver_ about
  the mystery of the ____qgiver_ Ripper.
- %g wants the Ripper caught in =total_
+ %G wants the Ripper caught in =total_
  days before all ___qgiver_ turns into an
  angry mob. My only lead is a scholar named
  _contact_ who has the letters
@@ -216,7 +216,7 @@ Message:  1024
  came calling before I did. In %g2
  house I did find a letter from someone named
  _rippername_. Sounded skittish
- enough to be our Ripper. Worth investigating
+ enough to be our Ripper. Worth investigating,
  anyhow.
 
 Message:  1025

--- a/Assets/StreamingAssets/Quests/R0C11Y28.txt
+++ b/Assets/StreamingAssets/Quests/R0C11Y28.txt
@@ -28,11 +28,11 @@ QuestorOffer:  [1000]
 RefuseQuest:  [1001]
 <ce>                 Not an uncommon response. Then I have
 <ce>                 little choice, but to call on some of
-<ce>                 my less savoury contacts for help --
+<ce>                 my less-savoury contacts for help --
 <ce>                   an option I was hoping to avoid.
 
 AcceptQuest:  [1002]
-<ce>                      Thank %god for that anyway.
+<ce>                      Thank %god for that, anyway.
 <ce>                    The people of %reg are becoming
 <ce>               anxious about the lack of progress in the
 <ce>                official investigations. I fear that we
@@ -100,7 +100,7 @@ QuestLogEntry:  [1010]
 <ce>              doubtless been told that I've become a bit
 <ce>               of a hermit ever since I began receiving
 <ce>                those letters threatening my life if I
-<ce>              did not abandoned my investigations. Well,
+<ce>               did not abandon my investigations. Well,
 <ce>               now I have an old colleague in town with
 <ce>                whose assistance I may be able to solve
 <ce>               these murders. I would like you to bring
@@ -121,7 +121,7 @@ _contact_,
  blindly into an inferno.
  
  If you continue, you will die before your
- studies are finished. Consider this this a
+ studies are finished. Consider this a
  serious warning.
  
 <ce>                             A Well-Wisher
@@ -188,12 +188,12 @@ Autopsy report for %fn:
  interesting case he reported at last year's
  Conclave). Bruising indicates some time
  between attack and death? (Could be unrelated
- to attack? Check on background of victim)
+ to attack? Check on background of victim).
 
 Message:  1015
 <ce>                    So, for all the days _contact_
 <ce>                has spent with those flyblown cadavers
-<ce>                       and all %g comes up with
+<ce>                         all %g comes up with
 <ce>                     is this. %god, with this as a
 <ce>                      start, _contact_ won't get
 <ce>                an intimation of the Slayer's identity
@@ -220,7 +220,7 @@ _vamp_ is one of the %vcn, sent to ___bookstore_ to eliminate the mad Slayer.
 _vamp_ is a %vcn vampire here to stop the risk to %g3 security, the Slayer.
 
 Message:  1018
-Poor _widow_ stays at _widowhouse_ every since the Slayer got %g3 brother.
+Poor _widow_ stays at _widowhouse_ ever since the Slayer got %g3 brother.
 <--->
 The %reg Slayer killed _widow_'s brother, and now %g never leaves _widowhouse_.
 
@@ -268,7 +268,7 @@ Message:  1021
 Message:  1022
 %qdat:
  I got to _bookstore_ too late.
- Apparently _contact_'s death
+ Apparently, _contact_'s death
  threats were very real. Among the letters
  I found was one from a colleague interested in
  meeting with _contact_, someone

--- a/Assets/StreamingAssets/Quests/R0C20Y07.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y07.txt
@@ -27,7 +27,7 @@ RefuseQuest:  [1001]
 AcceptQuest:  [1002]
 <ce>           Excellent, I knew you'd help. Now then, my friend
 <ce>                     is _qgfriend_ of ___qgfriend_.
-<ce>        %g has lost a gem, a sapphire, and my spies have tracked
+<ce>        %G has lost a gem, a sapphire, and my spies have tracked
 <ce>                it down to ___itemdung_, of all places.
 <ce>                      _qgfriend_ needs this stone,
 <ce>               because %g borrowed it from a third party.
@@ -46,7 +46,7 @@ QuestFail:  [1003]
 QuestComplete:  [1004]
 <ce>                     Oh, %pcf, you don't know how
 <ce>              relieved I am that you found that sapphire.
-<ce>               I don't even want to think about it if you
+<ce>             I wouldn't even want to think about it if you
 <ce>              hadn't. Here's the finest reward I can give
 <ce>                   you, a _reward_. Please accept it,
 <ce>                        with my sincere thanks.
@@ -74,8 +74,8 @@ I'm glad to see you again. My friend appreciated the little blue gift.
 QuestorPostfailure:  [1009]
 <ce>                     I'm impressed by your nerve,
 <ce>                          %pcn. You failed the
-<ce>                      quest and yet return with no
-<ce>                               sapphire.
+<ce>                      quest to retrieve the sapphire,
+<ce>                          and yet you return.
 
 QuestLogEntry:  [1010]
 %qdt:

--- a/Assets/StreamingAssets/Quests/R0C20Y22.txt
+++ b/Assets/StreamingAssets/Quests/R0C20Y22.txt
@@ -78,7 +78,7 @@ QuestLogEntry:  [1010]
  _questgiver_ has hired me
  to deliver a _item_ to someone
  in ___contact_ named _contact_.
- %g will meet me at __contact_
+ %G will meet me at __contact_
  in =queston_ days to reward me if I have not
  already been minced by the orcs who are also
  after the _item_.
@@ -92,7 +92,7 @@ Message:  1013
 _orsinium_ is well-known in ___orsinium_ as an orc sympathizer.
 <--->
 <ce>I know for a fact that _orsinium_ is a filthy orc-lover.  I've seen %g2
-<ce> myself, meeting with the brutes outside of ___orsinium_.  %g should be run out
+<ce> myself, meeting with the brutes outside of ___orsinium_.  %G should be run out
 <ce>                        of town, if you ask me.
 
 Message:  1015

--- a/Assets/StreamingAssets/Quests/R0C30Y25.txt
+++ b/Assets/StreamingAssets/Quests/R0C30Y25.txt
@@ -14,7 +14,7 @@ QuestorOffer:  [1000]
 <ce>              I need someone to bring a certain item to a
 <ce>                    contact of mine in ___contact_.
 <ce>              You will receive an item in return. If you
-<ce>              bring that item back to me, I will happy to
+<ce>              bring that item back to me, I will be happy to
 <ce>                 reward you with _reward_ gold pieces.
 <ce>                             Do you agree?
 

--- a/Assets/StreamingAssets/Quests/R0C4XY23.txt
+++ b/Assets/StreamingAssets/Quests/R0C4XY23.txt
@@ -103,7 +103,7 @@ Message:  1012
 Message:  1013
 _oblivion_ is a powerful mage living in ___oblivion_.
 <--->
-_oblivion_ of ___oblivion_?  %g's in league with the Daedra, I hear.
+_oblivion_ of ___oblivion_?  %G's in league with the Daedra, I hear.
 
 Message:  1014
 _oblivion_ is some kind of sorcerer, I think.  Try __oblivion_ in ___oblivion_.

--- a/Assets/StreamingAssets/Quests/R0C60Y24.txt
+++ b/Assets/StreamingAssets/Quests/R0C60Y24.txt
@@ -54,9 +54,9 @@ Someone found a very lovely _item_ around here recently.
 I hear _questgiver_ is mad as hell at some %ra adventurer.
 
 RumorsPostsuccess:  [1007]
-It seems safer to walk the streets in %reg I've noticed.
+It seems safer to walk the streets in %reg, I've noticed.
 <--->
-Sure vampire attacks are becoming rarer. But it's not time to get cocky yet.
+Sure, vampire attacks are becoming rarer. But it's not time to get cocky yet.
 
 QuestorPostsuccess:  [1008]
 I guess the bloodsuckers learned their lesson, eh, %pcf? What can I do for you?
@@ -139,7 +139,7 @@ Message:  1040
  once -- I will wait for you at _vamphouse_ in
  __vamphouse_.
  
-                            Yours in death,
+                            Yours in Death,
  
                             _vampire_
 

--- a/Assets/StreamingAssets/Quests/S0000001.txt
+++ b/Assets/StreamingAssets/Quests/S0000001.txt
@@ -46,7 +46,7 @@ QuestComplete:  [1004]
 <ce>                     as the dowager Queen mother.
 <ce>                                    
 <ce>              I don't know where Medora went, but I know
-<ce>              she has an enormous castle somewhere on the
+<ce>              she has an enormous tower somewhere on the
 <ce>              Isle of Balfiera. But I also heard there is
 <ce>             some kind of curse on her, and she can never
 <ce>              leave. I don't know if that helps you, but
@@ -156,10 +156,10 @@ QuestLogEntry:  [1010]
  
  But I did not study magic. I studied history, so I
  leave this letter -- not to revenge myself, but as
- an historic document.
+ a historic document.
 
 Message:  1011
-<ce>            A thin, rail of a woman steps forward and hands
+<ce>            A thin rail of a woman steps forward and hands
 <ce>            you a note. She turns aside all your questions
 <ce>                  with a gaunt, expressionless face.
 
@@ -196,8 +196,8 @@ Message:  1014
  Dear %pcn,
  
      You do not know me but I know you. I know that you were
- shipwrecked. I know that you are trying to dispell the ghost
- of King Lisandus. If you want, I can tell you what I know,
+ shipwrecked. I know that you are trying to dispel the ghost
+ of King Lysandus. If you want, I can tell you what I know,
  but I need your help in return.
      If you want to talk, my name is Prince Lhotun and I live
  in Sentinel at Samaruik, which is usually called Castle
@@ -210,7 +210,7 @@ Message:  1014
 <ce>                          Prince of Sentinel
 
 Message:  1015
-___ukcrypt_ used to be the Underking's crypt, but now it's a Sentilian prison.
+___ukcrypt_ used to be the Underking's crypt, but now it's a Sentinelian prison.
 <--->
 ___ukcrypt_ is just %di of here. Some say it's still a crypt of the Underking.
 

--- a/Assets/StreamingAssets/Quests/S0000002.txt
+++ b/Assets/StreamingAssets/Quests/S0000002.txt
@@ -3,7 +3,7 @@
 -- QuestId: 2
 Messages: 51
 Quest: S0000002
-DisplayName: Blackmailing Prince Helseth
+DisplayName: Prince Helseth's Blackmail
 -- Message panels
 QRC:
 
@@ -16,7 +16,7 @@ QuestorOffer:  [1000]
 <ce>              for this, I will not only reward you with a
 <ce>                _magicitem_, but also put in a positive
 <ce>           word for you with the king and queen of Wayrest,
-<ce>          but I will give you some information on the affair
+<ce>          and I will give you some information on the affair
 <ce>         with Daggerfall I doubt you would receive elsewhere.
 <ce>            Does this sound like an agreeable arrangement?
 
@@ -26,7 +26,7 @@ RefuseQuest:  [1001]
 
 AcceptQuest:  [1002]
 <ce>            Excellent. Meet me here this time tomorrow and
-<ce>              I will give you the letter and the name and
+<ce>              I will give you the letter, and the name and
 <ce>                      location of the recipient.
 
 QuestFail:  [1003]
@@ -46,10 +46,10 @@ QuestComplete:  [1004]
 <ce>               the eve of the Battle of Cryngaine Field.
 <ce>            Lysandus was disgustingly loyal to the emperor,
 <ce>             where Camaron was fighting for more autonomy.
-<ce>            According to the advisor's report, they arrived
+<ce>            According to the advisors' report, they arrived
 <ce>            too late because they were waylaid by the orcs
 <ce>              of Gortwog en route. However, I have heard
-<ce>              stories that, at least some of our advisors
+<ce>              stories that at least some of our advisors
 <ce>              arrived at Lysandus' tent and spoke to him
 <ce>             briefly. At this time, I cannot say more. If
 <ce>            I receive more information or if the situation
@@ -117,13 +117,13 @@ My Dear Lord Castellian,
 <ce>                           Prince of Wayrest
 
 Message:  1011
-<ce>                            Well done %pcn.
+<ce>                            Well done, %pcn.
 <ce>            Your budding reputation appears to be deserved.
 <ce>                 Lord Castellian is quite pliable now.
 
 Message:  1012
 <ce>             It is really too bad that you were not a bit
-<ce>                   faster %pcf. My sister Elysana is
+<ce>                   faster, %pcf. My sister Elysana is
 <ce>             betrothed. Without her opposition, it was not
 <ce>            truly necessary to deliver that letter to Lord
 <ce>             Castellian. However, I'm sure I can turn this
@@ -165,7 +165,7 @@ Message:  1024
 Prince Helseth,
     I appreciate your kindness, and I
  will meet with you very shortly at
- your convenience."
+ your convenience.
  
 <ce>                            Lord Castellian
 
@@ -180,7 +180,7 @@ My Dear Lord Castellian,
       Forgive this rough delivery, but it
  would have been impolitic to approach you
  at the palace with this potential problem.
- Unfortunately, your much deserved vacation
+ Unfortunately, your much-deserved vacation
  will have to be temporarily suspended until
  this matter is settled.
  
@@ -207,8 +207,8 @@ My Dear Lord Castellian,
  
       Do not doubt, sir, that I am convinced
  of your integrity as senior member of the
- Elder Circle of Wayrest. I only wish for the
- matter of the financial records be straightened
+ Elder Council of Wayrest. I only wish for the
+ matter of the financial records to be straightened
  so if they are brought to Eadwyre's attention,
  they can be confidently defended.
  
@@ -253,12 +253,12 @@ Message:  1030
 Message:  1031
 <ce>                   So you like to read the missives
 <ce>                   of your betters. Don't expect me
-<ce>                     trust you again anytime soon.
+<ce>                   to trust you again anytime soon.
 
 Message:  1040
 Dear %pcn,
  
- Due to the recent marraige of my sister Elysana,
+ Due to the recent marriage of my sister Elysana,
  I shall not be needing your services with regard
  to the delivery of the letter to Lord Castellian.
  Since you have acted on my behalf with honor, I

--- a/Assets/StreamingAssets/Quests/S0000003.txt
+++ b/Assets/StreamingAssets/Quests/S0000003.txt
@@ -8,7 +8,7 @@ DisplayName: Freeing Medora
 QRC:
 
 QuestorOffer:  [1000]
-<ce>                      Greetings %pcf. I am Medora
+<ce>                      Greetings, %pcf. I am Medora
 <ce>               Direnni, former sorceress to the court of
 <ce>               Daggerfall. I have an interest in helping
 <ce>               you in your aim to exorcise the spirit of
@@ -108,7 +108,7 @@ QuestorPostsuccess:  [1008]
 QuestorPostfailure:  [1009]
 <ce>               Of course I will give Medora the horn of
 <ce>               the Great Unicorn. She was a favorite of
-<ce>                    my beloved Lysandus after all.
+<ce>                    my beloved Lysandus, after all.
 
 QuestLogEntry:  [1010]
 %qdt:

--- a/Assets/StreamingAssets/Quests/S0000004.txt
+++ b/Assets/StreamingAssets/Quests/S0000004.txt
@@ -18,12 +18,12 @@ QuestorOffer:  [1000]
 
 RefuseQuest:  [1001]
 <ce>              Pity. I will find someone else to help me.
-<ce>             But who will you find to help you, I wonder.
+<ce>             But who will you find to help you, I wonder?
 
 AcceptQuest:  [1002]
 <ce>               %oth, that is a relief to me. Do not ask
 <ce>             any questions -- get this letter to a certain
-<ce>               high level sorcerer at the Necromancers'
+<ce>               high-level sorcerer at the Necromancers'
 <ce>                crypt, Scourg Barrow in the Dragontail
 <ce>               Mountains. Avoid the rift. If you see it,
 <ce>                        you have gone too far.
@@ -59,7 +59,7 @@ QuestComplete:  [1004]
 <ce>            to Aubk-i. The girl is innocent to a fault, and
 <ce>             everyone knows that Gothryd is not the loyal
 <ce>           empire toady that Lysandus was. Of course my own
-<ce>           family...well enough of this boring court gossip.
+<ce>           family... well enough of this boring court gossip.
 <ce>                                    
 <ce>              If you really want to find this letter, you
 <ce>             should get in good with Mynisera, the former
@@ -82,7 +82,7 @@ Princess Morgiah is engaged to the King of Firsthold. A miracle of %god indeed.
 <--->
 What could've possessed the King of Firsthold to propose marriage to Morgiah?
 <--->
-Morgiah has a three year engagement! Royals are a strange lot.
+Morgiah has a three-year engagement! Royals are a strange lot.
 
 QuestorPostfailure:  [1009]
 <ce>                  You've failed me, %pcf. I required an answer from _necs_ within one month.
@@ -93,7 +93,7 @@ _necs_,
 <ce>                                    
 <ce>                I agree to your terms. I will give you
 <ce>              my first and you will exert your influence
-<ce>              on the King of Firsthold on Sumerset Isle.
+<ce>              on the King of Firsthold on Sumurset Isle.
 <ce>               Only you can let him speak with his dead
 <ce>              son. For that, he would even marry Nulfaga!
 <ce>                                    
@@ -148,7 +148,7 @@ Message:  1016
 <ce>                  Very good. If you are not rewarded
 <ce>                   with death by the loyal servants
 <ce>                   of the Barrow, give this note to
-<ce>                       Princess Morgiah please.
+<ce>                       Princess Morgiah, please.
 
 
 -- Symbols used in the QRC file:

--- a/Assets/StreamingAssets/Quests/S0000005.txt
+++ b/Assets/StreamingAssets/Quests/S0000005.txt
@@ -10,7 +10,7 @@ QRC:
 QuestorOffer:  [1000]
 <ce>                My husband's poor grandmother, Nulfaga,
 <ce>                is rumored to be in very frail health,
-<ce>                her once brilliant mind almost utterly
+<ce>                her once-brilliant mind almost utterly
 <ce>                 destroyed. She has locked herself in
 <ce>                her castle in the Wrothgarian Mountains
 <ce>                and experiments in magical studies with

--- a/Assets/StreamingAssets/Quests/S0000006.txt
+++ b/Assets/StreamingAssets/Quests/S0000006.txt
@@ -47,7 +47,7 @@ QuestComplete:  [1004]
 <ce>             Oh, how marvelous you are. Here, let me give
 <ce>               you the _jewelry_ I promised you. I hope
 <ce>             Lord Castellian appreciates the extra work I
-<ce>               put into the robe. It is a real attention
+<ce>               put into the robe. It is a real attention-
 <ce>              getter now. Let me give you something more
 <ce>                  than the _jewelry_, %pcf. My father
 <ce>             is very interested in a certain ancient relic
@@ -55,7 +55,7 @@ QuestComplete:  [1004]
 <ce>             spies all over the place looking for it. When
 <ce>             they find it, my father will need someone to
 <ce>             secure it. Obviously, whoever he chooses will
-<ce>              be fabulously well rewarded. I'll give him
+<ce>              be fabulously well-rewarded. I'll give him
 <ce>                your name. That is the least I can do.
 
 RumorsDuringQuest:  [1005]
@@ -100,7 +100,7 @@ Message:  1020
 
 Message:  1021
 <ce>                       Death to the traitor that
-<ce>                     assasinated Lord Castellian!
+<ce>                     assassinated Lord Castellian!
                                      <--->
 <ce>                       You shall pay for killing
 <ce>                            my liege lord.
@@ -119,7 +119,7 @@ Message:  1022
 <ce>                             ripped open.
 
 Message:  1023
-<ce>                      Leave this place little %ra.
+<ce>                     Leave this place, little %ra.
 <ce>                      We have come to claim Lord
 <ce>                    Castellian. You have done your
 <ce>                    part by delivering his funeral

--- a/Assets/StreamingAssets/Quests/S0000007.txt
+++ b/Assets/StreamingAssets/Quests/S0000007.txt
@@ -74,14 +74,14 @@ Poor Aubk-i. Her maid's been spreading the wildest tales about her.
 RumorsPostfailure:  [1006]
 That werewolf moved on, out of Tristore Laboratory. Migratory beasts they are.
 <--->
-Didn't expect that loop to live in Tristore Laboratory for as long as it did.
+Didn't expect that loup to live in Tristore Laboratory for as long as it did.
 <--->
 Boy, those Shapeshifters sure put the kibosh on some %ra out yonder.
 
 RumorsPostsuccess:  [1007]
 Some %ra adventurer chased the werewolf at Tristore Laboratory out of Betony.
 <--->
-The peasants who live around Tristore Laboratory are happy the loop is gone.
+The peasants who live around Tristore Laboratory are happy the loup is gone.
 <--->
 The Shapeshifters have some %ra to thank for saving one of their own.
 
@@ -242,7 +242,7 @@ Sibling rivalry's all the rage over in ___wereBrother_.
 Tsk. The things youngsters will try to get attention.
 
 Message:  1026
-Property of the Shapeshifter's Guild
+Property of the Shapeshifter's Guild.
 
 Message:  1027
 You feel a sickening jolt as the _relic_ vanishes.
@@ -251,12 +251,12 @@ Message:  1028
 <ce>                    Have you lost your mind, %pct?
 <ce>                 I was inclined to help you, but after
 <ce>                   your assault on _wereBrother_ ...
-<ce>                Slink along back to that whore Cyndassa
-<ce>                why don't you. Worthless piece of %ra.
+<ce>                Slink along back to that whore Cyndassa,
+<ce>                why don't you? Worthless piece of %ra.
 
 Message:  1029
 <ce>                  On second thought, %pct, why don't
-<ce>                   I just tag along.  I'll hold the
+<ce>                   I just tag along?  I'll hold the
 <ce>                         _relic_, as it can be
 <ce>                         a bit tricky to use.
 
@@ -282,7 +282,7 @@ Message:  1032
 Message:  1033
 <ce>              Now, if I might beg the favor of escorting
 <ce>                us to the Beldama of the Sisters of the
-<ce>                  Bluff. You'll find it on the map in
+<ce>                   Bluff. You'll find it on the map
 <ce>                        in Daggerfall province.
 
 Message:  1034

--- a/Assets/StreamingAssets/Quests/S0000008.txt
+++ b/Assets/StreamingAssets/Quests/S0000008.txt
@@ -26,12 +26,12 @@ QuestorOffer:  [1000]
 <ce>                           of Tiber Septim?
 
 RefuseQuest:  [1001]
-<ce>                These are dark times indeed. If Gothryd
+<ce>                These are dark times, indeed. If Gothryd
 <ce>                gets the Mantella as well, Tamriel will
 <ce>                      be thrown into a civil war.
 
 AcceptQuest:  [1002]
-<ce>                   I knew I could count on you %pcf.
+<ce>                   I knew I could count on you, %pcf.
 <ce>              The Totem is most likely in the Daggerfall
 <ce>                  treasury. It is a huge room, quite
 <ce>                unmistakable. I am leaving in a couple
@@ -128,7 +128,7 @@ Message:  1022
  will bring them to equal standing with the
  other races of Tamriel. To do this I must
  have the Totem of Tiber Septim. I will not
- insult you by promises that no blood will
+ insult you by promising that no blood will
  be shed. I do swear by my crown and by my
  heirs I shall not attempt to hold sway
  beyond the borders of Orsinium. My goal is
@@ -144,7 +144,7 @@ Message:  1023
 %pcn,
  
  You will soon have the Totem of Tiber Septim
- in your hands. It is forseen in the stars,
+ in your hands. It is foreseen in the stars,
  and I have read them. Know you this. All of
  mortal stature are filled with pride and greed.
  To give the Totem to any of them is to let
@@ -178,7 +178,7 @@ Message:  1024
  I have won and lost an empire. I have no desire
  to tamper further with mortal affairs. I have in
  my possession the _artifact2_, one of the
- world's greatest artifacts. You may have it in
+ world's greatest artifacts. You may have it
  in exchange for the Totem.
  
  My most loyal agent will await your arrival in
@@ -209,7 +209,7 @@ Message:  1031
 <ce>             a word. He leaves as silently as he arrived.
 
 Message:  1032
-<ce>             A heavily cloaked figure shuffles toward you.
+<ce>             A heavily-cloaked figure shuffles toward you.
 <ce>             As you prepare to defend yourself, a gnarled
 <ce>            green hand shoots forth with a letter. Stunned,
 <ce>              you do nothing as the figure shuffles away.
@@ -218,8 +218,8 @@ Message:  1033
 <ce>            A hand grips your wrist from behind. Spinning,
 <ce>             you open your mouth to shout for the guards.
 <ce>           A skeletal hand stuffs a letter into your mouth.
-<ce>            The heavily robed skeleton releases your wrist
-<ce>             and turns away, unnoticed by other passerby.
+<ce>            The heavily-robed skeleton releases your wrist
+<ce>             and turns away, unnoticed by other passersby.
 
 Message:  1034
 <ce>              A letter floats through the air toward you.
@@ -240,15 +240,15 @@ Message:  1042
 <ce>                           whoever that is.
 
 Message:  1043
-<ce>               You don't even have it! Now I'm going to
+<ce>               You don't even have it?! Now I'm going to
 <ce>                   kill you just for the fun of it.
 
 Message:  1050
 <ce>             The Totem of Tiber Septim! It is a priceless
 <ce>             artifact. I shall guard it well and keep the
 <ce>              rebellious powers of Daggerfall and Wayrest
-<ce>                 in check. Take your reward %pcf. You
-<ce>              have earned it ten fold. You must keep your
+<ce>                 in check. Take your reward, %pcf. You
+<ce>              have earned it tenfold. You must keep your
 <ce>              keen eyes open for the Mantella. Any rumors
 <ce>              must be hunted down with vigor. Without the
 <ce>                    Mantella, the Totem is useless.
@@ -267,7 +267,7 @@ Message:  1052
 Message:  1053
 <ce>             I see you have come to your senses. I should
 <ce>           have you slain, but I have more honor than that.
-<ce>           Instead I shall reward you. Here take _goldgoth_
+<ce>           Instead I shall reward you. Here, take _goldgoth_
 <ce>            gold pieces for your turnabout loyalty. Deliver
 <ce>             the Mantella to me, and my trust in you will
 <ce>                        be once again restored.
@@ -282,7 +282,7 @@ Message:  1054
 
 Message:  1055
 <ce>                The Underking will be most pleased. He
-<ce>              has searched many life times for this lost
+<ce>               has searched many lifetimes for this lost
 <ce>             item. I have been instructed to give you this
 <ce>             object. Use it wisely. Should you ever locate
 <ce>               the Mantella, the Underking would be most

--- a/Assets/StreamingAssets/Quests/S0000009.txt
+++ b/Assets/StreamingAssets/Quests/S0000009.txt
@@ -35,7 +35,7 @@ AcceptQuest:  [1002]
 <ce>                       time with _contact_. Go to
 <ce>                      ___contact_ of ____contact_,
 <ce>                     to a place called __contact_.
-<ce>                %g will pay you =reward_ gold pieces for
+<ce>                %G will pay you =reward_ gold pieces for
 <ce>                     bringing %g2 _foil_. Don't you
 <ce>                  just love these dangerous missions?
 
@@ -43,16 +43,16 @@ QuestFail:  [1003]
 <ce>                  I have nothing to discuss with you.
 
 QuestComplete:  [1004]
-<ce>                      %pcf! How did...I mean, I'm
+<ce>                      %pcf! How did... I mean, I'm
 <ce>                      glad to see you. And _foil_
-<ce>                too. Here take the gold. Object? What's
-<ce>                a totem? Well, its been nice talking to
+<ce>                too. Here, take the gold. Object? What's
+<ce>                a totem? Well, it's been nice talking to
 <ce>                            you. Gotta run!
 
 RumorsDuringQuest:  [1005]
 A crowd of shady characters was here a while ago, looking for a %ra mercenary.
 <--->
-Princess Elysana been spending a lot of time in the Wayrest wilderness, I hear.
+Princess Elysana's been spending a lot of time in the Wayrest wilderness, I hear.
 
 RumorsPostfailure:  [1006]
 Hear about the gang that ambushed that %ra? Funny business that, if you ask me.
@@ -62,18 +62,18 @@ Those guys who ambushed that %ra weren't from around here. Hired assassins.
 RumorsPostsuccess:  [1007]
 Hear some mystery man is hiring assassins to kill a certain %ra mercenary.
 <--->
-_contact_ was mad as can be. You'd think %g's be happy to see %g2 cousin.
+_contact_ was mad as can be. You'd think %g'd be happy to see %g3 cousin.
 
 QuestLogEntry:  [1010]
 %qdt:
  Princess Elysana has asked me to escort
  her cousin _foil_ to ___contact_
- of ____contact_ to meet _contact_. %g will pay
+ of ____contact_ to meet _contact_. %G will pay
  me =reward_ gold, and give me something
  relative to the Totem.
 
 Message:  1011
-<ce>                    _foil_ suddenly runs away, %g2
+<ce>                    _foil_ suddenly runs away, %g3
 <ce>               feet making no sound as %g disappears into
 <ce>                              the shadows.
 

--- a/Assets/StreamingAssets/Quests/S0000011.txt
+++ b/Assets/StreamingAssets/Quests/S0000011.txt
@@ -19,11 +19,11 @@ QuestorOffer:  [1000]
 <ce>                  someone I can trust to correct some
 <ce>              wayward revolutionaries. For _reward_ gold
 <ce>                pieces, will you perform such a service
-<ce>                 for me? I am also prepared to reward
-<ce>            you with information as well as _reward_ gold.
+<ce>                    for me? I am prepared to reward
+<ce>                    you with information, as well.
 
 RefuseQuest:  [1001]
-<ce>                 That is a pity indeed. Prince Helseth
+<ce>                 That is a pity, indeed. Prince Helseth
 <ce>                is usually correct in his assessment of
 <ce>                people, but it would appear that he is
 <ce>                         wrong in this matter.
@@ -34,7 +34,7 @@ AcceptQuest:  [1002]
 <ce>            biography of me which my worst enemy would call
 <ce>            cruel and defamatory. Because the book was also
 <ce>             excessively critical of the Empire and Septim
-<ce>           Imperial family, it was wisely suppressed and its
+<ce>           Imperial family, it was widely suppressed and its
 <ce>            author executed. Unfortunately, chapters of the
 <ce>          book resurface from time to time. I have reason to
 <ce>          believe one chapter of the book has been purchased
@@ -52,7 +52,7 @@ QuestComplete:  [1004]
 <ce>                         Very well done, %pcf.
 
 RumorsDuringQuest:  [1005]
-Queen Barenziah is supposedly in a bad mood. You can never tell though.
+Queen Barenziah is supposedly in a bad mood. You can never tell, though.
 <--->
 A book's coming out with the real story about the former Queen of Mournhold.
 
@@ -91,7 +91,7 @@ Chapter 6
  
  "You dance on the edge of a volcano, child," Drelliane
  scolded, as Barenziah admired the emerald ring her lover
- had given her to celebrate their one month anniversary.
+ had given her to celebrate their one-month anniversary.
  
  "How so? We make one another happy. We harm no one.
  Symmachus bade me to be discriminate and discreet. Who
@@ -104,7 +104,7 @@ Chapter 6
  
  Barenziah shrugged. Even before she and Septim had
  become lovers she'd had no more from his family than bare
- civility. Threadbare civility. "What matter? It is Tiber
+ civility. Threadbare civility. "What's it matter? It is Tiber
  who holds power."
  
  "It is his son who holds the future. Do not hold his mother
@@ -121,8 +121,8 @@ Chapter 6
  They come and go as the seasons do, but the families of the
  powerful live on for a time. You must be a family friend if
  you would see lasting profit from your relationship. Ah,
- how can I make you truly see, you who are so young and
- human-bred as well! If you take care you and Mournhold are
+ how can I make you truly see, you who are so young, and
+ human-bred as well! If you take care, you and Mournhold are
  like to live to see the fall of Septim's dynasty, if indeed
  he has founded one, as you have seen its rise. It is the way
  of human history. They ebb and flow like the tides. Their
@@ -138,9 +138,9 @@ Chapter 6
  filled with joy and pleasure, and the nights yet better.
  
  "What is wrong with me?" Barenziah lamented. "Look, not one
- of my skirts fit? What's become of my waist? Am I getting
+ of my skirts fit. What's become of my waist? Am I getting
  fat?" Barenziah regarded her thin arms and legs and her
- undeniably thickened waist in the mirror with displeasure.
+ undeniably-thickened waist in the mirror with displeasure.
  
  Drelliane shrugged. "You appear to be with child, young as
  you are. Constant pairing with a human has brought you early
@@ -162,7 +162,7 @@ Chapter 6
  "With child?" He looked shocked. Stunned. "You're sure of
  it? I was told elves do not bear so young."
  
- Barenziah smile uneasily, "How can I be sure? I've never -- "
+ Barenziah smiled uneasily, "How can I be sure? I've never -- "
  
  "I'll fetch my healer."
  
@@ -208,7 +208,7 @@ Chapter 6
  to soothe the pain and clean the blood that pooled under her
  legs, but there was nothing to fill the emptiness. Tiber
  Septim sent gifts and flowers, and came for short visits,
- always well attended. Barenziah received these visits with
+ always well-attended. Barenziah received these visits with
  pleasure, but he came no more at night nor did she wish for
  him. After a month, when she was physically recovered, it
  was announced that Symmachus had requested she come to
@@ -273,10 +273,10 @@ Message:  1050
 
 Message:  1051
 <ce>             What a shame. Ah well, we'll hire some other
-<ce>                            mercenary then.
+<ce>                            mercenary, then.
 
 Message:  1052
-<ce>                     Very good. Off with you then.
+<ce>                     Very good. Off with you, then.
 
 Message:  1054
 <ce>                        Here is your _jewelry_.
@@ -290,7 +290,7 @@ Message:  1060
  has hired me to continue the quest that
  the Queen of Wayrest began: finding the
  lost chapter of her biography. Rumor
- has it that it is in the Necromancers
+ has it that it is in the Necromancers'
  stronghold, Scourg Barrow, in the
  Dragontail Mountains.
 

--- a/Assets/StreamingAssets/Quests/S0000012.txt
+++ b/Assets/StreamingAssets/Quests/S0000012.txt
@@ -17,8 +17,8 @@ QuestorOffer:  [1000]
 <ce>                    delivered such a letter to me.
 <ce>                                    
 <ce>                 I would like you to investigate this
-<ce>                      further, %pcn. It could be
-<ce>                 dangerous to poke into the affairs of
+<ce>                 further, %pcn. It could be dangerously
+<ce>                 difficult to poke into the affairs of
 <ce>                 Aubk-i without enraging King Gothryd,
 <ce>                     even though he is my own son.
 <ce>                           Are you willing?
@@ -38,15 +38,15 @@ AcceptQuest:  [1002]
 <ce>             soul, died at Cryngaine, as did King Camaron.
 <ce>              Lysandus' body was not recovered, so he has
 <ce>              a monument erected there rather than a true
-<ce>                      tomb. Ah...my mind wanders.
+<ce>                      tomb. Ah... my mind wanders.
 <ce>                                    
 <ce>                  The emperor uses _messenger_ as his
-<ce>             messenger in Daggerfall. %g could be anywhere
+<ce>             messenger in Daggerfall. %G could be anywhere
 <ce>              in the region delivering missives. However,
 <ce>                    _messenger_ is a member of the
 <ce>              Knights of the Dragon. Go to _location_ in
 <ce>                 __location_ and ask for _dispatcher_.
-<ce>                %g may know where to find _messenger_.
+<ce>                %G may know where to find _messenger_.
 <ce>               Try to find out why a letter addressed to
 <ce>                      me was delivered to Aubk-i.
 
@@ -85,12 +85,12 @@ QuestLogEntry:  [1010]
 Message:  1011
 %qdt:
  Mynisera's signet ring bought the trust of
- _dispatcher_. %g told me that _messenger_
+ _dispatcher_. %G told me that _messenger_
  would be in __palace_ at
- _palace_ in =2palace_ days time.
+ _palace_ in =2palace_ days' time.
 
 Message:  1015
-<ce>              The letter from the Emperor? Actually %pcf
+<ce>              The letter from the Emperor? Actually, %pcf,
 <ce>              this is rather embarrassing. The letter was
 <ce>             stolen from me the same day I received it. I
 <ce>              never did read it. I have been hoping that
@@ -120,7 +120,7 @@ Message:  1020
 <ce>              I would not normally tell anyone who is not
 <ce>           a Knight of the Dragon where to find _messenger_.
 <ce>             However, I am loyal to Queen Mynisera. I also
-<ce>                   know that _messenger_ disembowled
+<ce>                   know that _messenger_ disemboweled
 <ce>               the last person that tried to ambush %g2.
 <ce>             In =2palace_ days %g is due to be at _palace_
 <ce>                     in __palace_. Try %g2 there.

--- a/Assets/StreamingAssets/Quests/S0000012.txt
+++ b/Assets/StreamingAssets/Quests/S0000012.txt
@@ -16,9 +16,9 @@ QuestorOffer:  [1000]
 <ce>                  I can tell you %pcf, that she never
 <ce>                    delivered such a letter to me.
 <ce>                                    
-<ce>                 I would like you to investigate this
-<ce>                 further, %pcn. It could be dangerously
-<ce>                 difficult to poke into the affairs of
+<ce>                    I would like you to investigate
+<ce>                    this further, %pcn. It could be
+<ce>                   risky to poke into the affairs of
 <ce>                 Aubk-i without enraging King Gothryd,
 <ce>                     even though he is my own son.
 <ce>                           Are you willing?

--- a/Assets/StreamingAssets/Quests/S0000013.txt
+++ b/Assets/StreamingAssets/Quests/S0000013.txt
@@ -13,7 +13,7 @@ QuestorOffer:  [1000]
 <ce>               me on your ancestors' honor that you will
 <ce>              do what you can to help me and never breathe
 <ce>                of what I say or what you see to anyone
-<ce>                   else anywhere. Will you so swear?
+<ce>                   else, anywhere. Will you so swear?
 
 RefuseQuest:  [1001]
 <ce>               It would be worse, I suppose, for you to
@@ -55,7 +55,7 @@ QuestComplete:  [1004]
 <ce>                 Poor Mynisera. Everyone at court knows
 <ce>               that her husband, the late King Lysandus,
 <ce>              preferred the face and form of another woman
-<ce>               to her, but she still attempts to hide all
+<ce>               to hers, but she still attempts to hide all
 <ce>               evidence of it. Her loyalty to Lysandus is
 <ce>               almost as great as his foolish loyalty to
 <ce>                              the emperor.

--- a/Assets/StreamingAssets/Quests/S0000015.txt
+++ b/Assets/StreamingAssets/Quests/S0000015.txt
@@ -37,7 +37,7 @@ Page 7
  (which he is bound to do, sooner rather than later)
  I will be king.
     If it weren't for that bitch queen and her brats,
- I would and could be patient. Never trust a dark elf
+ I would and could be patient. Never trust a dark elf,
  the old saying goes, for you cannot read truth in
  their eyes. If Barenziah has her way, Helseth will
  be heir and Elysana will be married off to some far-
@@ -52,15 +52,15 @@ Page 7
     First it is important to solidify my power base.
  I can (almost certainly) rely on Gothryd to support
  my bid for the throne, if Helseth is made heir. I
- have a spy network equalling Eadwyre, Gothryd,
- Akorith-i, or the Emperor. Perhaps the Necromancers
+ have a spy network equaling that of Eadwyre, Gothryd,
+ Akorithi, or the Emperor. Perhaps the Necromancers
  and the Underking's networks are more extensive, but
  I doubt it. The problem is raw physical power. I do
  not have a standing army. I need the gold to raise
 
 Message:  1018
 %qdt:
- I found a most damning couple of pages
+ I found a most-damning couple of pages
  in Woodborne Hall. I'm sure Lord Woodborne
  would be quite livid if they were to fall
  into the wrong hands.
@@ -117,17 +117,17 @@ Message:  1032
 <ce>               Lysandus. There shall be justice, and it
 <ce>              shall come from my hand! You would do best
 <ce>              to stay clear of Woodborne Hall and Wayrest
-<ce>                          for some time %pcn.
+<ce>                          for some time, %pcn.
 
 Message:  1033
-<ce>               This information is quite valuable %pcf.
+<ce>               This information is quite valuable, %pcf.
 <ce>              Let me gift you with _gold_ gold for giving
 <ce>               it to me. This will be quite handy in the
 <ce>                           coming conflict.
 
 Message:  1034
 <ce>               You were completely correct to bring this
-<ce>               to me. Otherwise it might have gotten out
+<ce>               to me. Otherwise, it might have gotten out
 <ce>               where it could do Lord Woodborne damage.
 <ce>                        Guards! Kill this %ra!
 

--- a/Assets/StreamingAssets/Quests/S0000016.txt
+++ b/Assets/StreamingAssets/Quests/S0000016.txt
@@ -25,7 +25,7 @@ Message:  1012
 <ce>                                    
 <ce>          I do not know who of these seven is most worthy of
 <ce>          the Power, for too long have I let my passions make
-<ce>           me mad. Sometimes the fate of a world hangs on the
+<ce>          me mad. Sometimes the fate of a world hangs on the
 <ce>           decision of one person. You have chosen who will
 <ce>          command great Numidium. You bear the burden for the
 <ce>                             consequences.
@@ -36,13 +36,13 @@ Message:  1012
 <ce>            freed. You will be transported back to my side.
 
 Message:  1020
-<ce>                   Your work is done %pcn. The world
+<ce>                   Your work is done, %pcn. The world
 <ce>            is no longer as it once was. Such is the way of
 <ce>             things. Oh, and if you tell my lich statue to
 <ce>              shut up, the door to my chamber will open.
 
 Message:  1050
-<ce>                  Nulfaga cackles, "Not so fast %pcn.
+<ce>                  Nulfaga cackles, "Not so fast, %pcn.
 <ce>          Don't you want to see the result of your handiwork?
 <ce>           Look now into the Book of the Time. Read upon its
 <ce>            pages the history of what shall pass within the

--- a/Assets/StreamingAssets/Quests/S0000017.txt
+++ b/Assets/StreamingAssets/Quests/S0000017.txt
@@ -12,7 +12,7 @@ QuestorOffer:  [1000]
 <ce>                  I trust you have had a comfortable
 <ce>                 stay so far. Let me get right to the
 <ce>                  point. My son, Prince Lhotun, says
-<ce>                 you are a well respected and trusted
+<ce>                 you are a well-respected and trusted
 <ce>                    %ra. I have need of your sort.
 <ce>                  I am willing to pay you _gold_ gold
 <ce>                   to infiltrate Castle Wayrest and
@@ -24,15 +24,15 @@ RefuseQuest:  [1001]
 <ce>                        standing in this court.
 
 AcceptQuest:  [1002]
-<ce>                   What Bounty! There is an item, a
+<ce>                   What bounty! There is an item, a
 <ce>                  painting, that is hidden somewhere
 <ce>                    within Castle Wayrest. I desire
 <ce>                  this item for reasons you need not
 <ce>                   worry about. Bring it to me and I
-<ce>                      will pay your _gold_ gold.
+<ce>                      will pay you _gold_ gold.
 
 QuestComplete:  [1004]
-<ce>                    Here is your _gold_ gold %pcf.
+<ce>                    Here is your _gold_ gold, %pcf.
 
 QuestLogEntry:  [1010]
 %qdt:
@@ -55,7 +55,7 @@ Dear %pcn,
 
 Message:  1012
 <ce>               A page girl bearing the crest of Sentinel
-<ce>                stiffly presents you a crisply pressed
+<ce>                stiffly presents you a crisply-pressed
 <ce>              envelope. Ignoring your queries, she turns
 <ce>                            and walks away.
 
@@ -87,7 +87,7 @@ Message:  1021
 <ce>                  not only loyal, but also obedient.
 
 Message:  1022
-<ce>                        You presume much %pcn.
+<ce>                        You presume much, %pcn.
 <ce>                  What you saw is not for the prying
 <ce>                    eyes of the masses. It concerns
 <ce>                 matters of royalty and will be dealt

--- a/Assets/StreamingAssets/Quests/S0000018.txt
+++ b/Assets/StreamingAssets/Quests/S0000018.txt
@@ -13,15 +13,15 @@ QuestorOffer:  [1000]
 <ce>                Lysandus will I do this. The Dust can be
 <ce>                       found in ___crypt_ on her
 <ce>               own island. Tell Medora that the price is
-<ce>                 her support of my claim to the heart.
+<ce>               her support of my claim to Tiber's heart.
 <ce>                       She'll know what it means.
 
 QuestLogEntry:  [1010]
 %qdt:
  Medora came to me in a vision and told me
- that Lysandus ghost could be soothed if I
- can convince Gortwog, Lord of the Orcs in
- Orsinium, to tell me where it is.
+ that Lysandus' ghost could be soothed if I
+ can convince Gortwog, Warlord of the Orcs
+ in Orsinium, to tell me where it is.
 
 Message:  1011
 %qdt:
@@ -53,7 +53,7 @@ Message:  1015
 <ce>                            other folks do.
 
 Message:  1016
-A packet of midnight black powder.
+A packet of midnight-black powder.
 
 Message:  1020
 <ce>               This parchment was used as a wrap for the

--- a/Assets/StreamingAssets/Quests/S0000020.txt
+++ b/Assets/StreamingAssets/Quests/S0000020.txt
@@ -36,8 +36,8 @@ QuestLogEntry:  [1010]
  the orc warlord, a letter from her.
 
 Message:  1015
-So, Mynisera seeks to sweet talk me.
- Bah! Her letter is of no value to me
+So, Mynisera seeks to sweet-talk me.
+ Bah! Her old letter is of no value to me
  anymore. She may have it. However, my
  people may not be so lenient toward a
  %ra wandering the halls of Orsinium.
@@ -51,7 +51,7 @@ Lord Gortwog,
  King of Orcs,
  Warlord of the Subterranean Realms
  
-    Hail and long life King Gortwog. Long
+    Hail and long life, King Gortwog. Long
  have you and the Orcish people sought
  formal recognition by the empire. My dead
  husband King Lysandus supported your claim
@@ -88,17 +88,17 @@ Queen Mynisera,
 
 Message:  1030
 <ce>                    %pcf, this letter is dangerous.
- Gortwog had undoubtedly sold copies of it
- to everyone from Wayrest to the Underking.
- After all, if the powers of the Iliac Bay
- become embroiled in war over the Totem, he
- stands to gain quite a lot.
+<ce>               Gortwog has undoubtedly sold copies of it
+<ce>               to everyone from Wayrest to the Underking.
+<ce>               After all, if the powers of the Iliac Bay
+<ce>               become embroiled in war over the Totem, he
+<ce>                      stands to gain quite a lot.
  
- Go now. You have done your job. I am sure
- the Totem will find its way into your life
- somehow. You seem to have a knack for such
- things. Just remember, the only safe master
- of the Totem is the emperor.
+<ce>               Go now. You have done your job. I am sure
+<ce>               the Totem will find its way into your life
+<ce>               somehow. You seem to have a knack for such
+<ce>               things. Just remember, the only safe master
+<ce>                      of the Totem is the emperor.
 
 Message:  1040
 <ce>               You still don't know where the Emperor's

--- a/Assets/StreamingAssets/Quests/S0000021.txt
+++ b/Assets/StreamingAssets/Quests/S0000021.txt
@@ -40,7 +40,7 @@ AcceptQuest:  [1002]
 <ce>                      tale few mortals have heard.
 
 QuestComplete:  [1004]
-<ce>                     Well done %pcf. I am sure the
+<ce>                     Well done, %pcf. I am sure the
 <ce>                prince will be most cooperative. Please
 <ce>                       accept this _magicitem_ as
 <ce>                a token of my appreciation. In addition,

--- a/Assets/StreamingAssets/Quests/S0000022.txt
+++ b/Assets/StreamingAssets/Quests/S0000022.txt
@@ -25,13 +25,13 @@ AcceptQuest:  [1002]
 <ce>                 I do know that it is not on the field
 <ce>                 of Cryngaine where they erected that
 <ce>                  monument to him. If you do speak to
-<ce>                   him...could you tell him I still
-<ce>                     love him. Death will not be a
+<ce>                   him... could you tell him I still
+<ce>                     love him? Death will not be a
 <ce>                        barrier to us for long.
 
 QuestLogEntry:  [1010]
 %qdt:
- Medora has told me, it would take her
+ Medora has told me it would take her
  a month to prepare the Dust. When this
  time has passed, I should visit her
  again at her home in the Direnni Tower.

--- a/Assets/StreamingAssets/Quests/S0000100.txt
+++ b/Assets/StreamingAssets/Quests/S0000100.txt
@@ -9,14 +9,14 @@ QRC:
 Message:  1015
 <ce>                 Queen Akorithi has sent us to relieve
 <ce>                 you of a heavy burden. The Totem must
-<ce>                  be such a weight on your mind. Its
+<ce>                  be such a weight on your mind. It's
 <ce>                 too bad you didn't try harder to stay
 <ce>                 on her good side. She also ordered us
-<ce>                 to kill you. No witnesses of course.
+<ce>                 to kill you. No witnesses, of course.
                                      <--->
-<ce>                     We're here to kill you %pcn.
+<ce>                     We're here to kill you, %pcn.
 <ce>                  No hard feelings. We just want the
-<ce>                     Totem and you're in the way.
+<ce>                     Totem, and you're in the way.
 
 
 -- Symbols used in the QRC file:

--- a/Assets/StreamingAssets/Quests/S0000103.txt
+++ b/Assets/StreamingAssets/Quests/S0000103.txt
@@ -14,7 +14,7 @@ Message:  1015
 <ce>                              it to him.
                                      <--->
 <ce>                 I will take the Totem and drink from
-<ce>                you veins on this night. Just surrender
+<ce>               your veins on this night. Just surrender
 <ce>                  and it will be relatively painless.
                                      <--->
 <ce>                  The King of Worms wants the Totem.

--- a/Assets/StreamingAssets/Quests/S0000104.txt
+++ b/Assets/StreamingAssets/Quests/S0000104.txt
@@ -11,7 +11,7 @@ Message:  1015
 <ce>                             You must die.
                                      <--->
 <ce>                   You have shown no loyalty to the
-<ce>                   Underking. Therefore you must die
+<ce>                  Underking. Therefore, you must die
 <ce>                       for him to get the Totem.
                                      <--->
 <ce>                  I have come for the Totem of Tiber

--- a/Assets/StreamingAssets/Quests/S0000500.txt
+++ b/Assets/StreamingAssets/Quests/S0000500.txt
@@ -29,7 +29,7 @@ Message:  1020
  _contact1_, asking me to meet %g2
  at _tavern_ in __tavern_,
  ____tavern_, on some matter having
- do with _traitor_ of Sentinel.
+ to do with _traitor_ of Sentinel.
 
 Message:  1021
 %qdt:
@@ -62,11 +62,11 @@ Dear %pcn:
 <ce>                              _contact1_
 
 Message:  1040
-<ce>                     %pcn? You were my last hope!
+<ce>                     %pcn? You are my last hope!
 <ce>                    _traitor_'s friends and allies
 <ce>                    have all proven faithless after
 <ce>                     he was arrested by the tyrant
-<ce>                     _queen_ on trumped up charges
+<ce>                     _queen_ on trumped-up charges
 <ce>                     of treason. He is now locked
 <ce>                       in the dungeons of Castle
 <ce>                     Sentinel, awaiting execution.

--- a/Assets/StreamingAssets/Quests/S0000501.txt
+++ b/Assets/StreamingAssets/Quests/S0000501.txt
@@ -11,7 +11,7 @@ QuestComplete:  [1004]
 <ce>                  %pcn, I knew I could count on you.
 <ce>                The friendship of the Queen of Sentinel
 <ce>                 is reward enough, but I have prepared
-<ce>                   some more tangible gifts as well.
+<ce>                   some more-tangible gifts, as well.
 
 RumorsDuringQuest:  [1005]
 <ce>    _traitor_ escaped from the dungeons of Castle Sentinel, I hear.
@@ -81,7 +81,7 @@ Message:  1040
 <ce>            and I want you to find him and bring him back.
 <ce>             Alive if possible, but kill him if necessary.
 <ce>                     Do not let him escape again.
-<ce>               You have =time2_ days.
+<ce>                          You have =time2_ days.
 
 Message:  1041
 <ce>                    You again! %oth, will you give

--- a/Assets/StreamingAssets/Quests/S0000502.txt
+++ b/Assets/StreamingAssets/Quests/S0000502.txt
@@ -90,7 +90,7 @@ Message:  1043
 <ce>                        again sometime.  Ta ta!
 
 Message:  1050
-<ce>                       Take that! and that! you
+<ce>                       Take that! And that! You
 <ce>                           moldy old thing!
 
 Message:  1051

--- a/Assets/StreamingAssets/Quests/S0000503.txt
+++ b/Assets/StreamingAssets/Quests/S0000503.txt
@@ -112,7 +112,7 @@ Message:  1053
 <ce>                     is now mine, and mine alone!
 
 Message:  1054
-<ce>             "Well, friend %pcf, an enjoyable little jaunt
+<ce>             "Well, friend %pcf, an enjoyable little jaunt,
 <ce>             eh?  I'll take the _item_ and be on my way."
 <ce>                                    
 <ce>                  Do you give the _item_ to _rebel_?

--- a/Assets/StreamingAssets/Quests/S0000988.txt
+++ b/Assets/StreamingAssets/Quests/S0000988.txt
@@ -37,7 +37,7 @@ Message:  1011
 Dear %pcf,
  
  Numidium was Tiber Septim's secret weapon in his
- bid for supreme power: a thousand foot tall automaton,
+ bid for supreme power: a thousand-foot-tall automaton,
  a golem or an atronach of sorts powered by a gem called
  the Mantella. The Mantella was infused with the life
  force of Tiber Septim's Imperial Battlemage, and with
@@ -74,7 +74,7 @@ Dear %pcf,
  all covet. You must know the truth about what you are asked.
  
  The Totem was crafted by the original Imperial Battlemage
- of Tamriel, by orders of Tiber Septim. It is essentially a
+ of Tamriel, by order of Tiber Septim. It is essentially a
  means of controlling a gargantuan creature called the
  Numidium. Without it, the Numidium would simply not
  function. The Imperial Battlemage placed a seal on the
@@ -105,10 +105,10 @@ Message:  1020
 <ce>               the courier. As you take it, the courier
 <ce>                     turns and walks quickly away.
                                      <--->
-<ce>                Reaching into you pack for something to
+<ce>                Reaching into your pack for something to
 <ce>             eat, you spy a note. It wasn't there before.
                                      <--->
-<ce>             A redfaced courier startles you with a cry of
+<ce>             A red-faced courier startles you with a cry of
 <ce>                  "Letter for %pcn! Hey that must be
 <ce>                 you. Here, take this. Gotta go. Other
 <ce>                        deliveries to be made."

--- a/Assets/StreamingAssets/Quests/S0000999.txt
+++ b/Assets/StreamingAssets/Quests/S0000999.txt
@@ -64,10 +64,10 @@ Message:  1026
 <ce>               Reaching into your pack for something to
 <ce>             eat, you spy a note. It wasn't there before.
                                      <--->
-<ce>             A redfaced courier startles you with a cry of
+<ce>             A red-faced courier startles you with a cry of
 <ce>                  "Letter for %pcn! Hey that must be
 <ce>                 you. Here, take this. Gotta go. Other
-<ce>                        deliveries to be made.
+<ce>                        deliveries to be made."
 
 Message:  1031
 <ce>                        %pcn, I have a special
@@ -80,32 +80,32 @@ Message:  1031
                                      <--->
 <ce>              Your bravery and skill are beyond reproach.
 <ce>             If I felt I could trust you, I would send you
-<ce>            on a particularly sensative mission. Come back
-<ce>             and visit me when you shown I can trust you.
+<ce>            on a particularly-sensitive mission. Come back
+<ce>            and visit me when you've shown I can trust you.
 
 Message:  1032
 <ce>                      %pcn, I have a special task
 <ce>            that would be perfect for you. However, I would
 <ce>            just be signing your death warrant if I were to
-<ce>            give it to you now. When you are more skillful
+<ce>            give it to you now. When you are more skillful,
 <ce>              return to me and I may give it to you then.
                                      <--->
-<ce>                   Its really too bad, %pcf. I have
+<ce>                   It's really too bad, %pcf. I have
 <ce>             a special assignment that requires someone I
 <ce>            trust, such as yourself. However, it also needs
-<ce>             someone of greater skill in order to survive.
+<ce>            someone of greater skill in order to survive it.
 <ce>             Come back and visit me when you have improved
 <ce>                        your skills some more.
 
 Message:  1033
-<ce>                      %pcn, You might be just the
+<ce>                      %pcn, you might be just the
 <ce>               person ta help me. But I don't trusts ya
-<ce>                well nuff yet. If I hears that you are
+<ce>                well 'nuff yet. If I hears that you are
 <ce>                 a standup %ra, maybe you should come
 <ce>                        back and ask me again.
 
 Message:  1034
-<ce>                    I could sure use yer help %pcn.
+<ce>                    I could sure use yer help, %pcn.
 <ce>               But you just ain't tough enough ta handle
 <ce>              what I gotta have done. You get better and
 <ce>                           then come see me.

--- a/Assets/StreamingAssets/Quests/T0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/T0C00Y00.txt
@@ -79,7 +79,7 @@ RumorsPostfailure:  [1006]
 RumorsPostsuccess:  [1007]
 It's not a real tragedy about =monster_ -- I mean, %g was a real goody-goody.
 <--->
-<ce>I'm not glad =monster_'s dead, but %g3 message was ... well, rather extreme
+<ce>I'm not glad =monster_'s dead, but %g3 message was ... well, rather extreme,
  don't you think?
 
 Message:  1011

--- a/Assets/StreamingAssets/Quests/U0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/U0C00Y00.txt
@@ -14,7 +14,7 @@ QuestorOffer:  [1000]
 <ce>                Power, hah! Would a Mundus-crawling %ra
 <ce>             know what to do with real power? You mean you
 <ce>              want to be able to bully a few other mortals
-<ce>             around, don't you? Well that can be arranged.
+<ce>             around, don't you? Well, that can be arranged.
 <ce>              I want you to show me you have the mettle to
 <ce>              actually use what I give you. Will you kill
 <ce>                            someone for it?
@@ -29,7 +29,7 @@ AcceptQuest:  [1002]
 <ce>             anyhow. The spellsword I have in mind for you
 <ce>                   to butcher for power is =monster_,
 <ce>             a perfectly charming and charitable ass who's
-<ce>              been annoying the hell out me for years. You
+<ce>            been annoying the hell out of me for years. You
 <ce>             will find %g2 at %g3 fortress, a place called
 <ce>                     ___mondung_. Now, don't think
 <ce>                     that just because =monster_ is
@@ -89,7 +89,7 @@ Boethiah is the Daedra Prince of Cruelty and Torture. Not a nice lady.
 She's a Prince of Oblivion, one of the Daedric Regents, and a real killer.
 
 Message:  1014
-_artifact_ protects it's wearer from many kinds of harm. Fire and life draining are the two commonly known.
+_artifact_ protects its wearer from many kinds of harm. Fire and life-draining are the two commonly known.
 
 QuestLogEntry:  [1010]
 %qdt:
@@ -140,7 +140,7 @@ Message:  1042
  ___mondung_, but I have
  learned that %g is now
  hiding in ___hideout_.
- %g will not get away a
+ %G will not get away a
  second time.
 
 

--- a/Assets/StreamingAssets/Quests/V0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/V0C00Y00.txt
@@ -51,7 +51,7 @@ QuestFail:  [1003]
 <ce>              I'll tell you this -- he don't like anything
 <ce>                done halfway. I know that werewolf ain't
 <ce>               dead, and if you think you can fool Vile,
-<ce>  you're an idiot. No dead werewolf, no _artifact_.  Simple as that.
+<ce>  you're an idiot. No dead werewolf, no _artifact_. Simple as that.
 
 QuestComplete:  [1004]
 <ce>                   Ah, %pcf, Vile told me to expect
@@ -68,9 +68,9 @@ I hear the werewolf's found a lair in someplace called ___mondung_.
 Didja hear that howling last night? Wolf howling?
 
 RumorsPostfailure:  [1006]
-Werewolves are real nomads, I guess. I hear our loop moved down south.
+Werewolves are real nomads, I guess. I hear our loup moved down south.
 <--->
-My cousin tells me that our werewolf was spotted down south aways.
+My cousin tells me that our werewolf was spotted down south a ways.
 
 RumorsPostsuccess:  [1007]
 Some kind of weird cult activity started up over by ___mondung_.
@@ -82,10 +82,10 @@ You heard about that werewolf some %ra hunted down?
 Message:  1011
 Clavicus Vile is the consummate politician of Oblivion.
 <--->
-You won't find a more carefully neutral Daedric Prince that Clavicus Vile.
+You won't find a more carefully neutral Daedric Prince than Clavicus Vile.
 
 Message:  1012
-That smooth talking =contact_ is %di of here in __contact_.
+That smooth-talking =contact_ is %di of here in __contact_.
 <--->
 If you go %di of here in __contact_, just look for a =contact_.
 

--- a/Assets/StreamingAssets/Quests/W0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/W0C00Y00.txt
@@ -58,12 +58,12 @@ QuestComplete:  [1004]
 <ce>                         See you later, maybe.
 
 RumorsDuringQuest:  [1005]
-They say _enemy_ got all %g3 power direct from the daedras themselves.
+They say _enemy_ got all %g3 power direct from the daedra themselves.
 <--->
 _enemy_ must have made a deal with the daedra. No one can be that lucky.
 
 RumorsPostfailure:  [1006]
-_enemy_ left %reg quick as you like. I guess %g's past caught up with %g2.
+_enemy_ left %reg quick as you like. I guess %g3 past caught up with %g2.
 <--->
 You can cheat the daedra. _enemy_ did. Had to run away, but %g's still alive.
 
@@ -85,7 +85,7 @@ Hermaeus Mora has a mind as old as Tamriel. And a body of slime.
 Message:  1013
 The Oghma Infinium is the book of knowledge. But knowledge can be forgotten.
 <--->
-It is the book that gifts its reader with stronger bodies and abler minds.
+It is the book that gifts its readers with stronger bodies and abler minds.
 
 Message:  1020
 %qdt:

--- a/Assets/StreamingAssets/Quests/Y0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/Y0C00Y00.txt
@@ -96,7 +96,7 @@ Message:  1020
  to meet with _contact_ and receive
  _artifact_ for slaying the frost
  daedra for Mehrunes Dagon.
- %g will wait for me at _tavern_
+ %G will wait for me at _tavern_
  in __tavern_.
 
 Message:  1030

--- a/Assets/StreamingAssets/Quests/Z0C00Y00.txt
+++ b/Assets/StreamingAssets/Quests/Z0C00Y00.txt
@@ -51,9 +51,9 @@ QuestComplete:  [1004]
 <ce>             did cast some doubts about the chances of you
 <ce>                 surviving the encounter with _enemy_.
 <ce>           Well, it's a good thing I brought the Blade, then,
-<ce>              isn't it? Sorry if you got a bad talking to
+<ce>              isn't it? Sorry if you got a bad talking-to
 <ce>                       from Mephala. With _enemy_
-<ce>               dead, she should be in a lot better mood.
+<ce>               dead, she should be in a much better mood.
 <ce>                    And for that alone, I thank you.
 
 --removed odd <---> in 1004.
@@ -84,7 +84,7 @@ _qgfriend_ is one of Mephala's agents in %reg, operating out of __qgfriend_.
 _qgfriend_ is a pawn of Mephala; %g's a =qgfriend_ at __qgfriend_.
 
 Message:  1013
-Mephala is the Daedra Regent of Murder and Patroness of the Dark Brotherhood.
+Mephala is the Daedra Regent of Murder, and Patroness of the Dark Brotherhood.
 <--->
 Mephala is one of the Princes of Oblivion whose sphere is Murder.
 

--- a/Assets/StreamingAssets/Quests/_BRISIEN.txt
+++ b/Assets/StreamingAssets/Quests/_BRISIEN.txt
@@ -62,7 +62,7 @@ Message:  1011
  of these fiefdoms.
 
 Message:  1012
-Lady Magnessen? She's the emmisary of the Blades in Daggerfall.
+Lady Magnessen? She's the emissary of the Blades in Daggerfall.
 <--->
 Lady Magnessen is a part of the set regularly at Castle Daggerfall.
 <--->
@@ -78,7 +78,7 @@ I heard Lady Magnessen was accused of spying. Nobody knows where she is now.
 Message:  1015
 <ce>              Ah, thank you for responding to my letter,
 <ce>                    %pcf. I am Lady Brisienna. Let
-<ce>             me bring you to date on affairs. The spectre
+<ce>            me bring you up to date on affairs. The spectre
 <ce>                of King Lysandus haunts the streets of
 <ce>              Daggerfall at night. Trying to communicate
 <ce>               with him is futile. He will occasionally
@@ -198,7 +198,7 @@ Message:  1026
 <ce>             A redfaced courier startles you with a cry of
 <ce>                  "Letter for %pcn! Hey that must be
 <ce>                 you. Here, take this. Gotta go. Other
-<ce>                        deliveries to be made.
+<ce>                        deliveries to be made."
 
 Message:  1025
 <ce>             You wake and look around the room. Some hours

--- a/Assets/StreamingAssets/Quests/_TUTOR__.txt
+++ b/Assets/StreamingAssets/Quests/_TUTOR__.txt
@@ -11,11 +11,11 @@ QRC:
 
 
 RumorsPostfailure:  [1006]
-I'll give you a hint %ra. If you want to succeed in magic, join the mages guild.
+I'll give you a hint %ra. If you want to succeed in magic, join the Mages Guild.
                                      <--->
 A small tip for you. Put your money in the bank of %reg. Have them give you letters of credit. They hardly weigh a thing.
                                      <--->
-Specialty shops are the best place to find unsual items.
+Specialty shops are the best place to find unusual items.
                                      <---> 
 They just passed a vagrancy law. You can't sleep in the streets. The guards even patrol outside the walls. You have to get a room at an Inn.
                                      <--->
@@ -34,23 +34,23 @@ I've heard that Sentinel is a good place to earn quick gold and the opportunity 
 
 QuestLogEntry:  [1010]
 <ce>             Daggerfall Unity has an updated tutorial.
-<ce>           It will teach you the basics of gameplay.
+<ce>             It will teach you the basics of gameplay.
 <ce>          Make sure to take notes on the info it presents.
-<ce>               Do you want to use this tutorial?
+<ce>                 Do you want to use this tutorial?
 
 Message:  1012
 <ce>                           Page 1
 <ce>                                    
 <ce>           The very first thing you want to do is to check
-<ce>           your keybinds. Press Escape and click on Controls.
-<ce>           The most important ones for now are your movement (WASD)
-<ce>           and your Swing Weapon (Mouse1 by default). Attacking
-<ce>           may involve holding the Swing Weapon button down
-<ce>           and moving the mouse; OR clicking the Swing Weapon
+<ce>           your controls. Press Escape and click on Controls.
+<ce>           The most important ones for now are movement (WASD)
+<ce>           and Swing Weapon (right mouse click by default).
+<ce>           Attacking may involve holding the Swing Weapon button
+<ce>           down and moving the mouse, OR clicking the Swing Weapon
 <ce>           button, OR holding it down. This can be changed
 <ce>           in the Advanced section of the Controls screen.
 <ce>           
-<ce>           Make sure your binds are acceptable,
+<ce>           Make sure your controls are acceptable,
 <ce>           and another message will appear in 10 seconds.
 
 Message:  1013
@@ -59,7 +59,7 @@ Message:  1013
 <ce>          Now press F6 to open your inventory. Equip any armor
 <ce>           available to you, and the best weapon you have.
 <ce>           "Best weapon" refers to a weapon that your character is skilled in,
-<ce>           and/or is a very strong material (ie: Elven, Dwarven).
+<ce>           and/or is a very strong material (e.g. Elven, Dwarven).
 <ce>           Without those two advantages, you will almost never hit enemies.
 <ce>           
 <ce>           (Next message in 15 seconds. Press No to end tutorial.)
@@ -87,14 +87,14 @@ Message:  1025
 <ce>                           Page 5
 <ce>                                    
 <ce>         Characters with magic available can also try casting spells,
-<ce>         though enemies will often resist your spells. Press Backspace
+<ce>         though enemies will often resist them. Press Backspace
 <ce>         to open your spellbook, if you are a spellcaster. Double-click
-<ce>         on a spell to ready it.
+<ce>         on a spell to cast it.
 <ce>         
-<ce>         Some spells require a target, and others are cast automatically
+<ce>         Some spells require a target, while others are cast automatically
 <ce>         on yourself. If it's a targeted spell, use left mouse click
-<ce>         to cast it after it's readied. Use Q to re-ready a spell that you
-<ce>         cast before, so you can rapid-fire spells as needed.
+<ce>         to fire it after it's cast. Use Q to re-cast the most recent
+<ce>         spell, so you can rapid-fire spells as needed.
 <ce>           
 <ce>           (Next message in 10 seconds. Press No to end tutorial.)
 
@@ -111,18 +111,18 @@ Message:  1030
 Message:  1031
 <ce>                         Page 7
 <ce>           
-<ce>           Your first step to escape this cave is to exit this room.
+<ce>           Your first step to escaping this cave is to exit this room.
 <ce>           Go down the hallway opposite the campfire.
 <ce>           After the turn, you will find a door resembling a brick wall.
 <ce>           Click on the door to open it. Beyond, you will see a small room
-<ce>           with a rat and a treasure pile on an altar.
+<ce>           with a rat, and a treasure pile on an altar.
 <ce>           
 <ce>           Clicking on the treasure pile will open the inventory.
 <ce>           You will see the treasure pile's contents on the right side
-<ce>           of the inventory screen. With the "remove" option highlighted,
+<ce>           of the inventory screen. With the "Remove" option highlighted,
 <ce>           click on the items to grab them for yourself.
 <ce>           
-<ce>           You can also loot enemy corpses after killing them,
+<ce>           You can also loot enemies after killing them,
 <ce>            but the rat will have no treasure.
 <ce>           
 <ce>           (Next message in 45 seconds. Press No to end tutorial.)
@@ -146,24 +146,24 @@ Message:  1040
 <ce>                                    
 <ce>         Some monsters are stronger than you. You can escape from them
 <ce>         without consequence. If an enemy is giving you a lot of trouble,
-<ce>         run away and leave it behind. You don't gain experience from killing
-<ce>         enemies, so a strong enemy gives no more reward than a weak one.
+<ce>         run away and leave it behind. Character growth is tied to skill
+<ce>         usage, rather than killing challenging enemies.
 <ce>           
 <ce>           (Next message in 5 seconds. Press No to end tutorial.)
 
 Message:  1041
 <ce>                           Page 10
 <ce>         
-<ce>         Some objects can be clicked on. In the main hall of this
-<ce>        dungeon, you will find a throne and a lever next to it.
+<ce>         Some objects can be interacted with. In the main hall of this
+<ce>        dungeon, you will find a throne with a lever next to it.
 <ce>        When you see the lever, click on it to raise the throne
 <ce>        like an elevator. Other dungeons will have objects
 <ce>         with more effects, such as wheels and secret switches.
 <ce>
 <ce>         To escape this dungeon, you need to look for a dark, stone
 <ce>        archway set into a wall, about the same height as you.
-<ce>        When you click on it, you will exit the dungeon and enter
-<ce>        the outdoors. The next message will appear at that time.
+<ce>        When you click on it, you will exit the dungeon and arrive
+<ce>        outdoors.
 <ce>           
 <ce>           (Next message when you exit the dungeon. Press No to end tutorial.)
 
@@ -205,7 +205,7 @@ Message:  1047
 <ce>  
 <ce>    The conversation window also has options for
 <ce>        finding people and asking for news,
-<ce>    including for local quests as "Work." Look at the top left
+<ce>    including for local quests as "Work." Look at the top-left
 <ce>        corner of the conversation window when it's open to see
 <ce>        the different topics you can ask about.
 <ce>           
@@ -247,7 +247,7 @@ Message:  1050
 <ce>        
 <ce>        You can only be a member of one temple and one knightly order. 
 <ce>                                    
-<ce>         There are other hidden guilds in the game as well.
+<ce>         There are other, hidden, guilds in the game as well.
 <ce>           
 <ce>           (Next message in 10 seconds. Press No to end tutorial.)
 
@@ -258,12 +258,13 @@ Message:  1055
 <ce>        Daggerfall's quests are radiant, choosing locations
 <ce>        around you as places where things will happen.
 <ce>  
-<ce>        Doing quests for guilds will help you increase
-<ce>        in rank with them, so they may be a priority for you.
-<ce>        After you have joined the guild, find someone inside the
+<ce>        Guild quests can be the most beneficial ones,
+<ce>        so they may be a priority for you.
+<ce>        After you have joined a guild, find someone inside the
 <ce>        guild building with the button "Get Quest."
 <ce>         Accept or reject the quest you are given.
-<ce>        Rejecting a quest has no consequences.
+<ce>        Rejecting a quest has no consequences, so long as
+<ce>        it's unrelated to the main story.
 <ce>
 <ce>     (Next message will appear immediately. Press No to end tutorial.)
 
@@ -273,10 +274,10 @@ Message:  1056
 <ce>             Page 17
 <ce>
 <ce>  Many quests will send you to other towns.
-<ce>        If they do, enter your journal (normally L) and click
+<ce>  If they do, enter your logbook (normally L) and click
 <ce>  on the quest log entry about that quest.
 <ce>        Many times, it will automatically plan
-<ce>  a travel to your quest destination.
+<ce>  travel to your quest destination.
 <ce>        Otherwise, you can open the travel screen
 <ce>  and choose the location yourself.
 <ce>  


### PR DESCRIPTION
This contains hundreds of corrections to spelling & grammar errors/typos in the quest files, all done by hand.
The files were also updated to implement the new upper-case gender-specific pronoun macros, my code supporting which having already been merged.

The main quest's files were gone over twice, so as to make them the most polished; going by my second pass, I probably found ~95% of the textual issues with the other quests. I also revised the new text for the updated tutorial to reduce jargon and improve accuracy.

It was recommended that I split my project into parts submitted one at a time, so this second part is just the quest files.
[quests notes.txt](https://github.com/user-attachments/files/26350960/quests.notes.txt)
