### PR TITLE
Performance Enhancement: GameObject Culling

### DIFF
--- a/Assets/Resources/defaults.ini.txt
+++ b/Assets/Resources/defaults.ini.txt
@@ -31,6 +31,7 @@ DungeonShadowDistance=20.0
 InteriorShadowDistance=30.0
 ExteriorShadowDistance=90.0
 EnableTextureArrays=True
+EnableObjectCulling=True
 RandomDungeonTextures=0
 
 [Effects]

--- a/Assets/Scenes/DaggerfallUnityGame.unity
+++ b/Assets/Scenes/DaggerfallUnityGame.unity
@@ -2894,3 +2894,78 @@ PrefabInstance:
       objectReference: {fileID: 1769263313}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bbe5e15c9f6b3dc47bb9485a437750a0, type: 3}
+--- !u!114 &69466200359737372
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1834928754549345153}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 43fe9d3db5f70f24bb00284402a4d97e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  culledObjectsParent: {fileID: 1269490794079082448}
+--- !u!4 &357226078190250312
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1834928754549345153}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 14.787919, y: 27.745857, z: 29.176554}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2109761705362116671}
+  m_Father: {fileID: 0}
+  m_RootOrder: 23
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1269490794079082448
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2109761705362116671}
+  m_Layer: 0
+  m_Name: CulledObjects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!1 &1834928754549345153
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 357226078190250312}
+  - component: {fileID: 69466200359737372}
+  m_Layer: 0
+  m_Name: CulledGameObjectManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2109761705362116671
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1269490794079082448}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 357226078190250312}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/ActiveGameObjectDatabase.cs
+++ b/Assets/Scripts/ActiveGameObjectDatabase.cs
@@ -29,7 +29,7 @@ namespace DaggerfallWorkshop
 
         // Returns all the active GameObjects in the cache
         // If a system calls SetActive(false) on an object without destroying it, it will not be returned here
-        public IEnumerable<GameObject> GetActiveObjects()
+        public IEnumerable<GameObject> GetActiveObjects(bool includeInactive = false)
         {
             cacheLock.EnterReadLock();
             try
@@ -42,7 +42,7 @@ namespace DaggerfallWorkshop
                         // A null check on a GameObject does more than C#'s reference check,
                         // it also checks if the object has been destroyed
                         // Like Object.FindObjectsOfType, we should only include active objects 
-                        if (activeObject != null && activeObject.activeInHierarchy)
+                        if (activeObject != null && (includeInactive || activeObject.activeInHierarchy))
                             gameObjects.Add(activeObject);
                     }
                 }
@@ -57,12 +57,12 @@ namespace DaggerfallWorkshop
 
         // Returns all the enabled components of active GameObjects in the cache
         // If a system calls SetActive(false) on an object without destroying it, it will not be returned here
-        public IEnumerable<T> GetActiveComponents<T>() where T : MonoBehaviour
+        public IEnumerable<T> GetActiveComponents<T>(bool includeInactive = false) where T : MonoBehaviour
         {
-            foreach (GameObject gameObject in GetActiveObjects())
+            foreach (GameObject gameObject in GetActiveObjects(includeInactive))
             {
                 var t = gameObject.GetComponent<T>();
-                if (t != null && t.isActiveAndEnabled)
+                if (t != null && (includeInactive || t.isActiveAndEnabled))
                     yield return t;
             }
         }
@@ -201,35 +201,51 @@ namespace DaggerfallWorkshop
         static GameObjectCache staticNpcCache = new GameObjectCache("Static NPC");
         static GameObjectCache actionDoorCache = new GameObjectCache("Action Door");
         static GameObjectCache rdbCache = new GameObjectCache("RDB");
+        static GameObjectCache billboardCache = new GameObjectCache("Billboard");
+
+        public static IEnumerable<GameObject> GetActiveBillboardObjects(bool includeInactive = false)
+        {
+            return billboardCache.GetActiveObjects(includeInactive);
+        }
+
+        public static IEnumerable<DaggerfallBillboard> GetActiveBillboards(bool includeInactive = false)
+        {
+            return billboardCache.GetActiveComponents<DaggerfallBillboard>(includeInactive);
+        }
+
+        public static void RegisterBillboard(GameObject billboard)
+        {
+            billboardCache.AddObject(billboard);
+        }
 
         // Gets all the active enemy GameObjects. Must be registered as Enemy (see below)
