### PR TITLE
Added null srcImage check to the other DrawTexture overload.

### DIFF
--- a/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
+++ b/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
@@ -237,7 +237,7 @@ namespace DaggerfallWorkshop.Game.Utility
 
         void DrawTexture(ImageData srcImage, DaggerfallUnityItem item = null)
         {
-            if (srcImage.texture == null)
+            if (srcImage.texture == null || srcImage.offset == null)
                 return;
 
             DrawTexture(

--- a/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
+++ b/Assets/Scripts/Game/Utility/PaperDollRenderer.cs
@@ -237,6 +237,9 @@ namespace DaggerfallWorkshop.Game.Utility
 
         void DrawTexture(ImageData srcImage, DaggerfallUnityItem item = null)
         {
+            if (srcImage.texture == null)
+                return;
+
             DrawTexture(
                 srcImage,
                 new Rect(0, 0, 1, 1),


### PR DESCRIPTION
Extends #2757 to prevent the exception in #2740 from happening by calling the overload.