### PR TITLE
Fall damage handling moved to FormulaHelper

### DIFF
--- a/Assets/Scripts/Game/EnemyMotor.cs
+++ b/Assets/Scripts/Game/EnemyMotor.cs
@@ -11,6 +11,7 @@
 
 using UnityEngine;
 using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Formulas;
 using DaggerfallWorkshop.Game.MagicAndEffects;
 using System.Collections.Generic;
 using DaggerfallWorkshop.Utility;
@@ -32,6 +33,7 @@ namespace DaggerfallWorkshop.Game
         #region Member Variables
 
         public float OpenDoorDistance = 2f;         // Maximum distance to open door
+        public float fallingDamageThreshold = 5.0f;
         const float attackSpeedDivisor = 2f;        // How much to slow down during attack animations
         float stopDistance = 1.7f;                  // Used to prevent orbiting
         const float doorCrouchingHeight = 1.65f;    // How low enemies dive to pass thru doors
@@ -1383,10 +1385,6 @@ namespace DaggerfallWorkshop.Game
 
         void ApplyFallDamage()
         {
-            // Assuming the same formula is used for the player and enemies
-            const float fallingDamageThreshold = 5.0f;
-            const float HPPerMetre = 5f;
-
             if (controller.isGrounded)
             {
                 // did enemy just land?
@@ -1395,18 +1393,22 @@ namespace DaggerfallWorkshop.Game
                     float fallDistance = LastGroundedY - transform.position.y;
                     if (fallDistance > fallingDamageThreshold)
                     {
-                        int damage = (int)(HPPerMetre * (fallDistance - fallingDamageThreshold));
+                        // Assuming the same formula is used for the player and enemies
+                        int damage = FormulaHelper.CalculateFallDamage(entityBehaviour.Entity, fallingDamageThreshold, fallDistance);
 
-                        EnemyEntity enemyEntity = entityBehaviour.Entity as EnemyEntity;
-                        enemyEntity.DecreaseHealth(damage);
-
-                        if (entityBlood)
+                        if (damage > 0)
                         {
-                            // Like in classic, falling enemies bleed at the center. It must hurt the center of mass ;)
-                            entityBlood.ShowBloodSplash(0, transform.position);
-                        }
+                            EnemyEntity enemyEntity = entityBehaviour.Entity as EnemyEntity;
+                            enemyEntity.DecreaseHealth(damage);
 
-                        DaggerfallUI.Instance.DaggerfallAudioSource.PlayClipAtPoint((int)SoundClips.FallDamage, FindGroundPosition());
+                            if (entityBlood)
+                            {
+                                // Like in classic, falling enemies bleed at the center. It must hurt the center of mass ;)
+                                entityBlood.ShowBloodSplash(0, transform.position);
+                            }
+
+                            DaggerfallUI.Instance.DaggerfallAudioSource.PlayClipAtPoint((int)SoundClips.FallDamage, FindGroundPosition());
+                        }
                     }
                 }
 

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -427,13 +427,12 @@ namespace DaggerfallWorkshop.Game.Formulas
             return VampireClans.Lyrezi;
         }
 
-        public static int CalculateFallDamage(float distance)
+        public static int CalculateFallDamage(DaggerfallEntity entity, float threshold, float distance)
         {
-            Func<float, int> del;
+            Func<DaggerfallEntity, float, float, int> del;
             if (TryGetOverride("CalculateFallDamage", out del))
-                return del(distance);
+                return del(entity, threshold, distance);
 
-            float threshold = GameManager.Instance.AcrobatMotor.fallingDamageThreshold;
             float HPPerMetre = 5;
 
             int damage = (int)(HPPerMetre * (distance - threshold));

--- a/Assets/Scripts/Game/Formulas/FormulaHelper.cs
+++ b/Assets/Scripts/Game/Formulas/FormulaHelper.cs
@@ -427,6 +427,20 @@ namespace DaggerfallWorkshop.Game.Formulas
             return VampireClans.Lyrezi;
         }
 
