### PR TITLE
Suppress compilation warnings for CS0108 and CS0168

### DIFF
--- a/Assets/Game/Addons/RmbBlockEditor/Automap.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Automap.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -15,7 +15,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
     public class Automap : MonoBehaviour
     {
         public Byte[] automapData;
-        private MeshRenderer renderer;
+        private MeshRenderer meshRenderer;
 
         public void CreateObject(Byte[] automapData)
         {
@@ -26,7 +26,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
             groundPlane.transform.localScale = new Vector3(10.24f, 1f, 10.24f);
             groundPlane.transform.position = new Vector3(51.2f, 0, -51.2f);
             groundPlane.transform.rotation = Quaternion.Euler(0, 0, 0);
-            renderer = groundPlane.GetComponent<MeshRenderer>();
+            meshRenderer = groundPlane.GetComponent<MeshRenderer>();
             Update();
         }
 
@@ -99,7 +99,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
 
             tex.SetPixels32(0, 0, 64, 64, colors);
             tex.Apply();
-            renderer.sharedMaterial.mainTexture = tex;
+            meshRenderer.sharedMaterial.mainTexture = tex;
         }
     }
     #endif

--- a/Assets/Game/Addons/RmbBlockEditor/Persisted/BuildingTemplates.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Persisted/BuildingTemplates.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -42,7 +42,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     var deserialized = JsonConvert.DeserializeObject<BuildingTemplates>(data);
                     this._list = deserialized._list;
                 }
-                catch (Exception error)
+                catch (Exception)
                 {
                     // The file is corrupt, so save a new one
                     Save();
@@ -52,7 +52,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     reader.Close();
                 }
             }
-            catch (Exception error)
+            catch (Exception)
             {
                 // The file does not exist, so save the default catalog
                 var path = Environment.CurrentDirectory + this.DefaultTemplatesPath;

--- a/Assets/Game/Addons/RmbBlockEditor/Persisted/BuildingTemplates.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Persisted/BuildingTemplates.cs
@@ -5,11 +5,12 @@
 // Source Code:     https://github.com/Interkarma/daggerfall-unity
 // Original Author: Podleron (podleron@gmail.com)
 
+using DaggerfallWorkshop.Utility.AssetInjection;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using DaggerfallWorkshop.Utility.AssetInjection;
-using Newtonsoft.Json;
+using UnityEditor.PackageManager;
 using UnityEngine;
 
 namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
@@ -42,8 +43,9 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     var deserialized = JsonConvert.DeserializeObject<BuildingTemplates>(data);
                     this._list = deserialized._list;
                 }
-                catch (Exception)
+                catch (Exception error)
                 {
+                    Debug.LogException(error);
                     // The file is corrupt, so save a new one
                     Save();
                 }
@@ -52,8 +54,9 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     reader.Close();
                 }
             }
-            catch (Exception)
+            catch (Exception error)
             {
+                Debug.LogException(error);
                 // The file does not exist, so save the default catalog
                 var path = Environment.CurrentDirectory + this.DefaultTemplatesPath;
                 try

--- a/Assets/Game/Addons/RmbBlockEditor/Persisted/BuildingTemplates.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Persisted/BuildingTemplates.cs
@@ -10,7 +10,6 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEditor.PackageManager;
 using UnityEngine;
 
 namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor

--- a/Assets/Game/Addons/RmbBlockEditor/Persisted/Catalog.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Persisted/Catalog.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -47,7 +47,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     _list = deserialized._list;
                     GenerateCatalogDictionaries(_list, ref _items, ref _subcategories, ref _categories);
                 }
-                catch (Exception error)
+                catch (Exception)
                 {
                     // The file is corrupt, so save a new one
                     Save();
@@ -57,7 +57,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     reader.Close();
                 }
             }
-            catch (Exception error)
+            catch (Exception)
             {
                 // The file does not exist, so save the default catalog
                 RestoreDefaults();

--- a/Assets/Game/Addons/RmbBlockEditor/Persisted/Catalog.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Persisted/Catalog.cs
@@ -47,8 +47,9 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     _list = deserialized._list;
                     GenerateCatalogDictionaries(_list, ref _items, ref _subcategories, ref _categories);
                 }
