### PR TITLE
Raycast look-ahead for projectiles and Bounding Box-based weapon collision + fixes and optimizations.

### DIFF
--- a/Assets/Localization/StringTables/Internal_Settings Shared Data.asset
+++ b/Assets/Localization/StringTables/Internal_Settings Shared Data.asset
@@ -143,6 +143,18 @@ MonoBehaviour:
     m_Key: textureArrayInfo
     m_Metadata:
       m_Items: []
+  - m_Id: 392878225761951744
+    m_Key: meleeAttackDetectionModes
+    m_Metadata:
+      m_Items: []
+  - m_Id: 392920400377864192
+    m_Key: meleeAttackDetection
+    m_Metadata:
+      m_Items: []
+  - m_Id: 392920453876211712
+    m_Key: meleeAttackFriendlyProtection
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/StringTables/Internal_Settings_en.asset
+++ b/Assets/Localization/StringTables/Internal_Settings_en.asset
@@ -236,5 +236,19 @@ MonoBehaviour:
       and modding support
     m_Metadata:
       m_Items: []
+  - m_Id: 392878225761951744
+    m_Localized: 'Performance
+
+      Quality'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 392920400377864192
+    m_Localized: Hit Detection
+    m_Metadata:
+      m_Items: []
+  - m_Id: 392920453876211712
+    m_Localized: Protect Friendlies and Neutrals
+    m_Metadata:
+      m_Items: []
   references:
     version: 1

--- a/Assets/Prefabs/Missiles/ArrowMissile.prefab
+++ b/Assets/Prefabs/Missiles/ArrowMissile.prefab
@@ -11,11 +11,8 @@ GameObject:
   - component: {fileID: 4928002457579466}
   - component: {fileID: 82343321333735398}
   - component: {fileID: 114835290752812540}
-  - component: {fileID: 135236093773449130}
   - component: {fileID: 108732554255048532}
   - component: {fileID: 114624404217668130}
-  - component: {fileID: 54102960107042576}
-  - component: {fileID: 64298782196861766}
   m_Layer: 14
   m_Name: ArrowMissile
   m_TagString: Untagged
@@ -150,19 +147,6 @@ MonoBehaviour:
   PreviewIndex: 0
   PreviewID: 3
   PreviewClip: 0
---- !u!135 &135236093773449130
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1712884651827938}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 0
-  serializedVersion: 2
-  m_Radius: 0.4
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!108 &108732554255048532
 Light:
   m_ObjectHideFlags: 0
@@ -250,33 +234,3 @@ MonoBehaviour:
   PostImpactLifespanInSeconds: 0.6
   PostImpactLightMultiplier: 1.5
   ImpactSound: 4
---- !u!54 &54102960107042576
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1712884651827938}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 1
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!64 &64298782196861766
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1712884651827938}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 0
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 0}

--- a/Assets/Prefabs/Missiles/ColdMissile.prefab
+++ b/Assets/Prefabs/Missiles/ColdMissile.prefab
@@ -11,10 +11,8 @@ GameObject:
   - component: {fileID: 4187251767156800}
   - component: {fileID: 82507643407150988}
   - component: {fileID: 114467433757248316}
-  - component: {fileID: 135961771109985534}
   - component: {fileID: 108958489047367644}
   - component: {fileID: 114701158002484598}
-  - component: {fileID: 54482902062701562}
   m_Layer: 14
   m_Name: ColdMissile
   m_TagString: Untagged
@@ -149,19 +147,6 @@ MonoBehaviour:
   PreviewIndex: 0
   PreviewID: 3
   PreviewClip: 0
---- !u!135 &135961771109985534
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.4
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!108 &108958489047367644
 Light:
   m_ObjectHideFlags: 0
@@ -249,19 +234,3 @@ MonoBehaviour:
   PostImpactLifespanInSeconds: 0.6
   PostImpactLightMultiplier: 1.5
   ImpactSound: 90
---- !u!54 &54482902062701562
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0

--- a/Assets/Prefabs/Missiles/FireMissile.prefab
+++ b/Assets/Prefabs/Missiles/FireMissile.prefab
@@ -11,10 +11,8 @@ GameObject:
   - component: {fileID: 4187251767156800}
   - component: {fileID: 82507643407150988}
   - component: {fileID: 114467433757248316}
-  - component: {fileID: 135961771109985534}
   - component: {fileID: 108958489047367644}
   - component: {fileID: 114701158002484598}
-  - component: {fileID: 54482902062701562}
   m_Layer: 14
   m_Name: FireMissile
   m_TagString: Untagged
@@ -149,19 +147,6 @@ MonoBehaviour:
   PreviewIndex: 0
   PreviewID: 3
   PreviewClip: 0
---- !u!135 &135961771109985534
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.4
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!108 &108958489047367644
 Light:
   m_ObjectHideFlags: 0
@@ -249,19 +234,3 @@ MonoBehaviour:
   PostImpactLifespanInSeconds: 0.6
   PostImpactLightMultiplier: 1.5
   ImpactSound: 89
---- !u!54 &54482902062701562
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0

--- a/Assets/Prefabs/Missiles/MagicMissile.prefab
+++ b/Assets/Prefabs/Missiles/MagicMissile.prefab
@@ -11,10 +11,8 @@ GameObject:
   - component: {fileID: 4187251767156800}
   - component: {fileID: 82507643407150988}
   - component: {fileID: 114467433757248316}
-  - component: {fileID: 135961771109985534}
   - component: {fileID: 108958489047367644}
   - component: {fileID: 114701158002484598}
-  - component: {fileID: 54482902062701562}
   m_Layer: 14
   m_Name: MagicMissile
   m_TagString: Untagged
@@ -149,19 +147,6 @@ MonoBehaviour:
   PreviewIndex: 0
   PreviewID: 3
   PreviewClip: 0
---- !u!135 &135961771109985534
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.4
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!108 &108958489047367644
 Light:
   m_ObjectHideFlags: 0
@@ -249,19 +234,3 @@ MonoBehaviour:
   PostImpactLifespanInSeconds: 0.6
   PostImpactLightMultiplier: 1.5
   ImpactSound: 86
---- !u!54 &54482902062701562
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0

--- a/Assets/Prefabs/Missiles/PoisonMissile.prefab
+++ b/Assets/Prefabs/Missiles/PoisonMissile.prefab
@@ -11,10 +11,8 @@ GameObject:
   - component: {fileID: 4187251767156800}
   - component: {fileID: 82507643407150988}
   - component: {fileID: 114467433757248316}
-  - component: {fileID: 135961771109985534}
   - component: {fileID: 108958489047367644}
   - component: {fileID: 114701158002484598}
-  - component: {fileID: 54482902062701562}
   m_Layer: 14
   m_Name: PoisonMissile
   m_TagString: Untagged
@@ -149,19 +147,6 @@ MonoBehaviour:
   PreviewIndex: 0
   PreviewID: 3
   PreviewClip: 0
---- !u!135 &135961771109985534
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.4
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!108 &108958489047367644
 Light:
   m_ObjectHideFlags: 0
@@ -249,19 +234,3 @@ MonoBehaviour:
   PostImpactLifespanInSeconds: 0.6
   PostImpactLightMultiplier: 1.5
   ImpactSound: 87
---- !u!54 &54482902062701562
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0

--- a/Assets/Prefabs/Missiles/ShockMissile.prefab
+++ b/Assets/Prefabs/Missiles/ShockMissile.prefab
@@ -11,10 +11,8 @@ GameObject:
   - component: {fileID: 4187251767156800}
   - component: {fileID: 82507643407150988}
   - component: {fileID: 114467433757248316}
-  - component: {fileID: 135961771109985534}
   - component: {fileID: 108958489047367644}
   - component: {fileID: 114701158002484598}
-  - component: {fileID: 54482902062701562}
   m_Layer: 14
   m_Name: ShockMissile
   m_TagString: Untagged
