### PR TITLE
Bug fix in Dialogs window

### DIFF
--- a/Assets/Scripts/Game/TalkManager.cs
+++ b/Assets/Scripts/Game/TalkManager.cs
@@ -3570,6 +3570,9 @@ namespace DaggerfallWorkshop.Game
                 string textFragment = tokens[i].text;
                 if (textFragment != null && textFragment != string.Empty)
                     builder.Append(textFragment);
+                else if (tokens[i].formatting == TextFile.Formatting.JustifyCenter)
+					// To avoid consecutive lines with [/center] in dialog screen to stick together.
+                    builder.Append(" ");
                 else
                     builder.Append(separatorString);
             }


### PR DESCRIPTION
Replace the JustifyCenter token by a space so that successive lines of a record into Internal_RSC separated by a [/center] are not sticked together  when displayed into the Dialogs window.

Example:
8570,"Ah, at last! I was beginning to think you[/center]
wouldn't get this far.[/center]
[/end]"

With current code into TextManager.cs:
<img width="496" height="119" alt="Daggerfall_Unity_2026-06-16_14-34-31" src="https://github.com/user-attachments/assets/676098b8-9295-4c32-bf0c-961b2488dc8f" />

After bug fix:
<img width="347" height="85" alt="Unity_2026-06-17_15-19-19" src="https://github.com/user-attachments/assets/7e7592e6-1af1-41a2-a59b-f79521dbe456" />
