### PR TITLE
Basic camera clamping fix

### DIFF
--- a/Assets/Scripts/Game/PlayerMouseLook.cs
+++ b/Assets/Scripts/Game/PlayerMouseLook.cs
@@ -141,7 +141,7 @@ namespace DaggerfallWorkshop.Game
             }
 
             // Clamp target look pitch to range of straight down to straight up
-            lookTarget.y = Mathf.Clamp(lookTarget.y, pitchMin, pitchMax);
+            lookTarget.y = Mathf.Clamp(lookTarget.y, -pitchMax, -pitchMin);
 
             ApplySmoothing();
 


### PR DESCRIPTION
Swaps and reverses the signs of the min and max pitch values when clamping the lookTarget vector in PlayerMouseLook.

Following up from my testing of PR #2704, I figured that the issue was stemming from vectors and angles treating signed values differently. When used in angles, a positive value limits how far you can look **down** and vice versa for negative values. In vectors, a positive Y-value rotates the vector to point **upwards**.

At first, I commented out the line clamping the vector in Update and the individual clamping values started working. On the other hand, the unclamped vector caused the player's camera to get stuck if the target vector's pitch was beyond the min/max bounds.

I then decided to just reverse the signs and swap pitch values on the vector clamping and it worked. I then tested it with the vanilla attack control scheme and some mods.

To illustrate: [Video of Enhanced Riding](https://streamable.com/ad7klc) from Roleplay & Realism by @ajrb.
In the above video Enhanced Riding limits how far the player can look down, but the current release causes both up/down to be limited. With this fix, the player can now look up freely while being limited when looking down.

I also tested it with Free Rein and [Auto-Sight](https://streamable.com/lny2h9) and they also worked just as well, so in addition to fixing the clamping, the original usage of the SetFacing methods is preserved.