@@ -149,19 +147,6 @@ MonoBehaviour:
   PreviewIndex: 0
   PreviewID: 3
   PreviewClip: 0
---- !u!135 &135961771109985534
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.4
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!108 &108958489047367644
 Light:
   m_ObjectHideFlags: 0
@@ -249,19 +234,3 @@ MonoBehaviour:
   PostImpactLifespanInSeconds: 0.6
   PostImpactLightMultiplier: 1.5
   ImpactSound: 88
---- !u!54 &54482902062701562
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1770169996000996}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0

--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -118,6 +118,10 @@ QuestRumorWeight = 50
 DisableEnemyDeathAlert=False
 HideLoginName=False
 
+[MeleeAttacks]
+MeleeAttackDetection=0
+MeleeAttackFriendlyProtection=True
+
 [Spells]
 EnableSpellLighting=True
 EnableSpellShadows=True

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -211,26 +211,7 @@ namespace DaggerfallWorkshop.Game
                 // Create and orient 3d arrow
                 goModel = GameObjectHelper.CreateDaggerfallMeshGameObject(99800, transform, ignoreCollider: true);
 
-                // Offset up so it comes from same place LOS check is done from
-                Vector3 adjust;
-                if (caster != GameManager.Instance.PlayerEntityBehaviour)
-                {
-                    CharacterController controller = caster.transform.GetComponent<CharacterController>();
-                    adjust = caster.transform.forward * 0.6f;
-                    adjust.y += controller.height / 3;
-                }
-                else
-                {
-                    // Adjust slightly downward to match bow animation
-                    adjust = (GameManager.Instance.MainCamera.transform.rotation * -Caster.transform.up) * 0.11f;
-                    // Adjust to the right or left to match bow animation
-                    if (!GameManager.Instance.WeaponManager.ScreenWeapon.FlipHorizontal)
-                        adjust += GameManager.Instance.MainCamera.transform.right * 0.15f;
-                    else
-                        adjust -= GameManager.Instance.MainCamera.transform.right * 0.15f;
-                }
-
-                goModel.transform.localPosition = adjust;
+                goModel.transform.localPosition = Vector3.zero;
                 goModel.transform.rotation = Quaternion.LookRotation(GetAimDirection());
                 goModel.layer = gameObject.layer;
             }
@@ -332,6 +313,7 @@ namespace DaggerfallWorkshop.Game
                 castFoundHit = Physics.Raycast(colliderPosition, direction, out hitInfo, displacement.magnitude + ColliderRadius, layerMask);
             else
                 castFoundHit = Physics.SphereCast(colliderPosition, ColliderRadius, direction, out hitInfo, displacement.magnitude + ColliderRadius, layerMask);
