### PR TITLE
Moddable weapon reach

### DIFF
--- a/Assets/Scripts/Game/MagicAndEffects/Effects/Special/LycanthropyEffect.cs
+++ b/Assets/Scripts/Game/MagicAndEffects/Effects/Special/LycanthropyEffect.cs
@@ -337,7 +337,7 @@ namespace DaggerfallWorkshop.Game.MagicAndEffects.MagicEffects
                 target.MetalType = MetalTypes.None;
                 target.DrawWeaponSound = SoundClips.None;
                 target.SwingWeaponSound = SoundClips.SwingHighPitch;
-                target.Reach = WeaponManager.defaultWeaponReach;
+                target.Reach = GameManager.Instance.WeaponManager.WeaponReach;
                 return true;
             }
 

--- a/Assets/Scripts/Game/WeaponManager.cs
+++ b/Assets/Scripts/Game/WeaponManager.cs
@@ -34,6 +34,23 @@ namespace DaggerfallWorkshop.Game
         const float defaultBowReach = 50f;
         public const float defaultWeaponReach = 2.25f;
 
+        float weaponReachOverride = 0;
+        public float WeaponReach
+        {
+            get
+            {
+                if (weaponReachOverride > 0)
+                    return weaponReachOverride;
+
+                return defaultWeaponReach;
+            }
+            set
+            {
+                weaponReachOverride = value;
+                ScreenWeapon.Reach = WeaponReach;
+            }
+        }
+
         // Equip delay times for weapons
         public static ushort[] EquipDelayTimes = { 500, 700, 1200, 900, 900, 1800, 1600, 1700, 1700, 3000, 3400, 2000, 2200, 2000, 2200, 2000, 4000, 5000 };
 
@@ -754,7 +771,7 @@ namespace DaggerfallWorkshop.Game
                     SetWeapon(ScreenWeapon, currentLeftHandWeapon);
             }
 
-            ScreenWeapon.Reach = defaultWeaponReach;
+            ScreenWeapon.Reach = WeaponReach;
         }
 
         void SetMelee(FPSWeapon target)


### PR DESCRIPTION
Added a getter/setter to WeaponManager that can override the player's weapon reach.

The intention is to maintain the current behavior but allow mods to change the value of the reach. Currently, WeaponManager will continuously set FPSWeapon's Reach property to the defaultWeaponReach value every time the hands are updated so it's a massive pain to keep changing it from outside as a mod. In this PR, there is a getter/setter that can return either the default weapon reach value or a new public override variable. The override variable will only be used if the set value is greater than 0. Otherwise, the current default weapon reach value is used.

This change allows mods to set a custom value for the weapon reach once, and also easily reset it by setting the override to 0.

Existing mods that read FPSWeapon.Reach to determine the player's attack range will automatically work with this change. Those that read the WeaponManager.defaultWeaponReach will function as normal but not benefit from this change.

Currently, bashing static doors does not benefit from longer weapon reach due to how PlayerActivate checks against the DoorActivationDistance. I decided to not change this behavior as I do not feel like being able to enter/exit buildings from far away is a desirable mechanic.

Action objects (like interior doors and levers) with the Attack trigger type will activate when bashed, as is the normal behavior.

Testing changing values in-game via mod:

<img width="820" height="122" alt="image" src="https://github.com/user-attachments/assets/724e3810-c87e-48e7-b719-f57b58d3c580" />

<img width="1217" height="916" alt="image" src="https://github.com/user-attachments/assets/d30cfc0a-f607-4921-8d73-cf15624db9e9" />

<img width="1213" height="917" alt="image" src="https://github.com/user-attachments/assets/295402d2-a46c-455a-8f65-53ae8288550b" />

Resetting override, reach set to default value:
<img width="1215" height="917" alt="image" src="https://github.com/user-attachments/assets/81df7d1c-fb89-4e89-b954-073689b20780" />

Suggestions to improve are welcome.