+        public static int CalculateFallDamage(float distance)
+        {
+            Func<float, int> del;
+            if (TryGetOverride("CalculateFallDamage", out del))
+                return del(distance);
+
+            float threshold = GameManager.Instance.AcrobatMotor.fallingDamageThreshold;
+            float HPPerMetre = 5;
+
+            int damage = (int)(HPPerMetre * (distance - threshold));
+
+            return damage;
+        }
+
         #endregion
 
         #region Combat & Damage

--- a/Assets/Scripts/Game/PlayerHealth.cs
+++ b/Assets/Scripts/Game/PlayerHealth.cs
@@ -51,7 +51,7 @@ namespace DaggerfallWorkshop.Game
         {
             if (entityBehaviour)
             {
-                int damage = FormulaHelper.CalculateFallDamage(fallDistance);
+                int damage = FormulaHelper.CalculateFallDamage(entityBehaviour.Entity,GameManager.Instance.AcrobatMotor.fallingDamageThreshold,fallDistance);
 
                 if (damage > 0)
                     RemoveHealth(damage);

--- a/Assets/Scripts/Game/PlayerHealth.cs
+++ b/Assets/Scripts/Game/PlayerHealth.cs
@@ -1,4 +1,4 @@
-﻿// Project:         Daggerfall Unity
+// Project:         Daggerfall Unity
 // Copyright:       Copyright (C) 2009-2023 Daggerfall Workshop
 // Web Site:        http://www.dfworkshop.net
 // License:         MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -12,6 +12,7 @@
 using UnityEngine;
 using System.Collections;
 using DaggerfallWorkshop.Game.Entity;
+using DaggerfallWorkshop.Game.Formulas;
 
 namespace DaggerfallWorkshop.Game
 {
@@ -48,13 +49,12 @@ namespace DaggerfallWorkshop.Game
         /// </summary>
         void ApplyPlayerFallDamage(float fallDistance)
         {
-            const float threshold = 5f;
-            const float HPPerMetre = 5f;
-
             if (entityBehaviour)
             {
-                int damage = (int)(HPPerMetre * (fallDistance - threshold));
-                RemoveHealth(damage);
+                int damage = FormulaHelper.CalculateFallDamage(fallDistance);
+
+                if (damage > 0)
+                    RemoveHealth(damage);
             }
         }
     }


### PR DESCRIPTION
Unified the disparate ways that fall damage is calculated between [PlayerHealth](https://github.com/Interkarma/daggerfall-unity/blob/master/Assets/Scripts/Game/PlayerHealth.cs#L49) and [EnemyMotor](https://github.com/Interkarma/daggerfall-unity/blob/master/Assets/Scripts/Game/EnemyMotor.cs#L1384) into an overridable formula.

For players, the formula by default can now directly reflect the value of **fallingDamageThreshold** set in [AcrobatMotor](https://github.com/Interkarma/daggerfall-unity/blob/master/Assets/Scripts/Game/Player/AcrobatMotor.cs#L20) instead of using its own const variable.

For enemies, EnemyMotor now has a public **fallingDamageThreshold** property that can be set by mods if necessary.

The intention is to maintain the current behavior but open up fall damage mechanics to modding, making it possible to have skills or spell effects be able to reduce fall damage or increase the distance to fall before taking damage, or even have enemies that can be resistant to fall damage (eg, Acrobats, spiders, etc).

Example used to test overriding the formula:

<img width="1029" height="340" alt="image" src="https://github.com/user-attachments/assets/286acaf8-adc7-4ab7-8257-c1f6aed1d2ad" />

<img width="1093" height="266" alt="image" src="https://github.com/user-attachments/assets/cf096068-6d95-4b06-8799-bd278ee2d43b" />

This example also showcases the formula allowing for different handling of fall damage between players and NPCs (or even specific NPCs) if required.