### PR TITLE
Implement error logging and exception catching in `FolderBrowser`

### DIFF
--- a/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
+++ b/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
@@ -240,7 +240,8 @@ namespace DaggerfallWorkshop.Game.UserInterface
             {
                 folders.Clear();
                 folderList.ClearItems();
-                return;
+                if (currentPath != drives[driveList.SelectedIndex])
+                    folderList.AddItem(parentDirectory);
             }
         }
 

--- a/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
+++ b/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
@@ -236,8 +236,9 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 folderScroller.ScrollIndex = 0;
                 folderList.SelectedIndex = 0;
             }
-            catch
+            catch (Exception e)
             {
+                Debug.LogErrorFormat("FolderBrowser: Failed to enumerate '{0}': {1}", currentPath, e.Message);
                 folders.Clear();
                 folderList.ClearItems();
                 if (currentPath != drives[driveList.SelectedIndex])

--- a/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
+++ b/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
@@ -250,6 +250,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 folderList.ClearItems();
                 if (currentPath != drives[driveList.SelectedIndex])
                     folderList.AddItem(parentDirectory);
+                folderList.AddItem("(could not read directory)");
             }
         }
 

--- a/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
+++ b/Assets/Scripts/Game/UserInterface/FolderBrowser.cs
@@ -222,12 +222,19 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
                 foreach (var directory in directoryList)
                 {
-                    DirectoryInfo info = new DirectoryInfo(directory);
-                    if (showHiddenFilesCheck.IsChecked || (info.Attributes & FileAttributes.Hidden) == 0)
+                    try
                     {
-                        string name = Path.GetFileName(directory);
-                        folders.Add(name);
-                        folderList.AddItem(name);
+                        DirectoryInfo info = new DirectoryInfo(directory);
+                        if (showHiddenFilesCheck.IsChecked || (info.Attributes & FileAttributes.Hidden) == 0)
+                        {
+                            string name = Path.GetFileName(directory);
+                            folders.Add(name);
+                            folderList.AddItem(name);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogWarningFormat("FolderBrowser: Skipping inaccessible directory '{0}': {1}", directory, e.Message);
                     }
                 }
 


### PR DESCRIPTION
`FolderBrowser` uses `Directory.GetDirectories` to scan the filesystem, which can throw for numerous reasons (path too long, any subdirectory failing, etc.). This is fine but, currently, in the event of an error:
- Nothing is communicated to the user
- The parent directory is not added to the list so the user must click on their filesystem root to get the game back to an interactable state

This PR fixes those issues by:
- Explicitly adding the `..` directory to the list if an exception is caught
- Logging all directory errors to the console with Unity's APIs

Closes #2796 
*Be aware that this does not fix any underlying potential issue. It just clearly communicates any errors to the player.*