+
             if (castFoundHit)
             {
                 // Place self at meeting point with collider and do collision logic.
@@ -496,6 +478,30 @@ namespace DaggerfallWorkshop.Game
             if (caster == GameManager.Instance.PlayerEntityBehaviour)
             {
                 aimPosition = GameManager.Instance.MainCamera.transform.position;
+            }
+
+            //projectile offset code moved here for accuracy
+            if (isArrow)
+            {
+                // Offset up so it comes from same place LOS check is done from
+                Vector3 adjust;
+                if (caster != GameManager.Instance.PlayerEntityBehaviour)
+                {
+                    CharacterController controller = caster.transform.GetComponent<CharacterController>();
+                    adjust = caster.transform.forward * 0.6f;
+                    adjust.y += controller.height / 3;
+                }
+                else
+                {
+                    // Adjust slightly downward to match bow animation
+                    adjust = (GameManager.Instance.MainCamera.transform.rotation * -Caster.transform.up) * 0.11f;
+                    // Adjust to the right or left to match bow animation
+                    if (!GameManager.Instance.WeaponManager.ScreenWeapon.FlipHorizontal)
+                        adjust += GameManager.Instance.MainCamera.transform.right * 0.15f;
+                    else
+                        adjust -= GameManager.Instance.MainCamera.transform.right * 0.15f;
+                }
+                aimPosition += adjust;
             }
 
             return aimPosition;

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -4,7 +4,7 @@
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Gavin Clayton (interkarma@dfworkshop.net)
-// Contributors:    Allofich
+// Contributors:    Allofich, Numidium
 // 
 // Notes:
 //
@@ -27,9 +27,6 @@ namespace DaggerfallWorkshop.Game
     /// Currently ranged missiles can only move in a straight line as per classic.
     /// </summary>
     [RequireComponent(typeof(Light))]
-    [RequireComponent(typeof(SphereCollider))]
-    [RequireComponent(typeof(MeshCollider))]
-    [RequireComponent(typeof(Rigidbody))]
     [RequireComponent(typeof(DaggerfallAudioSource))]
     public class DaggerfallMissile : MonoBehaviour
     {
@@ -64,11 +61,11 @@ namespace DaggerfallWorkshop.Game
         public const float SphereCastRadius = 0.25f;
         public const float TouchRange = 3.0f;
 
+        Vector3 colliderPosition;
+
         Vector3 direction;
         Light myLight;
-        SphereCollider myCollider;
         DaggerfallAudioSource audioSource;
-        Rigidbody myRigidbody;
         Billboard myBillboard;
         bool forceDisableSpellLighting;
         bool noSpellsSpatialBlend = false;
@@ -87,6 +84,8 @@ namespace DaggerfallWorkshop.Game
         bool isArrowSummoned = false;
         GameObject goModel = null;
         EnemySenses enemySenses;
+
+        int layerMask;
 
         List<DaggerfallEntityBehaviour> targetEntities = new List<DaggerfallEntityBehaviour>();
 
@@ -182,14 +181,6 @@ namespace DaggerfallWorkshop.Game
             initialRange = myLight.range;
             initialIntensity = myLight.intensity;
 
-            // Setup collider
-            myCollider = GetComponent<SphereCollider>();
-            myCollider.radius = ColliderRadius;
-
-            // Setup rigidbody
-            myRigidbody = GetComponent<Rigidbody>();
-            myRigidbody.useGravity = false;
-
             // Use payload when available
             if (payload != null)
             {
@@ -216,11 +207,7 @@ namespace DaggerfallWorkshop.Game
             if (isArrow)
             {
                 // Create and orient 3d arrow
-                goModel = GameObjectHelper.CreateDaggerfallMeshGameObject(99800, transform);
-                MeshCollider arrowCollider = goModel.GetComponent<MeshCollider>();
-                arrowCollider.sharedMesh = goModel.GetComponent<MeshFilter>().sharedMesh;
-                arrowCollider.convex = true;
-                arrowCollider.isTrigger = true;
+                goModel = GameObjectHelper.CreateDaggerfallMeshGameObject(99800, transform, ignoreCollider: true);
 
                 // Offset up so it comes from same place LOS check is done from
                 Vector3 adjust;
@@ -234,8 +221,6 @@ namespace DaggerfallWorkshop.Game
                 {
                     // Adjust slightly downward to match bow animation
                     adjust = (GameManager.Instance.MainCamera.transform.rotation * -Caster.transform.up) * 0.11f;
-                    // Offset forward to avoid collision with player
-                    adjust += GameManager.Instance.MainCamera.transform.forward * 0.6f;
                     // Adjust to the right or left to match bow animation
                     if (!GameManager.Instance.WeaponManager.ScreenWeapon.FlipHorizontal)
                         adjust += GameManager.Instance.MainCamera.transform.right * 0.15f;
@@ -248,9 +233,14 @@ namespace DaggerfallWorkshop.Game
                 goModel.layer = gameObject.layer;
             }
 
-            // Ignore missile collision with caster (this is a different check to AOE targets)
-            if (caster)
-                Physics.IgnoreCollision(caster.GetComponent<Collider>(), this.GetComponent<Collider>());
+            string layerName;
+            if (caster && caster != GameManager.Instance.PlayerEntityBehaviour)
+                layerName = "SpellMissiles";
+            else
+                layerName = "Player";
+
+            layerMask = ~(1 << LayerMask.NameToLayer(layerName));
+            layerMask = layerMask & ~(1 << LayerMask.NameToLayer("Ignore Raycast"));
         }
 
         private void Update()
@@ -283,12 +273,13 @@ namespace DaggerfallWorkshop.Game
                 transform.position += (direction * MovementSpeed) * Time.deltaTime;
 
                 // Update lifespan and self-destruct if expired (e.g. spell fired straight up and will never hit anything)
-                lifespan += Time.deltaTime;
                 if (lifespan > LifespanInSeconds)
                     Destroy(gameObject);
             }
             else
             {
+                transform.position = colliderPosition;
+
                 // Notify listeners work is done and automatically assign impact
                 if (!impactAssigned)
                 {
@@ -313,35 +304,41 @@ namespace DaggerfallWorkshop.Game
             UpdateLight();
         }
 
+        private void FixedUpdate()
+        {
+            if (!missileReleased || impactDetected)
+                return;
+            lifespan += Time.fixedDeltaTime;
+            // Do fixed-interval transformation with raycast lookahead.
+            var displacement = (direction * MovementSpeed) * Time.fixedDeltaTime;
+            RaycastHit hitInfo;
+            bool castFoundHit;
+            if (isArrow || lifespan == Time.fixedDeltaTime) // First test should always be a raycast in case the caster is hugging a wall.
+                castFoundHit = Physics.Raycast(colliderPosition, direction, out hitInfo, displacement.magnitude + ColliderRadius, layerMask);
+            else
+                castFoundHit = Physics.SphereCast(colliderPosition, ColliderRadius, direction, out hitInfo, displacement.magnitude + ColliderRadius, layerMask);
+            if (castFoundHit)
+            {
+                // Place self at meeting point with collider and do collision logic.
+                if (isArrow)
+                    colliderPosition = hitInfo.point - transform.forward * ColliderRadius;
+                else
+                    colliderPosition += direction.normalized * hitInfo.distance; // Stop at center of sphere cast.
+                DoCollision(null, hitInfo.collider);
+            }
+            else
+                colliderPosition += displacement;
+        }
+
         #endregion
 
         #region Collision Handling
-
-        private void OnCollisionEnter(Collision collision)
-        {
-            DoCollision(collision, null);
-        }
-
-        private void OnTriggerEnter(Collider other)
-        {
-            DoCollision(null, other);
-        }
 
         void DoCollision(Collision collision, Collider other)
         {
             // Missile collision should only happen once
             if (impactDetected)
                 return;
-
-            // Set my collider to trigger and rigidbody to kinematic immediately after impact
-            // This helps prevent mobiles from walking over low missiles or the missile bouncing off in some other direction
-            // Seems to eliminate the combined worst-case scenario where mobile will "ride" a missile bounce, throwing them high into the air
-            // Now the worst that seems to happen is mobile will "bump" over low missiles occasionally
-            // TODO: Review later and find a better way to eliminate issue other than this quick workaround
-            if (myCollider)
-                myCollider.isTrigger = true;
-            if (myRigidbody)
-                myRigidbody.isKinematic = true;
 
             // Play spell impact animation, this replaces spell missile animation
             if (elementType != ElementTypes.None && targetType != TargetTypes.ByTouch)
@@ -380,7 +377,7 @@ namespace DaggerfallWorkshop.Game
             // If missile is area at range
             if (targetType == TargetTypes.AreaAtRange)
             {
-                DoAreaOfEffect(transform.position);
+                DoAreaOfEffect(colliderPosition);
             }
         }
 
@@ -410,11 +407,6 @@ namespace DaggerfallWorkshop.Game
         {
             transform.position = caster.transform.position;
 
-            // Touch does not use default missile collider
-            // This prevent touch missile check colliding with self and blocking spell transfer
-            if (myCollider)
-                myCollider.enabled = false;
-
             DaggerfallEntityBehaviour entityBehaviour = GetEntityTargetInTouchRange(GetAimPosition(), GetAimDirection());
             if (entityBehaviour && entityBehaviour != caster)
             {
@@ -431,7 +423,8 @@ namespace DaggerfallWorkshop.Game
         void DoMissile()
         {
             direction = GetAimDirection();
-            transform.position = GetAimPosition() + direction * ArmLength;
+            transform.position = GetAimPosition();
+            colliderPosition = transform.position;
             missileReleased = true;
         }
 
@@ -440,7 +433,7 @@ namespace DaggerfallWorkshop.Game
         {
             List<DaggerfallEntityBehaviour> entities = new List<DaggerfallEntityBehaviour>();
 
-            transform.position = position;
+            colliderPosition = position;
 
             // Collect AOE targets and ignore duplicates
             Collider[] overlaps = Physics.OverlapSphere(position, ExplosionRadius);

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -85,6 +85,8 @@ namespace DaggerfallWorkshop.Game
         GameObject goModel = null;
         EnemySenses enemySenses;
 
+        private static int layerMaskDefault = -1;
+        private static int layerMaskPlayer = -1;
         int layerMask;
 
         List<DaggerfallEntityBehaviour> targetEntities = new List<DaggerfallEntityBehaviour>();
@@ -233,14 +235,27 @@ namespace DaggerfallWorkshop.Game
                 goModel.layer = gameObject.layer;
             }
 
-            string layerName;
-            if (caster && caster != GameManager.Instance.PlayerEntityBehaviour)
-                layerName = "SpellMissiles";
-            else
-                layerName = "Player";
+            //if layer mask has not yet been initialized, do it now
+            if (layerMaskDefault == -1)
+                InitializeLayerMasks();
 
-            layerMask = ~(1 << LayerMask.NameToLayer(layerName));
-            layerMask = layerMask & ~(1 << LayerMask.NameToLayer("Ignore Raycast"));
+            //assign layer mask
+            if (caster && caster != GameManager.Instance.PlayerEntityBehaviour)
+                layerMask = layerMaskDefault;
+            else
+                layerMask = layerMaskPlayer;
+        }
+
+        static void InitializeLayerMasks()
+        {
+            layerMaskDefault = Physics.DefaultRaycastLayers;
+            layerMaskDefault &= ~(1 << Physics.IgnoreRaycastLayer);
+            layerMaskDefault &= ~(1 << LayerMask.NameToLayer("Automap"));
+
+            layerMaskPlayer = Physics.DefaultRaycastLayers;
+            layerMaskPlayer &= ~(1 << Physics.IgnoreRaycastLayer);
+            layerMaskPlayer &= ~(1 << LayerMask.NameToLayer("Player"));
+            layerMaskPlayer &= ~(1 << LayerMask.NameToLayer("Automap"));
         }
 
         private void Update()
@@ -385,14 +400,23 @@ namespace DaggerfallWorkshop.Game
 
         #region Static Methods
 
-        public static DaggerfallEntityBehaviour GetEntityTargetInTouchRange(Vector3 aimPosition, Vector3 aimDirection)
+        public static DaggerfallEntityBehaviour GetEntityTargetInTouchRange(Vector3 aimPosition, Vector3 aimDirection, int layerMaskTouch = -1)
         {
+            //set the default layer mask if none was passed
+            if (layerMaskTouch == -1)
+            {
+                //Initialize the layer masks if they're still not
+                if (layerMaskDefault == -1)
+                    InitializeLayerMasks();
+
+                layerMaskTouch = layerMaskDefault;
+            }
+
             // Fire ray along caster facing
             // Origin point of ray is set back slightly to fix issue where strikes against target capsules touching caster capsule do not connect
             RaycastHit hit;
-            aimPosition -= aimDirection * 0.1f;
             Ray ray = new Ray(aimPosition, aimDirection);
-            if (Physics.SphereCast(ray, SphereCastRadius, out hit, TouchRange))
+            if (Physics.SphereCast(ray, SphereCastRadius, out hit, TouchRange, layerMaskTouch))
                 return hit.transform.GetComponent<DaggerfallEntityBehaviour>();
             else
                 return null;
@@ -407,7 +431,7 @@ namespace DaggerfallWorkshop.Game
         {
             transform.position = caster.transform.position;
 
-            DaggerfallEntityBehaviour entityBehaviour = GetEntityTargetInTouchRange(GetAimPosition(), GetAimDirection());
+            DaggerfallEntityBehaviour entityBehaviour = GetEntityTargetInTouchRange(GetAimPosition(), GetAimDirection(), layerMask);
             if (entityBehaviour && entityBehaviour != caster)
             {
                 targetEntities.Add(entityBehaviour);

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -61,6 +61,18 @@ namespace DaggerfallWorkshop.Game
         public const float SphereCastRadius = 0.25f;
         public const float TouchRange = 3.0f;
 
+        private static readonly Collider[] aoeBuffer = new Collider[64];
+        private readonly List<DaggerfallEntityBehaviour> tmpTargets = new List<DaggerfallEntityBehaviour>(32);
+
+        // Cached references
+        private GameManager gm;
+        private Camera mainCamera;
+        private WeaponManager weaponManager;
+        private Collider casterCollider;
+        private EnemySenses cachedEnemySenses;
+        private EnemyAttack cachedEnemyAttack;
+        private CharacterController casterController;
+
         Vector3 colliderPosition;
 
         Vector3 direction;
@@ -170,39 +182,53 @@ namespace DaggerfallWorkshop.Game
         private void Awake()
         {
             audioSource = transform.GetComponent<DaggerfallAudioSource>();
+
+            gm = GameManager.Instance;
+            mainCamera = gm.MainCamera;
+            weaponManager = gm.WeaponManager;
+            audioSource = GetComponent<DaggerfallAudioSource>();
         }
 
         private void Start()
         {
             // Setup light and shadows
             myLight = GetComponent<Light>();
-            myLight.enabled = EnableLight;
+            myLight.enabled = EnableLight && DaggerfallUnity.Settings.EnableSpellLighting;
             forceDisableSpellLighting = !DaggerfallUnity.Settings.EnableSpellLighting;
-            if (forceDisableSpellLighting) myLight.enabled = false;
-            if (!DaggerfallUnity.Settings.EnableSpellShadows) myLight.shadows = LightShadows.None;
+            if (!DaggerfallUnity.Settings.EnableSpellShadows)
+            {
+                myLight.shadows = LightShadows.None;
+            }
+
             initialRange = myLight.range;
             initialIntensity = myLight.intensity;
 
             // Use payload when available
             if (payload != null)
             {
-                // Set payload missile properties
                 caster = payload.CasterEntityBehaviour;
                 targetType = payload.Settings.TargetType;
                 elementType = payload.Settings.ElementType;
 
                 // Set spell billboard anims automatically from payload for mobile missiles
-                if (targetType == TargetTypes.SingleTargetAtRange ||
-                    targetType == TargetTypes.AreaAtRange)
+                if (targetType == TargetTypes.SingleTargetAtRange || targetType == TargetTypes.AreaAtRange)
                 {
                     UseSpellBillboardAnims();
                 }
             }
 
             // Setup senses
-            if (caster && caster != GameManager.Instance.PlayerEntityBehaviour)
+            if (caster)
             {
-                enemySenses = caster.GetComponent<EnemySenses>();
+                casterCollider = caster.GetComponent<Collider>();
+                cachedEnemySenses = caster.GetComponent<EnemySenses>();
+                cachedEnemyAttack = caster.GetComponent<EnemyAttack>();
+                casterController = caster.GetComponent<CharacterController>();
+            }
+
+            if (caster && caster != gm.PlayerEntityBehaviour)
+            {
+                enemySenses = cachedEnemySenses;
             }
 
             // Setup arrow
@@ -230,13 +256,11 @@ namespace DaggerfallWorkshop.Game
         static void InitializeLayerMasks()
         {
             layerMaskDefault = Physics.DefaultRaycastLayers;
-            layerMaskDefault &= ~(1 << Physics.IgnoreRaycastLayer);
             layerMaskDefault &= ~(1 << LayerMask.NameToLayer("Automap"));
 
             layerMaskPlayer = Physics.DefaultRaycastLayers;
-            layerMaskPlayer &= ~(1 << Physics.IgnoreRaycastLayer);
-            layerMaskPlayer &= ~(1 << LayerMask.NameToLayer("Player"));
             layerMaskPlayer &= ~(1 << LayerMask.NameToLayer("Automap"));
+            layerMaskPlayer &= ~(1 << LayerMask.NameToLayer("Player"));
         }
 
         private void Update()
@@ -398,10 +422,12 @@ namespace DaggerfallWorkshop.Game
             // Origin point of ray is set back slightly to fix issue where strikes against target capsules touching caster capsule do not connect
             RaycastHit hit;
             Ray ray = new Ray(aimPosition, aimDirection);
-            if (Physics.SphereCast(ray, SphereCastRadius, out hit, TouchRange, layerMaskTouch))
+            if (Physics.SphereCast(ray, SphereCastRadius, out hit, TouchRange, layerMaskTouch, QueryTriggerInteraction.Ignore))
+            {
                 return hit.transform.GetComponent<DaggerfallEntityBehaviour>();
-            else
-                return null;
+            }
+
+            return null;
         }
 
         #endregion
@@ -437,29 +463,34 @@ namespace DaggerfallWorkshop.Game
         // AOE can strike any number of targets within range with an option to exclude caster
         void DoAreaOfEffect(Vector3 position, bool ignoreCaster = false)
         {
-            List<DaggerfallEntityBehaviour> entities = new List<DaggerfallEntityBehaviour>();
-
             colliderPosition = position;
 
-            // Collect AOE targets and ignore duplicates
-            Collider[] overlaps = Physics.OverlapSphere(position, ExplosionRadius);
-            for (int i = 0; i < overlaps.Length; i++)
+            int count = Physics.OverlapSphereNonAlloc(position, ExplosionRadius, aoeBuffer, layerMaskDefault, QueryTriggerInteraction.Ignore);
+            tmpTargets.Clear();
+
+            for (int i = 0; i < count; i++)
             {
-                DaggerfallEntityBehaviour aoeEntity = overlaps[i].GetComponent<DaggerfallEntityBehaviour>();
-
-                if (ignoreCaster && aoeEntity == caster)
-                    continue;
-
-                if (aoeEntity && !targetEntities.Contains(aoeEntity))
+                var beh = aoeBuffer[i].GetComponent<DaggerfallEntityBehaviour>();
+                if (!beh)
                 {
-                    entities.Add(aoeEntity);
-                    //Debug.LogFormat("Missile hit target {0} by AOE", aoeEntity.name);
+                    continue;
+                }
+
+                if (ignoreCaster && beh == caster)
+                {
+                    continue;
+                }
+
+                if (!targetEntities.Contains(beh))
+                {
+                    tmpTargets.Add(beh);
                 }
             }
 
-            // Add collection to target entities
-            if (entities.Count > 0)
-                targetEntities.AddRange(entities);
+            if (tmpTargets.Count > 0)
+            {
+                targetEntities.AddRange(tmpTargets);
+            }
 
             impactDetected = true;
             missileReleased = true;
@@ -485,21 +516,24 @@ namespace DaggerfallWorkshop.Game
             {
                 // Offset up so it comes from same place LOS check is done from
                 Vector3 adjust;
-                if (caster != GameManager.Instance.PlayerEntityBehaviour)
+                if (caster != gm.PlayerEntityBehaviour)
                 {
-                    CharacterController controller = caster.transform.GetComponent<CharacterController>();
                     adjust = caster.transform.forward * 0.6f;
-                    adjust.y += controller.height / 3;
+                    if (casterController)
+                    {
+                        adjust.y += casterController.height / 3;
+                    }
                 }
                 else
                 {
                     // Adjust slightly downward to match bow animation
-                    adjust = (GameManager.Instance.MainCamera.transform.rotation * -Caster.transform.up) * 0.11f;
+                    adjust = (gm.MainCamera.transform.rotation * -caster.transform.up) * 0.11f;
                     // Adjust to the right or left to match bow animation
-                    if (!GameManager.Instance.WeaponManager.ScreenWeapon.FlipHorizontal)
-                        adjust += GameManager.Instance.MainCamera.transform.right * 0.15f;
+                    var right = gm.MainCamera.transform.right * 0.15f;
+                    if (!gm.WeaponManager.ScreenWeapon.FlipHorizontal)
+                        adjust += right;
                     else
-                        adjust -= GameManager.Instance.MainCamera.transform.right * 0.15f;
+                        adjust -= right;
                 }
                 aimPosition += adjust;
             }
@@ -631,7 +665,13 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 Transform hitTransform = arrowHitCollider.gameObject.transform;
-                GameManager.Instance.WeaponManager.WeaponDamage(GameManager.Instance.WeaponManager.LastBowUsed, true, isArrowSummoned, hitTransform, hitTransform.position, goModel.transform.forward);
+                GameManager.Instance.WeaponManager.WeaponDamage(
+                    GameManager.Instance.WeaponManager.LastBowUsed,
+                    true,
+                    isArrowSummoned,
+                    hitTransform,
+                    hitTransform.position,
+                    goModel.transform.forward);
             }
         }
 

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -247,10 +247,10 @@ namespace DaggerfallWorkshop.Game
                 InitializeLayerMasks();
 
             //assign layer mask
-            if (caster && caster != GameManager.Instance.PlayerEntityBehaviour)
-                layerMask = layerMaskDefault;
-            else
+            if (caster && caster == gm.PlayerEntityBehaviour)
                 layerMask = layerMaskPlayer;
+            else
+                layerMask = layerMaskDefault;
         }
 
         static void InitializeLayerMasks()
@@ -506,9 +506,9 @@ namespace DaggerfallWorkshop.Game
             // Aim position is from eye level for player or origin for other mobile
             // Player must aim from camera position or it feels out of alignment
             Vector3 aimPosition = caster.transform.position;
-            if (caster == GameManager.Instance.PlayerEntityBehaviour)
+            if (caster == gm.PlayerEntityBehaviour)
             {
-                aimPosition = GameManager.Instance.MainCamera.transform.position;
+                aimPosition = gm.MainCamera.transform.position;
             }
 
             //projectile offset code moved here for accuracy
@@ -550,9 +550,9 @@ namespace DaggerfallWorkshop.Game
 
             // Aim direction should be from camera for player or facing for other mobile
             Vector3 aimDirection = Vector3.zero;
-            if (caster == GameManager.Instance.PlayerEntityBehaviour)
+            if (caster == gm.PlayerEntityBehaviour)
             {
-                aimDirection = GameManager.Instance.MainCamera.transform.forward;
+                aimDirection = gm.MainCamera.transform.forward;
             }
             else if (enemySenses)
             {
@@ -568,7 +568,7 @@ namespace DaggerfallWorkshop.Game
                     aimDirection = (predictedPosition - caster.transform.position).normalized;
 
                 // Enemy archers must aim lower to compensate for crouched player capsule
-                if (IsArrow && enemySenses.Target?.EntityType == EntityTypes.Player && GameManager.Instance.PlayerMotor.IsCrouching)
+                if (IsArrow && enemySenses.Target?.EntityType == EntityTypes.Player && gm.PlayerMotor.IsCrouching)
                     aimDirection += Vector3.down * 0.05f;
             }
 
@@ -651,7 +651,7 @@ namespace DaggerfallWorkshop.Game
                 return;
             }
 
-            if (caster != GameManager.Instance.PlayerEntityBehaviour)
+            if (caster != gm.PlayerEntityBehaviour)
             {
                 if (targetEntities[0] == caster.GetComponent<EnemySenses>().Target)
                 {
@@ -665,8 +665,8 @@ namespace DaggerfallWorkshop.Game
             else
             {
                 Transform hitTransform = arrowHitCollider.gameObject.transform;
-                GameManager.Instance.WeaponManager.WeaponDamage(
-                    GameManager.Instance.WeaponManager.LastBowUsed,
+                gm.WeaponManager.WeaponDamage(
+                    gm.WeaponManager.LastBowUsed,
                     true,
                     isArrowSummoned,
                     hitTransform,

--- a/Assets/Scripts/Game/DaggerfallMissile.cs
+++ b/Assets/Scripts/Game/DaggerfallMissile.cs
@@ -430,6 +430,19 @@ namespace DaggerfallWorkshop.Game
             return null;
         }
 
+        //allow other classes to use the layer masks
+        public static int GetLayerMask(bool player)
+        {
+            //Initialize the layer masks if they're still not
+            if (layerMaskDefault == -1)
+                InitializeLayerMasks();
+
+            if (player)
+                return layerMaskPlayer;
+
+            return layerMaskDefault;
+        }
+
         #endregion
 
         #region Private Methods

--- a/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/EntityEffectManager.cs
@@ -414,7 +414,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects
             {
                 Vector3 aimPosition = GameManager.Instance.MainCamera.transform.position;
                 Vector3 aimDirection = GameManager.Instance.MainCamera.transform.forward;
-                if (DaggerfallMissile.GetEntityTargetInTouchRange(aimPosition, aimDirection) == null)
+                if (DaggerfallMissile.GetEntityTargetInTouchRange(aimPosition, aimDirection, DaggerfallMissile.GetLayerMask(true)) == null)
                 {
                     //Debug.Log("Target entity not in range for touch spell.");
                     return;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -140,6 +140,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         HorizontalSlider dungeonAmbientLightScale;
         HorizontalSlider nightAmbientLightScale;
         HorizontalSlider playerTorchLightScale;
+        HorizontalSlider meleeAttackDetection;
+        Checkbox meleeAttackFriendlyProtection;
 
         // Video
         HorizontalSlider resolution;
@@ -270,6 +272,12 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             musicVolume = AddSlider(rightPanel, "musicVolume", 0, 100, DaggerfallUnity.Settings.MusicVolume * 100);
             musicVolume.DisplayUnits = 100;
             musicVolume.OnScroll += MusicVolume_OnScroll;
+
+            // Melee Attacks
+            AddSectionTitle(rightPanel, "meleeAttacks");
+            meleeAttackDetection = AddSlider(rightPanel, "meleeAttackDetection",
+                DaggerfallUnity.Settings.MeleeAttackDetection, TextManager.Instance.GetLocalizedTextList("meleeAttackDetectionModes", TextCollections.TextSettings));
+            meleeAttackFriendlyProtection = AddCheckbox(rightPanel, "meleeAttackFriendlyProtection", DaggerfallUnity.Settings.MeleeAttackFriendlyProtection);
 
             // Spells
             AddSectionTitle(rightPanel, "spells");
@@ -443,6 +451,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             DaggerfallUnity.Settings.EnableSpellLighting = spellLighting.IsChecked;
             DaggerfallUnity.Settings.EnableSpellShadows = spellShadows.IsChecked;
+
+            DaggerfallUnity.Settings.MeleeAttackDetection = meleeAttackDetection.ScrollIndex;
+            DaggerfallUnity.Settings.MeleeAttackFriendlyProtection = meleeAttackFriendlyProtection.IsChecked;
 
             /* GUI */
 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallUnityMouseControlsWindow.cs
@@ -49,6 +49,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected TextBox weaponAttackThresholdTextbox;
         protected Button continueButton;
 
+        protected HorizontalSlider meleeAttackDetectionSlider;
+        protected Checkbox meleeAttackFriendlyProtectionCheckbox;
+
         protected List<Button> buttonGroup = new List<Button>();
 
         bool waitingForInput = false;
@@ -125,6 +128,9 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             weaponSwingModeSlider = CreateSlider(TextManager.Instance.GetLocalizedText("weaponSwingMode", TextCollections.TextSettings), 150, 90, DaggerfallUnity.Settings.WeaponSwingMode, TextManager.Instance.GetLocalizedTextList("weaponSwingModes", TextCollections.TextSettings));
             bowDrawbackCheckbox = AddOption(150, 120, TextManager.Instance.GetLocalizedText("bowDrawback", TextCollections.TextSettings), DaggerfallUnity.Settings.BowDrawback);
             toggleSneakCheckbox = AddOption(150, 130, TextManager.Instance.GetLocalizedText("toggleSneak", TextCollections.TextSettings), DaggerfallUnity.Settings.ToggleSneak);
+
+            meleeAttackDetectionSlider = CreateSlider(TextManager.Instance.GetLocalizedText("meleeAttackDetection", TextCollections.TextSettings),20, 145, DaggerfallUnity.Settings.MeleeAttackDetection, TextManager.Instance.GetLocalizedTextList("meleeAttackDetectionModes", TextCollections.TextSettings));
+            meleeAttackFriendlyProtectionCheckbox = AddOption(150, 145, TextManager.Instance.GetLocalizedText("meleeAttackFriendlyProtection", TextCollections.TextSettings), DaggerfallUnity.Settings.MeleeAttackFriendlyProtection);
 
             weaponAttackThresholdTextbox = AddTextbox(TextManager.Instance.GetLocalizedText("mouseWeaponAttackThreshold", TextCollections.TextSettings), 20, 90, DaggerfallUnity.Settings.WeaponAttackThreshold.ToString());
 
@@ -352,6 +358,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.WeaponSwingMode = weaponSwingModeSlider.ScrollIndex;
             DaggerfallUnity.Settings.BowDrawback = bowDrawbackCheckbox.IsChecked;
             DaggerfallUnity.Settings.ToggleSneak = toggleSneakCheckbox.IsChecked;
+            DaggerfallUnity.Settings.MeleeAttackDetection = meleeAttackDetectionSlider.ScrollIndex;
+            DaggerfallUnity.Settings.MeleeAttackFriendlyProtection = meleeAttackFriendlyProtectionCheckbox.IsChecked;
 
             float weaponAttackThresholdValue;
             if (float.TryParse(weaponAttackThresholdTextbox.Text, out weaponAttackThresholdValue))

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -196,9 +196,13 @@ namespace DaggerfallWorkshop.Game
             //weaponSensitivity = DaggerfallUnity.Settings.WeaponSensitivity;
             mainCamera = GameObject.FindGameObjectWithTag("MainCamera");
             player = transform.gameObject;
-            playerLayerMask = ~(1 << LayerMask.NameToLayer("Player"));
+
+            playerLayerMask = Physics.DefaultRaycastLayers;
+            playerLayerMask &= ~(1 << LayerMask.NameToLayer("Player"));
+            playerLayerMask &= ~(1 << LayerMask.NameToLayer("Automap"));
+
             _gesture = new Gesture();
-            _longestDim = Math.Max(Screen.width, Screen.height);
+            _longestDim = Mathf.Max(Screen.width, Screen.height);
             SetMelee(ScreenWeapon);
         }
 

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -903,19 +903,191 @@ namespace DaggerfallWorkshop.Game
             if (!mainCamera || !weapon)
                 return;
 
-            // Fire ray along player facing using weapon range
-            RaycastHit hit;
+            //start of bounding box based attack code
+            //bool radialReach = false;
+
+            DaggerfallUnityItem strikingWeapon = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;
+
+            //make bounding box in front of player view
+            float weaponReach = weapon.Reach + SphereCastRadius;
+            Vector3 boundsPos = mainCamera.transform.position + (mainCamera.transform.forward * (weaponReach * 0.5f));
+            Quaternion boundsRot = mainCamera.transform.rotation;
+            Vector3 boundsSize = new Vector3(weaponReach * 2, weaponReach, weaponReach);
+
+            Collider[] colliders = Physics.OverlapBox(boundsPos, boundsSize, boundsRot, playerLayerMask);
+            List<Collider> hitColliders = new List<Collider>();
+
+            RaycastHit hit = new RaycastHit();
             Ray ray = new Ray(mainCamera.transform.position, mainCamera.transform.forward);
-            if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach, playerLayerMask))
+
+            if (colliders.Length > 0)
             {
-                DaggerfallUnityItem strikingWeapon = usingRightHand ? currentRightHandWeapon : currentLeftHandWeapon;
-                if(!WeaponEnvDamage(strikingWeapon, hit)
-                   // Fall back to simple ray for narrow cages https://forums.dfworkshop.net/viewtopic.php?f=5&t=2195#p39524
-                   || Physics.Raycast(ray, out hit, weapon.Reach, playerLayerMask))
+                Vector3 center = Vector3.zero;
+                foreach (Collider collider in colliders)
                 {
-                    hitEnemy = WeaponDamage(strikingWeapon, false, false, hit.transform, hit.point, mainCamera.transform.forward);
+                    //check if collider is entity
+                    DaggerfallEntityBehaviour behaviour = collider.GetComponent<DaggerfallEntityBehaviour>();
+                    if (behaviour != null)
+                    {
+                        //exclude allies, pacified NPCs and wandering commoners from bounding box check
+                        if (DaggerfallUnity.Settings.MeleeAttackFriendlyProtection)
+                        {
+                            if (behaviour.Entity.Team == MobileTeams.PlayerAlly)
+                                continue;
+
+                            EnemyMotor motor = collider.GetComponent<EnemyMotor>();
+                            if (motor != null && !motor.IsHostile)
+                                continue;
+
+                            MobilePersonNPC mobileNpc = collider.GetComponent<MobilePersonNPC>();
+                            if (mobileNpc != null)
+                                continue;
+                        }
+
+                        bool canHit = true;
+
+                        CharacterController controller = collider.GetComponent<CharacterController>();
+
+                        //check if target center is in FOV
+                        center = collider.bounds.center;
+                        if (!IsPositionInCameraView(center))
+                        {
+                            //center is not in FOV
+                            canHit = false;
+
+                            if (DaggerfallUnity.Settings.MeleeAttackDetection > 0 && controller != null)
+                            {
+                                //check if other parts of the enemy are in view
+                                if (IsPositionInCameraView(center + (mainCamera.transform.up * (controller.height * 0.25f))))
+                                    canHit = true;
+
+                                if (!canHit && IsPositionInCameraView(center - (mainCamera.transform.up * (controller.height * 0.25f))))
+                                    canHit = true;
+
+                                if (!canHit && IsPositionInCameraView(center + (mainCamera.transform.right * (controller.radius * 0.5f))))
+                                    canHit = true;
+
+                                if (!canHit && IsPositionInCameraView(center - (mainCamera.transform.right * (controller.radius * 0.5f))))
+                                    canHit = true;
+                            }
+                        }
+
+                        //target is out of FOV, no need to check LOS
+                        if (!canHit)
+                            continue;
+
+                        //check if target has clear LOS
+                        center = collider.bounds.center;
+                        ray.direction = center - ray.origin;
+                        if (Physics.Raycast(ray, out hit, weaponReach, playerLayerMask))
+                        {
+                            if (hit.collider != collider)
+                            {
+                                //target center does not have LOS
+                                //Debug.DrawRay(ray.origin, hit.point - ray.origin, Color.blue, 3);
+                                canHit = false;
+
+                                //if target is an enemy, check if head, feet, or sides have clear LOS
+                                if (DaggerfallUnity.Settings.MeleeAttackDetection > 0 && controller != null)
+                                {
+                                    Vector3 point = Vector3.zero;
+                                    point = center + (mainCamera.transform.up * (controller.height * 0.25f));
+                                    ray.direction = point - ray.origin;
+                                    if (Physics.Raycast(ray, out hit, 6, playerLayerMask, QueryTriggerInteraction.Ignore))
+                                    {
+                                        if (hit.collider == collider)
+                                            canHit = true;
+                                    }
+                                    if (!canHit)
+                                    {
+                                        //if head is obstructed, check feet
+                                        point = center - (mainCamera.transform.up * (controller.height * 0.25f));
+                                        ray.direction = point - ray.origin;
+                                        if (Physics.Raycast(ray, out hit, 6, playerLayerMask, QueryTriggerInteraction.Ignore))
+                                        {
+                                            if (hit.collider == collider)
+                                                canHit = true;
+                                        }
+                                    }
+                                    if (!canHit)
+                                    {
+                                        //if feet is obstructed, check right flank
+                                        point = center + (mainCamera.transform.right * (controller.radius * 0.5f));
+                                        ray.direction = point - ray.origin;
+                                        if (Physics.Raycast(ray, out hit, 6, playerLayerMask, QueryTriggerInteraction.Ignore))
+                                        {
+                                            if (hit.collider == collider)
+                                                canHit = true;
+                                        }
+                                    }
+                                    if (!canHit)
+                                    {
+                                        //if right flank is obstructed, check left flank
+                                        point = center - (mainCamera.transform.right * (controller.radius * 0.5f));
+                                        ray.direction = point - ray.origin;
+                                        if (Physics.Raycast(ray, out hit, 6, playerLayerMask, QueryTriggerInteraction.Ignore))
+                                        {
+                                            if (hit.collider == collider)
+                                                canHit = true;
+                                        }
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                //Target is unobstructed
+                                //Debug.DrawRay(ray.origin, hit.point - ray.origin, Color.green, 3);
+                            }
+                        }
+                        else
+                        {
+                            //Target is outside radial weapon reach
+                            //Debug.DrawRay(ray.origin, ray.direction * weaponReach, Color.yellow, 3);
+                            /*if (radialReach)
+                                canHit = false;*/
+                        }
+
+                        if (canHit)
+                            hitColliders.Add(collider);
+                    }
                 }
             }
+
+            if (hitColliders.Count > 0)
+            {
+                //perform weapon attack on each collider in list
+                foreach (Collider hitCollider in hitColliders)
+                {
+                    Vector3 hitPoint = hitCollider.ClosestPoint(mainCamera.transform.position);
+                    hitEnemy = WeaponDamage(strikingWeapon, false, false, hitCollider.transform, hitPoint, (hitPoint - mainCamera.transform.position).normalized);
+                }
+            }
+            else
+            {
+                //if no hits were detected from bounds check, do vanilla attack check for bashing and hitting pacified NPCs and wandering commoners
+                //Logic: pacified NPCs and commoners can only be attacked if they are the only targets in front of the player
+                ray.origin = mainCamera.transform.position;
+                ray.direction = mainCamera.transform.forward;
+                if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach, playerLayerMask))
+                {
+                    if (!WeaponEnvDamage(strikingWeapon, hit) || Physics.Raycast(ray, out hit, weaponReach, playerLayerMask))
+                        hitEnemy = WeaponDamage(strikingWeapon, false, false, hit.transform, hit.point, mainCamera.transform.forward);
+                }
+            }
+        }
+
+        public bool IsPositionInCameraView(Vector3 worldPos)
+        {
+            Vector3 point = GameManager.Instance.MainCamera.WorldToViewportPoint(worldPos);
+
+            if (point.x < 0 ||
+                point.x > 1 ||
+                point.y < 0 ||
+                point.y > 1 ||
+                point.z < 0)
+                return false;
+
+            return true;
         }
 
         private void UpdateRightHandGfxCache(DaggerfallUnityItem rightHandItem)

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -983,68 +983,60 @@ namespace DaggerfallWorkshop.Game
                         {
                             if (hit.collider != collider)
                             {
-                                //target center does not have LOS
-                                //Debug.DrawRay(ray.origin, hit.point - ray.origin, Color.blue, 3);
+                                //Target center does not have LOS
                                 canHit = false;
-
-                                //if target is an enemy, check if head, feet, or sides have clear LOS
-                                if (DaggerfallUnity.Settings.MeleeAttackDetection > 0 && controller != null)
-                                {
-                                    Vector3 point = Vector3.zero;
-                                    point = center + (mainCamera.transform.up * (controller.height * 0.25f));
-                                    ray.direction = point - ray.origin;
-                                    if (Physics.Raycast(ray, out hit, 6, playerLayerMask, QueryTriggerInteraction.Ignore))
-                                    {
-                                        if (hit.collider == collider)
-                                            canHit = true;
-                                    }
-                                    if (!canHit)
-                                    {
-                                        //if head is obstructed, check feet
-                                        point = center - (mainCamera.transform.up * (controller.height * 0.25f));
-                                        ray.direction = point - ray.origin;
-                                        if (Physics.Raycast(ray, out hit, 6, playerLayerMask, QueryTriggerInteraction.Ignore))
-                                        {
-                                            if (hit.collider == collider)
-                                                canHit = true;
-                                        }
-                                    }
-                                    if (!canHit)
-                                    {
-                                        //if feet is obstructed, check right flank
-                                        point = center + (mainCamera.transform.right * (controller.radius * 0.5f));
-                                        ray.direction = point - ray.origin;
-                                        if (Physics.Raycast(ray, out hit, 6, playerLayerMask, QueryTriggerInteraction.Ignore))
-                                        {
-                                            if (hit.collider == collider)
-                                                canHit = true;
-                                        }
-                                    }
-                                    if (!canHit)
-                                    {
-                                        //if right flank is obstructed, check left flank
-                                        point = center - (mainCamera.transform.right * (controller.radius * 0.5f));
-                                        ray.direction = point - ray.origin;
-                                        if (Physics.Raycast(ray, out hit, 6, playerLayerMask, QueryTriggerInteraction.Ignore))
-                                        {
-                                            if (hit.collider == collider)
-                                                canHit = true;
-                                        }
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                //Target is unobstructed
-                                //Debug.DrawRay(ray.origin, hit.point - ray.origin, Color.green, 3);
                             }
                         }
                         else
                         {
-                            //Target is outside radial weapon reach
-                            //Debug.DrawRay(ray.origin, ray.direction * weaponReach, Color.yellow, 3);
-                            /*if (radialReach)
-                                canHit = false;*/
+                            //Target center is outside radial weapon reach
+                            canHit = false;
+                        }
+
+                        //If basic collision check fails and setting is Quality, do complex collision check
+                        if (DaggerfallUnity.Settings.MeleeAttackDetection > 0 && !canHit && controller != null)
+                        {
+                            Vector3 point = Vector3.zero;
+                            point = center + (mainCamera.transform.up * (controller.height * 0.25f));
+                            ray.direction = point - ray.origin;
+                            if (Physics.Raycast(ray, out hit, weaponReach, playerLayerMask, QueryTriggerInteraction.Ignore))
+                            {
+                                if (hit.collider == collider)
+                                    canHit = true;
+                            }
+                            if (!canHit)
+                            {
+                                //if head is obstructed, check feet
+                                point = center - (mainCamera.transform.up * (controller.height * 0.25f));
+                                ray.direction = point - ray.origin;
+                                if (Physics.Raycast(ray, out hit, weaponReach, playerLayerMask, QueryTriggerInteraction.Ignore))
+                                {
+                                    if (hit.collider == collider)
+                                        canHit = true;
+                                }
+                            }
+                            if (!canHit)
+                            {
+                                //if feet is obstructed, check right flank
+                                point = center + (mainCamera.transform.right * (controller.radius * 0.5f));
+                                ray.direction = point - ray.origin;
+                                if (Physics.Raycast(ray, out hit, weaponReach, playerLayerMask, QueryTriggerInteraction.Ignore))
+                                {
+                                    if (hit.collider == collider)
+                                        canHit = true;
+                                }
+                            }
+                            if (!canHit)
+                            {
+                                //if right flank is obstructed, check left flank
+                                point = center - (mainCamera.transform.right * (controller.radius * 0.5f));
+                                ray.direction = point - ray.origin;
+                                if (Physics.Raycast(ray, out hit, weaponReach, playerLayerMask, QueryTriggerInteraction.Ignore))
+                                {
+                                    if (hit.collider == collider)
+                                        canHit = true;
+                                }
+                            }
                         }
 
                         if (canHit)
@@ -1068,10 +1060,13 @@ namespace DaggerfallWorkshop.Game
                 //Logic: pacified NPCs and commoners can only be attacked if they are the only targets in front of the player
                 ray.origin = mainCamera.transform.position;
                 ray.direction = mainCamera.transform.forward;
+
                 if (Physics.SphereCast(ray, SphereCastRadius, out hit, weapon.Reach, playerLayerMask))
                 {
                     if (!WeaponEnvDamage(strikingWeapon, hit) || Physics.Raycast(ray, out hit, weaponReach, playerLayerMask))
+                    {
                         hitEnemy = WeaponDamage(strikingWeapon, false, false, hit.transform, hit.point, mainCamera.transform.forward);
+                    }
                 }
             }
         }

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -79,6 +79,7 @@ namespace DaggerfallWorkshop
         const string sectionChildGuard = "ChildGuard";
         const string sectionGUI = "GUI";
         const string sectionSpells = "Spells";
+        const string sectionMeleeAttacks = "MeleeAttacks";
         const string sectionControls = "Controls";
         const string sectionMap = "Map";
         const string sectionStartup = "Startup";
@@ -272,6 +273,10 @@ namespace DaggerfallWorkshop
         // [Spells]
         public bool EnableSpellLighting { get; set; }
         public bool EnableSpellShadows { get; set; }
+
+        // [MeleeAttacks]
+        public int MeleeAttackDetection { get; set; }
+        public bool MeleeAttackFriendlyProtection { get; set; }
 
         // [Controls]
         public bool InvertMouseVertical { get; set; }
@@ -508,6 +513,9 @@ namespace DaggerfallWorkshop
             DisableEnemyDeathAlert = GetBool(sectionGUI, "DisableEnemyDeathAlert");
             HideLoginName = GetBool(sectionGUI, "HideLoginName");
 
+            MeleeAttackDetection = GetInt(sectionMeleeAttacks, "MeleeAttackDetection", 0, 1);
+            MeleeAttackFriendlyProtection = GetBool(sectionMeleeAttacks, "MeleeAttackFriendlyProtection");
+
             EnableSpellLighting = GetBool(sectionSpells, "EnableSpellLighting");
             EnableSpellShadows = GetBool(sectionSpells, "EnableSpellShadows");
 
@@ -704,6 +712,9 @@ namespace DaggerfallWorkshop
             SetInt(sectionGUI, "QuestRumorWeight", QuestRumorWeight);
             SetBool(sectionGUI, "DisableEnemyDeathAlert", DisableEnemyDeathAlert);
             SetBool(sectionGUI, "HideLoginName", HideLoginName);
+
+            SetInt(sectionMeleeAttacks, "MeleeAttackDetection", MeleeAttackDetection);
+            SetBool(sectionMeleeAttacks, "MeleeAttackFriendlyProtection", MeleeAttackFriendlyProtection);
 
             SetBool(sectionSpells, "EnableSpellLighting", EnableSpellLighting);
             SetBool(sectionSpells, "EnableSpellShadows", EnableSpellShadows);

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -14,6 +14,7 @@ game,                                               Game
 controls,                                           Controls
 audio,                                              Audio
 spells,                                             Spells
+meleeAttacks,                                       Melee Attacks
 tooltips,                                           Tooltips
 hud,                                                HUD
 gui,                                                GUI
@@ -59,6 +60,10 @@ bowDrawback,                                        Bows - draw and release
 bowDrawbackInfo,                                    Enables bow drawback while holding RH mouse; release to fire
 toggleSneak,                                        Toggle Sneak
 toggleSneakInfo,                                    Allows the Sneak action to be toggled rather than held
+meleeAttackDetection,                               Hit Detection
+meleeAttackDetectionInfo,                           Complexity of melee attack targeting
+meleeAttackFriendlyProtection,                      Protect Friendlies and Neutrals
+meleeAttackFriendlyProtectionInfo,                  Prevents non-hostile entities from being unintentionally attacked
 
 toolTips,                                           Tool Tips
 toolTipsInfo,                                       Shows information about GUI items


### PR DESCRIPTION
Implemented raycast-based collision for DaggerfallMissile from PR #2472 by [numidium](https://github.com/numidium) . Revised the layer mask switching and fixed the now-off-center arrow model resulting from the change. Also applies the layer mask to the Touch spell detection and tweaks the GetAimPosition method to prevent the player from targeting themselves with their own Touch spells addressing Issue #2768.

Additionally, incorporated the optimizations to DaggerfallMissile from PR #2770 by [DanyilYedelkin](https://github.com/DanyilYedelkin), taking into account the new raycast-based collision when needed. Original PR had an issue which applied the Player-excluding layer mask to all projectiles and area-of-effect regardless of caster which has been corrected. Also included the changes to WeaponManager that fixes the player melee attacks being blocked by colliders on the IgnoreRaycast layer (Issue #2767), as well as an optimization.

UPDATE:
Implemented the bounding box-based weapon collision for players. At the default settings, this does the following things when the player performs a melee attack:
1. Uses Physics.OverlapBox() to grab all colliders (using the WeaponManager layermask) in front of the player in an area based on the default weapon reach + spherecast radius.
2. For each collider, check if it is an entity
3. Check if collider's center is inside the camera's field-of-view
4. Check if line-of-sight to collider's center is unobstructed by environment and other entities (as well as within the weapon reach value)
5. Add collider to list (hitColliders)
6. After all overlapped colliders have been finished, perform WeaponDamage() on all colliders in hitColliders list
7. If hitColliders is empty, perform the old spherecast check to handle bashing doors and other actionable objects.

Two settings are included: **Hit Detection** and **Protect Friendlies and Neutrals**.

By default, **Hit Detection** is set to **Performance** and behaves as described above. If **Hit Detection** is set to **Quality**, then there are additional checks that happen in Steps 3 and 4 if their initial checks fail. There can be up to 4 tests checking if some other part of the target is in view or has clear LOS. If a test succeeds, the following tests are skipped. This lets the player hit entities that may be partially covered by the environment or other entities.

**Protect Friendlies and Neutrals** is enabled by default. While enabled, the check in Step 1 will skip wandering commoners and entities that are pacified, and these targets can only be damaged/killed by the old spherecast check in Step 7. This prevents attacking them by accident if the player is fighting an enemy while they're around.

Both settings can be accessed in the DFU Advanced Settings menu under Gameplay. They can also be changed mid-game from the Advanced Controls window.

For illustration:
<img width="689" height="407" alt="image" src="https://github.com/user-attachments/assets/1818c532-3c42-46f0-ae4f-e1f3e1950be5" />
<img width="550" height="415" alt="image" src="https://github.com/user-attachments/assets/4d52f4cb-9324-4c1e-a882-9b06651b69a6" />

The green capsule is the default DFU attack spherecast. The red box is the OverlapBox check. After the field-of-view, line-of-sight and weapon reach checks, the player's attack area is reduced to the semi-spherical shape inside the blue lines. In effect, it is somewhat like sweeping the spherecast across the whole of the player's view.

If the player increases the camera FOV through the settings, this will also increase the attack area but not the total weapon reach, for consistency:
<img width="700" height="436" alt="image" src="https://github.com/user-attachments/assets/d5de937f-82ca-402a-90b2-ea8dd459e872" />
