### PR TITLE
Replace WWW with UnityWebRequest for sound replacement

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
@@ -5,7 +5,7 @@
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: TheLacus
 // Contributors:
-// 
+//
 // Notes:
 //
 
@@ -13,6 +13,7 @@ using System.Collections;
 using System.IO;
 using UnityEngine;
 using DaggerfallWorkshop.Game.Utility.ModSupport;
+using UnityEngine.Networking;
 
 namespace DaggerfallWorkshop.Utility.AssetInjection
 {
@@ -86,20 +87,42 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
                 string path = Path.Combine(soundPath, name + extension);
                 if (File.Exists(path))
                 {
-                    WWW www = new WWW("file://" + path); // TODO: Replace with UnityWebRequest
-                    if (streaming) {
-                        audioClip = www.GetAudioClip(true, true);
+                    string url = "file://" + path;
+                    AudioType audioType = GetAudioTypeFromExtension(extension);
+
+                    UnityWebRequest request = UnityWebRequestMultimedia.GetAudioClip(url, audioType);
+                    DownloadHandlerAudioClip downloadHandler = request.downloadHandler as DownloadHandlerAudioClip;
+
+                    if (downloadHandler == null)
+                    {
+                        Debug.LogErrorFormat("Failed to create audio download handler for {0}", path);
+                        audioClip = null;
+                        request.Dispose();
+                        return false;
+                    }
+                    
+                    downloadHandler.streamAudio = streaming;
+
+                    request.SendWebRequest();
+
+                    if (streaming)
+                    {
+                        // Synchronous waiting otherwise the whole architecture has to be redone
+                        while (request.downloadedBytes < 128 * 1024) { }
+                        audioClip = downloadHandler.audioClip;
                     }
                     else
                     {
-                        audioClip = www.GetAudioClip();
-                        DaggerfallUnity.Instance.StartCoroutine(LoadAudioData(www, audioClip));
+                        // Synchronous waiting, otherwise the whole architecture has to be redone
+                        while (!request.isDone) { }
+                        audioClip = downloadHandler.audioClip;
                     }
+
                     return true;
                 }
 
                 // Seek from mods
-                if (ModManager.Instance != null && ModManager.Instance.TryGetAsset(name, false, out audioClip))
+                if (ModManager.Instance && ModManager.Instance.TryGetAsset(name, false, out audioClip))
                 {
                     if (audioClip.preloadAudioData || audioClip.LoadAudioData())
                         return true;
@@ -111,6 +134,7 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             audioClip = null;
             return false;
         }
+
 
         /// <summary>
         /// Import midi data from modding locations as a byte array.
@@ -143,17 +167,22 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
             return false;
         }
 
-        /// <summary>
-        /// Load audio data from WWW in background.
-        /// </summary>
-        private static IEnumerator LoadAudioData(WWW www, AudioClip clip) // TODO: Replace with UnityWebRequest
+        private static AudioType GetAudioTypeFromExtension(string extension)
         {
-            yield return www;
-
-            if (clip.loadState == AudioDataLoadState.Failed)
-                Debug.LogErrorFormat("Failed to load audioclip: {0}", www.error);
-
-            www.Dispose();
+            switch (extension.ToLowerInvariant())
+            {
+                case ".wav":
+                    return AudioType.WAV;
+                case ".mp3":
+                    return AudioType.MPEG;
+                case ".ogg":
+                    return AudioType.OGGVORBIS;
+                case ".aif":
+                case ".aiff":
+                    return AudioType.AIFF;
+                default:
+                    return AudioType.UNKNOWN;
+            }
         }
 
         #endregion


### PR DESCRIPTION
Updates the audio loading logic to use UnityWebRequestMultimedia instead of the deprecated WWW class. This implementation uses synchronous waiting to maintain compatibility with the existing architecture.

This implementation is based around how the whole sound caching in DFU works.

It would need a little bit more effort if going the full and correct asynchronous workflow but works for now and gets rid of the warning + might also fixes #2760 

Tested with .wav and .ogg replacing music and in-game sounds.