-                catch (Exception)
+                catch (Exception error)
                 {
+                    Debug.LogException(error);
                     // The file is corrupt, so save a new one
                     Save();
                 }
@@ -57,8 +58,9 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     reader.Close();
                 }
             }
-            catch (Exception)
+            catch (Exception error)
             {
+                Debug.LogException(error);
                 // The file does not exist, so save the default catalog
                 RestoreDefaults();
             }

--- a/Assets/Game/Addons/RmbBlockEditor/Persisted/PersistedBuildingsCatalog.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Persisted/PersistedBuildingsCatalog.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -46,7 +46,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                 {
                     _catalog.LoadFromFile(data);
                 }
-                catch (Exception error)
+                catch (Exception)
                 {
                     // The file is corrupt, so save a new one
                     Save();
@@ -56,7 +56,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     reader.Close();
                 }
             }
-            catch (Exception error)
+            catch (Exception)
             {
                 RestoreDefault();
             }

--- a/Assets/Game/Addons/RmbBlockEditor/Persisted/PersistedBuildingsCatalog.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Persisted/PersistedBuildingsCatalog.cs
@@ -46,9 +46,10 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                 {
                     _catalog.LoadFromFile(data);
                 }
-                catch (Exception)
+                catch (Exception error)
                 {
                     // The file is corrupt, so save a new one
+                    Debug.LogException(error);
                     Save();
                 }
                 finally
@@ -56,8 +57,9 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     reader.Close();
                 }
             }
-            catch (Exception)
+            catch (Exception error)
             {
+                Debug.LogException(error);
                 RestoreDefault();
             }
         }

--- a/Assets/Game/Addons/RmbBlockEditor/Persisted/PersistedSettings.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Persisted/PersistedSettings.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -46,7 +46,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     _settings._climateSeason = deserialized._climateSeason;
                     _settings._windowStyle = deserialized._windowStyle;
                 }
-                catch (Exception error)
+                catch (Exception)
                 {
                     // The file is corrupt, so save a new one
                     Save();
@@ -56,7 +56,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     reader.Close();
                 }
             }
-            catch (Exception error)
+            catch (Exception)
             {
                 // The settings file does not exist, so save a new one
                 Save();

--- a/Assets/Game/Addons/RmbBlockEditor/Persisted/PersistedSettings.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/Persisted/PersistedSettings.cs
@@ -46,8 +46,9 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     _settings._climateSeason = deserialized._climateSeason;
                     _settings._windowStyle = deserialized._windowStyle;
                 }
-                catch (Exception)
+                catch (Exception error)
                 {
+                    Debug.LogException(error);  
                     // The file is corrupt, so save a new one
                     Save();
                 }
@@ -56,8 +57,9 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
                     reader.Close();
                 }
             }
-            catch (Exception)
+            catch (Exception error)
             {
+                Debug.LogException(error);  
                 // The settings file does not exist, so save a new one
                 Save();
             }

--- a/Assets/Game/Addons/RmbBlockEditor/RmbBlockHelper.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/RmbBlockHelper.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Tools For Unity
+// Project:         Daggerfall Tools For Unity
 // Copyright:       Copyright (C) 2009-2022 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -348,7 +348,7 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
 
                 return go;
             }
-            catch (Exception error)
+            catch (Exception)
             {
                 // Return a magenta-colored flat if the id can't be found
                 Texture2D texture = new Texture2D(1, 1);

--- a/Assets/Game/Addons/RmbBlockEditor/RmbBlockHelper.cs
+++ b/Assets/Game/Addons/RmbBlockEditor/RmbBlockHelper.cs
@@ -348,8 +348,9 @@ namespace DaggerfallWorkshop.Game.Addons.RmbBlockEditor
 
                 return go;
             }
-            catch (Exception)
+            catch (Exception error)
             {
+                Debug.LogException(error);
                 // Return a magenta-colored flat if the id can't be found
                 Texture2D texture = new Texture2D(1, 1);
                 texture.SetPixel(0, 0, Color.magenta);


### PR DESCRIPTION
Compilation warnings linked to the name of an inherited method (automap.cs) and data declared but not used (5 other files).
Code was updated so that these warnings are not anymore displayed.