### PR TITLE
Fix SoundReplacement.cs

### DIFF
--- a/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
+++ b/Assets/Scripts/Utility/AssetInjection/SoundReplacement.cs
@@ -105,18 +105,9 @@ namespace DaggerfallWorkshop.Utility.AssetInjection
 
                     request.SendWebRequest();
 
-                    if (streaming)
-                    {
-                        // Synchronous waiting otherwise the whole architecture has to be redone
-                        while (request.downloadedBytes < 128 * 1024) { }
-                        audioClip = downloadHandler.audioClip;
-                    }
-                    else
-                    {
-                        // Synchronous waiting, otherwise the whole architecture has to be redone
-                        while (!request.isDone) { }
-                        audioClip = downloadHandler.audioClip;
-                    }
+                    // Synchronous waiting otherwise the whole architecture has to be redone
+                    while (!request.isDone) { }
+                    audioClip = downloadHandler.audioClip;
 
                     return true;
                 }


### PR DESCRIPTION
Fix an issue into SoundReplacement.cs introduced with PR #2782.
If a proposed OGG file to replace a standard tune of the game is lower than 128 Kb, the game will enter an infinite loop and freeze.
Now the code is the same whatever is the size of the OGG file.
