### PR TITLE
Fix for overlapping text in some books

### DIFF
--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBookReaderWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallBookReaderWindow.cs
@@ -318,6 +318,7 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
             foreach (TextLabel label in bookLabels)
             {
                 label.Position = new Vector2(x, y);
+                label.Parent = pagePanel; // Establish parent scale before measuring wrapped text.
                 label.MaxWidth = (int)pagePanel.Size.x;
                 label.RectRestrictedRenderArea = pagePanel.RectRestrictedRenderArea;
                 label.RestrictedRenderAreaCoordinateType = TextLabel.RestrictedRenderArea_CoordinateType.ParentCoordinates;


### PR DESCRIPTION
#2619 introduced an issue with books sometimes having overlapping text.

Example: The Real Barenziah, Part V

<img width="677" height="184" alt="image" src="https://github.com/user-attachments/assets/512c93ef-24d4-4567-af57-fde77ec02b37" />

The fix was a single line. Just needed to set the TextLabel's parent to the pagePanel *before* calculating its size.

After the fix:
<img width="668" height="281" alt="image" src="https://github.com/user-attachments/assets/6ae9bad1-8b22-4093-9748-e8fca2a05cfc" />
