### PR TITLE
Fix #2750 incomplete

### DIFF
--- a/Assets/Localization/StringTables/Internal_Strings Shared Data.asset
+++ b/Assets/Localization/StringTables/Internal_Strings Shared Data.asset
@@ -3971,6 +3971,10 @@ MonoBehaviour:
     m_Key: pronounHis2
     m_Metadata:
       m_Items: []
+  - m_Id: 779742122305716224
+    m_Key: cityWall
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/StringTables/Internal_Strings_en.asset
+++ b/Assets/Localization/StringTables/Internal_Strings_en.asset
@@ -5231,5 +5231,9 @@ MonoBehaviour:
     m_Localized: his
     m_Metadata:
       m_Items: []
+  - m_Id: 779742122305716224
+    m_Localized: City Wall
+    m_Metadata:
+      m_Items: []
   references:
     version: 1


### PR DESCRIPTION
When looking at city walls, DFU now displays the LocaleText-NotFound message.

The text was added to the locales template, but not to the English locale. If current town is corrupted, you need to run the "refresh_buildingnames" command in the console to fix it.

(Also, should translation be "City Wall" or "City Walls"? I've seen the latter mentioned in other texts)