-        public static IEnumerable<GameObject> GetActiveEnemyObjects()
+        public static IEnumerable<GameObject> GetActiveEnemyObjects(bool includeInactive = false)
         {
-            return enemyCache.GetActiveObjects();
+            return enemyCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallEntityBehaviour components from active registered enemies
-        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveEnemyBehaviours()
+        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveEnemyBehaviours(bool includeInactive = false)
         {
-            return enemyCache.GetActiveComponents<DaggerfallEntityBehaviour>();
+            return enemyCache.GetActiveComponents<DaggerfallEntityBehaviour>(includeInactive);
         }
 
         // Gets all the enabled DaggerfallEnemy components from active registered enemies
-        public static IEnumerable<DaggerfallEnemy> GetActiveEnemyEntities()
+        public static IEnumerable<DaggerfallEnemy> GetActiveEnemyEntities(bool includeInactive = false)
         {
-            return enemyCache.GetActiveComponents<DaggerfallEnemy>();
+            return enemyCache.GetActiveComponents<DaggerfallEnemy>(includeInactive);
         }
 
         // Gets all the enabled QuestResourceBehaviour components from active registered enemies
-        public static IEnumerable<QuestResourceBehaviour> GetActiveEnemyQuestResourceBehaviours()
+        public static IEnumerable<QuestResourceBehaviour> GetActiveEnemyQuestResourceBehaviours(bool includeInactive = false)
         {
-            return enemyCache.GetActiveComponents<QuestResourceBehaviour>();
+            return enemyCache.GetActiveComponents<QuestResourceBehaviour>(includeInactive);
         }
 
         // Gets all the enabled EnemyMotor components from active registered enemies
-        public static IEnumerable<EnemyMotor> GetActiveEnemyMotors()
+        public static IEnumerable<EnemyMotor> GetActiveEnemyMotors(bool includeInactive = false)
         {
-            return enemyCache.GetActiveComponents<EnemyMotor>();
+            return enemyCache.GetActiveComponents<EnemyMotor>(includeInactive);
         }
 
         // Registers an enemy (monster or class) to the enemy cache. Does not have to be active
@@ -239,15 +255,15 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active Civilian Mobile GameObjects. Must be registered as Civilian Mobile (see below)
-        public static IEnumerable<GameObject> GetActiveCivilianMobileObjects()
+        public static IEnumerable<GameObject> GetActiveCivilianMobileObjects(bool includeInactive = false)
         {
-            return civilianCache.GetActiveObjects();
+            return civilianCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallEntityBehaviour components from active registered Civilian Mobiles
-        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveCivilianMobileBehaviours()
+        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveCivilianMobileBehaviours(bool includeInactive = false)
         {
-            return civilianCache.GetActiveComponents<DaggerfallEntityBehaviour>();
+            return civilianCache.GetActiveComponents<DaggerfallEntityBehaviour>(includeInactive);
         }
 
         // Registers a mobile civilian NPC to the civilian cache. Does not have to be active
@@ -257,15 +273,15 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active loot GameObjects. Must be registered as Loot (see below)
-        public static IEnumerable<GameObject> GetActiveLootObjects()
+        public static IEnumerable<GameObject> GetActiveLootObjects(bool includeInactive = false)
         {
-            return lootCache.GetActiveObjects();
+            return lootCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallLoot components from active registered loot
-        public static IEnumerable<DaggerfallLoot> GetActiveLoot()
+        public static IEnumerable<DaggerfallLoot> GetActiveLoot(bool includeInactive = false)
         {
-            return lootCache.GetActiveComponents<DaggerfallLoot>();
+            return lootCache.GetActiveComponents<DaggerfallLoot>(includeInactive);
         }
 
         // Registers a loot object to the loot cache. Does not have to be active
@@ -275,15 +291,15 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active Foe Spawner GameObjects. Must be registered as Foe Spawner (see below)
-        public static IEnumerable<GameObject> GetActiveFoeSpawnerObjects()
+        public static IEnumerable<GameObject> GetActiveFoeSpawnerObjects(bool includeInactive = false)
         {
-            return foeSpawnerCache.GetActiveObjects();
+            return foeSpawnerCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled FoeSpawner components from active registered foe spawners
-        public static IEnumerable<FoeSpawner> GetActiveFoeSpawners()
+        public static IEnumerable<FoeSpawner> GetActiveFoeSpawners(bool includeInactive = false)
         {
-            return foeSpawnerCache.GetActiveComponents<FoeSpawner>();
+            return foeSpawnerCache.GetActiveComponents<FoeSpawner>(includeInactive);
         }
 
         // Registers a foe spawner object to the foe spawner cache. Does not have to be active
@@ -293,21 +309,21 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active Static NPC GameObjects. Must be registered as a Static NPC (see below)
-        public static IEnumerable<GameObject> GetActiveStaticNPCObjects()
+        public static IEnumerable<GameObject> GetActiveStaticNPCObjects(bool includeInactive = false)
         {
-            return staticNpcCache.GetActiveObjects();
+            return staticNpcCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled StaticNPC components from active registered static NPCs
-        public static IEnumerable<StaticNPC> GetActiveStaticNPCs()
+        public static IEnumerable<StaticNPC> GetActiveStaticNPCs(bool includeInactive = false)
         {
-            return staticNpcCache.GetActiveComponents<StaticNPC>();
+            return staticNpcCache.GetActiveComponents<StaticNPC>(includeInactive);
         }
 
         // Gets all the enabled QuestResourceBehaviour components from active registered static NPCs
-        public static IEnumerable<QuestResourceBehaviour> GetActiveStaticNPCQuestResourceBehaviours()
+        public static IEnumerable<QuestResourceBehaviour> GetActiveStaticNPCQuestResourceBehaviours(bool includeInactive = false)
         {
-            return staticNpcCache.GetActiveComponents<QuestResourceBehaviour>();
+            return staticNpcCache.GetActiveComponents<QuestResourceBehaviour>(includeInactive);
         }
 
         // Registers a static NPC object to the Static NPC cache. Does not have to be active
@@ -317,15 +333,15 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active Action Door GameObjects. Must be registered as Action Door (see below)
-        public static IEnumerable<GameObject> GetActiveActionDoorObjects()
+        public static IEnumerable<GameObject> GetActiveActionDoorObjects(bool includeInactive = false)
         {
-            return actionDoorCache.GetActiveObjects();
+            return actionDoorCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallActionDoor components from active registered doors
-        public static IEnumerable<DaggerfallActionDoor> GetActiveActionDoors()
+        public static IEnumerable<DaggerfallActionDoor> GetActiveActionDoors(bool includeInactive = false)
         {
-            return actionDoorCache.GetActiveComponents<DaggerfallActionDoor>();
+            return actionDoorCache.GetActiveComponents<DaggerfallActionDoor>(includeInactive);
         }
 
         // Registers an Action Door object to the Action Door cache. Does not have to be active
@@ -336,15 +352,15 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active RDB GameObjects. Must be registered as RDB (see below)
-        public static IEnumerable<GameObject> GetActiveRDBObjects()
+        public static IEnumerable<GameObject> GetActiveRDBObjects(bool includeInactive = false)
         {
-            return rdbCache.GetActiveObjects();
+            return rdbCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallStaticDoors components from active registered RDBs
-        public static IEnumerable<DaggerfallStaticDoors> GetActiveRDBStaticDoors()
+        public static IEnumerable<DaggerfallStaticDoors> GetActiveRDBStaticDoors(bool includeInactive = false)
         {
-            return rdbCache.GetActiveComponents<DaggerfallStaticDoors>();
+            return rdbCache.GetActiveComponents<DaggerfallStaticDoors>(includeInactive);
         }
 
         // Registers a Daggerfall dungeon block "RDB" game object to the RDB cache. Does not have to be active
@@ -363,6 +379,7 @@ namespace DaggerfallWorkshop
             yield return staticNpcCache.GetDebugString();
             yield return actionDoorCache.GetDebugString();
             yield return rdbCache.GetDebugString();
+            yield return billboardCache.GetDebugString();
         }
     }
 }

--- a/Assets/Scripts/ActiveGameObjectDatabase.cs
+++ b/Assets/Scripts/ActiveGameObjectDatabase.cs
@@ -29,7 +29,12 @@ namespace DaggerfallWorkshop
 
         // Returns all the active GameObjects in the cache
         // If a system calls SetActive(false) on an object without destroying it, it will not be returned here
-        public IEnumerable<GameObject> GetActiveObjects(bool includeInactive = false)
+        public IEnumerable<GameObject> GetActiveObjects()
+        {
+            return GetActiveObjects(false);
+        }
+
+        public IEnumerable<GameObject> GetActiveObjects(bool includeInactive)
         {
             cacheLock.EnterReadLock();
             try
@@ -57,7 +62,12 @@ namespace DaggerfallWorkshop
 
         // Returns all the enabled components of active GameObjects in the cache
         // If a system calls SetActive(false) on an object without destroying it, it will not be returned here
-        public IEnumerable<T> GetActiveComponents<T>(bool includeInactive = false) where T : MonoBehaviour
+        public IEnumerable<T> GetActiveComponents<T>() where T : MonoBehaviour
+        {
+            return GetActiveComponents<T>(false);
+        }
+
+        public IEnumerable<T> GetActiveComponents<T>(bool includeInactive) where T : MonoBehaviour
         {
             foreach (GameObject gameObject in GetActiveObjects(includeInactive))
             {
@@ -203,12 +213,22 @@ namespace DaggerfallWorkshop
         static GameObjectCache rdbCache = new GameObjectCache("RDB");
         static GameObjectCache billboardCache = new GameObjectCache("Billboard");
 
-        public static IEnumerable<GameObject> GetActiveBillboardObjects(bool includeInactive = false)
+        public static IEnumerable<GameObject> GetActiveBillboardObjects()
+        {
+            return GetActiveBillboardObjects(false);
+        }
+
+        public static IEnumerable<GameObject> GetActiveBillboardObjects(bool includeInactive)
         {
             return billboardCache.GetActiveObjects(includeInactive);
         }
 
-        public static IEnumerable<DaggerfallBillboard> GetActiveBillboards(bool includeInactive = false)
+        public static IEnumerable<DaggerfallBillboard> GetActiveBillboards()
+        {
+            return GetActiveBillboards(false);
+        }
+
+        public static IEnumerable<DaggerfallBillboard> GetActiveBillboards(bool includeInactive)
         {
             return billboardCache.GetActiveComponents<DaggerfallBillboard>(includeInactive);
         }
@@ -219,31 +239,56 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active enemy GameObjects. Must be registered as Enemy (see below)
-        public static IEnumerable<GameObject> GetActiveEnemyObjects(bool includeInactive = false)
+        public static IEnumerable<GameObject> GetActiveEnemyObjects()
+        {
+            return GetActiveEnemyObjects(false);
+        }
+
+        public static IEnumerable<GameObject> GetActiveEnemyObjects(bool includeInactive)
         {
             return enemyCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallEntityBehaviour components from active registered enemies
-        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveEnemyBehaviours(bool includeInactive = false)
+        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveEnemyBehaviours()
+        {
+            return GetActiveEnemyBehaviours(false);
+        }
+
+        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveEnemyBehaviours(bool includeInactive)
         {
             return enemyCache.GetActiveComponents<DaggerfallEntityBehaviour>(includeInactive);
         }
 
         // Gets all the enabled DaggerfallEnemy components from active registered enemies
-        public static IEnumerable<DaggerfallEnemy> GetActiveEnemyEntities(bool includeInactive = false)
+        public static IEnumerable<DaggerfallEnemy> GetActiveEnemyEntities()
+        {
+            return GetActiveEnemyEntities(false);
+        }
+
+        public static IEnumerable<DaggerfallEnemy> GetActiveEnemyEntities(bool includeInactive)
         {
             return enemyCache.GetActiveComponents<DaggerfallEnemy>(includeInactive);
         }
 
         // Gets all the enabled QuestResourceBehaviour components from active registered enemies
-        public static IEnumerable<QuestResourceBehaviour> GetActiveEnemyQuestResourceBehaviours(bool includeInactive = false)
+        public static IEnumerable<QuestResourceBehaviour> GetActiveEnemyQuestResourceBehaviours()
+        {
+            return GetActiveEnemyQuestResourceBehaviours(false);
+        }
+
+        public static IEnumerable<QuestResourceBehaviour> GetActiveEnemyQuestResourceBehaviours(bool includeInactive)
         {
             return enemyCache.GetActiveComponents<QuestResourceBehaviour>(includeInactive);
         }
 
         // Gets all the enabled EnemyMotor components from active registered enemies
-        public static IEnumerable<EnemyMotor> GetActiveEnemyMotors(bool includeInactive = false)
+        public static IEnumerable<EnemyMotor> GetActiveEnemyMotors()
+        {
+            return GetActiveEnemyMotors(false);
+        }
+
+        public static IEnumerable<EnemyMotor> GetActiveEnemyMotors(bool includeInactive)
         {
             return enemyCache.GetActiveComponents<EnemyMotor>(includeInactive);
         }
@@ -255,13 +300,23 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active Civilian Mobile GameObjects. Must be registered as Civilian Mobile (see below)
-        public static IEnumerable<GameObject> GetActiveCivilianMobileObjects(bool includeInactive = false)
+        public static IEnumerable<GameObject> GetActiveCivilianMobileObjects()
+        {
+            return GetActiveCivilianMobileObjects(false);
+        }
+
+        public static IEnumerable<GameObject> GetActiveCivilianMobileObjects(bool includeInactive)
         {
             return civilianCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallEntityBehaviour components from active registered Civilian Mobiles
-        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveCivilianMobileBehaviours(bool includeInactive = false)
+        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveCivilianMobileBehaviours()
+        {
+            return GetActiveCivilianMobileBehaviours(false);
+        }
+
+        public static IEnumerable<DaggerfallEntityBehaviour> GetActiveCivilianMobileBehaviours(bool includeInactive)
         {
             return civilianCache.GetActiveComponents<DaggerfallEntityBehaviour>(includeInactive);
         }
@@ -273,13 +328,23 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active loot GameObjects. Must be registered as Loot (see below)
-        public static IEnumerable<GameObject> GetActiveLootObjects(bool includeInactive = false)
+        public static IEnumerable<GameObject> GetActiveLootObjects()
+        {
+            return GetActiveLootObjects(false);
+        }
+
+        public static IEnumerable<GameObject> GetActiveLootObjects(bool includeInactive)
         {
             return lootCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallLoot components from active registered loot
-        public static IEnumerable<DaggerfallLoot> GetActiveLoot(bool includeInactive = false)
+        public static IEnumerable<DaggerfallLoot> GetActiveLoot()
+        {
+            return GetActiveLoot(false);
+        }
+
+        public static IEnumerable<DaggerfallLoot> GetActiveLoot(bool includeInactive)
         {
             return lootCache.GetActiveComponents<DaggerfallLoot>(includeInactive);
         }
@@ -291,13 +356,23 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active Foe Spawner GameObjects. Must be registered as Foe Spawner (see below)
-        public static IEnumerable<GameObject> GetActiveFoeSpawnerObjects(bool includeInactive = false)
+        public static IEnumerable<GameObject> GetActiveFoeSpawnerObjects()
+        {
+            return GetActiveFoeSpawnerObjects(false);
+        }
+
+        public static IEnumerable<GameObject> GetActiveFoeSpawnerObjects(bool includeInactive)
         {
             return foeSpawnerCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled FoeSpawner components from active registered foe spawners
-        public static IEnumerable<FoeSpawner> GetActiveFoeSpawners(bool includeInactive = false)
+        public static IEnumerable<FoeSpawner> GetActiveFoeSpawners()
+        {
+            return GetActiveFoeSpawners(false);
+        }
+
+        public static IEnumerable<FoeSpawner> GetActiveFoeSpawners(bool includeInactive)
         {
             return foeSpawnerCache.GetActiveComponents<FoeSpawner>(includeInactive);
         }
@@ -309,19 +384,34 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active Static NPC GameObjects. Must be registered as a Static NPC (see below)
-        public static IEnumerable<GameObject> GetActiveStaticNPCObjects(bool includeInactive = false)
+        public static IEnumerable<GameObject> GetActiveStaticNPCObjects()
+        {
+            return GetActiveStaticNPCObjects(false);
+        }
+
+        public static IEnumerable<GameObject> GetActiveStaticNPCObjects(bool includeInactive)
         {
             return staticNpcCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled StaticNPC components from active registered static NPCs
-        public static IEnumerable<StaticNPC> GetActiveStaticNPCs(bool includeInactive = false)
+        public static IEnumerable<StaticNPC> GetActiveStaticNPCs()
+        {
+            return GetActiveStaticNPCs(false);
+        }
+
+        public static IEnumerable<StaticNPC> GetActiveStaticNPCs(bool includeInactive)
         {
             return staticNpcCache.GetActiveComponents<StaticNPC>(includeInactive);
         }
 
         // Gets all the enabled QuestResourceBehaviour components from active registered static NPCs
-        public static IEnumerable<QuestResourceBehaviour> GetActiveStaticNPCQuestResourceBehaviours(bool includeInactive = false)
+        public static IEnumerable<QuestResourceBehaviour> GetActiveStaticNPCQuestResourceBehaviours()
+        {
+            return GetActiveStaticNPCQuestResourceBehaviours(false);
+        }
+
+        public static IEnumerable<QuestResourceBehaviour> GetActiveStaticNPCQuestResourceBehaviours(bool includeInactive)
         {
             return staticNpcCache.GetActiveComponents<QuestResourceBehaviour>(includeInactive);
         }
@@ -333,13 +423,23 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active Action Door GameObjects. Must be registered as Action Door (see below)
-        public static IEnumerable<GameObject> GetActiveActionDoorObjects(bool includeInactive = false)
+        public static IEnumerable<GameObject> GetActiveActionDoorObjects()
+        {
+            return GetActiveActionDoorObjects(false);
+        }
+
+        public static IEnumerable<GameObject> GetActiveActionDoorObjects(bool includeInactive)
         {
             return actionDoorCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallActionDoor components from active registered doors
-        public static IEnumerable<DaggerfallActionDoor> GetActiveActionDoors(bool includeInactive = false)
+        public static IEnumerable<DaggerfallActionDoor> GetActiveActionDoors()
+        {
+            return GetActiveActionDoors(false);
+        }
+
+        public static IEnumerable<DaggerfallActionDoor> GetActiveActionDoors(bool includeInactive)
         {
             return actionDoorCache.GetActiveComponents<DaggerfallActionDoor>(includeInactive);
         }
@@ -352,13 +452,23 @@ namespace DaggerfallWorkshop
         }
 
         // Gets all the active RDB GameObjects. Must be registered as RDB (see below)
-        public static IEnumerable<GameObject> GetActiveRDBObjects(bool includeInactive = false)
+        public static IEnumerable<GameObject> GetActiveRDBObjects()
+        {
+            return GetActiveRDBObjects(false);
+        }
+
+        public static IEnumerable<GameObject> GetActiveRDBObjects(bool includeInactive)
         {
             return rdbCache.GetActiveObjects(includeInactive);
         }
 
         // Gets all the enabled DaggerfallStaticDoors components from active registered RDBs
-        public static IEnumerable<DaggerfallStaticDoors> GetActiveRDBStaticDoors(bool includeInactive = false)
+        public static IEnumerable<DaggerfallStaticDoors> GetActiveRDBStaticDoors()
+        {
+            return GetActiveRDBStaticDoors(false);
+        }
+
+        public static IEnumerable<DaggerfallStaticDoors> GetActiveRDBStaticDoors(bool includeInactive)
         {
             return rdbCache.GetActiveComponents<DaggerfallStaticDoors>(includeInactive);
         }

--- a/Assets/Scripts/Game/CulledGameObjectManager.cs
+++ b/Assets/Scripts/Game/CulledGameObjectManager.cs
@@ -1,0 +1,336 @@
+using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Serialization;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace DaggerfallWorkshop.Game
+{
+    public struct CulledGameObject
+    {
+        public GameObject gameObject;
+        public Transform originalParent;
+        public Vector3 originalLocalPosition;
+        public Quaternion originalLocalRotation;
+        public bool wasOriginalParentNull;
+        public bool wasObjectInside;
+        public CulledGameObject(GameObject objectToCull)
+        {
+            gameObject = objectToCull;
+            originalParent = objectToCull.transform.parent;
+            originalLocalPosition = objectToCull.transform.localPosition;
+            originalLocalRotation = objectToCull.transform.localRotation;
+            wasOriginalParentNull = objectToCull.transform.parent == null;
+            wasObjectInside = GameManager.Instance.IsPlayerInside;
+        }
+    }
+
+    public class CulledGameObjectManager : MonoBehaviour
+    {
+        public static CulledGameObjectManager Instance { get; private set; }
+        public const float UnscaledBlockRange = 2060;
+        public const float ScaledBlockRange = UnscaledBlockRange * MeshReader.GlobalScale;
+        public const float ScaledBlockRangeSquared = ScaledBlockRange * ScaledBlockRange;
+
+        [SerializeField]
+        private GameObject culledObjectsParent;
+
+        private Dictionary<int, CulledGameObject> culledObjects = new Dictionary<int, CulledGameObject>();
+        private List<int> keysToRemove = new List<int>();
+        private int cullIteration = 0;
+
+        private int lastFrameCulledAndUnculledAllObjects = -1;
+
+        private Vector3 lastPlayerPosition = new Vector3(0, 0, 0);
+        private bool wasPlayerInside = false;
+
+        private void Awake()
+        {
+            if (Instance == null)
+            {
+                Instance = this;
+            }
+            else
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            if (culledObjectsParent == null)
+            {
+                culledObjectsParent = new GameObject("CulledObjectsParent");
+                culledObjectsParent.transform.parent = transform;
+                culledObjectsParent.SetActive(false);
+            }
+        }
+        private void Start()
+        {
+            lastPlayerPosition = GameManager.Instance.PlayerMotor.transform.position;
+            SaveLoadManager.OnLoad += OnLoadEvent;
+        }
+        private void OnDestroy()
+        {
+            SaveLoadManager.OnLoad -= OnLoadEvent;
+        }
+        private void Update()
+        {
+            if (!DaggerfallUnity.Settings.EnableObjectCulling)
+            {
+                UnCullAllObjects();
+                return;
+            }
+
+            Vector3 playerPosition = GameManager.Instance.PlayerMotor.transform.position;
+            // Remove any deleted gameObjects from the culled objects
+            RemoveAnyDeletedObjectsFromCulledDictionary();
+            if (GameManager.Instance.IsPlayerInside != wasPlayerInside
+                || (playerPosition - lastPlayerPosition).sqrMagnitude > ScaledBlockRangeSquared / 4
+                || culledObjects.Count == 0) // make sure everything is updated instantly upon teleport/transition
+            {
+                UpdateAllCullableObjects(playerPosition);
+            }
+            else
+                UpdateCullableObjectsBasedOnIteration(cullIteration, playerPosition); // otherwise do a new batch of objects every other frame.
+            cullIteration++;
+            cullIteration %= 12;
+            lastPlayerPosition = playerPosition;
+            wasPlayerInside = GameManager.Instance.IsPlayerInside;
+        }
+
+        public bool IsObjectCulled(GameObject obj)
+        {
+            return obj && culledObjects.ContainsKey(obj.GetInstanceID());
+        }
+        private void UpdateAllCullableObjects(Vector3 playerPosition, bool skipDoors = true)
+        {
+            // prevent multiple calls updating all cullable objects in the same frame
+            if (Time.frameCount == lastFrameCulledAndUnculledAllObjects)
+                return;
+            lastFrameCulledAndUnculledAllObjects = Time.frameCount;
+
+            // now iterate through and cull/uncull all objects
+            for (int i = 0; i <= 10; i += 2)
+            {
+                if (skipDoors && i == 4)
+                    continue; // skip doors if asked to do so
+                UpdateCullableObjectsBasedOnIteration(i, playerPosition);
+            }
+            cullIteration = 10; // jump to iteration 10 so it's a couple frames and then it starts over
+        }
+        private void UpdateCullableObjectsBasedOnIteration(int cullIteration, Vector3 playerPosition)
+        {
+            // Cull and un-cull objects based on range. All objects outside of the ScaledBlockRange distance from player should be culled.
+            switch (cullIteration)
+            {
+                case 0:
+                    if (!GameManager.Instance.IsPlayerInside)
+                        CullAndUncullDistantObjects(playerPosition, ActiveGameObjectDatabase.GetActiveBillboardObjects(true), 150 * 150);
+                    CullAndUncullDistantObjects(playerPosition, ActiveGameObjectDatabase.GetActiveFoeSpawnerObjects(true));
+                    break;
+                case 2:
+                    CullAndUncullDistantObjects(playerPosition, ActiveGameObjectDatabase.GetActiveEnemyObjects(true));
+                    CullAndUncullDistantDungeonBlocks(playerPosition, ActiveGameObjectDatabase.GetActiveRDBObjects(true).Where(p => !p.transform.root || p.transform.root.gameObject.name != "Automap"));
+                    break;
+                case 4:
+                    CullAndUncullDistantObjects(playerPosition, ActiveGameObjectDatabase.GetActiveActionDoorObjects(true));
+                    break;
+                case 6:
+                    CullAndUncullDistantObjects(playerPosition, ActiveGameObjectDatabase.GetActiveStaticNPCObjects(true));
+                    break;
+                case 8:
+                    CullAndUncullDistantObjects(playerPosition, ActiveGameObjectDatabase.GetActiveLootObjects(true));
+                    break;
+                case 10:
+                    break;
+                //disabled since civilian mobile objects already cull themselves.
+                //case 5:
+                //    //allCullableObjects.AddRange(ActiveGameObjectDatabase.GetActiveCivilianMobileObjects(true)); 
+                //    break;
+
+            }
+        }
+
+        private void RemoveAnyDeletedObjectsFromCulledDictionary()
+        {
+            foreach (var kvp in culledObjects)
+            {
+                if (!kvp.Value.gameObject || !kvp.Value.wasOriginalParentNull && !kvp.Value.originalParent || kvp.Value.wasObjectInside != GameManager.Instance.IsPlayerInside)
+                    keysToRemove.Add(kvp.Key);
+            }
+            foreach (int k in keysToRemove)
+            {
+                if (culledObjects[k].gameObject)
+                    Destroy(culledObjects[k].gameObject);
+                culledObjects.Remove(k);
+            }
+            keysToRemove.Clear();
+        }
+        private void CullAndUncullDistantObjects(Vector3 playerPosition, IEnumerable<GameObject> cullableObjects, float maxSquaredDistance = ScaledBlockRangeSquared)
+        {
+            foreach (GameObject obj in cullableObjects)
+            {
+                if (obj.transform.position.sqrMagnitude < 0.0001f)  // Don't cull objects spawned at world origin.
+                    continue;                                       // These are usually things like quest spawners.
+
+                float sqrDistance = (playerPosition - obj.transform.position).sqrMagnitude;
+                if (sqrDistance > maxSquaredDistance)
+                {
+                    if (!IsObjectCulled(obj))
+                    {
+                        CullObject(obj);
+                    }
+                }
+                else
+                {
+                    if (IsObjectCulled(obj))
+                    {
+                        UnCullObject(obj);
+                    }
+                }
+            }
+        }
+        private void CullAndUncullDistantDungeonBlocks(Vector3 playerPosition, IEnumerable<GameObject> cullableRDBObjects)
+        {
+            foreach (GameObject block in cullableRDBObjects)
+            {
+                // Constructing bounds manually based on the block's footprint and pivot information
+                Vector3 blockCenter = block.transform.position + Vector3.one * (1024 * MeshReader.GlobalScale); // Center of the block
+                Vector3 blockSize = Vector3.one * (2048 * MeshReader.GlobalScale); // Assuming infinite height for simplicity
+                Bounds blockBounds = new Bounds(blockCenter, blockSize);
+
+                // Check if the player is within the ScaledBlockRange from the closest point on the bounds
+                float closestPointDistance = Vector3.Distance(playerPosition, blockBounds.ClosestPoint(playerPosition));
+                if (closestPointDistance > ScaledBlockRange && !blockBounds.Contains(playerPosition)) // Check if outside range and player not inside block
+                {
+                    if (!IsObjectCulled(block))
+                    {
+                        CullDungeonBlock(block);
+                    }
+                }
+                else
+                {
+                    if (IsObjectCulled(block))
+                    {
+                        UnCullDungeonBlock(block);
+                    }
+                }
+            }
+        }
+
+        private bool CullObject(GameObject objectToCull)
+        {
+            if (!objectToCull)
+                return false;
+            int objectToCullID = objectToCull.GetInstanceID();
+            if (objectToCull == null || culledObjects.ContainsKey(objectToCullID))
+                return false;
+
+            CulledGameObject culledObject = new CulledGameObject(objectToCull);
+
+            objectToCull.transform.SetParent(culledObjectsParent.transform, true);
+            culledObjects[objectToCullID] = culledObject;
+            return true;
+        }
+
+        private bool UnCullObject(GameObject objectToUnCull)
+        {
+            if (!objectToUnCull)
+                return false;
+            int objectToUncullID = objectToUnCull.GetInstanceID();
+            if (!culledObjects.ContainsKey(objectToUncullID))
+                return false;
+            CulledGameObject culledObject = culledObjects[objectToUncullID];
+
+            if (culledObject.gameObject != null)
+            {
+                if (!culledObject.wasOriginalParentNull && !culledObject.originalParent) // If the original parent was destroyed
+                {
+                    Destroy(culledObject.gameObject); // Destroy the object, since it would have been destroyed along with the parent
+                }
+                else // Parent exists or it didn't have one in the first place. Restore the original parent and transform
+                {
+                    culledObject.gameObject.transform.SetParent(culledObject.originalParent, true);
+                    culledObject.gameObject.transform.localPosition = culledObject.originalLocalPosition;
+                    culledObject.gameObject.transform.localRotation = culledObject.originalLocalRotation;
+                }
+            }
+            culledObjects.Remove(objectToUncullID);
+            return true;
+        }
+
+        private bool CullDungeonBlock(GameObject dungeonBlock)
+        {
+            if (!dungeonBlock)
+                return false;
+            int objectToCullID = dungeonBlock.GetInstanceID();
+            if (dungeonBlock == null || culledObjects.ContainsKey(objectToCullID))
+                return false;
+
+            CulledGameObject culledObject = new CulledGameObject(dungeonBlock);
+
+            SetDungeonBlockCulled(culledObject.gameObject, true);
+            culledObjects[objectToCullID] = culledObject;
+            return true;
+        }
+
+        private bool UnCullDungeonBlock(GameObject dungeonBlock)
+        {
+            if (!dungeonBlock)
+                return false;
+            int objectToUncullID = dungeonBlock.GetInstanceID();
+            if (!culledObjects.ContainsKey(objectToUncullID))
+                return false;
+            CulledGameObject culledObject = culledObjects[objectToUncullID];
+            SetDungeonBlockCulled(culledObject.gameObject, false);
+            culledObjects.Remove(objectToUncullID);
+            return true;
+        }
+        private void SetDungeonBlockCulled(GameObject block, bool culled)
+        {
+            if (!block)
+                return;
+            for (int i = 0; i < block.transform.childCount; ++i)
+            {
+                GameObject blockChild = block.transform.GetChild(i).gameObject;
+                blockChild.SetActive(!culled ? true : blockChild.name == "Models" || blockChild.name == "Action Models");
+            }
+            block.transform.Find("Models").GetComponentsInChildren<MeshRenderer>().ToList().ForEach(p => p.enabled = !culled);
+            block.transform.Find("Action Models").GetComponentsInChildren<MeshRenderer>().ToList().ForEach(p => p.enabled = !culled);
+        }
+
+        private void UnCullAllObjects()
+        {
+            if (culledObjects.Count == 0)
+                return;
+
+            keysToRemove.Clear();
+            foreach (var kvp in culledObjects)
+                keysToRemove.Add(kvp.Key);
+
+            foreach (int key in keysToRemove)
+            {
+                CulledGameObject culledObject = culledObjects[key];
+                if (!culledObject.gameObject)
+                {
+                    culledObjects.Remove(key);
+                    continue;
+                }
+
+                if (culledObject.gameObject.transform.parent == culledObjectsParent.transform)
+                    UnCullObject(culledObject.gameObject);
+                else
+                    UnCullDungeonBlock(culledObject.gameObject);
+            }
+
+            keysToRemove.Clear();
+        }
+
+        private void OnLoadEvent(SaveData_v1 saveData)
+        {
+            if (DaggerfallUnity.Settings.EnableObjectCulling)
+                UpdateAllCullableObjects(GameManager.Instance.PlayerMotor.transform.position);
+            else
+                UnCullAllObjects();
+        }
+    }
+}

--- a/Assets/Scripts/Game/CulledGameObjectManager.cs
+++ b/Assets/Scripts/Game/CulledGameObjectManager.cs
@@ -193,14 +193,19 @@ namespace DaggerfallWorkshop.Game
         {
             foreach (GameObject block in cullableRDBObjects)
             {
-                // Constructing bounds manually based on the block's footprint and pivot information
+                // Construct bounds manually based on the block's horizontal footprint and pivot information.
                 Vector3 blockCenter = block.transform.position + Vector3.one * (1024 * MeshReader.GlobalScale); // Center of the block
-                Vector3 blockSize = Vector3.one * (2048 * MeshReader.GlobalScale); // Assuming infinite height for simplicity
+                Vector3 blockSize = Vector3.one * (2048 * MeshReader.GlobalScale);
                 Bounds blockBounds = new Bounds(blockCenter, blockSize);
 
-                // Check if the player is within the ScaledBlockRange from the closest point on the bounds
-                float closestPointDistance = Vector3.Distance(playerPosition, blockBounds.ClosestPoint(playerPosition));
-                if (closestPointDistance > ScaledBlockRange && !blockBounds.Contains(playerPosition)) // Check if outside range and player not inside block
+                // Dungeon blocks can contain geometry far above or below their origin. Ignore vertical distance so
+                // deep and tall areas remain visible while their block is horizontally close to the player.
+                float closestX = Mathf.Clamp(playerPosition.x, blockBounds.min.x, blockBounds.max.x);
+                float closestZ = Mathf.Clamp(playerPosition.z, blockBounds.min.z, blockBounds.max.z);
+                float deltaX = playerPosition.x - closestX;
+                float deltaZ = playerPosition.z - closestZ;
+                float closestPointSquaredDistance = deltaX * deltaX + deltaZ * deltaZ;
+                if (closestPointSquaredDistance > ScaledBlockRangeSquared)
                 {
                     if (!IsObjectCulled(block))
                     {

--- a/Assets/Scripts/Game/CulledGameObjectManager.cs.meta
+++ b/Assets/Scripts/Game/CulledGameObjectManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43fe9d3db5f70f24bb00284402a4d97e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallAdvancedSettingsWindow.cs
@@ -157,6 +157,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         Checkbox interiorLightShadows;
         Checkbox exteriorLightShadows;
         Checkbox ambientLitInteriors;
+        Checkbox enableObjectCulling;
 
         // Accessibility
         Button automapTempleColor;
@@ -378,6 +379,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             interiorLightShadows = AddCheckbox(rightPanel, "interiorLightShadows", DaggerfallUnity.Settings.InteriorLightShadows);
             exteriorLightShadows = AddCheckbox(rightPanel, "exteriorLightShadows", DaggerfallUnity.Settings.ExteriorLightShadows);
             ambientLitInteriors = AddCheckbox(rightPanel, "ambientLitInteriors", DaggerfallUnity.Settings.AmbientLitInteriors);
+            enableObjectCulling = AddCheckbox(rightPanel, "enableObjectCulling", DaggerfallUnity.Settings.EnableObjectCulling);
             string textureArrayLabel = TextManager.Instance.GetLocalizedText("textureArrayLabel", TextCollections.TextSettings);
             if (!SystemInfo.supports2DArrayTextures)
                 textureArrayLabel += TextManager.Instance.GetLocalizedText("unsupported", TextCollections.TextSettings);
@@ -531,6 +533,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             DaggerfallUnity.Settings.InteriorLightShadows = interiorLightShadows.IsChecked;
             DaggerfallUnity.Settings.ExteriorLightShadows = exteriorLightShadows.IsChecked;
             DaggerfallUnity.Settings.AmbientLitInteriors = ambientLitInteriors.IsChecked;
+            DaggerfallUnity.Settings.EnableObjectCulling = enableObjectCulling.IsChecked;
 
             /* Accessibility */
             DaggerfallUnity.Settings.AutomapTempleColor = automapTempleColor.BackgroundColor;

--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -82,6 +82,8 @@ namespace DaggerfallWorkshop
                     // Example is the treasury in Daggerfall castle, some action records flow through the quest item marker
                     meshRenderer.enabled = false;
                 }
+
+                ActiveGameObjectDatabase.RegisterBillboard(gameObject);
             }
         }
 

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -179,6 +179,7 @@ namespace DaggerfallWorkshop
         public float InteriorShadowDistance { get; set; }
         public float ExteriorShadowDistance { get; set; }
         public bool EnableTextureArrays { get; set; }
+        public bool EnableObjectCulling { get; set; }
         public int RandomDungeonTextures { get; set; }
         public int CursorWidth { get; set; }
         public int CursorHeight { get; set; }
@@ -425,6 +426,7 @@ namespace DaggerfallWorkshop
             InteriorShadowDistance = GetFloat(sectionVideo, "InteriorShadowDistance", 0.1f, 50.0f);
             ExteriorShadowDistance = GetFloat(sectionVideo, "ExteriorShadowDistance", 0.1f, 150.0f);
             EnableTextureArrays = GetBool(sectionVideo, "EnableTextureArrays");
+            EnableObjectCulling = GetBool(sectionVideo, "EnableObjectCulling");
             RandomDungeonTextures = GetInt(sectionVideo, "RandomDungeonTextures", 0, 4);
 
             AntialiasingMethod = GetInt(sectionEffects, "AntialiasingMethod", 0, 3);
@@ -622,6 +624,7 @@ namespace DaggerfallWorkshop
             SetFloat(sectionVideo, "InteriorShadowDistance", InteriorShadowDistance);
             SetFloat(sectionVideo, "ExteriorShadowDistance", ExteriorShadowDistance);
             SetBool(sectionVideo, "EnableTextureArrays", EnableTextureArrays);
+            SetBool(sectionVideo, "EnableObjectCulling", EnableObjectCulling);
             SetInt(sectionVideo, "RandomDungeonTextures", RandomDungeonTextures);
 
             SetInt(sectionEffects, "AntialiasingMethod", AntialiasingMethod);

--- a/Assets/StreamingAssets/Text/GameSettings.txt
+++ b/Assets/StreamingAssets/Text/GameSettings.txt
@@ -172,6 +172,8 @@ terrainDistance,                                    Terrain Distance
 terrainDistanceInfo,                                Maximum distance of active terrains from player position
 shadowResolutionMode,                               Shadow Resolution
 shadowResolutionModeInfo,                           Quality of shadows
+enableObjectCulling,                                Object Culling
+enableObjectCullingInfo,                            Cull distant objects to improve performance
 dungeonLightShadows,                                Dungeon Light Shadows
 dungeonLightShadowsInfo,                            Dungeon lights cast shadows
 interiorLightShadows,                               Interior Light Shadows


### PR DESCRIPTION
### Performance Enhancement: GameObject Culling

This feature has been part of the Android fork for the past couple years. It greatly improves performance on mobile, and the performance gains are pretty great on desktop as well.

On my machine in the Wayrest dungeon with culling disabled, Profiler shows constant stuttering to 30fps and an occasional 15fps lag spike. With culling _enabled_, it stays closer to 60fps, occasionally spiking to 30fps. The remaining lag is due to AutoMapper, which is optimized in Android and I'd like to open a separate PR for that.

#### How it works

The CulledGameObjectManager disables Billboards, Foe Spawners, Enemies, Action Doors, Static NPCs, Loot, and Dungeon Blocks that are further than 2060 unscaled units away from the player. It does so by moving them under a disabled game object parent, so that their local enabled/disabled state is unchanged.

It culls these object types on separate frames, which helps smooth out any lag from enabling and disabling a ton of GameObjects all at once.

#### Implementation Notes

* added relevant 'Object Culling' setting to Video settings (defaulted to enabled)
* ActiveGameObjectDatabase now supports inactive object lookups (required for culling disabled objects, otherwise you can have e.g. enemies walking around in disabled dungeon blocks)
* billboards are now registered with the ActiveGameObjectDatabase (so they may also be culled; we only bother doing so when the player is outside)
* added CulledGameObjectManager to the game scene